### PR TITLE
fix: export to pickle (instead of parquet)

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -46,4 +46,4 @@ def get_exported_files(directory: Path) -> List[Path]:
     list: List[Path]
         List of paths of the exported files.
     """
-    return list(directory.glob("*.parquet"))
+    return list(directory.glob("*.pickle"))

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -112,10 +112,10 @@ class Model:
             return DimensionDataType.CATEGORICAL
         raise ValueError("Unrecognized dimension type")
 
-    def export_events_as_parquet_file(
+    def export_events_as_pickle_file(
         self,
         rows: Mapping[DatasetRole, Iterable[int]],
-        parquet_file: BinaryIO,
+        output_file: BinaryIO,
     ) -> None:
         """
         Given row numbers, exports dataframe subset into parquet file.
@@ -125,14 +125,14 @@ class Model:
         ----------
         rows: Mapping[DatasetRole, Iterable[int]]
             mapping of dataset type to list of row numbers
-        parquet_file: file handle
-            output parquet file handle
+        output_file: file handle
+            pickle file handle
         """
         pd.concat(
             dataset.get_events(rows.get(dataset_role, ()))
             for dataset_role, dataset in self.__datasets.items()
             if dataset is not None
-        ).to_parquet(parquet_file, index=False)
+        ).to_pickle(output_file)
 
 
 def _get_embedding_dimensions(

--- a/src/phoenix/server/api/types/ExportEventsMutation.py
+++ b/src/phoenix/server/api/types/ExportEventsMutation.py
@@ -30,11 +30,11 @@ class ExportEventsMutation:
             file_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         row_ids = parse_event_ids(event_ids)
         path = info.context.export_path
-        with open(path / (file_name + ".parquet"), "wb") as fd:
+        with open(path / (file_name + ".pickle"), "wb") as fd:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 None,
-                info.context.model.export_events_as_parquet_file,
+                info.context.model.export_events_as_pickle_file,
                 row_ids,
                 fd,
             )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -92,7 +92,7 @@ class Download(HTTPEndpoint):
 
     async def get(self, request: Request) -> FileResponse:
         params = QueryParams(request.query_params)
-        file = self.path / (params.get("filename", "") + ".parquet")
+        file = self.path / (params.get("filename", "") + ".pickle")
         if not file.is_file():
             raise HTTPException(status_code=404)
         return FileResponse(

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -45,7 +45,7 @@ class ExportedData(_BaseList):
         )
         self.paths.update(new_paths)
         self.names.extend(path.stem for path in new_paths)
-        self.data.extend(pd.read_parquet(path) for path in new_paths)
+        self.data.extend(pd.read_pickle(path) for path in new_paths)
 
 
 class Session(ABC):


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/556

issue with nanoseconds: 
> "message":"Casting from timestamp[ns, tz=UTC] to timestamp[us] would lose data: 1675044332003721984"