### PR TITLE
fix(traces): refetch traces and spans even when searching

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -76,7 +76,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:traces:random & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/package.json
+++ b/app/package.json
@@ -90,7 +90,7 @@
     "dev:server:traces:llama_index_rag": "python3 -m phoenix.server.main trace-fixture llama_index_rag --simulate-streaming true",
     "dev:server:traces:llama_index_calculator_agent": "python3 -m phoenix.server.main trace-fixture llama_index_calculator_agent",
     "dev:server:traces:langchain_qa_with_sources": "python3 -m phoenix.server.main trace-fixture langchain_qa_with_sources",
-    "dev:server:traces:random": "python3 -m phoenix.server.main trace-fixture random",
+    "dev:server:traces:random": "python3 -m phoenix.server.main trace-fixture random --simulate-streaming true",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ./src",
     "prettier": "prettier --write './src/**/*'",

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -15,6 +15,7 @@ import {
   ModelPage,
   ModelRoot,
   TracePage,
+  TracingRoot,
 } from "./pages";
 
 const router = createBrowserRouter(
@@ -54,8 +55,9 @@ const router = createBrowserRouter(
       <Route
         path="/tracing"
         handle={{ crumb: () => "tracing" }}
-        element={<TracingHomePage />}
+        element={<TracingRoot />}
       >
+        <Route index element={<TracingHomePage />} />
         <Route path="traces">
           <Route path=":traceId" element={<TracePage />} />
         </Route>

--- a/app/src/contexts/StreamStateContext.tsx
+++ b/app/src/contexts/StreamStateContext.tsx
@@ -1,0 +1,65 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  startTransition,
+  useCallback,
+  useState,
+} from "react";
+
+export type StreamStateContextType = {
+  /**
+   * Whether or not streaming is enabled.
+   * @default true
+   */
+  isStreaming: boolean;
+  /**
+   * Enables or disables streaming.
+   */
+  setIsStreaming: (isStreaming: boolean) => void;
+  /**
+   * The fetch key for the current data.
+   * E.g. this acts as a unique identifier for the data
+   * It can be the count of traces or a hash of the data
+   */
+  fetchKey: string;
+  /**
+   * Sets the fetchKey to force a refetch
+   */
+  setFetchKey: (fetchKey: string) => void;
+};
+
+export const StreamStateContext = createContext<StreamStateContextType | null>(
+  null
+);
+
+export function useStreamState() {
+  const context = React.useContext(StreamStateContext);
+  if (context === null) {
+    throw new Error("useStreamState must be used within a StreamStateProvider");
+  }
+  return context;
+}
+
+export function StreamStateProvider({
+  initialFetchKey = "initial",
+  children,
+}: PropsWithChildren<{ initialFetchKey?: string }>) {
+  const [isStreaming, setIsStreaming] = useState<boolean>(true);
+  const [fetchKey, _setFetchKey] = useState<string>(initialFetchKey);
+
+  const setFetchKey = useCallback(
+    (fetchKey: string) => {
+      startTransition(() => {
+        _setFetchKey(fetchKey);
+      });
+    },
+    [_setFetchKey]
+  );
+  return (
+    <StreamStateContext.Provider
+      value={{ isStreaming, setIsStreaming, fetchKey, setFetchKey }}
+    >
+      {children}
+    </StreamStateContext.Provider>
+  );
+}

--- a/app/src/pages/ErrorElement.tsx
+++ b/app/src/pages/ErrorElement.tsx
@@ -30,8 +30,8 @@ export function ErrorElement() {
       <section
         css={css`
           width: 500px;
-          /* Add spacing on the bottom so it gets pushed up */
-          margin-bottom: 500px;
+          /* Add spacing on the bottom so it gets pushed down */
+          margin-top: 200px;
           display: flex;
           flex-direction: column;
         `}

--- a/app/src/pages/TracingRoot.tsx
+++ b/app/src/pages/TracingRoot.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Outlet } from "react-router";
+
+import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
+
+export function TracingRoot() {
+  return (
+    <StreamStateProvider>
+      <Outlet />
+    </StreamStateProvider>
+  );
+}

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -7,3 +7,4 @@ export * from "./tracing";
 export * from "./Layout";
 export * from "./ErrorElement";
 export * from "./ModelRoot";
+export * from "./TracingRoot";

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -196,19 +196,24 @@ export function SpansTable(props: SpansTableProps) {
       isMountedRef.current = true;
       return;
     }
+
     const sort = sorting[0];
+
     startTransition(() => {
-      refetch({
-        sort: sort
-          ? {
-              col: sort.id as SpanSort["col"],
-              dir: sort.desc ? "desc" : "asc",
-            }
-          : DEFAULT_SORT,
-        after: null,
-        first: PAGE_SIZE,
-        filterCondition,
-      });
+      refetch(
+        {
+          sort: sort
+            ? {
+                col: sort.id as SpanSort["col"],
+                dir: sort.desc ? "desc" : "asc",
+              }
+            : DEFAULT_SORT,
+          after: null,
+          first: PAGE_SIZE,
+          filterCondition,
+        },
+        { fetchPolicy: "store-and-network" }
+      );
     });
   }, [sorting, refetch, filterCondition, fetchKey]);
   const fetchMoreOnBottomReached = React.useCallback(
@@ -248,7 +253,7 @@ export function SpansTable(props: SpansTableProps) {
         overflow: hidden;
       `}
     >
-      <View padding="size-100" backgroundColor="grey-200">
+      <View padding="size-100" backgroundColor="grey-200" flex="none">
         <SpanFilterConditionField onValidCondition={setFilterCondition} />
       </View>
 

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -27,6 +27,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 
 import {
   SpansTable_spans$key,
@@ -48,6 +49,7 @@ const DEFAULT_SORT: SpanSort = {
   dir: "desc",
 };
 export function SpansTable(props: SpansTableProps) {
+  const { fetchKey } = useStreamState();
   const isMountedRef = useRef<boolean>(false);
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -208,7 +210,7 @@ export function SpansTable(props: SpansTableProps) {
         filterCondition,
       });
     });
-  }, [sorting, refetch, filterCondition]);
+  }, [sorting, refetch, filterCondition, fetchKey]);
   const fetchMoreOnBottomReached = React.useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -50,7 +50,6 @@ const DEFAULT_SORT: SpanSort = {
 };
 export function SpansTable(props: SpansTableProps) {
   const { fetchKey } = useStreamState();
-  const isMountedRef = useRef<boolean>(false);
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -192,11 +191,6 @@ export function SpansTable(props: SpansTableProps) {
 
   useEffect(() => {
     //if the sorting changes, we need to reset the pagination
-    if (!isMountedRef.current) {
-      isMountedRef.current = true;
-      return;
-    }
-
     const sort = sorting[0];
 
     startTransition(() => {

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -307,7 +307,7 @@ export function TracesTable(props: TracesTableProps) {
           filterCondition: filterCondition,
         },
         {
-          fetchPolicy: "network-only",
+          fetchPolicy: "store-and-network",
         }
       );
     });

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -33,6 +33,7 @@ import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { ISpanItem } from "@phoenix/components/trace/types";
 import { createSpanTree, SpanTreeNode } from "@phoenix/components/trace/utils";
+import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 
 import {
   SpanStatusCode,
@@ -88,6 +89,7 @@ export function TracesTable(props: TracesTableProps) {
   const [filterCondition, setFilterCondition] = useState<string>("");
 
   const navigate = useNavigate();
+  const { fetchKey } = useStreamState();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<TracesTableQuery, TracesTable_spans$key>(
       graphql`
@@ -309,7 +311,7 @@ export function TracesTable(props: TracesTableProps) {
         }
       );
     });
-  }, [sorting, refetch, filterCondition]);
+  }, [sorting, refetch, filterCondition, fetchKey]);
   const fetchMoreOnBottomReached = React.useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -83,7 +83,6 @@ function spanTreeToNestedSpanTableRows<TSpan extends ISpanItem>(
 
 export function TracesTable(props: TracesTableProps) {
   //we need a reference to the scrolling element for logic down below
-  const isMountedRef = useRef<boolean>(false);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
@@ -288,10 +287,6 @@ export function TracesTable(props: TracesTableProps) {
 
   useEffect(() => {
     //if the sorting changes, we need to reset the pagination
-    if (!isMountedRef.current) {
-      isMountedRef.current = true;
-      return;
-    }
     const sort = sorting[0];
     startTransition(() => {
       refetch(

--- a/app/src/pages/tracing/TracingHomePage.tsx
+++ b/app/src/pages/tracing/TracingHomePage.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, Suspense, useCallback, useState } from "react";
+import React, { Suspense } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Outlet } from "react-router";
 import { css } from "@emotion/react";
@@ -11,21 +11,32 @@ import { StreamToggle } from "./StreamToggle";
 import { TracesTable } from "./TracesTable";
 import { TracingHomePageHeader } from "./TracingHomePageHeader";
 
-/**
- * Sets the refetch key to trigger a refetch
- */
-const useRefetch = (): [number, () => void] => {
-  const [fetchKey, setFetchKey] = useState<number>(0);
-  const refetch = useCallback(() => {
-    startTransition(() => {
-      setFetchKey((prev) => prev + 1);
-    });
-  }, [setFetchKey]);
-  return [fetchKey, refetch];
-};
+const mainCSS = css`
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  .ac-tabs {
+    flex: 1 1 auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    .ac-tabs__pane-container {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      div[role="tabpanel"]:not([hidden]) {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+    }
+  }
+`;
 
 export function TracingHomePage() {
-  const [fetchKey, refetch] = useRefetch();
   const data = useLazyLoadQuery<TracingHomePageQuery>(
     graphql`
       query TracingHomePageQuery {
@@ -37,40 +48,14 @@ export function TracingHomePage() {
     `,
     {},
     {
-      fetchKey,
       fetchPolicy: "store-and-network",
     }
   );
   return (
-    <main
-      css={css`
-        flex: 1 1 auto;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-        .ac-tabs {
-          flex: 1 1 auto;
-          overflow: hidden;
-          display: flex;
-          flex-direction: column;
-          .ac-tabs__pane-container {
-            flex: 1 1 auto;
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
-            div[role="tabpanel"]:not([hidden]) {
-              flex: 1 1 auto;
-              display: flex;
-              flex-direction: column;
-              overflow: hidden;
-            }
-          }
-        }
-      `}
-    >
+    <main css={mainCSS}>
       <TracingHomePageHeader
         query={data}
-        extra={<StreamToggle query={data} onRefresh={() => refetch()} />}
+        extra={<StreamToggle query={data} />}
       />
       <Tabs>
         <TabPane name="Traces">

--- a/app/src/pages/tracing/TracingHomePageHeader.tsx
+++ b/app/src/pages/tracing/TracingHomePageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 
 import { Flex, Text, View } from "@arizeai/components";
@@ -44,7 +44,7 @@ export function TracingHomePageHeader(props: {
   );
 
   // Refetch the count of traces if the fetchKey changes
-  React.useEffect(() => {
+  useEffect(() => {
     refetch({}, { fetchPolicy: "store-and-network" });
   }, [fetchKey, refetch]);
 

--- a/app/src/pages/tracing/TracingHomePageHeader.tsx
+++ b/app/src/pages/tracing/TracingHomePageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode, startTransition, useEffect } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 
 import { Flex, Text, View } from "@arizeai/components";
@@ -45,7 +45,9 @@ export function TracingHomePageHeader(props: {
 
   // Refetch the count of traces if the fetchKey changes
   useEffect(() => {
-    refetch({}, { fetchPolicy: "store-and-network" });
+    startTransition(() => {
+      refetch({}, { fetchPolicy: "store-and-network" });
+    });
   }, [fetchKey, refetch]);
 
   const latencyMsP50 = data?.traceDatasetInfo?.latencyMsP50;

--- a/app/src/pages/tracing/__generated__/TracingHomePageHeaderQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracingHomePageHeaderQuery.graphql.ts
@@ -1,0 +1,139 @@
+/**
+ * @generated SignedSource<<806f1b612c0a2b4b5c1e412f97ada4f6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TracingHomePageHeaderQuery$variables = {};
+export type TracingHomePageHeaderQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"TracingHomePageHeader_stats">;
+};
+export type TracingHomePageHeaderQuery = {
+  response: TracingHomePageHeaderQuery$data;
+  variables: TracingHomePageHeaderQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TracingHomePageHeaderQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "TracingHomePageHeader_stats"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TracingHomePageHeaderQuery",
+    "selections": [
+      {
+        "alias": "totalTraces",
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "rootSpansOnly",
+            "value": true
+          }
+        ],
+        "concreteType": "SpanConnection",
+        "kind": "LinkedField",
+        "name": "spans",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "spans(rootSpansOnly:true)"
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TraceDatasetInfo",
+        "kind": "LinkedField",
+        "name": "traceDatasetInfo",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "startTime",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endTime",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "tokenCountTotal",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "latencyMsP50",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "latencyMsP99",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "255ca23484c93b4be948bee27042ae58",
+    "id": null,
+    "metadata": {},
+    "name": "TracingHomePageHeaderQuery",
+    "operationKind": "query",
+    "text": "query TracingHomePageHeaderQuery {\n  ...TracingHomePageHeader_stats\n}\n\nfragment TracingHomePageHeader_stats on Query {\n  totalTraces: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n  traceDatasetInfo {\n    startTime\n    endTime\n    tokenCountTotal\n    latencyMsP50\n    latencyMsP99\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "2f4140d22a5444b5a9fea58801814504";
+
+export default node;

--- a/app/src/pages/tracing/__generated__/TracingHomePageHeader_stats.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracingHomePageHeader_stats.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<08057209caeeee181fb7f353d0d43b81>>
+ * @generated SignedSource<<84642d1ed540a6aeb64bda24707d0050>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type TracingHomePageHeader_stats$data = {
   readonly totalTraces: {
@@ -33,7 +33,13 @@ export type TracingHomePageHeader_stats$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./TracingHomePageHeaderQuery.graphql')
+    }
+  },
   "name": "TracingHomePageHeader_stats",
   "selections": [
     {
@@ -122,6 +128,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "3a78a98b4a7c56223d844d32bcf539ca";
+(node as any).hash = "2f4140d22a5444b5a9fea58801814504";
 
 export default node;


### PR DESCRIPTION
resolves #1674 

From a user's perspective, this makes it so that you can continue to stream traces / spans even when you have a filter condition set.

# Implementation details

This fixes the fact that `react-relay` makes the refetchable fragments "stateful" once the params are changed. This means that a new query at the root query has no bearing on the fragment (e.g. it becomes detached). This PR adds a `fetchKey` that tracks the number of traces and refeches all fragments related to. traces if that key changes.