### PR TITLE
ci: stub out open AI key during CI to avoid embedding model downloads in llama_index

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
     pip-version: 23.1.2
+    PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0 # disable memory warnings
 
 jobs:
     lint:

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
     pip-version: 23.1.2
-    PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.7 # disable memory warnings
+    OPENAI_API_KEY: "sk-fake-openai-key" # fake openai key so that llama_index doesn't download huggingface embeddings
 
 jobs:
     lint:

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
     pip-version: 23.1.2
-    PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0 # disable memory warnings
+    PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.7 # disable memory warnings
 
 jobs:
     lint:

--- a/src/phoenix/trace/evaluation_conventions.py
+++ b/src/phoenix/trace/evaluation_conventions.py
@@ -14,13 +14,13 @@ A list of relevancies for the documents of a retriever span. An Int value of 1 o
 EVAL_DOCUMENTS_PRECISION = "eval.documents_precision"
 """
 The precision of a retriever.
-This is the proportion (expressed as a value between 0 and 1) of relevant documents over the total
+This is the proportion (expressed as a value between 0 and 1) of relevant documents over the total.
 """
 
 EVAL_DOCUMENTS_PRECISION_AT_K_TEMPLATE = "eval.documents_precision_at_{k}"
 """
 The prefix given to an evaluation metric that captures the precision of a
 retriever up to K. E.x. you would have eval.documents_precision_at_1,
-eval.documents_precision_at_2, etc. This value
-would be computed on top of the document_relevancy attribute of each document.
+eval.documents_precision_at_2, etc. This value would be computed on top of the
+document_relevancy attribute of each document.
 """


### PR DESCRIPTION
resolves #1660 