### PR TITLE
fix: change float16 to float32 as dtype for the nan series

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -220,7 +220,7 @@ class _ConstantValueSeriesFactory:
 
     def __post_init__(self) -> None:
         if isinstance(self.value, float) and math.isnan(self.value):
-            object.__setattr__(self, "_dtype", np.float16)
+            object.__setattr__(self, "_dtype", np.float32)
 
     def __call__(self, length: int) -> "pd.Series[Any]":
         with self._lock:


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/836

It turns out pandas can't work with `float16`: https://github.com/pandas-dev/pandas/blob/bc7b3948d2460439f2c476583feae78f57b60b9e/pandas/core/indexes/base.py#L575
