### PR TITLE
feat(rag): eval relevancy conventions

### DIFF
--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -1,7 +1,9 @@
 # Evaluation conventions
-# a sub-category of conventions that maps to the evaluation of the different types of spans
+
+# a sub-category of semantic conventions that maps to the evaluation of the different types of spans
 # and traces. evaluation attributes differ from other attributes in that they rely on evaluators
 # that are run on the spans to generate the evaluation results.
+
 
 EVAL_DOCUMENT_RELEVANCY = "eval.document_relevancy"
 """
@@ -21,9 +23,10 @@ The precision of a retriever.
 This is the percentage of relevant documents over the total
 """
 
-EVAL_DOCUMENTS_PRECISION_AT_K = "eval.documents_precision_at_k"
+EVAL_DOCUMENTS_PRECISION_AT_K_TEMPLATE = "eval.documents_precision_at_{k}"
 """
-An K dimensional array of precision values for each K in the range [1, K].
-This value would be computed on top of the document_relevancy attribute of each document.
-E.x. a relevancy of [0, 1, 1, 0, 1] would result in a precision_at_k of [0, 0.5, 0.66, 0.5, 0.6]
+The prefix given to an evaluation metric that captures the precision of a
+retriever up to K. E.x. you would have eval.documents_precision_at_1,
+eval.documents_precision_at_2, up to the max number of documents This value
+would be computed on top of the document_relevancy attribute of each document.
 """

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -20,7 +20,7 @@ outputted by the span (typically a retriever).
 EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
 """
 The precision of a retriever.
-This is the percentage of relevant documents over the total
+This is the proportion (expressed as a value between 0 and 1) of relevant documents over the total
 """
 
 EVAL_DOCUMENTS_PRECISION_AT_K_TEMPLATE = "eval.documents_precision_at_{k}"

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -11,13 +11,6 @@ A list of relevancies for the documents of a retriever span. An Int value of 1 o
 0 indicates whether the document is relevant to the input query.
 """
 
-EVAL_DOCUMENTS_RELEVANCY_RATIO = "eval.documents_relevancy_ratio"
-"""
-Span level attribute denoting the ratio of relevant documents that were
-outputted by the span (typically a retriever). E.g. if the document_relevancies
-is [1, 0, 1, 1, 0], then the documents_relevancy_ratio would be 0.6
-"""
-
 EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
 """
 The precision of a retriever.

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -5,7 +5,7 @@
 # that are run on the spans to generate the evaluation results.
 
 
-EVAL_DOCUMENT_RELEVANCY = "eval.document_relevancy"
+EVAL_DOCUMENT_RELEVANCIES = "eval.document_relevancies"
 """
 Attached to a document within a retriever span. An Int value of 1 or
 0 indicating whether the document is relevant to the input query.

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -7,14 +7,15 @@
 
 EVAL_DOCUMENT_RELEVANCIES = "eval.document_relevancies"
 """
-Attached to a document within a retriever span. An Int value of 1 or
-0 indicating whether the document is relevant to the input query.
+A list of relevancies for the documents of a retriever span. An Int value of 1 or
+0 indicates whether the document is relevant to the input query.
 """
 
-EVAL_DOCUMENTS_RELEVANCY_PERCENT = "eval.documents_relevancy_percent"
+EVAL_DOCUMENTS_RELEVANCY_RATIO = "eval.documents_relevancy_ratio"
 """
-Span level attribute denoting the percentage of relevant documents that were
-outputted by the span (typically a retriever).
+Span level attribute denoting the ratio of relevant documents that were
+outputted by the span (typically a retriever). E.g. if the document_relevancies
+is [1, 0, 1, 1, 0], then the documents_relevancy_ratio would be 0.6
 """
 
 EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -27,6 +27,6 @@ EVAL_DOCUMENTS_PRECISION_AT_K_TEMPLATE = "eval.documents_precision_at_{k}"
 """
 The prefix given to an evaluation metric that captures the precision of a
 retriever up to K. E.x. you would have eval.documents_precision_at_1,
-eval.documents_precision_at_2, up to the max number of documents This value
+eval.documents_precision_at_2, etc. This value
 would be computed on top of the document_relevancy attribute of each document.
 """

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -1,0 +1,29 @@
+# Evaluation conventions
+# a sub-category of conventions that maps to the evaluation of the different types of spans
+# and traces. evaluation attributes differ from other attributes in that they rely on evaluators
+# that are run on the spans to generate the evaluation results.
+
+EVAL_DOCUMENT_RELEVANCY = "eval.document_relevancy"
+"""
+Attached to a document within a retriever span. An Int value of 1 or
+0 indicating whether the document is relevant to the input query.
+"""
+
+EVAL_DOCUMENTS_RELEVANCY_PERCENT = "eval.documents_relevancy_percent"
+"""
+Span level attribute denoting the percentage of relevant documents that were
+outputted by the span (typically a retriever).
+"""
+
+EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
+"""
+The precision of a retriever.
+This is the percentage of relevant documents over the total
+"""
+
+EVAL_DOCUMENTS_PRECISION_AT_K = "eval.documents_precision_at_k"
+"""
+An K dimensional array of precision values for each K in the range [1, K].
+This value would be computed on top of the document_relevancy attribute of each document.
+E.x. a relevancy of [0, 1, 1, 0, 1] would result in a precision_at_k of [0, 0.5, 0.66, 0.5, 0.6]
+"""

--- a/src/phoenix/trace/semantic_conventions.py
+++ b/src/phoenix/trace/semantic_conventions.py
@@ -224,3 +224,10 @@ EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
 The precision of a retriever or reranker.
 This is the percentage of relevant documents over the total
 """
+
+EVAL_DOCUMENTS_PRECISION_AT_K = "eval.documents_precision_at_k"
+"""
+An K dimensional array of precision values for each K in the range [1, K].
+This value would be computed on top of the document_relevancy attribute of each document.
+E.x. a relevancy of [0, 1, 1, 0, 1] would result in a precision_at_k of [0, 0.5, 0.66, 0.5, 0.6]
+"""

--- a/src/phoenix/trace/semantic_conventions.py
+++ b/src/phoenix/trace/semantic_conventions.py
@@ -200,34 +200,3 @@ RERANKER_TOP_K = "reranker.top_k"
 """
 Top K parameter of the reranker
 """
-
-
-# Evaluation semantic conventions
-# a sub-category of semantic conventions that maps to the evaluation of the different types of spans
-# and traces. evaluation attributes differ from other attributes in that they rely on evaluators
-# that are run on the spans to generate the evaluation results.
-
-EVAL_DOCUMENT_RELEVANCY = "eval.document_relevancy"
-"""
-Attached to a document within a retriever or reranker span. An Int value of 1 or
-0 indicating whether the document is relevant to the input query.
-"""
-
-EVAL_DOCUMENTS_RELEVANCY_PERCENT = "eval.documents_relevancy_percent"
-"""
-Span level attribute denoting the percentage of relevant documents that were
-outputted by the span (typically a retriever or reranker).
-"""
-
-EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
-"""
-The precision of a retriever or reranker.
-This is the percentage of relevant documents over the total
-"""
-
-EVAL_DOCUMENTS_PRECISION_AT_K = "eval.documents_precision_at_k"
-"""
-An K dimensional array of precision values for each K in the range [1, K].
-This value would be computed on top of the document_relevancy attribute of each document.
-E.x. a relevancy of [0, 1, 1, 0, 1] would result in a precision_at_k of [0, 0.5, 0.66, 0.5, 0.6]
-"""

--- a/src/phoenix/trace/semantic_conventions.py
+++ b/src/phoenix/trace/semantic_conventions.py
@@ -200,3 +200,27 @@ RERANKER_TOP_K = "reranker.top_k"
 """
 Top K parameter of the reranker
 """
+
+
+# Evaluation semantic conventions
+# a sub-category of semantic conventions that maps to the evaluation of the different types of spans
+# and traces. evaluation attributes differ from other attributes in that they rely on evaluators
+# that are run on the spans to generate the evaluation results.
+
+EVAL_DOCUMENT_RELEVANCY = "eval.document_relevancy"
+"""
+Attached to a document within a retriever or reranker span. An Int value of 1 or
+0 indicating whether the document is relevant to the input query.
+"""
+
+EVAL_DOCUMENTS_RELEVANCY_PERCENT = "eval.documents_relevancy_percent"
+"""
+Span level attribute denoting the percentage of relevant documents that were
+outputted by the span (typically a retriever or reranker).
+"""
+
+EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
+"""
+The precision of a retriever or reranker.
+This is the percentage of relevant documents over the total
+"""


### PR DESCRIPTION
resolves #1585 

This PR aims to outline the MVP set of span attributes that would be used to start annotating span attributes with the necessary evals to augment the trace data for analysis based on evals.

Note that this data doesn't have to exist with the span but the colocation does result in an easily digestible payload that can be stored.

Example attributes payload where evaluation values are added in addition to the runtime conventions.
```json
{
  
  "attributes": {
      "eval.documents_relevancy_percent": 66.6,
      "eval.precision_at_1": 1,
      "eval.precision_at_2": 0.5,
      "eval.precision_at_3": 0.66,
      "documents": [
        {
           "eval.document_relevancy": 1,
        },
        {
           "eval.document_relevancy": 0,
        },
        {
           "eval.document_relevancy": 1,
        }
      ]
  }
}
```

## Decisions
- prefixing all evals with the eval moniker seemed like the cleanest way to delineate evals / non eval attributes.
- percent relevant seemed like a good enough name to start - though `hit_rate` does seem to be another name that gets used https://gpt-index.readthedocs.io/en/latest/examples/evaluation/retrieval/retriever_eval.html