### PR TITLE
fix: failed imports from typing_extensions 4.5.0 in Colab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,8 @@ dependencies = [
   "requests",
   "protobuf==3.20",  # version minimum (for tests)
   "responses",
-  "tiktoken"
+  "tiktoken",
+  "typing-extensions<4.6.0",  # for Colab
 ]
 
 [tool.hatch.envs.type]

--- a/src/phoenix/utilities/error_handling.py
+++ b/src/phoenix/utilities/error_handling.py
@@ -1,8 +1,6 @@
 import logging
 import traceback
-from typing import Any, Callable, Iterable, Optional, Type
-
-from typing_extensions import TypeVar, cast
+from typing import Any, Callable, Iterable, Optional, Type, TypeVar, cast
 
 F = TypeVar("F", bound=Callable[..., Any])
 


### PR DESCRIPTION
resolves #1619 

This PR also puts a version ceiling on `typing-extensions<4.6.0` for our CI because that's what's in Colab right now.

> tensorflow 2.13.0 requires typing-extensions<4.6.0