### PR TITLE
chore: improve logging for llm_eval_binary

### DIFF
--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -148,9 +148,9 @@ def _snap_to_rail(string: str, rails: Set[str]) -> Optional[str]:
 
     processed_string = string.strip()
     if processed_string not in rails:
-        logger.info(
+        logger.warning(
             f"LLM output cannot be snapped to rails {list(rails)}, returning None. "
-            'Output: "{input_string}"'
+            f'Output: "{string}"'
         )
         return None
     return processed_string

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -96,12 +96,15 @@ class BaseEvalModel(ABC):
                 f"but found {type(prompts)}."
             )
         try:
-            results = [
-                self._generate(prompt=prompt, instruction=instruction) for prompt in tqdm(prompts)
-            ]
+            outputs = []
+            for prompt in tqdm(prompts):
+                output = self._generate(prompt=prompt, instruction=instruction)
+                logger.info(f"Prompt: {prompt}\nInstruction: {instruction}\nOutput: {output}")
+                outputs.append(output)
+
         except (KeyboardInterrupt, Exception) as e:
             raise e
-        return results
+        return outputs
 
     async def agenerate(self, prompts: List[str], instruction: Optional[str] = None) -> List[str]:
         if not is_list_of(prompts, str):

--- a/tutorials/internal/logging.ipynb
+++ b/tutorials/internal/logging.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "from phoenix.experimental.evals import (\n",
+    "    RAG_RELEVANCY_PROMPT_TEMPLATE_STR,\n",
+    "    OpenAiModel,\n",
+    "    download_benchmark_dataset,\n",
+    "    llm_eval_binary,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.basicConfig(level=logging.INFO, stream=sys.stdout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = download_benchmark_dataset(\n",
+    "    task=\"binary-relevance-classification\", dataset_name=\"wiki_qa-train\"\n",
+    ").rename(columns={\"query_text\": \"query\", \"document_text\": \"reference\"})\n",
+    "df.head()\n",
+    "\n",
+    "llm_eval_binary(\n",
+    "    dataframe=df,\n",
+    "    template=RAG_RELEVANCY_PROMPT_TEMPLATE_STR,\n",
+    "    model=OpenAiModel(),\n",
+    "    rails=[\"relevant\", \"irrelevant\"],\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/internal/logging.ipynb
+++ b/tutorials/internal/logging.ipynb
@@ -38,8 +38,9 @@
     "df.head()\n",
     "\n",
     "llm_eval_binary(\n",
-    "    dataframe=df,\n",
+    "    dataframe=df[:2],\n",
     "    template=RAG_RELEVANCY_PROMPT_TEMPLATE_STR,\n",
+    "    # template=\"hello world\",\n",
     "    model=OpenAiModel(),\n",
     "    rails=[\"relevant\", \"irrelevant\"],\n",
     ")"


### PR DESCRIPTION
Improves logging for users of `llm_eval_binary`.

For developers iterating on prompts in their notebook, they can enable logging in their notebook with the following lines:

```python
import logging
import sys

logging.basicConfig(level=logging.INFO, stream=sys.stdout)
```

Example output when using our RAG relevancy template.

```python
INFO:phoenix.experimental.evals.models.base:Prompt: 
You are comparing a reference text to a question and trying to determine if the reference text
contains information relevant to answering the question. Here is the data:
    [BEGIN DATA]
    ************
    [Question]: how are glacier caves formed?
    ************
    [Reference text]: A partly submerged glacier cave on Perito Moreno Glacier . The ice facade is approximately 60 m high Ice formations in the Titlis glacier cave A glacier cave is a cave formed within the ice of a glacier . Glacier caves are often called ice caves , but this term is properly used to describe bedrock caves that contain year-round ice.
    [END DATA]

Compare the Question above to the Reference text. You must determine whether the Reference text
contains information that can answer the Question. Please focus on whether the very specific
question can be answered by the information in the Reference text.
Your response must be single word, either "relevant" or "irrelevant",
and should not contain any text or characters aside from that word.
"irrelevant" means that the reference text does not contain an answer to the Question.
"relevant" means the reference text contains an answer to the Question.

Instruction: None
Output: irrelevant
 ... (more hidden) ...INFO:phoenix.experimental.evals.models.base:Prompt: 
You are comparing a reference text to a question and trying to determine if the reference text
contains information relevant to answering the question. Here is the data:
    [BEGIN DATA]
    ************
    [Question]: how an outdoor wood boiler works
    ************
    [Reference text]: The outdoor wood boiler is a variant of the classic wood stove adapted for set-up outdoors while still transferring the heat to interior buildings.
    [END DATA]

Compare the Question above to the Reference text. You must determine whether the Reference text
contains information that can answer the Question. Please focus on whether the very specific
question can be answered by the information in the Reference text.
Your response must be single word, either "relevant" or "irrelevant",
and should not contain any text or characters aside from that word.
"irrelevant" means that the reference text does not contain an answer to the Question.
"relevant" means the reference text contains an answer to the Question.

Instruction: None
Output: irrelevant
```

This PR does not solve the pain for users whose templates produce output that cannot be parsed. The reason is that we only rail the output after all of the LLM calls have been made. To change this would require a refactor of the code.

```python
  0%|                                                                                      | 0/2 [00:00<?, ?it/s]INFO:phoenix.experimental.evals.models.base:Prompt: hello world
Instruction: None
Output: Hello! How can I assist you today?
 50%|███████████████████████████████████████                                       | 1/2 [00:01<00:01,  1.15s/it]INFO:phoenix.experimental.evals.models.base:Prompt: hello world
Instruction: None
Output: Hello! How can I assist you today?
100%|██████████████████████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.08s/it]
INFO:phoenix.experimental.evals.functions.binary:LLM output cannot be snapped to rails ['relevant', 'irrelevant'], returning None. Output: "Hello! How can I assist you today?"
INFO:phoenix.experimental.evals.functions.binary:LLM output cannot be snapped to rails ['relevant', 'irrelevant'], returning None. Output: "Hello! How can I assist you today?"
```

(Notice that the messages telling the user that the output cannot be snapped to the rails only appears after all the LLM calls have been made).