### PR TITLE
fix: remove copy= from set_axis for older pandas

### DIFF
--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -328,10 +328,7 @@ class Column:
             except KeyError:
                 # It's important to glue the index to the default series,
                 # so it would look like the series came from the dataframe.
-                return self._default(len(data)).set_axis(
-                    data.index,
-                    copy=False,
-                )
+                return self._default(len(data)).set_axis(data.index)
         if isinstance(data, pd.Series):
             try:
                 return data.at[self.name]
@@ -736,10 +733,7 @@ class Dataset(Events):
     def __getitem__(self, key: Any) -> Any:
         if isinstance(key, list):
             return Events(
-                self.iloc[key].set_axis(
-                    key,
-                    copy=False,
-                ),
+                self.iloc[key].set_axis(key),
                 role=self._self_role,
                 _model=self._self_model,
             )
@@ -1390,7 +1384,6 @@ def _coerce_str_column_names(
         df.set_axis(
             df.columns.astype(str),
             axis=1,
-            copy=False,
         )
         for df in dataframes
     )

--- a/src/phoenix/core/model_schema_adapter.py
+++ b/src/phoenix/core/model_schema_adapter.py
@@ -43,7 +43,6 @@ def create_model_from_datasets(*datasets: Optional[Dataset]) -> Model:
         df = df.set_axis(
             map(str, df.columns),
             axis=1,
-            copy=False,
         )
         named_dataframes.append((dataset.name, df))
         dataset_schema = dataset.schema if dataset.schema is not None else DatasetSchema()

--- a/src/phoenix/metrics/binning.py
+++ b/src/phoenix/metrics/binning.py
@@ -154,7 +154,6 @@ class IntervalBinning(BinningMethod):
         return summary.set_axis(
             categories,
             axis=0,
-            copy=False,
         )
 
 

--- a/src/phoenix/metrics/timeseries.py
+++ b/src/phoenix/metrics/timeseries.py
@@ -191,7 +191,6 @@ def _results(
                     timezone.utc,
                 ),
                 axis=0,
-                copy=False,
             )
 
         yield res.loc[result_slice, :]

--- a/tests/core/test_model_schema.py
+++ b/tests/core/test_model_schema.py
@@ -194,10 +194,7 @@ def test_singular_dimensional_role_one_df(
         if column_spec in df.columns:
             assert_series_equal(
                 model[role][PRIMARY],
-                series.set_axis(
-                    model[PRIMARY].index,
-                    copy=False,
-                ),
+                series.set_axis(model[PRIMARY].index),
                 check_names=False,
             )
 

--- a/tests/metrics/test_binning.py
+++ b/tests/metrics/test_binning.py
@@ -275,7 +275,6 @@ def test_segmented_summary_with_interval_binning(
             ordered=True,
         ),
         axis=0,
-        copy=False,
     )
     _compare_summaries(metrics, actual, desired)
 
@@ -369,7 +368,6 @@ def test_segmented_summary_with_categorical_binning(
             ordered=False,
         ),
         axis=0,
-        copy=False,
     )
     _compare_summaries(metrics, actual, desired)
 


### PR DESCRIPTION
copy= for set_axis is new in pandas version 1.5.0