### PR TITLE
fix: restricting pydantic version for unit tests with llama-index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,9 @@ dependencies = [
   "llama-index==0.8.1",
   "openai",
   "tenacity",
-  "nltk==3.8.1", 
+  "nltk==3.8.1",
   "sentence-transformers==2.2.2",
+  "pydantic<2",  # for langchain root_validator
 ]
 
 [tool.hatch.envs.type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ ignore-nested-classes = false
 ignore-setters = false
 
 [tool.mypy]
-plugins = ["strawberry.ext.mypy_plugin"]
+plugins = ["strawberry.ext.mypy_plugin", "pydantic.mypy"]
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs  = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dependencies = [
   "tenacity",
   "nltk==3.8.1",
   "sentence-transformers==2.2.2",
-  "pydantic<2",  # for langchain root_validator
+  "pydantic<2",  # for @root_validator in llama-index
 ]
 
 [tool.hatch.envs.type]

--- a/scripts/data/build_langchain_vector_store.py
+++ b/scripts/data/build_langchain_vector_store.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         chunk_size=200,
     )
 
-    embedding_model = OpenAIEmbeddings(model=embedding_model_name)  # type: ignore
+    embedding_model = OpenAIEmbeddings(model=embedding_model_name)
     shutil.rmtree(args.persist_path, ignore_errors=True)
     vector_store = Chroma.from_documents(
         chunked_langchain_documents, embedding=embedding_model, persist_directory=args.persist_path


### PR DESCRIPTION
> tests/experimental/callbacks/conftest.py:4: in <module>
    from llama_index.embeddings.base import BaseEmbedding
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/llama_index/__init__.py:12: in <module>
    from llama_index.data_structs.struct_type import IndexStructType
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/llama_index/data_structs/__init__.py:3: in <module>
    from llama_index.data_structs.data_structs import (
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/llama_index/data_structs/data_structs.py:14: in <module>
    from llama_index.schema import BaseNode, TextNode
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/llama_index/schema.py:215: in <module>
    class TextNode(BaseNode):
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/llama_index/schema.py:243: in TextNode
    def _check_hash(cls, values: dict) -> dict:
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/pydantic/deprecated/class_validators.py:222: in root_validator
    return root_validator()(*__args)  # type: ignore
../../../Library/Application Support/hatch/env/virtual/arize-phoenix/ms61Mhcn/test.py3.8/lib/python3.8/site-packages/pydantic/deprecated/class_validators.py:228: in root_validator
    raise PydanticUserError(
E   pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.
E   
E   For further information visit https://errors.pydantic.dev/2.2/u/root-validator-pre-skip