### PR TITLE
fix(traces): support token counts for custom models in llama_index

### DIFF
--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -13,16 +13,41 @@ import json
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, TypedDict, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    cast,
+)
 from uuid import uuid4
 
 from llama_index.callbacks.base_handler import BaseCallbackHandler
-from llama_index.callbacks.schema import TIMESTAMP_FORMAT, CBEvent, CBEventType, EventPayload
+from llama_index.callbacks.schema import (
+    TIMESTAMP_FORMAT,
+    CBEvent,
+    CBEventType,
+    EventPayload,
+)
 from llama_index.llms.base import ChatMessage, ChatResponse
 from llama_index.tools import ToolMetadata
 
 from phoenix.trace.exporter import HttpExporter
-from phoenix.trace.schemas import Span, SpanEvent, SpanException, SpanID, SpanKind, SpanStatusCode
+from phoenix.trace.schemas import (
+    Span,
+    SpanEvent,
+    SpanException,
+    SpanID,
+    SpanKind,
+    SpanStatusCode,
+)
 from phoenix.trace.semantic_conventions import (
     DOCUMENT_CONTENT,
     DOCUMENT_ID,
@@ -133,7 +158,13 @@ def payload_to_semantic_attributes(
         if (raw := getattr(response, "raw", None)) is not None:
             attributes.update(_get_output_messages(raw))
             if (usage := getattr(raw, "usage", None)) is not None:
+                # OpenAI token counts are available on raw.usage but more
+                # also available in additional_kwargs
                 attributes.update(_get_token_counts(usage))
+        # Look for token counts in additional_kwargs of the completion payload
+        # This is needed for non-OpenAI models
+        if (additional_kwargs := getattr(response, "additional_kwargs", None)) is not None:
+            attributes.update(_get_token_counts(additional_kwargs))
     if event_type is CBEventType.RERANKING:
         if EventPayload.TOP_K in payload:
             attributes[RERANKER_TOP_K] = payload[EventPayload.TOP_K]
@@ -495,12 +526,40 @@ def _get_output_messages(raw: object) -> Iterator[Tuple[str, Any]]:
     yield LLM_OUTPUT_MESSAGES, messages
 
 
-def _get_token_counts(usage: object) -> Iterator[Tuple[str, Any]]:
+def _get_token_counts(usage: Union[object, Mapping[str, Any]]) -> Iterator[Tuple[str, Any]]:
+    """
+    Yields token count attributes from a object or mapping
+    """
+    # Call the appropriate function based on the type of usage
+    if isinstance(usage, Mapping):
+        yield from _get_token_counts_from_mapping(usage)
+    elif isinstance(usage, object):
+        yield from _get_token_counts_from_object(usage)
+
+
+def _get_token_counts_from_object(usage: object) -> Iterator[Tuple[str, Any]]:
+    """
+    Yields token count attributes from response.raw.usage
+    """
     if (prompt_tokens := getattr(usage, "prompt_tokens", None)) is not None:
         yield LLM_TOKEN_COUNT_PROMPT, prompt_tokens
     if (completion_tokens := getattr(usage, "completion_tokens", None)) is not None:
         yield LLM_TOKEN_COUNT_COMPLETION, completion_tokens
     if (total_tokens := getattr(usage, "total_tokens", None)) is not None:
+        yield LLM_TOKEN_COUNT_TOTAL, total_tokens
+
+
+def _get_token_counts_from_mapping(
+    usage_mapping: Mapping[str, Any],
+) -> Iterator[Tuple[str, Any]]:
+    """
+    Yields token count attributes from a mapping (e.x. completion kwargs payload)
+    """
+    if (prompt_tokens := usage_mapping.get("prompt_tokens")) is not None:
+        yield LLM_TOKEN_COUNT_PROMPT, prompt_tokens
+    if (completion_tokens := usage_mapping.get("completion_tokens")) is not None:
+        yield LLM_TOKEN_COUNT_COMPLETION, completion_tokens
+    if (total_tokens := usage_mapping.get("total_tokens")) is not None:
         yield LLM_TOKEN_COUNT_TOTAL, total_tokens
 
 

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -158,8 +158,8 @@ def payload_to_semantic_attributes(
         if (raw := getattr(response, "raw", None)) is not None:
             attributes.update(_get_output_messages(raw))
             if (usage := getattr(raw, "usage", None)) is not None:
-                # OpenAI token counts are available on raw.usage but more
-                # also available in additional_kwargs
+                # OpenAI token counts are available on raw.usage but can also be
+                # found in additional_kwargs. Thus the duplicate handling.
                 attributes.update(_get_token_counts(usage))
         # Look for token counts in additional_kwargs of the completion payload
         # This is needed for non-OpenAI models

--- a/tests/trace/llama_index/conftest.py
+++ b/tests/trace/llama_index/conftest.py
@@ -100,3 +100,8 @@ def mock_service_context(
     return ServiceContext.from_defaults(
         embed_model=MockEmbedding(),
     )
+
+
+@pytest.fixture()
+def mock_embed_model() -> BaseEmbedding:
+    return MockEmbedding()

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -228,7 +228,7 @@ def test_custom_llm(mock_embed_model) -> None:
             },
         )
 
-    class Llama7B(CustomLLM):
+    class Llama2(CustomLLM):
         @property
         def metadata(self) -> LLMMetadata:
             """Get LLM metadata."""
@@ -253,7 +253,7 @@ def test_custom_llm(mock_embed_model) -> None:
         def stream_complete(self, prompt: str, **kwargs: Any) -> CompletionResponseGen:
             raise NotImplementedError()
 
-    llm = Llama7B()
+    llm = Llama2()
 
     question = "What are the seven wonders of the world?"
     callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -7,7 +8,14 @@ import responses
 from llama_index import ListIndex, ServiceContext, get_response_synthesizer
 from llama_index.callbacks import CallbackManager
 from llama_index.callbacks.schema import CBEventType
-from llama_index.llms import OpenAI
+from llama_index.llms import (
+    CompletionResponse,
+    CompletionResponseGen,
+    CustomLLM,
+    LLMMetadata,
+    OpenAI,
+)
+from llama_index.llms.base import llm_completion_callback
 from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.schema import Document, TextNode
 from openai import ChatCompletion
@@ -24,6 +32,7 @@ from phoenix.trace.semantic_conventions import (
     INPUT_VALUE,
     LLM_PROMPT_TEMPLATE,
     LLM_PROMPT_TEMPLATE_VARIABLES,
+    LLM_TOKEN_COUNT_TOTAL,
     OUTPUT_VALUE,
     RETRIEVAL_DOCUMENTS,
 )
@@ -201,3 +210,74 @@ def test_end_trace_handler_fails_gracefully(mock_handler_internals, caplog) -> N
     assert caplog.records[0].levelname == "ERROR"
     assert "end_trace" in caplog.records[0].message
     assert "CallbackError" in caplog.records[0].message
+
+
+def test_custom_llm(mock_embed_model) -> None:
+    """Make sure token counts are captured when a custom LLM such as lama2-13B is used."""
+
+    prompt_tokens = 100
+    completion_tokens = 200
+
+    def sendPromptToLama(prompt: str):
+        return (
+            "LLM Predict",
+            prompt_tokens,
+            completion_tokens,
+            {
+                "text": "LLM Predict",
+            },
+        )
+
+    class Llama7B(CustomLLM):
+        @property
+        def metadata(self) -> LLMMetadata:
+            """Get LLM metadata."""
+            return LLMMetadata(
+                context_window=4000,
+                num_output=100,
+                model_name="lama2-13B",
+            )
+
+        @llm_completion_callback()
+        def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+            (text, input_tokens, output_tokens, response) = sendPromptToLama(prompt)
+
+            additional_kwargs = {
+                "prompt_tokens": input_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            }
+            print(additional_kwargs)
+            return CompletionResponse(text=text, raw=response, additional_kwargs=additional_kwargs)
+
+        @llm_completion_callback()
+        def stream_complete(self, prompt: str, **kwargs: Any) -> CompletionResponseGen:
+            raise NotImplementedError()
+
+    llm = Llama7B()
+
+    question = "What are the seven wonders of the world?"
+    callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())
+    callback_manager = CallbackManager([callback_handler])
+    index = ListIndex(nodes)
+    retriever = index.as_retriever(retriever_mode="default")
+    service_context = ServiceContext.from_defaults(
+        llm=llm, embed_model=mock_embed_model, callback_manager=callback_manager
+    )
+    response_synthesizer = get_response_synthesizer(service_context)
+    query_engine = RetrieverQueryEngine(
+        retriever=retriever,
+        response_synthesizer=response_synthesizer,
+        callback_manager=callback_manager,
+    )
+
+    response = query_engine.query(question)
+
+    # Just check that the callback handler is called using the patched LLM
+    assert response.response == "LLM Predict"
+    spans = list(callback_handler.get_spans())
+    assert len(spans) >= 1
+    llm_spans = [span for span in spans if span.span_kind == SpanKind.LLM]
+    assert len(llm_spans) == 1
+    # Make sure the custom token counts are captured from the kwargs
+    assert llm_spans[0].attributes[LLM_TOKEN_COUNT_TOTAL] == prompt_tokens + completion_tokens

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -247,7 +247,6 @@ def test_custom_llm(mock_embed_model) -> None:
                 "completion_tokens": output_tokens,
                 "total_tokens": input_tokens + output_tokens,
             }
-            print(additional_kwargs)
             return CompletionResponse(text=text, raw=response, additional_kwargs=additional_kwargs)
 
         @llm_completion_callback()


### PR DESCRIPTION
resolves #1667 

When custom models are implemented, it seems as though the usage payload can be appended to the `additional_kwargs` as a dictionary. This adds a bit of redundancy that to look for the usage metrics in either place. This provides a bit more flexibility for custom models. 

In addition this adds a bit of robustness arround the type `usage` - as it now handles both `Mapping` and `object` - a tad confusing as `Mapping` so it seems like `get` could be the common method? 