### PR TITLE
fix: pin pandas version greater than or equal to 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
   "scikit-learn<1.3.0",
   "numpy",
-  "pandas",
+  "pandas>=1.5.0",
   "umap-learn",
   "hdbscan>=0.8.33, <1.0.0",
   "starlette",


### PR DESCRIPTION
Resolves #1277

From the [release notes for pandas 1.5.0](https://pandas.pydata.org/docs/whatsnew/v1.5.0.html):

<img width="715" alt="Screenshot 2023-09-07 at 5 25 56 PM" src="https://github.com/Arize-ai/phoenix/assets/15664869/ee8b5699-5f19-4112-9214-5c89567e4cdb">
