### PR TITLE
fix: pin HDBSCAN to cython3 compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "numpy",
   "pandas",
   "umap-learn",
-  "hdbscan>=0.8.32, <1.0.0",
+  "hdbscan>=0.8.33, <1.0.0",
   "starlette",
   "uvicorn",
   "psutil",


### PR DESCRIPTION
resolves #937 

Due to the cython 3 release, HDBSCAN needed to issue a series of patches. This hopefully is the last one that downgrades their compilation to be compatible.