### PR TITLE
fix: replace NaT (Not a Time) with now (when dataset is empty)

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -599,10 +599,8 @@ class Events(ModelData):
     @cached_property
     def time_range(self) -> TimeRange:
         if self._self_model is None or self.empty:
-            # NOTE: as of Python 3.8.16, pandas 1.5.3:
-            # >>> isinstance(pd.NaT, datetime.datetime)
-            # True
-            return TimeRange(pd.NaT, pd.NaT)  # type: ignore
+            now = datetime.now(timezone.utc)
+            return TimeRange(now, now)
         model = cast(Model, self._self_model)
         min_max = _agg_min_max(model[TIMESTAMP](self))
         start_time = cast(datetime, min_max.min())

--- a/src/phoenix/datasets/dataset.py
+++ b/src/phoenix/datasets/dataset.py
@@ -443,7 +443,11 @@ def _normalize_timestamps(
     if (timestamp_column_name := schema.timestamp_column_name) is None:
         timestamp_column_name = "timestamp"
         schema = replace(schema, timestamp_column_name=timestamp_column_name)
-        timestamp_column = Series([default_timestamp] * len(dataframe), index=dataframe.index)
+        timestamp_column = (
+            Series([default_timestamp] * len(dataframe), index=dataframe.index)
+            if len(dataframe)
+            else Series([default_timestamp]).iloc[:0].set_axis(dataframe.index, axis=0)
+        )
     elif is_numeric_dtype(timestamp_column_dtype := dataframe[timestamp_column_name].dtype):
         timestamp_column = to_datetime(dataframe[timestamp_column_name], unit="s", utc=True)
     elif is_datetime64tz_dtype(timestamp_column_dtype):


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/841

when dataset is empty, return `now` instead of NaT

<img width="511" alt="Screenshot 2023-06-13 at 5 37 57 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/1eee8f67-6b4d-4c05-83e9-7d3760747cf9">
