### PR TITLE
feat: remove llm_eval_binary

### DIFF
--- a/src/phoenix/experimental/evals/__init__.py
+++ b/src/phoenix/experimental/evals/__init__.py
@@ -1,4 +1,4 @@
-from .functions import llm_classify, llm_eval_binary, llm_generate, run_relevance_eval
+from .functions import llm_classify, llm_generate, run_relevance_eval
 from .models import OpenAIModel, VertexAIModel
 from .retrievals import compute_precisions_at_k
 from .templates import (
@@ -19,7 +19,6 @@ __all__ = [
     "compute_precisions_at_k",
     "download_benchmark_dataset",
     "llm_classify",
-    "llm_eval_binary",
     "llm_generate",
     "OpenAIModel",
     "VertexAIModel",

--- a/src/phoenix/experimental/evals/functions/__init__.py
+++ b/src/phoenix/experimental/evals/functions/__init__.py
@@ -1,4 +1,4 @@
-from .classify import llm_classify, llm_eval_binary, run_relevance_eval
+from .classify import llm_classify, run_relevance_eval
 from .generate import llm_generate
 
-__all__ = ["llm_classify", "llm_eval_binary", "run_relevance_eval", "llm_generate"]
+__all__ = ["llm_classify", "run_relevance_eval", "llm_generate"]

--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import warnings
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import pandas as pd
@@ -130,64 +129,6 @@ def llm_classify(
         data["explanation"] = explanations
 
     return pd.DataFrame(data=data, index=dataframe.index)
-
-
-def llm_eval_binary(
-    dataframe: pd.DataFrame,
-    model: BaseEvalModel,
-    template: Union[PromptTemplate, str],
-    rails: List[str],
-    system_instruction: Optional[str] = None,
-    verbose: bool = False,
-) -> List[str]:
-    """Performs a binary classification on the rows of the input dataframe using an LLM.
-
-    Args:
-        dataframe (pandas.DataFrame): A pandas dataframe in which each row represents a record to be
-        classified. All template variable names must appear as column names in the dataframe (extra
-        columns unrelated to the template are permitted).
-
-        template (Union[PromptTemplate, str]): The prompt template as either an instance of
-        PromptTemplate or a string. If the latter, the variable names should be surrounded by
-        curly braces so that a call to `.format` can be made to substitute variable values.
-
-        model (BaseEvalModel): An LLM model class.
-
-        rails (List[str]): A list of strings representing the possible output classes of the model's
-        predictions.
-
-        system_instruction (Optional[str], optional): An optional system message.
-
-        verbose (bool, optional): If True, prints detailed info to stdout such as model invocation
-        parameters and details about retries and snapping to rails. Default False.
-
-    Returns:
-        List[str]: A list of strings representing the predicted class for each record in the
-        dataframe. The list should have the same length as the input dataframe and its values should
-        be the entries in the rails argument or "NOT_PARSABLE" if the model's prediction could not
-        be parsed.
-    """
-
-    warnings.warn(
-        "This function will soon be deprecated. "
-        "Use llm_classify instead, which has the same function signature "
-        "and provides support for multi-class classification "
-        "in addition to binary classification.",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    return (
-        llm_classify(
-            dataframe=dataframe,
-            model=model,
-            template=template,
-            rails=rails,
-            system_instruction=system_instruction,
-            verbose=verbose,
-        )
-        .iloc[:, 0]
-        .tolist()
-    )
 
 
 def run_relevance_eval(


### PR DESCRIPTION
- removes `llm_eval_binary`, which has been deprecated in favor of `llm_classify`