### PR TITLE
fix: replace IntEnum with Enum for DatasetRole

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timedelta, timezone
-from enum import IntEnum, auto, unique
+from enum import Enum, IntEnum, auto, unique
 from functools import cached_property
 from itertools import chain, groupby, repeat, starmap
 from random import random
@@ -171,7 +171,7 @@ class Embedding(CompositeDimensionSpec):
                 yield value
 
 
-class DatasetRole(IntEnum):
+class DatasetRole(Enum):
     """A dataframe's role in a Model: primary or reference (as
     baseline for drift).
     """


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/888

In Python 3.11, `IntEnum` is printed differently than in prior Python versions

[changed in 3.11](https://docs.python.org/3/library/enum.html#enum.IntEnum:~:text=with%201.-,Changed%20in%20version%203.11%3A%20__str__()%20is%20now%20int.__str__()%20to%20better%20support%20the%20replacement%20of%20existing%20constants%20use%2Dcase.%20__format__()%20was%20already%20int.__format__()%20for%20that%20same%20reason.,-class%20enum.):

> Changed in version 3.11: [`__str__()`](https://docs.python.org/3/reference/datamodel.html#object.__str__) is now `int.__str__()` to better support the replacement of existing constants use-case. [`__format__()`](https://docs.python.org/3/reference/datamodel.html#object.__format__) was already `int.__format__()` for that same reason.

## Python 3.11
<img width="719" alt="Screenshot 2023-06-26 at 11 38 35 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/9495b454-6142-4e5f-bb14-59effe69b197">

## Python 3.10
<img width="705" alt="Screenshot 2023-06-26 at 11 47 47 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/1026cab6-4970-4209-b955-b03963bbd165">

