### PR TITLE
fix: numba.jit() deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ exclude = [
 module = [
   "hdbscan",
   "umap",
+  "numba.*",
   "scipy.*",
   "sklearn.*",
   "arize.*",

--- a/src/phoenix/pointcloud/projectors.py
+++ b/src/phoenix/pointcloud/projectors.py
@@ -4,9 +4,13 @@ from typing import cast
 
 import numpy as np
 import numpy.typing as npt
-from numba.core.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
 from typing_extensions import TypeAlias
 
+with warnings.catch_warnings():
+    from numba.core.errors import NumbaWarning
+
+    warnings.simplefilter("ignore", category=NumbaWarning)
+    from umap import UMAP
 Matrix: TypeAlias = npt.NDArray[np.float64]
 
 
@@ -20,8 +24,4 @@ class Umap:
     min_dist: float = 0.1
 
     def project(self, mat: Matrix, n_components: int) -> Matrix:
-        warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
-        warnings.simplefilter("ignore", category=NumbaPendingDeprecationWarning)
-        from umap import UMAP
-
         return _center(UMAP(**asdict(self), n_components=n_components).fit_transform(mat))

--- a/src/phoenix/pointcloud/projectors.py
+++ b/src/phoenix/pointcloud/projectors.py
@@ -1,10 +1,11 @@
+import warnings
 from dataclasses import asdict, dataclass
 from typing import cast
 
 import numpy as np
 import numpy.typing as npt
+from numba.core.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
 from typing_extensions import TypeAlias
-from umap import UMAP
 
 Matrix: TypeAlias = npt.NDArray[np.float64]
 
@@ -19,4 +20,8 @@ class Umap:
     min_dist: float = 0.1
 
     def project(self, mat: Matrix, n_components: int) -> Matrix:
+        warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
+        warnings.simplefilter("ignore", category=NumbaPendingDeprecationWarning)
+        from umap import UMAP
+
         return _center(UMAP(**asdict(self), n_components=n_components).fit_transform(mat))


### PR DESCRIPTION
Resolves #709
Tested via jupyter(taylor_swift_lyrics.ipynb) & pytests from IDE. All numba.jit() deprecation warnings are suppressed as numba is transitively being used by umap.