### PR TITLE
fix(embeddings): force re-render clusters when opacity changes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -68,7 +68,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:credit_card_fraud:single & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:llm & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/components/pointcloud/PointCloudClusters.tsx
+++ b/app/src/components/pointcloud/PointCloudClusters.tsx
@@ -57,15 +57,16 @@ export function PointCloudClusters({ radius }: PointCloudClustersProps) {
   return (
     <>
       {clustersWithData.map((cluster, index) => {
+        const opacity = clusterOpacity({
+          selected: cluster.id === selectedClusterId,
+          highlighted: cluster.id === highlightedClusterId,
+          clusterColorMode: clusterColorMode,
+        });
         return (
           <Cluster
-            key={cluster.id}
+            key={`${cluster.id}__opacity_${String(opacity)}`} // NB: since the cluster id is not fully unique, we need to add the opacity to the key
             data={cluster.data}
-            opacity={clusterOpacity({
-              selected: cluster.id === selectedClusterId,
-              highlighted: cluster.id === highlightedClusterId,
-              clusterColorMode: clusterColorMode,
-            })}
+            opacity={opacity}
             wireframe
             pointRadius={radius}
             color={clusterColor({


### PR DESCRIPTION
The react reconciler was getting confused with regards to the opacity of the cluster. This forces the render key to be unique so that the reconciler runs again when the opacity changes.