### PR TITLE
feat(gql): distinguish discrete vs continuous data

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -64,7 +64,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:mnist & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:credit_card_fraud & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -48,6 +48,9 @@ type Dimension implements Node {
 
   """The data type of the column. Categorical or numeric."""
   dataType: DimensionDataType!
+
+  """Whether the dimension data is continuous or discrete."""
+  shape: DimensionShape!
   driftMetric(metric: ScalarDriftMetric!, timeRange: TimeRange = null): Float
   dataQualityMetric(metric: DataQualityMetric!, timeRange: TimeRange = null): Float
 
@@ -85,6 +88,11 @@ type DimensionEdge {
 input DimensionInput {
   name: String!
   type: DimensionType!
+}
+
+enum DimensionShape {
+  continuous
+  discrete
 }
 
 enum DimensionType {

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -331,7 +331,7 @@ class EmbeddingDimension(Dimension):
             object.__setattr__(self, "display_name", self.name)
 
     @classmethod
-    def from_(cls, emb: Embedding, **kwargs: Any) -> "EmbeddingDimension":
+    def from_dimension(cls, emb: Embedding, **kwargs: Any) -> "EmbeddingDimension":
         """Use `from_` instead of `__init__` because the latter is needed by
         replace() and we don't want to clobber the generated version.
         """
@@ -981,7 +981,7 @@ class Schema(SchemaSpec):
                 else:
                     yield ScalarDimension(spec, role=role, data_type=data_type)
             elif isinstance(spec, Embedding):
-                yield EmbeddingDimension.from_(spec, role=role, data_type=data_type)
+                yield EmbeddingDimension.from_dimension(spec, role=role, data_type=data_type)
             else:
                 raise TypeError(f"{role} has unrecognized type: {type(spec)}")
 

--- a/src/phoenix/server/api/types/Dimension.py
+++ b/src/phoenix/server/api/types/Dimension.py
@@ -10,6 +10,7 @@ from ..input_types.Granularity import Granularity
 from ..input_types.TimeRange import TimeRange
 from .DataQualityMetric import DataQualityMetric
 from .DimensionDataType import DimensionDataType
+from .DimensionShape import DimensionShape
 from .DimensionType import DimensionType
 from .node import Node
 from .ScalarDriftMetricEnum import ScalarDriftMetric
@@ -30,6 +31,9 @@ class Dimension(Node):
     )
     dataType: DimensionDataType = strawberry.field(
         description="The data type of the column. Categorical or numeric."
+    )
+    shape: DimensionShape = strawberry.field(
+        description="Whether the dimension data is continuous or discrete."
     )
     dimension: strawberry.Private[ScalarDimension]
 
@@ -131,4 +135,5 @@ def to_gql_dimension(id_attr: int, dimension: ScalarDimension) -> Dimension:
         type=DimensionType.from_(dimension),
         dataType=DimensionDataType.from_(dimension),
         dimension=dimension,
+        shape=DimensionShape.from_(dimension),
     )

--- a/src/phoenix/server/api/types/Dimension.py
+++ b/src/phoenix/server/api/types/Dimension.py
@@ -132,8 +132,8 @@ def to_gql_dimension(id_attr: int, dimension: ScalarDimension) -> Dimension:
     return Dimension(
         id_attr=id_attr,
         name=dimension.name,
-        type=DimensionType.from_(dimension),
-        dataType=DimensionDataType.from_(dimension),
+        type=DimensionType.from_dimension(dimension),
+        dataType=DimensionDataType.from_dimension(dimension),
         dimension=dimension,
-        shape=DimensionShape.from_(dimension),
+        shape=DimensionShape.from_dimension(dimension),
     )

--- a/src/phoenix/server/api/types/DimensionDataType.py
+++ b/src/phoenix/server/api/types/DimensionDataType.py
@@ -11,8 +11,8 @@ class DimensionDataType(Enum):
     numeric = "numeric"
 
     @classmethod
-    def from_(cls, dim: Dimension) -> "DimensionDataType":
-        data_type = dim.data_type
+    def from_(cls, dimension: Dimension) -> "DimensionDataType":
+        data_type = dimension.data_type
         if data_type in (CONTINUOUS,):
             return cls.numeric
         return cls.categorical

--- a/src/phoenix/server/api/types/DimensionDataType.py
+++ b/src/phoenix/server/api/types/DimensionDataType.py
@@ -11,7 +11,7 @@ class DimensionDataType(Enum):
     numeric = "numeric"
 
     @classmethod
-    def from_(cls, dimension: Dimension) -> "DimensionDataType":
+    def from_dimension(cls, dimension: Dimension) -> "DimensionDataType":
         data_type = dimension.data_type
         if data_type in (CONTINUOUS,):
             return cls.numeric

--- a/src/phoenix/server/api/types/DimensionShape.py
+++ b/src/phoenix/server/api/types/DimensionShape.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+import strawberry
+
+from phoenix.core.model_schema import CONTINUOUS, Dimension
+
+
+@strawberry.enum
+class DimensionShape(Enum):
+    continuous = "continuous"
+    discrete = "discrete"
+
+    @classmethod
+    def from_(cls, dim: Dimension) -> "DimensionShape":
+        data_type = dim.data_type
+        if data_type in (CONTINUOUS,):
+            return cls.continuous
+
+        # For now we assume all non-continuous data is discrete
+        # E.g. floats are the only dimension data type that is continuous
+        return cls.discrete

--- a/src/phoenix/server/api/types/DimensionShape.py
+++ b/src/phoenix/server/api/types/DimensionShape.py
@@ -11,7 +11,7 @@ class DimensionShape(Enum):
     discrete = "discrete"
 
     @classmethod
-    def from_(cls, dim: Dimension) -> "DimensionShape":
+    def from_dimension(cls, dim: Dimension) -> "DimensionShape":
         data_type = dim.data_type
         if data_type in (CONTINUOUS,):
             return cls.continuous

--- a/src/phoenix/server/api/types/DimensionType.py
+++ b/src/phoenix/server/api/types/DimensionType.py
@@ -21,7 +21,7 @@ class DimensionType(Enum):
     actual = "actual"
 
     @classmethod
-    def from_(cls, dim: Dimension) -> "DimensionType":
+    def from_dimension(cls, dim: Dimension) -> "DimensionType":
         role = dim.role
         if role in (FEATURE,):
             return cls.feature

--- a/tests/server/api/types/test_pagination.py
+++ b/tests/server/api/types/test_pagination.py
@@ -11,6 +11,7 @@ def test_connection_from_list():
             name="first",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
         Dimension(
@@ -18,6 +19,7 @@ def test_connection_from_list():
             name="second",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
         Dimension(
@@ -25,6 +27,7 @@ def test_connection_from_list():
             name="third",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
     ]
@@ -49,6 +52,7 @@ def test_connection_from_list_reverse():
             name="first",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
         Dimension(
@@ -56,6 +60,7 @@ def test_connection_from_list_reverse():
             name="second",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
         Dimension(
@@ -63,6 +68,7 @@ def test_connection_from_list_reverse():
             name="third",
             type="feature",
             dataType="categorical",
+            shape="discrete",
             dimension=ms.Dimension(role=FEATURE),
         ),
     ]


### PR DESCRIPTION
resolves #683 
unblocks #665 
Showing cardinality metrics doesn't really make sense in the case of continuous data. This PR adds a `DimensionShape` (not to confuse with data type) that exposes if the data is `discrete` or `continuous` so that certain fields can be hidden/shown without querying.


```graphql
{
  model {
    dimensions {
      edges {
        node {
          name
          shape
        }
      }
    }
  }
}
```

### Explanation


|| Discrete | Continuous |
|-|-|-|
| Categorical | Gender: M, F | (n/a) |
| Numeric | Length of stay: 1, 2, ... | Income: $23456, ... |

here's a [literature](https://www150.statcan.gc.ca/n1/edu/power-pouvoir/ch8/5214817-eng.htm) reference to make things more precise: 

|| Discrete | Continuous |
|-|-|-|
| Nominal | Gender: M, F | (n/a) |
| Ordinal | Grade: A, B, C, ... | (n/a) |
| Numeric | Length of stay: 1, 2, ... | Income: $23456, ... |