### PR TITLE
feat(evals): llm_generate for synthesizing data

### DIFF
--- a/src/phoenix/experimental/evals/__init__.py
+++ b/src/phoenix/experimental/evals/__init__.py
@@ -1,4 +1,4 @@
-from .functions import llm_eval_binary, run_relevance_eval
+from .functions import llm_eval_binary, llm_generate, run_relevance_eval
 from .models import OpenAiModel
 from .retrievals import compute_precisions_at_k
 from .templates import (
@@ -12,6 +12,7 @@ __all__ = [
     "compute_precisions_at_k",
     "download_benchmark_dataset",
     "llm_eval_binary",
+    "llm_generate",
     "OpenAiModel",
     "PromptTemplate",
     "HALLUCINATION_PROMPT_TEMPLATE_STR",

--- a/src/phoenix/experimental/evals/functions/__init__.py
+++ b/src/phoenix/experimental/evals/functions/__init__.py
@@ -1,3 +1,4 @@
 from .binary import llm_eval_binary, run_relevance_eval
+from .generate import llm_generate
 
-__all__ = ["llm_eval_binary", "run_relevance_eval"]
+__all__ = ["llm_eval_binary", "run_relevance_eval", "llm_generate"]

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -46,11 +46,6 @@ def llm_eval_binary(
 
     eval_template = normalize_template(template)
 
-    # I was considering to construct the prompts and generate answers concurrently. However,
-    # if there's errors in the prompt construction it could interrupt the process and we
-    # would've used API credits for nothing. We could solve this problem by streaming the
-    # answers so that, if there is an error, we keep the answers obtained up to that point.
-    # These are out of scope for M0, but good to keep in mind and consider for the future.
     prompts = map_template(dataframe, eval_template)
 
     responses = model.generate(prompts.to_list(), system_instruction)

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -7,7 +7,9 @@ from ..models.openai import OpenAiModel
 from ..templates import (
     RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
     PromptTemplate,
+    normalize_template,
 )
+from .common import map_template
 
 
 def llm_eval_binary(
@@ -20,12 +22,12 @@ def llm_eval_binary(
     """Runs binary classifications using an LLM.
 
     Args:
-        df (pandas.DataFrame): A pandas dataframe in which each row represents a record to be
+        dataframe (pandas.DataFrame): A pandas dataframe in which each row represents a record to be
         classified. All template variable names must appear as column names in the dataframe (extra
         columns unrelated to the template are permitted).
 
         template (Union[PromptTemplate, str]): The prompt template as either an instance of
-        PromptTemplate or a Python string. If the latter, the variable names should be surrounded by
+        PromptTemplate or a string. If the latter, the variable names should be surrounded by
         curly braces so that a call to `.format` can be made to substitute variable values.
 
         model (BaseEvalModel): An LLM model class.
@@ -42,40 +44,14 @@ def llm_eval_binary(
         parsed.
     """
 
-    if not (isinstance(template, PromptTemplate) or isinstance(template, str)):
-        raise TypeError(
-            "Invalid type for argument `template`. Expected a string or PromptTemplate "
-            f"but found {type(template)}."
-        )
-    if isinstance(template, str):
-        try:
-            eval_template = PromptTemplate(text=template)
-        except Exception as e:
-            raise RuntimeError(f"Error while initializing the PromptTemplate: {e}")
-    else:
-        eval_template = template
+    eval_template = normalize_template(template)
 
     # I was considering to construct the prompts and generate answers concurrently. However,
     # if there's errors in the prompt construction it could interrupt the process and we
     # would've used API credits for nothing. We could solve this problem by streaming the
     # answers so that, if there is an error, we keep the answers obtained up to that point.
     # These are out of scope for M0, but good to keep in mind and consider for the future.
-    try:
-        prompts = dataframe.apply(
-            lambda row: eval_template.format(
-                variable_values={var_name: row[var_name] for var_name in eval_template.variables}
-            ),
-            axis=1,
-        )
-    except KeyError as e:
-        raise RuntimeError(
-            f"Error while constructing the prompts from the template and dataframe. "
-            f"The template variable {e} is not found as a column in the dataframe."
-        )
-    except Exception as e:
-        raise RuntimeError(
-            f"Error while constructing the prompts from the template and dataframe variables: {e}."
-        )
+    prompts = map_template(dataframe, eval_template)
 
     responses = model.generate(prompts.to_list(), system_instruction)
     rail_classes = set(rails)

--- a/src/phoenix/experimental/evals/functions/common.py
+++ b/src/phoenix/experimental/evals/functions/common.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from ..templates import PromptTemplate
+
+
+def map_template(dataframe: pd.DataFrame, template: PromptTemplate) -> pd.Series[str]:
+    """
+    Maps over a dataframe to construct a list of prompts from a template and a dataframe.
+    """
+    # Was considering to construct the prompts and generate answers concurrently. However,
+    # if there's errors in the prompt construction it could interrupt the process and we
+    # would've used API credits for nothing. We could solve this problem by streaming the
+    # answers so that, if there is an error, we keep the answers obtained up to that point.
+    # These are out of scope for M0, but good to keep in mind and consider for the future.
+    try:
+        prompts = dataframe.apply(
+            lambda row: template.format(
+                variable_values={var_name: row[var_name] for var_name in template.variables}
+            ),
+            axis=1,
+        )
+        return prompts
+    except KeyError as e:
+        raise RuntimeError(
+            f"Error while constructing the prompts from the template and dataframe. "
+            f"The template variable {e} is not found as a column in the dataframe."
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Error while constructing the prompts from the template and dataframe variables: {e}."
+        )

--- a/src/phoenix/experimental/evals/functions/common.py
+++ b/src/phoenix/experimental/evals/functions/common.py
@@ -3,7 +3,7 @@ import pandas as pd
 from ..templates import PromptTemplate
 
 
-def map_template(dataframe: pd.DataFrame, template: PromptTemplate) -> pd.Series[str]:
+def map_template(dataframe: pd.DataFrame, template: PromptTemplate) -> "pd.Series[str]":
     """
     Maps over a dataframe to construct a list of prompts from a template and a dataframe.
     """

--- a/src/phoenix/experimental/evals/functions/generate.py
+++ b/src/phoenix/experimental/evals/functions/generate.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional, Union
 
 import pandas as pd
@@ -11,13 +12,15 @@ from .common import map_template
 def llm_generate(
     dataframe: pd.DataFrame,
     template: Union[PromptTemplate, str],
-    model: Optional[BaseEvalModel],
-    system_instruction: Optional[str],
+    model: Optional[BaseEvalModel] = None,
+    system_instruction: Optional[str] = None,
 ) -> List[str]:
     """
-    Generates a text using a template using an LLM. Args:
+    Generates a text using a template using an LLM. This function is useful
+    if you want to generate synthetic data, such as irrelevant responses
+    Args:
         dataframe (pandas.DataFrame): A pandas dataframe in which each row
-        represents a record to be used as in inpute to the template. All
+        represents a record to be used as in input to the template. All
         template variable names must appear as column names in the dataframe
         (extra columns unrelated to the template are permitted).
 
@@ -37,6 +40,8 @@ def llm_generate(
     """
     model = model or OpenAiModel()
     template = normalize_template(template)
+    logging.info(f"Template: \n{template.text}\n")
+    logging.info(f"Template variables: {template.variables}")
     prompts = map_template(dataframe, template)
 
     responses = model.generate(prompts.to_list(), system_instruction)

--- a/src/phoenix/experimental/evals/functions/generate.py
+++ b/src/phoenix/experimental/evals/functions/generate.py
@@ -1,0 +1,43 @@
+from typing import List, Optional, Union
+
+import pandas as pd
+
+from ..models import BaseEvalModel
+from ..models.openai import OpenAiModel
+from ..templates import PromptTemplate, normalize_template
+from .common import map_template
+
+
+def llm_generate(
+    dataframe: pd.DataFrame,
+    template: Union[PromptTemplate, str],
+    model: Optional[BaseEvalModel],
+    system_instruction: Optional[str],
+) -> List[str]:
+    """
+    Generates a text using a template using an LLM. Args:
+        dataframe (pandas.DataFrame): A pandas dataframe in which each row
+        represents a record to be used as in inpute to the template. All
+        template variable names must appear as column names in the dataframe
+        (extra columns unrelated to the template are permitted).
+
+        template (Union[PromptTemplate, str]): The prompt template as either an
+        instance of PromptTemplate or a string. If the latter, the variable
+        names should be surrounded by curly braces so that a call to `.format`
+        can be made to substitute variable values.
+
+        model (BaseEvalModel): An LLM model class.
+
+        system_instruction (Optional[str], optional): An optional system
+        message.
+    Returns:
+        List[Optional[str]]: A list of strings representing the output of the
+        model for each record
+
+    """
+    model = model or OpenAiModel()
+    template = normalize_template(template)
+    prompts = map_template(dataframe, template)
+
+    responses = model.generate(prompts.to_list(), system_instruction)
+    return responses

--- a/src/phoenix/experimental/evals/templates/__init__.py
+++ b/src/phoenix/experimental/evals/templates/__init__.py
@@ -1,8 +1,12 @@
-from .default_templates import HALLUCINATION_PROMPT_TEMPLATE_STR, RAG_RELEVANCY_PROMPT_TEMPLATE_STR
-from .template import PromptTemplate
+from .default_templates import (
+    HALLUCINATION_PROMPT_TEMPLATE_STR,
+    RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
+)
+from .template import PromptTemplate, normalize_template
 
 __all__ = [
     "PromptTemplate",
     "RAG_RELEVANCY_PROMPT_TEMPLATE_STR",
     "HALLUCINATION_PROMPT_TEMPLATE_STR",
+    "normalize_template",
 ]

--- a/src/phoenix/experimental/evals/templates/template.py
+++ b/src/phoenix/experimental/evals/templates/template.py
@@ -81,3 +81,27 @@ class PromptTemplate:
                 variables.append(variable_name)
 
         return variables
+
+
+def normalize_template(template: Union[PromptTemplate, str]) -> PromptTemplate:
+    """
+    Normalizes a template to a PromptTemplate object.
+    Args:
+        template (Union[PromptTemplate, str]): The template to be normalized.
+    Returns:
+        PromptTemplate: The normalized template.
+    """
+    normalized_template = template
+    if not (isinstance(template, PromptTemplate) or isinstance(template, str)):
+        raise TypeError(
+            "Invalid type for argument `template`. Expected a string or PromptTemplate "
+            f"but found {type(template)}."
+        )
+    if isinstance(template, str):
+        try:
+            normalized_template = PromptTemplate(text=template)
+        except Exception as e:
+            raise RuntimeError(f"Error while initializing the PromptTemplate: {e}")
+    else:
+        normalized_template = template
+    return normalized_template

--- a/src/phoenix/experimental/evals/templates/template.py
+++ b/src/phoenix/experimental/evals/templates/template.py
@@ -83,7 +83,7 @@ class PromptTemplate:
         return variables
 
 
-def normalize_template(template: Union[PromptTemplate, str]) -> PromptTemplate:
+def normalize_template(template: Union[PromptTemplate, str]) -> "PromptTemplate":
     """
     Normalizes a template to a PromptTemplate object.
     Args:

--- a/tests/experimental/evals/functions/test_generate.py
+++ b/tests/experimental/evals/functions/test_generate.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import responses
+from phoenix.experimental.evals import OpenAiModel, llm_generate
+
+
+@responses.activate
+def test_llm_generate(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-0123456789")
+    dataframe = pd.DataFrame(
+        [
+            {
+                "query": "What is Python?",
+                "reference": "Python is a programming language.",
+            },
+            {
+                "query": "What is Python?",
+                "reference": "Ruby is a programming language.",
+            },
+            {
+                "query": "What is C++?",
+                "reference": "C++ is a programming language.",
+            },
+            {
+                "query": "What is C++?",
+                "reference": "irrelevant",
+            },
+        ]
+    )
+    for message_content in [
+        "it's a dialect of french",
+        "it's a music notation",
+        "It's a crazy language",
+        "it's a programming language",
+    ]:
+        responses.post(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "content": message_content,
+                        },
+                    }
+                ],
+            },
+            status=200,
+        )
+    template = (
+        "Given {query} and a golden answer {reference}, generate an answer that is incorrect."
+    )
+    generated = llm_generate(
+        dataframe=dataframe,
+        template=template,
+        model=OpenAiModel(),
+    )
+    assert generated == [
+        "it's a dialect of french",
+        "it's a music notation",
+        "It's a crazy language",
+        "it's a programming language",
+    ]


### PR DESCRIPTION
resolves #1309 

This PR adds `llm_generate` which lets you use the LLM to synthesize data per row by applying the template. This is useful for debugging or even for synthesizing data that is needed for evaluation like a bad response or GPT answer to use as a comparison.