### PR TITLE
refactor: snap to rail after each llm call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
   "arize",
   "langchain>=0.0.324",
   "llama-index>=0.8.29",
-  "openai",
+  "openai<1.0.0",
   "tenacity",
   "nltk==3.8.1",
   "sentence-transformers==2.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ dependencies = [
   "types-tqdm",
   "types-requests",
   "types-protobuf",
+  "openai<1.0.0",
 ]
 
 [tool.hatch.envs.style]

--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import pandas as pd
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from phoenix.experimental.evals.models import BaseEvalModel, OpenAIModel, set_verbosity
 from phoenix.experimental.evals.templates import (

--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -120,10 +120,13 @@ def llm_classify(
                     explanation = None
             labels.append(_snap_to_rail(unrailed_label, rails, verbose=verbose))
             explanations.append(explanation)
-    return pd.DataFrame(
-        data={"label": labels, **({"explanation": explanations} if provide_explanation else {})},
-        index=dataframe.index,
-    )
+        return pd.DataFrame(
+            data={
+                "label": labels,
+                **({"explanation": explanations} if provide_explanation else {}),
+            },
+            index=dataframe.index,
+        )
 
 
 def run_relevance_eval(

--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -101,6 +101,9 @@ def llm_classify(
     prompts = map_template(dataframe, eval_template)
     labels: List[str] = []
     explanations: List[Optional[str]] = []
+    if generation_info := model.verbose_generation_info():
+        printif(verbose, generation_info)
+
     with set_verbosity(model, verbose) as verbose_model:
         for prompt in tqdm(prompts):
             response = verbose_model(prompt, instruction=system_instruction, **model_kwargs)

--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import pandas as pd
+from tqdm import tqdm
 
 from phoenix.experimental.evals.models import BaseEvalModel, OpenAIModel, set_verbosity
 from phoenix.experimental.evals.templates import (
@@ -101,7 +102,7 @@ def llm_classify(
     labels: List[str] = []
     explanations: List[Optional[str]] = []
     with set_verbosity(model, verbose) as verbose_model:
-        for prompt in prompts:
+        for prompt in tqdm(prompts):
             response = verbose_model(prompt, instruction=system_instruction, **model_kwargs)
             if not use_openai_function_call:
                 unrailed_label = response

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -95,8 +95,6 @@ class BaseEvalModel(ABC):
                 "Invalid type for argument `instruction`. Expected a string but found "
                 f"{type(instruction)}."
             )
-        if extra_info := self._verbose_generation_info():
-            printif(self._verbose, extra_info)
         return self._generate(prompt=prompt, instruction=instruction, **kwargs)
 
     async def async_call(self, prompt: str, instruction: Optional[str] = None) -> str:
@@ -119,7 +117,7 @@ class BaseEvalModel(ABC):
         self, prompts: List[str], instruction: Optional[str] = None, **kwargs: Any
     ) -> List[str]:
         printif(self._verbose, f"Generating responses for {len(prompts)} prompts...")
-        if extra_info := self._verbose_generation_info():
+        if extra_info := self.verbose_generation_info():
             printif(self._verbose, extra_info)
         if not is_list_of(prompts, str):
             raise TypeError(
@@ -153,7 +151,7 @@ class BaseEvalModel(ABC):
             raise e
         return result
 
-    def _verbose_generation_info(self) -> str:
+    def verbose_generation_info(self) -> str:
         # if defined, returns additional model-specific information to display if `generate` is
         # run with `verbose=True`
         return ""

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -95,6 +95,8 @@ class BaseEvalModel(ABC):
                 "Invalid type for argument `instruction`. Expected a string but found "
                 f"{type(instruction)}."
             )
+        if extra_info := self._verbose_generation_info():
+            printif(self._verbose, extra_info)
         return self._generate(prompt=prompt, instruction=instruction, **kwargs)
 
     async def async_call(self, prompt: str, instruction: Optional[str] = None) -> str:

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -82,7 +82,7 @@ class BaseEvalModel(ABC):
             before_sleep=log_retry,
         )
 
-    def __call__(self, prompt: str, instruction: Optional[str] = None) -> str:
+    def __call__(self, prompt: str, instruction: Optional[str] = None, **kwargs: Any) -> str:
         """Run the LLM on the given prompt."""
         if not isinstance(prompt, str):
             raise TypeError(
@@ -95,7 +95,7 @@ class BaseEvalModel(ABC):
                 "Invalid type for argument `instruction`. Expected a string but found "
                 f"{type(instruction)}."
             )
-        return self.generate(prompts=[prompt], instruction=instruction)[0]
+        return self.generate(prompts=[prompt], instruction=instruction, **kwargs)[0]
 
     async def async_call(self, prompt: str, instruction: Optional[str] = None) -> str:
         """Run the LLM on the given prompt."""

--- a/src/phoenix/experimental/evals/models/base.py
+++ b/src/phoenix/experimental/evals/models/base.py
@@ -95,7 +95,7 @@ class BaseEvalModel(ABC):
                 "Invalid type for argument `instruction`. Expected a string but found "
                 f"{type(instruction)}."
             )
-        return self.generate(prompts=[prompt], instruction=instruction, **kwargs)[0]
+        return self._generate(prompt=prompt, instruction=instruction, **kwargs)
 
     async def async_call(self, prompt: str, instruction: Optional[str] = None) -> str:
         """Run the LLM on the given prompt."""

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -148,7 +148,7 @@ class OpenAIModel(BaseEvalModel):
             messages.insert(0, {"role": "system", "content": str(system_instruction)})
         return messages
 
-    def _verbose_generation_info(self) -> str:
+    def verbose_generation_info(self) -> str:
         return f"OpenAI invocation parameters: {self.public_invocation_params}"
 
     def _generate(self, prompt: str, **kwargs: Any) -> str:

--- a/src/phoenix/experimental/evals/models/vertexai.py
+++ b/src/phoenix/experimental/evals/models/vertexai.py
@@ -77,7 +77,7 @@ class VertexAIModel(BaseEvalModel):
         else:
             self._model = model.from_pretrained(self.model_name)
 
-    def _verbose_generation_info(self) -> str:
+    def verbose_generation_info(self) -> str:
         return f"VertexAI invocation parameters: {self.invocation_params}"
 
     def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:

--- a/src/phoenix/utilities/logging.py
+++ b/src/phoenix/utilities/logging.py
@@ -2,7 +2,9 @@
 
 from typing import Any
 
+from tqdm.auto import tqdm
+
 
 def printif(condition: bool, *args: Any, **kwargs: Any) -> None:
     if condition:
-        print(*args, **kwargs)
+        tqdm.write(*args, **kwargs)

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -52,6 +52,7 @@ def test_llm_classify(monkeypatch: pytest.MonkeyPatch):
         template=RAG_RELEVANCY_PROMPT_TEMPLATE_STR,
         model=model,
         rails=["relevant", "irrelevant"],
+        use_function_calling_if_available=False,
     )
     labels = ["relevant", "irrelevant", "relevant", NOT_PARSABLE]
     assert result.iloc[:, 0].tolist() == labels
@@ -189,6 +190,7 @@ def test_llm_classify_prints_to_stdout_with_verbose_flag(monkeypatch: pytest.Mon
         model=model,
         rails=["relevant", "irrelevant"],
         verbose=True,
+        use_function_calling_if_available=False,
     )
 
     out, _ = capfd.readouterr()


### PR DESCRIPTION
- Updates `llm_classify` to snap to rail after each LLM call.
- Edits `__call__` on `BaseEvalModel` to use single-record `_generate` rather than batch `generate`. This makes more sense since `__call__` is invoked on single records. It is also needed to avoid weird behavior with progress bars.
- Converts `_verbose_generation_info` to `verbose_generation_info` (i.e., makes it a public method) and moves the responsibility for verbose logging to the caller.
- Changes `printif` to use `tqdm.auto.tqdm.write` for compatibility with `tqdm` progress bars.