### PR TITLE
fix: toxicity notebook bug

### DIFF
--- a/tutorials/evals/evaluate_toxicity_classifications.ipynb
+++ b/tutorials/evals/evaluate_toxicity_classifications.ipynb
@@ -46,7 +46,7 @@
     "# 10,000 samples GPT-4 ~170 min / GPT-3.5 ~ 70min\n",
     "N_EVAL_SAMPLE_SIZE = 100\n",
     "# Balance the toxicity class data for the test\n",
-    "BALANCE_DATA = True\n"
+    "BALANCE_DATA = True"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "from pycm import ConfusionMatrix\n",
     "from sklearn.metrics import classification_report\n",
     "\n",
-    "pd.set_option(\"display.max_colwidth\", None)\n"
+    "pd.set_option(\"display.max_colwidth\", None)"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "outputs": [],
    "source": [
     "df = download_benchmark_dataset(task=\"toxicity-classification\", dataset_name=\"wiki_toxic-test\")\n",
-    "df.head()\n"
+    "df.head()"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(TOXICITY_PROMPT_TEMPLATE_STR)\n"
+    "print(TOXICITY_PROMPT_TEMPLATE_STR)"
    ]
   },
   {
@@ -166,7 +166,7 @@
     "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
     "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
     "openai.api_key = openai_api_key\n",
-    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key\n"
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "        n=N_EVAL_SAMPLE_SIZE\n",
     "    )  # The second sample function is to shuffle the row\n",
     "else:\n",
-    "    df_sample = df.sample(n=N_EVAL_SAMPLE_SIZE).reset_index(drop=True)\n"
+    "    df_sample = df.sample(n=N_EVAL_SAMPLE_SIZE).reset_index(drop=True)"
    ]
   },
   {
@@ -220,7 +220,7 @@
    "source": [
     "df_sample = df_sample.rename(\n",
     "    columns={\"comment_text\": \"text\"},\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -243,7 +243,7 @@
     "model = OpenAIModel(\n",
     "    model_name=\"gpt-4\",\n",
     "    temperature=0.0,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model(\"Hello world, this is a test if you are working?\")\n"
+    "model(\"Hello world, this is a test if you are working?\")"
    ]
   },
   {
@@ -285,7 +285,7 @@
     "    template=TOXICITY_PROMPT_TEMPLATE_STR,\n",
     "    model=model,\n",
     "    rails=rails,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -319,7 +319,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = OpenAIModel(model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20)\n"
+    "model = OpenAIModel(model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20)"
    ]
   },
   {
@@ -357,7 +357,7 @@
     "    template=TOXICITY_PROMPT_TEMPLATE_STR,\n",
     "    model=model,\n",
     "    rails=rails,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -380,7 +380,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ")\n"
+    ")"
    ]
   }
  ],

--- a/tutorials/evals/evaluate_toxicity_classifications.ipynb
+++ b/tutorials/evals/evaluate_toxicity_classifications.ipynb
@@ -46,7 +46,7 @@
     "# 10,000 samples GPT-4 ~170 min / GPT-3.5 ~ 70min\n",
     "N_EVAL_SAMPLE_SIZE = 100\n",
     "# Balance the toxicity class data for the test\n",
-    "BALANCE_DATA = True"
+    "BALANCE_DATA = True\n"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "from pycm import ConfusionMatrix\n",
     "from sklearn.metrics import classification_report\n",
     "\n",
-    "pd.set_option(\"display.max_colwidth\", None)"
+    "pd.set_option(\"display.max_colwidth\", None)\n"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "outputs": [],
    "source": [
     "df = download_benchmark_dataset(task=\"toxicity-classification\", dataset_name=\"wiki_toxic-test\")\n",
-    "df.head()"
+    "df.head()\n"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(TOXICITY_PROMPT_TEMPLATE_STR)"
+    "print(TOXICITY_PROMPT_TEMPLATE_STR)\n"
    ]
   },
   {
@@ -166,7 +166,7 @@
     "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
     "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
     "openai.api_key = openai_api_key\n",
-    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key\n"
    ]
   },
   {
@@ -193,8 +193,8 @@
     "    # The data set is unbalanced, lets balance so we can test with smaller sample sizes\n",
     "    # At 100 samples sometimes you only get 6 toxic classes\n",
     "    # Split the dataset into two groups: toxic and non-toxic\n",
-    "    toxic_df = df[df[\"toxic\"] is True]\n",
-    "    non_toxic_df = df[df[\"toxic\"] is False]\n",
+    "    toxic_df = df[df[\"toxic\"]]\n",
+    "    non_toxic_df = df[df[\"toxic\"]]\n",
     "\n",
     "    # Get the minimum count between the two groups\n",
     "    min_count = min(len(toxic_df), len(non_toxic_df))\n",
@@ -208,7 +208,7 @@
     "        n=N_EVAL_SAMPLE_SIZE\n",
     "    )  # The second sample function is to shuffle the row\n",
     "else:\n",
-    "    df_sample = df.sample(n=N_EVAL_SAMPLE_SIZE).reset_index(drop=True)"
+    "    df_sample = df.sample(n=N_EVAL_SAMPLE_SIZE).reset_index(drop=True)\n"
    ]
   },
   {
@@ -220,7 +220,7 @@
    "source": [
     "df_sample = df_sample.rename(\n",
     "    columns={\"comment_text\": \"text\"},\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -243,7 +243,7 @@
     "model = OpenAIModel(\n",
     "    model_name=\"gpt-4\",\n",
     "    temperature=0.0,\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model(\"Hello world, this is a test if you are working?\")"
+    "model(\"Hello world, this is a test if you are working?\")\n"
    ]
   },
   {
@@ -285,7 +285,7 @@
     "    template=TOXICITY_PROMPT_TEMPLATE_STR,\n",
     "    model=model,\n",
     "    rails=rails,\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -319,7 +319,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = OpenAIModel(model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20)"
+    "model = OpenAIModel(model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20)\n"
    ]
   },
   {
@@ -357,7 +357,7 @@
     "    template=TOXICITY_PROMPT_TEMPLATE_STR,\n",
     "    model=model,\n",
     "    rails=rails,\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -380,7 +380,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ")"
+    ")\n"
    ]
   }
  ],

--- a/tutorials/evals/evaluate_toxicity_classifications.ipynb
+++ b/tutorials/evals/evaluate_toxicity_classifications.ipynb
@@ -194,7 +194,7 @@
     "    # At 100 samples sometimes you only get 6 toxic classes\n",
     "    # Split the dataset into two groups: toxic and non-toxic\n",
     "    toxic_df = df[df[\"toxic\"]]\n",
-    "    non_toxic_df = df[df[\"toxic\"]]\n",
+    "    non_toxic_df = df[~df[\"toxic\"]]\n",
     "\n",
     "    # Get the minimum count between the two groups\n",
     "    min_count = min(len(toxic_df), len(non_toxic_df))\n",


### PR DESCRIPTION
- fixes bug preventing toxicity notebook from running

This bug is introduced by our formatter, which converts `df[df["toxic"] == True]` to `df[df["toxic"] is True]`. I changed it to something that the formatter won't mess up.