### PR TITLE
fix(embeddings): disable metric selector while loading points

### DIFF
--- a/app/src/pages/embedding/Embedding.tsx
+++ b/app/src/pages/embedding/Embedding.tsx
@@ -209,6 +209,7 @@ function EmbeddingMain() {
   );
   const getMetric = usePointCloudContext((state) => state.getMetric);
   const resetPointCloud = usePointCloudContext((state) => state.reset);
+  const setLoading = usePointCloudContext((state) => state.setLoading);
   const [showChart, setShowChart] = useState<boolean>(true);
   const [queryReference, loadQuery, disposeQuery] =
     useQueryLoader<UMAPQueryType>(EmbeddingUMAPQuery);
@@ -239,6 +240,7 @@ function EmbeddingMain() {
   useEffect(() => {
     // dispose of the selections in the context
     resetPointCloud();
+    setLoading(true);
     const metric = getMetric();
     loadQuery(
       {
@@ -261,6 +263,7 @@ function EmbeddingMain() {
       disposeQuery();
     };
   }, [
+    setLoading,
     resetPointCloud,
     embeddingDimensionId,
     loadQuery,

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -142,6 +142,7 @@ export function MetricSelector({
   const { referenceDataset } = useDatasets();
   const hasReferenceDataset = !!referenceDataset;
   const metric = usePointCloudContext((state) => state.metric);
+  const loading = usePointCloudContext((state) => state.loading);
   const setMetric = usePointCloudContext((state) => state.setMetric);
   const numericDimensions = data.numericDimensions.edges.map(
     (edge) => edge.node
@@ -166,6 +167,7 @@ export function MetricSelector({
       selectedKey={metric ? getMetricKey(metric) : undefined}
       onSelectionChange={onSelectionChange}
       placeholder="Select a metric..."
+      isDisabled={loading}
     >
       {hasReferenceDataset ? (
         <Section title="Drift">

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -439,6 +439,10 @@ export interface PointCloudState extends PointCloudProps {
    */
   setErrorMessage: (message: string | null) => void;
   /**
+   * Set the loading state
+   */
+  setLoading: (loading: boolean) => void;
+  /**
    * Set the overall metric used in the point-cloud
    */
   setMetric(metric: MetricDefinition): void;

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -226,6 +226,11 @@ export type MetricDefinition =
  */
 export interface PointCloudProps {
   /**
+   * Whether or not the point cloud is loading
+   * @default false
+   */
+  loading: boolean;
+  /**
    * The point information that is currently loaded into view
    */
   points: readonly Point[];
@@ -487,6 +492,7 @@ export type PointCloudStore = ReturnType<typeof createPointCloudStore>;
 export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
   // The default props irrespective of the number of datasets
   const defaultProps: PointCloudProps = {
+    loading: false,
     errorMessage: null,
     points: [],
     eventIdToDataMap: new Map(),
@@ -549,6 +555,7 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
         .sort(clusterSortFn(pointCloud.clusterSort));
 
       set({
+        loading: false,
         points: points,
         eventIdToDataMap,
         clusters: sortedClusters,
@@ -800,6 +807,7 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
     getHDSCANParameters: () => get().hdbscanParameters,
     getMetric: () => get().metric,
     setErrorMessage: (errorMessage) => set({ errorMessage }),
+    setLoading: (loading: boolean) => set({ loading }),
     setMetric: async (metric) => {
       const pointCloud = get();
       set({ metric, clustersLoading: true });


### PR DESCRIPTION
resolves: #859 

Disables the metric selector while the main points are loading so that we don't have to cancel ongoing requests. Keeps the UI a bit simpler for now.