### PR TITLE
fix: coerce timestamps in exported parquet files

### DIFF
--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -132,7 +132,12 @@ class Model:
             dataset.get_events(rows.get(dataset_role, ()))
             for dataset_role, dataset in self.__datasets.items()
             if dataset is not None
-        ).to_parquet(parquet_file, index=False)
+        ).to_parquet(
+            parquet_file,
+            index=False,
+            allow_truncated_timestamps=True,
+            coerce_timestamps="ms",
+        )
 
 
 def _get_embedding_dimensions(


### PR DESCRIPTION
resolves #556 