### PR TITLE
feat: export interim spans for llama-index

### DIFF
--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -1,5 +1,6 @@
 import gzip
 import logging
+import time
 import weakref
 from queue import SimpleQueue
 from threading import Thread
@@ -65,6 +66,7 @@ class HttpExporter:
         pb_span = encode(span)
         serialized = pb_span.SerializeToString()
         data = gzip.compress(serialized)
+        self._session.headers["span_version"] = str(time.time())
         try:
             self._session.post(self._url, data=data)
         except Exception as e:


### PR DESCRIPTION
resolves #1437 

## Caveats

### Hard requirements
1. The `event_id` from llama-index must be a UUID, which we use directly as our `span_id` for the purpose of tracking multiple versions of the same spans. If we have to maintain a separate system of span_ids, we would not know when to clear it out, leaving us with a memory leak.

### Trade-offs

Backward compatibility for the llama-index handler requires that:
1. The handler can be initialized with a `callback: Callable[[List[Span]], None]` parameter.
    - Note that the input to `callback` is `List[span]`.
    - The original intent was to allow the user to clear the internal buffer of spans stored in a list, which can otherwise grow without limit.
2. The handler has a `.get_trace()` method that can iterate the spans without duplication.
    - This is used to iterate the spans in the notebook and to save them to `.jsonl` files.

Decision: the `callback` parameter is removed because the internal buffer is no longer a list. The buffer is now a dict in order to exclude duplicates. The callback would need to be changed to operate on a dict in order to accomplish the goal of capping the memory usage.

## Illustration
### Interim spans
Note that each span is its own trace.

<img width="649" alt="Screenshot 2023-09-27 at 9 32 11 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/7c0869f3-0b6d-417a-ae94-ba3ed668cf82">

### Finalized spans
Note that the number of traces changed from four to one.

<img width="637" alt="Screenshot 2023-09-27 at 9 32 26 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/dc6fa756-37ff-44ca-83e9-3e11c4adf355">
