### PR TITLE
fix: skip empty interval bin with infinity endpoints (when all data are missing values)

### DIFF
--- a/src/phoenix/server/api/types/Segments.py
+++ b/src/phoenix/server/api/types/Segments.py
@@ -85,11 +85,11 @@ class Segments:
 
     def append(self, other: Segment) -> None:
         if (
-            other.counts.primary_value == 0
-            and other.counts.reference_value == 0
-            and isinstance(other.bin, IntervalBin)
+            isinstance(other.bin, IntervalBin)
             and not math.isfinite(other.bin.range.start)
             and not math.isfinite(other.bin.range.end)
+            and other.counts.primary_value == 0
+            and other.counts.reference_value == 0
         ):
             # Skip the interval bin with zero counts if it has -inf and +inf
             # as the endpoints, as it could occur due to all values being

--- a/src/phoenix/server/api/types/Segments.py
+++ b/src/phoenix/server/api/types/Segments.py
@@ -84,5 +84,19 @@ class Segments:
     )
 
     def append(self, other: Segment) -> None:
+        if (
+            other.counts.primary_value == 0
+            and other.counts.reference_value == 0
+            and isinstance(other.bin, IntervalBin)
+            and not math.isfinite(other.bin.range.start)
+            and not math.isfinite(other.bin.range.end)
+        ):
+            # Skip the interval bin with zero counts if it has -inf and +inf
+            # as the endpoints, as it could occur due to all values being
+            # missing. Because such bin can exist a priori, the caller may
+            # still try to append it, but the bin has no real value at this
+            # point (and can cause problems for graphql because of the end
+            # points are not serializable to JSON).
+            return
         self.segments.append(other)
         self.total_counts += other.counts


### PR DESCRIPTION
what the bug looks like

> Error fetching GraphQL query 'DimensionDriftBreakdownSegmentBarChartQuery' with variables '{"dimensionId":"RGltZW5zaW9uOjg=","timeRange":{"start":"2023-06-11T07:00:00.000Z","end":"2023-06-13T07:00:00.000Z"}}': [{"message":"Float cannot represent non numeric value: -inf","locations":[{"line":20,"column":17}],"path":["dimension","segmentsComparison","segments",0,"bin","range","start"]}]

what it looks like when it's fixed

<img width="893" alt="Screenshot 2023-06-13 at 12 49 42 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/9e22e663-e31d-4a9b-9ec4-5e82831ce6c0">
