### PR TITLE
ci: test only python 3.8

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -51,7 +51,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, windows-latest, ubuntu-latest]
-                python-version: ["3.8", "3.9", "3.10"]
+                python-version: ["3.8"]
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3


### PR DESCRIPTION
I don't think we need more than python 3.8 since that's the most restrictive.