### PR TITLE
fix: server thread should be daemon

### DIFF
--- a/src/phoenix/server/thread_server.py
+++ b/src/phoenix/server/thread_server.py
@@ -30,7 +30,7 @@ class ThreadServer(Server):
 
     def run_in_thread(self) -> Generator[Thread, None, None]:
         """A coroutine to keep the server running in a thread."""
-        thread = Thread(target=self.run)
+        thread = Thread(target=self.run, daemon=True)
         thread.start()
         time_limit = time() + 5  # 5 seconds
         try:


### PR DESCRIPTION
## `daemon=False`: Python runtime can't exit

https://github.com/Arize-ai/phoenix/assets/80478925/90300cd5-edce-4255-a7b9-6d23479c1f87

## `daemon=True`

https://github.com/Arize-ai/phoenix/assets/80478925/f804234d-1fb4-4d8a-9fff-f193459c58d2