### PR TITLE
feat(trace): prompt template UI

### DIFF
--- a/app/src/openInference/tracing/semanticConventions.ts
+++ b/app/src/openInference/tracing/semanticConventions.ts
@@ -14,6 +14,12 @@ export const LLMAttributePostfixes = {
   output_messages: "output_messages",
   invocation_parameters: "invocation_parameters",
   prompts: "prompts",
+  prompt_template: "prompt_template",
+} as const;
+
+export const LLMPromptTemplateAttributePostfixes = {
+  variables: "variables",
+  template: "template",
 } as const;
 
 export const RetrievalAttributePostfixes = {

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -4,10 +4,10 @@ import {
   DOCUMENT_METADATA,
   DOCUMENT_SCORE,
   EMBEDDING_TEXT,
+  LLMPromptTemplateAttributePostfixes,
   MESSAGE_CONTENT,
   MESSAGE_NAME,
   MESSAGE_ROLE,
-  LLMPromptTemplateAttributePostfixes,
 } from "./semanticConventions";
 
 export type AttributeMessage = {
@@ -35,10 +35,3 @@ export type AttributePromptTemplate = {
   [LLMPromptTemplateAttributePostfixes.variables]: Record<string, string>;
   [key: string]: unknown;
 };
-
-export function isAttributePromptTemplate(value: unknown): value is AttributePromptTemplate {
-  if (typeof value === "object") {  // TODO: Fix type guard.
-    return true;
-  }
-  return false;
-}

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -7,6 +7,7 @@ import {
   MESSAGE_CONTENT,
   MESSAGE_NAME,
   MESSAGE_ROLE,
+  LLMPromptTemplateAttributePostfixes,
 } from "./semanticConventions";
 
 export type AttributeMessage = {
@@ -28,3 +29,16 @@ export type AttributeEmbedding = {
   [EMBEDDING_TEXT]?: string;
   [key: string]: unknown;
 };
+
+export type AttributePromptTemplate = {
+  [LLMPromptTemplateAttributePostfixes.template]: string;
+  [LLMPromptTemplateAttributePostfixes.variables]: Record<string, string>;
+  [key: string]: unknown;
+};
+
+export function isAttributePromptTemplate(value: unknown): value is AttributePromptTemplate {
+  if (typeof value === "object") {  // TODO: Fix type guard.
+    return true;
+  }
+  return false;
+}

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -59,6 +59,7 @@ import {
   AttributeDocument,
   AttributeEmbedding,
   AttributeMessage,
+  isAttributePromptTemplate,
 } from "@phoenix/openInference/tracing/types";
 import { assertUnreachable, isStringArray } from "@phoenix/typeUtils";
 import { numberFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -361,6 +362,19 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
       return [];
     }
     return maybePrompts;
+  }, [llmAttributes]);
+
+  const promptTemplate = useMemo<string | null>(() => {
+    if (llmAttributes == null) {
+      return null;
+    }
+    let promptTemplate: string | null = null;
+    const maybePromptTemplate = llmAttributes[LLMAttributePostfixes.prompt_template];
+    if (!isAttributePromptTemplate(maybePromptTemplate)) {
+      promptTemplate = [];
+    }
+    return maybePromptTemplate;
+    return promptTemplate;
   }, [llmAttributes]);
 
   const invocation_parameters_str = useMemo<string>(() => {


### PR DESCRIPTION
Adds prompt template UI in the LLM import card to display which parts is the template and which parts are variables.
<img width="993" alt="Screenshot 2023-09-28 at 12 07 49 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/771f0060-7df4-496e-8501-9dcf3ff6550a">
