### PR TITLE
feat: support ISO8601 formatted strings in timestamp column

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,7 +53,7 @@ Make sure you have npm (node package manager) available on your terminal as well
 Install `phoenix` in development mode (using the `-e` flag) and with development dependencies (using the `[dev]` extra) by running
 
 ```bash
-pip install -e '.[dev]'
+pip install -e ".[dev]"
 ```
 
 from the repository root.
@@ -227,7 +227,7 @@ mkvirtualenv phoenix-env
 Activate your virtual environment. You can now [install a `phoenix` build](#installing-a-phoenix-build). Alternatively, if you wish to run `phoenix` from source, clone the repo and install `phoenix` in development mode with
 
 ```powershell
-pip install -e '.[dev]'
+pip install -e ".[dev]"
 ```
 
 ### Configuring a Remote Interpreter

--- a/docs/api/dataset-and-schema.md
+++ b/docs/api/dataset-and-schema.md
@@ -87,10 +87,11 @@ A dataclass that assigns the columns of a pandas dataframe to the appropriate mo
 ### Parameters
 
 * **prediction\_id\_column\_name** \_\_ (Optional\[str]): The name of the dataframe's prediction ID column, if one exists. Prediction IDs are strings that uniquely identify each record in a Phoenix dataset (equivalently, each row in the dataframe). If no prediction ID column name is provided, Phoenix will automatically generate unique UUIDs for each record of the dataset upon [phoenix.Dataset](dataset-and-schema.md#phoenix.dataset) initialization.
-* **timestamp\_column\_name** (Optional\[str]): The name of the dataframe's timestamp column, if one exists. Timestamp columns must be pandas Series with numeric or datetime dtypes.
+* **timestamp\_column\_name** (Optional\[str]): The name of the dataframe's timestamp column, if one exists. Timestamp columns must be pandas Series with numeric, datetime or object dtypes.
   * If the timestamp column has numeric dtype (`int` or `float`), the entries of the column are interpreted as Unix timestamps, i.e., the number of seconds since midnight on January 1st, 1970.
   * If the column has datetime dtype and contains timezone-naive timestamps, Phoenix assumes those timestamps belong to the UTC timezone.
   * If the column has datetime dtype and contains timezone-aware timestamps, those timestamps are converted to UTC.
+  * If the column has object dtype having ISO8601 formatted timestamp strings, those entries are converted to datetime dtype timestamps having UTC timezone; if timezone-naive(assumed as UTC) or timezone-aware(converted to UTC).
   * If no timestamp column is provided, each record in the dataset is assigned the current timestamp upon [phoenix.Dataset](dataset-and-schema.md#phoenix.dataset) initialization.
 * **feature\_column\_names** (Optional\[List\[str]]): The names of the dataframe's feature columns, if any exist. If no feature column names are provided, all dataframe column names that are not included elsewhere in the schema and are not explicitly excluded in `excluded_column_names` are assumed to be features.
 * **tag\_column\_names** (Optional\[List\[str]]): The names of the dataframe's tag columns, if any exist. Tags, like features, are attributes that can be used for filtering records of the dataset while using the app. Unlike features, tags are not model inputs and are not used for computing metrics.

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -14,6 +14,7 @@ from pandas.api.types import (
     is_datetime64_any_dtype,
     is_datetime64tz_dtype,
     is_numeric_dtype,
+    is_object_dtype,
 )
 from typing_extensions import TypeAlias
 
@@ -554,8 +555,9 @@ def _normalize_timestamps(
 ) -> Tuple[DataFrame, Schema]:
     """
     Ensures that the dataframe has a timestamp column and the schema has a timestamp field. If the
-    input dataframe contains a Unix or datetime timestamp column, it is converted to UTC timestamps.
-    If the input dataframe and schema do not contain timestamps, the default timestamp is used.
+    input dataframe contains a Unix or datetime timestamp or ISO8601 timestamp strings column, it
+    is converted to UTC timestamps. If the input dataframe and schema do not contain timestamps,
+    the default timestamp is used.
     """
     timestamp_column: Series[Timestamp]
     if (timestamp_column_name := schema.timestamp_column_name) is None:
@@ -568,6 +570,8 @@ def _normalize_timestamps(
         timestamp_column = dataframe[timestamp_column_name].dt.tz_convert(pytz.utc)
     elif is_datetime64_any_dtype(timestamp_column_dtype):
         timestamp_column = dataframe[timestamp_column_name].dt.tz_localize(pytz.utc)
+    elif is_object_dtype(timestamp_column_dtype):
+        timestamp_column = to_datetime(dataframe[timestamp_column_name], utc=True)
     else:
         raise ValueError(
             "When provided, input timestamp column must have numeric or datetime dtype, "

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1070,6 +1070,201 @@ def random_uuids(num_records: int):
             Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
             id="us_pacific_timestamps_converted_to_utc",
         ),
+        pytest.param(
+            DataFrame(
+                {
+                    "timestamp": Series(
+                        [
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=1,
+                                hour=0,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=2,
+                                hour=1,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=3,
+                                hour=2,
+                                minute=0,
+                                second=0,
+                            ),
+                        ]
+                    ).apply(lambda val: val.isoformat()),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            None,
+            DataFrame(
+                {
+                    "timestamp": Series(
+                        [
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=1,
+                                hour=0,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=2,
+                                hour=1,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=3,
+                                hour=2,
+                                minute=0,
+                                second=0,
+                            ),
+                        ]
+                    ).dt.tz_localize(pytz.utc),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            id="iso8601_tz_naive_strings_converted_to_utc_timestamps",
+        ),
+        pytest.param(
+            DataFrame(
+                {
+                    "timestamp": Series(
+                        [
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=1,
+                                hour=0,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=2,
+                                hour=1,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=3,
+                                hour=2,
+                                minute=0,
+                                second=0,
+                            ),
+                        ]
+                    )
+                    .dt.tz_localize(pytz.timezone("US/Pacific"))
+                    .apply(lambda val: val.isoformat()),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            None,
+            DataFrame(
+                {
+                    "timestamp": Series(
+                        [
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=1,
+                                hour=8,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=2,
+                                hour=9,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2022,
+                                month=1,
+                                day=3,
+                                hour=10,
+                                minute=0,
+                                second=0,
+                            ),
+                        ]
+                    ).dt.tz_localize(pytz.utc),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            id="iso8601_us_pacific_strings_converted_to_utc_timestamps",
+        ),
+        pytest.param(
+            DataFrame(
+                {
+                    "timestamp": [
+                        "24-03-2023 10:00:00 UTC",
+                        "24-03-2023 11:30:00 UTC",
+                        "24-03-2023 14:15:00 UTC",
+                    ],
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            None,
+            DataFrame(
+                {
+                    "timestamp": Series(
+                        [
+                            Timestamp(
+                                year=2023,
+                                month=3,
+                                day=24,
+                                hour=10,
+                                minute=0,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2023,
+                                month=3,
+                                day=24,
+                                hour=11,
+                                minute=30,
+                                second=0,
+                            ),
+                            Timestamp(
+                                year=2023,
+                                month=3,
+                                day=24,
+                                hour=14,
+                                minute=15,
+                                second=0,
+                            ),
+                        ]
+                    ).dt.tz_localize(pytz.utc),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            id="pandas_flexible_format_parsing_previously_invalid_input_test",
+        ),
     ],
 )
 def test_normalize_timestamps_produces_expected_output_for_valid_input(
@@ -1092,9 +1287,9 @@ def test_normalize_timestamps_raises_value_error_for_invalid_input() -> None:
             dataframe=DataFrame(
                 {
                     "timestamp": [
-                        "2023-03-24 10:00:00 UTC",
-                        "2023-03-24 11:30:00 UTC",
-                        "2023-03-24 14:15:00 UTC",
+                        "24-03-2023 invalidCharacter 14:15:00",
+                        "24-03-2023 invalidCharacter 10:30:00",
+                        "24-03-2023 invalidCharacter 18:45:00",
                     ],
                     "prediction_id": [1, 2, 3],
                 }


### PR DESCRIPTION
Resolves #592 
1. Object dtype timestamp support and parameterized tests added, old invalid test modified.
2. Documentation updated.
3. Windows-friendly quotes change in phoenix dev install command. (Works in UNIX too)