### PR TITLE
fix(traces): Keep traces visible behind the details slideover

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -58,8 +58,10 @@ const router = createBrowserRouter(
         element={<TracingRoot />}
       >
         <Route index element={<TracingHomePage />} />
-        <Route path="traces">
-          <Route path=":traceId" element={<TracePage />} />
+        <Route element={<TracingHomePage />}>
+          <Route path="traces">
+            <Route path=":traceId" element={<TracePage />} />
+          </Route>
         </Route>
       </Route>
     </Route>


### PR DESCRIPTION
resolves #1708

The traces route was no longer still mounting the home page due to how a react-router outlet was added to the root of the rooute and the index route then became a sibling.
