### PR TITLE
feat: show retrieval in the slide-over

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^0.12.3",
+        "@arizeai/components": "^0.12.6",
         "@arizeai/point-cloud": "^3.0.2",
         "@react-three/drei": "9.5.7",
         "@react-three/fiber": "8.0.12",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.12.3.tgz",
-      "integrity": "sha512-cNawaWTJPz/xVhNDMqrIqAeowQMTGJBMc7fJnEaxXsCInWCxWvxeXasN9Ky9EDscx26zBgBysuGgTmsaa6Thig==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.12.6.tgz",
+      "integrity": "sha512-e3GvqzrBaJWUBEK7L/vnyzopXUh45dgc2vLrNKCfnzw0pTV8Zvrx3ZC/cZ6DH202oqTPPJRVA2TRWHLX8jMIXg==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^0.12.3",
+    "@arizeai/components": "^0.12.6",
     "@arizeai/point-cloud": "^3.0.2",
     "@react-three/drei": "9.5.7",
     "@react-three/fiber": "8.0.12",

--- a/app/src/@types/dataset.d.ts
+++ b/app/src/@types/dataset.d.ts
@@ -2,4 +2,4 @@
  * The role of dataset.E.g. primary is the dataset under test, reference is the
  * dataset used for comparison.
  */
-declare type DatasetRole = "primary" | "reference";
+declare type DatasetRole = "primary" | "reference" | "corpus";

--- a/app/src/components/pointcloud/PointCloudPointTooltip.tsx
+++ b/app/src/components/pointcloud/PointCloudPointTooltip.tsx
@@ -16,12 +16,13 @@ const TOOLTIP_SIZE = 200;
  * The offset from the mouse position to the tooltip
  */
 const TOOLTIP_OFFSET = 10;
+
 /**
  * Re-used position vector
  */
 const vec = new THREE.Vector3();
 export const PointCloudPointTooltip = () => {
-  const { primaryDataset, referenceDataset } = useDatasets();
+  const { getDatasetNameByRole } = useDatasets();
   const hoveredEventId = usePointCloudContext((state) => state.hoveredEventId);
   const eventIdToDataMap = usePointCloudContext(
     (state) => state.eventIdToDataMap
@@ -42,10 +43,7 @@ export const PointCloudPointTooltip = () => {
   const group = eventIdToGroup[hoveredEventId];
   const color = pointGroupColors[eventIdToGroup[hoveredEventId]];
   const datasetRole = getDatasetRoleFromEventId(hoveredEventId);
-  const datasetName =
-    datasetRole === "primary"
-      ? primaryDataset.name
-      : referenceDataset?.name ?? "reference";
+  const datasetName = getDatasetNameByRole(datasetRole);
   return (
     <Html
       position={baseEvent.position}

--- a/app/src/contexts/DatasetsContext.tsx
+++ b/app/src/contexts/DatasetsContext.tsx
@@ -1,15 +1,19 @@
 import React, { createContext, ReactNode } from "react";
 
+import { DatasetRole } from "@phoenix/types";
+import { assertUnreachable } from "@phoenix/typeUtils";
+
 type DatasetDef = {
   name: string;
   startTime: string;
   endTime: string;
 };
 
-type DatasetsContextType = {
+export type DatasetsContextType = {
   primaryDataset: DatasetDef;
   referenceDataset: DatasetDef | null;
   corpusDataset: DatasetDef | null;
+  getDatasetNameByRole: (role: DatasetRole) => string;
 };
 
 export const DatasetsContext = createContext<DatasetsContextType | null>(null);
@@ -36,6 +40,18 @@ export function DatasetsProvider(props: DatasetsProviderProps) {
         primaryDataset: props.primaryDataset,
         referenceDataset: props.referenceDataset,
         corpusDataset: props.corpusDataset,
+        getDatasetNameByRole: (datasetRole: DatasetRole) => {
+          switch (datasetRole) {
+            case DatasetRole.primary:
+              return props.primaryDataset.name;
+            case DatasetRole.reference:
+              return props.referenceDataset?.name ?? "reference";
+            case DatasetRole.corpus:
+              return props.corpusDataset?.name ?? "corpus";
+            default:
+              assertUnreachable(datasetRole);
+          }
+        },
       }}
     >
       {props.children}

--- a/app/src/pages/dimension/DimensionCardinalityStats.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityStats.tsx
@@ -38,11 +38,7 @@ export function DimensionCardinalityStats(props: {
       </Text>
       <Text textSize="xlarge">{intFormatter(data.cardinality)}</Text>
       {data.referenceCardinality != null && (
-        <Text
-          textSize="medium"
-          color="designationPurple"
-          title="the reference cardinality"
-        >
+        <Text textSize="medium" color="designationPurple">
           {intFormatter(data.referenceCardinality)}
         </Text>
       )}

--- a/app/src/pages/dimension/DimensionPercentEmptyStats.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyStats.tsx
@@ -38,11 +38,7 @@ export function DimensionPercentEmptyStats(props: {
       </Text>
       <Text textSize="xlarge">{percentFormatter(data.percentEmpty)}</Text>
       {data.referencePercentEmpty != null && (
-        <Text
-          textSize="medium"
-          color="designationPurple"
-          title="the reference percent empty"
-        >
+        <Text textSize="medium" color="designationPurple">
           {percentFormatter(data.referencePercentEmpty)}
         </Text>
       )}

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -35,6 +35,8 @@ function TextPre(props: PropsWithChildren) {
  * Displays the details of an event in a slide over panel
  */
 export function EventDetails({ event }: { event: ModelEvent }) {
+  const hasRetrievals =
+    event.retrievedDocuments && event.retrievedDocuments.length > 0;
   return (
     <section
       css={css`
@@ -108,6 +110,11 @@ export function EventDetails({ event }: { event: ModelEvent }) {
         <AccordionItem id="dimensions" title="Dimensions">
           <EmbeddingDimensionsTable dimensions={event.dimensions} />
         </AccordionItem>
+        {hasRetrievals && (
+          <AccordionItem id="retrievals" title="Retrieved Documents">
+            {JSON.stringify(event.retrievedDocuments)}
+          </AccordionItem>
+        )}
       </Accordion>
     </section>
   );

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -5,10 +5,12 @@ import { css } from "@emotion/react";
 import {
   Accordion,
   AccordionItem,
+  Counter,
   Flex,
   Heading,
+  Icon,
+  Icons,
   Label,
-  Text,
   View,
 } from "@arizeai/components";
 
@@ -29,7 +31,7 @@ const detailsListCSS = css`
     dt {
       font-weight: bold;
       flex: none;
-      width: 120px;
+      width: 130px;
     }
     dd {
       flex: 1 1 auto;
@@ -119,20 +121,22 @@ export function EventDetails({ event }: { event: ModelEvent }) {
           </AccordionItem>
         ) : (
           <AccordionItem id="document" title={"Document Details"}>
-            {event.predictionId != null && (
-              <div>
-                <dt>Document ID</dt>
-                <dd
-                  css={css`
-                    display: flex;
-                    align-items: center;
-                  `}
-                >
-                  {/* TODO - find a way to make the ID more semantic like a record ID */}
-                  {event.predictionId}
-                </dd>
-              </div>
-            )}
+            <dl css={detailsListCSS}>
+              {event.predictionId != null && (
+                <div>
+                  <dt>Document ID</dt>
+                  <dd
+                    css={css`
+                      display: flex;
+                      align-items: center;
+                    `}
+                  >
+                    {/* TODO - find a way to make the ID more semantic like a record ID */}
+                    {event.predictionId}
+                  </dd>
+                </div>
+              )}
+            </dl>
           </AccordionItem>
         )}
         <AccordionItem id="dimensions" title="Dimensions">
@@ -142,8 +146,11 @@ export function EventDetails({ event }: { event: ModelEvent }) {
           <AccordionItem
             id="retrievals"
             title="Retrieved Documents"
-            // TODO(mikeldking) - add enough contrast to make this work
-            // titleExtra={<Counter>{event.retrievedDocuments.length}</Counter>}
+            titleExtra={
+              <Counter variant="light">
+                {event.retrievedDocuments.length}
+              </Counter>
+            }
           >
             <ul
               css={css`
@@ -179,10 +186,15 @@ function DocumentItem({ document }: { document: RetrievalDocument }) {
             margin="size-100"
             alignItems="center"
           >
-            <Heading level={5}>Document {document.id}</Heading>
-            <Label color="blue">{`relevance ${numberFormatter(
-              document.relevance
-            )}`}</Label>
+            <Flex direction="row" gap="size-50" alignItems="center">
+              <Icon svg={<Icons.FileOutline />} />
+              <Heading level={4}>document {document.id}</Heading>
+            </Flex>
+            {typeof document.relevance === "number" && (
+              <Label color="blue">{`relevance ${numberFormatter(
+                document.relevance
+              )}`}</Label>
+            )}
           </Flex>
         </View>
         <pre

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -112,7 +112,15 @@ export function EventDetails({ event }: { event: ModelEvent }) {
         </AccordionItem>
         {hasRetrievals && (
           <AccordionItem id="retrievals" title="Retrieved Documents">
-            {JSON.stringify(event.retrievedDocuments)}
+            <ul>
+              {event.retrievedDocuments.map((document) => {
+                return (
+                  <li key={document.id}>
+                    <TextPre>{document.text}</TextPre>
+                  </li>
+                );
+              })}
+            </ul>
           </AccordionItem>
         )}
       </Accordion>

--- a/app/src/pages/embedding/PointSelectionGrid.tsx
+++ b/app/src/pages/embedding/PointSelectionGrid.tsx
@@ -3,7 +3,6 @@ import { css } from "@emotion/react";
 
 import { EventItem } from "@phoenix/components/pointcloud";
 import { useDatasets, usePointCloudContext } from "@phoenix/contexts";
-import { DatasetRole } from "@phoenix/types";
 import { getDatasetRoleFromEventId } from "@phoenix/utils/pointCloudUtils";
 
 import { EventsList } from "./types";
@@ -13,7 +12,7 @@ type PointSelectionGridProps = {
 };
 
 export function PointSelectionGrid(props: PointSelectionGridProps) {
-  const { primaryDataset, referenceDataset } = useDatasets();
+  const { getDatasetNameByRole } = useDatasets();
   const { events, onItemSelected } = props;
   const eventIdToDataMap = usePointCloudContext(
     (state) => state.eventIdToDataMap
@@ -71,10 +70,7 @@ export function PointSelectionGrid(props: PointSelectionGridProps) {
           const { predictionLabel = null, actualLabel = null } =
             data?.eventMetadata ?? {};
           const datasetRole = getDatasetRoleFromEventId(event.id);
-          const datasetName =
-            datasetRole === DatasetRole.primary
-              ? primaryDataset.name
-              : referenceDataset?.name || "reference";
+          const datasetName = getDatasetNameByRole(datasetRole);
           const group = eventIdToGroup[event.id];
           const color = pointGroupColors[group];
 

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -67,8 +67,8 @@ function convertGqlEventToRetrievalDocument({
   relevance: number | null;
 }): RetrievalDocument {
   return {
-    id: event.id,
-    text: event.promptAndResponse?.prompt ?? "",
+    id: event.eventMetadata.predictionId || "unknown id",
+    text: event.documentText ?? "empty document",
     relevance: relevance,
   };
 }

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -18,13 +18,14 @@ import { SelectionDisplayRadioGroup } from "@phoenix/components/pointcloud";
 import { SelectionGridSizeRadioGroup } from "@phoenix/components/pointcloud/SelectionGridSizeRadioGroup";
 import { SelectionDisplay } from "@phoenix/constants/pointCloudConstants";
 import { usePointCloudContext } from "@phoenix/contexts";
+import { EventData } from "@phoenix/store";
 
 import { PointSelectionPanelContentQuery } from "./__generated__/PointSelectionPanelContentQuery.graphql";
 import { EventDetails } from "./EventDetails";
 import { ExportSelectionButton } from "./ExportSelectionButton";
 import { PointSelectionGrid } from "./PointSelectionGrid";
 import { PointSelectionTable } from "./PointSelectionTable";
-import { ModelEvent } from "./types";
+import { ModelEvent, RetrievalDocument } from "./types";
 
 const pointSelectionPanelCSS = css`
   width: 100%;
@@ -57,6 +58,20 @@ const pointSelectionPanelCSS = css`
     }
   }
 `;
+
+function convertGqlEventToRetrievalDocument({
+  event,
+  relevance,
+}: {
+  event: EventData;
+  relevance: number | null;
+}): RetrievalDocument {
+  return {
+    id: event.id,
+    text: event.promptAndResponse?.prompt ?? "",
+    relevance: relevance,
+  };
+}
 
 export function PointSelectionPanelContent() {
   const selectedEventIds = usePointCloudContext(
@@ -203,10 +218,26 @@ export function PointSelectionPanelContent() {
   const eventIdToDataMap = usePointCloudContext(
     (state) => state.eventIdToDataMap
   );
+  const pointData = usePointCloudContext((state) => state.pointData);
 
   const allData: ModelEvent[] = useMemo(() => {
     return allSelectedEvents.map((event) => {
-      const pointData = eventIdToDataMap.get(event.id);
+      const point = eventIdToDataMap.get(event.id);
+      const documents: RetrievalDocument[] = [];
+      if (pointData != null && point?.retrievals != null) {
+        point.retrievals.forEach(({ documentId, relevance }) => {
+          const documentEvent = pointData[documentId];
+          if (documentEvent != null) {
+            documents.push(
+              convertGqlEventToRetrievalDocument({
+                event: documentEvent,
+                relevance,
+              })
+            );
+          }
+        });
+      }
+
       return {
         id: event.id,
         predictionId: event.eventMetadata?.predictionId ?? null,
@@ -214,14 +245,15 @@ export function PointSelectionPanelContent() {
         actualScore: event.eventMetadata?.actualScore ?? null,
         predictionLabel: event.eventMetadata?.predictionLabel ?? null,
         predictionScore: event.eventMetadata?.predictionScore ?? null,
-        rawData: pointData?.embeddingMetadata.rawData ?? null,
-        linkToData: pointData?.embeddingMetadata.linkToData ?? null,
+        rawData: point?.embeddingMetadata.rawData ?? null,
+        linkToData: point?.embeddingMetadata.linkToData ?? null,
         dimensions: event.dimensions,
         prompt: event.promptAndResponse?.prompt ?? null,
         response: event.promptAndResponse?.response ?? null,
+        retrievedDocuments: documents,
       };
     });
-  }, [allSelectedEvents, eventIdToDataMap]);
+  }, [allSelectedEvents, eventIdToDataMap, pointData]);
 
   const eventDetails: ModelEvent | null = useMemo(() => {
     if (selectedDetailPointId) {

--- a/app/src/pages/embedding/types.ts
+++ b/app/src/pages/embedding/types.ts
@@ -38,7 +38,7 @@ export interface ModelEvent {
   retrievedDocuments: RetrievalDocument[];
 }
 
-export interface RetrievalDocument {
+export type RetrievalDocument = {
   id: string;
   /**
    * The content of the retrieved corpus document
@@ -48,7 +48,7 @@ export interface RetrievalDocument {
    * How relevant the document was during retrieval
    */
   relevance: number | null;
-}
+};
 
 export type EventsList =
   PointSelectionPanelContentQuery$data["model"]["primaryDataset"]["events"];

--- a/app/src/pages/embedding/types.ts
+++ b/app/src/pages/embedding/types.ts
@@ -32,6 +32,22 @@ export interface ModelEvent {
    * the LLM response
    */
   response: string | null;
+  /**
+   * Retrievals from a corpus (e.x. a vector store)
+   */
+  retrievedDocuments: RetrievalDocument[];
+}
+
+export interface RetrievalDocument {
+  id: string;
+  /**
+   * The content of the retrieved corpus document
+   */
+  text: string;
+  /**
+   * How relevant the document was during retrieval
+   */
+  relevance: number | null;
 }
 
 export type EventsList =

--- a/app/src/store/__generated__/pointCloudStore_eventsQuery.graphql.ts
+++ b/app/src/store/__generated__/pointCloudStore_eventsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8179e58b5a1d7012d060e1d572ea21ee>>
+ * @generated SignedSource<<aa89ee3ddadf6638ddf335867f8e3426>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type pointCloudStore_eventsQuery$data = {
         readonly eventMetadata: {
           readonly actualLabel: string | null;
           readonly actualScore: number | null;
+          readonly predictionId: string | null;
           readonly predictionLabel: string | null;
           readonly predictionScore: number | null;
         };
@@ -49,9 +50,11 @@ export type pointCloudStore_eventsQuery$data = {
           };
           readonly value: string | null;
         }>;
+        readonly documentText: string | null;
         readonly eventMetadata: {
           readonly actualLabel: string | null;
           readonly actualScore: number | null;
+          readonly predictionId: string | null;
           readonly predictionLabel: string | null;
           readonly predictionScore: number | null;
         };
@@ -72,9 +75,11 @@ export type pointCloudStore_eventsQuery$data = {
           };
           readonly value: string | null;
         }>;
+        readonly documentText: string | null;
         readonly eventMetadata: {
           readonly actualLabel: string | null;
           readonly actualScore: number | null;
+          readonly predictionId: string | null;
           readonly predictionLabel: string | null;
           readonly predictionScore: number | null;
         };
@@ -139,36 +144,18 @@ v6 = {
 v7 = {
   "alias": null,
   "args": null,
-  "concreteType": "DimensionWithValue",
-  "kind": "LinkedField",
-  "name": "dimensions",
-  "plural": true,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Dimension",
-      "kind": "LinkedField",
-      "name": "dimension",
-      "plural": false,
-      "selections": [
-        (v4/*: any*/),
-        (v5/*: any*/)
-      ],
-      "storageKey": null
-    },
-    (v6/*: any*/)
-  ],
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
   "concreteType": "EventMetadata",
   "kind": "LinkedField",
   "name": "eventMetadata",
   "plural": false,
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "predictionId",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -200,7 +187,7 @@ v8 = {
   ],
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "PromptResponse",
@@ -225,7 +212,45 @@ v9 = {
   ],
   "storageKey": null
 },
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "documentText",
+  "storageKey": null
+},
 v10 = [
+  (v3/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DimensionWithValue",
+    "kind": "LinkedField",
+    "name": "dimensions",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dimension",
+        "kind": "LinkedField",
+        "name": "dimension",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v6/*: any*/)
+    ],
+    "storageKey": null
+  },
+  (v7/*: any*/),
+  (v8/*: any*/),
+  (v9/*: any*/)
+],
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -255,12 +280,7 @@ v10 = [
             "kind": "LinkedField",
             "name": "events",
             "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
-              (v9/*: any*/)
-            ],
+            "selections": (v10/*: any*/),
             "storageKey": null
           }
         ],
@@ -315,6 +335,7 @@ v10 = [
                 ],
                 "storageKey": null
               },
+              (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/)
             ],
@@ -344,19 +365,7 @@ v10 = [
             "kind": "LinkedField",
             "name": "events",
             "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
-              (v9/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "documentText",
-                "storageKey": null
-              }
-            ],
+            "selections": (v10/*: any*/),
             "storageKey": null
           }
         ],
@@ -376,7 +385,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "pointCloudStore_eventsQuery",
-    "selections": (v10/*: any*/),
+    "selections": (v11/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
@@ -389,19 +398,19 @@ return {
     ],
     "kind": "Operation",
     "name": "pointCloudStore_eventsQuery",
-    "selections": (v10/*: any*/)
+    "selections": (v11/*: any*/)
   },
   "params": {
-    "cacheID": "39cbb7754746f581a2a9e81927095339",
+    "cacheID": "e26a15665d2dd03479941745a539410d",
     "id": null,
     "metadata": {},
     "name": "pointCloudStore_eventsQuery",
     "operationKind": "query",
-    "text": "query pointCloudStore_eventsQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n  $corpusEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            id\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    corpusDataset {\n      events(eventIds: $corpusEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n  }\n}\n"
+    "text": "query pointCloudStore_eventsQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n  $corpusEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            id\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n    corpusDataset {\n      events(eventIds: $corpusEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9b7c7837ce80c2c64f24c726b2881d33";
+(node as any).hash = "2ecca9b28388f179d9bd79010fae7bf2";
 
 export default node;

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -192,6 +192,7 @@ export type ClusterSort = {
 
 export type EventData =
   pointCloudStore_eventsQuery$data["model"]["primaryDataset"]["events"][number];
+
 /**
  * A mapping from a point ID to its data
  */
@@ -1180,6 +1181,7 @@ async function fetchPointEvents(eventIds: string[]): Promise<PointDataMap> {
                 value
               }
               eventMetadata {
+                predictionId
                 predictionLabel
                 predictionScore
                 actualLabel
@@ -1189,6 +1191,8 @@ async function fetchPointEvents(eventIds: string[]): Promise<PointDataMap> {
                 prompt
                 response
               }
+              # TODO: delineate between corpus events and dataset events
+              documentText
             }
           }
           referenceDataset {
@@ -1203,6 +1207,7 @@ async function fetchPointEvents(eventIds: string[]): Promise<PointDataMap> {
                 value
               }
               eventMetadata {
+                predictionId
                 predictionLabel
                 predictionScore
                 actualLabel
@@ -1212,6 +1217,7 @@ async function fetchPointEvents(eventIds: string[]): Promise<PointDataMap> {
                 prompt
                 response
               }
+              documentText
             }
           }
           corpusDataset {
@@ -1225,6 +1231,7 @@ async function fetchPointEvents(eventIds: string[]): Promise<PointDataMap> {
                 value
               }
               eventMetadata {
+                predictionId
                 predictionLabel
                 predictionScore
                 actualLabel

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -190,7 +190,7 @@ export type ClusterSort = {
   column: keyof Cluster;
 };
 
-type EventData =
+export type EventData =
   pointCloudStore_eventsQuery$data["model"]["primaryDataset"]["events"][number];
 /**
  * A mapping from a point ID to its data

--- a/src/phoenix/datasets/fixtures.py
+++ b/src/phoenix/datasets/fixtures.py
@@ -401,7 +401,7 @@ def get_datasets(
         corpus_dataset = Dataset(
             read_parquet(paths[DatasetRole.CORPUS]),
             fixture.corpus_schema,
-            "corpus",
+            "knowledge_base",
         )
     return primary_dataset, reference_dataset, corpus_dataset
 


### PR DESCRIPTION
resolves #942 

This PR shows the retrieved documents for a retrieval embedding on the detail view so you can view the details of the retrieval.

<img width="1749" alt="Screenshot 2023-07-20 at 6 36 31 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/0e0dde05-22c6-446d-b57c-fcb1f7ec030d">
