### PR TITLE
feat(tracing): graphQL span time bookends and sorting

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -450,7 +450,7 @@ type Query {
     """HDBSCAN cluster selection epsilon"""
     clusterSelectionEpsilon: Float! = 0
   ): [Cluster!]!
-  spans(first: Int = 50, last: Int, after: String, before: String): SpanConnection!
+  spans(first: Int = 50, last: Int, after: String, before: String, sort: SpanSort): SpanConnection!
 }
 
 type Retrieval {
@@ -475,11 +475,24 @@ type Segments {
   totalCounts: DatasetValues!
 }
 
+enum SortDir {
+  asc
+  desc
+}
+
 type Span {
   name: String!
+  startTime: DateTime!
+  endTime: DateTime!
+
+  """the parent span ID. If null, it is a root span"""
   parentId: ID
   spanKind: SpanKind!
   context: SpanContext!
+}
+
+enum SpanColumn {
+  startTime
 }
 
 type SpanConnection {
@@ -504,6 +517,11 @@ enum SpanKind {
   retriever
   embedding
   unknown
+}
+
+input SpanSort {
+  col: SpanColumn!
+  dir: SortDir!
 }
 
 input TimeRange {

--- a/app/src/pages/trace/SpansTable.tsx
+++ b/app/src/pages/trace/SpansTable.tsx
@@ -16,13 +16,15 @@ export function SpansTable(props: SpansTableProps) {
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 50 }
         cursor: { type: "String", defaultValue: null }
+        sort: { type: "SpanSort", defaultValue: { col: startTime, dir: desc } }
       ) {
-        spans(first: $count, after: $cursor)
+        spans(first: $count, after: $cursor, sort: $sort)
           @connection(key: "SpansTable_spans") {
           edges {
             span: node {
               spanKind
               name
+              startTime
               context {
                 spanId
                 traceId
@@ -65,6 +67,7 @@ export function SpansTable(props: SpansTableProps) {
       Header: "name",
       accessor: "name",
     },
+    { Header: "start time", accessor: "startTime" },
   ];
   return <Table columns={columns} data={tableData} />;
 }

--- a/app/src/pages/trace/__generated__/SpansTableSpansQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpansTableSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5914e63cab1cb78a15e301e7c4921eeb>>
+ * @generated SignedSource<<4b66d06c2cac214e69472e467dc6dfcb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,9 +10,16 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type SortDir = "asc" | "desc";
+export type SpanColumn = "startTime";
+export type SpanSort = {
+  col: SpanColumn;
+  dir: SortDir;
+};
 export type SpansTableSpansQuery$variables = {
   count?: number | null;
   cursor?: string | null;
+  sort?: SpanSort | null;
 };
 export type SpansTableSpansQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"SpansTable_spans">;
@@ -33,9 +40,22 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "cursor"
+  },
+  {
+    "defaultValue": {
+      "col": "startTime",
+      "dir": "desc"
+    },
+    "kind": "LocalArgument",
+    "name": "sort"
   }
 ],
-v1 = [
+v1 = {
+  "kind": "Variable",
+  "name": "sort",
+  "variableName": "sort"
+},
+v2 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -45,7 +65,8 @@ v1 = [
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
-  }
+  },
+  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -65,7 +86,8 @@ return {
             "kind": "Variable",
             "name": "cursor",
             "variableName": "cursor"
-          }
+          },
+          (v1/*: any*/)
         ],
         "kind": "FragmentSpread",
         "name": "SpansTable_spans"
@@ -82,7 +104,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
@@ -116,6 +138,13 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "startTime",
                     "storageKey": null
                   },
                   {
@@ -204,8 +233,10 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
-        "filters": null,
+        "args": (v2/*: any*/),
+        "filters": [
+          "sort"
+        ],
         "handle": "connection",
         "key": "SpansTable_spans",
         "kind": "LinkedHandle",
@@ -214,16 +245,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d0340243cada8c9990357fcaf120d78e",
+    "cacheID": "190e2cb2688d78630c8b3d7242941dac",
     "id": null,
     "metadata": {},
     "name": "SpansTableSpansQuery",
     "operationKind": "query",
-    "text": "query SpansTableSpansQuery(\n  $count: Int = 50\n  $cursor: String = null\n) {\n  ...SpansTable_spans_1G22uz\n}\n\nfragment SpansTable_spans_1G22uz on Query {\n  spans(first: $count, after: $cursor) {\n    edges {\n      span: node {\n        spanKind\n        name\n        context {\n          spanId\n          traceId\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SpansTableSpansQuery(\n  $count: Int = 50\n  $cursor: String = null\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...SpansTable_spans_1RfMLO\n}\n\nfragment SpansTable_spans_1RfMLO on Query {\n  spans(first: $count, after: $cursor, sort: $sort) {\n    edges {\n      span: node {\n        spanKind\n        name\n        startTime\n        context {\n          spanId\n          traceId\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0d55717965759fe0048939bb211159db";
+(node as any).hash = "484eed39cb35d63c53782219b07d0fcc";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7a4d450cc07b874013d8c67c2532feb8>>
+ * @generated SignedSource<<e8e9945ccf345c5819075b9e887e1513>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,7 @@ export type SpansTable_spans$data = {
         };
         readonly name: string;
         readonly spanKind: SpanKind;
+        readonly startTime: string;
       };
     }>;
   };
@@ -46,6 +47,14 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "cursor"
+    },
+    {
+      "defaultValue": {
+        "col": "startTime",
+        "dir": "desc"
+      },
+      "kind": "LocalArgument",
+      "name": "sort"
     }
   ],
   "kind": "Fragment",
@@ -75,7 +84,13 @@ return {
   "selections": [
     {
       "alias": "spans",
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort"
+        }
+      ],
       "concreteType": "SpanConnection",
       "kind": "LinkedField",
       "name": "__SpansTable_spans_connection",
@@ -109,6 +124,13 @@ return {
                   "args": null,
                   "kind": "ScalarField",
                   "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "startTime",
                   "storageKey": null
                 },
                 {
@@ -201,6 +223,6 @@ return {
 };
 })();
 
-(node as any).hash = "0d55717965759fe0048939bb211159db";
+(node as any).hash = "484eed39cb35d63c53782219b07d0fcc";
 
 export default node;

--- a/app/src/pages/trace/__generated__/TracePageQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TracePageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1d2128d2865aca4470e22b4afd82882>>
+ * @generated SignedSource<<4e8b734e796837a98b60ebeb4606404a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,14 @@ var v0 = [
     "kind": "Literal",
     "name": "first",
     "value": 50
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": {
+      "col": "startTime",
+      "dir": "desc"
+    }
   }
 ];
 return {
@@ -85,6 +93,13 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "startTime",
                     "storageKey": null
                   },
                   {
@@ -169,12 +184,14 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "spans(first:50)"
+        "storageKey": "spans(first:50,sort:{\"col\":\"startTime\",\"dir\":\"desc\"})"
       },
       {
         "alias": null,
         "args": (v0/*: any*/),
-        "filters": null,
+        "filters": [
+          "sort"
+        ],
         "handle": "connection",
         "key": "SpansTable_spans",
         "kind": "LinkedHandle",
@@ -183,12 +200,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7012f608596f909ae204ddadff15eded",
+    "cacheID": "e433a8eecb277f44ef5896d0bd06c49f",
     "id": null,
     "metadata": {},
     "name": "TracePageQuery",
     "operationKind": "query",
-    "text": "query TracePageQuery {\n  ...SpansTable_spans\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 50) {\n    edges {\n      span: node {\n        spanKind\n        name\n        context {\n          spanId\n          traceId\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query TracePageQuery {\n  ...SpansTable_spans\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 50, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        startTime\n        context {\n          spanId\n          traceId\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/phoenix/server/api/input_types/SpanSort.py
+++ b/src/phoenix/server/api/input_types/SpanSort.py
@@ -1,13 +1,14 @@
 from enum import Enum
 
 import strawberry
+from pandas import DataFrame
 
 from phoenix.server.api.types.SortDir import SortDir
 
 
 @strawberry.enum
 class SpanColumn(Enum):
-    startTime = "startTime"
+    startTime = "start_time"
 
 
 @strawberry.input
@@ -18,3 +19,12 @@ class SpanSort:
 
     col: SpanColumn
     dir: SortDir
+
+    def apply(self, spans: DataFrame) -> DataFrame:
+        """
+        Sorts the spans by the given column and direction
+        """
+        return spans.sort_values(
+            by=self.col.value,
+            ascending=self.dir.value == SortDir.asc.value,
+        )

--- a/src/phoenix/server/api/input_types/SpanSort.py
+++ b/src/phoenix/server/api/input_types/SpanSort.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+import strawberry
+
+from phoenix.server.api.types.SortDir import SortDir
+
+
+@strawberry.enum
+class SpanColumn(Enum):
+    startTime = "startTime"
+
+
+@strawberry.input
+class SpanSort:
+    """
+    The sort column and direction for span connections
+    """
+
+    col: SpanColumn
+    dir: SortDir

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -30,7 +30,7 @@ from .types.Functionality import Functionality
 from .types.Model import Model
 from .types.node import GlobalID, Node, from_global_id
 from .types.pagination import Connection, ConnectionArgs, Cursor, connection_from_list
-from .types.Span import Span, SpanContext
+from .types.Span import Span, to_gql_span
 
 
 @strawberry.type
@@ -203,18 +203,7 @@ class Query:
         spans = (
             []
             if info.context.traces is None
-            else [
-                Span(
-                    name=row["name"],
-                    parent_id=row["parent_id"],
-                    span_kind=row["span_kind"],
-                    context=SpanContext(
-                        trace_id=row["context.trace_id"],
-                        span_id=row["context.span_id"],
-                    ),
-                )
-                for _, row in info.context.traces._dataframe.iterrows()
-            ]
+            else [to_gql_span(row) for _, row in info.context.traces._dataframe.iterrows()]
         )
 
         return connection_from_list(

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from itertools import chain
-from typing import Dict, List, Optional, Set, Union, cast
+from typing import Dict, List, Optional, Set, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -206,12 +206,7 @@ class Query:
         sort: Optional[SpanSort] = UNSET,
     ) -> Connection[Span]:
         # The default sort order is by start time
-        sort = cast(
-            SpanSort,
-            sort
-            if sort not in (UNSET, None)
-            else SpanSort(col=SpanColumn.startTime, dir=SortDir.asc),
-        )
+        sort = sort or SpanSort(col=SpanColumn.startTime, dir=SortDir.asc)
         # Convert dataframe rows to Span objects
         spans = (
             []

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -15,7 +15,7 @@ from phoenix.server.api.input_types.ClusterInput import ClusterInput
 from phoenix.server.api.types.Cluster import Cluster, to_gql_clusters
 
 from .context import Context
-from .input_types import Coordinates
+from .input_types import Coordinates, SpanSort
 from .types.DatasetRole import AncillaryDatasetRole, DatasetRole
 from .types.Dimension import to_gql_dimension
 from .types.EmbeddingDimension import (
@@ -198,6 +198,7 @@ class Query:
         last: Optional[int] = UNSET,
         after: Optional[Cursor] = UNSET,
         before: Optional[Cursor] = UNSET,
+        sort: Optional[SpanSort] = UNSET,
     ) -> Connection[Span]:
         # Convert dataframe rows to Span objects
         spans = (

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -12,10 +12,14 @@ from typing_extensions import Annotated
 from phoenix.pointcloud.clustering import Hdbscan
 from phoenix.server.api.helpers import ensure_list
 from phoenix.server.api.input_types.ClusterInput import ClusterInput
+from phoenix.server.api.input_types.Coordinates import (
+    InputCoordinate2D,
+    InputCoordinate3D,
+)
+from phoenix.server.api.input_types.SpanSort import SpanSort
 from phoenix.server.api.types.Cluster import Cluster, to_gql_clusters
 
 from .context import Context
-from .input_types import Coordinates, SpanSort
 from .types.DatasetRole import AncillaryDatasetRole, DatasetRole
 from .types.Dimension import to_gql_dimension
 from .types.EmbeddingDimension import (
@@ -83,13 +87,13 @@ class Query:
             ),
         ],
         coordinates_2d: Annotated[
-            Optional[List[Coordinates.InputCoordinate2D]],
+            Optional[List[InputCoordinate2D]],
             strawberry.argument(
                 description="Point coordinates. Must be either 2D or 3D.",
             ),
         ] = UNSET,
         coordinates_3d: Annotated[
-            Optional[List[Coordinates.InputCoordinate3D]],
+            Optional[List[InputCoordinate3D]],
             strawberry.argument(
                 description="Point coordinates. Must be either 2D or 3D.",
             ),

--- a/src/phoenix/server/api/types/Model.py
+++ b/src/phoenix/server/api/types/Model.py
@@ -40,11 +40,6 @@ class Model:
         include: Optional[DimensionFilter] = UNSET,
         exclude: Optional[DimensionFilter] = UNSET,
     ) -> Connection[Dimension]:
-        """
-        A non-trivial implementation should efficiently fetch only
-        the necessary books after the offset.
-        For simplicity, here we build the list and then slice it accordingly
-        """
         model = info.context.model
         return connection_from_list(
             [

--- a/src/phoenix/server/api/types/SortDir.py
+++ b/src/phoenix/server/api/types/SortDir.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class SortDir(Enum):
+    """
+    Sort directions
+    """
+
+    asc = "asc"
+    desc = "desc"

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -44,6 +44,9 @@ class Span:
 
 
 def to_gql_span(row: Series[Any]) -> Span:
+    """
+    Converts a dataframe row to a graphQL span
+    """
     return Span(
         name=row["name"],
         parent_id=row["parent_id"],

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -43,7 +43,7 @@ class Span:
     context: SpanContext
 
 
-def to_gql_span(row: Series[Any]) -> Span:
+def to_gql_span(row: "Series[Any]") -> Span:
     """
     Converts a dataframe row to a graphQL span
     """

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 import strawberry
+from pandas import Series
 from strawberry import ID
 
 from phoenix.trace.schemas import SpanKind as CoreSpanKind
@@ -32,6 +34,24 @@ class SpanContext:
 @strawberry.type
 class Span:
     name: str
-    parent_id: Optional[ID]
+    start_time: datetime
+    end_time: datetime
+    parent_id: Optional[ID] = strawberry.field(
+        description="the parent span ID. If null, it is a root span"
+    )
     span_kind: SpanKind
     context: SpanContext
+
+
+def to_gql_span(row: Series[Any]) -> Span:
+    return Span(
+        name=row["name"],
+        parent_id=row["parent_id"],
+        span_kind=row["span_kind"],
+        start_time=row["start_time"],
+        end_time=row["end_time"],
+        context=SpanContext(
+            trace_id=row["context.trace_id"],
+            span_id=row["context.span_id"],
+        ),
+    )

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -15,6 +15,16 @@ REQUIRED_COLUMNS = [
 ]
 
 
+def normalize_dataframe(dataframe: DataFrame) -> "DataFrame":
+    """Makes the dataframe have appropriate data types"""
+
+    # Convert the start and end times to datetime
+    dataframe["start_time"] = pd.to_datetime(dataframe["start_time"])
+    dataframe["end_time"] = pd.to_datetime(dataframe["end_time"])
+
+    return dataframe
+
+
 class TraceDataset:
     """
     A TraceDataset is a wrapper around a dataframe which is a flattened representation
@@ -34,4 +44,4 @@ class TraceDataset:
             raise ValueError(
                 f"The dataframe is missing some required columns: {', '.join(missing_columns)}"
             )
-        self.dataframe = dataframe
+        self.dataframe = normalize_dataframe(dataframe)


### PR DESCRIPTION
resolves #1062 
resolves #1069
NB: does not include UI sorting.

Adds graphql sorting support for start/end times and sorting based on the startTime. For now only supporting single column sort, though we could extend this pretty easily by making it a list of sorts in the future.