### PR TITLE
fix: validation incompatibility

### DIFF
--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -48,11 +48,14 @@ class Dataset:
         name: Optional[str] = None,
         persist_to_disc: bool = True,
     ):
-        for errors in validate_dataset_inputs(dataframe=dataframe, schema=schema):
+        errors = validate_dataset_inputs(
+            dataframe=dataframe,
+            schema=schema,
+        )
+        if errors:
             for e in errors:
                 logger.error(e)
-            if errors:
-                raise err.DatasetError(errors)
+            raise err.DatasetError(errors)
         parsed_dataframe, parsed_schema = _parse_dataframe_and_schema(dataframe, schema)
         self.__dataframe: DataFrame = parsed_dataframe
         self.__schema: Schema = parsed_schema

--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -1,4 +1,4 @@
-from typing import Generator, List
+from typing import List
 
 from pandas import DataFrame
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
@@ -31,12 +31,17 @@ def _check_valid_schema(schema: Schema) -> List[err.ValidationError]:
     return []
 
 
-def validate_dataset_inputs(
-    dataframe: DataFrame, schema: Schema
-) -> Generator[List[err.ValidationError], None, None]:
-    yield _check_missing_columns(dataframe, schema)
-    yield _check_column_types(dataframe, schema)
-    yield _check_valid_schema(schema)
+def validate_dataset_inputs(dataframe: DataFrame, schema: Schema) -> List[err.ValidationError]:
+    errors = _check_missing_columns(dataframe, schema)
+    if errors:
+        return errors
+    errors = _check_column_types(dataframe, schema)
+    if errors:
+        return errors
+    errors = _check_valid_schema(schema)
+    if errors:
+        return errors
+    return []
 
 
 def _check_column_types(dataframe: DataFrame, schema: Schema) -> List[err.ValidationError]:


### PR DESCRIPTION
This PR updates the validation steps so that it stops when it can't proceed further. For example, if a column is missing, we can't validate its type, so we should stop when we have a missing column.