### PR TITLE
fix(tracing): suspense boundary causing search to lose focus

### DIFF
--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { startTransition, useEffect, useMemo, useState } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
@@ -184,16 +184,18 @@ export function SpansTable(props: SpansTableProps) {
   useEffect(() => {
     //if the sorting changes, we need to reset the pagination
     const sort = sorting[0];
-    refetch({
-      sort: sort
-        ? {
-            col: sort.id as SpanSort["col"],
-            dir: sort.desc ? "desc" : "asc",
-          }
-        : DEFAULT_SORT,
-      after: null,
-      first: PAGE_SIZE,
-      filterCondition,
+    startTransition(() => {
+      refetch({
+        sort: sort
+          ? {
+              col: sort.id as SpanSort["col"],
+              dir: sort.desc ? "desc" : "asc",
+            }
+          : DEFAULT_SORT,
+        after: null,
+        first: PAGE_SIZE,
+        filterCondition,
+      });
     });
   }, [sorting, refetch, filterCondition]);
   const fetchMoreOnBottomReached = React.useCallback(

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { startTransition, useEffect, useMemo, useState } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
@@ -279,16 +279,18 @@ export function TracesTable(props: TracesTableProps) {
   useEffect(() => {
     //if the sorting changes, we need to reset the pagination
     const sort = sorting[0];
-    refetch({
-      sort: sort
-        ? {
-            col: sort.id as SpanSort["col"],
-            dir: sort.desc ? "desc" : "asc",
-          }
-        : DEFAULT_SORT,
-      after: null,
-      first: PAGE_SIZE,
-      filterCondition: filterCondition,
+    startTransition(() => {
+      refetch({
+        sort: sort
+          ? {
+              col: sort.id as SpanSort["col"],
+              dir: sort.desc ? "desc" : "asc",
+            }
+          : DEFAULT_SORT,
+        after: null,
+        first: PAGE_SIZE,
+        filterCondition: filterCondition,
+      });
     });
   }, [sorting, refetch, filterCondition]);
   const fetchMoreOnBottomReached = React.useCallback(

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -5,7 +5,7 @@ from .session.session import Session, active_session, close_app, launch_app
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
 
-__version__ = "0.0.46"
+__version__ = "0.0.47"
 
 # module level doc-string
 __doc__ = """


### PR DESCRIPTION
Because every keystroke invokes a query, the suspense boundary is getting hit. This should make the boundary not hit but I should also consider adding a throttling. https://github.com/Arize-ai/phoenix/issues/1623