### PR TITLE
ci: re-pin version for strawberry-graphql

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "starlette",
   "uvicorn",
   "psutil",
-  "strawberry-graphql==0.177.1",
+  "strawberry-graphql==0.178.0",
   "pyarrow",
   "typing_extensions",
   "scipy",
@@ -46,7 +46,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-lazy-fixture",
-  "strawberry-graphql[debug-server]==0.177.1",
+  "strawberry-graphql[debug-server]==0.178.0",
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
 ]


### PR DESCRIPTION
0.177.1 seems to be [unavailable](https://github.com/conda-forge/strawberry-graphql-feedstock/pulls?q=is%3Apr+is%3Aclosed) on conda, hence the need to bump its version to one that is actually found (0.178.0)