### PR TITLE
refactor(tracing): make SpanIO type have mimetype value pair be required

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -502,8 +502,8 @@ type Span {
   tokenCountTotal: Int
   tokenCountPrompt: Int
   tokenCountCompletion: Int
-  input: SpanIOValue!
-  output: SpanIOValue!
+  input: SpanIOValue
+  output: SpanIOValue
   events: [SpanEvent!]!
 
   """All descendant spans (children, grandchildren, etc.)"""
@@ -542,7 +542,7 @@ type SpanEvent {
 
 type SpanIOValue {
   mimeType: MimeType!
-  value: String
+  value: String!
 }
 
 enum SpanKind {

--- a/app/src/pages/tracing/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/tracing/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<153efabbd137d63e9e0562f5cbaa8699>>
+ * @generated SignedSource<<1be23033bf88ab61ca88b79f028338af>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,14 +23,14 @@ export type SpansTable_spans$data = {
         };
         readonly input: {
           readonly mimeType: MimeType;
-          readonly value: string | null;
-        };
+          readonly value: string;
+        } | null;
         readonly latencyMs: number;
         readonly name: string;
         readonly output: {
           readonly mimeType: MimeType;
-          readonly value: string | null;
-        };
+          readonly value: string;
+        } | null;
         readonly spanKind: SpanKind;
         readonly startTime: string;
         readonly statusCode: SpanStatusCode;

--- a/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b7ec51c220a9476278161ccf9afeb818>>
+ * @generated SignedSource<<533089643ce2730bd212c7f1073a0242>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,13 +26,13 @@ export type TracesTable_spans$data = {
             readonly traceId: string;
           };
           readonly input: {
-            readonly value: string | null;
-          };
+            readonly value: string;
+          } | null;
           readonly latencyMs: number;
           readonly name: string;
           readonly output: {
-            readonly value: string | null;
-          };
+            readonly value: string;
+          } | null;
           readonly parentId: string | null;
           readonly spanKind: SpanKind;
           readonly startTime: string;
@@ -40,13 +40,13 @@ export type TracesTable_spans$data = {
           readonly tokenCountTotal: number | null;
         }>;
         readonly input: {
-          readonly value: string | null;
-        };
+          readonly value: string;
+        } | null;
         readonly latencyMs: number;
         readonly name: string;
         readonly output: {
-          readonly value: string | null;
-        };
+          readonly value: string;
+        } | null;
         readonly parentId: string | null;
         readonly spanKind: SpanKind;
         readonly startTime: string;


### PR DESCRIPTION
As an API consumer, it's better to be able to know if IO is entirely missing or does exist in it's entirety. This adjusts it so that the typing is simpler as a consumer.