### PR TITLE
fix: handle templating event in llama-index

### DIFF
--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -42,6 +42,8 @@ from phoenix.trace.semantic_conventions import (
     LLM_INVOCATION_PARAMETERS,
     LLM_MESSAGES,
     LLM_MODEL_NAME,
+    LLM_PROMPT_TEMPLATE,
+    LLM_PROMPT_TEMPLATE_VARIABLES,
     LLM_PROMPTS,
     LLM_TOKEN_COUNT_COMPLETION,
     LLM_TOKEN_COUNT_PROMPT,
@@ -87,6 +89,14 @@ def payload_to_semantic_attributes(
     if event_type in (CBEventType.NODE_PARSING, CBEventType.CHUNKING):
         # TODO(maybe): handle these events
         return attributes
+    if event_type == CBEventType.TEMPLATING:
+        if template := payload.get(EventPayload.TEMPLATE):
+            attributes[LLM_PROMPT_TEMPLATE] = template
+        if template_vars := payload.get(EventPayload.TEMPLATE_VARS):
+            attributes[LLM_PROMPT_TEMPLATE_VARIABLES] = template_vars
+        # TODO(maybe)
+        # EventPayload.SYSTEM_PROMPT
+        # EventPayload.QUERY_WRAPPER_PROMPT
     if EventPayload.CHUNKS in payload and EventPayload.EMBEDDINGS in payload:
         attributes[EMBEDDING_EMBEDDINGS] = [
             {EMBEDDING_TEXT: text, EMBEDDING_VECTOR: vector}

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -94,7 +94,7 @@ def payload_to_semantic_attributes(
             attributes[LLM_PROMPT_TEMPLATE] = template
         if template_vars := payload.get(EventPayload.TEMPLATE_VARS):
             attributes[LLM_PROMPT_TEMPLATE_VARIABLES] = template_vars
-        # TODO(maybe)
+        # TODO(maybe): other keys in the same payload
         # EventPayload.SYSTEM_PROMPT
         # EventPayload.QUERY_WRAPPER_PROMPT
     if EventPayload.CHUNKS in payload and EventPayload.EMBEDDINGS in payload:


### PR DESCRIPTION
resolves #1378 

Also see llama-index [source code](https://github.com/jerryjliu/llama_index/blob/5b8d3295665541232e9dc3ba0ed3946918e5fb9a/llama_index/llm_predictor/base.py#L127-L130)

<img width="968" alt="Screenshot 2023-09-19 at 3 25 29 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/ebb51e6b-e36a-4425-87ac-0ae9e1d49124">
