### PR TITLE
docs: use phoenix logo url instead of rel path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a target="_blank" href="https://arize.com" style="background:none">
-        <img alt="phoenix logo" src="./assets/phoenix-logo-light.svg" width="auto" height="200"></img>
+        <img alt="phoenix logo" src="https://github.com/Arize-ai/phoenix/blob/main/assets/phoenix-logo-light.svg" width="auto" height="200"></img>
     </a>
     <br/>
     <br/>


### PR DESCRIPTION
Use the Phoenix logo URL instead of a relative path so the logo will still show up in other contexts when we go public, e.g., PyPI.