### PR TITLE
ci: allow python 3.11

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -17,7 +17,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    pip-version: 22.3.1
+    pip-version: 23.1.2
 
 jobs:
     lint:
@@ -26,10 +26,10 @@ jobs:
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3
-            - name: Set up python 3.10
+            - name: Set up python 3.8
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.10"
+                  python-version: "3.8"
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip==${{ env.pip-version }}
@@ -70,7 +70,7 @@ jobs:
                   pip install hatch
             - name: Run tests
               run: |
-                  hatch run tests
+                  hatch run test:tests
 
     # test-coverage:
     #     name: Test Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix"
 description = "ML Observability in your notebook"
 readme = "README.md"
-requires-python = ">=3.8, <3.11"
+requires-python = ">=3.8, <3.12"
 license = "Elastic-2.0"
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
   "numpy",
@@ -123,7 +124,7 @@ tests = "pytest {args}"
 coverage = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/phoenix --cov=tests {args}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8"]
+python = ["3.8", "3.11"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -202,7 +202,7 @@ class _ConstantValueSeriesFactory:
     value: Any = field(default=float("nan"))
     _cached_array: npt.NDArray[np.float64] = field(
         init=False,
-        default=np.empty(0),
+        default_factory=lambda: np.empty(0),
     )
     """If a longer Series is requested, the cached array is expanded;
     otherwise, a subset can be returned, assuming it won't be altered by the

--- a/src/phoenix/metrics/binning.py
+++ b/src/phoenix/metrics/binning.py
@@ -292,7 +292,7 @@ class CategoricalBinning(BinningMethod):
 Distribution: TypeAlias = "pd.Series[float]"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Normalizer(ABC):
     """A function that normalizes counts/frequencies to probabilities."""
 
@@ -301,7 +301,7 @@ class Normalizer(ABC):
         ...
 
 
-@dataclass
+@dataclass(frozen=True)
 class AdditiveSmoothing(Normalizer):
     r"""A function that normalizes counts/frequencies to probabilities with
     additive smoothing. Defaults to Laplace smoothing with `pseudocount=1`.

--- a/src/phoenix/metrics/mixins.py
+++ b/src/phoenix/metrics/mixins.py
@@ -4,7 +4,7 @@ BaseMetric. Other mixins provide specialized functionalities. Mixins rely
 on cooperative multiple inheritance and method resolution order in Python.
 """
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any, Iterator, Mapping
 
@@ -96,7 +96,9 @@ class EvaluationMetric(BaseMetric, ABC):
 
 @dataclass(frozen=True)
 class DriftOperator(UnaryOperator, BaseMetric, ABC):
-    reference_data: pd.DataFrame = pd.DataFrame()
+    reference_data: pd.DataFrame = field(
+        default_factory=pd.DataFrame,
+    )
 
 
 Distribution: TypeAlias = "pd.Series[float]"


### PR DESCRIPTION
resolves #680

numba now [supports](https://numba.readthedocs.io/en/stable/release-notes.html#version-0-57-0-1-may-2023) Python 3.11


# Note

1. use `hatch run test:tests` to run test for both python versions
2. the host python must be 3.8 (otherwise the 3.8 tests will not work)
3. python 3.11 forbids mutable defaults for dataclass fields, hence the code changes in the PR