### PR TITLE
feat(evals): default retry to 20, needs to be higher

### DIFF
--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -56,7 +56,7 @@ class OpenAIModel(BaseEvalModel):
     """Batch size to use when passing multiple documents to generate."""
     request_timeout: Optional[Union[float, Tuple[float, float]]] = None
     """Timeout for requests to OpenAI completion API. Default is 600 seconds."""
-    max_retries: int = 6
+    max_retries: int = 20
     """Maximum number of retries to make when generating."""
     retry_min_seconds: int = 10
     """Minimum number of seconds to wait when retrying."""


### PR DESCRIPTION
I'm finding I'm needing to set this to 20 for a lot of general use cases for timeouts and backoffs to work correctly. Setting this to the default, as not sure most people will figure this out on their own. 