### PR TITLE
feat: Enable generative prompt/response pair

### DIFF
--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -143,7 +143,7 @@ def _get_embedding_dimensions(
     primary_dataset: Dataset, reference_dataset: Optional[Dataset]
 ) -> List[EmbeddingDimension]:
     embedding_dimensions: List[EmbeddingDimension] = []
-    embedding_features: Dict[str, EmbeddingColumnNames] = {}
+    embedding_features: EmbeddingFeatures = {}
 
     primary_embedding_features: Optional[
         EmbeddingFeatures

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -151,7 +151,7 @@ def _get_embedding_dimensions(
     if primary_embedding_features is not None:
         embedding_features.update(primary_embedding_features)
     primary_prompt_column_names: Optional[
-        EmbeddingFeatures
+        EmbeddingColumnNames
     ] = primary_dataset.schema.prompt_column_names
     if primary_prompt_column_names is not None:
         embedding_features.update({"prompt": primary_prompt_column_names})

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -156,7 +156,7 @@ def _get_embedding_dimensions(
     if primary_prompt_column_names is not None:
         embedding_features.update({"prompt": primary_prompt_column_names})
     primary_response_column_names: Optional[
-        EmbeddingFeatures
+        EmbeddingColumnNames
     ] = primary_dataset.schema.response_column_names
     if primary_response_column_names is not None:
         embedding_features.update({"response": primary_response_column_names})

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -173,7 +173,7 @@ def _get_embedding_dimensions(
         if reference_prompt_column_names is not None:
             embedding_features.update({"prompt": reference_prompt_column_names})
         reference_response_column_names: Optional[
-            EmbeddingFeatures
+            EmbeddingColumnNames
         ] = reference_dataset.schema.response_column_names
         if reference_response_column_names is not None:
             embedding_features.update({"response": reference_response_column_names})

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -149,15 +149,35 @@ def _get_embedding_dimensions(
     primary_embedding_features: Optional[
         EmbeddingFeatures
     ] = primary_dataset.schema.embedding_feature_column_names
-
     if primary_embedding_features is not None:
         embedding_features.update(primary_embedding_features)
+    primary_prompt_column_names: Optional[
+        EmbeddingFeatures
+    ] = primary_dataset.schema.prompt_column_names
+    if primary_prompt_column_names is not None:
+        embedding_features.update({"prompt": primary_prompt_column_names})
+    primary_response_column_names: Optional[
+        EmbeddingFeatures
+    ] = primary_dataset.schema.response_column_names
+    if primary_response_column_names is not None:
+        embedding_features.update({"response": primary_response_column_names})
+
     if reference_dataset is not None:
         reference_embedding_features: Optional[
-            Dict[str, EmbeddingColumnNames]
+            EmbeddingFeatures
         ] = reference_dataset.schema.embedding_feature_column_names
         if reference_embedding_features is not None:
             embedding_features.update(reference_embedding_features)
+        reference_prompt_column_names: Optional[
+            EmbeddingFeatures
+        ] = reference_dataset.schema.prompt_column_names
+        if reference_prompt_column_names is not None:
+            embedding_features.update({"prompt": reference_prompt_column_names})
+        reference_response_column_names: Optional[
+            EmbeddingFeatures
+        ] = reference_dataset.schema.response_column_names
+        if reference_response_column_names is not None:
+            embedding_features.update({"response": reference_response_column_names})
 
     for embedding_feature, embedding_column_names in embedding_features.items():
         embedding_dimensions.append(EmbeddingDimension(name=embedding_feature))

--- a/src/phoenix/core/model.py
+++ b/src/phoenix/core/model.py
@@ -168,7 +168,7 @@ def _get_embedding_dimensions(
         if reference_embedding_features is not None:
             embedding_features.update(reference_embedding_features)
         reference_prompt_column_names: Optional[
-            EmbeddingFeatures
+            EmbeddingColumnNames
         ] = reference_dataset.schema.prompt_column_names
         if reference_prompt_column_names is not None:
             embedding_features.update({"prompt": reference_prompt_column_names})

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -551,7 +551,6 @@ def _normalize_timestamps(
     return dataframe, schema
 
 
-# TODO(Kiko): Add prompt_response
 def _get_schema_from_unknown_schema_param(schemaLike: SchemaLike) -> Schema:
     """
     Compatibility function for converting from arize.utils.types.Schema to phoenix.datasets.Schema

--- a/src/phoenix/datasets/errors.py
+++ b/src/phoenix/datasets/errors.py
@@ -153,6 +153,26 @@ class EmbeddingVectorSizeMismatch(ValidationError):
         )
 
 
+class InvalidEmbeddingReservedName(ValidationError):
+    """An error raised when there is an embedding feature with a name, i.e. dictionary key,
+    that is reserved
+    """
+
+    def __init__(
+        self,
+        reserved_name: str,
+        schema_field: str,
+    ) -> None:
+        self.reserved_name = reserved_name
+        self.schema_field = schema_field
+
+    def error_message(self) -> str:
+        return (
+            f"Embedding feature name '{self.reserved_name}' is reserved and cannot be used. "
+            f"This is the case when '{self.schema_field}' is not None."
+        )
+
+
 class InvalidEmbeddingVectorSize(ValidationError):
     """An error raised when there is an embedding feature with an invalid vector length"""
 

--- a/src/phoenix/datasets/schema.py
+++ b/src/phoenix/datasets/schema.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 EmbeddingFeatures = Dict[str, "EmbeddingColumnNames"]
@@ -38,6 +38,12 @@ class Schema(Dict[SchemaFieldName, SchemaFieldValue]):
     response_column_names: Optional[EmbeddingColumnNames] = None
     embedding_feature_column_names: Optional[EmbeddingFeatures] = None
     excluded_column_names: Optional[List[str]] = None
+
+    def replace(self, **changes):
+        return replace(self, **changes)
+
+    def asdict(self) -> Dict[str, str]:
+        return asdict(self)
 
     def to_json(self) -> str:
         "Converts the schema to a dict for JSON serialization"

--- a/src/phoenix/datasets/schema.py
+++ b/src/phoenix/datasets/schema.py
@@ -39,7 +39,7 @@ class Schema(Dict[SchemaFieldName, SchemaFieldValue]):
     embedding_feature_column_names: Optional[EmbeddingFeatures] = None
     excluded_column_names: Optional[List[str]] = None
 
-    def replace(self, **changes):
+    def replace(self, **changes: str) -> "Schema":
         return replace(self, **changes)
 
     def asdict(self) -> Dict[str, str]:

--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -59,9 +59,8 @@ def _check_valid_embedding_data(dataframe: DataFrame, schema: Schema) -> List[er
 
     embedding_errors: List[err.ValidationError] = []
     for embedding_name, column_names in embedding_col_names.items():
-        vector_column = dataframe[column_names.vector_column_name]
         embedding_errors += _validate_embedding_vector(
-            embedding_name, vector_column, column_names.vector_column_name
+            dataframe, embedding_name, column_names.vector_column_name
         )
 
     return embedding_errors
@@ -78,17 +77,17 @@ def _check_valid_prompt_response_data(
     }
     for name, column_names in prompt_response_column_names.items():
         if column_names is not None:
-            vector_column = dataframe[column_names.vector_column_name]
             prompt_response_errors += _validate_embedding_vector(
-                name, vector_column, column_names.vector_column_name
+                dataframe, name, column_names.vector_column_name
             )
 
     return prompt_response_errors
 
 
 def _validate_embedding_vector(
-    name: str, vector_column: Series[float], vector_column_name: str
+    dataframe: DataFrame, name: str, vector_column_name: str
 ) -> List[err.ValidationError]:
+    vector_column = dataframe[vector_column_name]
     errors: List[err.ValidationError] = []
     vector_length = None
 

--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -199,33 +199,20 @@ def _check_missing_columns(dataframe: DataFrame, schema: Schema) -> List[err.Val
             ):
                 missing_columns.append(emb_col_names.link_to_data_column_name)
 
-    if schema.prompt_column_names is not None:
-        if schema.prompt_column_names.vector_column_name not in existing_columns:
-            missing_columns.append(schema.prompt_column_names.vector_column_name)
-        if (
-            schema.prompt_column_names.raw_data_column_name is not None
-            and schema.prompt_column_names.raw_data_column_name not in existing_columns
-        ):
-            missing_columns.append(schema.prompt_column_names.raw_data_column_name)
-        if (
-            schema.prompt_column_names.link_to_data_column_name is not None
-            and schema.prompt_column_names.link_to_data_column_name not in existing_columns
-        ):
-            missing_columns.append(schema.prompt_column_names.link_to_data_column_name)
-
-    if schema.response_column_names is not None:
-        if schema.response_column_names.vector_column_name not in existing_columns:
-            missing_columns.append(schema.response_column_names.vector_column_name)
-        if (
-            schema.response_column_names.raw_data_column_name is not None
-            and schema.response_column_names.raw_data_column_name not in existing_columns
-        ):
-            missing_columns.append(schema.response_column_names.raw_data_column_name)
-        if (
-            schema.response_column_names.link_to_data_column_name is not None
-            and schema.response_column_names.link_to_data_column_name not in existing_columns
-        ):
-            missing_columns.append(schema.response_column_names.link_to_data_column_name)
+    for column_names in (schema.prompt_column_names, schema.response_column_names):
+        if column_names is not None:
+            if column_names.vector_column_name not in existing_columns:
+                missing_columns.append(column_names.vector_column_name)
+            if (
+                column_names.raw_data_column_name is not None
+                and column_names.raw_data_column_name not in existing_columns
+            ):
+                missing_columns.append(column_names.raw_data_column_name)
+            if (
+                column_names.link_to_data_column_name is not None
+                and column_names.link_to_data_column_name not in existing_columns
+            ):
+                missing_columns.append(column_names.link_to_data_column_name)
 
     if missing_columns:
         return [err.MissingColumns(missing_columns)]

--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -46,6 +46,9 @@ def validate_dataset_inputs(dataframe: DataFrame, schema: Schema) -> List[err.Va
     errors = _check_valid_embedding_data(dataframe, schema)
     if errors:
         return errors
+    errors = _check_valid_prompt_response_data(dataframe, schema)
+    if errors:
+        return errors
     return []
 
 
@@ -56,60 +59,89 @@ def _check_valid_embedding_data(dataframe: DataFrame, schema: Schema) -> List[er
 
     embedding_errors: List[err.ValidationError] = []
     for embedding_name, column_names in embedding_col_names.items():
-        vector_length = None
         vector_column = dataframe[column_names.vector_column_name]
-
-        for vector in vector_column:
-            vector_is_missing = vector is None or (isinstance(vector, float) and math.isnan(vector))
-            if vector_is_missing:
-                continue
-
-            # Fail if vector is not of supported iterable type
-            if not isinstance(vector, (list, np.ndarray, Series)):
-                embedding_errors.append(
-                    err.InvalidEmbeddingVectorDataType(
-                        embedding_feature_name=embedding_name,
-                        vector_column_type=str(type(vector)),
-                    )
-                )
-                break
-
-            # Fail if not all elements in every vector are int/floats
-            allowed_types = (int, float, np.int16, np.int32, np.float16, np.float32)
-            if not all(isinstance(val, allowed_types) for val in vector):
-                embedding_errors.append(
-                    err.InvalidEmbeddingVectorValuesDataType(
-                        embedding_feature_name=embedding_name,
-                        vector_column_name=column_names.vector_column_name,
-                        vector=vector,
-                    )
-                )
-                break
-
-            if vector_length is None:
-                vector_length = len(vector)
-
-            # Fail if vectors in the dataframe are not of the same length, or of length <= 1
-            if len(vector) != vector_length:
-                embedding_errors.append(
-                    err.EmbeddingVectorSizeMismatch(
-                        embedding_name,
-                        column_names.vector_column_name,
-                        [vector_length, len(vector)],
-                    )
-                )
-                break
-            elif vector_length <= 1:
-                embedding_errors.append(
-                    err.InvalidEmbeddingVectorSize(
-                        embedding_name,
-                        column_names.vector_column_name,
-                        vector_length,
-                    )
-                )
-                break
+        embedding_errors += _validate_embedding_vector(
+            embedding_name, vector_column, column_names.vector_column_name
+        )
 
     return embedding_errors
+
+
+def _check_valid_prompt_response_data(
+    dataframe: DataFrame, schema: Schema
+) -> List[err.ValidationError]:
+    prompt_response_errors: List[err.ValidationError] = []
+
+    prompt_response_column_names = {
+        "prompt": schema.prompt_column_names,
+        "response": schema.response_column_names,
+    }
+    for name, column_names in prompt_response_column_names.items():
+        if column_names is not None:
+            vector_column = dataframe[column_names.vector_column_name]
+            prompt_response_errors += _validate_embedding_vector(
+                name, vector_column, column_names.vector_column_name
+            )
+
+    return prompt_response_errors
+
+
+def _validate_embedding_vector(
+    name: str, vector_column: Series, vector_column_name: str
+) -> List[err.ValidationError]:
+    errors = []
+    vector_length = None
+
+    for vector in vector_column:
+        vector_is_missing = vector is None or (isinstance(vector, float) and math.isnan(vector))
+        if vector_is_missing:
+            continue
+
+        # Fail if vector is not of supported iterable type
+        if not isinstance(vector, (list, np.ndarray, Series)):
+            errors.append(
+                err.InvalidEmbeddingVectorDataType(
+                    embedding_feature_name=name,
+                    vector_column_type=str(type(vector)),
+                )
+            )
+            break
+
+        # Fail if not all elements in every vector are int/floats
+        allowed_types = (int, float, np.int16, np.int32, np.float16, np.float32)
+        if not all(isinstance(val, allowed_types) for val in vector):  # type: ignore
+            errors.append(
+                err.InvalidEmbeddingVectorValuesDataType(
+                    embedding_feature_name=name,
+                    vector_column_name=vector_column_name,
+                    vector=vector,
+                )
+            )
+            break
+
+        if vector_length is None:
+            vector_length = len(vector)  # type: ignore
+
+        # Fail if vectors in the dataframe are not of the same length, or of length <= 1
+        if len(vector) != vector_length:  # type: ignore
+            errors.append(
+                err.EmbeddingVectorSizeMismatch(
+                    name,
+                    vector_column_name,
+                    [vector_length, len(vector)],  # type: ignore
+                )
+            )
+            break
+        elif vector_length <= 1:
+            errors.append(
+                err.InvalidEmbeddingVectorSize(
+                    name,
+                    vector_column_name,
+                    vector_length,
+                )
+            )
+            break
+    return errors
 
 
 def _check_column_types(dataframe: DataFrame, schema: Schema) -> List[err.ValidationError]:
@@ -167,6 +199,34 @@ def _check_missing_columns(dataframe: DataFrame, schema: Schema) -> List[err.Val
                 and emb_col_names.link_to_data_column_name not in existing_columns
             ):
                 missing_columns.append(emb_col_names.link_to_data_column_name)
+
+    if schema.prompt_column_names is not None:
+        if schema.prompt_column_names.vector_column_name not in existing_columns:
+            missing_columns.append(schema.prompt_column_names.vector_column_name)
+        if (
+            schema.prompt_column_names.raw_data_column_name is not None
+            and schema.prompt_column_names.raw_data_column_name not in existing_columns
+        ):
+            missing_columns.append(schema.prompt_column_names.raw_data_column_name)
+        if (
+            schema.prompt_column_names.link_to_data_column_name is not None
+            and schema.prompt_column_names.link_to_data_column_name not in existing_columns
+        ):
+            missing_columns.append(schema.prompt_column_names.link_to_data_column_name)
+
+    if schema.response_column_names is not None:
+        if schema.response_column_names.vector_column_name not in existing_columns:
+            missing_columns.append(schema.response_column_names.vector_column_name)
+        if (
+            schema.response_column_names.raw_data_column_name is not None
+            and schema.response_column_names.raw_data_column_name not in existing_columns
+        ):
+            missing_columns.append(schema.response_column_names.raw_data_column_name)
+        if (
+            schema.response_column_names.link_to_data_column_name is not None
+            and schema.response_column_names.link_to_data_column_name not in existing_columns
+        ):
+            missing_columns.append(schema.response_column_names.link_to_data_column_name)
 
     if missing_columns:
         return [err.MissingColumns(missing_columns)]

--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -87,9 +87,9 @@ def _check_valid_prompt_response_data(
 
 
 def _validate_embedding_vector(
-    name: str, vector_column: Series, vector_column_name: str
+    name: str, vector_column: Series[float], vector_column_name: str
 ) -> List[err.ValidationError]:
-    errors = []
+    errors: List[err.ValidationError] = []
     vector_length = None
 
     for vector in vector_column:
@@ -109,7 +109,7 @@ def _validate_embedding_vector(
 
         # Fail if not all elements in every vector are int/floats
         allowed_types = (int, float, np.int16, np.int32, np.float16, np.float32)
-        if not all(isinstance(val, allowed_types) for val in vector):  # type: ignore
+        if not all(isinstance(val, allowed_types) for val in vector):
             errors.append(
                 err.InvalidEmbeddingVectorValuesDataType(
                     embedding_feature_name=name,
@@ -120,15 +120,15 @@ def _validate_embedding_vector(
             break
 
         if vector_length is None:
-            vector_length = len(vector)  # type: ignore
+            vector_length = len(vector)
 
         # Fail if vectors in the dataframe are not of the same length, or of length <= 1
-        if len(vector) != vector_length:  # type: ignore
+        if len(vector) != vector_length:
             errors.append(
                 err.EmbeddingVectorSizeMismatch(
                     name,
                     vector_column_name,
-                    [vector_length, len(vector)],  # type: ignore
+                    [vector_length, len(vector)],
                 )
             )
             break

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -105,7 +105,7 @@ class Download(HTTPEndpoint):
 def create_app(
     export_path: Path,
     primary_dataset: Dataset,
-    reference_dataset: Optional[Dataset],
+    reference_dataset: Optional[Dataset] = None,
     debug: bool = False,
 ) -> Starlette:
     model = Model(

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -9,12 +9,10 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+import phoenix.datasets.errors as err
 import pytest
 import pytz
 from pandas import DataFrame, Series, Timestamp
-from pytest import LogCaptureFixture, raises
-
-import phoenix.datasets.errors as err
 from phoenix.datasets.dataset import (
     Dataset,
     EmbeddingColumnNames,
@@ -23,6 +21,7 @@ from phoenix.datasets.dataset import (
     _parse_dataframe_and_schema,
 )
 from phoenix.datasets.errors import DatasetError
+from pytest import LogCaptureFixture, raises
 
 
 class TestParseDataFrameAndSchema:

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -12,6 +12,9 @@ import pandas as pd
 import pytest
 import pytz
 from pandas import DataFrame, Series, Timestamp
+from pytest import LogCaptureFixture, raises
+
+import phoenix.datasets.errors as err
 from phoenix.datasets.dataset import (
     Dataset,
     EmbeddingColumnNames,
@@ -20,7 +23,6 @@ from phoenix.datasets.dataset import (
     _parse_dataframe_and_schema,
 )
 from phoenix.datasets.errors import DatasetError
-from pytest import LogCaptureFixture, raises
 
 
 class TestParseDataFrameAndSchema:
@@ -725,8 +727,10 @@ class TestDataset:
             excluded_column_names=["prediction_id"],
         )
 
-        with raises(DatasetError):
+        with pytest.raises(Exception) as exc_info:
             Dataset(dataframe=input_df, schema=input_schema)
+        assert isinstance(exc_info.value, DatasetError)
+        assert isinstance(exc_info.value.errors[0], err.InvalidSchemaError)
 
     def test_dataset_bookends(self) -> None:
         raw_data_min_time = Timestamp(year=2023, month=1, day=1, hour=2, second=30, tzinfo=pytz.utc)

--- a/tests/datasets/test_schema.py
+++ b/tests/datasets/test_schema.py
@@ -2,20 +2,22 @@ from phoenix.datasets import EmbeddingColumnNames, Schema
 
 
 def test_json_serialization():
-    s = Schema(
+    schema = Schema(
         feature_column_names=["feature_1"],
         embedding_feature_column_names={
             "embedding_feature": EmbeddingColumnNames(vector_column_name="embedding_vector")
         },
+        prompt_column_names=EmbeddingColumnNames(
+            vector_column_name="prompt_vector",
+            raw_data_column_name="prompt_text",
+        ),
+        response_column_names=EmbeddingColumnNames(
+            vector_column_name="response_vector",
+            raw_data_column_name="response_text",
+        ),
     )
 
     # serialize and deserialize.
-    p = s.to_json()
-    schema_from_json = Schema.from_json(p)
+    schema_from_json = Schema.from_json(schema.to_json())
 
-    assert schema_from_json.embedding_feature_column_names is not None
-    assert schema_from_json.embedding_feature_column_names["embedding_feature"] is not None
-    assert (
-        schema_from_json.embedding_feature_column_names["embedding_feature"].vector_column_name
-        == "embedding_vector"
-    )
+    assert schema_from_json == schema

--- a/tests/datasets/test_validation.py
+++ b/tests/datasets/test_validation.py
@@ -1,12 +1,9 @@
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
+
 from phoenix.datasets import errors as err
-from phoenix.datasets.dataset import (
-    EmbeddingColumnNames,
-    Schema,
-    validate_dataset_inputs,
-)
+from phoenix.datasets.dataset import EmbeddingColumnNames, Schema, validate_dataset_inputs
 
 _NUM_RECORDS = 5
 _EMBEDDING_DIMENSION = 7
@@ -113,3 +110,69 @@ def test_embeddings_vector_invalid_type():
     assert len(errors) == 2
     assert isinstance(errors[0], err.InvalidEmbeddingVectorDataType)
     assert isinstance(errors[1], err.InvalidEmbeddingVectorValuesDataType)
+
+
+def test_embedding_reserved_columns():
+    input_dataframe = DataFrame(
+        {
+            "prediction_id": [str(x) for x in range(_NUM_RECORDS)],
+            "timestamp": [pd.Timestamp.now() for x in range(_NUM_RECORDS)],
+            "embedding_vector": [np.random.rand(_EMBEDDING_DIMENSION) for _ in range(_NUM_RECORDS)],
+            "raw_data_column": [f"some-text{index}" for index in range(_NUM_RECORDS)],
+            "link_to_data": [f"some-link{index}" for index in range(_NUM_RECORDS)],
+        }
+    )
+    input_schema = Schema(
+        prediction_id_column_name="prediction_id",
+        timestamp_column_name="timestamp",
+        embedding_feature_column_names={
+            "prompt": EmbeddingColumnNames(
+                vector_column_name="embedding_vector",
+                link_to_data_column_name="link_to_data",
+                raw_data_column_name="raw_data_column",
+            ),
+            "response": EmbeddingColumnNames(
+                vector_column_name="embedding_vector",
+                link_to_data_column_name="link_to_data",
+                raw_data_column_name="raw_data_column",
+            ),
+        },
+    )
+    errors = validate_dataset_inputs(
+        dataframe=input_dataframe,
+        schema=input_schema,
+    )
+    assert len(errors) == 0
+
+    emb_col_names = EmbeddingColumnNames(
+        vector_column_name="embedding_vector",
+        raw_data_column_name="raw_data_column",
+    )
+    input_schema = input_schema.replace(prompt_column_names=emb_col_names)
+
+    errors = validate_dataset_inputs(
+        dataframe=input_dataframe,
+        schema=input_schema,
+    )
+    assert len(errors) == 1
+    assert isinstance(errors[0], err.InvalidEmbeddingReservedName)
+    assert (
+        errors[0].error_message()
+        == err.InvalidEmbeddingReservedName("prompt", "schema.prompt_column_names").error_message()
+    )
+
+    input_schema = input_schema.replace(prompt_column_names=None)
+    input_schema = input_schema.replace(response_column_names=emb_col_names)
+
+    errors = validate_dataset_inputs(
+        dataframe=input_dataframe,
+        schema=input_schema,
+    )
+    assert len(errors) == 1
+    assert isinstance(errors[0], err.InvalidEmbeddingReservedName)
+    assert (
+        errors[0].error_message()
+        == err.InvalidEmbeddingReservedName(
+            "response", "schema.response_column_names"
+        ).error_message()
+    )

--- a/tests/datasets/test_validation.py
+++ b/tests/datasets/test_validation.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-
 from phoenix.datasets import errors as err
 from phoenix.datasets.dataset import EmbeddingColumnNames, Schema, validate_dataset_inputs
 


### PR DESCRIPTION
Adds the ability to log in prompt/response pairs. They are added to the embeddings features dictionary with the keys "prompt" and "response".

Closes #538 
Closes #539 
Closes #540 