### PR TITLE
feat(embeddings): show prompt and response for LLMs in event details

### DIFF
--- a/app/src/@types/event.d.ts
+++ b/app/src/@types/event.d.ts
@@ -1,0 +1,10 @@
+declare type PromptResponse = {
+  /**
+   * A prompt that a LLM model takes in as input
+   */
+  prompt?: string | null;
+  /**
+   * A response that a LLM model outputs to the prompt
+   */
+  response?: string | null;
+};

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -9,10 +9,6 @@ import { Shape, ShapeIcon } from "./ShapeIcon";
 
 type EventItemSize = "small" | "medium" | "large";
 
-type PromptResponse = {
-  prompt: string;
-  response: string;
-};
 /**
  * The type of preview to display for the event item. For a large display, the top two previews are shown
  */
@@ -86,7 +82,7 @@ function getSecondaryPreviewType(
   props: EventItemProps,
 ): EventPreviewType | null {
   const { rawData } = props;
-  if (primaryPreviewType) {
+  if (primaryPreviewType === "prompt_response") {
     return null;
   } else if (primaryPreviewType === "image" && rawData != null) {
     return "raw";

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { PropsWithChildren, useMemo } from "react";
 import { Column, useTable } from "react-table";
 import { css } from "@emotion/react";
 
@@ -9,11 +9,34 @@ import { tableCSS } from "@phoenix/components/table/styles";
 
 import { ModelEvent } from "./types";
 
+function TextPre(props: PropsWithChildren) {
+  return (
+    <div
+      css={css`
+        max-height: 200px;
+        overflow-y: auto;
+      `}
+    >
+      <pre
+        css={(theme) => css`
+          padding: var(--px-spacing-lg);
+          background-color: ${theme.colors.gray900};
+          color: ${theme.textColors.white90};
+          white-space: normal;
+          margin: 0;
+        `}
+      >
+        {props.children}
+      </pre>
+    </div>
+  );
+}
 /**
  * Displays the details of an event in a slide over panel
  */
 export function EventDetails({ event }: { event: ModelEvent }) {
   const imageUrl = event.linkToData || undefined;
+  const promptAndResponse = event.promptAndResponse;
   return (
     <section
       css={css`
@@ -33,19 +56,7 @@ export function EventDetails({ event }: { event: ModelEvent }) {
           `}
         />
       ) : null}
-      {event.rawData ? (
-        <pre
-          css={(theme) => css`
-            padding: var(--px-spacing-lg);
-            background-color: ${theme.colors.gray900};
-            color: ${theme.textColors.white90};
-            white-space: normal;
-            margin: 0;
-          `}
-        >
-          {event.rawData}
-        </pre>
-      ) : null}
+      {event.rawData ? <TextPre>{event.rawData}</TextPre> : null}
       <Accordion variant="compact">
         <AccordionItem id="prediction" title="Prediction Details">
           <dl
@@ -108,6 +119,16 @@ export function EventDetails({ event }: { event: ModelEvent }) {
             )} */}
           </dl>
         </AccordionItem>
+        {promptAndResponse ? (
+          <AccordionItem id="prompt" title="Prompt">
+            <TextPre>{promptAndResponse.prompt}</TextPre>
+          </AccordionItem>
+        ) : null}
+        {promptAndResponse ? (
+          <AccordionItem id="response" title="Response">
+            <TextPre>{promptAndResponse.response}</TextPre>
+          </AccordionItem>
+        ) : null}
         <AccordionItem id="dimensions" title="Dimensions">
           <EmbeddingDimensionsTable dimensions={event.dimensions} />
         </AccordionItem>

--- a/app/src/pages/embedding/types.ts
+++ b/app/src/pages/embedding/types.ts
@@ -21,6 +21,7 @@ export interface ModelEvent {
     };
     value: string | null;
   }[];
+  promptAndResponse?: PromptResponse;
 }
 
 export type EventsList =


### PR DESCRIPTION
resolves #544 

Displays prompt response pairs in the embedding details view 

<img width="1457" alt="Screenshot 2023-04-18 at 12 56 21 PM" src="https://user-images.githubusercontent.com/5640648/232878081-2826c462-e28f-4b1d-a7b9-b9869d0af384.png">
