### PR TITLE
fix: Remove trivial warnings

### DIFF
--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -119,13 +119,8 @@ class OpenAIModel(BaseEvalModel):
         elif self.model_name in MODEL_TOKEN_LIMIT_MAPPING.keys():
             self._openai_api_model_name = self.model_name
         elif "gpt-3.5-turbo" in self.model_name:
-            logger.warning(
-                "gpt-3.5-turbo may update over time. Returning num tokens assuming "
-                "gpt-3.5-turbo-0613."
-            )
             self._openai_api_model_name = "gpt-3.5-turbo-0613"
         elif "gpt-4" in self.model_name:
-            logger.warning("gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.")
             self._openai_api_model_name = "gpt-4-0613"
         else:
             raise NotImplementedError(


### PR DESCRIPTION
resolves #1586 

Removes trivial warnings that were producing needless noise.

I did a scan through some other warnings we raise and I thought these might also be candidates for removal:

- A warning about `tiktoken` fallbacks if an appropriate model can't be found
- A warning about not finding excluded columns when processing data

What do you think @mikeldking?