### PR TITLE
feat(embeddings): plumb through prompt / response pairs to the UI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
       rev: "6f3cb139ef36133b6f903b97facc57b07cef57c9"
       hooks:
           - id: prettier
-            files: '\.(jsx?|tsx?|css)$'
+            files: \.(jsx?|tsx?|css)$
+            exclude: \.*__generated__.*$
             additional_dependencies:
                 - prettier@2.8.7
     - repo: https://github.com/pre-commit/mirrors-eslint

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -247,7 +247,7 @@ function PromptResponsePreview(
           padding: var(--px-spacing-sm);
           font-size: var(--px-font-size-sm);
           section {
-            flex: 1 1 auto;
+            flex: 1 1 0;
             overflow: hidden;
             header {
               display: none;
@@ -260,7 +260,7 @@ function PromptResponsePreview(
           gap: var(--px-spacing-sm);
           padding: var(--px-spacing-med);
           section {
-            flex: 1 1 auto;
+            flex: 1 1 0;
             overflow: hidden;
           }
         }
@@ -269,6 +269,7 @@ function PromptResponsePreview(
           flex-direction: row;
           section {
             padding: var(--px-spacing-sm);
+            flex: 1 1 0;
           }
         }
         & > section {

--- a/app/src/pages/embedding/PointSelectionGrid.tsx
+++ b/app/src/pages/embedding/PointSelectionGrid.tsx
@@ -85,7 +85,7 @@ export function PointSelectionGrid(props: PointSelectionGridProps) {
                 size={selectionGridSize}
                 predictionLabel={predictionLabel}
                 actualLabel={actualLabel}
-                promptAndResponse={null}
+                promptAndResponse={event.promptAndResponse}
               />
             </li>
           );

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -121,6 +121,10 @@ export function PointSelectionPanelContent(props: {
                 predictionLabel
                 actualLabel
               }
+              promptAndResponse {
+                prompt
+                response
+              }
             }
           }
           referenceDataset {
@@ -136,6 +140,10 @@ export function PointSelectionPanelContent(props: {
               eventMetadata {
                 predictionLabel
                 actualLabel
+              }
+              promptAndResponse {
+                prompt
+                response
               }
             }
           }
@@ -169,8 +177,8 @@ export function PointSelectionPanelContent(props: {
         rawData: pointData?.embeddingMetadata.rawData ?? null,
         linkToData: pointData?.embeddingMetadata.linkToData ?? null,
         dimensions: event.dimensions,
-        prompt: null,
-        response: null,
+        prompt: event.promptAndResponse?.prompt ?? null,
+        response: event.promptAndResponse?.response ?? null,
       };
     });
   }, [allSelectedEvents, eventIdToDataMap]);

--- a/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 export type DimensionType = "actual" | "feature" | "prediction" | "tag";
 export type PointSelectionPanelContentQuery$variables = {
   primaryEventIds: ReadonlyArray<string>;
@@ -63,214 +63,214 @@ export type PointSelectionPanelContentQuery = {
   variables: PointSelectionPanelContentQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = [
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "primaryEventIds"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "referenceEventIds"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DimensionWithValue",
+    "kind": "LinkedField",
+    "name": "dimensions",
+    "plural": true,
+    "selections": [
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "primaryEventIds",
+        "alias": null,
+        "args": null,
+        "concreteType": "Dimension",
+        "kind": "LinkedField",
+        "name": "dimension",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "type",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
       },
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "referenceEventIds",
-      },
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "value",
+        "storageKey": null
+      }
     ],
-    v1 = [
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EventMetadata",
+    "kind": "LinkedField",
+    "name": "eventMetadata",
+    "plural": false,
+    "selections": [
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "id",
-        storageKey: null,
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "predictionLabel",
+        "storageKey": null
       },
       {
-        alias: null,
-        args: null,
-        concreteType: "DimensionWithValue",
-        kind: "LinkedField",
-        name: "dimensions",
-        plural: true,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            concreteType: "Dimension",
-            kind: "LinkedField",
-            name: "dimension",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "name",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "type",
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "value",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        concreteType: "EventMetadata",
-        kind: "LinkedField",
-        name: "eventMetadata",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "predictionLabel",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "actualLabel",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        concreteType: "PromptResponse",
-        kind: "LinkedField",
-        name: "promptAndResponse",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "prompt",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "response",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "actualLabel",
+        "storageKey": null
+      }
     ],
-    v2 = [
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PromptResponse",
+    "kind": "LinkedField",
+    "name": "promptAndResponse",
+    "plural": false,
+    "selections": [
       {
-        alias: null,
-        args: null,
-        concreteType: "Model",
-        kind: "LinkedField",
-        name: "model",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            concreteType: "Dataset",
-            kind: "LinkedField",
-            name: "primaryDataset",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: [
-                  {
-                    kind: "Variable",
-                    name: "eventIds",
-                    variableName: "primaryEventIds",
-                  },
-                ],
-                concreteType: "Event",
-                kind: "LinkedField",
-                name: "events",
-                plural: true,
-                selections: v1 /*: any*/,
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "Dataset",
-            kind: "LinkedField",
-            name: "referenceDataset",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: [
-                  {
-                    kind: "Variable",
-                    name: "eventIds",
-                    variableName: "referenceEventIds",
-                  },
-                ],
-                concreteType: "Event",
-                kind: "LinkedField",
-                name: "events",
-                plural: true,
-                selections: v1 /*: any*/,
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "prompt",
+        "storageKey": null
       },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Fragment",
-      metadata: null,
-      name: "PointSelectionPanelContentQuery",
-      selections: v2 /*: any*/,
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Operation",
-      name: "PointSelectionPanelContentQuery",
-      selections: v2 /*: any*/,
-    },
-    params: {
-      cacheID: "f9e7b91fc6c0556ccfbcd94cc783655e",
-      id: null,
-      metadata: {},
-      name: "PointSelectionPanelContentQuery",
-      operationKind: "query",
-      text: "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n  }\n}\n",
-    },
-  };
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "response",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Model",
+    "kind": "LinkedField",
+    "name": "model",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dataset",
+        "kind": "LinkedField",
+        "name": "primaryDataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "eventIds",
+                "variableName": "primaryEventIds"
+              }
+            ],
+            "concreteType": "Event",
+            "kind": "LinkedField",
+            "name": "events",
+            "plural": true,
+            "selections": (v1/*: any*/),
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dataset",
+        "kind": "LinkedField",
+        "name": "referenceDataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "eventIds",
+                "variableName": "referenceEventIds"
+              }
+            ],
+            "concreteType": "Event",
+            "kind": "LinkedField",
+            "name": "events",
+            "plural": true,
+            "selections": (v1/*: any*/),
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PointSelectionPanelContentQuery",
+    "selections": (v2/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PointSelectionPanelContentQuery",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "f9e7b91fc6c0556ccfbcd94cc783655e",
+    "id": null,
+    "metadata": {},
+    "name": "PointSelectionPanelContentQuery",
+    "operationKind": "query",
+    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "e104d47d175f9301d04a0303e0af2227";

--- a/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f9c24ee4c80e79a4f34c54f611dd3e0>>
+ * @generated SignedSource<<aa31c843d963c0dee7a0e3bcd8fd2ae4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,10 @@ export type PointSelectionPanelContentQuery$data = {
           readonly predictionLabel: string | null;
         };
         readonly id: string;
+        readonly promptAndResponse: {
+          readonly prompt: string | null;
+          readonly response: string | null;
+        } | null;
       }>;
     };
     readonly referenceDataset: {
@@ -46,6 +50,10 @@ export type PointSelectionPanelContentQuery$data = {
           readonly predictionLabel: string | null;
         };
         readonly id: string;
+        readonly promptAndResponse: {
+          readonly prompt: string | null;
+          readonly response: string | null;
+        } | null;
       }>;
     } | null;
   };
@@ -143,6 +151,31 @@ v1 = [
       }
     ],
     "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PromptResponse",
+    "kind": "LinkedField",
+    "name": "promptAndResponse",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "prompt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "response",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
   }
 ],
 v2 = [
@@ -230,16 +263,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "4ab2b408ffa6453b5ba49fc362c0b25b",
+    "cacheID": "f9e7b91fc6c0556ccfbcd94cc783655e",
     "id": null,
     "metadata": {},
     "name": "PointSelectionPanelContentQuery",
     "operationKind": "query",
-    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "89d17228e9e6465e198d6996afd02c24";
+(node as any).hash = "e104d47d175f9301d04a0303e0af2227";
 
 export default node;

--- a/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest, Query } from "relay-runtime";
 export type DimensionType = "actual" | "feature" | "prediction" | "tag";
 export type PointSelectionPanelContentQuery$variables = {
   primaryEventIds: ReadonlyArray<string>;
@@ -63,214 +63,214 @@ export type PointSelectionPanelContentQuery = {
   variables: PointSelectionPanelContentQuery$variables;
 };
 
-const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "primaryEventIds"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "referenceEventIds"
-  }
-],
-v1 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "id",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "DimensionWithValue",
-    "kind": "LinkedField",
-    "name": "dimensions",
-    "plural": true,
-    "selections": [
+const node: ConcreteRequest = (function () {
+  var v0 = [
       {
-        "alias": null,
-        "args": null,
-        "concreteType": "Dimension",
-        "kind": "LinkedField",
-        "name": "dimension",
-        "plural": false,
-        "selections": [
+        defaultValue: null,
+        kind: "LocalArgument",
+        name: "primaryEventIds",
+      },
+      {
+        defaultValue: null,
+        kind: "LocalArgument",
+        name: "referenceEventIds",
+      },
+    ],
+    v1 = [
+      {
+        alias: null,
+        args: null,
+        kind: "ScalarField",
+        name: "id",
+        storageKey: null,
+      },
+      {
+        alias: null,
+        args: null,
+        concreteType: "DimensionWithValue",
+        kind: "LinkedField",
+        name: "dimensions",
+        plural: true,
+        selections: [
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
+            alias: null,
+            args: null,
+            concreteType: "Dimension",
+            kind: "LinkedField",
+            name: "dimension",
+            plural: false,
+            selections: [
+              {
+                alias: null,
+                args: null,
+                kind: "ScalarField",
+                name: "name",
+                storageKey: null,
+              },
+              {
+                alias: null,
+                args: null,
+                kind: "ScalarField",
+                name: "type",
+                storageKey: null,
+              },
+            ],
+            storageKey: null,
           },
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "type",
-            "storageKey": null
-          }
+            alias: null,
+            args: null,
+            kind: "ScalarField",
+            name: "value",
+            storageKey: null,
+          },
         ],
-        "storageKey": null
+        storageKey: null,
       },
       {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "value",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "EventMetadata",
-    "kind": "LinkedField",
-    "name": "eventMetadata",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "predictionLabel",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "actualLabel",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "PromptResponse",
-    "kind": "LinkedField",
-    "name": "promptAndResponse",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "prompt",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "response",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  }
-],
-v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Model",
-    "kind": "LinkedField",
-    "name": "model",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Dataset",
-        "kind": "LinkedField",
-        "name": "primaryDataset",
-        "plural": false,
-        "selections": [
+        alias: null,
+        args: null,
+        concreteType: "EventMetadata",
+        kind: "LinkedField",
+        name: "eventMetadata",
+        plural: false,
+        selections: [
           {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "eventIds",
-                "variableName": "primaryEventIds"
-              }
-            ],
-            "concreteType": "Event",
-            "kind": "LinkedField",
-            "name": "events",
-            "plural": true,
-            "selections": (v1/*: any*/),
-            "storageKey": null
-          }
+            alias: null,
+            args: null,
+            kind: "ScalarField",
+            name: "predictionLabel",
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            kind: "ScalarField",
+            name: "actualLabel",
+            storageKey: null,
+          },
         ],
-        "storageKey": null
+        storageKey: null,
       },
       {
-        "alias": null,
-        "args": null,
-        "concreteType": "Dataset",
-        "kind": "LinkedField",
-        "name": "referenceDataset",
-        "plural": false,
-        "selections": [
+        alias: null,
+        args: null,
+        concreteType: "PromptResponse",
+        kind: "LinkedField",
+        name: "promptAndResponse",
+        plural: false,
+        selections: [
           {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "eventIds",
-                "variableName": "referenceEventIds"
-              }
-            ],
-            "concreteType": "Event",
-            "kind": "LinkedField",
-            "name": "events",
-            "plural": true,
-            "selections": (v1/*: any*/),
-            "storageKey": null
-          }
+            alias: null,
+            args: null,
+            kind: "ScalarField",
+            name: "prompt",
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            kind: "ScalarField",
+            name: "response",
+            storageKey: null,
+          },
         ],
-        "storageKey": null
-      }
+        storageKey: null,
+      },
     ],
-    "storageKey": null
-  }
-];
-return {
-  "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "PointSelectionPanelContentQuery",
-    "selections": (v2/*: any*/),
-    "type": "Query",
-    "abstractKey": null
-  },
-  "kind": "Request",
-  "operation": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Operation",
-    "name": "PointSelectionPanelContentQuery",
-    "selections": (v2/*: any*/)
-  },
-  "params": {
-    "cacheID": "f9e7b91fc6c0556ccfbcd94cc783655e",
-    "id": null,
-    "metadata": {},
-    "name": "PointSelectionPanelContentQuery",
-    "operationKind": "query",
-    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n  }\n}\n"
-  }
-};
+    v2 = [
+      {
+        alias: null,
+        args: null,
+        concreteType: "Model",
+        kind: "LinkedField",
+        name: "model",
+        plural: false,
+        selections: [
+          {
+            alias: null,
+            args: null,
+            concreteType: "Dataset",
+            kind: "LinkedField",
+            name: "primaryDataset",
+            plural: false,
+            selections: [
+              {
+                alias: null,
+                args: [
+                  {
+                    kind: "Variable",
+                    name: "eventIds",
+                    variableName: "primaryEventIds",
+                  },
+                ],
+                concreteType: "Event",
+                kind: "LinkedField",
+                name: "events",
+                plural: true,
+                selections: v1 /*: any*/,
+                storageKey: null,
+              },
+            ],
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            concreteType: "Dataset",
+            kind: "LinkedField",
+            name: "referenceDataset",
+            plural: false,
+            selections: [
+              {
+                alias: null,
+                args: [
+                  {
+                    kind: "Variable",
+                    name: "eventIds",
+                    variableName: "referenceEventIds",
+                  },
+                ],
+                concreteType: "Event",
+                kind: "LinkedField",
+                name: "events",
+                plural: true,
+                selections: v1 /*: any*/,
+                storageKey: null,
+              },
+            ],
+            storageKey: null,
+          },
+        ],
+        storageKey: null,
+      },
+    ];
+  return {
+    fragment: {
+      argumentDefinitions: v0 /*: any*/,
+      kind: "Fragment",
+      metadata: null,
+      name: "PointSelectionPanelContentQuery",
+      selections: v2 /*: any*/,
+      type: "Query",
+      abstractKey: null,
+    },
+    kind: "Request",
+    operation: {
+      argumentDefinitions: v0 /*: any*/,
+      kind: "Operation",
+      name: "PointSelectionPanelContentQuery",
+      selections: v2 /*: any*/,
+    },
+    params: {
+      cacheID: "f9e7b91fc6c0556ccfbcd94cc783655e",
+      id: null,
+      metadata: {},
+      name: "PointSelectionPanelContentQuery",
+      operationKind: "query",
+      text: "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          actualLabel\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n  }\n}\n",
+    },
+  };
 })();
 
 (node as any).hash = "e104d47d175f9301d04a0303e0af2227";


### PR DESCRIPTION
Adds prompt / response pairs to the embeddings view

<img width="2111" alt="Screenshot 2023-04-19 at 4 33 17 PM" src="https://user-images.githubusercontent.com/5640648/233216366-c49d3c48-dd41-422b-90f5-406fc033d54e.png">

