### PR TITLE
fix: don't compile js/html if exists - unblock conda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ only-packages = true
 dependencies = ["hatch-jupyter-builder"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = ["src/phoenix/server/static/index.js", "src/phoenix/server/static/index.html"]
+skip-if-exists = ["src/phoenix/server/static/index.js", "src/phoenix/server/static/index.html"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 path = "app"


### PR DESCRIPTION
Skip the NPM build if possible so that conda pipeline works