### PR TITLE
fix: remove quiet flags

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,7 +157,7 @@ The code below installs the `main` branch in [Colab](https://colab.research.goog
 !npm install -g -s n
 !n latest
 !npm install -g -s npm@latest
-%pip install -qqq git+https://github.com/Arize-ai/phoenix.git@main
+%pip install git+https://github.com/Arize-ai/phoenix.git@main
 ```
 
 ## Setting Up Your Windows Test Environment

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Here is an example of running the RAG relevance eval on a dataset of Wikipedia q
 
 ```shell
 # Install phoenix as well as the experimental subpackage
-pip install -qq arize-phoenix[experimental] ipython matplotlib openai pycm scikit-learn
+pip install arize-phoenix[experimental] ipython matplotlib openai pycm scikit-learn
 ```
 
 ```python

--- a/examples/anthropic_evals_persona.ipynb
+++ b/examples/anthropic_evals_persona.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq arize-phoenix arize[\"AutoEmbeddings\"]"
+    "!pip install arize-phoenix arize[\"AutoEmbeddings\"]"
    ]
   },
   {
@@ -15,6 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
+    "\n",
     "import pandas as pd\n",
     "import phoenix as px"
    ]
@@ -26,7 +28,6 @@
    "outputs": [],
    "source": [
     "import requests\n",
-    "import json\n",
     "\n",
     "# The url of the persona dataset\n",
     "url = \"https://raw.githubusercontent.com/anthropics/evals/main/persona/anti-LGBTQ-rights.jsonl\"\n",

--- a/examples/dolly-pythia-fine-tuned/dolly_vs_pythia.ipynb
+++ b/examples/dolly-pythia-fine-tuned/dolly_vs_pythia.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix"
+    "!pip install arize-phoenix"
    ]
   },
   {
@@ -35,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ast\n",
     "import hashlib\n",
     "import re\n",
     "\n",

--- a/examples/taylor_swift_lyrics.ipynb
+++ b/examples/taylor_swift_lyrics.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix"
+    "!pip install arize-phoenix"
    ]
   },
   {
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize[\"AutoEmbeddings\"]"
+    "!pip install arize[\"AutoEmbeddings\"]"
    ]
   },
   {

--- a/scripts/rag/llamaindex_retrieval_chunk_eval.ipynb
+++ b/scripts/rag/llamaindex_retrieval_chunk_eval.ipynb
@@ -171,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q cohere matplotlib lxml openai arize-phoenix llama_index"
+    "!pip install cohere matplotlib lxml openai arize-phoenix llama_index"
    ]
   },
   {

--- a/tutorials/credit_card_fraud_tutorial.ipynb
+++ b/tutorials/credit_card_fraud_tutorial.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix \"arize[AutoEmbeddings]\""
+    "!pip install arize-phoenix \"arize[AutoEmbeddings]\""
    ]
   },
   {

--- a/tutorials/evals/evaluate_QA_classifications.ipynb
+++ b/tutorials/evals/evaluate_QA_classifications.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/evals/evaluate_code_readability_classifications.ipynb
+++ b/tutorials/evals/evaluate_code_readability_classifications.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/evals/evaluate_hallucination_classifications.ipynb
+++ b/tutorials/evals/evaluate_hallucination_classifications.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/evals/evaluate_relevance_classifications.ipynb
+++ b/tutorials/evals/evaluate_relevance_classifications.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/evals/evaluate_summarization_classifications.ipynb
+++ b/tutorials/evals/evaluate_summarization_classifications.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/evals/evaluate_toxicity_classifications.ipynb
+++ b/tutorials/evals/evaluate_toxicity_classifications.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
+    "!pip install \"arize-phoenix[experimental]\" ipython matplotlib openai pycm scikit-learn tiktoken"
    ]
   },
   {

--- a/tutorials/example_datasets.ipynb
+++ b/tutorials/example_datasets.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix"
+    "!pip install arize-phoenix"
    ]
   },
   {

--- a/tutorials/internal/langchain_retrieval_qa_with_sources_chain_tracing_tutorial.ipynb
+++ b/tutorials/internal/langchain_retrieval_qa_with_sources_chain_tracing_tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qqq arize-phoenix[experimental] langchain chromadb openai tiktoken playwright asyncio nest_asyncio"
+    "!pip install arize-phoenix[experimental] langchain chromadb openai tiktoken playwright asyncio nest_asyncio"
    ]
   },
   {

--- a/tutorials/internal/llama_index_tracing_example.ipynb
+++ b/tutorials/internal/llama_index_tracing_example.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q \"arize-phoenix[experimental]\" gcsfs llama-index tqdm"
+    "!pip install \"arize-phoenix[experimental]\" gcsfs llama-index tqdm"
    ]
   },
   {

--- a/tutorials/langchain_pinecone_search_and_retrieval_tutorial.ipynb
+++ b/tutorials/langchain_pinecone_search_and_retrieval_tutorial.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix langchain openai pinecone-client"
+    "!pip install arize-phoenix langchain openai pinecone-client"
    ]
   },
   {
@@ -103,8 +103,8 @@
     "import os\n",
     "import textwrap\n",
     "from datetime import timedelta\n",
-    "from typing import Dict, List, Optional, Tuple\n",
     "from getpass import getpass\n",
+    "from typing import Dict, List, Optional, Tuple\n",
     "\n",
     "import numpy as np\n",
     "import openai\n",

--- a/tutorials/llama_index_search_and_retrieval_tutorial.ipynb
+++ b/tutorials/llama_index_search_and_retrieval_tutorial.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q \"arize-phoenix[experimental]\" gcsfs langchain llama-index openai"
+    "!pip install \"arize-phoenix[experimental]\" gcsfs langchain llama-index openai"
    ]
   },
   {

--- a/tutorials/llm_summarization_tutorial.ipynb
+++ b/tutorials/llm_summarization_tutorial.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q \"arize-phoenix\" \"arize[AutoEmbeddings, LLM_Evaluation]\""
+    "!pip install \"arize-phoenix\" \"arize[AutoEmbeddings, LLM_Evaluation]\""
    ]
   },
   {

--- a/tutorials/milvus_llamaindex_search_and_retrieval_tutorial.ipynb
+++ b/tutorials/milvus_llamaindex_search_and_retrieval_tutorial.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q gcsfs \"arize-phoenix[experimental]\" openai"
+    "!pip install gcsfs \"arize-phoenix[experimental]\" openai"
    ]
   },
   {
@@ -126,6 +126,7 @@
     "import urllib.request\n",
     "from datetime import timedelta\n",
     "from getpass import getpass\n",
+    "\n",
     "import numpy as np\n",
     "import openai\n",
     "import pandas as pd\n",

--- a/tutorials/ragas_retrieval_evals_tutorial.ipynb
+++ b/tutorials/ragas_retrieval_evals_tutorial.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix gcsfs langchain llama-index datasets ragas"
+    "!pip install arize-phoenix gcsfs langchain llama-index datasets ragas"
    ]
   },
   {
@@ -97,12 +97,12 @@
    "source": [
     "import os\n",
     "import textwrap\n",
+    "from getpass import getpass\n",
     "\n",
     "import numpy as np\n",
     "import openai\n",
     "import pandas as pd\n",
     "import phoenix as px\n",
-    "from getpass import getpass\n",
     "from datasets import Dataset\n",
     "from gcsfs import GCSFileSystem\n",
     "from langchain.chat_models import ChatOpenAI\n",

--- a/tutorials/sentiment_classification_tutorial.ipynb
+++ b/tutorials/sentiment_classification_tutorial.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q \"arize[AutoEmbeddings]\" arize-phoenix"
+    "!pip install \"arize[AutoEmbeddings]\" arize-phoenix"
    ]
   },
   {

--- a/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq arize-phoenix langchain openai"
+    "!pip install arize-phoenix langchain openai"
    ]
   },
   {

--- a/tutorials/tracing/langchain_google_palm_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_google_palm_tracing_tutorial.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" google-generativeai langchain"
+    "!pip install \"arize-phoenix[experimental]\" google-generativeai langchain"
    ]
   },
   {

--- a/tutorials/tracing/langchain_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_tracing_tutorial.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q arize-phoenix langchain openai tiktoken"
+    "!pip install arize-phoenix langchain openai tiktoken"
    ]
   },
   {

--- a/tutorials/tracing/langchain_vertex_ai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_vertex_ai_tracing_tutorial.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" google-api-python-client \"google-cloud-aiplatform[preview]\" langchain"
+    "!pip install \"arize-phoenix[experimental]\" google-api-python-client \"google-cloud-aiplatform[preview]\" langchain"
    ]
   },
   {

--- a/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq arize-phoenix llama-index openai"
+    "!pip install arize-phoenix llama-index openai"
    ]
   },
   {

--- a/tutorials/tracing/llama_index_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_tracing_tutorial.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[experimental]\" gcsfs \"llama-index>0.8.36\" openai"
+    "!pip install \"arize-phoenix[experimental]\" gcsfs \"llama-index>0.8.36\" openai"
    ]
   },
   {

--- a/tutorials/tracing/openai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/openai_tracing_tutorial.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qq arize-phoenix jsonschema openai"
+    "!pip install arize-phoenix jsonschema openai"
    ]
   },
   {


### PR DESCRIPTION
Removes `-q`, `-qq`, and `-qqq` flags from all notebooks and installation guides. These flags are swallowing the "Restart Runtime" button on Colab when there is an installation issue, making it more difficult for users to troubleshoot installation issues themselves.