### PR TITLE
refactor(tracing): change llm messages to a list of objects

### DIFF
--- a/src/phoenix/experimental/callbacks/llama_index_trace_callback_handler.py
+++ b/src/phoenix/experimental/callbacks/llama_index_trace_callback_handler.py
@@ -34,6 +34,8 @@ from phoenix.trace.semantic_conventions import (
     INPUT_MIME_TYPE,
     INPUT_VALUE,
     LLM_MESSAGES,
+    MESSAGE_CONTENT,
+    MESSAGE_ROLE,
     OUTPUT_MIME_TYPE,
     OUTPUT_VALUE,
     RETRIEVAL_DOCUMENTS,
@@ -83,7 +85,10 @@ def payload_to_semantic_attributes(payload: Dict[str, Any]) -> Dict[str, Any]:
         ...
     if EventPayload.MESSAGES in payload:
         attributes[LLM_MESSAGES] = [
-            [message_data.role.value, message_data.content]
+            {
+                MESSAGE_ROLE: message_data.role.value,
+                MESSAGE_CONTENT: message_data.content,
+            }
             for message_data in payload[EventPayload.MESSAGES]
         ]
     if EventPayload.COMPLETION in payload:

--- a/src/phoenix/trace/semantic_conventions.py
+++ b/src/phoenix/trace/semantic_conventions.py
@@ -92,7 +92,15 @@ Invocation parameters passed to the LLM or API, such as the model name, temperat
 """
 LLM_MESSAGES = "llm.messages"
 """
-Messages (system, user, role) provided to a chat API.
+Messages provided to a chat API.
+"""
+MESSAGE_ROLE = "message.role"
+"""
+The role of the message, such as "user" or "system".
+"""
+MESSAGE_CONTENT = "message.content"
+"""
+The content of the message to the llm
 """
 LLM_MODEL_NAME = "llm.model_name"
 """

--- a/tests/server/api/types/test_span.py
+++ b/tests/server/api/types/test_span.py
@@ -13,6 +13,10 @@ def test_nested_attributes() -> None:
             "metadata": ...,
             "score": ...,
         },
+        "message": {
+            "content": ...,
+            "role": ...,
+        },
         "exception": {
             "message": ...,
         },


### PR DESCRIPTION
resolves #1253 

Aligns the messages to more closely corrolate with how OpenAI structures things and also conforms more closely to the semantic conventions.

expample: 
```json
[
  {
    "message.role": "system",
    "message.content": "You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines."
  },
  {
    "message.role": "user",
    "message.content": "Context information is below.\n---------------------\nIf the 'Data Ingestion' tab shows values that deviate from what's expected, dig into potential ingestion issues based on what you sent.&#x20;\n\nLet's check if Arize has received your model correctly! Navigate to the **'Data Ingestion' tab** within your model. You should see bar charts representing the volume of data received for predictions, actuals, and feature importance values. Hover over the bars to ensure the volume represents what's expected.&#x20;\n\nData Ingestion Visualization \n\n{% hint style=\"info\" %}\nIt can take \\~1 minute for bar charts to appear and \\~10 minutes for data to fully load in the 'Data Ingestion' tab and appear across the platform. We suggest grabbing a cup of coffee ☕ while you wait!&#x20;\n{% endhint %}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: I see data in the data ingestion tab but none of the charts are showing data. What's going wrong?\nAnswer: "
  }
]
```