### PR TITLE
feat: enhance input types of run_relevance_eval

### DIFF
--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, Optional, Set, Union, cast
+from typing import Any, Iterable, List, Optional, Set, Union, cast
 
 import pandas as pd
 
@@ -154,7 +154,7 @@ def run_relevance_eval(
     return outputs
 
 
-def _get_contents_from_openinference_documents(documents: Any) -> List[Optional[str]]:
+def _get_contents_from_openinference_documents(documents: Iterable[Any]) -> List[Optional[str]]:
     """
     Get OpenInference documents.
     """

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -70,12 +70,19 @@ def run_relevance_eval(
     document_column_name: str = "reference",
 ) -> List[List[str]]:
     """
-    Given a pandas dataframe containing queries and retrieved documents,
-    classifies the relevance of each retrieved document to the corresponding
-    query using an LLM.
+    Given a pandas dataframe containing queries and retrieved documents, classifies the relevance of
+    each retrieved document to the corresponding query using an LLM.
 
     Args:
-        dataframe (pd.DataFrame): A pandas dataframe containing queries and retrieved documents.
+        dataframe (pd.DataFrame): A pandas dataframe containing queries and retrieved documents. The
+        queries should be contained in a column of strings. The retrieved documents should be
+        contained in a column for which each entry is a lists of strings, and each list may contain
+        an arbitrary number of document texts retrieved for the corresponding query. Alternatively,
+        the entries in the retrieved document column may be lists of OpenInference document objects,
+        which are dictionaries that store the document text under the key "document.content". This
+        latter format is intended for running evaluations on exported OpenInference trace
+        dataframes. For more information on the OpenInference tracing specification, see
+        https://github.com/Arize-ai/open-inference-spec/
 
         model (BaseEvalModel): The model used for evaluation.
 

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -49,8 +49,8 @@ def llm_eval_binary(
     Returns:
         List[str]: A list of strings representing the predicted class for each record in the
         dataframe. The list should have the same length as the input dataframe and its values should
-        be the entries in the `rails` argument or None if the model's prediction could not be
-        parsed.
+        be the entries in the rails argument or "NOT_PARSABLE" if the model's prediction could not
+        be parsed.
     """
 
     eval_template = normalize_template(template)

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -74,15 +74,26 @@ def run_relevance_eval(
     each retrieved document to the corresponding query using an LLM.
 
     Args:
-        dataframe (pd.DataFrame): A pandas dataframe containing queries and retrieved documents. The
-        queries should be contained in a column of strings. The retrieved documents should be
-        contained in a column for which each entry is a lists of strings, and each list may contain
-        an arbitrary number of document texts retrieved for the corresponding query. Alternatively,
-        the entries in the retrieved document column may be lists of OpenInference document objects,
-        which are dictionaries that store the document text under the key "document.content". This
-        latter format is intended for running evaluations on exported OpenInference trace
+        dataframe (pd.DataFrame): A pandas dataframe containing queries and retrieved documents. If
+        both query_column_name and reference_column_name are present in the input dataframe, those
+        columns are used as inputs and should appear in the following format:
+
+        - The entries of the query column must be strings.
+        - The entries of the documents column must be lists of strings. Each list may contain an
+          arbitrary number of document texts retrieved for the corresponding query.
+
+        If the input dataframe is lacking either query_column_name or reference_column_name but has
+        query and retrieved document columns in OpenInference trace format named
+        "attributes.input.value" and "attributes.retrieval.documents", respectively, then those
+        columns are used as inputs and should appear in the following format:
+
+        - The entries of the query column must be strings.
+        - The entries of the document column must be lists of OpenInference document objects, each
+          object being a dictionary that stores the document text under the key "document.content".
+
+        This latter format is intended for running evaluations on exported OpenInference trace
         dataframes. For more information on the OpenInference tracing specification, see
-        https://github.com/Arize-ai/open-inference-spec/
+        https://github.com/Arize-ai/open-inference-spec/.
 
         model (BaseEvalModel): The model used for evaluation.
 
@@ -91,9 +102,11 @@ def run_relevance_eval(
         rails (List[str], optional): A list of strings representing the possible output classes of
         the model's predictions.
 
-        query_template_variable (str, optional): The name of the query template variable.
+        query_column_name (str, optional): The name of the query column in the dataframe, which
+        should also be a template variable.
 
-        reference_template_variable (str, optional): The name of the document template variable.
+        reference_column_name (str, optional): The name of the document column in the dataframe,
+        which should also be a template variable.
 
         system_instruction (Optional[str], optional): An optional system message.
 
@@ -156,7 +169,8 @@ def run_relevance_eval(
 
 def _get_contents_from_openinference_documents(documents: Iterable[Any]) -> List[Optional[str]]:
     """
-    Get OpenInference documents.
+    Get document contents from an iterable of OpenInference document objects, which are dictionaries
+    containing the document text under the "document.content" key.
     """
     return [doc.get(DOCUMENT_CONTENT) if isinstance(doc, dict) else None for doc in documents]
 

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -81,6 +81,8 @@ def run_relevance_eval(
     rails: List[str] = list(RAG_RELEVANCY_PROMPT_RAILS_MAP.values()),
     query_column_name: str = OPENINFERENCE_QUERY_COLUMN_NAME,
     document_column_name: str = OPENINFERENCE_DOCUMENT_COLUMN_NAME,
+    query_template_variable: str = "query",
+    document_template_variable: str = "reference",
 ) -> List[List[str]]:
     """
     Given a pandas dataframe containing queries and retrieved documents,
@@ -100,6 +102,10 @@ def run_relevance_eval(
         query_column_name (str, optional): The name of the column containing the queries.
 
         document_column_name (str, optional): The name of the column containing the retrieved.
+
+        query_template_variable (str, optional): The name of the query template variable.
+
+        reference_template_variable (str, optional): The name of the document template variable.
 
     Returns:
         List[List[str]]: A list of relevant and not relevant classifications. The "shape" of the
@@ -131,8 +137,8 @@ def run_relevance_eval(
     predictions = llm_eval_binary(
         dataframe=pd.DataFrame(
             {
-                "query": [query for query, _ in query_document_pairs],
-                "reference": [document for _, document in query_document_pairs],
+                query_template_variable: [query for query, _ in query_document_pairs],
+                document_template_variable: [document for _, document in query_document_pairs],
             }
         ),
         model=model,

--- a/src/phoenix/experimental/evals/functions/binary.py
+++ b/src/phoenix/experimental/evals/functions/binary.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 OPENINFERENCE_QUERY_COLUMN_NAME = "attributes." + INPUT_VALUE
 OPENINFERENCE_DOCUMENT_COLUMN_NAME = "attributes." + RETRIEVAL_DOCUMENTS
-DocumentObject = Dict[str, str]
 
 
 def llm_eval_binary(
@@ -150,7 +149,7 @@ def run_relevance_eval(
     return outputs
 
 
-def _get_contents(documents: List[Union[str, DocumentObject]], key: str) -> List[Optional[str]]:
+def _get_contents(documents: List[Union[str, Dict[str, str]]], key: str) -> List[Optional[str]]:
     """Gets the contents from documents.
 
     Args:

--- a/tests/experimental/evals/functions/test_binary.py
+++ b/tests/experimental/evals/functions/test_binary.py
@@ -84,6 +84,13 @@ def test_run_relevance_eval(monkeypatch):
                 ),
             },
             {
+                "attributes.input.value": "What is Python?",
+                "attributes.retrieval.documents": [
+                    "Python is a programming language.",
+                    "Ruby is a programming language.",
+                ],
+            },
+            {
                 "attributes.input.value": "What is Ruby?",
                 "attributes.retrieval.documents": [
                     {"document.content": "Ruby is a programming language."},
@@ -122,6 +129,8 @@ def test_run_relevance_eval(monkeypatch):
         "irrelevant",
         "relevant",
         "irrelevant",
+        "relevant",
+        "irrelevant",
         "\nrelevant ",
         "unparsable",
         "relevant",
@@ -141,14 +150,15 @@ def test_run_relevance_eval(monkeypatch):
         )
     relevance_classifications = run_relevance_eval(dataframe, model=OpenAIModel())
     assert relevance_classifications == [
-        [True, False],
-        [True, False],
-        [True],
-        [None, True],
-        None,
-        None,
-        None,
-        None,
+        ["relevant", "irrelevant"],
+        ["relevant", "irrelevant"],
+        ["relevant", "irrelevant"],
+        ["relevant"],
+        [NOT_PARSABLE, "relevant"],
+        [],
+        [],
+        [],
+        [],
     ]
 
 

--- a/tests/experimental/evals/functions/test_binary.py
+++ b/tests/experimental/evals/functions/test_binary.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 import responses
 from phoenix.experimental.evals import (
     NOT_PARSABLE,
@@ -63,150 +64,126 @@ def test_llm_eval_binary(monkeypatch):
 
 
 @responses.activate
-def test_run_relevance_eval_on_standard_dataframe(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-0123456789")
-    dataframe = pd.DataFrame(
-        [
-            {
-                "attributes.input.value": "What is Python?",
-                "attributes.retrieval.documents": [
-                    "Python is a programming language.",
-                    "Ruby is a programming language.",
-                ],
-            },
-            {
-                "attributes.input.value": "What is Python?",
-                "attributes.retrieval.documents": np.array(
-                    [
-                        "Python is a programming language.",
-                        "Ruby is a programming language.",
-                    ]
-                ),
-            },
-            {
-                "attributes.input.value": "What is Ruby?",
-                "attributes.retrieval.documents": [
-                    "Ruby is a programming language.",
-                ],
-            },
-            {
-                "attributes.input.value": "What is C++?",
-                "attributes.retrieval.documents": [
-                    "Ruby is a programming language.",
-                    "C++ is a programming language.",
-                ],
-            },
-            {
-                "attributes.input.value": "What is C#?",
-                "attributes.retrieval.documents": [],
-            },
-            {
-                "attributes.input.value": "What is Golang?",
-                "attributes.retrieval.documents": None,
-            },
-            {
-                "attributes.input.value": None,
-                "attributes.retrieval.documents": [
-                    "Python is a programming language.",
-                    "Ruby is a programming language.",
-                ],
-            },
-            {
-                "attributes.input.value": None,
-                "attributes.retrieval.documents": None,
-            },
-        ]
-    )
-    for message_content in [
-        "relevant",
-        "irrelevant",
-        "relevant",
-        "irrelevant",
-        "\nrelevant ",
-        "unparsable",
-        "relevant",
-    ]:
-        responses.post(
-            "https://api.openai.com/v1/chat/completions",
-            json={
-                "choices": [
+@pytest.mark.parametrize(
+    "dataframe",
+    [
+        pytest.param(
+            pd.DataFrame(
+                [
                     {
-                        "message": {
-                            "content": message_content,
-                        },
-                    }
-                ],
-            },
-            status=200,
-        )
-    relevance_classifications = run_relevance_eval(dataframe, model=OpenAIModel())
-    assert relevance_classifications == [
-        ["relevant", "irrelevant"],
-        ["relevant", "irrelevant"],
-        ["relevant"],
-        [NOT_PARSABLE, "relevant"],
-        [],
-        [],
-        [],
-        [],
-    ]
-
-
-@responses.activate
-def test_run_relevance_eval_on_openinference_dataframe(monkeypatch):
+                        "attributes.input.value": "What is Python?",
+                        "attributes.retrieval.documents": [
+                            "Python is a programming language.",
+                            "Ruby is a programming language.",
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is Python?",
+                        "attributes.retrieval.documents": np.array(
+                            [
+                                "Python is a programming language.",
+                                "Ruby is a programming language.",
+                            ]
+                        ),
+                    },
+                    {
+                        "attributes.input.value": "What is Ruby?",
+                        "attributes.retrieval.documents": [
+                            "Ruby is a programming language.",
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is C++?",
+                        "attributes.retrieval.documents": [
+                            "Ruby is a programming language.",
+                            "C++ is a programming language.",
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is C#?",
+                        "attributes.retrieval.documents": [],
+                    },
+                    {
+                        "attributes.input.value": "What is Golang?",
+                        "attributes.retrieval.documents": None,
+                    },
+                    {
+                        "attributes.input.value": None,
+                        "attributes.retrieval.documents": [
+                            "Python is a programming language.",
+                            "Ruby is a programming language.",
+                        ],
+                    },
+                    {
+                        "attributes.input.value": None,
+                        "attributes.retrieval.documents": None,
+                    },
+                ]
+            ),
+            id="standard-dataframe",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [
+                    {
+                        "attributes.input.value": "What is Python?",
+                        "attributes.retrieval.documents": [
+                            {"document.content": "Python is a programming language."},
+                            {"document.content": "Ruby is a programming language."},
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is Python?",
+                        "attributes.retrieval.documents": np.array(
+                            [
+                                {"document.content": "Python is a programming language."},
+                                {"document.content": "Ruby is a programming language."},
+                            ]
+                        ),
+                    },
+                    {
+                        "attributes.input.value": "What is Ruby?",
+                        "attributes.retrieval.documents": [
+                            {"document.content": "Ruby is a programming language."},
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is C++?",
+                        "attributes.retrieval.documents": [
+                            {"document.content": "Ruby is a programming language."},
+                            {"document.content": "C++ is a programming language."},
+                        ],
+                    },
+                    {
+                        "attributes.input.value": "What is C#?",
+                        "attributes.retrieval.documents": [],
+                    },
+                    {
+                        "attributes.input.value": "What is Golang?",
+                        "attributes.retrieval.documents": None,
+                    },
+                    {
+                        "attributes.input.value": None,
+                        "attributes.retrieval.documents": [
+                            {"document.content": "Python is a programming language."},
+                            {"document.content": "Ruby is a programming language."},
+                        ],
+                    },
+                    {
+                        "attributes.input.value": None,
+                        "attributes.retrieval.documents": None,
+                    },
+                ]
+            ),
+            id="openinference-dataframe",
+        ),
+    ],
+)
+def test_run_relevance_eval(
+    monkeypatch: pytest.MonkeyPatch,
+    dataframe: pd.DataFrame,
+):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-0123456789")
-    dataframe = pd.DataFrame(
-        [
-            {
-                "attributes.input.value": "What is Python?",
-                "attributes.retrieval.documents": [
-                    {"document.content": "Python is a programming language."},
-                    {"document.content": "Ruby is a programming language."},
-                ],
-            },
-            {
-                "attributes.input.value": "What is Python?",
-                "attributes.retrieval.documents": np.array(
-                    [
-                        {"document.content": "Python is a programming language."},
-                        {"document.content": "Ruby is a programming language."},
-                    ]
-                ),
-            },
-            {
-                "attributes.input.value": "What is Ruby?",
-                "attributes.retrieval.documents": [
-                    {"document.content": "Ruby is a programming language."},
-                ],
-            },
-            {
-                "attributes.input.value": "What is C++?",
-                "attributes.retrieval.documents": [
-                    {"document.content": "Ruby is a programming language."},
-                    {"document.content": "C++ is a programming language."},
-                ],
-            },
-            {
-                "attributes.input.value": "What is C#?",
-                "attributes.retrieval.documents": [],
-            },
-            {
-                "attributes.input.value": "What is Golang?",
-                "attributes.retrieval.documents": None,
-            },
-            {
-                "attributes.input.value": None,
-                "attributes.retrieval.documents": [
-                    {"document.content": "Python is a programming language."},
-                    {"document.content": "Ruby is a programming language."},
-                ],
-            },
-            {
-                "attributes.input.value": None,
-                "attributes.retrieval.documents": None,
-            },
-        ]
-    )
     for message_content in [
         "relevant",
         "irrelevant",

--- a/tests/experimental/evals/functions/test_binary.py
+++ b/tests/experimental/evals/functions/test_binary.py
@@ -84,13 +84,6 @@ def test_run_relevance_eval(monkeypatch):
                 ),
             },
             {
-                "attributes.input.value": "What is Python?",
-                "attributes.retrieval.documents": [
-                    "Python is a programming language.",
-                    "Ruby is a programming language.",
-                ],
-            },
-            {
                 "attributes.input.value": "What is Ruby?",
                 "attributes.retrieval.documents": [
                     {"document.content": "Ruby is a programming language."},
@@ -129,8 +122,6 @@ def test_run_relevance_eval(monkeypatch):
         "irrelevant",
         "relevant",
         "irrelevant",
-        "relevant",
-        "irrelevant",
         "\nrelevant ",
         "unparsable",
         "relevant",
@@ -150,7 +141,6 @@ def test_run_relevance_eval(monkeypatch):
         )
     relevance_classifications = run_relevance_eval(dataframe, model=OpenAIModel())
     assert relevance_classifications == [
-        ["relevant", "irrelevant"],
         ["relevant", "irrelevant"],
         ["relevant", "irrelevant"],
         ["relevant"],


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/1331
- enhance `run_relevance_eval` to accept documents strings or objects in the document column
- simplify implementation
- update unit test