### PR TITLE
fix: `LlamaIndex` callback handler should fail gracefully

### DIFF
--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -167,6 +167,15 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
     https://github.com/Arize-ai/open-inference-spec
     """
 
+    def _fallback_handler(self, *args: Any, **kwargs: Any) -> None:
+        """
+        A fallback handler that prints a notification that this callback handler is failing.
+        """
+
+        print(
+            "OpenInferenceCallbackHandler callback failed, more info is logged to the root logger"
+        )
+
     def __init__(
         self,
         callback: Optional[Callable[[List[Span]], None]] = None,
@@ -176,6 +185,7 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         self._tracer = Tracer(on_append=callback, exporter=exporter or HttpExporter())
         self._event_id_to_event_data: EventData = defaultdict(lambda: CBEventData())
 
+    @graceful_fallback(_fallback_handler)
     def on_event_start(
         self,
         event_type: CBEventType,
@@ -202,6 +212,7 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
 
         return event_id
 
+    @graceful_fallback(_fallback_handler)
     def on_event_end(
         self,
         event_type: CBEventType,
@@ -224,9 +235,11 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
                 payload_to_semantic_attributes(event_type, payload),
             )
 
+    @graceful_fallback(_fallback_handler)
     def start_trace(self, trace_id: Optional[str] = None) -> None:
         self._event_id_to_event_data = defaultdict(lambda: CBEventData())
 
+    @graceful_fallback(_fallback_handler)
     def end_trace(
         self,
         trace_id: Optional[str] = None,

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -178,11 +178,7 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         self._event_id_to_event_data: EventData = defaultdict(lambda: CBEventData())
 
     def _null_fallback(self, *args: Any, **kwargs: Any) -> None:
-        msg = (
-            "OpenInferenceCallbackHandler trace processing failed, more info is logged to the root"
-            "logger"
-        )
-        logger.exception(msg)
+        return
 
     def _on_event_fallback(
         self,
@@ -191,11 +187,6 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         event_id: CBEventID = "",
         **kwargs: Any,
     ) -> CBEventID:
-        msg = (
-            "OpenInferenceCallbackHandler trace processing failed, more info is logged to the root"
-            "logger"
-        )
-        logger.exception(msg)
         return event_id or str(uuid4())
 
     @graceful_fallback(_on_event_fallback)

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -1,11 +1,18 @@
 import logging
-from typing import Any, Iterable, Optional, Type
+from typing import Any, Callable, Iterable, Optional, Type
+
+from typing_extensions import TypeVar, cast
+
+G = TypeVar("G", bound=Callable[..., Any])
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def graceful_fallback(fallback_method, exceptions: Optional[Iterable[Type[BaseException]]] = None):
-    exceptions = (BaseException,) if exceptions is None else exceptions
+def graceful_fallback(
+    fallback_method: Callable[..., Any], exceptions: Optional[Iterable[Type[BaseException]]] = None
+) -> Callable[[F], F]:
+    exceptions = (BaseException,) if exceptions is None else tuple(exceptions)
 
-    def decorator(func):
+    def decorator(func: F) -> F:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             try:
                 return func(*args, **kwargs)
@@ -13,6 +20,6 @@ def graceful_fallback(fallback_method, exceptions: Optional[Iterable[Type[BaseEx
                 logging.error(f"Exception in {func.__name__}: {exc}")
             return fallback_method(*args, **kwargs)
 
-        return wrapper
+        return cast(F, wrapper)
 
     return decorator

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -1,0 +1,18 @@
+import logging
+from typing import Any, Iterable, Optional, Type
+
+
+def graceful_fallback(fallback_method, exceptions: Optional[Iterable[Type[BaseException]]] = None):
+    exceptions = (BaseException,) if exceptions is None else exceptions
+
+    def decorator(func):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except exceptions as exc:
+                logging.error(f"Exception in {func.__name__}: {exc}")
+            return fallback_method(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -10,6 +10,24 @@ F = TypeVar("F", bound=Callable[..., Any])
 def graceful_fallback(
     fallback_method: Callable[..., Any], exceptions: Optional[Iterable[Type[BaseException]]] = None
 ) -> Callable[[F], F]:
+    """
+    Decorator that reroutes failing functions to a specified fallback method.
+
+    While it is generally not advisable to catch all exceptions, this decorator can be used to
+    gracefully degrade a function in situations when raising an error might be too disruptive.
+    Exceptions supprssed by this decorator will be logged to the root logger, and all inputs
+    to the wrapped function will be passed to the fallback method.
+
+
+    Args:
+
+    fallback_method (Callable[..., Any]): The fallback method to be called when the wrapped
+    function fails.
+
+    exceptions: An optional iterable of exceptions that should be suppressed by this decorator. If
+    unset, all exceptions will be suppressed.
+    """
+
     exceptions = (BaseException,) if exceptions is None else tuple(exceptions)
 
     def decorator(func: F) -> F:

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from typing import Any, Callable, Iterable, Optional, Type
 
 from typing_extensions import TypeVar, cast
@@ -36,10 +37,14 @@ def graceful_fallback(
             except exceptions as exc:
                 msg = (
                     f"Exception occurred in function '{func.__name__}':\n"
-                    f"  Args: {args}\n"
-                    f"  Kwargs: {kwargs}\n"
-                    f"  Exception Type: {type(exc).__name__}\n"
-                    f"  Exception Message: {str(exc)}"
+                    f"-Args: {args}\n"
+                    f"-Kwargs: {kwargs}\n"
+                    f"-Exception type: {type(exc).__name__}\n"
+                    f"-Exception message: {str(exc)}\n"
+                    f"{'*' * 50}\n"
+                    f"{traceback.format_exc()}\n"
+                    f"{'*' * 50}\n"
+                    f"Rerouting to fallback method '{fallback_method.__name__}'"
                 )
                 logging.error(msg)
             return fallback_method(*args, **kwargs)

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -35,7 +35,14 @@ def graceful_fallback(
             try:
                 return func(*args, **kwargs)
             except exceptions as exc:
-                logging.error(f"Exception in {func.__name__}: {exc}")
+                msg = (
+                    f"Exception occurred in function '{func.__name__}':\n"
+                    f"  Args: {args}\n"
+                    f"  Kwargs: {kwargs}\n"
+                    f"  Exception Type: {type(exc).__name__}\n"
+                    f"  Exception Message: {str(exc)}"
+                )
+                logging.error(msg)
             return fallback_method(*args, **kwargs)
 
         return cast(F, wrapper)

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Iterable, Optional, Type
 
 from typing_extensions import TypeVar, cast
 
-G = TypeVar("G", bound=Callable[..., Any])
 F = TypeVar("F", bound=Callable[..., Any])
 
 

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -148,7 +148,8 @@ def test_callback_llm_rate_limit_error_has_exception_event(
     assert isinstance(event.attributes[EXCEPTION_STACKTRACE], str)
 
 
-def test_callback_breaks_silently(mock_service_context: ServiceContext) -> None:
+@patch("phoenix.trace.llama_index.callback.payload_to_semantic_attributes")
+def test_callback_breaks_silently(mock_handler_fn, mock_service_context: ServiceContext) -> None:
     # callback handlers should *never* introduce errors in user code if they fail
     question = "What are the seven wonders of the world?"
     callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())
@@ -162,6 +163,5 @@ def test_callback_breaks_silently(mock_service_context: ServiceContext) -> None:
         callback_manager=CallbackManager([callback_handler]),
     )
 
-    with patch.object(callback_handler, "on_event_start") as failing_handler:
-        failing_handler.side_effect = CallbackException("callback exception")
-        query_engine.query(question)
+    mock_handler_fn.side_effect = CallbackException("callback exception")
+    query_engine.query(question)

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -173,8 +173,6 @@ def test_on_event_start_handler_fails_gracefully(
     assert caplog.records[0].levelname == "ERROR"
     assert "on_event_start" in caplog.records[0].message
     assert "CallbackError" in caplog.records[0].message
-    assert caplog.records[1].levelname == "ERROR"
-    assert "trace processing failed" in caplog.records[1].message
 
 
 def test_on_event_end_handler_fails_gracefully(
@@ -187,12 +185,9 @@ def test_on_event_end_handler_fails_gracefully(
     callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())
     callback_handler.on_event_end(event_type, faulty_payload, event_id)
 
-    assert len(caplog.records) == 2, "Both the fallback fn and the decorator should emit logs"
     assert caplog.records[0].levelname == "ERROR"
     assert "on_event_end" in caplog.records[0].message
     assert "KeyError" in caplog.records[0].message
-    assert caplog.records[1].levelname == "ERROR"
-    assert "trace processing failed" in caplog.records[1].message
 
 
 @patch("phoenix.trace.llama_index.callback._add_spans_to_tracer")
@@ -203,9 +198,6 @@ def test_end_trace_handler_fails_gracefully(mock_handler_internals, caplog) -> N
     callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())
     callback_handler.end_trace(trace_id, trace_map=trace_map)
 
-    assert len(caplog.records) == 2, "Both the fallback fn and the decorator should emit logs"
     assert caplog.records[0].levelname == "ERROR"
     assert "end_trace" in caplog.records[0].message
     assert "CallbackError" in caplog.records[0].message
-    assert caplog.records[1].levelname == "ERROR"
-    assert "trace processing failed" in caplog.records[1].message

--- a/tests/utilities/test_error_handling.py
+++ b/tests/utilities/test_error_handling.py
@@ -27,6 +27,9 @@ def test_graceful_fallback_logs_errors(caplog):
     assert "failing_function" in caplog.records[0].message, "Failing function should be logged"
     assert "foo" in caplog.records[0].message, "Positional arguments should be logged"
     assert "'bar': 'baz'" in caplog.records[0].message, "Keyword arguments should be logged"
+    assert (
+        "Traceback (most recent call last):" in caplog.records[0].message
+    ), "Traceback should be logged"
 
 
 def test_graceful_fallback_only_suppresses_specified_errors():

--- a/tests/utilities/test_error_handling.py
+++ b/tests/utilities/test_error_handling.py
@@ -1,5 +1,4 @@
 import pytest
-
 from phoenix.utilities.error_handling import graceful_fallback
 
 

--- a/tests/utilities/test_error_handling.py
+++ b/tests/utilities/test_error_handling.py
@@ -1,0 +1,39 @@
+import pytest
+
+from phoenix.utilities.error_handling import graceful_fallback
+
+
+def test_graceful_fallback_forwards_call_to_fallback_function():
+    def fallback(v) -> int:
+        return v - 1
+
+    @graceful_fallback(fallback_method=fallback)
+    def check_the_answer(v) -> int:
+        if v == 42:
+            raise ValueError("42 is not the answer")
+        return v
+
+    assert check_the_answer(42) == 41
+
+
+def test_graceful_fallback_logs_errors(caplog):
+    @graceful_fallback(fallback_method=lambda *args, **kwargs: None)
+    def failing_function(*args, **kwargs):
+        raise ValueError("This is a test error.")
+
+    failing_function("foo", bar="baz")  # graceful_fallback suppresses the error
+    assert len(caplog.records) == 1, "graceful_fallback should log errors"
+    assert "ValueError" in caplog.records[0].message, "Error type should be logged"
+    assert "This is a test error." in caplog.records[0].message, "Error message should be logged"
+    assert "failing_function" in caplog.records[0].message, "Failing function should be logged"
+    assert "foo" in caplog.records[0].message, "Positional arguments should be logged"
+    assert "'bar': 'baz'" in caplog.records[0].message, "Keyword arguments should be logged"
+
+
+def test_graceful_fallback_only_suppresses_specified_errors():
+    @graceful_fallback(fallback_method=lambda *args, **kwargs: None, exceptions=(ValueError,))
+    def bad_division():
+        return 1 / 0
+
+    with pytest.raises(ZeroDivisionError):
+        bad_division()  # graceful_fallback should not suppress ZeroDivisionError


### PR DESCRIPTION
`phoenix` instrumentation should not cause errors in user code. Here I add a pattern to gracefully degrade the behavior of methods that might raise exceptions in situations where an error would be undesirable.

The motivation is that we want to avoid simply suppressing exceptions in our instrumentation code because that will make it extremely hard to debug issues in the future. As an alternative, we can use a graceful degredation pattern where we fall back to more limited, but less-error prone codepath. Additionally, any time we fall back the error we encountered is logged instead of raised.

resolves #1579 