### PR TITLE
fix: typo in requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "psutil",
   "strawberry-graphql==0.208.2",
   "pyarrow",
-  "typing_extensions",
+  "typing-extensions",
   "scipy",
   "wrapt",
   "sortedcontainers",


### PR DESCRIPTION
note that both works, but underscore looks like a typo