### PR TITLE
refactor: move to time axis

### DIFF
--- a/app/src/components/chart/ChartTooltip.tsx
+++ b/app/src/components/chart/ChartTooltip.tsx
@@ -79,7 +79,7 @@ export function ChartTooltipDivider() {
       css={(theme) => css`
         height: 1px;
         background-color: ${theme.colors.gray400};
-        width: 100%%;
+        width: 100%;
       `}
     />
   );

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -1,0 +1,28 @@
+import { ReferenceLineProps, XAxisProps } from "recharts";
+
+import { theme } from "@arizeai/components";
+
+/**
+ * Re-usable default props for the XAxis component.
+ */
+export const defaultTimeXAxisProps: XAxisProps = {
+  dataKey: "timestamp",
+  stroke: theme.colors.gray200,
+  style: { fill: theme.textColors.white70 },
+  scale: "time",
+  type: "number",
+  domain: ["auto", "auto"],
+  padding: "gap",
+};
+
+export const defaultSelectedTimestampReferenceLineProps: ReferenceLineProps = {
+  stroke: "white",
+  label: {
+    value: "▼",
+    position: "top",
+    style: {
+      fill: "#fabe32",
+      fontSize: theme.typography.sizes.small.fontSize,
+    },
+  },
+};

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,4 +1,3 @@
 export * from "./timeFormatter";
 export * from "./ChartTooltip";
-export * from "./TimeXAxis";
-export * from "./SelectedTimestampReferenceLine";
+export * from "./defaults";

--- a/app/src/components/chart/index.tsx
+++ b/app/src/components/chart/index.tsx
@@ -1,2 +1,4 @@
 export * from "./timeFormatter";
 export * from "./ChartTooltip";
+export * from "./TimeXAxis";
+export * from "./SelectedTimestampReferenceLine";

--- a/app/src/pages/embedding/CountTimeSeries.tsx
+++ b/app/src/pages/embedding/CountTimeSeries.tsx
@@ -4,9 +4,11 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   TooltipProps,
+  XAxis,
   YAxis,
 } from "recharts";
 import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
@@ -18,9 +20,9 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
+  defaultSelectedTimestampReferenceLineProps,
+  defaultTimeXAxisProps,
   fullTimeFormatter,
-  SelectedTimestampReferenceLine,
-  TimeXAxis,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
@@ -139,8 +141,6 @@ export function CountTimeSeries({
       timestamp: new Date(d.timestamp).getTime(),
     };
   });
-
-  const showSelectedTimestamp = selectedTimestamp != null;
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ComposedChart
@@ -154,7 +154,11 @@ export function CountTimeSeries({
             <stop offset="95%" stopColor={barColor} stopOpacity={0.4} />
           </linearGradient>
         </defs>
-        <TimeXAxis />
+        <XAxis
+          {...defaultTimeXAxisProps}
+          // TODO: Fix this to be a cleaner interface
+          tickFormatter={(x) => fullTimeFormatter(new Date(x))}
+        />
         <YAxis
           stroke={theme.colors.gray200}
           label={{
@@ -172,9 +176,10 @@ export function CountTimeSeries({
         />
         <Tooltip content={<TooltipContent />} />
         <Bar dataKey="value" fill="url(#barColor)" spacing={5} />
-        {showSelectedTimestamp ? (
-          <SelectedTimestampReferenceLine
-            timestampEpochMs={selectedTimestamp.getTime()}
+        {selectedTimestamp != null ? (
+          <ReferenceLine
+            {...defaultSelectedTimestampReferenceLineProps}
+            x={selectedTimestamp.getTime()}
           />
         ) : null}
       </ComposedChart>

--- a/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
+++ b/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
@@ -5,11 +5,9 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   TooltipProps,
-  XAxis,
   YAxis,
 } from "recharts";
 import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
@@ -30,6 +28,8 @@ import {
   ChartTooltipDivider,
   ChartTooltipItem,
   fullTimeFormatter,
+  SelectedTimestampReferenceLine,
+  TimeXAxis,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
@@ -169,21 +169,23 @@ export function EuclideanDistanceTimeSeries({
     [setSelectedTimestamp]
   );
 
-  let chartData = data.embedding.euclideanDistanceTimeSeries?.data || [];
+  const chartRawData = data.embedding.euclideanDistanceTimeSeries?.data || [];
   const trafficDataMap =
     data.embedding.trafficTimeSeries?.data.reduce((acc, traffic) => {
       acc[traffic.timestamp] = traffic.value;
       return acc;
     }, {} as Record<string, number | null>) ?? {};
 
-  chartData = chartData.map((d) => {
+  const chartData = chartRawData.map((d) => {
     const traffic = trafficDataMap[d.timestamp];
     return {
       ...d,
       traffic: traffic,
-      timestamp: new Date(d.timestamp).toISOString(),
+      timestamp: new Date(d.timestamp).valueOf(),
     };
   });
+
+  const showSelectedReferenceLine = selectedTimestamp != null;
   return (
     <section
       css={css`
@@ -228,13 +230,7 @@ export function EuclideanDistanceTimeSeries({
                 <stop offset="95%" stopColor={barColor} stopOpacity={0} />
               </linearGradient>
             </defs>
-            <XAxis
-              dataKey="timestamp"
-              stroke={theme.colors.gray200}
-              // TODO: Fix this to be a cleaner interface
-              tickFormatter={(x) => fullTimeFormatter(new Date(x))}
-              style={{ fill: theme.textColors.white70 }}
-            />
+            <TimeXAxis />
             <YAxis
               stroke={theme.colors.gray200}
               label={{
@@ -254,7 +250,7 @@ export function EuclideanDistanceTimeSeries({
                 position: "insideRight",
                 style: { textAnchor: "middle", fill: theme.textColors.white90 },
               }}
-              style={{ fill: theme.textColors.white70 }}
+              style={{ fill: "theme.textColors.white70" }}
             />
             <CartesianGrid
               strokeDasharray="4 4"
@@ -275,22 +271,10 @@ export function EuclideanDistanceTimeSeries({
               fillOpacity={1}
               fill="url(#colorUv)"
             />
-
-            {selectedTimestamp != null ? (
-              <>
-                <ReferenceLine
-                  x={selectedTimestamp.toISOString()}
-                  stroke="white"
-                  label={{
-                    value: "▼",
-                    position: "top",
-                    style: {
-                      fill: "#fabe32",
-                      fontSize: theme.typography.sizes.small.fontSize,
-                    },
-                  }}
-                />
-              </>
+            {showSelectedReferenceLine ? (
+              <SelectedTimestampReferenceLine
+                timestampEpochMs={selectedTimestamp.valueOf()}
+              />
             ) : null}
           </ComposedChart>
         </ResponsiveContainer>

--- a/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
+++ b/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
@@ -5,9 +5,11 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   TooltipProps,
+  XAxis,
   YAxis,
 } from "recharts";
 import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
@@ -27,9 +29,9 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
+  defaultSelectedTimestampReferenceLineProps,
+  defaultTimeXAxisProps,
   fullTimeFormatter,
-  SelectedTimestampReferenceLine,
-  TimeXAxis,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
@@ -181,11 +183,9 @@ export function EuclideanDistanceTimeSeries({
     return {
       ...d,
       traffic: traffic,
-      timestamp: new Date(d.timestamp).valueOf(),
+      timestamp: new Date(d.timestamp).getTime(),
     };
   });
-
-  const showSelectedReferenceLine = selectedTimestamp != null;
   return (
     <section
       css={css`
@@ -230,7 +230,11 @@ export function EuclideanDistanceTimeSeries({
                 <stop offset="95%" stopColor={barColor} stopOpacity={0} />
               </linearGradient>
             </defs>
-            <TimeXAxis />
+            <XAxis
+              {...defaultTimeXAxisProps}
+              // TODO: Fix this to be a cleaner interface
+              tickFormatter={(x) => fullTimeFormatter(new Date(x))}
+            />
             <YAxis
               stroke={theme.colors.gray200}
               label={{
@@ -250,7 +254,7 @@ export function EuclideanDistanceTimeSeries({
                 position: "insideRight",
                 style: { textAnchor: "middle", fill: theme.textColors.white90 },
               }}
-              style={{ fill: "theme.textColors.white70" }}
+              style={{ fill: theme.textColors.white70 }}
             />
             <CartesianGrid
               strokeDasharray="4 4"
@@ -271,9 +275,11 @@ export function EuclideanDistanceTimeSeries({
               fillOpacity={1}
               fill="url(#colorUv)"
             />
-            {showSelectedReferenceLine ? (
-              <SelectedTimestampReferenceLine
-                timestampEpochMs={selectedTimestamp.valueOf()}
+
+            {selectedTimestamp != null ? (
+              <ReferenceLine
+                {...defaultSelectedTimestampReferenceLineProps}
+                x={selectedTimestamp.getTime()}
               />
             ) : null}
           </ComposedChart>

--- a/app/src/pages/home/Home.tsx
+++ b/app/src/pages/home/Home.tsx
@@ -80,7 +80,7 @@ export function Home(_props: HomePageProps) {
             <TabPane name="Embeddings" key="embeddings">
               <ModelEmbeddingsTable model={data} />
             </TabPane>
-            <TabPane name="Dimensions" key="embeddings">
+            <TabPane name="Dimensions" key="dimensions">
               <ModelSchemaTable model={data} />
             </TabPane>
           </Tabs>


### PR DESCRIPTION
During development I wasn't sure how to plot timeseries data using recharts. This PR switches from using `categories` and instead moves to using `time` scale plus `number` to make things continuous on the xAxis.

Note on the composition model of recharts - recharts uses function components so you cannot wrap their component primitives. This PR introduces reasonable defaults for the axis and selections.