### PR TITLE
feat(datasets): make corpus schema declaration more semantic

### DIFF
--- a/src/phoenix/datasets/fixtures.py
+++ b/src/phoenix/datasets/fixtures.py
@@ -339,8 +339,8 @@ wikipedia_fixture = Fixture(
         response_column_names="answer",
     ),
     corpus_schema=Schema(
-        prediction_id_column_name="id",
-        prompt_column_names=EmbeddingColumnNames(
+        id_column_name="id",
+        document_column_names=EmbeddingColumnNames(
             vector_column_name="embedding",
             raw_data_column_name="text",
         ),

--- a/src/phoenix/datasets/schema.py
+++ b/src/phoenix/datasets/schema.py
@@ -79,6 +79,7 @@ class RetrievalEmbeddingColumnNames(EmbeddingColumnNames):
 @dataclass(frozen=True)
 class Schema:
     prediction_id_column_name: Optional[str] = None
+    id_column_name: Optional[str] = None  # Syntax sugar for prediction_id_column_name
     timestamp_column_name: Optional[str] = None
     feature_column_names: Optional[List[str]] = None
     tag_column_names: Optional[List[str]] = None
@@ -88,8 +89,21 @@ class Schema:
     actual_score_column_name: Optional[str] = None
     prompt_column_names: Optional[Union[EmbeddingColumnNames, RetrievalEmbeddingColumnNames]] = None
     response_column_names: Optional[Union[str, EmbeddingColumnNames]] = None
+    # document_column_names is used explicitly when the schema is used to capture a corpus
+    document_column_names: Optional[EmbeddingColumnNames] = None
     embedding_feature_column_names: Optional[EmbeddingFeatures] = None
     excluded_column_names: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        # re-map document_column_names to be in the prompt_column_names position
+        # This is a shortcut to leverage the same schema for model and corpus datasets
+        if self.document_column_names is not None:
+            object.__setattr__(self, "prompt_column_names", self.document_column_names)
+            object.__setattr__(self, "document_column_names", None)
+
+        if self.id_column_name is not None:
+            object.__setattr__(self, "prediction_id_column_name", self.id_column_name)
+            object.__setattr__(self, "id_column_name", None)
 
     def replace(self, **changes: str) -> "Schema":
         return replace(self, **changes)

--- a/tests/datasets/test_schema.py
+++ b/tests/datasets/test_schema.py
@@ -62,3 +62,23 @@ def test_json_serialization_with_relationships():
 
     assert schema_from_json.prompt_column_names is not None
     assert schema_from_json.prompt_column_names.context_retrieval_ids_column_name == "ids_1"
+
+
+def test_corpus_schema_normalization():
+    s = Schema(
+        id_column_name="id_1",
+        document_column_names=EmbeddingColumnNames(
+            vector_column_name="vec_1",
+            raw_data_column_name="raw_1",
+        ),
+    )
+
+    # In the post-init, the document should be re-mapped to the prompt
+    assert s.document_column_names is None
+    assert s.prompt_column_names is not None
+    assert s.prompt_column_names.vector_column_name == "vec_1"
+    assert s.prompt_column_names.raw_data_column_name == "raw_1"
+
+    # The id column should be re-mapped to the prediction_id_column_name
+    assert s.id_column_name is None
+    assert s.prediction_id_column_name == "id_1"


### PR DESCRIPTION
resolves #941 
Adds attribute aliases to make corpus dataset construction more declarative. This avoids doing all the plumbing in favor of just re-mapping the columns as they serve the same functionality.

```python
corpus_schema=Schema(
        id_column_name="id",
        document_column_names=EmbeddingColumnNames(
            vector_column_name="embedding",
            raw_data_column_name="text",
        ),
    )
```