### PR TITLE
fix: llm_eval_binary Argument Order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ model = OpenAIModel(
     temperature=0.0,
 )
 rails =list(RAG_RELEVANCY_PROMPT_RAILS_MAP.values())
-df["eval_relevance"] = llm_eval_binary(df, RAG_RELEVANCY_PROMPT_TEMPLATE_STR, model, rails)
+df["eval_relevance"] = llm_eval_binary(df, model, RAG_RELEVANCY_PROMPT_TEMPLATE_STR, rails)
 #Golden dataset has True/False map to -> "irrelevant" / "relevant"
 #we can then scikit compare to output of template - same format
 y_true = df["relevant"].map({True: "relevant", False: "irrelevant"})


### PR DESCRIPTION
I was running this example and noticed the model and template arguments are reversed.
Specifically, [`model` comes before `template`](https://github.com/Arize-ai/phoenix/blob/main/src/phoenix/experimental/evals/functions/binary.py#L24)