### PR TITLE
Add support for Palm, Claude-2, Cohere, Azure OpenAI, Replicate Llama2 CodeLlama, Ollama, (100+LLMs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 ]
 experimental = [
   "openai",
+  "litellm",
   "tenacity",
 ]
 

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -12,6 +12,14 @@ except ImportError:
         "Please install them with `pip install openai`."
     )
 
+try:
+    import litellm
+except ImportError:
+    raise ImportError(
+        "Could not import necessary dependencies: litellm. "
+        "Please install them with `pip install litellm`."
+    )
+
 OPENAI_RETRY_ERRORS = [
     openai.error.Timeout,
     openai.error.APIError,
@@ -92,7 +100,7 @@ class OpenAIModel(BaseEvalModel):
 
         @retry_decorator
         def _completion_with_retry(**kwargs: Any) -> Any:
-            return openai.ChatCompletion.create(**kwargs)  # type:ignore
+            return litellm.completion(**kwargs)  # type:ignore
 
         return _completion_with_retry(**kwargs)
 


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```