### PR TITLE
fix: missing `port` value in error message

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -321,7 +321,7 @@ def launch_app(
 
     host = host or get_env_host()
     port = port or get_env_port()
-    
+
     if run_in_thread:
         _session = ThreadSession(primary, reference, corpus, trace, host=host, port=port)
         # TODO: catch exceptions from thread

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -319,6 +319,9 @@ def launch_app(
         )
         _session.end()
 
+    host = host or get_env_host()
+    port = port or get_env_port()
+    
     if run_in_thread:
         _session = ThreadSession(primary, reference, corpus, trace, host=host, port=port)
         # TODO: catch exceptions from thread


### PR DESCRIPTION
if server fails to start, the error message references the `port` variable, so it needs to be filled out beforehand

<img width="663" alt="Screenshot 2023-09-19 at 4 24 36 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/6f133cee-a166-4a1c-8c99-774894e7a2e5">
