### PR TITLE
chore(traces): remove unused semantic conventions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -2,24 +2,27 @@
     "version": "0.2",
     "language": "en",
     "words": [
-        "Colab",
-        "gitbook",
-        "Evals",
-        "dataframe",
+        "actuals",
         "arize",
+        "chatbot",
+        "Colab",
+        "conda",
+        "dataframe",
+        "Evals",
+        "gitbook",
         "HDBSCAN",
         "Instrumentor",
         "langchain",
         "llamaindex",
-        "actuals",
-        "conda",
+        "NDJSON",
         "numpy",
-        "rgba",
-        "UMAP",
-        "tracedataset",
-        "chatbot",
         "quickstart",
-        "NDJSON"
+        "RERANKER",
+        "rgba",
+        "tracedataset",
+        "UMAP"
     ],
-    "flagWords": ["hte"]
+    "flagWords": [
+        "hte"
+    ]
 }

--- a/src/phoenix/trace/semantic_conventions.py
+++ b/src/phoenix/trace/semantic_conventions.py
@@ -1,42 +1,9 @@
 """
 Semantic conventions for the attributes of a span
-
-Inspiration from OpenTelemetry:
-https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/span-general/
+https://github.com/Arize-ai/open-inference-spec/blob/main/trace/spec/semantic_conventions.md
 """
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional
-
-
-@dataclass(frozen=True)
-class AttributeDescription(Dict[str, Any]):
-    id: str
-    brief: str
-    type: str
-
-
-class AttributeGroup:
-    """
-    AttributeGroup is a collection of attributes that are
-    semantically related to each other
-    """
-
-    id: str
-    attributes: Dict[str, AttributeDescription]
-
-
-class DeploymentAttributes(AttributeGroup):
-    id = "deployment"
-    prefix = "deployment"
-    attributes = {
-        "environment": AttributeDescription(
-            id="deployment.environment",
-            brief="The environment where the service is deployed",
-            type="string",
-        ),
-    }
-
+from typing import Any, Optional
 
 EXCEPTION_TYPE = "exception.type"
 EXCEPTION_MESSAGE = "exception.message"

--- a/tests/trace/test_schemas.py
+++ b/tests/trace/test_schemas.py
@@ -34,7 +34,6 @@ from phoenix.trace.semantic_conventions import (
     OUTPUT_MIME_TYPE,
     OUTPUT_VALUE,
     RETRIEVAL_DOCUMENTS,
-    DeploymentAttributes,
     MimeType,
 )
 from phoenix.trace.v1 import decode, encode
@@ -66,9 +65,7 @@ def test_span_with_exception():
         span_kind="TOOL",
         status_code="OK",
         status_message="",
-        attributes={
-            DeploymentAttributes.attributes["environment"].id: "dev",
-        },
+        attributes={},
         events=[SpanException(timestamp=datetime.now(), message="")],
         context=SpanContext(trace_id=uuid4(), span_id=uuid4()),
         conversation=None,

--- a/tests/trace/test_schemas.py
+++ b/tests/trace/test_schemas.py
@@ -72,7 +72,6 @@ def test_span_with_exception():
     )
     assert span.name == "exception-span"
     assert span.events[0].name == "exception"
-    assert span.attributes["deployment.environment"] == "dev"
 
 
 def test_pb_span_encode_decode():

--- a/tests/trace/test_tracer.py
+++ b/tests/trace/test_tracer.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from phoenix.trace.exporter import NoOpExporter
 from phoenix.trace.schemas import Span, SpanException, SpanStatusCode
-from phoenix.trace.semantic_conventions import DeploymentAttributes
 from phoenix.trace.span_json_decoder import json_string_to_span
 from phoenix.trace.span_json_encoder import spans_to_jsonl
 from phoenix.trace.tracer import Tracer
@@ -45,9 +44,7 @@ def test_span_buffer_accumulation():
         status_code="ERROR",
         status_message="",
         events=[SpanException(timestamp=datetime.now(), message="")],
-        attributes={
-            DeploymentAttributes.attributes["environment"].id: "dev",
-        },
+        attributes={},
     )
 
     assert len(tracer.span_buffer) == 2
@@ -75,4 +72,3 @@ def test_span_buffer_accumulation():
     assert parsed_span_2.events[0].name == "exception"
     assert parsed_span_2.events[0].attributes == {"exception.message": ""}
     assert parsed_span_2.events[0].timestamp is not None
-    assert parsed_span_2.attributes[DeploymentAttributes.attributes["environment"].id] == "dev"


### PR DESCRIPTION
Just removing dead code that was a strawman of the semantic conventions organization
