### PR TITLE
ci: Exclude evals notebooks from cleaning output in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
           - id: clean-notebooks
             name: clean-notebooks
             files: \.ipynb$
+            exclude: ^tutorials/evals/.*\.ipynb$
             stages: [commit]
             language: system
             entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace


### PR DESCRIPTION
Resolves #1559 