### PR TITLE
fix(embeddings): properly attribute points as unknown correctness when predictions/actuals are missing

### DIFF
--- a/tutorials/quickstart.ipynb
+++ b/tutorials/quickstart.ipynb
@@ -97,8 +97,8 @@
    "source": [
     "train_schema = px.Schema(\n",
     "    timestamp_column_name=\"prediction_ts\",\n",
-    "    # prediction_label_column_name=\"predicted_action\",\n",
-    "    # actual_label_column_name=\"actual_action\",\n",
+    "    prediction_label_column_name=\"predicted_action\",\n",
+    "    actual_label_column_name=\"actual_action\",\n",
     "    embedding_feature_column_names={\n",
     "        \"image_embedding\": px.EmbeddingColumnNames(\n",
     "            vector_column_name=\"image_vector\",\n",
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "session = px.launch_app(prod_ds)"
+    "session = px.launch_app(prod_ds, train_ds)"
    ]
   },
   {


### PR DESCRIPTION
resolves #523

For now the UI renders all points as "unknown" correctness. I think there's probably some optimization we can do when actuals are missing but for now this at least renders a point-cloud
<img width="2527" alt="Screenshot 2023-04-10 at 10 48 42 AM" src="https://user-images.githubusercontent.com/5640648/230952198-fdc7b4af-78a1-4b9b-b537-5d619bc66e38.png">
