### PR TITLE
fix: enable BedrockModel to be imported directly from phoenix.evals.models sub-module

### DIFF
--- a/src/phoenix/experimental/evals/models/__init__.py
+++ b/src/phoenix/experimental/evals/models/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseEvalModel, set_verbosity
+from .bedrock import BedrockModel
 from .openai import OpenAIModel
 from .vertexai import VertexAIModel
 
-__all__ = ["BaseEvalModel", "OpenAIModel", "VertexAIModel", "set_verbosity"]
+__all__ = ["BedrockModel", "BaseEvalModel", "OpenAIModel", "VertexAIModel", "set_verbosity"]


### PR DESCRIPTION
Adds the ability for the user to import `BedrockModel` in the following manner

```python
from phoenix.experimental.evals.models import BedrockModel
```

in keeping with other model types.