### PR TITLE
chore: make langchain notebook and scripts a bit more re-usable

### DIFF
--- a/scripts/data/build_langchain_vector_store.py
+++ b/scripts/data/build_langchain_vector_store.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
 """
 Builds and persists a LangChain vector store over the Arize documentation using Chroma.
 """
 
 import argparse
+import getpass
 import logging
 import shutil
 import sys
@@ -89,7 +91,13 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--persist-path", type=str, required=True, help="Path to persist index.")
+    parser.add_argument(
+        "--persist-path",
+        type=str,
+        required=False,
+        help="Path to persist index.",
+        default=f"/Users/{getpass.getuser()}/langchain-chroma-arize-docs",
+    )
     args = parser.parse_args()
 
     docs_url = "https://docs.arize.com/arize/"

--- a/tutorials/internal/langchain_callback.ipynb
+++ b/tutorials/internal/langchain_callback.ipynb
@@ -22,6 +22,7 @@
     "\n",
     "import openai\n",
     "import phoenix as px\n",
+    "import getpass\n",
     "from langchain.chains import RetrievalQA\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.embeddings import OpenAIEmbeddings\n",
@@ -37,9 +38,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "openai_api_key = getpass(\"Enter your OpenAI API key\")\n",
-    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key\n",
-    "openai.api_key = openai_api_key"
+    "if os.environ.get(\"OPENAI_API_KEY\") is None:\n",
+    "    openai_api_key = getpass.getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "    openai.api_key = openai_api_key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai.api_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log_to_langsmith = True\n",
+    "\n",
+    "# Log to Langsmith if the key exists\n",
+    "if os.environ.get(\"LANGCHAIN_API_KEY\") and log_to_langsmith:\n",
+    "    os.environ[\"LANGCHAIN_TRACING_V2\"]=\"true\"\n",
+    "    os.environ[\"LANGCHAIN_ENDPOINT\"]=\"https://api.smith.langchain.com\"\n",
+    "    os.environ[\"LANGCHAIN_PROJECT\"]=\"phoenix-develop\"\n",
+    "    print(\"🔑 Langsmith API key found, logging to Langsmith\")\n",
+    "else:\n",
+    "    print(\"💤 No Langsmith API key found, not logging to Langsmith\")    "
    ]
   },
   {
@@ -50,13 +70,14 @@
    "source": [
     "embeddings = OpenAIEmbeddings(model=\"text-embedding-ada-002\")\n",
     "vector_store = Chroma(\n",
-    "    persist_directory=\"/Users/mikeldking/langchain-chroma-arize-docs\", embedding_function=embeddings\n",
+    "    persist_directory=f\"/Users/{getpass.getuser()}/langchain-chroma-arize-docs\", embedding_function=embeddings\n",
     ")\n",
+    "chain_type = \"refine\" # stuff, refine, map_reduce, and map_rerank\n",
     "chat_model_name = \"gpt-3.5-turbo\"\n",
     "llm = ChatOpenAI(model_name=chat_model_name)\n",
     "chain = RetrievalQA.from_chain_type(\n",
     "    llm=llm,\n",
-    "    chain_type=\"stuff\",\n",
+    "    chain_type=chain_type,\n",
     "    retriever=vector_store.as_retriever(),\n",
     ")\n",
     "tracer = OpenInferenceTracer()"

--- a/tutorials/internal/langchain_callback.ipynb
+++ b/tutorials/internal/langchain_callback.ipynb
@@ -54,12 +54,12 @@
     "\n",
     "# Log to Langsmith if the key exists\n",
     "if os.environ.get(\"LANGCHAIN_API_KEY\") and log_to_langsmith:\n",
-    "    os.environ[\"LANGCHAIN_TRACING_V2\"]=\"true\"\n",
-    "    os.environ[\"LANGCHAIN_ENDPOINT\"]=\"https://api.smith.langchain.com\"\n",
-    "    os.environ[\"LANGCHAIN_PROJECT\"]=\"phoenix-develop\"\n",
+    "    os.environ[\"LANGCHAIN_TRACING_V2\"] = \"true\"\n",
+    "    os.environ[\"LANGCHAIN_ENDPOINT\"] = \"https://api.smith.langchain.com\"\n",
+    "    os.environ[\"LANGCHAIN_PROJECT\"] = \"phoenix-develop\"\n",
     "    print(\"🔑 Langsmith API key found, logging to Langsmith\")\n",
     "else:\n",
-    "    print(\"💤 No Langsmith API key found, not logging to Langsmith\")    "
+    "    print(\"💤 No Langsmith API key found, not logging to Langsmith\")"
    ]
   },
   {
@@ -70,9 +70,10 @@
    "source": [
     "embeddings = OpenAIEmbeddings(model=\"text-embedding-ada-002\")\n",
     "vector_store = Chroma(\n",
-    "    persist_directory=f\"/Users/{getpass.getuser()}/langchain-chroma-arize-docs\", embedding_function=embeddings\n",
+    "    persist_directory=f\"/Users/{getpass.getuser()}/langchain-chroma-arize-docs\",\n",
+    "    embedding_function=embeddings,\n",
     ")\n",
-    "chain_type = \"refine\" # stuff, refine, map_reduce, and map_rerank\n",
+    "chain_type = \"refine\"  # stuff, refine, map_reduce, and map_rerank\n",
     "chat_model_name = \"gpt-3.5-turbo\"\n",
     "llm = ChatOpenAI(model_name=chat_model_name)\n",
     "chain = RetrievalQA.from_chain_type(\n",


### PR DESCRIPTION
Makes paths a bit more consistent, makes the chain_type easier to swap out, and allows you to compare with langsmith runs.