### PR TITLE
feat: show human-friendly names for datasets in the UI

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -61,7 +61,7 @@
     "build:ts": "node ./esbuild.config.mjs",
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
-    "dev": "npm run dev:server:credit_card_fraud & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:mnist & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -21,14 +21,14 @@ type DataQualityTimeSeries implements TimeSeries {
 }
 
 type Dataset {
-  """The given name of the dataset"""
-  name: String!
-
   """The start bookend of the data"""
   startTime: DateTime!
 
   """The end bookend of the data"""
   endTime: DateTime!
+
+  """Returns a human friendly name for the dataset."""
+  name: String!
   events(eventIds: [ID!]!, dimensions: [DimensionInput!]): [Event!]!
 }
 

--- a/app/src/components/filter/PrimaryDatasetTimeRange.tsx
+++ b/app/src/components/filter/PrimaryDatasetTimeRange.tsx
@@ -12,6 +12,7 @@ import {
   TriggerWrap,
 } from "@arizeai/components";
 
+import { useDatasets } from "@phoenix/contexts";
 import { TimePreset, useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 
 /**
@@ -27,6 +28,10 @@ export function PrimaryDatasetTimeRange(_: PrimaryDatasetTimeRangeProps) {
     timePreset: selectedTimePreset,
     setTimePreset,
   } = useTimeRange();
+  const {
+    primaryDataset: { name },
+  } = useDatasets();
+  const nameAbbr = name.slice(0, 10);
   return (
     <FieldColorDesignation color={"designationTurquoise"}>
       <TooltipTrigger delay={0} placement="bottom right">
@@ -35,7 +40,7 @@ export function PrimaryDatasetTimeRange(_: PrimaryDatasetTimeRangeProps) {
             defaultSelectedKey={selectedTimePreset}
             data-testid="dataset-time-range"
             aria-label={`Time range for the primary dataset`}
-            addonBefore={"primary"}
+            addonBefore={nameAbbr}
             onSelectionChange={(key) => {
               if (key !== selectedTimePreset) {
                 setTimePreset(key as TimePreset);

--- a/app/src/components/filter/ReferenceDatasetTimeRange.tsx
+++ b/app/src/components/filter/ReferenceDatasetTimeRange.tsx
@@ -10,6 +10,8 @@ import {
   TriggerWrap,
 } from "@arizeai/components";
 
+import { useDatasets } from "@phoenix/contexts";
+
 const timeFormatter = timeFormat("%x %X");
 type ReferenceDatasetTimeRangeProps = {
   datasetRole: DatasetRole;
@@ -22,6 +24,9 @@ type ReferenceDatasetTimeRangeProps = {
 export function ReferenceDatasetTimeRange({
   timeRange,
 }: ReferenceDatasetTimeRangeProps) {
+  const { referenceDataset } = useDatasets();
+  const name = referenceDataset?.name ?? "reference";
+  const nameAbbr = name.slice(0, 10);
   return (
     <div
       css={css`
@@ -39,7 +44,7 @@ export function ReferenceDatasetTimeRange({
               value={`${timeFormatter(timeRange.start)} - ${timeFormatter(
                 timeRange.end
               )}`}
-              addonBefore={"reference"}
+              addonBefore={nameAbbr}
             />
           </TriggerWrap>
           <Tooltip>The static time range of the reference dataset</Tooltip>

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react";
 import { transparentize } from "polished";
 import { css } from "@emotion/react";
 
+import { useDatasets } from "@phoenix/contexts";
 import { DatasetRole } from "@phoenix/types";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
@@ -391,6 +392,9 @@ function EventItemFooter({
 }: Pick<EventItemProps, "group" | "color" | "datasetRole"> & {
   showDataset: boolean;
 }) {
+  const { primaryDataset, referenceDataset } = useDatasets();
+  const datasetName =
+    datasetRole === "primary" ? primaryDataset.name : referenceDataset?.name;
   return (
     <footer
       css={css`
@@ -414,7 +418,7 @@ function EventItemFooter({
         {group}
       </div>
       {showDataset ? (
-        <div title="the dataset the point belongs to">{datasetRole}</div>
+        <div title="the dataset the point belongs to">{datasetName}</div>
       ) : null}
     </footer>
   );

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -30,6 +30,8 @@ PHOENIX_DIR = Path(__file__).resolve().parent
 SERVER_DIR = PHOENIX_DIR / "server"
 # The port the server will run on after launch_app is called
 PORT = 6060
+# The prefix of datasets that are auto-assigned a name
+GENERATED_DATASET_NAME_PREFIX = "phoenix_dataset_"
 
 
 def get_exported_files(directory: Path) -> List[Path]:

--- a/src/phoenix/core/embedding_dimension.py
+++ b/src/phoenix/core/embedding_dimension.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
 from typing import Set
 
+from phoenix.datasets.dataset import DatasetRole
 from phoenix.datasets.event import EventId
-
-from .model_schema import DatasetRole
 
 
 @dataclass

--- a/src/phoenix/core/embedding_dimension.py
+++ b/src/phoenix/core/embedding_dimension.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from typing import Set
 
-from phoenix.datasets.dataset import DatasetRole
 from phoenix.datasets.event import EventId
+
+from .model_schema import DatasetRole
 
 
 @dataclass

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -43,6 +43,8 @@ from pandas.core.dtypes.common import (
 from typing_extensions import TypeAlias, TypeGuard
 from wrapt import ObjectProxy
 
+from phoenix.config import GENERATED_DATASET_NAME_PREFIX
+
 
 class DimensionRole(IntEnum):
     ...
@@ -552,6 +554,19 @@ class Dataset(Events):
     @property
     def name(self) -> str:
         return self._self_name
+
+    @property
+    def display_name(self) -> str:
+        """
+        Return a human-readable name for this dataset. If the user doesn't
+        provide a name, the name is generated but this name is not human
+        friendly. Falls back to the role of the dataset if no name is provided.
+        """
+        ds_name = self._self_name
+        if ds_name.startswith(GENERATED_DATASET_NAME_PREFIX):
+            # The generated names are UUIDs so use the role as the name
+            return "primary" if self.role is DatasetRole.PRIMARY else "reference"
+        return ds_name
 
     @property
     def role(self) -> DatasetRole:
@@ -1196,4 +1211,5 @@ def _objectify(json_data: Any) -> Any:
             return cls(**json_data)  # type: ignore
         except TypeError:
             pass
+    raise ValueError(f"invalid json data: {repr(json_data)}")
     raise ValueError(f"invalid json data: {repr(json_data)}")

--- a/src/phoenix/datasets/__init__.py
+++ b/src/phoenix/datasets/__init__.py
@@ -1,4 +1,4 @@
-from .dataset import GENERATED_NAME_PREFIX, Dataset
+from .dataset import Dataset
 from .fixtures import ExampleDatasets, load_example
 from .schema import EmbeddingColumnNames, Schema
 
@@ -8,5 +8,4 @@ __all__ = [
     "EmbeddingColumnNames",
     "load_example",
     "ExampleDatasets",
-    "GENERATED_NAME_PREFIX",
 ]

--- a/src/phoenix/datasets/__init__.py
+++ b/src/phoenix/datasets/__init__.py
@@ -1,5 +1,12 @@
-from .dataset import Dataset
-from .fixtures import load_example, ExampleDatasets
+from .dataset import GENERATED_NAME_PREFIX, Dataset
+from .fixtures import ExampleDatasets, load_example
 from .schema import EmbeddingColumnNames, Schema
 
-__all__ = ["Dataset", "Schema", "EmbeddingColumnNames", "load_example", "ExampleDatasets"]
+__all__ = [
+    "Dataset",
+    "Schema",
+    "EmbeddingColumnNames",
+    "load_example",
+    "ExampleDatasets",
+    "GENERATED_NAME_PREFIX",
+]

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -17,7 +17,7 @@ from pandas.api.types import (
 )
 from typing_extensions import TypeAlias
 
-from phoenix.config import DATASET_DIR
+from phoenix.config import DATASET_DIR, GENERATED_DATASET_NAME_PREFIX
 
 from . import errors as err
 from .schema import (
@@ -31,9 +31,6 @@ from .schema import (
     SchemaFieldValue,
 )
 from .validation import validate_dataset_inputs
-
-# The prefix of datasets that are auto-assigned a name
-GENERATED_NAME_PREFIX = "phoenix_dataset_"
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +93,7 @@ class Dataset:
         self.__dataframe: DataFrame = dataframe
         self.__schema: Schema = schema
         self.__name: str = (
-            name if name is not None else f"""{GENERATED_NAME_PREFIX}{str(uuid.uuid4())}"""
+            name if name is not None else f"{GENERATED_DATASET_NAME_PREFIX}{str(uuid.uuid4())}"
         )
         logger.info(f"""Dataset: {self.__name} initialized""")
 

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -3,7 +3,6 @@ import uuid
 from copy import deepcopy
 from dataclasses import fields, replace
 from datetime import datetime, timedelta
-from enum import Enum
 from functools import cached_property
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
@@ -31,6 +30,9 @@ from .schema import (
     SchemaFieldValue,
 )
 from .validation import validate_dataset_inputs
+
+# The prefix of datasets that are auto-assigned a name
+GENERATED_NAME_PREFIX = "phoenix_dataset_"
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +94,9 @@ class Dataset:
         dataframe = _sort_dataframe_rows_by_timestamp(dataframe, schema)
         self.__dataframe: DataFrame = dataframe
         self.__schema: Schema = schema
-        self.__name: str = name if name is not None else f"""dataset_{str(uuid.uuid4())}"""
+        self.__name: str = (
+            name if name is not None else f"""{GENERATED_NAME_PREFIX}{str(uuid.uuid4())}"""
+        )
         logger.info(f"""Dataset: {self.__name} initialized""")
 
     def __repr__(self) -> str:
@@ -531,11 +535,6 @@ def _create_and_normalize_dataframe_and_schema(
         parsed_dataframe[pred_id_col_name] = parsed_dataframe[pred_id_col_name].astype(str)
 
     return parsed_dataframe, parsed_schema
-
-
-class DatasetRole(Enum):
-    PRIMARY = 0
-    REFERENCE = 1
 
 
 def _sort_dataframe_rows_by_timestamp(dataframe: DataFrame, schema: Schema) -> DataFrame:

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -3,6 +3,7 @@ import uuid
 from copy import deepcopy
 from dataclasses import fields, replace
 from datetime import datetime, timedelta
+from enum import Enum
 from functools import cached_property
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
@@ -642,3 +643,8 @@ def _get_schema_from_unknown_schema_param(schemaLike: SchemaLike) -> Schema:
 
 def _add_prediction_id(num_rows: int) -> List[str]:
     return [str(uuid.uuid4()) for _ in range(num_rows)]
+
+
+class DatasetRole(Enum):
+    PRIMARY = 0
+    REFERENCE = 1

--- a/src/phoenix/datasets/fixtures.py
+++ b/src/phoenix/datasets/fixtures.py
@@ -335,29 +335,19 @@ def download_fixture_if_missing(fixture_name: str) -> Tuple[Dataset, Optional[Da
     locally.
     """
     fixture = _get_fixture_by_name(fixture_name=fixture_name)
-    primary_dataset_name, reference_dataset_name = get_dataset_names_from_fixture_name(fixture_name)
     primary_dataset = _download_dataset_if_missing(
-        dataset_name=primary_dataset_name,
+        dataset_name="production",
         dataset_url=fixture.primary_dataset_url,
         schema=fixture.primary_schema,
     )
     reference_dataset = None
     if fixture.reference_dataset_url is not None:
         reference_dataset = _download_dataset_if_missing(
-            dataset_name=reference_dataset_name,
+            dataset_name="training",
             dataset_url=fixture.reference_dataset_url,
             schema=fixture.reference_schema,
         )
     return primary_dataset, reference_dataset
-
-
-def get_dataset_names_from_fixture_name(fixture_name: str) -> Tuple[str, str]:
-    """
-    Gets primary and reference dataset names from fixture name.
-    """
-    primary_dataset_name = f"{fixture_name}_primary"
-    reference_dataset_name = f"{fixture_name}_reference"
-    return primary_dataset_name, reference_dataset_name
 
 
 def _get_fixture_by_name(fixture_name: str) -> Fixture:

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -8,6 +8,7 @@ from strawberry.unset import UNSET
 
 import phoenix.core.model_schema as ms
 from phoenix.core.model_schema import FEATURE, TAG, ScalarDimension
+from phoenix.datasets import GENERATED_NAME_PREFIX, DatasetRole
 
 from ..context import Context
 from ..input_types.DimensionInput import DimensionInput
@@ -17,10 +18,20 @@ from .Event import Event, create_event, parse_event_ids
 
 @strawberry.type
 class Dataset:
-    name: str = strawberry.field(description="The given name of the dataset")
     start_time: datetime = strawberry.field(description="The start bookend of the data")
     end_time: datetime = strawberry.field(description="The end bookend of the data")
     dataset: strawberry.Private[ms.Dataset]
+
+    @strawberry.field
+    def name(self) -> str:
+        """
+        Returns a human friendly name for the dataset.
+        """
+        ds_name = self.dataset.name
+        if ds_name.startswith(GENERATED_NAME_PREFIX):
+            # The generated names are UUIDs so use the role as the name
+            return "primary" if self.dataset.role is DatasetRole.PRIMARY else "reference"
+        return ds_name
 
     @strawberry.field
     def events(

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -7,8 +7,8 @@ from strawberry.types import Info
 from strawberry.unset import UNSET
 
 import phoenix.core.model_schema as ms
-from phoenix.core.model_schema import FEATURE, TAG, ScalarDimension
-from phoenix.datasets import GENERATED_NAME_PREFIX, DatasetRole
+from phoenix.core.model_schema import FEATURE, TAG, DatasetRole, ScalarDimension
+from phoenix.datasets import GENERATED_NAME_PREFIX
 
 from ..context import Context
 from ..input_types.DimensionInput import DimensionInput

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -7,8 +7,7 @@ from strawberry.types import Info
 from strawberry.unset import UNSET
 
 import phoenix.core.model_schema as ms
-from phoenix.core.model_schema import FEATURE, TAG, DatasetRole, ScalarDimension
-from phoenix.datasets import GENERATED_NAME_PREFIX
+from phoenix.core.model_schema import FEATURE, TAG, ScalarDimension
 
 from ..context import Context
 from ..input_types.DimensionInput import DimensionInput
@@ -25,11 +24,7 @@ class Dataset:
     # type ignored here to get around the following: https://github.com/strawberry-graphql/strawberry/issues/1929
     @strawberry.field(description="Returns a human friendly name for the dataset.")  # type: ignore
     def name(self) -> str:
-        ds_name = self.dataset.name
-        if ds_name.startswith(GENERATED_NAME_PREFIX):
-            # The generated names are UUIDs so use the role as the name
-            return "primary" if self.dataset.role is DatasetRole.PRIMARY else "reference"
-        return ds_name
+        return self.dataset.display_name
 
     @strawberry.field
     def events(

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -22,11 +22,9 @@ class Dataset:
     end_time: datetime = strawberry.field(description="The end bookend of the data")
     dataset: strawberry.Private[ms.Dataset]
 
-    @strawberry.field
+    # type ignored here to get around the following: https://github.com/strawberry-graphql/strawberry/issues/1929
+    @strawberry.field(description="Returns a human friendly name for the dataset.")  # type: ignore
     def name(self) -> str:
-        """
-        Returns a human friendly name for the dataset.
-        """
         ds_name = self.dataset.name
         if ds_name.startswith(GENERATED_NAME_PREFIX):
             # The generated names are UUIDs so use the role as the name

--- a/src/phoenix/server/api/types/Model.py
+++ b/src/phoenix/server/api/types/Model.py
@@ -51,7 +51,6 @@ class Model:
         dataset = info.context.model[PRIMARY]
         start, end = dataset.time_range
         return Dataset(
-            name=dataset.name,
             start_time=start,
             end_time=end,
             dataset=dataset,
@@ -63,7 +62,6 @@ class Model:
             return None
         start, end = dataset.time_range
         return Dataset(
-            name=dataset.name,
             start_time=start,
             end_time=end,
             dataset=dataset,

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -11,11 +11,7 @@ import uvicorn
 import phoenix.config as config
 from phoenix.core.model_schema_adapter import create_model_from_datasets
 from phoenix.datasets import Dataset
-from phoenix.datasets.fixtures import (
-    FIXTURES,
-    download_fixture_if_missing,
-    get_dataset_names_from_fixture_name,
-)
+from phoenix.datasets.fixtures import FIXTURES, download_fixture_if_missing
 from phoenix.server.app import create_app
 
 logger = logging.getLogger(__name__)
@@ -74,16 +70,10 @@ if __name__ == "__main__":
     else:
         fixture_name = args.fixture
         primary_only = args.primary_only
-        primary_dataset_name, reference_dataset_name = get_dataset_names_from_fixture_name(
-            fixture_name
-        )
         primary_dataset, reference_dataset = download_fixture_if_missing(fixture_name)
         if primary_only:
             reference_dataset_name = None
             reference_dataset = None
-
-    print(f"1️⃣ primary dataset: {primary_dataset_name}")
-    print(f"2️⃣ reference dataset: {reference_dataset_name}")
 
     model = create_model_from_datasets(
         primary_dataset,


### PR DESCRIPTION
resolves #535 

If a name is given to a dataset, the name is used throughout the UI strategically to make it clear what they are looking at.

# Prod vs Train
<img width="2054" alt="Screenshot 2023-04-26 at 4 07 52 PM" src="https://user-images.githubusercontent.com/5640648/234722216-44ff01c0-419c-4291-b4dd-306e603fb990.png">
