### PR TITLE
feat: allow iso 8601 timestamps

### DIFF
--- a/src/phoenix/datasets/validation.py
+++ b/src/phoenix/datasets/validation.py
@@ -3,7 +3,6 @@ from typing import List
 
 import numpy as np
 from pandas import DataFrame, Series
-from pandas.api.types import is_datetime64_any_dtype as is_datetime
 from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 from . import errors as err
@@ -159,15 +158,6 @@ def _validate_embedding_vector(
 
 def _check_column_types(dataframe: DataFrame, schema: Schema) -> List[err.ValidationError]:
     wrong_type_cols: List[str] = []
-    if schema.timestamp_column_name is not None:
-        if not (
-            is_numeric_dtype(dataframe.dtypes[schema.timestamp_column_name])
-            or is_datetime(dataframe.dtypes[schema.timestamp_column_name])
-        ):
-            wrong_type_cols.append(
-                f"{schema.timestamp_column_name} should be of timestamp or numeric type"
-            )
-
     if schema.prediction_id_column_name is not None:
         if not (
             is_numeric_dtype(dataframe.dtypes[schema.prediction_id_column_name])

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -742,24 +742,6 @@ class TestDataset:
         with raises(DatasetError):
             Dataset(dataframe=input_df, schema=input_schema)
 
-    def test_dataset_validate_invalid_timestamp_datatype(self) -> None:
-        input_df = DataFrame(
-            {
-                "prediction_label": [f"label{index}" for index in range(self.num_records)],
-                "feature0": np.zeros(self.num_records),
-                "timestamp": random_uuids(self.num_records),
-            },
-        )
-
-        input_schema = Schema(
-            timestamp_column_name="timestamp",
-            feature_column_names=["feature0"],
-            prediction_label_column_name="prediction_label",
-        )
-
-        with raises(DatasetError):
-            Dataset(dataframe=input_df, schema=input_schema)
-
     def test_dataset_validate_invalid_schema_excludes_timestamp(self) -> None:
         input_df = DataFrame(
             {

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1094,6 +1094,18 @@ def random_uuids(num_records: int):
         pytest.param(
             DataFrame(
                 {
+                    "timestamp": [
+                        "2022-01-01T00:00:00Z",
+                        "2022-01-02T01:00:00Z",
+                        "2022-01-03T02:00:00Z",
+                    ],
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            None,
+            DataFrame(
+                {
                     "timestamp": Series(
                         [
                             Timestamp(
@@ -1121,7 +1133,21 @@ def random_uuids(num_records: int):
                                 second=0,
                             ),
                         ]
-                    ).apply(lambda val: val.isoformat()),
+                    ).dt.tz_localize(pytz.utc),
+                    "prediction_id": [1, 2, 3],
+                }
+            ),
+            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
+            id="iso8601_utc_tz_aware_strings_converted_to_utc_timestamps",
+        ),
+        pytest.param(
+            DataFrame(
+                {
+                    "timestamp": [
+                        "2022-01-01T00:00:00",
+                        "2022-01-02T01:00:00",
+                        "2022-01-03T02:00:00",
+                    ],
                     "prediction_id": [1, 2, 3],
                 }
             ),
@@ -1166,36 +1192,11 @@ def random_uuids(num_records: int):
         pytest.param(
             DataFrame(
                 {
-                    "timestamp": Series(
-                        [
-                            Timestamp(
-                                year=2022,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=0,
-                            ),
-                            Timestamp(
-                                year=2022,
-                                month=1,
-                                day=2,
-                                hour=1,
-                                minute=0,
-                                second=0,
-                            ),
-                            Timestamp(
-                                year=2022,
-                                month=1,
-                                day=3,
-                                hour=2,
-                                minute=0,
-                                second=0,
-                            ),
-                        ]
-                    )
-                    .dt.tz_localize(pytz.timezone("US/Pacific"))
-                    .apply(lambda val: val.isoformat()),
+                    "timestamp": [
+                        "2022-01-01T00:00:00-08:00",
+                        "2022-01-02T01:00:00-08:00",
+                        "2022-01-03T02:00:00-08:00",
+                    ],
                     "prediction_id": [1, 2, 3],
                 }
             ),
@@ -1236,55 +1237,6 @@ def random_uuids(num_records: int):
             ),
             Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
             id="iso8601_us_pacific_strings_converted_to_utc_timestamps",
-        ),
-        pytest.param(
-            DataFrame(
-                {
-                    "timestamp": [
-                        "24-03-2023 10:00:00 UTC",
-                        "24-03-2023 11:30:00 UTC",
-                        "24-03-2023 14:15:00 UTC",
-                    ],
-                    "prediction_id": [1, 2, 3],
-                }
-            ),
-            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
-            None,
-            DataFrame(
-                {
-                    "timestamp": Series(
-                        [
-                            Timestamp(
-                                year=2023,
-                                month=3,
-                                day=24,
-                                hour=10,
-                                minute=0,
-                                second=0,
-                            ),
-                            Timestamp(
-                                year=2023,
-                                month=3,
-                                day=24,
-                                hour=11,
-                                minute=30,
-                                second=0,
-                            ),
-                            Timestamp(
-                                year=2023,
-                                month=3,
-                                day=24,
-                                hour=14,
-                                minute=15,
-                                second=0,
-                            ),
-                        ]
-                    ).dt.tz_localize(pytz.utc),
-                    "prediction_id": [1, 2, 3],
-                }
-            ),
-            Schema(timestamp_column_name="timestamp", prediction_id_column_name="prediction_id"),
-            id="pandas_flexible_format_parsing_previously_invalid_input_test",
         ),
     ],
 )


### PR DESCRIPTION
We need to allow ISO 8601 timestamps for compatibility with the [OpenInference timestamp format](https://github.com/Arize-ai/open-inference-spec/blob/main/spec/timestamp.md). Our current validation code prevents Phoenix from launching with strings in the timestamp column. I've removed this code and rely on the validation [here](https://github.com/Arize-ai/phoenix/blob/315147b9ebe25dfda1ac7cfb227342e934f6bfe7/src/phoenix/datasets/dataset.py#L431), which currently handles the case where the timestamp is a string.