### PR TITLE
feat(infra): server-side template for index.html

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "scikit-learn<1.3.0",
   "numpy",
   "pandas",
+  "jinja2",
   "umap-learn",
   "hdbscan>=0.8.33, <1.0.0",
   "starlette",

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -1,7 +1,6 @@
 import logging
-from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, NamedTuple, Optional, Union
 
 from starlette.applications import Starlette
 from starlette.datastructures import QueryParams
@@ -12,14 +11,14 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import FileResponse, Response
 from starlette.routing import Mount, Route, WebSocketRoute
-from starlette.staticfiles import PathLike, StaticFiles
+from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from starlette.types import Scope
 from starlette.websockets import WebSocket
 from strawberry.asgi import GraphQL
 from strawberry.schema import BaseSchema
 
-from phoenix.config import SERVER_DIR, get_env_host, get_env_port
+from phoenix.config import SERVER_DIR
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
 from phoenix.server.api.context import Context
@@ -32,8 +31,6 @@ templates = Jinja2Templates(directory=SERVER_DIR / "templates")
 
 
 class Config(NamedTuple):
-    host: str
-    port: int
     has_corpus: bool
 
 
@@ -60,8 +57,6 @@ class Static(StaticFiles):
             response = templates.TemplateResponse(
                 "index.html",
                 context={
-                    "host": config.host,
-                    "port": config.port,
                     "has_corpus": config.has_corpus,
                     "request": Request(scope),
                 },
@@ -181,8 +176,6 @@ def create_app(
                 app=Static(
                     directory=SERVER_DIR / "static",
                     config=Config(
-                        host=get_env_host(),
-                        port=get_env_port(),
                         has_corpus=corpus is not None,
                     ),
                 ),

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -72,7 +72,7 @@ class Static(StaticFiles):
                 raise e
             # Fallback to to the index.html
             # TODO(mikeldking): support index.html to change the
-            #  host and port of the js and css bundles if host is not localhost
+            # host and port of the js and css bundles if host is not localhost
             response = templates.TemplateResponse(
                 "index.html",
                 context={

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -31,8 +31,7 @@ logger = logging.getLogger(__name__)
 templates = Jinja2Templates(directory=SERVER_DIR / "templates")
 
 
-@dataclass(frozen=True)
-class Config:
+class Config(NamedTuple):
     host: str
     port: int
     has_corpus: bool

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -43,24 +43,9 @@ class Static(StaticFiles):
 
     _config: Config
 
-    def __init__(
-        self,
-        *,
-        directory: Optional[PathLike] = None,
-        packages: Optional[List[Union[str, Tuple[str, str]]]] = None,
-        html: bool = False,
-        check_dir: bool = True,
-        follow_symlink: bool = False,
-        config: Config,
-    ):
+    def __init__(self, *, config: Config, **kwargs: Any):
         self._config = config
-        super().__init__(
-            directory=directory,
-            packages=packages,
-            html=html,
-            check_dir=check_dir,
-            follow_symlink=follow_symlink,
-        )
+        super().__init__(**kwargs)
 
     async def get_response(self, path: str, scope: Scope) -> Response:
         response = None

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -26,7 +26,6 @@
             }),
             writable: false
         });
-     
     })()</script>
     <script type="module" src="/index.js"></script>
   </body>

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -16,6 +16,18 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>(function() {
+        Object.defineProperty(window, "Config", {
+            // Place any server-side injected config here
+            // E.g. default UMAP parameters etc. that needs to be
+            // injected into the client before React runs
+            value: Object.freeze({
+                hasCorpus: Boolean("{{has_corpus}}"),
+            }),
+            writable: false
+        });
+     
+    })()</script>
     <script type="module" src="/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
resolves #1400 

Switches the mounding of index.html to be server-side so that we can inject environment variables and other config. This will potentially unblock mounting static assets for Sagemaker/Databricks notebooks as well as #1224 so that the defaults can be mounted into the browser runtime pre-react rendering.