### PR TITLE
fix: add jinja2 to requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "wrapt",
   "sortedcontainers",
   "protobuf>=3.20, <5.0",
+  "jinja2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
fixes [error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=789032&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=445) in our Conda feedstock

<img width="794" alt="Screenshot 2023-09-26 at 10 08 21 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/0b3f71d2-fe31-46bb-8dd6-ffec45d53375">
