### PR TITLE
ci: Use ruff formatter

### DIFF
--- a/examples/dolly-pythia-fine-tuned/create_data_with_dolly_and_pythia.ipynb
+++ b/examples/dolly-pythia-fine-tuned/create_data_with_dolly_and_pythia.ipynb
@@ -610,22 +610,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/examples/dolly-pythia-fine-tuned/create_data_with_dolly_and_pythia.ipynb
+++ b/examples/dolly-pythia-fine-tuned/create_data_with_dolly_and_pythia.ipynb
@@ -41,8 +41,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "openai.api_key = \"your key here\"\n",
-    "assert openai.api_key != \"your key here\", \"Set your key\""
+    "import datetime\n",
+    "import locale\n",
+    "import time\n",
+    "import uuid\n",
+    "\n",
+    "import openai\n",
+    "import pandas as pd\n",
+    "import phoenix as px\n",
+    "import torch\n",
+    "from datasets import load_dataset\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "locale.getpreferredencoding = lambda: \"UTF-8\"  # This resolves a Colab bug that occurs sometimes."
    ]
   },
   {
@@ -51,21 +62,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dataclasses import replace\n",
-    "import datetime\n",
-    "import locale\n",
-    "import re\n",
-    "import time\n",
-    "import uuid\n",
-    "\n",
-    "from datasets import load_dataset\n",
-    "import openai\n",
-    "import pandas as pd\n",
-    "import phoenix as px\n",
-    "import torch\n",
-    "from transformers import AutoTokenizer\n",
-    "\n",
-    "locale.getpreferredencoding = lambda: \"UTF-8\"  # This resolves a Colab bug that occurs sometimes."
+    "openai.api_key = \"your key here\"\n",
+    "assert openai.api_key != \"your key here\", \"Set your key\""
    ]
   },
   {
@@ -388,9 +386,9 @@
     "alpaca_df[\"prompt\"] = (\n",
     "    \"Below is an instruction that describes a task. Write a response that appropriately completes the request.\\n\"\n",
     "    + \"### Instruction:\\n\"\n",
-    "    + df[\"instruction\"]\n",
+    "    + alpaca_df[\"instruction\"]\n",
     "    + \"### Input:\\n\"\n",
-    "    + df[\"input\"]\n",
+    "    + alpaca_df[\"input\"]\n",
     "    + \"### Response:\\n\"\n",
     ")\n",
     "alpaca_df"
@@ -612,10 +610,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,8 +176,10 @@ check = [
 [tool.hatch.envs.style.scripts]
 check = [
   "ruff .",
+  "ruff format --check --diff .",
 ]
 fix = [
+  "ruff --fix .",
   "ruff format .",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".git", "__pycache__", "docs/source/conf.py", "*_pb2.py*"]
-extend-include = ["*.ipynb"]
+# extend-include = ["*.ipynb"]
 ignore-init-module-imports = true
 line-length = 100
 select = ["E", "F", "W", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,12 +269,15 @@ module = [
 ignore_missing_imports = true
 
 [tool.ruff]
-exclude = [".git", "__pycache__", "docs/source/conf.py", "*_pb2.py*"]
-# extend-include = ["*.ipynb"]
+exclude = [".git", "__pycache__", "docs/source/conf.py", "*_pb2.py*", "*.pyi"]
+extend-include = ["*.ipynb"]
 ignore-init-module-imports = true
 line-length = 100
 select = ["E", "F", "W", "I"]
 target-version = "py38"
+
+[tool.ruff.lint.per-file-ignores]
+"*.ipynb" = ["E402", "E501"]
 
 [tool.ruff.isort]
 force-single-line = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,8 +179,8 @@ check = [
   "ruff format --check --diff .",
 ]
 fix = [
-  "ruff --fix .",
   "ruff format .",
+  "ruff --fix .",
 ]
 
 [tool.hatch.envs.notebooks.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,11 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-  "black[jupyter]",
   "gcsfs",
   "hatch",
   "jupyter",
   "nbqa",
-  "ruff==0.0.290",
+  "ruff==0.1.3",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "pytest",
   "pytest-cov",
@@ -120,9 +119,7 @@ dependencies = [
 [tool.hatch.envs.style]
 detached = true
 dependencies = [
-  "black~=23.3.0",
-  "black[jupyter]~=23.3.0",
-  "ruff~=0.0.290",
+  "ruff~=0.1.3",
 ]
 
 [tool.hatch.envs.notebooks]
@@ -178,12 +175,10 @@ check = [
 
 [tool.hatch.envs.style.scripts]
 check = [
-  "black --check --diff --color .",
   "ruff .",
 ]
 fix = [
-  "black .",
-  "ruff --fix .",
+  "ruff format .",
 ]
 
 [tool.hatch.envs.notebooks.scripts]
@@ -206,10 +201,6 @@ pypi = [
   "check-wheel-contents dist/",
   "twine upload --verbose dist/*",
 ]
-
-[tool.black]
-line-length = 100
-exclude = '_pb2\.pyi?$'
 
 [tool.hatch.envs.docs.scripts]
 check = [
@@ -279,6 +270,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [".git", "__pycache__", "docs/source/conf.py", "*_pb2.py*"]
+extend-include = ["*.ipynb"]
 ignore-init-module-imports = true
 line-length = 100
 select = ["E", "F", "W", "I"]

--- a/src/phoenix/trace/langchain/tracer.py
+++ b/src/phoenix/trace/langchain/tracer.py
@@ -256,13 +256,16 @@ def _retrieval_documents(
 ) -> Iterator[Tuple[str, List[Any]]]:
     if run["run_type"] != "retriever":
         return
-    yield RETRIEVAL_DOCUMENTS, [
-        {
-            DOCUMENT_CONTENT: document.get("page_content"),
-            DOCUMENT_METADATA: document.get("metadata") or {},
-        }
-        for document in (run.get("outputs") or {}).get("documents") or []
-    ]
+    yield (
+        RETRIEVAL_DOCUMENTS,
+        [
+            {
+                DOCUMENT_CONTENT: document.get("page_content"),
+                DOCUMENT_METADATA: document.get("metadata") or {},
+            }
+            for document in (run.get("outputs") or {}).get("documents") or []
+        ],
+    )
 
 
 def _chat_model_start_fallback(

--- a/src/phoenix/trace/v1/__init__.py
+++ b/src/phoenix/trace/v1/__init__.py
@@ -390,10 +390,13 @@ def _encode_retrieval(
 def _decode_retrieval(
     pb_retrieval: pb.Retrieval,
 ) -> Iterator[Tuple[str, Any]]:
-    yield RETRIEVAL_DOCUMENTS, [
-        dict(_decode_retrieval_document(pb_retrieval_document))
-        for pb_retrieval_document in pb_retrieval.documents
-    ]
+    yield (
+        RETRIEVAL_DOCUMENTS,
+        [
+            dict(_decode_retrieval_document(pb_retrieval_document))
+            for pb_retrieval_document in pb_retrieval.documents
+        ],
+    )
 
 
 def _encode_retrieval_document(
@@ -455,10 +458,13 @@ def _decode_embedding(
 ) -> Iterator[Tuple[str, Any]]:
     if pb_embedding.HasField("model_name"):
         yield EMBEDDING_MODEL_NAME, pb_embedding.model_name.value
-    yield EMBEDDING_EMBEDDINGS, [
-        dict(_decode_embedding_embedding(pb_embedding_embedding))
-        for pb_embedding_embedding in pb_embedding.embeddings
-    ]
+    yield (
+        EMBEDDING_EMBEDDINGS,
+        [
+            dict(_decode_embedding_embedding(pb_embedding_embedding))
+            for pb_embedding_embedding in pb_embedding.embeddings
+        ],
+    )
 
 
 def _encode_embedding_embedding(

--- a/tutorials/evals/evaluate_QA_classifications.ipynb
+++ b/tutorials/evals/evaluate_QA_classifications.ipynb
@@ -732,7 +732,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ");"
+    ")"
    ]
   },
   {
@@ -830,7 +830,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ");"
+    ")"
    ]
   }
  ],

--- a/tutorials/evals/evaluate_summarization_classifications.ipynb
+++ b/tutorials/evals/evaluate_summarization_classifications.ipynb
@@ -665,7 +665,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ");"
+    ")"
    ]
   },
   {
@@ -764,7 +764,7 @@
     "    cmap=plt.colormaps[\"Blues\"],\n",
     "    number_label=True,\n",
     "    normalized=True,\n",
-    ");"
+    ")"
    ]
   }
  ],

--- a/tutorials/llm_generative_gpt_4.ipynb
+++ b/tutorials/llm_generative_gpt_4.ipynb
@@ -240,9 +240,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
-    "import os\n",
     "import getpass\n",
+    "import os\n",
+    "\n",
+    "import openai\n",
     "\n",
     "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
     "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",


### PR DESCRIPTION
resolves #1658 

Simplify CI toolchain by removing `black` in favor of `ruff format`

With the release of [ruff formatter](https://github.com/astral-sh/ruff/releases/tag/v0.1.3), we can use ruff for both formatting and linting, improving consistency and issues with black and ruff disagreeing with eachother.

For now I'm leaving out the jupyter notebook extension, since reformatting our notebooks will lead to a significant number of changes.