### PR TITLE
fix: minimum time resolution

### DIFF
--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -102,20 +102,21 @@ class Dataset:
         """Returns the datetime of the earliest inference in the dataset"""
         timestamp_col_name: str = cast(str, self.schema.timestamp_column_name)
         start_datetime: datetime = self.__dataframe[timestamp_col_name].min()
-        return start_datetime
+        return start_datetime.replace(second=0, microsecond=0)
 
     @cached_property
     def end_time(self) -> datetime:
         """
         Returns the datetime of the latest inference in the dataset.
         end_datetime equals max(timestamp) + 1 minute, so that it can be
-        used as part of a right-open interval.
+        used as part of a right-open interval. Note that one minute is the
+        smallest interval that is currently allowed.
         """
         timestamp_col_name: str = cast(str, self.schema.timestamp_column_name)
         end_datetime: datetime = self.__dataframe[timestamp_col_name].max() + timedelta(
             minutes=1,
-        )  # adding a minute, so it can be used as part of a right open interval
-        return end_datetime
+        )  # adding a minute, because it's the smallest interval allowed
+        return end_datetime.replace(second=0, microsecond=0)
 
     @property
     def dataframe(self) -> DataFrame:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -750,8 +750,14 @@ class TestDataset:
         )
         output_dataset = Dataset(dataframe=input_df, schema=input_schema)
 
-        assert output_dataset.start_time == raw_data_min_time
-        assert output_dataset.end_time == raw_data_max_time + timedelta(microseconds=1)
+        assert output_dataset.start_time == raw_data_min_time.replace(
+            second=0,
+            microsecond=0,
+        )
+        assert output_dataset.end_time == (raw_data_max_time + timedelta(minutes=1)).replace(
+            second=0,
+            microsecond=0,
+        )
 
     @property
     def num_records(self):


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/552

Because our granularity [parameters](https://github.com/Arize-ai/phoenix/blob/4634be1dcbd134a48ead89e694b757a0568b7c07/src/phoenix/server/api/input_types/Granularity.py#L21) are defined in terms of minutes and can only be integers, the smallest time range allowed is one minute. This PR sets that as the minimum for `end_time` - `start_time`.

This fixes the bug in issue:

<img width="414" alt="Screenshot 2023-04-10 at 9 53 26 AM" src="https://user-images.githubusercontent.com/80478925/230950753-9366acce-208b-4071-bbc1-0da441df4fd9.png">
