### PR TITLE
feat: show cluster count in tab header

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^0.9.22",
+        "@arizeai/components": "0.9.24",
         "@arizeai/point-cloud": "^2.1.5",
         "@emotion/react": "^11.10.5",
         "@react-three/drei": "9.5.7",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "0.9.22",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.9.22.tgz",
-      "integrity": "sha512-ZEln/53S2o05eX0U6JjRu224YaHC9FBx+ClByW/36G41AhUVugE71fBs0BwUg66cXvZtUgaIVyiZcHLRNS/BCw==",
+      "version": "0.9.24",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.9.24.tgz",
+      "integrity": "sha512-iPXWLkXsfwFGT0tgGnWlBDSQVKS4w4uCXlvOMyIuXxJzNtfGkdoh+GSSyxwQnfjq7zkQt6msDF7nutjl7BKJrA==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^0.9.22",
+    "@arizeai/components": "0.9.24",
     "@arizeai/point-cloud": "^2.1.5",
     "@emotion/react": "^11.10.5",
     "@react-three/drei": "9.5.7",

--- a/app/src/pages/embedding/Embedding.tsx
+++ b/app/src/pages/embedding/Embedding.tsx
@@ -15,7 +15,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { subDays } from "date-fns";
 import { css } from "@emotion/react";
 
-import { Switch, TabPane, Tabs } from "@arizeai/components";
+import { Counter, Switch, TabPane, Tabs } from "@arizeai/components";
 
 import { Loading, LoadingMask } from "@phoenix/components";
 import {
@@ -541,7 +541,7 @@ function ClustersPanelContents({
 
   return (
     <Tabs>
-      <TabPane name="Clusters">
+      <TabPane name="Clusters" extra={<Counter>{clusters.length}</Counter>}>
         <ul
           css={(theme) => css`
             flex: 1 1 auto;


### PR DESCRIPTION
Displays the cluster count in the tab for a better understanding of how many clusters have been found.
<img width="312" alt="Screenshot 2023-04-26 at 11 23 24 AM" src="https://user-images.githubusercontent.com/5640648/234668725-0b7df23f-1f18-4861-b537-93e911379b6e.png">
