### PR TITLE
fix: floor datetime to minute

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -1076,4 +1076,6 @@ def _title_case_no_underscore(name: str) -> str:
 
 def _floor_to_minute(t: datetime) -> datetime:
     MINUTE_FMT = "%Y-%m-%dT%H:%M:00%z"
-    return datetime.strptime(t.astimezone(timezone.utc).strftime(MINUTE_FMT), MINUTE_FMT)
+    return datetime.strptime(
+        t.astimezone(timezone.utc).strftime(MINUTE_FMT), MINUTE_FMT
+    ).astimezone(timezone.utc)

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -1074,11 +1074,14 @@ def _title_case_no_underscore(name: str) -> str:
     return _id_pat.sub("ID", name.replace("_", " ").title())
 
 
+MINUTE_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:00%z"
+
+
 def _floor_to_minute(t: datetime) -> datetime:
     """Floor datetime to the minute by taking a round-trip through string
     format because there isn't always an available function to strip the
     nanoseconds if present."""
-    MINUTE_FMT = "%Y-%m-%dT%H:%M:00%z"
     return datetime.strptime(
-        t.astimezone(timezone.utc).strftime(MINUTE_FMT), MINUTE_FMT
+        t.astimezone(timezone.utc).strftime(MINUTE_DATETIME_FORMAT),
+        MINUTE_DATETIME_FORMAT,
     ).astimezone(timezone.utc)

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -478,8 +478,8 @@ class Events(ModelData):
         # open and one minute is the smallest interval allowed.
         stop_time = end_time + timedelta(minutes=1)
         # Round down to the nearest minute.
-        start = start_time.replace(second=0, microsecond=0)
-        stop = stop_time.replace(second=0, microsecond=0)
+        start = _floor_to_minute(start_time)
+        stop = _floor_to_minute(stop_time)
         return TimeRange(start, stop)
 
     def __iter__(self) -> Iterator[Event]:
@@ -1072,3 +1072,8 @@ _id_pat = re.compile(r"\bid\b", re.IGNORECASE)
 def _title_case_no_underscore(name: str) -> str:
     """E.g. `PREDICTION_ID` turns into `Prediction ID`"""
     return _id_pat.sub("ID", name.replace("_", " ").title())
+
+
+def _floor_to_minute(t: datetime) -> datetime:
+    MINUTE_FMT = "%Y-%m-%dT%H:%M:00%z"
+    return datetime.strptime(t.astimezone(timezone.utc).strftime(MINUTE_FMT), MINUTE_FMT)

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -1075,6 +1075,9 @@ def _title_case_no_underscore(name: str) -> str:
 
 
 def _floor_to_minute(t: datetime) -> datetime:
+    """Floor datetime to the minute by taking a round-trip through string
+    format because there isn't always an available function to strip the
+    nanoseconds if present."""
     MINUTE_FMT = "%Y-%m-%dT%H:%M:00%z"
     return datetime.strptime(
         t.astimezone(timezone.utc).strftime(MINUTE_FMT), MINUTE_FMT


### PR DESCRIPTION
Floor datetimes to minute by taking round trips through string formatting because there isn't always an available function to strip the nanoseconds if present.