### PR TITLE
feat(embeddings): raise dataset sample size max to 10000

### DIFF
--- a/app/src/constants/pointCloudConstants.tsx
+++ b/app/src/constants/pointCloudConstants.tsx
@@ -14,7 +14,7 @@ export const MAX_MIN_DIST = 0.99;
  */
 export const DEFAULT_DATASET_SAMPLE_SIZE = 500;
 export const MIN_DATASET_SAMPLE_SIZE = 300;
-export const MAX_DATASET_SAMPLE_SIZE = 2500;
+export const MAX_DATASET_SAMPLE_SIZE = 10000;
 
 /**
  * HDBSCAN parameters


### PR DESCRIPTION
resolves #704 

Raises the limit to 10000 for a max of 20000 points. Can raise higher after some testing.