### PR TITLE
fix(tracing): capture function calls as tools

### DIFF
--- a/src/phoenix/experimental/callbacks/llama_index_trace_callback_handler.py
+++ b/src/phoenix/experimental/callbacks/llama_index_trace_callback_handler.py
@@ -300,4 +300,5 @@ def _get_span_kind(event_type: CBEventType) -> SpanKind:
         CBEventType.EMBEDDING: SpanKind.EMBEDDING,
         CBEventType.LLM: SpanKind.LLM,
         CBEventType.RETRIEVE: SpanKind.RETRIEVER,
+        CBEventType.FUNCTION_CALL: SpanKind.TOOL,
     }.get(event_type, SpanKind.CHAIN)


### PR DESCRIPTION
Function calls touch external APIs and should be considered `tools`