### PR TITLE
feat(ui): light theme

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^1.0.0-0",
+        "@arizeai/components": "^1.0.0-1",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "1.0.0-0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-0.tgz",
-      "integrity": "sha512-AjsyuC76VOuLpzOoWhHSftjtNlewMPbde8cWtc0YdLpZn3/nD071qpHexednxthW8B3MwidvluVCw8welEYtgw==",
+      "version": "1.0.0-1",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-1.tgz",
+      "integrity": "sha512-x6/d7VmhpGQszh6x08+XNHfx71DvO3/59HNFZg+E6XMGCbVzT6s6Ri0KbsKCOtUvdxTMvW+XXK9t/hTUr2gHfw==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10354,9 +10354,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "1.0.0-0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-0.tgz",
-      "integrity": "sha512-AjsyuC76VOuLpzOoWhHSftjtNlewMPbde8cWtc0YdLpZn3/nD071qpHexednxthW8B3MwidvluVCw8welEYtgw==",
+      "version": "1.0.0-1",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-1.tgz",
+      "integrity": "sha512-x6/d7VmhpGQszh6x08+XNHfx71DvO3/59HNFZg+E6XMGCbVzT6s6Ri0KbsKCOtUvdxTMvW+XXK9t/hTUr2gHfw==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^0.17.5",
+        "@arizeai/components": "^1.0.0-0",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.17.5.tgz",
-      "integrity": "sha512-sPXFpU+lH+NE23aLt9FnXDDYcAft9beVZ5terNTjtEZuFwzF6FSOFjIyAcAXzcPDyypWfYqQBicAu51ZbnYYkA==",
+      "version": "1.0.0-0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-0.tgz",
+      "integrity": "sha512-AjsyuC76VOuLpzOoWhHSftjtNlewMPbde8cWtc0YdLpZn3/nD071qpHexednxthW8B3MwidvluVCw8welEYtgw==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10354,9 +10354,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-0.17.5.tgz",
-      "integrity": "sha512-sPXFpU+lH+NE23aLt9FnXDDYcAft9beVZ5terNTjtEZuFwzF6FSOFjIyAcAXzcPDyypWfYqQBicAu51ZbnYYkA==",
+      "version": "1.0.0-0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-0.tgz",
+      "integrity": "sha512-AjsyuC76VOuLpzOoWhHSftjtNlewMPbde8cWtc0YdLpZn3/nD071qpHexednxthW8B3MwidvluVCw8welEYtgw==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^1.0.0",
+        "@arizeai/components": "^1.0.1",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0.tgz",
-      "integrity": "sha512-7U2q66aLwhWVDUZghsVzPqFjvmfEfuQ558p98tqMzFgWohXxZcWctzLY1KCDAeXlt4MlaJyTepVPOHnis50UCg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-EFAGwJReDRa9rzIE5ZyqJTAU2x43nODPmBrkiKA87TgtvK3G+rb1ZJzsmpycMN/keQkX4FEAl2R9HFtldTLaNw==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10238,9 +10238,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0.tgz",
-      "integrity": "sha512-7U2q66aLwhWVDUZghsVzPqFjvmfEfuQ558p98tqMzFgWohXxZcWctzLY1KCDAeXlt4MlaJyTepVPOHnis50UCg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-EFAGwJReDRa9rzIE5ZyqJTAU2x43nODPmBrkiKA87TgtvK3G+rb1ZJzsmpycMN/keQkX4FEAl2R9HFtldTLaNw==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^1.0.0-2",
+        "@arizeai/components": "^1.0.0-5",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "1.0.0-2",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-2.tgz",
-      "integrity": "sha512-KJ7B7+Pivpw6AAQNNaQNoSqNTEYcbLM2DugMNCblgE0up2DfWGBA0pCSv3Cfe8xuZNPkeP9SUvqynjEbTwrc/Q==",
+      "version": "1.0.0-5",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-5.tgz",
+      "integrity": "sha512-iXndzOTQdfUDV4sEzKVIiRtnSY4oht0m8jNNsidFVJZf6YyQ7wpO06odbCrzot82/VDlM4LI1CSJmxjeIMAMAA==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10354,9 +10354,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "1.0.0-2",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-2.tgz",
-      "integrity": "sha512-KJ7B7+Pivpw6AAQNNaQNoSqNTEYcbLM2DugMNCblgE0up2DfWGBA0pCSv3Cfe8xuZNPkeP9SUvqynjEbTwrc/Q==",
+      "version": "1.0.0-5",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-5.tgz",
+      "integrity": "sha512-iXndzOTQdfUDV4sEzKVIiRtnSY4oht0m8jNNsidFVJZf6YyQ7wpO06odbCrzot82/VDlM4LI1CSJmxjeIMAMAA==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^1.0.0-5",
+        "@arizeai/components": "^1.0.0",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "1.0.0-5",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-5.tgz",
-      "integrity": "sha512-iXndzOTQdfUDV4sEzKVIiRtnSY4oht0m8jNNsidFVJZf6YyQ7wpO06odbCrzot82/VDlM4LI1CSJmxjeIMAMAA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0.tgz",
+      "integrity": "sha512-7U2q66aLwhWVDUZghsVzPqFjvmfEfuQ558p98tqMzFgWohXxZcWctzLY1KCDAeXlt4MlaJyTepVPOHnis50UCg==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -118,7 +118,7 @@
         "@react-aria/utils": "^3.14.0",
         "@react-aria/virtualizer": "^3.5.1",
         "@react-aria/visually-hidden": "^3.5.0",
-        "@react-stately/collections": "3.5.1",
+        "@react-stately/collections": "^3.10.2",
         "@react-stately/layout": "^3.8.0",
         "@react-stately/list": "3.6.1",
         "@react-stately/overlays": "^3.4.2",
@@ -2335,18 +2335,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-aria/listbox/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-aria/listbox/node_modules/@react-stately/list": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.9.0.tgz",
@@ -2384,18 +2372,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/menu/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-aria/overlays": {
@@ -2490,18 +2466,6 @@
         "@react-aria/utils": "^3.18.0",
         "@react-stately/collections": "^3.9.0",
         "@react-stately/selection": "^3.13.2",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
@@ -2729,23 +2693,15 @@
       "integrity": "sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw=="
     },
     "node_modules/@react-stately/collections": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.5.1.tgz",
-      "integrity": "sha512-egzVrZC5eFc5RJBpqUkzxd2aJOHZ2T1o7horEi8tAWZkg4YI+AmKrqela4ijVrrB9l1GO9z06qPT1UoPkFrC1w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.10.2.tgz",
+      "integrity": "sha512-h+LzCa1gWhVRWVH8uR+ZxsKmFSx7kW3RIlcjWjhfyc59BzXCuojsOJKTTAyPVFP/3kOdJeltw8g/reV1Cw/x6Q==",
       "dependencies": {
-        "@react-types/shared": "^3.16.0",
-        "@swc/helpers": "^0.4.14"
+        "@react-types/shared": "^3.21.0",
+        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/collections/node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@react-stately/grid": {
@@ -2756,18 +2712,6 @@
         "@react-stately/collections": "^3.9.0",
         "@react-stately/selection": "^3.13.2",
         "@react-types/grid": "^3.1.8",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/grid/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
@@ -2786,18 +2730,6 @@
         "@react-types/grid": "^3.1.8",
         "@react-types/shared": "^3.18.1",
         "@react-types/table": "^3.7.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/layout/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
-        "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -2887,18 +2819,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-stately/select/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-stately/select/node_modules/@react-stately/list": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.9.0.tgz",
@@ -2921,18 +2841,6 @@
       "dependencies": {
         "@react-stately/collections": "^3.9.0",
         "@react-stately/utils": "^3.7.0",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/selection/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
@@ -2967,18 +2875,6 @@
         "@react-types/grid": "^3.1.8",
         "@react-types/shared": "^3.18.1",
         "@react-types/table": "^3.7.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/table/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
-        "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3021,18 +2917,6 @@
         "@react-stately/collections": "^3.9.0",
         "@react-stately/selection": "^3.13.2",
         "@react-stately/utils": "^3.7.0",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tree/node_modules/@react-stately/collections": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-      "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-      "dependencies": {
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
       },
@@ -3322,9 +3206,9 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.18.1.tgz",
-      "integrity": "sha512-OpTYRFS607Ctfd6Tmhyk6t6cbFyDhO5K+etU35X50pMzpypo1b7vF0mkngEeTc0Xwl0e749ONZNPZskMyu5k8w==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.21.0.tgz",
+      "integrity": "sha512-wJA2cUF8dP4LkuNUt9Vh2kkfiQb2NLnV2pPXxVnKJZ7d4x2/7VPccN+LYPnH8m0X3+rt50cxWuPKQmjxSsCFOg==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
@@ -10354,9 +10238,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "1.0.0-5",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-5.tgz",
-      "integrity": "sha512-iXndzOTQdfUDV4sEzKVIiRtnSY4oht0m8jNNsidFVJZf6YyQ7wpO06odbCrzot82/VDlM4LI1CSJmxjeIMAMAA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0.tgz",
+      "integrity": "sha512-7U2q66aLwhWVDUZghsVzPqFjvmfEfuQ558p98tqMzFgWohXxZcWctzLY1KCDAeXlt4MlaJyTepVPOHnis50UCg==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10378,7 +10262,7 @@
         "@react-aria/utils": "^3.14.0",
         "@react-aria/virtualizer": "^3.5.1",
         "@react-aria/visually-hidden": "^3.5.0",
-        "@react-stately/collections": "3.5.1",
+        "@react-stately/collections": "^3.10.2",
         "@react-stately/layout": "^3.8.0",
         "@react-stately/list": "3.6.1",
         "@react-stately/overlays": "^3.4.2",
@@ -12016,15 +11900,6 @@
         "@swc/helpers": "^0.5.0"
       },
       "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        },
         "@react-stately/list": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.9.0.tgz",
@@ -12057,17 +11932,6 @@
         "@react-types/menu": "^3.9.2",
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-aria/overlays": {
@@ -12150,17 +12014,6 @@
         "@react-stately/selection": "^3.13.2",
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-aria/separator": {
@@ -12334,22 +12187,12 @@
       "integrity": "sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw=="
     },
     "@react-stately/collections": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.5.1.tgz",
-      "integrity": "sha512-egzVrZC5eFc5RJBpqUkzxd2aJOHZ2T1o7horEi8tAWZkg4YI+AmKrqela4ijVrrB9l1GO9z06qPT1UoPkFrC1w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.10.2.tgz",
+      "integrity": "sha512-h+LzCa1gWhVRWVH8uR+ZxsKmFSx7kW3RIlcjWjhfyc59BzXCuojsOJKTTAyPVFP/3kOdJeltw8g/reV1Cw/x6Q==",
       "requires": {
-        "@react-types/shared": "^3.16.0",
-        "@swc/helpers": "^0.4.14"
-      },
-      "dependencies": {
-        "@swc/helpers": {
-          "version": "0.4.14",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-          "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        }
+        "@react-types/shared": "^3.21.0",
+        "@swc/helpers": "^0.5.0"
       }
     },
     "@react-stately/grid": {
@@ -12362,17 +12205,6 @@
         "@react-types/grid": "^3.1.8",
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-stately/layout": {
@@ -12387,17 +12219,6 @@
         "@react-types/shared": "^3.18.1",
         "@react-types/table": "^3.7.0",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-stately/list": {
@@ -12470,15 +12291,6 @@
         "@swc/helpers": "^0.5.0"
       },
       "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        },
         "@react-stately/list": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.9.0.tgz",
@@ -12502,17 +12314,6 @@
         "@react-stately/utils": "^3.7.0",
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-stately/slider": {
@@ -12540,17 +12341,6 @@
         "@react-types/shared": "^3.18.1",
         "@react-types/table": "^3.7.0",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-stately/toggle": {
@@ -12585,17 +12375,6 @@
         "@react-stately/utils": "^3.7.0",
         "@react-types/shared": "^3.18.1",
         "@swc/helpers": "^0.5.0"
-      },
-      "dependencies": {
-        "@react-stately/collections": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
-          "integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
-          "requires": {
-            "@react-types/shared": "^3.18.1",
-            "@swc/helpers": "^0.5.0"
-          }
-        }
       }
     },
     "@react-stately/utils": {
@@ -12782,9 +12561,9 @@
       }
     },
     "@react-types/shared": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.18.1.tgz",
-      "integrity": "sha512-OpTYRFS607Ctfd6Tmhyk6t6cbFyDhO5K+etU35X50pMzpypo1b7vF0mkngEeTc0Xwl0e749ONZNPZskMyu5k8w==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.21.0.tgz",
+      "integrity": "sha512-wJA2cUF8dP4LkuNUt9Vh2kkfiQb2NLnV2pPXxVnKJZ7d4x2/7VPccN+LYPnH8m0X3+rt50cxWuPKQmjxSsCFOg==",
       "requires": {}
     },
     "@react-types/slider": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "None",
       "dependencies": {
-        "@arizeai/components": "^1.0.0-1",
+        "@arizeai/components": "^1.0.0-2",
         "@arizeai/point-cloud": "^3.0.4",
         "@codemirror/autocomplete": "^6.9.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@arizeai/components": {
-      "version": "1.0.0-1",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-1.tgz",
-      "integrity": "sha512-x6/d7VmhpGQszh6x08+XNHfx71DvO3/59HNFZg+E6XMGCbVzT6s6Ri0KbsKCOtUvdxTMvW+XXK9t/hTUr2gHfw==",
+      "version": "1.0.0-2",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-2.tgz",
+      "integrity": "sha512-KJ7B7+Pivpw6AAQNNaQNoSqNTEYcbLM2DugMNCblgE0up2DfWGBA0pCSv3Cfe8xuZNPkeP9SUvqynjEbTwrc/Q==",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",
@@ -10354,9 +10354,9 @@
       }
     },
     "@arizeai/components": {
-      "version": "1.0.0-1",
-      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-1.tgz",
-      "integrity": "sha512-x6/d7VmhpGQszh6x08+XNHfx71DvO3/59HNFZg+E6XMGCbVzT6s6Ri0KbsKCOtUvdxTMvW+XXK9t/hTUr2gHfw==",
+      "version": "1.0.0-2",
+      "resolved": "https://registry.npmjs.org/@arizeai/components/-/components-1.0.0-2.tgz",
+      "integrity": "sha512-KJ7B7+Pivpw6AAQNNaQNoSqNTEYcbLM2DugMNCblgE0up2DfWGBA0pCSv3Cfe8xuZNPkeP9SUvqynjEbTwrc/Q==",
       "requires": {
         "@emotion/react": "^11.10.5",
         "@react-aria/breadcrumbs": "^3.4.1",

--- a/app/package.json
+++ b/app/package.json
@@ -76,7 +76,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:image & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.0.0-2",
+    "@arizeai/components": "^1.0.0-5",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -76,7 +76,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:image & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:llm & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.0.0-0",
+    "@arizeai/components": "^1.0.0-1",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.0.0-5",
+    "@arizeai/components": "^1.0.0",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",
@@ -76,7 +76,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:llm & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.0.0-1",
+    "@arizeai/components": "^1.0.0-2",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.0.0",
+    "@arizeai/components": "^1.0.1",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^0.17.5",
+    "@arizeai/components": "^1.0.0-0",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "^6.9.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,23 +1,29 @@
 import React, { Suspense } from "react";
 import { RelayEnvironmentProvider } from "react-relay";
-import { ThemeProvider } from "@emotion/react";
+import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 
 import { Provider, theme } from "@arizeai/components";
 
-import { NotificationProvider } from "./contexts";
+import { NotificationProvider, ThemeProvider, useTheme } from "./contexts";
 import { GlobalStyles } from "./GlobalStyles";
 import RelayEnvironment from "./RelayEnvironment";
 import { AppRoutes } from "./Routes";
 
 import "normalize.css";
 
-const componentsTheme =
-  localStorage.getItem("theme") == "light" ? "light" : "dark";
-
 export function App() {
   return (
+    <ThemeProvider>
+      <AppContent />
+    </ThemeProvider>
+  );
+}
+
+export function AppContent() {
+  const { theme: componentsTheme } = useTheme();
+  return (
     <Provider theme={componentsTheme}>
-      <ThemeProvider theme={theme}>
+      <EmotionThemeProvider theme={theme}>
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <GlobalStyles />
           <Suspense>
@@ -26,7 +32,7 @@ export function App() {
             </NotificationProvider>
           </Suspense>
         </RelayEnvironmentProvider>
-      </ThemeProvider>
+      </EmotionThemeProvider>
     </Provider>
   );
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,9 +11,12 @@ import { AppRoutes } from "./Routes";
 
 import "normalize.css";
 
+const componentsTheme =
+  localStorage.getItem("theme") == "light" ? "light" : "dark";
+
 export function App() {
   return (
-    <Provider>
+    <Provider theme={componentsTheme}>
       <ThemeProvider theme={theme}>
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <GlobalStyles />

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -61,20 +61,8 @@ export function GlobalStyles() {
         :root {
           --px-blue-color: ${theme.colors.arizeBlue};
 
-          --px-primary-color: #9efcfd;
-          --px-primary-color--transparent: rgb(158, 252, 253, 0.2);
-          --px-reference-color: #baa1f9;
-          --px-reference-color--transparent: #baa1f982;
-          --px-corpus-color: #92969c;
-          --px-corpus-color--transparent: #92969c63;
-
-          --px-background-color-500: ${theme.colors.gray500};
-
           --px-flex-gap-sm: ${theme.spacing.margin4}px;
           --px-flex-gap-sm: ${theme.spacing.margin8}px;
-
-          --px-border-color-500: ${theme.colors.gray500};
-          --px-border-color-300: var(--ac-global-color-grey-300);
 
           --px-section-background-color: ${theme.colors.gray500};
 
@@ -93,6 +81,23 @@ export function GlobalStyles() {
           --px-font-size-lg: ${theme.typography.sizes.large.fontSize}px;
 
           --px-gradient-bar-height: 8px;
+        }
+
+        .ac-theme--dark {
+          --px-primary-color: #9efcfd;
+          --px-primary-color--transparent: rgb(158, 252, 253, 0.2);
+          --px-reference-color: #baa1f9;
+          --px-reference-color--transparent: #baa1f982;
+          --px-corpus-color: #92969c;
+          --px-corpus-color--transparent: #92969c63;
+        }
+        .ac-theme--light {
+          --px-primary-color: #00add0;
+          --px-primary-color--transparent: rgba(0, 173, 208, 0.2);
+          --px-reference-color: #4500d9;
+          --px-reference-color--transparent: rgba(69, 0, 217, 0.2);
+          --px-corpus-color: #92969c;
+          --px-corpus-color--transparent: #92969c63;
         }
       `}
     />

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -38,7 +38,8 @@ export function GlobalStyles() {
           /* Works on Firefox */
           * {
             scrollbar-width: thin;
-            scrollbar-color: ${theme.colors.gray300} ${theme.colors.gray500};
+            scrollbar-color: var(--ac-global-color-grey-300)
+              var(--ac-global-color-grey-400);
           }
 
           /* Works on Chrome, Edge, and Safari */
@@ -47,19 +48,18 @@ export function GlobalStyles() {
           }
 
           *::-webkit-scrollbar-track {
-            background: ${theme.colors.gray700};
+            background: var(--ac-global-color-grey-100);
           }
 
           *::-webkit-scrollbar-thumb {
-            background-color: ${theme.colors.gray900};
+            background-color: var(--ac-global-color-grey-75);
             border-radius: 8px;
-            border: 1px solid ${theme.colors.gray300};
+            border: 1px solid var(--ac-global-color-grey-300);
           }
         }
 
         :root {
           --px-blue-color: ${theme.colors.arizeBlue};
-          --px-light-blue-color: ${theme.colors.arizeLightBlue};
 
           --px-primary-color: #9efcfd;
           --px-primary-color--transparent: rgb(158, 252, 253, 0.2);
@@ -68,14 +68,13 @@ export function GlobalStyles() {
           --px-corpus-color: #92969c;
           --px-corpus-color--transparent: #92969c63;
 
-          --px-background-color-800: ${theme.colors.gray800};
           --px-background-color-500: ${theme.colors.gray500};
 
           --px-flex-gap-sm: ${theme.spacing.margin4}px;
           --px-flex-gap-sm: ${theme.spacing.margin8}px;
 
           --px-border-color-500: ${theme.colors.gray500};
-          --px-border-color-300: ${theme.colors.gray300};
+          --px-border-color-300: var(--ac-global-color-grey-300);
 
           --px-section-background-color: ${theme.colors.gray500};
 

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -12,7 +12,8 @@ export function GlobalStyles() {
           font-size: ${theme.typography.sizes.medium.fontSize}px;
           margin: 0;
           #root,
-          #root > div[data-overlay-container="true"] {
+          #root > div[data-overlay-container="true"],
+          #root > div[data-overlay-container="true"] > .ac-theme {
             height: 100vh;
           }
         }

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -6,7 +6,7 @@ export function GlobalStyles() {
     <Global
       styles={(theme) => css`
         body {
-          background-color: var(--ac-global-color-gray-900);
+          background-color: var(--ac-global-color-grey-75);
           color: var(--ac-global-text-color-900);
           font-family: "Roboto";
           font-size: ${theme.typography.sizes.medium.fontSize}px;

--- a/app/src/components/ExternalLink.tsx
+++ b/app/src/components/ExternalLink.tsx
@@ -13,9 +13,9 @@ export function ExternalLink({ href, children }: ExternalLinkProps) {
     <a
       href={href}
       target="_blank"
-      css={(theme) => css`
-        color: ${theme.colors.arizeLightBlue};
-        txt-decoration: none;
+      css={css`
+        color: var(--ac-global-color-primary);
+        text-decoration: none;
         display: flex;
         flex-direction: row;
         align-items: end;

--- a/app/src/components/Link.tsx
+++ b/app/src/components/Link.tsx
@@ -6,8 +6,8 @@ export function Link(props: LinkProps) {
     // Stop propagation to prevent the click from being handled by the parent
     <div onClick={(e) => e.stopPropagation()}>
       <RouterLink
-        css={(theme) => css`
-          color: ${theme.colors.arizeLightBlue};
+        css={css`
+          color: var(--ac-global-color-primary);
           &:not(:hover) {
             text-decoration: none;
           }

--- a/app/src/components/LinkButton.tsx
+++ b/app/src/components/LinkButton.tsx
@@ -7,7 +7,7 @@ const linkButtonCSS = css`
   display: inline-flex;
   align-items: center;
   background: none;
-  color: var(--px-light-blue-color);
+  color: var(--ac-global-color-primary);
 
   background: none;
   border: none;

--- a/app/src/components/ViewSummaryAside.tsx
+++ b/app/src/components/ViewSummaryAside.tsx
@@ -10,7 +10,7 @@ export function ViewSummaryAside(props: PropsWithChildren) {
   return (
     <View
       width="size-1250"
-      backgroundColor="gray-700"
+      backgroundColor="light"
       borderStartWidth="thin"
       borderStartColor="dark"
       padding="size-200"

--- a/app/src/components/chart/ChartTooltip.tsx
+++ b/app/src/components/chart/ChartTooltip.tsx
@@ -16,11 +16,11 @@ type ChartTooltipProps = PropsWithChildren<object>;
 export function ChartTooltip(props: ChartTooltipProps) {
   return (
     <div
-      css={(theme) => css`
-        background-color: ${theme.colors.gray500};
-        border: 1px solid transparent;
+      css={css`
+        background-color: var(--ac-global-color-grey-200);
+        border: 1px solid var(--ac-global-color-grey-300);
         padding: var(--px-spacing-med);
-        border-radius: ${theme.rounding.rounding4}px;
+        border-radius: var(--ac-global-rounding-medium);
         display: flex;
         flex-direction: column;
         gap: var(--px-spacing-sm);
@@ -77,9 +77,9 @@ export function ChartTooltipItem(props: ChartTooltipItemProps) {
 export function ChartTooltipDivider() {
   return (
     <div
-      css={(theme) => css`
+      css={css`
         height: 1px;
-        background-color: ${theme.colors.gray400};
+        background-color: var(--ac-global-color-grey-300);
         width: 100%;
       `}
     />

--- a/app/src/components/chart/colors.tsx
+++ b/app/src/components/chart/colors.tsx
@@ -1,4 +1,42 @@
-export const colors = Object.freeze({
+import { useMemo } from "react";
+
+import { useTheme } from "@phoenix/contexts";
+
+export type ChartColors = {
+  readonly blue100: string;
+  readonly blue200: string;
+  readonly blue300: string;
+  readonly blue400: string;
+  readonly blue500: string;
+  readonly orange100: string;
+  readonly orange200: string;
+  readonly orange300: string;
+  readonly orange400: string;
+  readonly orange500: string;
+  readonly purple100: string;
+  readonly purple200: string;
+  readonly purple300: string;
+  readonly purple400: string;
+  readonly purple500: string;
+  readonly pink100: string;
+  readonly pink200: string;
+  readonly pink300: string;
+  readonly pink400: string;
+  readonly pink500: string;
+  readonly gray100: string;
+  readonly gray200: string;
+  readonly gray300: string;
+  readonly gray400: string;
+  readonly gray500: string;
+  readonly gray600: string;
+  readonly gray700: string;
+  readonly default: string;
+  // Colors specific to the dataset role
+  readonly primary: string;
+  readonly reference: string;
+};
+
+const darkColors: ChartColors = Object.freeze({
   blue100: "#A4C7E0",
   blue200: "#7EB0D2",
   blue300: "#5899C5",
@@ -25,9 +63,48 @@ export const colors = Object.freeze({
   gray400: "#969696",
   gray500: "#737373",
   gray600: "#525252",
-  gray800: "#252525",
-  white: "#ffffff",
+  gray700: "#252525",
+  default: "#ffffff",
   // Colors specific to the dataset role
   primary: "#9efcfd",
   reference: "#baa1f9",
 });
+
+const lightColors: ChartColors = Object.freeze({
+  default: "#000000",
+  blue100: "#2F6488",
+  blue200: "#3C80AE",
+  blue300: "#5899C5",
+  blue400: "#7EB0D2",
+  blue500: "#A4C7E0",
+  orange100: "#C46903",
+  orange200: "#F78403",
+  orange300: "#FC9C31",
+  orange400: "#FDB462",
+  orange500: "#FECC95",
+  purple100: "#4D4581",
+  purple200: "#6157A3",
+  purple300: "#7F77B6",
+  purple400: "#9E98C8",
+  purple500: "#BEBADA",
+  pink100: "#F10E82",
+  pink200: "#F33F9B",
+  pink300: "#F66FB4",
+  pink400: "#F99FCD",
+  pink500: "#FCCDE5",
+  gray100: "#252525",
+  gray200: "#525252",
+  gray300: "#737373",
+  gray400: "#969696",
+  gray500: "#bdbdbd",
+  gray600: "#d9d9d9",
+  gray700: "#f0f0f0",
+  // Colors specific to the dataset role
+  primary: "#00add0",
+  reference: "#4500d9",
+});
+
+export const useChartColors = (): ChartColors => {
+  const { theme } = useTheme();
+  return useMemo(() => (theme === "dark" ? darkColors : lightColors), [theme]);
+};

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -31,6 +31,6 @@ export const defaultSelectedTimestampReferenceLineProps: ReferenceLineProps = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const defaultBarChartTooltipProps: TooltipProps<any, any> = {
   cursor: {
-    fill: transparentize(0.3, theme.colors.gray200),
+    fill: "var(--ac-global-color-grey-300)",
   },
 };

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -8,7 +8,7 @@ import { theme } from "@arizeai/components";
  */
 export const defaultTimeXAxisProps: XAxisProps = {
   dataKey: "timestamp",
-  stroke: theme.colors.gray200,
+  stroke: "var(--ac-global-colo-grey-400)",
   style: { fill: "var(--ac-global-text-color-700)" },
   scale: "time",
   type: "number",
@@ -17,7 +17,7 @@ export const defaultTimeXAxisProps: XAxisProps = {
 };
 
 export const defaultSelectedTimestampReferenceLineProps: ReferenceLineProps = {
-  stroke: "white",
+  stroke: "var(--ac-global-color-grey-900)",
   label: {
     value: "▼",
     position: "top",

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -1,4 +1,3 @@
-import { transparentize } from "polished";
 import { ReferenceLineProps, TooltipProps, XAxisProps } from "recharts";
 
 import { theme } from "@arizeai/components";

--- a/app/src/components/filter/Toolbar.tsx
+++ b/app/src/components/filter/Toolbar.tsx
@@ -15,14 +15,14 @@ export function Toolbar(props: ToolbarProps) {
   return (
     <div
       role="toolbar"
-      css={(theme) => css`
+      css={css`
         padding: var(--px-spacing-sm) var(--px-spacing-lg);
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
         gap: var(--px-spacing-med);
-        border-bottom: 1px solid ${theme.colors.gray500};
+        border-bottom: 1px solid var(--ac-global-border-color-dark);
         flex: none;
         min-height: 29px;
         .toolbar__main {

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -6,10 +6,10 @@ import { Icons } from "@arizeai/components";
 
 import { Logo } from "./Logo";
 
-const navCSS = (theme: Theme) => css`
-  padding: ${theme.spacing.padding8}px ${theme.spacing.padding16}px;
-  border-bottom: 1px solid ${theme.colors.gray500};
-  background-color: ${theme.colors.gray900};
+const navCSS = css`
+  padding: var(--px-spacing-med) var(--px-spacing-lg);
+  border-bottom: 1px solid var(--ac-global-color-grey-200);
+  background-color: var(--ac-global-color-grey-75);
   flex: none;
   display: flex;
   flex-direction: row;
@@ -54,7 +54,7 @@ function IconLink(props: PropsWithChildren<{ href: string }>) {
         height: 20px;
         display: block;
         svg {
-          fill: ${theme.textColors.white50};
+          fill: var(--ac-global-text-color-500);
           transition: fill 0.2s ease-in-out;
         }
         &:hover svg {

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -4,6 +4,8 @@ import { css, Theme } from "@emotion/react";
 
 import { Icons } from "@arizeai/components";
 
+import { useTheme } from "@phoenix/contexts";
+
 import { Logo } from "./Logo";
 
 const navCSS = css`
@@ -15,6 +17,20 @@ const navCSS = css`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+`;
+
+const navIconCSS = css`
+  padding: var(--ac-global-static-size-100);
+  width: 20px;
+  height: 20px;
+  display: block;
+  svg {
+    fill: var(--ac-global-text-color-500);
+    transition: fill 0.2s ease-in-out;
+  }
+  &:hover svg {
+    fill: var(--ac-global-text-color-900);
+  }
 `;
 
 const brandCSS = (theme: Theme) => css`
@@ -45,27 +61,17 @@ const GitHubSVG = () => (
 
 function IconLink(props: PropsWithChildren<{ href: string }>) {
   return (
-    <a
-      href={props.href}
-      target="_blank"
-      css={(theme) => css`
-        padding: ${theme.spacing.padding4}px;
-        width: 20px;
-        height: 20px;
-        display: block;
-        svg {
-          fill: var(--ac-global-text-color-500);
-          transition: fill 0.2s ease-in-out;
-        }
-        &:hover svg {
-          fill: var(--ac-global-text-color-900);
-        }
-      `}
-      aria-label="GitHub"
-      rel="noreferrer"
-    >
+    <a href={props.href} target="_blank" css={navIconCSS} rel="noreferrer">
       {props.children}
     </a>
+  );
+}
+
+function IconButton(props: PropsWithChildren<{ onClick: () => void }>) {
+  return (
+    <button css={navIconCSS} onClick={props.onClick} className="button--reset">
+      {props.children}
+    </button>
   );
 }
 
@@ -82,6 +88,16 @@ export function DocsLink() {
     <IconLink href="https://docs.arize.com/phoenix">
       <Icons.BookFilled />
     </IconLink>
+  );
+}
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+  return (
+    <IconButton onClick={() => setTheme(isDark ? "light" : "dark")}>
+      {isDark ? <Icons.MoonOutline /> : <Icons.SunOutline />}
+    </IconButton>
   );
 }
 

--- a/app/src/components/pointcloud/CanvasDisplaySettingsDropdown.tsx
+++ b/app/src/components/pointcloud/CanvasDisplaySettingsDropdown.tsx
@@ -8,15 +8,12 @@ import {
   Icon,
   Icons,
   Slider,
-  Switch,
   View,
 } from "@arizeai/components";
 
 import { usePointCloudContext } from "@phoenix/contexts";
 
 export function CanvasDisplaySettingsDropdown() {
-  const canvasTheme = usePointCloudContext((state) => state.canvasTheme);
-  const setCanvasTheme = usePointCloudContext((state) => state.setCanvasTheme);
   const setPointSizeScale = usePointCloudContext(
     (state) => state.setPointSizeScale
   );
@@ -40,15 +37,6 @@ export function CanvasDisplaySettingsDropdown() {
               value={pointSizeScale}
               onChange={setPointSizeScale}
             />
-            <Switch
-              isSelected={canvasTheme === "light"}
-              labelPlacement="end"
-              onChange={() =>
-                setCanvasTheme(canvasTheme === "light" ? "dark" : "light")
-              }
-            >
-              Light Theme
-            </Switch>
           </Flex>
         </View>
       </DropdownMenu>

--- a/app/src/components/pointcloud/ClusterItem.tsx
+++ b/app/src/components/pointcloud/ClusterItem.tsx
@@ -103,12 +103,12 @@ export function ClusterItem(props: ClusterItemProps) {
         transition: background-color 0.2s ease-in-out;
         cursor: pointer;
         &:hover {
-          background-color: var(--ac-global-color-primary-500);
+          background-color: var(--ac-global-color-primary-700);
           border-color: var(--ac-global-color-primary);
         }
         &.is-selected {
           border-color: var(--ac-global-color-primary);
-          background-color: var(--ac-global-color-primary-500);
+          background-color: var(--ac-global-color-primary-700);
         }
       `}
       className={isSelected ? "is-selected" : ""}

--- a/app/src/components/pointcloud/ClusterItem.tsx
+++ b/app/src/components/pointcloud/ClusterItem.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { transparentize } from "polished";
 import { css } from "@emotion/react";
 
 import { Flex, Heading, Text } from "@arizeai/components";
@@ -97,19 +96,19 @@ export function ClusterItem(props: ClusterItemProps) {
   }, [driftRatio, primaryToCorpusRatio]);
   return (
     <div
-      css={(theme) => css`
-        border: 1px solid ${theme.colors.gray400};
-        border-radius: 4px;
+      css={css`
+        border: 1px solid var(--ac-global-border-color-light);
+        border-radius: var(--ac-global-rounding-medium);
         overflow: hidden;
         transition: background-color 0.2s ease-in-out;
         cursor: pointer;
         &:hover {
-          background-color: ${transparentize(0.9, theme.colors.arizeLightBlue)};
-          border-color: ${transparentize(0.5, theme.colors.arizeLightBlue)};
+          background-color: var(--ac-global-color-primary-500);
+          border-color: var(--ac-global-color-primary);
         }
         &.is-selected {
-          border-color: ${theme.colors.arizeLightBlue};
-          background-color: ${transparentize(0.8, theme.colors.arizeLightBlue)};
+          border-color: var(--ac-global-color-primary);
+          background-color: var(--ac-global-color-primary-500);
         }
       `}
       className={isSelected ? "is-selected" : ""}
@@ -119,8 +118,8 @@ export function ClusterItem(props: ClusterItemProps) {
       onMouseLeave={onMouseLeave}
     >
       <div
-        css={(theme) => css`
-          padding: ${theme.spacing.padding8}px;
+        css={css`
+          padding: var(--ac-global-dimension-static-size-100);
           display: flex;
           flex-direction: row;
           justify-content: space-between;

--- a/app/src/components/pointcloud/DatasetVisibilitySettings.tsx
+++ b/app/src/components/pointcloud/DatasetVisibilitySettings.tsx
@@ -1,12 +1,10 @@
 import React, { ChangeEvent, useCallback, useMemo } from "react";
 import { css } from "@emotion/react";
 
-import {
-  DEFAULT_COLOR_SCHEME,
-  FALLBACK_COLOR,
-} from "@phoenix/constants/pointCloudConstants";
+import { FALLBACK_COLOR } from "@phoenix/constants/pointCloudConstants";
 import { ColoringStrategy } from "@phoenix/constants/pointCloudConstants";
 import { usePointCloudContext } from "@phoenix/contexts";
+import { useDefaultColorScheme } from "@phoenix/pages/embedding/useDefaultColorScheme";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { Shape } from "./ShapeIcon";
@@ -42,6 +40,7 @@ export function DatasetVisibilitySettings({
     },
     [datasetVisibility, setDatasetVisibility]
   );
+  const DEFAULT_COLOR_SCHEME = useDefaultColorScheme();
 
   const primaryColor = useMemo(() => {
     switch (coloringStrategy) {
@@ -53,7 +52,7 @@ export function DatasetVisibilitySettings({
       default:
         assertUnreachable(coloringStrategy);
     }
-  }, [coloringStrategy]);
+  }, [coloringStrategy, DEFAULT_COLOR_SCHEME]);
 
   const referenceColor = useMemo(() => {
     switch (coloringStrategy) {
@@ -65,7 +64,7 @@ export function DatasetVisibilitySettings({
       default:
         assertUnreachable(coloringStrategy);
     }
-  }, [coloringStrategy]);
+  }, [coloringStrategy, DEFAULT_COLOR_SCHEME]);
   const corpusColor = FALLBACK_COLOR;
 
   const referenceShape =

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -366,12 +366,11 @@ function DocumentPreview(props: Pick<EventItemProps, "size" | "documentText">) {
         margin-block-start: 0;
         margin-block-end: 0;
         position: relative;
-        --text-preview-background-color: var(--px-background-color-800);
+        --text-preview-background-color: var(--ac-global-color-grey-100);
         background-color: var(--text-preview-background-color);
 
         &[data-size="small"] {
           padding: var(--px-spacing-sm);
-          font-size: var(--ac-global-color-gray-600);
           box-sizing: border-box;
         }
         &:before {

--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -146,7 +146,7 @@ export function EventItem(props: EventItemProps) {
 
         border-width: 1px;
         border-color: ${color};
-        border-radius: 8px;
+        border-radius: var(--ac-global-rounding-medium);
         transition: border-color 0.2s ease-in-out;
         transition: transform 0.2s ease-in-out;
         &:hover {
@@ -285,7 +285,7 @@ function PromptResponsePreview(
       data-size={props.size}
       css={css`
         --prompt-response-preview-background-color: var(
-          --px-background-color-500
+          --ac-global-color-grey-200
         );
         background-color: var(--prompt-response-preview-background-color);
         &[data-size="small"] {
@@ -486,7 +486,7 @@ function EventItemFooter({
         justify-content: space-between;
         padding: var(--px-spacing-sm) var(--px-spacing-med) var(--px-spacing-sm)
           7px;
-        border-top: 1px solid var(--px-item-border-color);
+        border-top: 1px solid var(--ac-global-border-color-dark);
       `}
     >
       <div

--- a/app/src/components/pointcloud/PointCloud.tsx
+++ b/app/src/components/pointcloud/PointCloud.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useCallback, useMemo, useState } from "react";
 import { useContextBridge } from "@react-three/drei";
 import { css } from "@emotion/react";
-import { ThemeContext } from "@emotion/react";
+import { ThemeContext as EmotionThemeContext } from "@emotion/react";
 
 import {
   ActionTooltip,
@@ -25,7 +25,9 @@ import { UNKNOWN_COLOR } from "@phoenix/constants/pointCloudConstants";
 import {
   DatasetsContext,
   PointCloudContext,
+  ThemeContext,
   usePointCloudContext,
+  useTheme,
 } from "@phoenix/contexts";
 import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
 import { CanvasMode } from "@phoenix/store";
@@ -196,7 +198,7 @@ function CanvasInfo() {
 }
 
 function CanvasWrap({ children }: { children: ReactNode }) {
-  const canvasTheme = usePointCloudContext((state) => state.canvasTheme);
+  const { theme } = useTheme();
   return (
     <div
       css={css`
@@ -210,10 +212,10 @@ function CanvasWrap({ children }: { children: ReactNode }) {
           );
         }
         &[data-theme="light"] {
-          background: linear-gradient(#d2def3 0%, #b2c5e8 74%);
+          background: linear-gradient(#f2f6fd 0%, #dbe6fc 74%);
         }
       `}
-      data-theme={canvasTheme}
+      data-theme={theme}
     >
       {children}
     </div>
@@ -245,7 +247,7 @@ const Projection = React.memo(function Projection() {
   const pointGroupVisibility = usePointCloudContext(
     (state) => state.pointGroupVisibility
   );
-  const canvasTheme = usePointCloudContext((state) => state.canvasTheme);
+  const { theme } = useTheme();
   const datasetVisibility = usePointCloudContext(
     (state) => state.datasetVisibility
   );
@@ -349,6 +351,7 @@ const Projection = React.memo(function Projection() {
   const ContextBridge = useContextBridge(
     PointCloudContext,
     DatasetsContext,
+    EmotionThemeContext,
     ThemeContext
   );
 
@@ -379,7 +382,7 @@ const Projection = React.memo(function Projection() {
           />
           <Axes
             size={(bounds.maxX - bounds.minX) / 4}
-            color={canvasTheme == "dark" ? "#fff" : "#505050"}
+            color={theme == "dark" ? "#fff" : "#505050"}
           />
           <PointCloudPoints
             primaryData={filteredPrimaryData}

--- a/app/src/components/pointcloud/PointCloudClusters.tsx
+++ b/app/src/components/pointcloud/PointCloudClusters.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from "react";
 import { interpolateSinebow } from "d3-scale-chromatic";
 
+import { ProviderTheme } from "@arizeai/components";
 import { Cluster, ThreeDimensionalPoint } from "@arizeai/point-cloud";
 
-import { usePointCloudContext } from "@phoenix/contexts";
-import { CanvasTheme, ClusterColorMode } from "@phoenix/store";
+import { usePointCloudContext, useTheme } from "@phoenix/contexts";
+import { ClusterColorMode } from "@phoenix/store";
 
 type PointCloudClustersProps = {
   /**
@@ -23,7 +24,7 @@ export function PointCloudClusters({ radius }: PointCloudClustersProps) {
     (state) => state.selectedClusterId
   );
   const clusters = usePointCloudContext((state) => state.clusters);
-  const canvasTheme = usePointCloudContext((state) => state.canvasTheme);
+  const { theme } = useTheme();
   const clusterColorMode = usePointCloudContext(
     (state) => state.clusterColorMode
   );
@@ -70,7 +71,7 @@ export function PointCloudClusters({ radius }: PointCloudClustersProps) {
             wireframe
             pointRadius={radius}
             color={clusterColor({
-              canvasTheme,
+              theme,
               clusterColorMode,
               index,
               clusterCount: clustersWithData.length,
@@ -87,13 +88,13 @@ export function PointCloudClusters({ radius }: PointCloudClustersProps) {
  * and cluster coloring mode
  */
 function clusterColor({
-  canvasTheme,
+  theme,
   clusterColorMode,
   index,
   clusterCount,
 }: {
   clusterColorMode: ClusterColorMode;
-  canvasTheme: CanvasTheme;
+  theme: ProviderTheme;
   /**
    * Where the cluster is in the list of clusters
    */
@@ -101,7 +102,7 @@ function clusterColor({
   clusterCount: number;
 }): string {
   if (clusterColorMode === ClusterColorMode.default) {
-    return canvasTheme === "dark" ? "#999999" : "#555555";
+    return theme === "dark" ? "#999999" : "#555555";
   }
   return interpolateSinebow(index / clusterCount);
 }

--- a/app/src/components/pointcloud/PointCloudClusters.tsx
+++ b/app/src/components/pointcloud/PointCloudClusters.tsx
@@ -102,7 +102,7 @@ function clusterColor({
   clusterCount: number;
 }): string {
   if (clusterColorMode === ClusterColorMode.default) {
-    return theme === "dark" ? "#999999" : "#555555";
+    return theme === "dark" ? "#999999" : "#bbbbbb";
   }
   return interpolateSinebow(index / clusterCount);
 }

--- a/app/src/components/pointcloud/PointCloudPoints.tsx
+++ b/app/src/components/pointcloud/PointCloudPoints.tsx
@@ -12,7 +12,7 @@ import { Point } from "@phoenix/store";
 import { PointColor } from "./types";
 
 const SHADE_AMOUNT = 0.5;
-const LIGHTEN_AMOUNT = 0.3;
+const LIGHTEN_AMOUNT = 0.5;
 
 /**
  * The amount of time to debounce the hover events

--- a/app/src/components/pointcloud/PointCloudPoints.tsx
+++ b/app/src/components/pointcloud/PointCloudPoints.tsx
@@ -6,7 +6,7 @@ import { lighten, shade } from "polished";
 import { PointBaseProps, Points } from "@arizeai/point-cloud";
 
 import { ColoringStrategy } from "@phoenix/constants/pointCloudConstants";
-import { usePointCloudContext } from "@phoenix/contexts";
+import { usePointCloudContext, useTheme } from "@phoenix/contexts";
 import { Point } from "@phoenix/store";
 
 import { PointColor } from "./types";
@@ -74,7 +74,7 @@ export function PointCloudPoints({
   const coloringStrategy = usePointCloudContext(
     (state) => state.coloringStrategy
   );
-  const canvasTheme = usePointCloudContext((state) => state.canvasTheme);
+  const { theme } = useTheme();
   const setSelectedEventIds = usePointCloudContext(
     (state) => state.setSelectedEventIds
   );
@@ -105,10 +105,8 @@ export function PointCloudPoints({
   );
 
   const colorDimFn = useMemo(() => {
-    return canvasTheme === "dark"
-      ? shade(SHADE_AMOUNT)
-      : lighten(LIGHTEN_AMOUNT);
-  }, [canvasTheme]);
+    return theme === "dark" ? shade(SHADE_AMOUNT) : lighten(LIGHTEN_AMOUNT);
+  }, [theme]);
 
   /** Colors to represent a dimmed variant of the color for "un-selected" */
   const dimmedColor = useMemo<PointColor>(() => {

--- a/app/src/components/pointcloud/PointGroupVisibilitySettings.tsx
+++ b/app/src/components/pointcloud/PointGroupVisibilitySettings.tsx
@@ -106,7 +106,7 @@ function PointGroupCheckbox() {
         flex-direction: row;
         gap: var(--px-flex-gap-sm);
         padding: var(--px-spacing-sm) var(--px-spacing-med);
-        background-color: var(--px-section-background-color);
+        background-color: var(--ac-global-background-color-light);
       `}
     >
       <input type="checkbox" checked={!allNotVisible} onChange={onChange} />

--- a/app/src/components/resize/styles.tsx
+++ b/app/src/components/resize/styles.tsx
@@ -2,7 +2,7 @@ import { css, Theme } from "@emotion/react";
 
 export const resizeHandleCSS = (theme: Theme) => css`
   transition: 250ms linear all;
-  background-color: ${theme.colors.gray600};
+  background-color: var(--ac-global-color-grey-200);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -31,11 +31,11 @@ export const resizeHandleCSS = (theme: Theme) => css`
   }
 
   &:hover {
-    background-color: ${theme.colors.gray200};
+    background-color: var(--ac-global-color-grey-400);
     border-radius: 4px;
     &:before,
     &:after {
-      background-color: ${theme.colors.arizeLightBlue};
+      background-color: var(--ac-global-color-primary);
     }
   }
 
@@ -45,14 +45,14 @@ export const resizeHandleCSS = (theme: Theme) => css`
     color: var(--color-solid-resize-bar);
     flex: 0 0 1rem;
     border-radius: 6px;
-    background-color: ${theme.colors.gray100};
+    background-color: var(--ac-global-color-grey-300);
     flex: none;
   }
 `;
 
 export const compactResizeHandleCSS = (theme: Theme) => css`
   transition: 250ms linear all;
-  background-color: ${theme.colors.gray600};
+  background-color: var(--ac-global-color-grey-200);
   --px-resize-handle-size: 4px;
   outline: none;
   &[data-panel-group-direction="vertical"] {

--- a/app/src/components/resize/styles.tsx
+++ b/app/src/components/resize/styles.tsx
@@ -31,7 +31,7 @@ export const resizeHandleCSS = css`
   }
 
   &:hover {
-    background-color: var(--ac-global-color-grey-400);
+    background-color: var(--ac-global-color-grey-300);
     border-radius: 4px;
     &:before,
     &:after {

--- a/app/src/components/resize/styles.tsx
+++ b/app/src/components/resize/styles.tsx
@@ -1,6 +1,6 @@
 import { css, Theme } from "@emotion/react";
 
-export const resizeHandleCSS = (theme: Theme) => css`
+export const resizeHandleCSS = css`
   transition: 250ms linear all;
   background-color: var(--ac-global-color-grey-200);
   display: flex;

--- a/app/src/components/table/TableExpandButton.tsx
+++ b/app/src/components/table/TableExpandButton.tsx
@@ -25,7 +25,7 @@ export function TableExpandButton(props: TableExpandButtonProps) {
         }
 
         &:hover {
-          color: var(--px-light-blue-color);
+          color: var(--ac-global-color-primary);
         }
       `}
     >

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -38,7 +38,7 @@ export const tableCSS = (theme: Theme) => css`
           touch-action: none;
           &.isResizing,
           &:hover {
-            background: var(--px-light-blue-color);
+            background: var(--ac-global-color-primary);
           }
         }
       }

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -5,7 +5,7 @@ export const tableCSS = (theme: Theme) => css`
   width: 100%;
   border-collapse: collapse;
   thead {
-    background-color: var(--ac-global-color-grey-200);
+    background-color: var(--ac-global-color-grey-300);
     position: sticky;
     top: 0;
     tr {
@@ -47,10 +47,10 @@ export const tableCSS = (theme: Theme) => css`
   tbody:not(.is-empty) {
     tr {
       &:nth-of-type(even) {
-        background-color: var(--ac-global-color-grey-200);
+        background-color: var(--ac-global-color-grey-75);
       }
       &:hover {
-        background-color: var(--ac-global-color-grey-300);
+        background-color: var(--ac-global-color-grey-200);
       }
       & > td {
         padding: ${theme.spacing.margin8}px ${theme.spacing.margin16}px;

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -47,10 +47,10 @@ export const tableCSS = (theme: Theme) => css`
   tbody:not(.is-empty) {
     tr {
       &:nth-of-type(even) {
-        background-color: var(--ac-global-color-grey-100);
+        background-color: var(--ac-global-color-grey-200);
       }
       &:hover {
-        background-color: var(--ac-global-color-grey-200);
+        background-color: var(--ac-global-color-grey-300);
       }
       & > td {
         padding: ${theme.spacing.margin8}px ${theme.spacing.margin16}px;

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -5,7 +5,7 @@ export const tableCSS = (theme: Theme) => css`
   width: 100%;
   border-collapse: collapse;
   thead {
-    background-color: ${theme.colors.gray600};
+    background-color: var(--ac-global-color-grey-200);
     position: sticky;
     top: 0;
     tr {
@@ -23,7 +23,7 @@ export const tableCSS = (theme: Theme) => css`
           display: inline-block;
         }
         &:hover .resizer {
-          background: ${theme.colors.gray300};
+          background: var(--ac-global-color-grey-300);
         }
         div.resizer {
           display: inline-block;
@@ -47,10 +47,10 @@ export const tableCSS = (theme: Theme) => css`
   tbody:not(.is-empty) {
     tr {
       &:nth-of-type(even) {
-        background-color: ${theme.colors.gray700};
+        background-color: var(--ac-global-color-grey-100);
       }
       &:hover {
-        background-color: ${theme.colors.gray600};
+        background-color: var(--ac-global-color-grey-200);
       }
       & > td {
         padding: ${theme.spacing.margin8}px ${theme.spacing.margin16}px;
@@ -77,5 +77,5 @@ export const paginationCSS = (theme: Theme) => css`
   align-items: center;
   padding: ${theme.spacing.margin8}px;
   gap: ${theme.spacing.margin4}px;
-  border-top: 1px solid ${theme.colors.gray500};
+  border-top: 1px solid var(--ac-global-color-grey-300);
 `;

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -47,7 +47,7 @@ export const tableCSS = (theme: Theme) => css`
   tbody:not(.is-empty) {
     tr {
       &:nth-of-type(even) {
-        background-color: var(--ac-global-color-grey-75);
+        background-color: var(--ac-global-color-grey-100);
       }
       &:hover {
         background-color: var(--ac-global-color-grey-200);

--- a/app/src/components/trace/SpanKindIcon.tsx
+++ b/app/src/components/trace/SpanKindIcon.tsx
@@ -221,7 +221,7 @@ export function SpanKindIcon({ spanKind }: { spanKind: string }) {
       icon = <LLMSVG />;
       break;
     case "chain":
-      color = "--px-light-blue-color";
+      color = "--ac-global-color-primary";
       icon = <ChainSVG />;
       break;
     case "retriever":

--- a/app/src/components/trace/SpanKindIcon.tsx
+++ b/app/src/components/trace/SpanKindIcon.tsx
@@ -214,14 +214,14 @@ const ChainSVG = () => (
 
 export function SpanKindIcon({ spanKind }: { spanKind: string }) {
   let icon = <></>;
-  let color = "--ac-global-text-color-900";
+  let color = "--ac-global-grey-900";
   switch (spanKind) {
     case "llm":
       color = "--ac-global-color-orange-1000";
       icon = <LLMSVG />;
       break;
     case "chain":
-      color = "--ac-global-color-primary";
+      color = "--ac-global-color-blue-1000";
       icon = <ChainSVG />;
       break;
     case "retriever":

--- a/app/src/components/trace/SpanKindLabel.tsx
+++ b/app/src/components/trace/SpanKindLabel.tsx
@@ -11,7 +11,7 @@ export function SpanKindLabel(props: { spanKind: string }) {
         color = "orange-1000";
         break;
       case "chain":
-        color = "blue";
+        color = "blue-1000";
         break;
       case "retriever":
         color = "seafoam-1000";
@@ -23,7 +23,7 @@ export function SpanKindLabel(props: { spanKind: string }) {
         color = "indigo-1000";
         break;
       case "agent":
-        color = "gray";
+        color = "grey-900";
         break;
       case "tool":
         color = "yellow-1200";

--- a/app/src/components/trace/SpanStatusCodeIcon.tsx
+++ b/app/src/components/trace/SpanStatusCodeIcon.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { css, Theme } from "@emotion/react";
 
-import { Icon, Icons } from "@arizeai/components";
+import { ColorValue, Icon, Icons } from "@arizeai/components";
 
 import { assertUnreachable } from "@phoenix/typeUtils";
 
@@ -12,33 +11,22 @@ export function SpanStatusCodeIcon<TCode extends SpanStatusCodeType>({
 }: {
   statusCode: TCode;
 }) {
-  let icon = <Icons.MinusCircleOutline />;
-  let color: keyof Theme["colors"] = "gray100";
+  let iconSVG = <Icons.MinusCircleOutline />;
+  let color: ColorValue = "grey-100";
   switch (statusCode) {
     case "OK":
-      icon = <Icons.CheckmarkCircleOutline />;
-      color = "statusSuccess";
+      iconSVG = <Icons.CheckmarkCircleOutline />;
+      color = "success";
       break;
     case "ERROR":
-      icon = <Icons.AlertCircleOutline />;
-      color = "statusDanger";
+      iconSVG = <Icons.AlertCircleOutline />;
+      color = "danger";
       break;
     case "UNSET":
-      icon = <Icons.MinusCircleOutline />;
+      iconSVG = <Icons.MinusCircleOutline />;
       break;
     default:
       assertUnreachable(statusCode);
   }
-  return (
-    <div
-      css={(theme) => css`
-        .ac-icon-wrap {
-          color: ${theme.colors[color]};
-        }
-      `}
-      aria-label={statusCode}
-    >
-      <Icon svg={icon} />
-    </div>
-  );
+  return <Icon svg={iconSVG} color={color} aria-label={statusCode} />;
 }

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -114,20 +114,20 @@ function SpanNodeWrap(props: PropsWithChildren<{ isSelected: boolean }>) {
       className={props.isSelected ? "is-selected" : ""}
       css={css`
         border-radius: var(--ac-global-dimension-static-size-150);
-        background-color: var(--ac-global-color-gray-700);
+        background-color: var(--ac-global-color-grey-200);
         padding: var(--ac-global-dimension-static-size-100)
           var(--ac-global-dimension-static-size-200)
           var(--ac-global-dimension-static-size-100)
           var(--ac-global-dimension-static-size-200);
         border-width: var(--ac-global-dimension-static-size-10);
         border-style: solid;
-        border-color: var(--ac-global-color-gray-400);
+        border-color: var(--ac-global-color-grey-300);
         &:hover {
-          border-color: var(--ac-global-color-gray-200);
-          background-color: var(--ac-global-color-gray-400);
+          border-color: var(--ac-global-color-grey-400);
+          background-color: var(--ac-global-color-grey-300);
         }
         &.is-selected {
-          border-color: var(--px-light-blue-color);
+          border-color: var(--ac-global-color-primary);
         }
       `}
     >

--- a/app/src/constants/pointCloudConstants.tsx
+++ b/app/src/constants/pointCloudConstants.tsx
@@ -67,8 +67,8 @@ export enum CorrectnessGroup {
   unknown = "unknown",
 }
 
-export const DEFAULT_COLOR_SCHEME = ["#05fbff", "#cb8afd"];
-
+export const DEFAULT_DARK_COLOR_SCHEME = ["#05fbff", "#cb8afd"];
+export const DEFAULT_LIGHT_COLOR_SCHEME = ["#00add0", "#4500d9"];
 /**
  * The default color to use when coloringStrategy does not apply.
  */

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -1,0 +1,41 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+import { ProviderTheme } from "@arizeai/components";
+
+export type ThemeContextType = {
+  theme: ProviderTheme;
+  setTheme: (theme: ProviderTheme) => void;
+};
+
+const localStorageTheme =
+  localStorage.getItem("theme") == "light" ? "light" : "dark";
+
+export const ThemeContext = createContext<ThemeContextType | null>(null);
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === null) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export function ThemeProvider(props: PropsWithChildren) {
+  const [theme, _setTheme] = useState<ProviderTheme>(localStorageTheme);
+  const setTheme = useCallback((theme: ProviderTheme) => {
+    localStorage.setItem("theme", theme);
+    _setTheme(theme);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {props.children}
+    </ThemeContext.Provider>
+  );
+}

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -13,8 +13,12 @@ export type ThemeContextType = {
   setTheme: (theme: ProviderTheme) => void;
 };
 
-const localStorageTheme =
-  localStorage.getItem("theme") == "light" ? "light" : "dark";
+const LOCAL_STORAGE_THEME_KEY = "arize-phoenix-theme";
+export function getCurrentTheme(): ProviderTheme {
+  return localStorage.getItem(LOCAL_STORAGE_THEME_KEY) == "light"
+    ? "light"
+    : "dark";
+}
 
 export const ThemeContext = createContext<ThemeContextType | null>(null);
 
@@ -27,9 +31,9 @@ export function useTheme() {
 }
 
 export function ThemeProvider(props: PropsWithChildren) {
-  const [theme, _setTheme] = useState<ProviderTheme>(localStorageTheme);
+  const [theme, _setTheme] = useState<ProviderTheme>(getCurrentTheme());
   const setTheme = useCallback((theme: ProviderTheme) => {
-    localStorage.setItem("theme", theme);
+    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, theme);
     _setTheme(theme);
   }, []);
 

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -13,11 +13,11 @@ export type ThemeContextType = {
   setTheme: (theme: ProviderTheme) => void;
 };
 
-const LOCAL_STORAGE_THEME_KEY = "arize-phoenix-theme";
+export const LOCAL_STORAGE_THEME_KEY = "arize-phoenix-theme";
+
 export function getCurrentTheme(): ProviderTheme {
-  return localStorage.getItem(LOCAL_STORAGE_THEME_KEY) == "light"
-    ? "light"
-    : "dark";
+  const themeFromLocalStorage = localStorage.getItem(LOCAL_STORAGE_THEME_KEY);
+  return themeFromLocalStorage === "light" ? "light" : "dark";
 }
 
 export const ThemeContext = createContext<ThemeContextType | null>(null);

--- a/app/src/contexts/index.tsx
+++ b/app/src/contexts/index.tsx
@@ -2,3 +2,4 @@ export * from "./DatasetsContext";
 export * from "./PointCloudContext";
 export * from "./TimeRangeContext";
 export * from "./NotificationContext";
+export * from "./ThemeContext";

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -8,6 +8,7 @@ import {
   GitHubLink,
   Navbar,
   NavBreadcrumb,
+  ThemeToggle,
 } from "@phoenix/components/nav";
 
 const layoutCSS = css`
@@ -29,7 +30,7 @@ const linksCSS = css`
   flex-direction: row;
   margin: 0;
   list-style: none;
-  gap: var(--px-spacing-sm);
+  gap: var(--ac-global-dimension-size-100);
   padding-inline-start: 0;
 `;
 
@@ -45,6 +46,9 @@ export function Layout() {
           </li>
           <li>
             <GitHubLink />
+          </li>
+          <li>
+            <ThemeToggle />
           </li>
         </ul>
       </Navbar>

--- a/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
@@ -17,8 +17,8 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
-  colors,
   defaultTimeXAxisProps,
+  useChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -32,13 +32,19 @@ const numberFormatter = new Intl.NumberFormat([], {
   maximumFractionDigits: 2,
 });
 
-const color = colors.gray300;
+const useColors = () => {
+  const { gray300 } = useChartColors();
+  return {
+    color: gray300,
+  };
+};
 
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number, string>) {
+  const { color } = useColors();
   if (active && payload && payload.length) {
     const cardinality = payload[0]?.value ?? null;
     const cardinalityString =
@@ -104,6 +110,7 @@ export function DimensionCardinalityTimeSeries({
     }
   );
 
+  const { color } = useColors();
   const chartData =
     data.dimension.cardinalityTimeSeries?.data.map((d) => {
       return {

--- a/app/src/pages/dimension/DimensionCountTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCountTimeSeries.tsx
@@ -16,9 +16,9 @@ import { Text, theme } from "@arizeai/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
-  colors,
   defaultBarChartTooltipProps,
   defaultTimeXAxisProps,
+  useChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -32,13 +32,19 @@ const numberFormatter = new Intl.NumberFormat([], {
   maximumFractionDigits: 2,
 });
 
-const barColor = colors.gray300;
+const useColors = () => {
+  const { gray300 } = useChartColors();
+  return {
+    barColor: gray300,
+  };
+};
 
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number, string>) {
+  const { barColor } = useColors();
   if (active && payload && payload.length) {
     const count = payload[0]?.value ?? null;
     const predictionCountString =
@@ -113,6 +119,7 @@ export function DimensionCountTimeSeries({
   const timeTickFormatter = useTimeTickFormatter({
     samplingIntervalMinutes: countGranularity.samplingIntervalMinutes,
   });
+  const { barColor } = useColors();
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
+++ b/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
@@ -18,9 +18,9 @@ import { Flex, Text, theme, View } from "@arizeai/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
-  colors,
   defaultBarChartTooltipProps,
   getBinName,
+  useChartColors,
 } from "@phoenix/components/chart";
 import { useDatasets } from "@phoenix/contexts";
 import { useTimeSlice } from "@phoenix/contexts/TimeSliceContext";
@@ -36,16 +36,22 @@ type BarChartItem = {
   referencePercent: number;
 };
 
-const primaryBarColor = colors.primary;
-const referenceBarColor = colors.reference;
-
 const formatter = format(".2f");
+
+const useColors = () => {
+  const { primary, reference } = useChartColors();
+  return {
+    primaryBarColor: primary,
+    referenceBarColor: reference,
+  };
+};
 
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<BarChartItem["primaryPercent"], BarChartItem["name"]>) {
+  const { primaryBarColor, referenceBarColor } = useColors();
   if (active && payload && payload.length) {
     const primaryLabel = payload[0]?.payload?.primaryName;
     const primaryValue = payload[0]?.value;
@@ -173,6 +179,7 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
     referenceName,
   ]);
 
+  const { primaryBarColor, referenceBarColor } = useColors();
   return (
     <Flex direction="column" height="100%">
       <View flex="none" paddingTop="size-100" paddingStart="size-200">

--- a/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
@@ -65,7 +65,7 @@ function TooltipContent({
             display: flex;
             flex-direction: row;
             align-items: center;
-            color: var(--px-light-blue-color);
+            color: var(--ac-global-color-primary);
             gap: var(--px-spacing-sm);
 
             margin-top: var(--px-spacing-sm);

--- a/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
@@ -21,9 +21,9 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
-  colors,
   defaultSelectedTimestampReferenceLineProps,
   defaultTimeXAxisProps,
+  useChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -38,14 +38,20 @@ import {
 import { DimensionDriftTimeSeriesQuery } from "./__generated__/DimensionDriftTimeSeriesQuery.graphql";
 import { timeSeriesChartMargins } from "./dimensionChartConstants";
 
-const color = colors.orange300;
-const barColor = "#93b3c841";
+const useColors = () => {
+  const { orange300, gray300 } = useChartColors();
+  return {
+    color: orange300,
+    barColor: gray300,
+  };
+};
 
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number, string>) {
+  const { color } = useColors();
   if (active && payload && payload.length) {
     const euclideanDistance = payload[1]?.value ?? null;
 
@@ -166,6 +172,7 @@ export function DimensionDriftTimeSeries({
     [setSelectedTimestamp]
   );
 
+  const { color, barColor } = useColors();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ComposedChart

--- a/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
@@ -16,8 +16,8 @@ import { Text, theme } from "@arizeai/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
-  colors,
   defaultTimeXAxisProps,
+  useChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -31,13 +31,19 @@ const numberFormatter = new Intl.NumberFormat([], {
   maximumFractionDigits: 2,
 });
 
-const color = colors.gray100;
+const useColors = () => {
+  const { gray100 } = useChartColors();
 
+  return {
+    color: gray100,
+  };
+};
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number, string>) {
+  const { color } = useColors();
   if (active && payload && payload.length) {
     const percentEmpty = payload[0]?.value ?? null;
     const percentEmptyString =
@@ -112,6 +118,7 @@ export function DimensionPercentEmptyTimeSeries({
     samplingIntervalMinutes: granularity.samplingIntervalMinutes,
   });
 
+  const { color } = useColors();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ComposedChart

--- a/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
@@ -20,8 +20,8 @@ import { Text, theme } from "@arizeai/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
-  colors,
   defaultTimeXAxisProps,
+  useChartColors,
   useTimeTickFormatter,
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -61,15 +61,20 @@ function formatValue(value: number | null) {
   return typeof value === "number" ? numberFormatter.format(value) : "--";
 }
 
-const outerColor = colors.gray500;
-const innerColor = colors.gray300;
-const lineColor = colors.white;
-
+const useColors = () => {
+  const colors = useChartColors();
+  return {
+    outerColor: colors.gray500,
+    innerColor: colors.gray300,
+    lineColor: colors.default,
+  };
+};
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number | Array<number | string>, string>) {
+  const { outerColor, innerColor, lineColor } = useColors();
   if (active && payload && payload.length) {
     const data: ChartDataItem = payload[0].payload;
     return (
@@ -232,6 +237,8 @@ export function DimensionQuantilesTimeSeries({
       [e.dataKey]: !chartState[e.dataKey as Label],
     });
   };
+
+  const { outerColor, innerColor, lineColor } = useColors();
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
+++ b/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
@@ -17,9 +17,9 @@ import { theme } from "@arizeai/components";
 import {
   ChartTooltip,
   ChartTooltipItem,
-  colors,
   defaultBarChartTooltipProps,
   getBinName,
+  useChartColors,
 } from "@phoenix/components/chart";
 
 import { DimensionSegmentsBarChart_dimension$key } from "./__generated__/DimensionSegmentsBarChart_dimension.graphql";
@@ -30,21 +30,26 @@ type BarChartItem = {
   percent: number;
 };
 
-const barColor = colors.primary;
-
 const formatter = format(".2f");
 
+const useColors = () => {
+  const { primary } = useChartColors();
+  return {
+    color: primary,
+  };
+};
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<BarChartItem["percent"], BarChartItem["name"]>) {
+  const { color } = useColors();
   if (active && payload && payload.length) {
     const value = payload[0]?.value;
     return (
       <ChartTooltip>
         <ChartTooltipItem
-          color={barColor}
+          color={color}
           shape="square"
           name={label}
           value={value != null ? `${formatter(value)}%` : "--"}
@@ -113,6 +118,7 @@ export function DimensionSegmentsBarChart(props: {
     });
   }, [data]);
 
+  const { color } = useColors();
   return (
     <ResponsiveContainer>
       <BarChart
@@ -132,8 +138,8 @@ export function DimensionSegmentsBarChart(props: {
             x2="0"
             y2="1"
           >
-            <stop offset="5%" stopColor={barColor} stopOpacity={1} />
-            <stop offset="95%" stopColor={barColor} stopOpacity={0.5} />
+            <stop offset="5%" stopColor={color} stopOpacity={1} />
+            <stop offset="95%" stopColor={color} stopOpacity={0.5} />
           </linearGradient>
         </defs>
         <XAxis

--- a/app/src/pages/embedding/EmbeddingPage.tsx
+++ b/app/src/pages/embedding/EmbeddingPage.tsx
@@ -59,9 +59,9 @@ import {
 import { useEmbeddingDimensionId } from "@phoenix/hooks";
 import {
   ClusterColorMode,
-  DEFAULT_DRIFT_POINT_CLOUD_PROPS,
-  DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS,
-  DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS,
+  getDefaultDriftPointCloudProps,
+  getDefaultRetrievalTroubleshootingPointCloudProps,
+  getDefaultSingleDatasetPointCloudProps,
   MetricDefinition,
   PointCloudProps,
 } from "@phoenix/store";
@@ -228,11 +228,11 @@ export function EmbeddingPage() {
       // If there is a corpus dataset, then initialize the page with the retrieval troubleshooting settings
       // TODO - this does make a bit of a leap of assumptions but is a short term solution in order to get the page working as intended
       defaultPointCloudProps =
-        DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS;
+        getDefaultRetrievalTroubleshootingPointCloudProps();
     } else if (referenceDataset != null) {
-      defaultPointCloudProps = DEFAULT_DRIFT_POINT_CLOUD_PROPS;
+      defaultPointCloudProps = getDefaultDriftPointCloudProps();
     } else {
-      defaultPointCloudProps = DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS;
+      defaultPointCloudProps = getDefaultSingleDatasetPointCloudProps();
     }
 
     // Apply the UMAP parameters from the server-sent config

--- a/app/src/pages/embedding/EmbeddingPage.tsx
+++ b/app/src/pages/embedding/EmbeddingPage.tsx
@@ -618,7 +618,7 @@ function PointSelectionPanelContentWrap(props: { children: ReactNode }) {
   return (
     <div
       css={css`
-        background-color: var(--ac-global-background-color-light);
+        background-color: var(--ac-global-color-grey-75);
         width: 100%;
         height: 100%;
       `}

--- a/app/src/pages/embedding/EmbeddingPage.tsx
+++ b/app/src/pages/embedding/EmbeddingPage.tsx
@@ -617,8 +617,8 @@ function SelectionPanel() {
 function PointSelectionPanelContentWrap(props: { children: ReactNode }) {
   return (
     <div
-      css={(theme) => css`
-        background-color: ${theme.colors.gray900};
+      css={css`
+        background-color: var(--ac-global-background-color-light);
         width: 100%;
         height: 100%;
       `}

--- a/app/src/pages/embedding/EmbeddingPage.tsx
+++ b/app/src/pages/embedding/EmbeddingPage.tsx
@@ -329,12 +329,11 @@ function EmbeddingMain() {
 
   return (
     <main
-      css={(theme) => css`
+      css={css`
         flex: 1 1 auto;
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        background-color: ${theme.colors.gray900};
       `}
     >
       <PointCloudNotifications />

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -94,7 +94,7 @@ function TooltipContent({
             display: flex;
             flex-direction: row;
             align-items: center;
-            color: var(--px-light-blue-color);
+            color: var(--ac-global-color-primary);
             gap: var(--px-spacing-sm);
 
             margin-top: var(--px-spacing-sm);

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -29,9 +29,9 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
-  colors,
   defaultSelectedTimestampReferenceLineProps,
   defaultTimeXAxisProps,
+  useChartColors,
 } from "@phoenix/components/chart";
 import { useTimeTickFormatter } from "@phoenix/components/chart";
 import { usePointCloudContext } from "@phoenix/contexts";
@@ -55,14 +55,22 @@ const numberFormatter = new Intl.NumberFormat([], {
   maximumFractionDigits: 2,
 });
 
-const color = colors.blue400;
-const barColor = colors.gray500;
+const useColors = () => {
+  const colors = useChartColors();
+  const color = colors.blue400;
+  const barColor = colors.gray500;
+  return {
+    color,
+    barColor,
+  };
+};
 
 function TooltipContent({
   active,
   payload,
   label,
 }: TooltipProps<number, string>) {
+  const { color, barColor } = useColors();
   if (active && payload && payload.length) {
     const metricValue = payload[1]?.value ?? null;
     const count = payload[0]?.value ?? null;
@@ -312,6 +320,7 @@ export function MetricTimeSeries({
   const metricShortName = getMetricShortName(metric);
   const metricDescription = getMetricDescription(metric);
 
+  const { color, barColor } = useColors();
   return (
     <section
       css={css`

--- a/app/src/pages/embedding/PointSelectionTable.tsx
+++ b/app/src/pages/embedding/PointSelectionTable.tsx
@@ -14,10 +14,10 @@ import { ExternalLink, LinkButton } from "@phoenix/components";
 import { Shape, ShapeIcon } from "@phoenix/components/pointcloud";
 import { FloatCell, TextCell } from "@phoenix/components/table";
 import { tableCSS } from "@phoenix/components/table/styles";
-import { DEFAULT_COLOR_SCHEME } from "@phoenix/constants/pointCloudConstants";
 import { useDatasets, usePointCloudContext } from "@phoenix/contexts";
 
 import { ModelEvent } from "./types";
+import { useDefaultColorScheme } from "./useDefaultColorScheme";
 
 interface TableDataItem extends ModelEvent {
   metric?: number | null;
@@ -276,6 +276,7 @@ function EventDatasetCell({
   referenceDatasetName: string;
 }) {
   const isPrimary = id.includes("PRIMARY");
+  const DEFAULT_COLOR_SCHEME = useDefaultColorScheme();
   return (
     <Flex direction="row" gap="size-100" alignItems="center">
       <ShapeIcon

--- a/app/src/pages/embedding/useDefaultColorScheme.ts
+++ b/app/src/pages/embedding/useDefaultColorScheme.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+
+import {
+  DEFAULT_DARK_COLOR_SCHEME,
+  DEFAULT_LIGHT_COLOR_SCHEME,
+} from "@phoenix/constants/pointCloudConstants";
+import { useTheme } from "@phoenix/contexts";
+
+export function useDefaultColorScheme() {
+  const { theme } = useTheme();
+  return useMemo(() => {
+    if (theme === "light") {
+      return DEFAULT_LIGHT_COLOR_SCHEME;
+    }
+    return DEFAULT_DARK_COLOR_SCHEME;
+  }, [theme]);
+}

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -40,6 +40,7 @@ import { resizeHandleCSS } from "@phoenix/components/resize";
 import { SpanItem } from "@phoenix/components/trace/SpanItem";
 import { SpanKindIcon } from "@phoenix/components/trace/SpanKindIcon";
 import { TraceTree } from "@phoenix/components/trace/TraceTree";
+import { useTheme } from "@phoenix/contexts";
 import {
   DOCUMENT_CONTENT,
   DOCUMENT_ID,
@@ -295,7 +296,7 @@ function SelectedSpanDetails({ selectedSpan }: { selectedSpan: Span }) {
         <TabPane
           name={"Events"}
           extra={
-            <Counter variant={hasExceptions ? "danger" : "default"}>
+            <Counter variant={hasExceptions ? "danger" : "light"}>
               {selectedSpan.events.length}
             </Counter>
           }
@@ -1074,6 +1075,8 @@ const codeMirrorCSS = css`
   }
 `;
 function CodeBlock({ value, mimeType }: { value: string; mimeType: MimeType }) {
+  const { theme } = useTheme();
+  const codeMirrorTheme = theme === "light" ? undefined : nord;
   let content;
   switch (mimeType) {
     case "json":
@@ -1090,7 +1093,7 @@ function CodeBlock({ value, mimeType }: { value: string; mimeType: MimeType }) {
           }}
           extensions={[json(), EditorView.lineWrapping]}
           editable={false}
-          theme={nord}
+          theme={codeMirrorTheme}
           css={codeMirrorCSS}
         />
       );
@@ -1099,7 +1102,7 @@ function CodeBlock({ value, mimeType }: { value: string; mimeType: MimeType }) {
       content = (
         <CodeMirror
           value={value}
-          theme={nord}
+          theme={codeMirrorTheme}
           editable={false}
           basicSetup={{
             lineNumbers: false,

--- a/app/src/pages/tracing/SpanFilterConditionField.tsx
+++ b/app/src/pages/tracing/SpanFilterConditionField.tsx
@@ -23,6 +23,7 @@ import {
   TriggerWrap,
 } from "@arizeai/components";
 
+import { useTheme } from "@phoenix/contexts";
 import environment from "@phoenix/RelayEnvironment";
 
 import { SpanFilterConditionFieldValidationQuery } from "./__generated__/SpanFilterConditionFieldValidationQuery.graphql";
@@ -220,6 +221,8 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [filterCondition, setFilterCondition] = useState<string>("");
   const deferredFilterCondition = useDeferredValue(filterCondition);
+  const { theme } = useTheme();
+  const codeMirrorTheme = theme === "dark" ? nord : undefined;
 
   useEffect(() => {
     isConditionValid(deferredFilterCondition).then((result) => {
@@ -259,7 +262,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
           onChange={setFilterCondition}
           height="36px"
           width="100%"
-          theme={nord}
+          theme={codeMirrorTheme}
           placeholder={placeholder}
           extensions={extensions}
         />

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -240,7 +240,7 @@ export function SpansTable(props: SpansTableProps) {
   return (
     <div>
       <div>
-        <View padding="size-100" backgroundColor="light">
+        <View padding="size-100" backgroundColor="grey-200">
           <SpanFilterConditionField onValidCondition={setFilterCondition} />
         </View>
       </div>

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -238,12 +238,18 @@ export function SpansTable(props: SpansTableProps) {
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
   return (
-    <div>
-      <div>
-        <View padding="size-100" backgroundColor="grey-200">
-          <SpanFilterConditionField onValidCondition={setFilterCondition} />
-        </View>
-      </div>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        overflow: hidden;
+      `}
+    >
+      <View padding="size-100" backgroundColor="grey-200">
+        <SpanFilterConditionField onValidCondition={setFilterCondition} />
+      </View>
+
       <div
         css={css`
           flex: 1 1 auto;

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -344,8 +344,15 @@ export function TracesTable(props: TracesTableProps) {
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
   return (
-    <div>
-      <View padding="size-100" backgroundColor="grey-200">
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        overflow: hidden;
+      `}
+    >
+      <View padding="size-100" backgroundColor="grey-200" flex="none">
         <SpanFilterConditionField onValidCondition={setFilterCondition} />
       </View>
       <div

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -345,7 +345,7 @@ export function TracesTable(props: TracesTableProps) {
   const isEmpty = rows.length === 0;
   return (
     <div>
-      <View padding="size-100" backgroundColor="light">
+      <View padding="size-100" backgroundColor="grey-200">
         <SpanFilterConditionField onValidCondition={setFilterCondition} />
       </View>
       <div

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -490,43 +490,49 @@ export interface PointCloudState extends PointCloudProps {
   setMetric(metric: MetricDefinition): void;
 }
 
-const DEFAULT_COLOR_SCHEME =
-  getCurrentTheme() === "light"
+const getDefaultColorScheme = () => {
+  const theme = getCurrentTheme();
+  return theme === "light"
     ? DEFAULT_LIGHT_COLOR_SCHEME
     : DEFAULT_DARK_COLOR_SCHEME;
-
-/**
- * The default point cloud properties in the case that there are two datasets.
- */
-export const DEFAULT_DRIFT_POINT_CLOUD_PROPS: Partial<PointCloudProps> = {
-  coloringStrategy: ColoringStrategy.dataset,
-  pointGroupVisibility: {
-    [DatasetGroup.primary]: true,
-    [DatasetGroup.reference]: true,
-  },
-  pointGroupColors: {
-    [DatasetGroup.primary]: DEFAULT_COLOR_SCHEME[0],
-    [DatasetGroup.reference]: DEFAULT_COLOR_SCHEME[1],
-    [DatasetGroup.corpus]: FALLBACK_COLOR,
-  },
-  metric: {
-    type: "drift",
-    metric: "euclideanDistance",
-  },
 };
 
 /**
  * The default point cloud properties in the case that there are two datasets.
  */
-export const DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS: Partial<PointCloudProps> =
-  {
+export function getDefaultDriftPointCloudProps(): Partial<PointCloudProps> {
+  const defaultColorScheme = getDefaultColorScheme();
+  return {
+    coloringStrategy: ColoringStrategy.dataset,
+    pointGroupVisibility: {
+      [DatasetGroup.primary]: true,
+      [DatasetGroup.reference]: true,
+    },
+    pointGroupColors: {
+      [DatasetGroup.primary]: defaultColorScheme[0],
+      [DatasetGroup.reference]: defaultColorScheme[1],
+      [DatasetGroup.corpus]: FALLBACK_COLOR,
+    },
+    metric: {
+      type: "drift",
+      metric: "euclideanDistance",
+    },
+  };
+}
+
+/**
+ * The default point cloud properties in the case that there are two datasets.
+ */
+export function getDefaultRetrievalTroubleshootingPointCloudProps(): Partial<PointCloudProps> {
+  const defaultColorScheme = getDefaultColorScheme();
+  return {
     coloringStrategy: ColoringStrategy.dataset,
     pointGroupVisibility: {
       [DatasetGroup.primary]: true,
       [DatasetGroup.corpus]: true,
     },
     pointGroupColors: {
-      [DatasetGroup.primary]: DEFAULT_COLOR_SCHEME[0],
+      [DatasetGroup.primary]: defaultColorScheme[0],
       [DatasetGroup.corpus]: FALLBACK_COLOR,
     },
     metric: {
@@ -536,12 +542,12 @@ export const DEFAULT_RETRIEVAL_TROUBLESHOOTING_POINT_CLOUD_PROPS: Partial<PointC
     // Since we are showing clusters by percent query, sort from highest query density to lowest
     clusterSort: { dir: "desc", column: "primaryMetricValue" },
   };
-
+}
 /**
  * The default point cloud properties in the case that there is only one dataset.
  */
-export const DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS: Partial<PointCloudProps> =
-  {
+export function getDefaultSingleDatasetPointCloudProps(): Partial<PointCloudProps> {
+  return {
     coloringStrategy: ColoringStrategy.correctness,
     pointGroupVisibility: {
       [CorrectnessGroup.correct]: true,
@@ -560,6 +566,7 @@ export const DEFAULT_SINGLE_DATASET_POINT_CLOUD_PROPS: Partial<PointCloudProps> 
     // Since we are showing clusters by accuracy, sort from lowest accuracy to highest
     clusterSort: { dir: "asc", column: "primaryMetricValue" },
   };
+}
 
 export type PointCloudStore = ReturnType<typeof createPointCloudStore>;
 
@@ -589,8 +596,8 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
     },
     pointGroupColors: {
       // TODO move to a single source of truth
-      [DatasetGroup.primary]: DEFAULT_COLOR_SCHEME[0],
-      [DatasetGroup.reference]: DEFAULT_COLOR_SCHEME[1],
+      [DatasetGroup.primary]: getDefaultColorScheme()[0],
+      [DatasetGroup.reference]: getDefaultColorScheme()[1],
       [DatasetGroup.corpus]: FALLBACK_COLOR,
     },
     eventIdToGroup: {},
@@ -749,8 +756,8 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
             },
             pointGroupColors: {
               // TODO move these colors to a constants file
-              [DatasetGroup.primary]: DEFAULT_COLOR_SCHEME[0],
-              [DatasetGroup.reference]: DEFAULT_COLOR_SCHEME[1],
+              [DatasetGroup.primary]: getDefaultColorScheme()[0],
+              [DatasetGroup.reference]: getDefaultColorScheme()[1],
               [DatasetGroup.corpus]: FALLBACK_COLOR,
             },
             dimension: null,

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -11,8 +11,9 @@ import {
   DatasetGroup,
   DEFAULT_CLUSTER_MIN_SAMPLES,
   DEFAULT_CLUSTER_SELECTION_EPSILON,
-  DEFAULT_COLOR_SCHEME,
+  DEFAULT_DARK_COLOR_SCHEME,
   DEFAULT_DATASET_SAMPLE_SIZE,
+  DEFAULT_LIGHT_COLOR_SCHEME,
   DEFAULT_MIN_CLUSTER_SIZE,
   DEFAULT_MIN_DIST,
   DEFAULT_N_NEIGHBORS,
@@ -21,6 +22,7 @@ import {
   SelectionGridSize,
   UNKNOWN_COLOR,
 } from "@phoenix/constants/pointCloudConstants";
+import { getCurrentTheme } from "@phoenix/contexts";
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 import { Dimension } from "@phoenix/types";
 import { assertUnreachable } from "@phoenix/typeUtils";
@@ -304,11 +306,6 @@ export interface PointCloudProps {
    */
   canvasMode: CanvasMode;
   /**
-   * The color scheme to use for the point cloud.
-   * @default "dark"
-   */
-  canvasTheme: CanvasTheme;
-  /**
    * The point size scale
    * @default 1
    */
@@ -418,10 +415,6 @@ export interface PointCloudState extends PointCloudProps {
    */
   setCanvasMode: (mode: CanvasMode) => void;
   /**
-   * Set canvas theme to light or dark
-   */
-  setCanvasTheme: (theme: CanvasTheme) => void;
-  /**
    * Set the point size scale
    * @param {number} scale
    */
@@ -496,6 +489,11 @@ export interface PointCloudState extends PointCloudProps {
    */
   setMetric(metric: MetricDefinition): void;
 }
+
+const DEFAULT_COLOR_SCHEME =
+  getCurrentTheme() === "light"
+    ? DEFAULT_LIGHT_COLOR_SCHEME
+    : DEFAULT_DARK_COLOR_SCHEME;
 
 /**
  * The default point cloud properties in the case that there are two datasets.
@@ -580,7 +578,6 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
     highlightedClusterId: null,
     selectedClusterId: null,
     canvasMode: CanvasMode.move,
-    canvasTheme: "dark",
     pointSizeScale: 1,
     clusterColorMode: ClusterColorMode.default,
     coloringStrategy: ColoringStrategy.dataset,
@@ -710,7 +707,6 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
     setHighlightedClusterId: (id) => set({ highlightedClusterId: id }),
     setSelectedClusterId: (id) =>
       set({ selectedClusterId: id, highlightedClusterId: null }),
-    setCanvasTheme: (theme) => set({ canvasTheme: theme }),
     setPointSizeScale: (scale) => set({ pointSizeScale: scale }),
     setCanvasMode: (mode) => set({ canvasMode: mode }),
     setClusterColorMode: (mode) => set({ clusterColorMode: mode }),


### PR DESCRIPTION
resolves #1659 

This adds a UI light theme as part of the component library's 1.0 release. This makes the entire UI rely on colors that rotate from dark -> light in saturation and hue. This PR is largely comprised of switching hard-coded theme values to CSS variables. The only functional difference is a unified `ThemeContext` that is used to drive light/dark preferences across the entire app and that is persisted in local storage.


https://github.com/Arize-ai/phoenix/assets/5640648/3ac6a002-20ea-4dba-875b-b120535c678b


https://github.com/Arize-ai/phoenix/assets/5640648/b94cbaca-66fd-4968-9bbc-a1094cd200ab

