### PR TITLE
feat: poll for server to start

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -66,15 +66,11 @@ if __name__ == "__main__":
         primary_dataset_name, reference_dataset_name = get_dataset_names_from_fixture_name(
             fixture_name
         )
-        print(f'Downloading fixture "{fixture_name}" if missing')
+        print(f'🌎 Downloading fixture "{fixture_name}" if missing')
         download_fixture_if_missing(fixture_name)
 
-    print("\n")
-    print(
-        f"""Starting Phoenix App
-            primary dataset: {primary_dataset_name}
-            reference dataset: {reference_dataset_name}"""
-    )
+    print(f"1️⃣ primary dataset: {primary_dataset_name}")
+    print(f"2️⃣ reference dataset: {reference_dataset_name}")
 
     app = create_app(
         primary_dataset_name=primary_dataset_name,

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -49,22 +49,20 @@ class Session:
         self._app_service.stop()
 
 
-def _wait_for_boot(
-    url: str, polling_interval_secs: Optional[int] = None, max_retries: Optional[int] = None
-) -> None:
-    polling_interval_secs = polling_interval_secs if polling_interval_secs is not None else 1
-    max_retries = max_retries if max_retries is not None else 100
+def _wait_for_boot(url: str, polling_interval_secs: int = 1, max_retries: int = 10) -> None:
     retries = 0
     while True:
         try:
             # Give some feedback to the user of the boot
-            sys.stdout.write(f"\rLaunching Phoenix{retries % 4 * '.'}")
+            sys.stdout.write(f"\r⏳Launching Phoenix{retries % 4 * '.'}")
             urlopen(url)
+            print("🚀 Phoenix launched")
             break
         except Exception:
             retries += 1
             if retries > max_retries:
-                raise Exception("Phoenix App failed to boot")
+                print("Phoenix failed to launch. Please try again.")
+                break
             time.sleep(polling_interval_secs)
 
 


### PR DESCRIPTION
It's not clear when the server is up when you launch. This forces a wait before the server starts to move on to the next cell.