### PR TITLE
fix: contain openai dependency

### DIFF
--- a/src/phoenix/experimental/evals/retrievals.py
+++ b/src/phoenix/experimental/evals/retrievals.py
@@ -4,7 +4,6 @@ Helper functions for evaluating the retrieval step of retrieval-augmented genera
 
 from typing import List, Optional
 
-from openai import ChatCompletion
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -75,6 +74,9 @@ def classify_relevance(query: str, document: str, model_name: str) -> Optional[b
             (True meaning relevant, False meaning irrelevant), or None if the LLM produces an
             unparseable output.
     """
+
+    from openai import ChatCompletion
+
     prompt = _QUERY_CONTEXT_PROMPT_TEMPLATE.format(
         query=query,
         reference=document,


### PR DESCRIPTION
- contain `openai` dependency

We recently removed `openai` as a dependency in our `experimental` extra [here](https://github.com/Arize-ai/phoenix/pull/1470). We need to contain the dependency now.