### PR TITLE
fix: add uvloop for uvicorn (not for Windows)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "umap-learn",
   "hdbscan>=0.8.33, <1.0.0",
   "starlette",
-  "uvloop; platform_system != "Windows"",
+  "uvloop; platform_system != 'Windows'",
   "uvicorn",
   "psutil",
   "strawberry-graphql==0.205.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "umap-learn",
   "hdbscan>=0.8.33, <1.0.0",
   "starlette",
-  "uvloop",
+  "uvloop; platform_system != "Windows"",
   "uvicorn",
   "psutil",
   "strawberry-graphql==0.205.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "umap-learn",
   "hdbscan>=0.8.33, <1.0.0",
   "starlette",
+  "uvloop",
   "uvicorn",
   "psutil",
   "strawberry-graphql==0.205.0",


### PR DESCRIPTION
runs a new event loop separate from the main thread

see [`uvicorn/loops/auto.py`](https://github.com/encode/uvicorn/blob/e2a39792cc65e45d9ccc5a3908fc79aaa75b7b12/uvicorn/loops/auto.py#L11), [`uvicorn/loops/uvloop.py`](https://github.com/encode/uvicorn/blob/e2a39792cc65e45d9ccc5a3908fc79aaa75b7b12/uvicorn/loops/uvloop.py#L7) and [`uvloop/__init__.py`](https://github.com/MagicStack/uvloop/blob/1dd40f17f3b0d37e3779b6ad5041bab335142337/uvloop/__init__.py#L41)