### PR TITLE
fix: add prediction_id to fixtures and tutorials

### DIFF
--- a/src/phoenix/datasets/fixtures.py
+++ b/src/phoenix/datasets/fixtures.py
@@ -24,6 +24,7 @@ class Fixture:
 FIXTURE_URL_PREFIX = "http://storage.googleapis.com/arize-assets/phoenix/datasets/"
 
 sentiment_classification_language_drift_schema = Schema(
+    prediction_id_column_name="prediction_id",
     timestamp_column_name="prediction_ts",
     prediction_label_column_name="pred_label",
     actual_label_column_name="label",

--- a/tutorials/quickstart.ipynb
+++ b/tutorials/quickstart.ipynb
@@ -415,6 +415,7 @@
    "outputs": [],
    "source": [
     "schema = px.Schema(\n",
+    "    prediction_id_column_name=\"prediction_id\",\n",
     "    timestamp_column_name=\"prediction_ts\",\n",
     "    prediction_label_column_name=\"pred_label\",\n",
     "    actual_label_column_name=\"label\",\n",

--- a/tutorials/sentiment_classification_tutorial.ipynb
+++ b/tutorials/sentiment_classification_tutorial.ipynb
@@ -123,6 +123,7 @@
     "    ),\n",
     "}\n",
     "schema = px.Schema(\n",
+    "    prediction_id_column_name=\"prediction_id\",\n",
     "    timestamp_column_name=\"prediction_ts\",\n",
     "    prediction_label_column_name=\"pred_label\",\n",
     "    actual_label_column_name=\"label\",\n",


### PR DESCRIPTION
Temporary workaround for #632

Adds prediction_id columns so the fields get revered and not discovered ad a feature