### PR TITLE
feat(tracing): gql validate_span_filter_condition

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -461,6 +461,7 @@ type Query {
   ): [Cluster!]!
   spans(timeRange: TimeRange, traceIds: [ID!], first: Int = 50, last: Int, after: String, before: String, sort: SpanSort, rootSpansOnly: Boolean = false, filterCondition: String = null): SpanConnection!
   traceDatasetInfo: TraceDatasetInfo
+  validateSpanFilterCondition(condition: String!): ValidationResult!
 }
 
 type Retrieval {
@@ -642,6 +643,11 @@ type UMAPPoints {
   clusters: [Cluster!]!
   corpusData: [UMAPPoint!]!
   contextRetrievals: [Retrieval!]!
+}
+
+type ValidationResult {
+  isValid: Boolean!
+  errorMessage: String
 }
 
 enum VectorDriftMetric {

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -40,6 +40,7 @@ from .types.Model import Model
 from .types.node import GlobalID, Node, from_global_id
 from .types.pagination import Connection, ConnectionArgs, Cursor, connection_from_list
 from .types.Span import Span, to_gql_span
+from .types.ValidationResult import ValidationResult
 
 
 @strawberry.type
@@ -260,6 +261,19 @@ class Query:
             latency_ms_p50=latency_ms_p50,
             latency_ms_p99=latency_ms_p99,
         )
+
+    @strawberry.field
+    def validate_span_filter_condition(
+        self, info: Info[Context, None], condition: str
+    ) -> ValidationResult:
+        try:
+            SpanFilter(condition)
+            return ValidationResult(is_valid=True, error_message=None)
+        except SyntaxError as e:
+            return ValidationResult(
+                is_valid=False,
+                error_message=e.msg,
+            )
 
 
 @strawberry.type

--- a/src/phoenix/server/api/types/ValidationResult.py
+++ b/src/phoenix/server/api/types/ValidationResult.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+import strawberry
+
+
+@strawberry.type
+class ValidationResult:
+    is_valid: bool
+    error_message: Optional[str]


### PR DESCRIPTION
resolves #1574 

This validation endpoint for the python query string is needed because the UI needs the ability to construct a query without the server erroring out and to place the error_message directly on the input validation.

```graphql
{
  validateSpanFilterCondition(condition: "span_kind=='llm' and context.trace_id == 'abc'") {
    isValid
    errorMessage
  }
}
```