### PR TITLE
fix: return nan on NotImplementedError (when binning on np.float16)

### DIFF
--- a/src/phoenix/metrics/__init__.py
+++ b/src/phoenix/metrics/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Iterable, List, Mapping, Optional, Union
@@ -6,6 +7,8 @@ import numpy as np
 import pandas as pd
 
 from phoenix.core.model_schema import Column
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -66,7 +69,8 @@ class Metric(ABC):
         ]
         try:
             return self.calc(df)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, NotImplementedError) as exc:
+            logger.warning(exc, exc_info=True)
             return self.initial_value
 
 


### PR DESCRIPTION
- don't crash graphql because this exception can happen when binning columns with np.float16
    - specifically https://github.com/pandas-dev/pandas/blob/bc7b3948d2460439f2c476583feae78f57b60b9e/pandas/core/indexes/base.py#L575
- add logging so it doesn't fail silently

here's how it looks like in jupyter notebook:

<img width="400" alt="Screenshot 2023-06-08 at 5 43 30 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/67bbb4b1-2008-4df7-9d6d-88ae7f60d4dc">
