### PR TITLE
fix: np.stack argument deprecation

### DIFF
--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -177,12 +177,10 @@ class Query:
             + grouped_event_ids[AncillaryDatasetRole.corpus]
         )
         stacked_coordinates = np.stack(
-            chain(
-                grouped_coordinates[DatasetRole.primary],
-                grouped_coordinates[DatasetRole.reference],
-                grouped_coordinates[AncillaryDatasetRole.corpus],
-            )
-        )  # type: ignore
+            grouped_coordinates[DatasetRole.primary]
+            + grouped_coordinates[DatasetRole.reference]
+            + grouped_coordinates[AncillaryDatasetRole.corpus]
+        )
 
         clusters = Hdbscan(
             min_cluster_size=min_cluster_size,

--- a/tests/pointcloud/test_pointcloud.py
+++ b/tests/pointcloud/test_pointcloud.py
@@ -44,7 +44,7 @@ def test_point_cloud(samp_size: int, n_features: int, n_components: int, n_clust
         n_components,
     )
 
-    assert np.stack(points.values()).shape == (samp_size, n_components)
+    assert np.stack(list(points.values())).shape == (samp_size, n_components)
     assert len(clustered_events) == n_clusters
     assert set(points.keys()) == set(data.keys())
     assert set(chain.from_iterable(clustered_events.values())) <= set(data.keys())


### PR DESCRIPTION
this fixes the unit tests for Python 3.11 (windows)

```TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.```