### PR TITLE
feat(embeddings): show corpus percent query

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -59,6 +59,8 @@ export function GlobalStyles() {
           --px-primary-color--transparent: rgb(158, 252, 253, 0.2);
           --px-reference-color: #baa1f9;
           --px-reference-color--transparent: #baa1f982;
+          --px-corpus-color: #92969c;
+          --px-corpus-color--transparent: #92969c63;
 
           --px-background-color-800: ${theme.colors.gray800};
           --px-background-color-500: ${theme.colors.gray500};

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -340,7 +340,7 @@ function DocumentPreview(props: Pick<EventItemProps, "size" | "documentText">) {
         margin-block-start: 0;
         margin-block-end: 0;
         position: relative;
-        --text-preview-background-color: var(--ac-background-color-light);
+        --text-preview-background-color: var(--px-background-color-800);
         background-color: var(--text-preview-background-color);
 
         &[data-size="small"] {

--- a/app/src/components/pointcloud/PointCloudPointTooltip.tsx
+++ b/app/src/components/pointcloud/PointCloudPointTooltip.tsx
@@ -84,6 +84,7 @@ export const PointCloudPointTooltip = () => {
           predictionLabel={baseEvent.eventMetadata.predictionLabel}
           actualLabel={baseEvent.eventMetadata.actualLabel}
           promptAndResponse={eventDetails.promptAndResponse}
+          documentText={eventDetails.documentText}
           datasetName={datasetName}
           group={group}
           color={color}

--- a/app/src/components/pointcloud/PointCloudPoints.tsx
+++ b/app/src/components/pointcloud/PointCloudPoints.tsx
@@ -46,6 +46,9 @@ type PointCloudPointsProps = {
    * Optional second set of data to display in the point cloud
    */
   referenceData: Point[] | null;
+  /**
+   * Optional set of data for the corpus (typically a knowledge base in a vector store)
+   */
   corpusData: Point[] | null;
   /**
    * How the points should be colored

--- a/app/src/pages/embedding/Embedding.tsx
+++ b/app/src/pages/embedding/Embedding.tsx
@@ -60,8 +60,10 @@ import { useEmbeddingDimensionId } from "@phoenix/hooks";
 import {
   ClusterColorMode,
   DEFAULT_DRIFT_POINT_CLOUD_PROPS,
+  DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS,
   DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS,
   MetricDefinition,
+  PointCloudProps,
 } from "@phoenix/store";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { getMetricShortNameByMetricKey } from "@phoenix/utils/metricFormatUtils";
@@ -192,6 +194,7 @@ const EmbeddingUMAPQuery = graphql`
             id
             eventIds
             driftRatio
+            primaryToCorpusRatio
             dataQualityMetric(
               metric: { columnName: $dataQualityMetricColumnName, metric: mean }
             ) @include(if: $fetchDataQualityMetric) {
@@ -216,14 +219,19 @@ const EmbeddingUMAPQuery = graphql`
 `;
 
 export function Embedding() {
-  const { referenceDataset } = useDatasets();
+  const { referenceDataset, corpusDataset } = useDatasets();
   const { timeRange } = useTimeRange();
   // Initialize the store based on whether or not there is a reference dataset
-  const defaultPointCloudProps = useMemo(() => {
-    return referenceDataset != null
-      ? DEFAULT_DRIFT_POINT_CLOUD_PROPS
-      : DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS;
-  }, [referenceDataset]);
+  const defaultPointCloudProps = useMemo<Partial<PointCloudProps>>(() => {
+    if (corpusDataset != null) {
+      // If there is a corpus dataset, then initialize the page with the retrieval troubleshooting settings
+      // TODO - this does make a bit of a leap of assumptions but is a short term solution in order to get the page working as intended
+      return DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS;
+    } else if (referenceDataset != null) {
+      return DEFAULT_DRIFT_POINT_CLOUD_PROPS;
+    }
+    return DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS;
+  }, [corpusDataset, referenceDataset]);
   return (
     <TimeSliceContextProvider initialTimestamp={timeRange.end}>
       <PointCloudProvider {...defaultPointCloudProps}>
@@ -680,6 +688,7 @@ const ClustersPanelContents = React.memo(function ClustersPanelContents() {
                       numPoints={cluster.eventIds.length}
                       isSelected={selectedClusterId === cluster.id}
                       driftRatio={cluster.driftRatio}
+                      primaryToCorpusRatio={cluster.primaryToCorpusRatio}
                       primaryMetricValue={cluster.primaryMetricValue}
                       referenceMetricValue={cluster.referenceMetricValue}
                       metricName={getClusterMetricName(metric)}
@@ -716,13 +725,22 @@ const ClustersPanelContents = React.memo(function ClustersPanelContents() {
   );
 });
 
-function getClusterMetricName(metric: MetricDefinition) {
+function getClusterMetricName(metric: MetricDefinition): string {
   const { type: metricType, metric: metricEnum } = metric;
   switch (metricType) {
     case "dataQuality":
       return `${metric.dimension.name} avg`;
-    case "drift":
-      return "cluster drift";
+    case "drift": {
+      switch (metricEnum) {
+        case "euclideanDistance":
+          return "Cluster Drift";
+        case "queryDistance":
+          return "% Query";
+        default:
+          assertUnreachable(metricEnum);
+      }
+      break;
+    }
     case "performance":
       return getMetricShortNameByMetricKey(metricEnum);
     default:

--- a/app/src/pages/embedding/Embedding.tsx
+++ b/app/src/pages/embedding/Embedding.tsx
@@ -734,8 +734,7 @@ function getClusterMetricName(metric: MetricDefinition): string {
       switch (metricEnum) {
         case "euclideanDistance":
           return "Cluster Drift";
-        case "queryDistance":
-          return "% Query";
+
         default:
           assertUnreachable(metricEnum);
       }
@@ -743,6 +742,15 @@ function getClusterMetricName(metric: MetricDefinition): string {
     }
     case "performance":
       return getMetricShortNameByMetricKey(metricEnum);
+    case "retrieval": {
+      switch (metricEnum) {
+        case "queryDistance":
+          return "% Query";
+        default:
+          assertUnreachable(metricEnum);
+      }
+      break;
+    }
     default:
       assertUnreachable(metricType);
   }

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -304,6 +304,7 @@ function EventPreview({ event }: { event: ModelEvent }) {
     event.prompt || event.response
       ? { prompt: event.prompt, response: event.response }
       : null;
+  const documentText = event.documentText;
   let content = null;
   if (imageUrl) {
     content = (
@@ -317,6 +318,14 @@ function EventPreview({ event }: { event: ModelEvent }) {
           background-color: black;
         `}
       />
+    );
+  } else if (documentText) {
+    content = (
+      <Accordion variant="compact">
+        <AccordionItem id="document" title="Document">
+          <TextPre>{documentText}</TextPre>
+        </AccordionItem>
+      </Accordion>
     );
   } else if (promptAndResponse) {
     content = (

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -16,6 +16,7 @@ import {
   DriftMetricDefinition,
   MetricDefinition,
   PerformanceMetricDefinition,
+  RetrievalMetricDefinition,
 } from "@phoenix/store";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
@@ -46,6 +47,8 @@ function getMetricKey(metric: MetricDefinition) {
   const { type, metric: metricName } = metric;
   switch (type) {
     case "drift":
+      return `${type}${METRIC_KEY_SEPARATOR}${metricName}`;
+    case "retrieval":
       return `${type}${METRIC_KEY_SEPARATOR}${metricName}`;
     case "performance":
       return `${type}${METRIC_KEY_SEPARATOR}${metricName}`;
@@ -79,6 +82,11 @@ function parseMetricKey({
   switch (type) {
     case "drift":
       return { type, metric: metricName as DriftMetricDefinition["metric"] };
+    case "retrieval":
+      return {
+        type,
+        metric: metricName as RetrievalMetricDefinition["metric"],
+      };
     case "performance":
       return {
         type,
@@ -185,11 +193,10 @@ export function MetricSelector({
         (null as unknown as CollectionElement<unknown>)
       )}
       {hasCorpusDataset ? (
-        // Intentionally not naming the section drift to avoid confusion
         <Section title="Retrieval">
           <Item
             key={getMetricKey({
-              type: "drift",
+              type: "retrieval",
               metric: "queryDistance",
             })}
           >

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -139,8 +139,9 @@ export function MetricSelector({
     `,
     model
   );
-  const { referenceDataset } = useDatasets();
+  const { referenceDataset, corpusDataset } = useDatasets();
   const hasReferenceDataset = !!referenceDataset;
+  const hasCorpusDataset = !!corpusDataset;
   const metric = usePointCloudContext((state) => state.metric);
   const loading = usePointCloudContext((state) => state.loading);
   const setMetric = usePointCloudContext((state) => state.setMetric);
@@ -169,6 +170,35 @@ export function MetricSelector({
       placeholder="Select a metric..."
       isDisabled={loading}
     >
+      {hasReferenceDataset ? (
+        <Section title="Drift">
+          <Item
+            key={getMetricKey({
+              type: "drift",
+              metric: "euclideanDistance",
+            })}
+          >
+            Euclidean Distance
+          </Item>
+        </Section>
+      ) : (
+        (null as unknown as CollectionElement<unknown>)
+      )}
+      {hasCorpusDataset ? (
+        // Intentionally not naming the section drift to avoid confusion
+        <Section title="Retrieval">
+          <Item
+            key={getMetricKey({
+              type: "drift",
+              metric: "queryDistance",
+            })}
+          >
+            Query Distance
+          </Item>
+        </Section>
+      ) : (
+        (null as unknown as CollectionElement<unknown>)
+      )}
       {hasReferenceDataset ? (
         <Section title="Drift">
           <Item

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -118,6 +118,8 @@ function getChartTitle(metric: MetricDefinition) {
       return "Model Performance";
     case "dataQuality":
       return "Data Quality";
+    case "retrieval":
+      return "Query Distance";
     default:
       assertUnreachable(metric);
   }
@@ -137,6 +139,8 @@ function getMetricShortName(metric: MetricDefinition | null): string {
       case "dataQuality":
         // TODO make this more generic and don't assume avg
         return `${metric.dimension.name} avg`;
+      case "retrieval":
+        return getMetricShortNameByMetricKey(metric.metric);
       default:
         assertUnreachable(metricType);
     }
@@ -151,6 +155,8 @@ function getMetricDescription(metric: MetricDefinition) {
       return getMetricDescriptionByMetricKey(metric.metric);
     case "dataQuality":
       return null;
+    case "retrieval":
+      return getMetricDescriptionByMetricKey(metric.metric);
     default:
       assertUnreachable(metric);
   }

--- a/app/src/pages/embedding/PointSelectionGrid.tsx
+++ b/app/src/pages/embedding/PointSelectionGrid.tsx
@@ -89,6 +89,7 @@ export function PointSelectionGrid(props: PointSelectionGridProps) {
                 predictionLabel={predictionLabel}
                 actualLabel={actualLabel}
                 promptAndResponse={event.promptAndResponse}
+                documentText={event.documentText}
               />
             </li>
           );

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -144,6 +144,7 @@ export function PointSelectionPanelContent() {
                 prompt
                 response
               }
+              documentText
             }
           }
           referenceDataset {
@@ -167,6 +168,7 @@ export function PointSelectionPanelContent() {
                 prompt
                 response
               }
+              documentText
             }
           }
           corpusDataset {
@@ -251,6 +253,7 @@ export function PointSelectionPanelContent() {
         prompt: event.promptAndResponse?.prompt ?? null,
         response: event.promptAndResponse?.response ?? null,
         retrievedDocuments: documents,
+        documentText: event.documentText ?? null,
       };
     });
   }, [allSelectedEvents, eventIdToDataMap, pointData]);

--- a/app/src/pages/embedding/PointSelectionTable.tsx
+++ b/app/src/pages/embedding/PointSelectionTable.tsx
@@ -38,7 +38,11 @@ export function PointSelectionTable({
     columns: Column<TableDataItem>[];
     tableData: TableDataItem[];
   }>(() => {
-    const tableData: TableDataItem[] = [...data];
+    // Corpus points cannot be shown under the  table as they don't contain data that is uniform nor data that is under analysis
+    // TODO(mikeldking): show corpus points under a separate tab
+    const tableData: TableDataItem[] = data.filter((point) => {
+      return point.id.includes("CORPUS") === false;
+    });
     let hasLinkToData = false,
       hasRawData = false,
       hasPromptAndResponse = false,

--- a/app/src/pages/embedding/__generated__/EmbeddingUMAPQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/EmbeddingUMAPQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<03e377e0998569b67cb79b18a4faa952>>
+ * @generated SignedSource<<82b459c7fbab9cd9838c7f1125866dac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,6 +43,7 @@ export type EmbeddingUMAPQuery$data = {
           readonly primaryValue: number | null;
           readonly referenceValue: number | null;
         };
+        readonly primaryToCorpusRatio: number | null;
       }>;
       readonly contextRetrievals: ReadonlyArray<{
         readonly documentId: string;
@@ -475,6 +476,13 @@ v19 = {
               "storageKey": null
             },
             {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "primaryToCorpusRatio",
+              "storageKey": null
+            },
+            {
               "condition": "fetchDataQualityMetric",
               "kind": "Condition",
               "passingValue": true,
@@ -655,16 +663,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e6211bb3d71d2178c1f18d6919bf0d59",
+    "cacheID": "88dc5478ae248f2e863fd779a080f725",
     "id": null,
     "metadata": {},
     "name": "EmbeddingUMAPQuery",
     "operationKind": "query",
-    "text": "query EmbeddingUMAPQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n  $minDist: Float!\n  $nNeighbors: Int!\n  $nSamples: Int!\n  $minClusterSize: Int!\n  $clusterMinSamples: Int!\n  $clusterSelectionEpsilon: Float!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  embedding: node(id: $id) {\n    __typename\n    ... on EmbeddingDimension {\n      UMAPPoints(timeRange: $timeRange, minDist: $minDist, nNeighbors: $nNeighbors, nSamples: $nSamples, minClusterSize: $minClusterSize, clusterMinSamples: $clusterMinSamples, clusterSelectionEpsilon: $clusterSelectionEpsilon) {\n        data {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        referenceData {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        corpusData {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        clusters {\n          id\n          eventIds\n          driftRatio\n          dataQualityMetric(metric: {columnName: $dataQualityMetricColumnName, metric: mean}) @include(if: $fetchDataQualityMetric) {\n            primaryValue\n            referenceValue\n          }\n          performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n            primaryValue\n            referenceValue\n          }\n        }\n        contextRetrievals {\n          queryId\n          documentId\n          relevance\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query EmbeddingUMAPQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n  $minDist: Float!\n  $nNeighbors: Int!\n  $nSamples: Int!\n  $minClusterSize: Int!\n  $clusterMinSamples: Int!\n  $clusterSelectionEpsilon: Float!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  embedding: node(id: $id) {\n    __typename\n    ... on EmbeddingDimension {\n      UMAPPoints(timeRange: $timeRange, minDist: $minDist, nNeighbors: $nNeighbors, nSamples: $nSamples, minClusterSize: $minClusterSize, clusterMinSamples: $clusterMinSamples, clusterSelectionEpsilon: $clusterSelectionEpsilon) {\n        data {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        referenceData {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        corpusData {\n          id\n          eventId\n          coordinates {\n            __typename\n            ... on Point3D {\n              x\n              y\n              z\n            }\n            ... on Point2D {\n              x\n              y\n            }\n          }\n          embeddingMetadata {\n            linkToData\n            rawData\n          }\n          eventMetadata {\n            predictionId\n            predictionLabel\n            actualLabel\n            predictionScore\n            actualScore\n          }\n        }\n        clusters {\n          id\n          eventIds\n          driftRatio\n          primaryToCorpusRatio\n          dataQualityMetric(metric: {columnName: $dataQualityMetricColumnName, metric: mean}) @include(if: $fetchDataQualityMetric) {\n            primaryValue\n            referenceValue\n          }\n          performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n            primaryValue\n            referenceValue\n          }\n        }\n        contextRetrievals {\n          queryId\n          documentId\n          relevance\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "316df421cda9a2cdb7cb984e16970b3f";
+(node as any).hash = "2e2ccd0cea43753749c8f4329b708d12";
 
 export default node;

--- a/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b007b0d952adcaca79f5144f9464e04f>>
+ * @generated SignedSource<<ddf3621710b2a1ab8bb4dad30852c82d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,6 +50,7 @@ export type PointSelectionPanelContentQuery$data = {
           };
           readonly value: string | null;
         }>;
+        readonly documentText: string | null;
         readonly eventMetadata: {
           readonly actualLabel: string | null;
           readonly actualScore: number | null;
@@ -73,6 +74,7 @@ export type PointSelectionPanelContentQuery$data = {
           };
           readonly value: string | null;
         }>;
+        readonly documentText: string | null;
         readonly eventMetadata: {
           readonly actualLabel: string | null;
           readonly actualScore: number | null;
@@ -110,134 +112,137 @@ v2 = {
   "kind": "LocalArgument",
   "name": "referenceEventIds"
 },
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "DimensionWithValue",
-  "kind": "LinkedField",
-  "name": "dimensions",
-  "plural": true,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Dimension",
-      "kind": "LinkedField",
-      "name": "dimension",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "type",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "value",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "EventMetadata",
-  "kind": "LinkedField",
-  "name": "eventMetadata",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "predictionId",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "predictionLabel",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "predictionScore",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "actualLabel",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "actualScore",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "PromptResponse",
-  "kind": "LinkedField",
-  "name": "promptAndResponse",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "prompt",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "response",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v7 = [
-  (v3/*: any*/),
-  (v4/*: any*/),
-  (v5/*: any*/),
-  (v6/*: any*/)
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DimensionWithValue",
+    "kind": "LinkedField",
+    "name": "dimensions",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dimension",
+        "kind": "LinkedField",
+        "name": "dimension",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "type",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "value",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "EventMetadata",
+    "kind": "LinkedField",
+    "name": "eventMetadata",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "predictionId",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "predictionLabel",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "predictionScore",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "actualLabel",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "actualScore",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PromptResponse",
+    "kind": "LinkedField",
+    "name": "promptAndResponse",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "prompt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "response",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "documentText",
+    "storageKey": null
+  }
 ],
-v8 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -267,7 +272,7 @@ v8 = [
             "kind": "LinkedField",
             "name": "events",
             "plural": true,
-            "selections": (v7/*: any*/),
+            "selections": (v3/*: any*/),
             "storageKey": null
           }
         ],
@@ -294,7 +299,7 @@ v8 = [
             "kind": "LinkedField",
             "name": "events",
             "plural": true,
-            "selections": (v7/*: any*/),
+            "selections": (v3/*: any*/),
             "storageKey": null
           }
         ],
@@ -321,19 +326,7 @@ v8 = [
             "kind": "LinkedField",
             "name": "events",
             "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v5/*: any*/),
-              (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "documentText",
-                "storageKey": null
-              }
-            ],
+            "selections": (v3/*: any*/),
             "storageKey": null
           }
         ],
@@ -353,7 +346,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "PointSelectionPanelContentQuery",
-    "selections": (v8/*: any*/),
+    "selections": (v4/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
@@ -366,19 +359,19 @@ return {
     ],
     "kind": "Operation",
     "name": "PointSelectionPanelContentQuery",
-    "selections": (v8/*: any*/)
+    "selections": (v4/*: any*/)
   },
   "params": {
-    "cacheID": "471571b29d6e81202f4be5dddcdb81f7",
+    "cacheID": "a1ce797d7fc303bb85730466d1a14bdd",
     "id": null,
     "metadata": {},
     "name": "PointSelectionPanelContentQuery",
     "operationKind": "query",
-    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n  $corpusEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n      }\n    }\n    corpusDataset {\n      events(eventIds: $corpusEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n  }\n}\n"
+    "text": "query PointSelectionPanelContentQuery(\n  $primaryEventIds: [ID!]!\n  $referenceEventIds: [ID!]!\n  $corpusEventIds: [ID!]!\n) {\n  model {\n    primaryDataset {\n      events(eventIds: $primaryEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n    referenceDataset {\n      events(eventIds: $referenceEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n    corpusDataset {\n      events(eventIds: $corpusEventIds) {\n        id\n        dimensions {\n          dimension {\n            name\n            type\n          }\n          value\n        }\n        eventMetadata {\n          predictionId\n          predictionLabel\n          predictionScore\n          actualLabel\n          actualScore\n        }\n        promptAndResponse {\n          prompt\n          response\n        }\n        documentText\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e14ed5433fc9438fb6d6794696ddf360";
+(node as any).hash = "6238f84e3d942c6c9af51ea7180b7608";
 
 export default node;

--- a/app/src/pages/embedding/types.ts
+++ b/app/src/pages/embedding/types.ts
@@ -33,6 +33,11 @@ export interface ModelEvent {
    */
   response: string | null;
   /**
+   * document text if the event is a document
+   * TODO: decouple this from the event
+   */
+  documentText: string | null;
+  /**
    * Retrievals from a corpus (e.x. a vector store)
    */
   retrievedDocuments: RetrievalDocument[];

--- a/app/src/store/__generated__/pointCloudStore_clusterMetricsQuery.graphql.ts
+++ b/app/src/store/__generated__/pointCloudStore_clusterMetricsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<158f240473ff0a8e7a67fbf6fe9d6dec>>
+ * @generated SignedSource<<24b9c24519f1a66f81e0652fdcc2b20a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,6 +34,7 @@ export type pointCloudStore_clusterMetricsQuery$data = {
       readonly primaryValue: number | null;
       readonly referenceValue: number | null;
     };
+    readonly primaryToCorpusRatio: number | null;
   }>;
 };
 export type pointCloudStore_clusterMetricsQuery = {
@@ -117,6 +118,13 @@ v6 = [
         "args": null,
         "kind": "ScalarField",
         "name": "driftRatio",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "primaryToCorpusRatio",
         "storageKey": null
       },
       {
@@ -216,16 +224,16 @@ return {
     "selections": (v6/*: any*/)
   },
   "params": {
-    "cacheID": "e8ef2d6ff8ff0b147a19312264f16ef3",
+    "cacheID": "86666967012812887ac0a0149d2d2535",
     "id": null,
     "metadata": {},
     "name": "pointCloudStore_clusterMetricsQuery",
     "operationKind": "query",
-    "text": "query pointCloudStore_clusterMetricsQuery(\n  $clusters: [ClusterInput!]!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  clusters(clusters: $clusters) {\n    id\n    eventIds\n    driftRatio\n    dataQualityMetric(metric: {metric: mean, columnName: $dataQualityMetricColumnName}) @include(if: $fetchDataQualityMetric) {\n      primaryValue\n      referenceValue\n    }\n    performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n      primaryValue\n      referenceValue\n    }\n  }\n}\n"
+    "text": "query pointCloudStore_clusterMetricsQuery(\n  $clusters: [ClusterInput!]!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  clusters(clusters: $clusters) {\n    id\n    eventIds\n    driftRatio\n    primaryToCorpusRatio\n    dataQualityMetric(metric: {metric: mean, columnName: $dataQualityMetricColumnName}) @include(if: $fetchDataQualityMetric) {\n      primaryValue\n      referenceValue\n    }\n    performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n      primaryValue\n      referenceValue\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fe9bbb56950c7ecfa063c043df7667cd";
+(node as any).hash = "dbfc8c02ba1ec4f2ba0317b371854d9b";
 
 export default node;

--- a/app/src/store/__generated__/pointCloudStore_clustersQuery.graphql.ts
+++ b/app/src/store/__generated__/pointCloudStore_clustersQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3a9324986e40886fea88900abbd1f555>>
+ * @generated SignedSource<<cdb8f833b38755be4313ffaa9ebfc1ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -39,6 +39,7 @@ export type pointCloudStore_clustersQuery$data = {
       readonly primaryValue: number | null;
       readonly referenceValue: number | null;
     };
+    readonly primaryToCorpusRatio: number | null;
   }>;
 };
 export type pointCloudStore_clustersQuery = {
@@ -165,6 +166,13 @@ v10 = [
         "storageKey": null
       },
       {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "primaryToCorpusRatio",
+        "storageKey": null
+      },
+      {
         "condition": "fetchDataQualityMetric",
         "kind": "Condition",
         "passingValue": true,
@@ -269,16 +277,16 @@ return {
     "selections": (v10/*: any*/)
   },
   "params": {
-    "cacheID": "6f74afd7fff7f035a547d33c9e35053b",
+    "cacheID": "a1a02d970d255935edfcdd797e4ca80d",
     "id": null,
     "metadata": {},
     "name": "pointCloudStore_clustersQuery",
     "operationKind": "query",
-    "text": "query pointCloudStore_clustersQuery(\n  $eventIds: [ID!]!\n  $coordinates: [InputCoordinate3D!]!\n  $minClusterSize: Int!\n  $clusterMinSamples: Int!\n  $clusterSelectionEpsilon: Float!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  hdbscanClustering(eventIds: $eventIds, coordinates3d: $coordinates, minClusterSize: $minClusterSize, clusterMinSamples: $clusterMinSamples, clusterSelectionEpsilon: $clusterSelectionEpsilon) {\n    id\n    eventIds\n    driftRatio\n    dataQualityMetric(metric: {metric: mean, columnName: $dataQualityMetricColumnName}) @include(if: $fetchDataQualityMetric) {\n      primaryValue\n      referenceValue\n    }\n    performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n      primaryValue\n      referenceValue\n    }\n  }\n}\n"
+    "text": "query pointCloudStore_clustersQuery(\n  $eventIds: [ID!]!\n  $coordinates: [InputCoordinate3D!]!\n  $minClusterSize: Int!\n  $clusterMinSamples: Int!\n  $clusterSelectionEpsilon: Float!\n  $fetchDataQualityMetric: Boolean!\n  $dataQualityMetricColumnName: String\n  $fetchPerformanceMetric: Boolean!\n  $performanceMetric: PerformanceMetric!\n) {\n  hdbscanClustering(eventIds: $eventIds, coordinates3d: $coordinates, minClusterSize: $minClusterSize, clusterMinSamples: $clusterMinSamples, clusterSelectionEpsilon: $clusterSelectionEpsilon) {\n    id\n    eventIds\n    driftRatio\n    primaryToCorpusRatio\n    dataQualityMetric(metric: {metric: mean, columnName: $dataQualityMetricColumnName}) @include(if: $fetchDataQualityMetric) {\n      primaryValue\n      referenceValue\n    }\n    performanceMetric(metric: {metric: $performanceMetric}) @include(if: $fetchPerformanceMetric) {\n      primaryValue\n      referenceValue\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4371042b8b65df77c8cba441031be7a0";
+(node as any).hash = "b26f299a862a3bc4f5487ace49db1d43";
 
 export default node;

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -224,9 +224,13 @@ type HDBSCANParameters = {
   clusterSelectionEpsilon: number;
 };
 
+export type RetrievalMetricDefinition = {
+  type: "retrieval";
+  metric: "queryDistance";
+};
 export type DriftMetricDefinition = {
   type: "drift";
-  metric: "euclideanDistance" | "queryDistance";
+  metric: "euclideanDistance";
 };
 
 export type PerformanceMetricDefinition = {
@@ -246,7 +250,8 @@ export type DataQualityMetricDefinition = {
 export type MetricDefinition =
   | DriftMetricDefinition
   | PerformanceMetricDefinition
-  | DataQualityMetricDefinition;
+  | DataQualityMetricDefinition
+  | RetrievalMetricDefinition;
 
 /**
  * The properties of the point cloud store.
@@ -520,7 +525,7 @@ export const DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS: Partial<PointC
       [DatasetGroup.corpus]: FALLBACK_COLOR,
     },
     metric: {
-      type: "drift",
+      type: "retrieval",
       metric: "queryDistance",
     },
     // Since we are showing clusters by percent query, sort from highest query density to lowest

--- a/app/src/utils/metricFormatUtils.ts
+++ b/app/src/utils/metricFormatUtils.ts
@@ -13,6 +13,11 @@ const METRIC_DEFINITIONS: Record<
     shortName: "Euc. Distance",
     definition: `Euclidean distance over time captures how much your primary dataset's embeddings are drifting from the reference data. Euclidean distance of the embeddings is calculated by taking the centroid of the embedding vectors for each dataset and calculating the distance between the two centroids.`,
   },
+  queryDistance: {
+    name: "Query Distance",
+    shortName: "Query Distance",
+    definition: `The query distance is the euclidean distance of the centroid of queries from the centroid of the corpus.`,
+  },
   accuracyScore: {
     name: "Accuracy Score",
     shortName: "Accuracy",

--- a/src/phoenix/datasets/fixtures.py
+++ b/src/phoenix/datasets/fixtures.py
@@ -347,7 +347,8 @@ wikipedia_fixture = Fixture(
     ),
     prefix="unstructured/search/wiki",
     primary_file_name="queries.parquet",
-    reference_file_name="queries2.parquet",
+    # The reference file is intended purely for troubleshooting bad data. Un-comment for testing.
+    # reference_file_name="queries2.parquet",
     corpus_file_name="corpus.parquet",
 )
 


### PR DESCRIPTION
resolves #928 

Adds a corpus ratio metric as "% query" to the clusters so you can identify clusters that have insufficient supporting documents. Not a perfect metric by any means and requires further investigation.
<img width="2560" alt="Screenshot 2023-07-24 at 9 52 12 AM" src="https://github.com/Arize-ai/phoenix/assets/5640648/eb4104e3-5eef-4acd-a9ec-38be9a3eca68">
