### PR TITLE
fix: restore schema JSON serialization

### DIFF
--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -10,7 +10,11 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 import pandas as pd
 import pytz
 from pandas import DataFrame, Series, Timestamp, read_parquet, to_datetime
-from pandas.api.types import is_datetime64_any_dtype, is_datetime64tz_dtype, is_numeric_dtype
+from pandas.api.types import (
+    is_datetime64_any_dtype,
+    is_datetime64tz_dtype,
+    is_numeric_dtype,
+)
 from typing_extensions import TypeAlias
 
 from phoenix.config import DATASET_DIR
@@ -631,7 +635,10 @@ def _get_schema_from_unknown_schema_param(schemaLike: SchemaLike) -> Schema:
             response_column_names=response_column_names,
         )
     except Exception:
-        raise ValueError("Unknown schema passed to Dataset. Please pass a phoenix Schema")
+        raise ValueError(
+            """Unsupported Arize Schema. Please pass a phoenix Schema or update
+            to the latest version of Arize."""
+        )
 
 
 def _add_prediction_id(num_rows: int) -> List[str]:

--- a/src/phoenix/datasets/schema.py
+++ b/src/phoenix/datasets/schema.py
@@ -55,7 +55,7 @@ class Schema(Dict[SchemaFieldName, SchemaFieldValue]):
         json_data = json.loads(json_string)
 
         # parse embedding_feature_column_names
-        if json_data["embedding_feature_column_names"] is not None:
+        if json_data.get("embedding_feature_column_names") is not None:
             embedding_feature_column_names = {}
             for feature_name, column_names in json_data["embedding_feature_column_names"].items():
                 embedding_feature_column_names[feature_name] = EmbeddingColumnNames(
@@ -66,7 +66,7 @@ class Schema(Dict[SchemaFieldName, SchemaFieldValue]):
             json_data["embedding_feature_column_names"] = embedding_feature_column_names
 
         # parse prompt_column_names
-        if json_data["prompt_column_names"] is not None:
+        if json_data.get("prompt_column_names") is not None:
             prompt_column_names = EmbeddingColumnNames(
                 vector_column_name=json_data["prompt_column_names"]["vector_column_name"],
                 raw_data_column_name=json_data["prompt_column_names"]["raw_data_column_name"],
@@ -74,7 +74,7 @@ class Schema(Dict[SchemaFieldName, SchemaFieldValue]):
             json_data["prompt_column_names"] = prompt_column_names
 
         # parse response_column_names
-        if json_data["response_column_names"] is not None:
+        if json_data.get("response_column_names") is not None:
             response_column_names = EmbeddingColumnNames(
                 vector_column_name=json_data["response_column_names"]["vector_column_name"],
                 raw_data_column_name=json_data["response_column_names"]["raw_data_column_name"],

--- a/tests/datasets/test_schema.py
+++ b/tests/datasets/test_schema.py
@@ -40,3 +40,5 @@ def test_json_serialization_with_LLM():
 
     assert schema_from_json.prompt_column_names is not None
     assert schema_from_json.prompt_column_names.vector_column_name == "prompt_vector"
+    assert schema_from_json.response_column_names is not None
+    assert schema_from_json.response_column_names.vector_column_name == "response_vector"

--- a/tests/datasets/test_schema.py
+++ b/tests/datasets/test_schema.py
@@ -2,11 +2,28 @@ from phoenix.datasets import EmbeddingColumnNames, Schema
 
 
 def test_json_serialization():
-    schema = Schema(
+    s = Schema(
         feature_column_names=["feature_1"],
         embedding_feature_column_names={
             "embedding_feature": EmbeddingColumnNames(vector_column_name="embedding_vector")
         },
+    )
+
+    # serialize and deserialize.
+    p = s.to_json()
+    schema_from_json = Schema.from_json(p)
+
+    assert schema_from_json.embedding_feature_column_names is not None
+    assert schema_from_json.embedding_feature_column_names["embedding_feature"] is not None
+    assert (
+        schema_from_json.embedding_feature_column_names["embedding_feature"].vector_column_name
+        == "embedding_vector"
+    )
+
+
+def test_json_serialization_with_LLM():
+    s = Schema(
+        feature_column_names=["feature_1"],
         prompt_column_names=EmbeddingColumnNames(
             vector_column_name="prompt_vector",
             raw_data_column_name="prompt_text",
@@ -18,6 +35,8 @@ def test_json_serialization():
     )
 
     # serialize and deserialize.
-    schema_from_json = Schema.from_json(schema.to_json())
+    p = s.to_json()
+    schema_from_json = Schema.from_json(p)
 
-    assert schema_from_json == schema
+    assert schema_from_json.prompt_column_names is not None
+    assert schema_from_json.prompt_column_names.vector_column_name == "prompt_vector"


### PR DESCRIPTION
Schema serialization was not working for the process based app, which is used for the development flow. This restores this functionality. 

broken in #456 