### PR TITLE
fix: don't guess data type when empty

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -981,6 +981,8 @@ def _group_names_by_dim_role(
 
 def _guess_data_type(series: Iterable["pd.Series[Any]"]) -> DataType:
     for s in series:
+        if s.empty:
+            continue
         if is_bool_dtype(s):
             break
         if is_numeric_dtype(s) or is_datetime64_any_dtype(s):


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/622

When the reference is missing, it's an empty DataFrame. Don't make guesses based that.