### PR TITLE
fix(embeddings): always place clusters with empty metrics at the bottom

### DIFF
--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -1205,10 +1205,14 @@ const clusterSortFn =
   (clusterA: Cluster, clusterB: Cluster): number => {
     const { dir, column } = sort;
     const isAsc = dir === "asc";
-    // For now assume a lack of a value is 0
-    const valueA = clusterA[column] || 0;
-    const valueB = clusterB[column] || 0;
-    if (valueA > valueB) {
+    const valueA = clusterA[column];
+    const valueB = clusterB[column];
+    if (valueA == null) {
+      // Always place null values at the end
+      return 1;
+    } else if (valueB == null) {
+      return -1;
+    } else if (valueA > valueB) {
       return isAsc ? 1 : -1;
     } else if (valueA < valueB) {
       return isAsc ? -1 : 1;


### PR DESCRIPTION
As a user, when I'm analyzing by a data quality metric (in particular against a context) - I want the "nullish" values to not be a part of the sort.
<img width="364" alt="Screenshot 2023-06-12 at 5 18 48 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/64eda0e2-9543-4100-ab43-bceb94f15b3d">
