### PR TITLE
fix(graphql): support connections on empty lists

### DIFF
--- a/src/phoenix/server/api/types/pagination.py
+++ b/src/phoenix/server/api/types/pagination.py
@@ -154,8 +154,9 @@ def connection_from_list_slice(
         for index, node in enumerate(slice)
     ]
 
-    first_edge = edges[0]
-    last_edge = edges[-1]
+    has_edges = len(edges) > 0
+    first_edge = edges[0] if has_edges else None
+    last_edge = edges[-1] if has_edges else None
     lower_bound = after_offset + 1 if args.after is not None else 0
     upper_bound = before_offset if args.before is not None else list_length
 

--- a/tests/server/api/types/test_pagination.py
+++ b/tests/server/api/types/test_pagination.py
@@ -41,3 +41,10 @@ def test_connection_from_list_reverse():
     )
     assert len(next_connection.edges) == 1
     assert next_connection.page_info.has_previous_page is False
+
+
+def test_connection_from_empty_list():
+    connection = connection_from_list([], ConnectionArgs(first=2))
+
+    assert len(connection.edges) == 0
+    assert connection.page_info.has_next_page is False


### PR DESCRIPTION
fixes the bug where you get an index out of bounds error if the list is empty