### PR TITLE
feat: Asyncronously submit openai requests 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "sortedcontainers",
   "protobuf>=3.20, <5.0",
   "ddsketch",
+  "nest-asyncio",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ dependencies = [
   "requests",
   "protobuf==3.20",  # version minimum (for tests)
   "responses",
+  "aioresponses",
   "tiktoken",
   "typing-extensions<4.6.0",  # for Colab
   "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ dependencies = [
   "tiktoken",
   "typing-extensions<4.6.0",  # for Colab
   "httpx",
+  "nest-asyncio",
 ]
 
 [tool.hatch.envs.type]
@@ -278,6 +279,7 @@ module = [
   "wrapt",
   "sortedcontainers",
   "langchain.*",
+  "nest_asyncio",
 ]
 ignore_missing_imports = true
 

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -4,8 +4,7 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import (TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple,
-                    Union)
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import requests
 from openai.openai_object import OpenAIObject

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import nest_asyncio
 import logging
 import os
 from dataclasses import dataclass, field
@@ -241,6 +242,11 @@ class OpenAIModel(BaseEvalModel):
     def generate(
         self, prompts: List[str], instruction: Optional[str] = None, num_consumers: int = 20
     ) -> List[str]:
+        try:
+            asyncio.get_running_loop()
+            nest_asyncio.apply()
+        except RuntimeError:
+            pass
         return asyncio.run(self._generate_async(prompts, instruction, num_consumers=num_consumers))
 
     async def _generate_async(

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -38,6 +38,18 @@ TQDM_BAR_FORMAT = (
     "[{elapsed}<{remaining}, {rate_fmt}{postfix}]"
 )
 
+# rate limits conservatively pulled from https://learn.microsoft.com/en-us/azure/ai-services/openai/quotas-limits
+AZURE_OPENAI_TOKEN_RATE_LIMITS = {
+    "gpt-35-turbo": 240000,
+    "gpt-35-turbo-16k": 240000,
+    "gpt-35-turbo-instruct": 240000,
+    "gpt-4": 20000,
+    "gpt-4-32k": 60000,
+    "text-embedding-ada-002": 240000,
+    "babbage-002": 50000,
+    "davinci-002": 50000,
+    "gpt-35-turbo-0613": 50000,
+}
 
 def openai_token_usage(chat_completion: OpenAIObject) -> int:
     try:
@@ -46,32 +58,39 @@ def openai_token_usage(chat_completion: OpenAIObject) -> int:
         return 0
 
 
-def openai_rate_limit_info(model_name: str, api_key: Optional[str]) -> Mapping[str, int]:
-    if api_key is None:
-        # TODO: Create custom AuthenticationError
-        raise RuntimeError(
-            "OpenAI's API key not provided. Pass it as an argument to 'openai_api_key' "
-            "or set it in your environment: 'export OPENAI_API_KEY=sk-****'"
+def openai_rate_limit_info(
+    model_name: str, api_key: Optional[str], base_url: Optional[str] = None
+) -> Mapping[str, int]:
+    if "openai.azure" in base_url:
+        token_limit = AZURE_OPENAI_TOKEN_RATE_LIMITS.get(model_name, 120000)
+        request_limit = None
+    else:
+        if api_key is None:
+            # TODO: Create custom AuthenticationError
+            raise RuntimeError(
+                "OpenAI's API key not provided. Pass it as an argument to 'openai_api_key' "
+                "or set it in your environment: 'export OPENAI_API_KEY=sk-****'"
+            )
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        data = {
+            "model": model_name,
+            "messages": [
+                {"role": "user", "content": "Test"},
+            ],
+        }
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions", headers=headers, json=data
         )
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}",
-    }
-    data = {
-        "model": model_name,
-        "messages": [
-            {"role": "user", "content": "Test"},
-        ],
-    }
-    response = requests.post(
-        "https://api.openai.com/v1/chat/completions", headers=headers, json=data
-    )
-    # default to tier 1 rate limits (https://platform.openai.com/docs/guides/rate-limits/overview)
-    request_limit = response.headers.get("x-ratelimit-limit-requests", 500)
-    token_limit = response.headers.get("x-ratelimit-limit-tokens", 10000)
+        # default to tier 1 rate limits (https://platform.openai.com/docs/guides/rate-limits/overview)
+        request_limit = int(response.headers.get("x-ratelimit-limit-requests", 500))
+        token_limit = int(response.headers.get("x-ratelimit-limit-tokens", 10000))
+
     limit_info = {
-        "request-limit": int(request_limit),
-        "token-limit": int(token_limit),
+        "request-limit": request_limit,
+        "token-limit": token_limit,
     }
     return limit_info
 
@@ -125,7 +144,9 @@ class OpenAIModel(BaseEvalModel):
     def rate_limiter(self, rate_limit_multiplier: float = 0.8) -> OpenAIRateLimiter:
         if self._rate_limiter is None:
             self._rate_limiter = OpenAIRateLimiter()
-            limit_info = openai_rate_limit_info(self.model_name, self.openai_api_key)
+            limit_info = openai_rate_limit_info(
+                self.model_name, self.openai_api_key, base_url=self.openai_api_base
+            )
             self._rate_limiter.set_rate_limits(
                 self.model_name,
                 # throttle our requests to some multiple of the absolute rate limit
@@ -240,12 +261,12 @@ class OpenAIModel(BaseEvalModel):
         queue: asyncio.Queue[Tuple[int, str, Optional[str]]] = asyncio.Queue(
             maxsize=2 * num_consumers
         )
-        SENTINEL = object()  # indicates when the queue is done
+        END_OF_QUEUE = object()  # sentinel indicating when the queue is done
         progress_bar = async_tqdm(total=len(prompts), bar_format=TQDM_BAR_FORMAT)
 
-        producer = self._producer(prompts, instruction, queue, num_consumers, SENTINEL)
+        producer = self._producer(prompts, instruction, queue, num_consumers, END_OF_QUEUE)
         consumers = [
-            asyncio.create_task(self._consumer(queue, outputs, SENTINEL, progress_bar))
+            asyncio.create_task(self._consumer(queue, outputs, END_OF_QUEUE, progress_bar))
             for _ in range(num_consumers)
         ]
 
@@ -258,23 +279,23 @@ class OpenAIModel(BaseEvalModel):
         instruction: Optional[str],
         queue: asyncio.Queue[Tuple[int, str, Optional[str]]],
         num_consumers: int,
-        sentinel: Any,
+        end_of_queue: Any,
     ) -> None:
         for index, prompt in enumerate(prompts):
             await queue.put((index, prompt, instruction))
-        # add a sentinel to the queue for each consumer
+        # add an end of queue sentinel for each consumer
         for _ in range(num_consumers):
-            await queue.put(sentinel)
+            await queue.put(end_of_queue)
 
     async def _consumer(
         self,
         queue: asyncio.Queue[Tuple[int, str, Optional[str]]],
         outputs: List[str],
-        sentinel: Any,
+        end_of_queue: Any,
         progress_bar: async_tqdm[Any],
     ) -> None:
         while True:
-            if (item := await queue.get()) is sentinel:
+            if (item := await queue.get()) is end_of_queue:
                 break
 
             index, prompt, instruction = item

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -60,8 +60,9 @@ def openai_rate_limit_info(model_name: str, api_key: str) -> Mapping[str, int]:
     response = requests.post(
         "https://api.openai.com/v1/chat/completions", headers=headers, json=data
     )
-    request_limit = response.headers.get("x-ratelimit-limit-requests", 0)
-    token_limit = response.headers.get("x-ratelimit-limit-tokens", 0)
+    # default to tier 1 rate limits (https://platform.openai.com/docs/guides/rate-limits/overview)
+    request_limit = response.headers.get("x-ratelimit-limit-requests", 500)
+    token_limit = response.headers.get("x-ratelimit-limit-tokens", 10000)
     limit_info = {
         "request-limit": int(request_limit),
         "token-limit": int(token_limit),

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import nest_asyncio
 import logging
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
 
+import nest_asyncio
 import requests
 from openai.openai_object import OpenAIObject
 from tqdm.asyncio import tqdm as async_tqdm
@@ -51,6 +51,7 @@ AZURE_OPENAI_TOKEN_RATE_LIMITS = {
     "davinci-002": 50000,
     "gpt-35-turbo-0613": 50000,
 }
+
 
 def openai_token_usage(chat_completion: OpenAIObject) -> int:
     try:

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import (TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple,
+                    Union)
 
 import requests
 from openai.openai_object import OpenAIObject
@@ -237,7 +240,7 @@ class OpenAIModel(BaseEvalModel):
         outputs = ["unset"] * len(prompts)
         queue: asyncio.Queue[Tuple[int, str, Optional[str]]] = asyncio.Queue()
         SENTINEL = object()  # indicates when the queue is done
-        progress_bar = async_tqdm(total=len(prompts))
+        progress_bar = async_tqdm(total=len(prompts), bar_format=TQDM_BAR_FORMAT)
 
         producer = self._producer(prompts, instruction, queue, num_consumers, SENTINEL)
         consumers = [

--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -182,7 +182,10 @@ class OpenAIRateLimiter:
         return f"openai:{model_name}"
 
     def set_rate_limits(
-        self, model_name: str, request_rate_limit: Optional[Numeric], token_rate_limit: Optional[Numeric]
+        self,
+        model_name: str,
+        request_rate_limit: Optional[Numeric],
+        token_rate_limit: Optional[Numeric],
     ) -> None:
         if request_rate_limit is not None:
             self._store.set_rate_limit(self.key(model_name), "requests", request_rate_limit)

--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -188,17 +188,19 @@ class OpenAIRateLimiter:
         self._store.set_rate_limit(self.key(model_name), "tokens", token_rate_limit)
 
     def limit(
-        self, model_name: str, token_cost: Numeric
+        self,
+        model_name: str,
+        response_cost_fn: Callable[..., Numeric],
     ) -> Callable[[Callable[ParameterSpec, GenericType]], Callable[ParameterSpec, GenericType]]:
         def rate_limit_decorator(
             fn: Callable[ParameterSpec, GenericType]
         ) -> Callable[ParameterSpec, GenericType]:
             @wraps(fn)
             def wrapper(*args: Any, **kwargs: Any) -> GenericType:
-                self._store.wait_for_rate_limits(
-                    self.key(model_name), {"requests": 1, "tokens": token_cost}
-                )
+                key = self.key(model_name)
+                self._store.wait_for_rate_limits(key, {"requests": 1, "tokens": 0})
                 result: GenericType = fn(*args, **kwargs)
+                self._store.spend_rate_limits(key, {"tokens": response_cost_fn(result)})
                 return result
 
             return wrapper

--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -182,10 +182,12 @@ class OpenAIRateLimiter:
         return f"openai:{model_name}"
 
     def set_rate_limits(
-        self, model_name: str, request_rate_limit: Numeric, token_rate_limit: Numeric
+        self, model_name: str, request_rate_limit: Optional[Numeric], token_rate_limit: Optional[Numeric]
     ) -> None:
-        self._store.set_rate_limit(self.key(model_name), "requests", request_rate_limit)
-        self._store.set_rate_limit(self.key(model_name), "tokens", token_rate_limit)
+        if request_rate_limit is not None:
+            self._store.set_rate_limit(self.key(model_name), "requests", request_rate_limit)
+        if token_rate_limit is not None:
+            self._store.set_rate_limit(self.key(model_name), "tokens", token_rate_limit)
 
     def limit(
         self,

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -18,6 +18,7 @@ from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 
 
 @pytest.fixture
+@responses.activate
 def mock_ratelimit_inspection():
     # Mock OpenAI API request used for reading the rate limit
     headers = {"x-ratelimit-limit-requests": "100_000", "x-ratelimit-limit-tokens": "100_000"}

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -130,19 +130,23 @@ def test_llm_classify_prints_to_stdout_with_verbose_flag(
                             },
                         }
                     ],
+                    "usage": {
+                        "total_tokens": 1,
+                    },
                 },
                 status=200,
             )
-            with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
-                model = OpenAIModel()
 
-            llm_classify(
-                dataframe=dataframe,
-                template=RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
-                model=model,
-                rails=["relevant", "irrelevant"],
-                verbose=True,
-            )
+        with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
+            model = OpenAIModel()
+
+        llm_classify(
+            dataframe=dataframe,
+            template=RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
+            model=model,
+            rails=["relevant", "irrelevant"],
+            verbose=True,
+        )
 
     out, _ = capfd.readouterr()
     assert "Snapped 'relevant' to rail: relevant" in out, "Snapping events should be printed"
@@ -231,7 +235,7 @@ def test_llm_classify_does_not_persist_verbose_flag(
         waiting_fn = "phoenix.experimental.evals.models.base.wait_random_exponential"
         stack.enter_context(patch(waiting_fn, return_value=False))
         stack.enter_context(patch.object(OpenAIModel, "_init_tiktoken", return_value=None))
-        stack.enter_context(patch.object(model._openai.ChatCompletion, "create", mock_openai))
+        stack.enter_context(patch.object(model._openai.ChatCompletion, "acreate", mock_openai))
         stack.enter_context(pytest.raises(model._openai_error.APIError))
         llm_classify(
             dataframe=dataframe,

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -6,11 +6,13 @@ import pandas as pd
 import pytest
 import responses
 from aioresponses import aioresponses
-
-from phoenix.experimental.evals import (NOT_PARSABLE,
-                                        RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
-                                        OpenAIModel, llm_classify,
-                                        run_relevance_eval)
+from phoenix.experimental.evals import (
+    NOT_PARSABLE,
+    RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
+    OpenAIModel,
+    llm_classify,
+    run_relevance_eval,
+)
 from phoenix.experimental.evals.functions.classify import _snap_to_rail
 from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -534,28 +534,13 @@ def test_run_relevance_eval_openinference_dataframe(
 
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     with aioresponses() as mocked_aiohttp:
-        for message_content in [
-            "relevant",
-            "irrelevant",
-            "relevant",
-            "irrelevant",
-            "\nrelevant ",
-            "unparsable",
-            "relevant",
-        ]:
-            mocked_aiohttp.post(
-                "https://api.openai.com/v1/chat/completions",
-                payload={
-                    "choices": [
-                        {
-                            "message": {
-                                "content": message_content,
-                            },
-                        }
-                    ],
-                },
-                status=200,
-            )
+        mocked_aiohttp.post(
+            "https://api.openai.com/v1/chat/completions",
+            status=200,
+            callback=response_callback,
+            repeat=True,
+        )
+
         with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
             model = OpenAIModel()
         relevance_classifications = run_relevance_eval(dataframe, model=model)

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -318,7 +318,7 @@ def test_run_relevance_eval_standard_dataframe(
                 ],
             },
             {
-                "query": "What is Python?",
+                "query": "Can you explain Python to me?",
                 "reference": np.array(
                     [
                         "Python is a programming language.",
@@ -444,7 +444,7 @@ def test_run_relevance_eval_openinference_dataframe(
                 ],
             },
             {
-                "attributes.input.value": "What is Python?",
+                "attributes.input.value": "Can you explain Python to me?",
                 "attributes.retrieval.documents": np.array(
                     [
                         {"document.content": "Python is a programming language."},

--- a/tests/experimental/evals/functions/test_generate.py
+++ b/tests/experimental/evals/functions/test_generate.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 import responses
 from aioresponses import aioresponses
-
 from phoenix.experimental.evals import OpenAIModel, llm_generate
 from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 

--- a/tests/experimental/evals/functions/test_generate.py
+++ b/tests/experimental/evals/functions/test_generate.py
@@ -3,12 +3,27 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 import responses
+from aioresponses import aioresponses
+
 from phoenix.experimental.evals import OpenAIModel, llm_generate
 from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 
 
-@responses.activate
-def test_llm_generate(monkeypatch: pytest.MonkeyPatch):
+@pytest.fixture
+def mock_ratelimit_inspection():
+    # Mock OpenAI API request used for reading the rate limit
+    headers = {"x-ratelimit-limit-requests": "100_000", "x-ratelimit-limit-tokens": "100_000"}
+    responses.add(
+        responses.POST,
+        "https://api.openai.com/v1/chat/completions",
+        json={},
+        status=200,
+        headers=headers,
+    )
+    return responses
+
+
+def test_llm_generate(mock_ratelimit_inspection, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     dataframe = pd.DataFrame(
         [
@@ -30,43 +45,45 @@ def test_llm_generate(monkeypatch: pytest.MonkeyPatch):
             },
         ]
     )
-    for message_content in [
-        "it's a dialect of french",
-        "it's a music notation",
-        "It's a crazy language",
-        "it's a programming language",
-    ]:
-        responses.post(
-            "https://api.openai.com/v1/chat/completions",
-            json={
-                "choices": [
-                    {
-                        "message": {
-                            "content": message_content,
-                        },
-                    }
-                ],
-            },
-            status=200,
+    with aioresponses() as mock_aiohttp:
+        for message_content in [
+            "it's a dialect of french",
+            "it's a music notation",
+            "It's a crazy language",
+            "it's a programming language",
+        ]:
+            mock_aiohttp.post(
+                "https://api.openai.com/v1/chat/completions",
+                payload={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": message_content,
+                            },
+                        }
+                    ],
+                },
+                status=200,
+            )
+        template = (
+            "Given {query} and a golden answer {reference}, generate an answer that is incorrect."
         )
-    template = (
-        "Given {query} and a golden answer {reference}, generate an answer that is incorrect."
-    )
 
-    with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
-        model = OpenAIModel()
+        with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
+            model = OpenAIModel()
 
-    generated = llm_generate(dataframe=dataframe, template=template, model=model)
-    assert generated == [
-        "it's a dialect of french",
-        "it's a music notation",
-        "It's a crazy language",
-        "it's a programming language",
-    ]
+        generated = llm_generate(dataframe=dataframe, template=template, model=model)
+        assert generated == [
+            "it's a dialect of french",
+            "it's a music notation",
+            "It's a crazy language",
+            "it's a programming language",
+        ]
 
 
-@responses.activate
-def test_llm_generate_prints_info_with_verbose_flag(monkeypatch: pytest.MonkeyPatch, capfd):
+def test_llm_generate_prints_info_with_verbose_flag(
+    mock_ratelimit_inspection, monkeypatch: pytest.MonkeyPatch, capfd
+):
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     dataframe = pd.DataFrame(
         [
@@ -88,33 +105,35 @@ def test_llm_generate_prints_info_with_verbose_flag(monkeypatch: pytest.MonkeyPa
             },
         ]
     )
-    for message_content in [
-        "it's a dialect of french",
-        "it's a music notation",
-        "It's a crazy language",
-        "it's a programming language",
-    ]:
-        responses.post(
-            "https://api.openai.com/v1/chat/completions",
-            json={
-                "choices": [
-                    {
-                        "message": {
-                            "content": message_content,
-                        },
-                    }
-                ],
-            },
-            status=200,
+
+    with aioresponses() as mock_aiohttp:
+        for message_content in [
+            "it's a dialect of french",
+            "it's a music notation",
+            "It's a crazy language",
+            "it's a programming language",
+        ]:
+            mock_aiohttp.post(
+                "https://api.openai.com/v1/chat/completions",
+                payload={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": message_content,
+                            },
+                        }
+                    ],
+                },
+                status=200,
+            )
+        template = (
+            "Given {query} and a golden answer {reference}, generate an answer that is incorrect."
         )
-    template = (
-        "Given {query} and a golden answer {reference}, generate an answer that is incorrect."
-    )
 
-    with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
-        model = OpenAIModel()
+        with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
+            model = OpenAIModel()
 
-    llm_generate(dataframe=dataframe, template=template, model=model, verbose=True)
+        llm_generate(dataframe=dataframe, template=template, model=model, verbose=True)
 
     out, _ = capfd.readouterr()
     assert "Generating responses for 4 prompts..." in out, "Response generation should be printed"

--- a/tests/experimental/evals/functions/test_generate.py
+++ b/tests/experimental/evals/functions/test_generate.py
@@ -9,6 +9,7 @@ from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 
 
 @pytest.fixture
+@responses.activate
 def mock_ratelimit_inspection():
     # Mock OpenAI API request used for reading the rate limit
     headers = {"x-ratelimit-limit-requests": "100_000", "x-ratelimit-limit-tokens": "100_000"}


### PR DESCRIPTION
This implements clientside ratelimiting for the OpenAI API.

recreating #1680 due to a rebase messing with the diff

Our objective is to submit API requests as fast as possible without running into rate limit issues. Our solution is to implement a clientside ratelimiter that throttles asyncronous ChatCompletion calls. For the time being I've overridden the generate method on the OpenAI model. Our other models do not have a rate limiter implemented yet and so cannot move to this asyncronous submission pattern.