### PR TITLE
feat(dimension): drift breakdown chart to isolate the difference in dimension segments distribution

### DIFF
--- a/app/src/components/ViewSummaryAside.tsx
+++ b/app/src/components/ViewSummaryAside.tsx
@@ -14,6 +14,7 @@ export function ViewSummaryAside(props: PropsWithChildren) {
       borderStartWidth="thin"
       borderStartColor="dark"
       padding="size-200"
+      flex="none"
     >
       <Flex
         direction="column"

--- a/app/src/components/chart/colors.tsx
+++ b/app/src/components/chart/colors.tsx
@@ -21,4 +21,5 @@ export const colors = Object.freeze({
   pink500: "#F10E82",
   // Colors specific to the dataset role
   primary: "#9efcfd",
+  reference: "#baa1f9",
 });

--- a/app/src/pages/dimension/Dimension.tsx
+++ b/app/src/pages/dimension/Dimension.tsx
@@ -15,6 +15,7 @@ import { DimensionCardinalityStats } from "./DimensionCardinalityStats";
 import { DimensionCardinalityTimeSeries } from "./DimensionCardinalityTimeSeries";
 import { DimensionCountStats } from "./DimensionCountStats";
 import { DimensionCountTimeSeries } from "./DimensionCountTimeSeries";
+import { DimensionDriftBreakdownSegmentBarChart } from "./DimensionDriftBreakdownSegmentBarChart";
 import { DimensionDriftStats } from "./DimensionDriftStats";
 import { DimensionDriftTimeSeries } from "./DimensionDriftTimeSeries";
 import { DimensionPercentEmptyStats } from "./DimensionPercentEmptyStats";
@@ -109,13 +110,30 @@ export function Dimension() {
                   borderColor="dark"
                   borderRadius="medium"
                   borderWidth="thin"
-                  height="size-1600"
                 >
-                  <Flex direction="row" alignItems="stretch" height="100%">
-                    <DimensionDriftTimeSeries dimensionId={dimensionId} />
-                    <ViewSummaryAside>
-                      <DimensionDriftStats dimension={data.dimension} />
-                    </ViewSummaryAside>
+                  <Flex direction="column" alignItems="stretch">
+                    <View width="100%" height="size-1600">
+                      <Flex direction="row" alignItems="stretch" height="100%">
+                        <View flex>
+                          <DimensionDriftTimeSeries dimensionId={dimensionId} />
+                        </View>
+                        <ViewSummaryAside>
+                          <DimensionDriftStats dimension={data.dimension} />
+                        </ViewSummaryAside>
+                      </Flex>
+                    </View>
+                    <View
+                      height="size-1600"
+                      width="100%"
+                      borderTopColor="dark"
+                      borderTopWidth="thin"
+                    >
+                      <Suspense fallback={<Loading />}>
+                        <DimensionDriftBreakdownSegmentBarChart
+                          dimensionId={dimensionId}
+                        />
+                      </Suspense>
+                    </View>
                   </Flex>
                 </View>
               ) : null}

--- a/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
@@ -43,7 +43,7 @@ function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
 
     return (
       <ChartTooltip>
-        <Text weight="heavy" textSize="large">{`${fullTimeFormatter(
+        <Text weight="heavy" textSize="medium">{`${fullTimeFormatter(
           new Date(label)
         )}`}</Text>
         <ChartTooltipItem

--- a/app/src/pages/dimension/DimensionCountTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCountTimeSeries.tsx
@@ -30,7 +30,7 @@ const numberFormatter = new Intl.NumberFormat([], {
   maximumFractionDigits: 2,
 });
 
-const barColor = colors.primary;
+const barColor = colors.blue300;
 
 function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
   if (active && payload && payload.length) {
@@ -39,7 +39,7 @@ function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" textSize="large">{`${fullTimeFormatter(
+        <Text weight="heavy" textSize="medium">{`${fullTimeFormatter(
           new Date(label)
         )}`}</Text>
         <ChartTooltipItem

--- a/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
+++ b/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
@@ -1,0 +1,293 @@
+import React, { useMemo } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { format } from "d3-format";
+import { subDays } from "date-fns";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Flex, Text, theme, View } from "@arizeai/components";
+
+import {
+  ChartTooltip,
+  ChartTooltipItem,
+  colors,
+} from "@phoenix/components/chart";
+import { fullTimeFormatter } from "@phoenix/components/filter";
+import { useDatasets } from "@phoenix/contexts";
+import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
+import { assertUnreachable } from "@phoenix/typeUtils";
+
+import {
+  DimensionDriftBreakdownSegmentBarChartQuery,
+  DimensionDriftBreakdownSegmentBarChartQuery$data,
+} from "./__generated__/DimensionDriftBreakdownSegmentBarChartQuery.graphql";
+// Type interfaces to conform to
+type BarChartItem = {
+  name: string;
+  primaryName: string;
+  referenceName: string;
+  primaryPercent: number;
+  referencePercent: number;
+};
+
+const primaryBarColor = colors.primary;
+const referenceBarColor = colors.reference;
+
+type Bin = NonNullable<
+  DimensionDriftBreakdownSegmentBarChartQuery$data["dimension"]["segmentsComparison"]
+>["segments"][number]["bin"];
+
+/**
+ * Formats each bin into a string for charting
+ * TODO(mikeldking) - refactor into an interface that can be re-used
+ * @param bin
+ * @returns
+ */
+function getBinName(bin: Bin): string {
+  const binType = bin.__typename;
+  switch (binType) {
+    case "NominalBin":
+      return bin.name;
+    case "IntervalBin":
+      // TODO(mikeldking) - add a general case number formatter
+      return `${bin.range.start} - ${bin.range.end}`;
+    case "MissingValueBin":
+      return "(empty)";
+    case "%other":
+      throw new Error("Unexpected bin type %other");
+    default:
+      assertUnreachable(binType);
+  }
+}
+
+const formatter = format(".2f");
+
+function TooltipContent({
+  active,
+  payload,
+  label,
+}: TooltipProps<BarChartItem["primaryPercent"], BarChartItem["name"]>) {
+  if (active && payload && payload.length) {
+    const primaryLabel = payload[0]?.payload?.primaryName;
+    const primaryValue = payload[0]?.value;
+    const referenceLabel = payload[0]?.payload?.referenceName;
+    const referenceValue = payload[1]?.value;
+
+    return (
+      <ChartTooltip>
+        <Text elementType="h3" textSize="medium" weight="heavy">
+          {label}
+        </Text>
+        <ChartTooltipItem
+          color={primaryBarColor}
+          shape="square"
+          name={primaryLabel}
+          value={primaryValue != null ? `${formatter(primaryValue)}%` : "--"}
+        />
+        <ChartTooltipItem
+          color={referenceBarColor}
+          shape="square"
+          name={referenceLabel}
+          value={
+            referenceValue != null ? `${formatter(referenceValue)}%` : "--"
+          }
+        />
+      </ChartTooltip>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Bar chart that displays the different segments of data for a given dimension
+ * at a given time range.
+ * E.x. dimension=state, segments=[CA, NY, TX, ...]
+ */
+export function DimensionDriftBreakdownSegmentBarChart(props: {
+  dimensionId: string;
+}) {
+  const { primaryDataset, referenceDataset } = useDatasets();
+  const primaryName = primaryDataset.name;
+  const referenceName = referenceDataset?.name || "reference";
+  const { selectedTimestamp } = useTimeSlice();
+  const endTime = useMemo(
+    () => selectedTimestamp ?? new Date(primaryDataset.endTime),
+    [selectedTimestamp, primaryDataset.endTime]
+  );
+  const timeRange = useMemo(() => {
+    return {
+      start: subDays(endTime, 2).toISOString(),
+      end: endTime.toISOString(),
+    };
+  }, [endTime]);
+  const data = useLazyLoadQuery<DimensionDriftBreakdownSegmentBarChartQuery>(
+    graphql`
+      query DimensionDriftBreakdownSegmentBarChartQuery(
+        $dimensionId: GlobalID!
+        $timeRange: TimeRange!
+      ) {
+        dimension: node(id: $dimensionId) {
+          id
+          ... on Dimension {
+            segmentsComparison(primaryTimeRange: $timeRange)
+              @required(action: THROW) {
+              segments {
+                bin {
+                  ... on NominalBin {
+                    __typename
+                    name
+                  }
+                  ... on IntervalBin {
+                    __typename
+                    range {
+                      start
+                      end
+                    }
+                  }
+                  ... on MissingValueBin {
+                    __typename
+                  }
+                }
+                counts {
+                  primaryValue
+                  referenceValue
+                }
+              }
+              totalCounts {
+                primaryValue
+                referenceValue
+              }
+            }
+          }
+        }
+      }
+    `,
+    { dimensionId: props.dimensionId, timeRange: timeRange }
+  );
+
+  const chartData = useMemo<BarChartItem[]>(() => {
+    const segments = data.dimension.segmentsComparison?.segments ?? [];
+    const primaryTotal =
+      data.dimension.segmentsComparison?.totalCounts?.primaryValue ?? 0;
+    const referenceTotal =
+      data.dimension.segmentsComparison?.totalCounts?.referenceValue ?? 0;
+    return segments.map((segment) => {
+      const primarySegmentCount = segment.counts?.primaryValue ?? 0;
+      const referenceSegmentCount = segment.counts?.referenceValue ?? 0;
+      const binName = getBinName(segment.bin);
+      const primaryPercent = (primarySegmentCount / primaryTotal) * 100;
+      const referencePercent = (referenceSegmentCount / referenceTotal) * 100;
+      return {
+        name: binName,
+        primaryName,
+        referenceName,
+        primaryPercent,
+        referencePercent,
+      };
+    });
+  }, [
+    data.dimension.segmentsComparison?.segments,
+    data.dimension.segmentsComparison?.totalCounts?.primaryValue,
+    data.dimension.segmentsComparison?.totalCounts?.referenceValue,
+    primaryName,
+    referenceName,
+  ]);
+
+  return (
+    <Flex direction="column" height="100%">
+      <View flex="none" paddingTop="size-100" paddingStart="size-200">
+        <Text
+          elementType="h3"
+          textSize="medium"
+          color="white70"
+        >{`Distribution comparison at ${fullTimeFormatter(
+          new Date(timeRange.end)
+        )}`}</Text>
+      </View>
+      <View flex>
+        <ResponsiveContainer>
+          <BarChart
+            data={chartData}
+            margin={{
+              top: 15,
+              right: 18,
+              left: 18,
+              bottom: 5,
+            }}
+          >
+            <defs>
+              <linearGradient
+                id="dimensionPrimarySegmentsBarColor"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop offset="5%" stopColor={primaryBarColor} stopOpacity={1} />
+                <stop
+                  offset="95%"
+                  stopColor={primaryBarColor}
+                  stopOpacity={0.5}
+                />
+              </linearGradient>
+              <linearGradient
+                id="dimensionReferenceSegmentsBarColor"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop
+                  offset="5%"
+                  stopColor={referenceBarColor}
+                  stopOpacity={1}
+                />
+                <stop
+                  offset="95%"
+                  stopColor={referenceBarColor}
+                  stopOpacity={0.5}
+                />
+              </linearGradient>
+            </defs>
+            <XAxis dataKey="name" style={{ fill: theme.textColors.white70 }} />
+            <YAxis
+              stroke={theme.colors.gray200}
+              label={{
+                value: "Percent",
+                angle: -90,
+                position: "insideLeft",
+                style: { textAnchor: "middle", fill: theme.textColors.white90 },
+              }}
+              style={{ fill: theme.textColors.white70 }}
+            />
+            <CartesianGrid
+              strokeDasharray="4 4"
+              stroke={theme.colors.gray200}
+              strokeOpacity={0.5}
+            />
+            <Tooltip content={<TooltipContent />} />
+            <Bar
+              dataKey="primaryPercent"
+              fill="url(#dimensionPrimarySegmentsBarColor)"
+              spacing={5}
+            />
+            <Bar
+              dataKey="referencePercent"
+              fill="url(#dimensionReferenceSegmentsBarColor)"
+              spacing={5}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </View>
+    </Flex>
+  );
+}

--- a/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
@@ -41,7 +41,7 @@ function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
         : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" textSize="large">{`${fullTimeFormatter(
+        <Text weight="heavy" textSize="medium">{`${fullTimeFormatter(
           new Date(label)
         )}`}</Text>
         <ChartTooltipItem

--- a/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
+++ b/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
@@ -83,6 +83,11 @@ function TooltipContent({
 
   return null;
 }
+
+/**
+ * Bar chart that displays the different segments of data for a given dimension
+ * E.x. dimension=state, segments=[CA, NY, TX, ...]
+ */
 export function DimensionSegmentsBarChart(props: {
   dimension: DimensionSegmentsBarChart_dimension$key;
 }) {

--- a/app/src/pages/dimension/__generated__/DimensionDriftBreakdownSegmentBarChartQuery.graphql.ts
+++ b/app/src/pages/dimension/__generated__/DimensionDriftBreakdownSegmentBarChartQuery.graphql.ts
@@ -1,0 +1,356 @@
+/**
+ * @generated SignedSource<<3c3e5613d07e6a73c7ddf91f8e0a22e0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type TimeRange = {
+  end: string;
+  start: string;
+};
+export type DimensionDriftBreakdownSegmentBarChartQuery$variables = {
+  dimensionId: string;
+  timeRange: TimeRange;
+};
+export type DimensionDriftBreakdownSegmentBarChartQuery$data = {
+  readonly dimension: {
+    readonly id: string;
+    readonly segmentsComparison?: {
+      readonly segments: ReadonlyArray<{
+        readonly bin: {
+          readonly __typename: "IntervalBin";
+          readonly range: {
+            readonly end: number;
+            readonly start: number;
+          };
+        } | {
+          readonly __typename: "MissingValueBin";
+        } | {
+          readonly __typename: "NominalBin";
+          readonly name: string;
+        } | {
+          // This will never be '%other', but we need some
+          // value in case none of the concrete values match.
+          readonly __typename: "%other";
+        };
+        readonly counts: {
+          readonly primaryValue: number | null;
+          readonly referenceValue: number | null;
+        };
+      }>;
+      readonly totalCounts: {
+        readonly primaryValue: number | null;
+        readonly referenceValue: number | null;
+      };
+    };
+  };
+};
+export type DimensionDriftBreakdownSegmentBarChartQuery = {
+  response: DimensionDriftBreakdownSegmentBarChartQuery$data;
+  variables: DimensionDriftBreakdownSegmentBarChartQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "dimensionId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "timeRange"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "dimensionId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "primaryTimeRange",
+    "variableName": "timeRange"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "NumericRange",
+  "kind": "LinkedField",
+  "name": "range",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "start",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "end",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "primaryValue",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "referenceValue",
+    "storageKey": null
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetValues",
+  "kind": "LinkedField",
+  "name": "counts",
+  "plural": false,
+  "selections": (v7/*: any*/),
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetValues",
+  "kind": "LinkedField",
+  "name": "totalCounts",
+  "plural": false,
+  "selections": (v7/*: any*/),
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DimensionDriftBreakdownSegmentBarChartQuery",
+    "selections": [
+      {
+        "alias": "dimension",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "kind": "RequiredField",
+                "field": {
+                  "alias": null,
+                  "args": (v3/*: any*/),
+                  "concreteType": "Segments",
+                  "kind": "LinkedField",
+                  "name": "segmentsComparison",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Segment",
+                      "kind": "LinkedField",
+                      "name": "segments",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": null,
+                          "kind": "LinkedField",
+                          "name": "bin",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "InlineFragment",
+                              "selections": [
+                                (v4/*: any*/),
+                                (v5/*: any*/)
+                              ],
+                              "type": "NominalBin",
+                              "abstractKey": null
+                            },
+                            {
+                              "kind": "InlineFragment",
+                              "selections": [
+                                (v4/*: any*/),
+                                (v6/*: any*/)
+                              ],
+                              "type": "IntervalBin",
+                              "abstractKey": null
+                            },
+                            {
+                              "kind": "InlineFragment",
+                              "selections": [
+                                (v4/*: any*/)
+                              ],
+                              "type": "MissingValueBin",
+                              "abstractKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        },
+                        (v8/*: any*/)
+                      ],
+                      "storageKey": null
+                    },
+                    (v9/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                "action": "THROW",
+                "path": "dimension.segmentsComparison"
+              }
+            ],
+            "type": "Dimension",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "DimensionDriftBreakdownSegmentBarChartQuery",
+    "selections": [
+      {
+        "alias": "dimension",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": "Segments",
+                "kind": "LinkedField",
+                "name": "segmentsComparison",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Segment",
+                    "kind": "LinkedField",
+                    "name": "segments",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "bin",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v5/*: any*/)
+                            ],
+                            "type": "NominalBin",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v6/*: any*/)
+                            ],
+                            "type": "IntervalBin",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v9/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Dimension",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7d11d88f419003f5ee8cd9d11312e427",
+    "id": null,
+    "metadata": {},
+    "name": "DimensionDriftBreakdownSegmentBarChartQuery",
+    "operationKind": "query",
+    "text": "query DimensionDriftBreakdownSegmentBarChartQuery(\n  $dimensionId: GlobalID!\n  $timeRange: TimeRange!\n) {\n  dimension: node(id: $dimensionId) {\n    __typename\n    id\n    ... on Dimension {\n      segmentsComparison(primaryTimeRange: $timeRange) {\n        segments {\n          bin {\n            __typename\n            ... on NominalBin {\n              __typename\n              name\n            }\n            ... on IntervalBin {\n              __typename\n              range {\n                start\n                end\n              }\n            }\n            ... on MissingValueBin {\n              __typename\n            }\n          }\n          counts {\n            primaryValue\n            referenceValue\n          }\n        }\n        totalCounts {\n          primaryValue\n          referenceValue\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6bb76e3cce4ee28c333e485b3aa2dffd";
+
+export default node;

--- a/app/src/pages/embedding/CountTimeSeries.tsx
+++ b/app/src/pages/embedding/CountTimeSeries.tsx
@@ -44,7 +44,7 @@ function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" textSize="large">{`${fullTimeFormatter(
+        <Text weight="heavy" textSize="medium">{`${fullTimeFormatter(
           new Date(label)
         )}`}</Text>
         <ChartTooltipItem

--- a/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
+++ b/app/src/pages/embedding/EuclideanDistanceTimeSeries.tsx
@@ -72,7 +72,7 @@ function TooltipContent({ active, payload, label }: TooltipProps<any, any>) {
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" textSize="large">{`${fullTimeFormatter(
+        <Text weight="heavy" textSize="medium">{`${fullTimeFormatter(
           new Date(label)
         )}`}</Text>
         <ChartTooltipItem


### PR DESCRIPTION
resolves #733 

Adds the ability to scrub through time and decipher the distribution at given points in thime.
<img width="900" alt="Screenshot 2023-05-17 at 5 48 04 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/fb063ac8-0c37-4469-8bac-306489b8ef43">
