### PR TITLE
fix: bug with np.floating

### DIFF
--- a/src/phoenix/server/api/interceptor.py
+++ b/src/phoenix/server/api/interceptor.py
@@ -2,6 +2,8 @@ import math
 from abc import ABC, abstractmethod
 from typing import Any
 
+import numpy as np
+
 
 class Interceptor(ABC):
     """an abstract class making use of the descriptor protocol
@@ -29,6 +31,6 @@ class NoneIfNan(Interceptor):
             instance,
             self.private_name,
             None
-            if value is self or isinstance(value, float) and not math.isfinite(value)
+            if value is self or isinstance(value, (float, np.floating)) and not math.isfinite(value)
             else value,
         )

--- a/tests/server/api/test_interceptor.py
+++ b/tests/server/api/test_interceptor.py
@@ -12,3 +12,4 @@ class T:
 
 def test_none_if_nan():
     assert T(x=np.nan).x is None
+    assert T(x=np.array([np.nan], dtype=np.half)[0]).x is None


### PR DESCRIPTION
```pycon
>>> isinstance(np.array([np.nan], dtype=np.float16), float)
False
>>> isinstance(np.array([np.nan], dtype=np.float16), np.floating)
True
```