### PR TITLE
ci: exclude scripts/data from type checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ disallow_incomplete_defs  = true
 strict = true
 exclude = [
   "dist/",
+  "scripts/data/",
   "sdist/",
   "tests/",
   "tutorials/",


### PR DESCRIPTION
to side step a recurring problem with OpenAIEmbeddings

> scripts/data/build_langchain_vector_store.py:112: error: Missing named argument "client" for "OpenAIEmbeddings"  [call-arg]