### PR TITLE
chore: Remove directory as property

### DIFF
--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -113,8 +113,8 @@ class Dataset:
             raise err.SchemaError(err.MissingField("embedding_feature_column_names"))
         embedding_feature_column_names = self.schema.embedding_feature_column_names
         if (
-                embedding_feature_name not in embedding_feature_column_names
-                or embedding_feature_column_names[embedding_feature_name] is None
+            embedding_feature_name not in embedding_feature_column_names
+            or embedding_feature_column_names[embedding_feature_name] is None
         ):
             raise err.SchemaError(err.MissingEmbeddingFeatureColumnNames(embedding_feature_name))
         return embedding_feature_column_names[embedding_feature_name]


### PR DESCRIPTION
About property decorator https://www.tutorialsteacher.com/python/property-decorator

The `Dataset` class does not have a field `__directory` so we don't need the property decorator