### PR TITLE
fix: Add uninmplemented methods to `VertexAIModel` from abstract class

### DIFF
--- a/scripts/rag/llama_index_w_evals_and_qa.py
+++ b/scripts/rag/llama_index_w_evals_and_qa.py
@@ -33,9 +33,9 @@ from llama_index.node_parser import SimpleNodeParser
 from llama_index.query_engine.multistep_query_engine import MultiStepQueryEngine
 from llama_index.query_engine.transform_query_engine import TransformQueryEngine
 from phoenix.experimental.evals import OpenAIModel, llm_eval_binary, run_relevance_eval
-from phoenix.experimental.evals.functions.common import NOT_PARSABLE
 from phoenix.experimental.evals.functions.processing import concatenate_and_truncate_chunks
 from phoenix.experimental.evals.models import BaseEvalModel
+from phoenix.experimental.evals.templates import NOT_PARSABLE
 from plotresults import (
     plot_latency_graphs,
     plot_mean_average_precision_graphs,

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -138,7 +138,7 @@ class BaseEvalModel(ABC):
             package_display_name = package_name
         msg = (
             f"Could not import necessary dependencies to use {package_display_name}. "
-            "Please install them with"
+            "Please install them with "
         )
         if package_min_version:
             msg += f"`pip install {package_name}>={package_min_version}`."
@@ -148,16 +148,16 @@ class BaseEvalModel(ABC):
 
     @abstractmethod
     def get_tokens_from_text(self, text: str) -> List[int]:
-        raise NotImplementedError
+        ...
 
     @abstractmethod
     def get_text_from_tokens(self, tokens: List[int]) -> str:
-        raise NotImplementedError
+        ...
 
     @abstractproperty
     def max_context_size(self) -> int:
-        raise NotImplementedError
+        ...
 
     @abstractproperty
     def encoder(self) -> "Encoding":
-        raise NotImplementedError
+        ...

--- a/src/phoenix/experimental/evals/models/vertexai.py
+++ b/src/phoenix/experimental/evals/models/vertexai.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from .base import BaseEvalModel, create_base_retry_decorator
 
@@ -132,6 +132,20 @@ class VertexAIModel(BaseEvalModel):
                 "top_k": self.top_k,
                 "top_p": self.top_p,
             }
+
+    def get_tokens_from_text(self, text: str) -> List[int]:
+        raise NotImplementedError
+
+    def get_text_from_tokens(self, tokens: List[int]) -> str:
+        raise NotImplementedError
+
+    @property
+    def max_context_size(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def encoder(self):  # type:ignore
+        raise NotImplementedError
 
 
 def is_codey_model(model_name: str) -> bool:


### PR DESCRIPTION
This PR fixes the following error. When using a `VertexAIModel` the abstract methods were not included, hence the instantiation failed

```python
from phoenix.experimental.evals import VertexAIModel
model = VertexAIModel()

TypeError: Can't instantiate abstract class VertexAIModel with abstract methods encoder, get_text_from_tokens, get_tokens_from_text, max_context_size
```
