### PR TITLE
fix: restrict scikit-learn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
+  "scikit-learn<1.3.0",
   "numpy",
   "pandas",
   "umap-learn",


### PR DESCRIPTION
HDBSCAN is failing due to the latest release of scikit-learn (1.3.0)

see https://github.com/scikit-learn-contrib/hdbscan/issues/597