### PR TITLE
feat(embeddings): display prompt response pairs in selection table

### DIFF
--- a/app/src/components/table/TextCell.tsx
+++ b/app/src/components/table/TextCell.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const MAX_LENGTH = 100;
+
+/**
+ * Truncates the text if it is too long.
+ * @param {string} text The text to truncate
+ * @returns {string} The truncated text
+ */
+function formatText(text: string) {
+  if (text.length > MAX_LENGTH) {
+    return `${text.slice(0, MAX_LENGTH)}...`;
+  }
+  return text;
+}
+/**
+ * A table cell that is designed to show text. It will truncate the text if it
+ * is too long.
+ */
+export function TextCell({ value }: { value: string | null }) {
+  const str = value != null ? formatText(value) : "--";
+  return <span title={value != null ? value : ""}>{str}</span>;
+}

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -2,3 +2,4 @@ export * from "./Table";
 export * from "./FloatCell";
 export * from "./IntCell";
 export * from "./PercentCell";
+export * from "./TextCell";

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -36,7 +36,10 @@ function TextPre(props: PropsWithChildren) {
  */
 export function EventDetails({ event }: { event: ModelEvent }) {
   const imageUrl = event.linkToData || undefined;
-  const promptAndResponse = event.promptAndResponse;
+  const promptAndResponse: PromptResponse | null =
+    event.prompt || event.response
+      ? { prompt: event.prompt, response: event.response }
+      : null;
   return (
     <section
       css={css`

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -169,6 +169,8 @@ export function PointSelectionPanelContent(props: {
         rawData: pointData?.embeddingMetadata.rawData ?? null,
         linkToData: pointData?.embeddingMetadata.linkToData ?? null,
         dimensions: event.dimensions,
+        prompt: null,
+        response: null,
       };
     });
   }, [allSelectedEvents, eventIdToDataMap]);

--- a/app/src/pages/embedding/PointSelectionTable.tsx
+++ b/app/src/pages/embedding/PointSelectionTable.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-table";
 
 import { ExternalLink, LinkButton } from "@phoenix/components";
+import { TextCell } from "@phoenix/components/table";
 import { tableCSS } from "@phoenix/components/table/styles";
 
 import { ModelEvent } from "./types";
@@ -24,13 +25,17 @@ export function PointSelectionTable({
 }) {
   const columns: Column<ModelEvent>[] = useMemo(() => {
     let hasLinkToData = false,
-      hasRawData = false;
+      hasRawData = false,
+      hasPromptAndResponse = false;
     data.forEach((point) => {
       if (point.linkToData) {
         hasLinkToData = true;
       }
       if (point.rawData) {
         hasRawData = true;
+      }
+      if (point.prompt || point.response) {
+        hasPromptAndResponse = true;
       }
     });
     // Columns that are only visible if certain data is available
@@ -48,7 +53,20 @@ export function PointSelectionTable({
         },
       });
     }
-    if (hasRawData) {
+    if (hasPromptAndResponse) {
+      dataDrivenColumns.push({
+        Header: "Prompt",
+        accessor: "prompt",
+        width: 300,
+        Cell: TextCell,
+      });
+      dataDrivenColumns.push({
+        Header: "Response",
+        accessor: "response",
+        width: 300,
+        Cell: TextCell,
+      });
+    } else if (hasRawData) {
       dataDrivenColumns.push({
         Header: "Raw Data",
         accessor: "rawData",

--- a/app/src/pages/embedding/types.ts
+++ b/app/src/pages/embedding/types.ts
@@ -21,7 +21,14 @@ export interface ModelEvent {
     };
     value: string | null;
   }[];
-  promptAndResponse?: PromptResponse;
+  /**
+   * the LLM prompt that was used to generate this event
+   */
+  prompt: string | null;
+  /**
+   * the LLM response
+   */
+  response: string | null;
 }
 
 export type EventsList =


### PR DESCRIPTION
resolves #543 
Adds support for displaying a truncated prompt / response pair in the selection table.