### PR TITLE
fix: snap to end of day

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -71,7 +71,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:traces & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:credit_card_fraud & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/contexts/TimeRangeContext.tsx
+++ b/app/src/contexts/TimeRangeContext.tsx
@@ -9,7 +9,6 @@ import React, {
 } from "react";
 import {
   addDays,
-  addSeconds,
   endOfDay,
   endOfHour,
   roundToNearestMinutes,

--- a/app/src/contexts/TimeRangeContext.tsx
+++ b/app/src/contexts/TimeRangeContext.tsx
@@ -67,7 +67,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
   const timeRange = useMemo(() => {
     // The timeRangeBounds come from the start / end of the primary dataset
     // Because our time windows are right open (don't include the right time), we need to expand it by a small amount
-    // endOfHourTime is used for hour level time ranges, and endOfDay is used for day level time ranges
+    // endOfHour is used for hour level time ranges, and endOfDay is used for day level time ranges
     const paddedEndTimeBounds = addSeconds(timeRangeBounds.end, 1);
 
     switch (timePreset) {

--- a/app/src/contexts/TimeRangeContext.tsx
+++ b/app/src/contexts/TimeRangeContext.tsx
@@ -65,15 +65,10 @@ type TimeRangeProviderProps = {
 
 function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
   const timeRange = useMemo(() => {
-    // The timeRangeBounds come from the start / end of the primary dataset
-    // Because our time windows are right open (don't include the right time), we need to expand it by a small amount
-    // endOfHour is used for hour level time ranges, and endOfDay is used for day level time ranges
-    const paddedEndTimeBounds = addSeconds(timeRangeBounds.end, 1);
-
     switch (timePreset) {
       case TimePreset.last_day: {
         const endTimeBounds = roundToNearestMinutes(
-          endOfHour(paddedEndTimeBounds),
+          endOfHour(timeRangeBounds.end),
           { roundingMethod: "floor" }
         );
         return {
@@ -83,7 +78,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
       }
       case TimePreset.last_week: {
         const endTimeBounds = roundToNearestMinutes(
-          endOfDay(paddedEndTimeBounds),
+          endOfDay(timeRangeBounds.end),
           { roundingMethod: "floor" }
         );
         return {
@@ -93,7 +88,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
       }
       case TimePreset.last_month: {
         const endTimeBounds = roundToNearestMinutes(
-          endOfDay(paddedEndTimeBounds),
+          endOfDay(timeRangeBounds.end),
           { roundingMethod: "floor" }
         );
         return {
@@ -103,7 +98,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
       }
       case TimePreset.last_3_months: {
         const endTimeBounds = roundToNearestMinutes(
-          endOfDay(paddedEndTimeBounds),
+          endOfDay(timeRangeBounds.end),
           { roundingMethod: "floor" }
         );
         return {
@@ -134,7 +129,7 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
       }
       case TimePreset.all: {
         const endTimeBounds = roundToNearestMinutes(
-          endOfDay(paddedEndTimeBounds),
+          endOfDay(timeRangeBounds.end),
           { roundingMethod: "floor" }
         );
         const startTimeBounds = startOfDay(timeRangeBounds.start);

--- a/app/src/contexts/TimeRangeContext.tsx
+++ b/app/src/contexts/TimeRangeContext.tsx
@@ -10,8 +10,10 @@ import React, {
 import {
   addDays,
   addSeconds,
+  endOfDay,
   endOfHour,
   roundToNearestMinutes,
+  startOfDay,
   startOfHour,
   subDays,
 } from "date-fns";
@@ -65,52 +67,82 @@ function useTimeRangeMemo(timePreset: TimePreset, timeRangeBounds: TimeRange) {
   const timeRange = useMemo(() => {
     // The timeRangeBounds come from the start / end of the primary dataset
     // Because our time windows are right open (don't include the right time), we need to expand it by a small amount
-    const endTimeBounds = roundToNearestMinutes(
-      endOfHour(addSeconds(timeRangeBounds.end, 1)),
-      { roundingMethod: "floor" }
-    );
-    const startTimeBounds = startOfHour(timeRangeBounds.start);
+    // endOfHourTime is used for hour level time ranges, and endOfDay is used for day level time ranges
+    const paddedEndTimeBounds = addSeconds(timeRangeBounds.end, 1);
+
     switch (timePreset) {
-      case TimePreset.last_day:
+      case TimePreset.last_day: {
+        const endTimeBounds = roundToNearestMinutes(
+          endOfHour(paddedEndTimeBounds),
+          { roundingMethod: "floor" }
+        );
         return {
           start: subDays(endTimeBounds, 1),
           end: endTimeBounds,
         };
-      case TimePreset.last_week:
+      }
+      case TimePreset.last_week: {
+        const endTimeBounds = roundToNearestMinutes(
+          endOfDay(paddedEndTimeBounds),
+          { roundingMethod: "floor" }
+        );
         return {
           start: subDays(endTimeBounds, 7),
           end: endTimeBounds,
         };
-      case TimePreset.last_month:
+      }
+      case TimePreset.last_month: {
+        const endTimeBounds = roundToNearestMinutes(
+          endOfDay(paddedEndTimeBounds),
+          { roundingMethod: "floor" }
+        );
         return {
           start: subDays(endTimeBounds, 30),
           end: endTimeBounds,
         };
-      case TimePreset.last_3_months:
+      }
+      case TimePreset.last_3_months: {
+        const endTimeBounds = roundToNearestMinutes(
+          endOfDay(paddedEndTimeBounds),
+          { roundingMethod: "floor" }
+        );
         return {
           start: subDays(endTimeBounds, 90),
           end: endTimeBounds,
         };
-      case TimePreset.first_day:
+      }
+      case TimePreset.first_day: {
+        const startTimeBounds = startOfHour(timeRangeBounds.start);
         return {
           start: startTimeBounds,
           end: addDays(startTimeBounds, 1),
         };
-      case TimePreset.first_week:
+      }
+      case TimePreset.first_week: {
+        const startTimeBounds = startOfDay(timeRangeBounds.start);
         return {
           start: startTimeBounds,
           end: addDays(startTimeBounds, 7),
         };
-      case TimePreset.first_month:
+      }
+      case TimePreset.first_month: {
+        const startTimeBounds = startOfDay(timeRangeBounds.start);
         return {
           start: startTimeBounds,
           end: addDays(startTimeBounds, 30),
         };
-      case TimePreset.all:
+      }
+      case TimePreset.all: {
+        const endTimeBounds = roundToNearestMinutes(
+          endOfDay(paddedEndTimeBounds),
+          { roundingMethod: "floor" }
+        );
+        const startTimeBounds = startOfDay(timeRangeBounds.start);
         return {
           start: startTimeBounds,
           end: endTimeBounds,
         };
+      }
       default:
         assertUnreachable(timePreset);
     }


### PR DESCRIPTION
Snaps the timestamps to the end of the day for larger time ranges to make the time buckets more intuitive.