### PR TITLE
chore: use semantic text color instead of white

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^0.16.0",
+        "@arizeai/components": "^0.17.0",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/view": "^6.16.0",
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.16.0.tgz",
-      "integrity": "sha512-xWl3xsVYMMlW1TlP5XjyVm5HovFRK9fiT+64asAY4Nw/9Gs0CZw3xu2kbeu0GimF57IO7OXjxO0sSyBpgpFMAg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.17.0.tgz",
+      "integrity": "sha512-EPZbOBQ3NHXAaLi+ZL3S6C1r9WVoALSvsAEu5cULNyFJ6mlYwhiQqNXpLqe4V0mEbPkLwa8BJTs15FjihgbANg==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -9890,9 +9890,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.16.0.tgz",
-      "integrity": "sha512-xWl3xsVYMMlW1TlP5XjyVm5HovFRK9fiT+64asAY4Nw/9Gs0CZw3xu2kbeu0GimF57IO7OXjxO0sSyBpgpFMAg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.17.0.tgz",
+      "integrity": "sha512-EPZbOBQ3NHXAaLi+ZL3S6C1r9WVoALSvsAEu5cULNyFJ6mlYwhiQqNXpLqe4V0mEbPkLwa8BJTs15FjihgbANg==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^0.16.0",
+    "@arizeai/components": "^0.17.0",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/view": "^6.16.0",
@@ -74,7 +74,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:image & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -6,8 +6,8 @@ export function GlobalStyles() {
     <Global
       styles={(theme) => css`
         body {
-          background-color: ${theme.colors.gray800};
-          color: ${theme.textColors.white90};
+          background-color: var(--ac-global-color-gray-900);
+          color: var(--ac-global-text-color-900);
           font-family: "Roboto";
           font-size: ${theme.typography.sizes.medium.fontSize}px;
           margin: 0;

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -9,7 +9,7 @@ import { theme } from "@arizeai/components";
 export const defaultTimeXAxisProps: XAxisProps = {
   dataKey: "timestamp",
   stroke: theme.colors.gray200,
-  style: { fill: theme.textColors.text - 700 },
+  style: { fill: "var(--ac-global-text-color-700)" },
   scale: "time",
   type: "number",
   domain: ["auto", "auto"],

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -9,7 +9,7 @@ import { theme } from "@arizeai/components";
 export const defaultTimeXAxisProps: XAxisProps = {
   dataKey: "timestamp",
   stroke: theme.colors.gray200,
-  style: { fill: theme.textColors.white70 },
+  style: { fill: theme.textColors.text - 700 },
   scale: "time",
   type: "number",
   domain: ["auto", "auto"],

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -18,7 +18,7 @@ const navCSS = (theme: Theme) => css`
 `;
 
 const brandCSS = (theme: Theme) => css`
-  color: ${theme.textColors.white90};
+  color: ${theme.textColors.text - 900};
   font-size: ${theme.typography.sizes.large.fontSize}px;
   text-decoration: none;
   svg {
@@ -58,7 +58,7 @@ function IconLink(props: PropsWithChildren<{ href: string }>) {
           transition: fill 0.2s ease-in-out;
         }
         &:hover svg {
-          fill: ${theme.textColors.white90};
+          fill: ${theme.textColors.text - 900};
         }
       `}
       aria-label="GitHub"

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -18,7 +18,7 @@ const navCSS = (theme: Theme) => css`
 `;
 
 const brandCSS = (theme: Theme) => css`
-  color: ${theme.textColors.text - 900};
+  color: var(--ac-global-text-color-900);
   font-size: ${theme.typography.sizes.large.fontSize}px;
   text-decoration: none;
   svg {
@@ -58,7 +58,7 @@ function IconLink(props: PropsWithChildren<{ href: string }>) {
           transition: fill 0.2s ease-in-out;
         }
         &:hover svg {
-          fill: ${theme.textColors.text - 900};
+          fill: var(--ac-global-text-color-900);
         }
       `}
       aria-label="GitHub"

--- a/app/src/components/pointcloud/ClusterItem.tsx
+++ b/app/src/components/pointcloud/ClusterItem.tsx
@@ -136,7 +136,7 @@ export function ClusterItem(props: ClusterItemProps) {
           <Flex direction="column" alignItems="start">
             <Heading level={3}>{`Cluster ${clusterId}`}</Heading>
             <Text
-              color="white70"
+              color="text-700"
               textSize="small"
             >{`${props.numPoints} points`}</Text>
           </Flex>
@@ -149,10 +149,10 @@ export function ClusterItem(props: ClusterItemProps) {
             align-items: end;
           `}
         >
-          <Text color="white70" textSize="small">
+          <Text color="text-700" textSize="small">
             {metricName}
           </Text>
-          <Text color="white90" textSize="medium">
+          <Text color="text-900" textSize="medium">
             {numberFormatter(primaryMetricValue)}
           </Text>
           {!hideReference ? (

--- a/app/src/pages/dimension/DimensionCardinalityStats.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityStats.tsx
@@ -33,7 +33,7 @@ export function DimensionCardinalityStats(props: {
 
   return (
     <>
-      <Text elementType="h3" textSize="small" color="white70">
+      <Text elementType="h3" textSize="small" color="text-700">
         Cardinality
       </Text>
       <Text textSize="xlarge">{intFormatter(data.cardinality)}</Text>

--- a/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
@@ -139,9 +139,12 @@ export function DimensionCardinalityTimeSeries({
             value: "Cardinality",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
@@ -139,9 +139,9 @@ export function DimensionCardinalityTimeSeries({
             value: "Cardinality",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionCountStats.tsx
+++ b/app/src/pages/dimension/DimensionCountStats.tsx
@@ -25,7 +25,7 @@ export function DimensionCountStats(props: {
 
   return (
     <>
-      <Text elementType="h3" textSize="small" color="white70">
+      <Text elementType="h3" textSize="small" color="text-700">
         Total Count
       </Text>
       <Text textSize="xlarge">{intFormatter(count)}</Text>

--- a/app/src/pages/dimension/DimensionCountTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCountTimeSeries.tsx
@@ -137,9 +137,9 @@ export function DimensionCountTimeSeries({
             value: "Count",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionCountTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCountTimeSeries.tsx
@@ -137,9 +137,12 @@ export function DimensionCountTimeSeries({
             value: "Count",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
+++ b/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
@@ -231,7 +231,7 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
             </defs>
             <XAxis
               dataKey="name"
-              style={{ fill: theme.textColors.text - 700 }}
+              style={{ fill: "var(--ac-global-text-color-700)" }}
             />
             <YAxis
               stroke={theme.colors.gray200}
@@ -241,10 +241,10 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
                 position: "insideLeft",
                 style: {
                   textAnchor: "middle",
-                  fill: theme.textColors.text - 900,
+                  fill: "var(--ac-global-text-color-900)",
                 },
               }}
-              style={{ fill: theme.textColors.text - 700 }}
+              style={{ fill: "var(--ac-global-text-color-700)" }}
             />
             <CartesianGrid
               strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
+++ b/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
@@ -179,7 +179,7 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
         <Text
           elementType="h3"
           textSize="medium"
-          color="white70"
+          color="text-700"
         >{`Distribution comparison at ${fullTimeFormatter(
           new Date(timeRange.end)
         )}`}</Text>
@@ -229,16 +229,22 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
                 />
               </linearGradient>
             </defs>
-            <XAxis dataKey="name" style={{ fill: theme.textColors.white70 }} />
+            <XAxis
+              dataKey="name"
+              style={{ fill: theme.textColors.text - 700 }}
+            />
             <YAxis
               stroke={theme.colors.gray200}
               label={{
                 value: "Percent",
                 angle: -90,
                 position: "insideLeft",
-                style: { textAnchor: "middle", fill: theme.textColors.white90 },
+                style: {
+                  textAnchor: "middle",
+                  fill: theme.textColors.text - 900,
+                },
               }}
-              style={{ fill: theme.textColors.white70 }}
+              style={{ fill: theme.textColors.text - 700 }}
             />
             <CartesianGrid
               strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionDriftStats.tsx
+++ b/app/src/pages/dimension/DimensionDriftStats.tsx
@@ -52,7 +52,7 @@ export function DimensionDriftStats(props: {
   return (
     <>
       <Flex direction="row" alignItems="center" gap="size-25">
-        <Text elementType="h3" textSize="small" color="white70">
+        <Text elementType="h3" textSize="small" color="text-700">
           PSI
         </Text>
         {contextualHelp}

--- a/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
@@ -200,9 +200,9 @@ export function DimensionDriftTimeSeries({
             value: "PSI",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <YAxis
           yAxisId="right"

--- a/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
@@ -200,9 +200,12 @@ export function DimensionDriftTimeSeries({
             value: "PSI",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <YAxis
           yAxisId="right"

--- a/app/src/pages/dimension/DimensionPercentEmptyStats.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyStats.tsx
@@ -33,7 +33,7 @@ export function DimensionPercentEmptyStats(props: {
 
   return (
     <>
-      <Text elementType="h3" textSize="small" color="white70">
+      <Text elementType="h3" textSize="small" color="text-700">
         % Empty
       </Text>
       <Text textSize="xlarge">{percentFormatter(data.percentEmpty)}</Text>

--- a/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
@@ -135,9 +135,12 @@ export function DimensionPercentEmptyTimeSeries({
             value: "% Empty",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
@@ -135,9 +135,9 @@ export function DimensionPercentEmptyTimeSeries({
             value: "% Empty",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionQuantilesStats.tsx
+++ b/app/src/pages/dimension/DimensionQuantilesStats.tsx
@@ -44,7 +44,7 @@ export function DimensionQuantilesStats(props: {
               align-items: flex-end;
             `}
           >
-            <Text elementType="h3" textSize="xsmall" color="white70">
+            <Text elementType="h3" textSize="xsmall" color="text-700">
               {statName}
             </Text>
             <Text textSize="medium" data-raw={stat}>

--- a/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
@@ -262,10 +262,10 @@ export function DimensionQuantilesTimeSeries({
             value: "Value",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
           tickFormatter={(x) => yTickFormatter(x)}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
@@ -262,10 +262,13 @@ export function DimensionQuantilesTimeSeries({
             value: "Value",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
           tickFormatter={(x) => yTickFormatter(x)}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
+++ b/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
@@ -136,16 +136,16 @@ export function DimensionSegmentsBarChart(props: {
             <stop offset="95%" stopColor={barColor} stopOpacity={0.5} />
           </linearGradient>
         </defs>
-        <XAxis dataKey="name" style={{ fill: theme.textColors.white70 }} />
+        <XAxis dataKey="name" style={{ fill: theme.textColors.text - 700 }} />
         <YAxis
           stroke={theme.colors.gray200}
           label={{
             value: "% Volume",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.white90 },
+            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
           }}
-          style={{ fill: theme.textColors.white70 }}
+          style={{ fill: theme.textColors.text - 700 }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
+++ b/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
@@ -136,16 +136,22 @@ export function DimensionSegmentsBarChart(props: {
             <stop offset="95%" stopColor={barColor} stopOpacity={0.5} />
           </linearGradient>
         </defs>
-        <XAxis dataKey="name" style={{ fill: theme.textColors.text - 700 }} />
+        <XAxis
+          dataKey="name"
+          style={{ fill: "var(--ac-global-text-color-700)" }}
+        />
         <YAxis
           stroke={theme.colors.gray200}
           label={{
             value: "% Volume",
             angle: -90,
             position: "insideLeft",
-            style: { textAnchor: "middle", fill: theme.textColors.text - 900 },
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
           }}
-          style={{ fill: theme.textColors.text - 700 }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
         />
         <CartesianGrid
           strokeDasharray="4 4"

--- a/app/src/pages/embedding/ClusterSortPicker.tsx
+++ b/app/src/pages/embedding/ClusterSortPicker.tsx
@@ -76,13 +76,13 @@ export function ClusterSortPicker() {
         .ac-action-button {
           background: none;
           border: none;
-          color: ${theme.textColors.text - 700};
+          color: ${"var(--ac-global-text-color-700)"};
           font-size: ${theme.typography.sizes.small.fontSize}px;
           line-height: ${theme.typography.sizes.small.lineHeight}px;
           cursor: pointer;
           outline: none;
           &:hover {
-            color: ${theme.textColors.text - 900};
+            color: var(--ac-global-text-color-900);
           }
         }
       `}

--- a/app/src/pages/embedding/ClusterSortPicker.tsx
+++ b/app/src/pages/embedding/ClusterSortPicker.tsx
@@ -76,13 +76,13 @@ export function ClusterSortPicker() {
         .ac-action-button {
           background: none;
           border: none;
-          color: ${theme.textColors.white70};
+          color: ${theme.textColors.text - 700};
           font-size: ${theme.typography.sizes.small.fontSize}px;
           line-height: ${theme.typography.sizes.small.lineHeight}px;
           cursor: pointer;
           outline: none;
           &:hover {
-            color: ${theme.textColors.white90};
+            color: ${theme.textColors.text - 900};
           }
         }
       `}

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -56,7 +56,7 @@ function TextPre(props: PropsWithChildren) {
       <pre
         css={(theme) => css`
           padding: var(--px-spacing-lg);
-          color: ${theme.textColors.text - 900};
+          color: var(--ac-global-text-color-900);
           white-space: normal;
           margin: 0;
         `}

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -54,7 +54,7 @@ function TextPre(props: PropsWithChildren) {
       `}
     >
       <pre
-        css={(theme) => css`
+        css={css`
           padding: var(--px-spacing-lg);
           color: var(--ac-global-text-color-900);
           white-space: normal;

--- a/app/src/pages/embedding/EventDetails.tsx
+++ b/app/src/pages/embedding/EventDetails.tsx
@@ -56,7 +56,7 @@ function TextPre(props: PropsWithChildren) {
       <pre
         css={(theme) => css`
           padding: var(--px-spacing-lg);
-          color: ${theme.textColors.white90};
+          color: ${theme.textColors.text - 900};
           white-space: normal;
           margin: 0;
         `}

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -365,7 +365,7 @@ export function MetricTimeSeries({
             <XAxis
               {...defaultTimeXAxisProps}
               tickFormatter={(x) => timeTickFormatter(new Date(x))}
-              style={{ fill: theme.textColors.white70 }}
+              style={{ fill: theme.textColors.text - 700 }}
             />
             <YAxis
               stroke={theme.colors.gray200}
@@ -373,9 +373,12 @@ export function MetricTimeSeries({
                 value: metricShortName,
                 angle: -90,
                 position: "insideLeft",
-                style: { textAnchor: "middle", fill: theme.textColors.white90 },
+                style: {
+                  textAnchor: "middle",
+                  fill: theme.textColors.text - 900,
+                },
               }}
-              style={{ fill: theme.textColors.white70 }}
+              style={{ fill: theme.textColors.text - 700 }}
             />
             <YAxis
               yAxisId="right"
@@ -384,9 +387,12 @@ export function MetricTimeSeries({
                 value: "Count",
                 angle: 90,
                 position: "insideRight",
-                style: { textAnchor: "middle", fill: theme.textColors.white90 },
+                style: {
+                  textAnchor: "middle",
+                  fill: theme.textColors.text - 900,
+                },
               }}
-              style={{ fill: theme.textColors.white70 }}
+              style={{ fill: theme.textColors.text - 700 }}
             />
             <CartesianGrid
               strokeDasharray="4 4"

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -365,7 +365,7 @@ export function MetricTimeSeries({
             <XAxis
               {...defaultTimeXAxisProps}
               tickFormatter={(x) => timeTickFormatter(new Date(x))}
-              style={{ fill: theme.textColors.text - 700 }}
+              style={{ fill: "var(--ac-global-text-color-700)" }}
             />
             <YAxis
               stroke={theme.colors.gray200}
@@ -375,10 +375,10 @@ export function MetricTimeSeries({
                 position: "insideLeft",
                 style: {
                   textAnchor: "middle",
-                  fill: theme.textColors.text - 900,
+                  fill: "var(--ac-global-text-color-900)",
                 },
               }}
-              style={{ fill: theme.textColors.text - 700 }}
+              style={{ fill: "var(--ac-global-text-color-700)" }}
             />
             <YAxis
               yAxisId="right"
@@ -389,10 +389,10 @@ export function MetricTimeSeries({
                 position: "insideRight",
                 style: {
                   textAnchor: "middle",
-                  fill: theme.textColors.text - 900,
+                  fill: "var(--ac-global-text-color-900)",
                 },
               }}
-              style={{ fill: theme.textColors.text - 700 }}
+              style={{ fill: "var(--ac-global-text-color-700)" }}
             />
             <CartesianGrid
               strokeDasharray="4 4"

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -624,7 +624,7 @@ function EmbeddingSpanInfo(props: {
                       borderWidth="thin"
                       borderRadius="medium"
                     >
-                      <Text color="white70" fontStyle="italic">
+                      <Text color="text-700" fontStyle="italic">
                         embedded text
                       </Text>
                       <pre
@@ -681,7 +681,7 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
               backgroundColor="light"
             >
               <Flex direction="column" alignItems="start" gap="size-50">
-                <Text color="white70" fontStyle="italic">
+                <Text color="text-700" fontStyle="italic">
                   Description
                 </Text>
                 <Text>{toolDescription as string}</Text>
@@ -698,7 +698,7 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
               borderBottomWidth="thin"
             >
               <Flex direction="column" alignItems="start" width="100%">
-                <Text color="white70" fontStyle="italic">
+                <Text color="text-700" fontStyle="italic">
                   Parameters
                 </Text>
                 <CodeBlock
@@ -809,7 +809,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
       {...messageStyles}
     >
       <Flex direction="column" alignItems="start">
-        <Text color="white70" fontStyle="italic">
+        <Text color="text-700" fontStyle="italic">
           {role}
           {message[MESSAGE_NAME] ? `: ${message[MESSAGE_NAME]}` : ""}
         </Text>
@@ -1046,10 +1046,10 @@ function SpanEventsList({ events }: { events: Span["events"] }) {
               </View>
               <Flex direction="column" gap="size-25" flex="1 1 auto">
                 <Text weight="heavy">{event.name}</Text>
-                <Text color="white70">{event.message}</Text>
+                <Text color="text-700">{event.message}</Text>
               </Flex>
               <View>
-                <Text color="white70">
+                <Text color="text-700">
                   {new Date(event.timestamp).toLocaleString()}
                 </Text>
               </View>

--- a/app/src/pages/tracing/TracingHomePageHeader.tsx
+++ b/app/src/pages/tracing/TracingHomePageHeader.tsx
@@ -43,7 +43,7 @@ export function TracingHomePageHeader(props: {
     >
       <Flex direction="row" gap="size-400" alignItems="center">
         <Flex direction="column">
-          <Text elementType="h3" textSize="medium" color="white70">
+          <Text elementType="h3" textSize="medium" color="text-700">
             Total Traces
           </Text>
           <Text textSize="xlarge">
@@ -51,13 +51,13 @@ export function TracingHomePageHeader(props: {
           </Text>
         </Flex>
         <Flex direction="column">
-          <Text elementType="h3" textSize="medium" color="white70">
+          <Text elementType="h3" textSize="medium" color="text-700">
             Total Tokens
           </Text>
           <Text textSize="xlarge">{intFormatter(tokenCountTotal)}</Text>
         </Flex>
         <Flex direction="column">
-          <Text elementType="h3" textSize="medium" color="white70">
+          <Text elementType="h3" textSize="medium" color="text-700">
             Latency P50
           </Text>
           {latencyMsP50 != null ? (
@@ -67,7 +67,7 @@ export function TracingHomePageHeader(props: {
           )}
         </Flex>
         <Flex direction="column">
-          <Text elementType="h3" textSize="medium" color="white70">
+          <Text elementType="h3" textSize="medium" color="text-700">
             Latency P99
           </Text>
 


### PR DESCRIPTION
This makes it so we use semantic color names rather than explicit colors so that we can eventually rotate the theme for light mode.

It also removes the crazy noise in the console.