### PR TITLE
feat(dimensions): Add the ability to filter by data_type

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -67,7 +67,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:llm & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:credit_card_fraud & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -136,6 +136,7 @@ type DimensionEdge {
 input DimensionFilter {
   types: [DimensionType!]
   shapes: [DimensionShape!]
+  dataTypes: [DimensionDataType!]
 }
 
 input DimensionInput {

--- a/src/phoenix/server/api/input_types/DimensionFilter.py
+++ b/src/phoenix/server/api/input_types/DimensionFilter.py
@@ -5,6 +5,7 @@ from strawberry import UNSET
 
 from phoenix.core.model_schema import Dimension
 from phoenix.server.api.helpers import ensure_list
+from phoenix.server.api.types.DimensionDataType import DimensionDataType
 from phoenix.server.api.types.DimensionShape import DimensionShape
 from phoenix.server.api.types.DimensionType import DimensionType
 
@@ -53,14 +54,18 @@ class DimensionFilter:
 
     types: Optional[List[DimensionType]] = UNSET
     shapes: Optional[List[DimensionShape]] = UNSET
+    data_types: Optional[List[DimensionDataType]] = UNSET
 
     def __post_init__(self) -> None:
         self.types = ensure_list(self.types)
         self.shapes = ensure_list(self.shapes)
+        self.data_types = ensure_list(self.data_types)
 
     def matches(self, dimension: Dimension) -> bool:
         if self.types and DimensionType.from_dimension(dimension) not in self.types:
             return False
         if self.shapes and DimensionShape.from_dimension(dimension) not in self.shapes:
+            return False
+        if self.data_types and DimensionDataType.from_dimension(dimension) not in self.data_types:
             return False
         return True


### PR DESCRIPTION
Need the ability to return just numeric dimensions for filtering:

```graphql
{
  model {
    dimensions(include: { dataTypes: [numeric]} ) {
      edges {
        node {
          name
          type
          dataType
        }
      }
    }
  }
}
```