### PR TITLE
feat: update OpenAIInstrumentor to support openai>=1.0.0 and deprecate support for openai<1.0.0

### DIFF
--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -75,21 +75,21 @@ class OpenAIInstrumentor:
         """
         openai = import_package("openai")
         is_instrumented = hasattr(
-            openai._base_client.SyncAPIClient,
+            openai.OpenAI,
             INSTRUMENTED_ATTRIBUTE_NAME,
         )
         if not is_instrumented:
-            openai._base_client.SyncAPIClient.request = _wrap_openai_api_requestor(
-                openai._base_client.SyncAPIClient.request, self._tracer
+            openai.OpenAI.request = _wrap_openai_client_request_function(
+                openai.OpenAI.request, self._tracer
             )
             setattr(
-                openai._base_client.SyncAPIClient,
+                openai.OpenAI,
                 INSTRUMENTED_ATTRIBUTE_NAME,
                 True,
             )
 
 
-def _wrap_openai_api_requestor(
+def _wrap_openai_client_request_function(
     request_fn: Callable[..., Any], tracer: Tracer
 ) -> Callable[..., Any]:
     """Wraps the OpenAI APIRequestor.request method to create spans for each API call.

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -78,7 +78,7 @@ def test_openai_instrumentor_includes_llm_attributes_on_chat_completion_success(
     expected_response_text = "France won the World Cup in 2018."
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(
-            200,
+            status_code=200,
             json={
                 "id": "chatcmpl-85eo7phshROhvmDvNeMVatGolg9JV",
                 "object": "chat.completion",
@@ -164,10 +164,9 @@ def test_openai_instrumentor_includes_function_call_attributes(
         }
     ]
     model = "gpt-4"
-
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(
-            200,
+            status_code=200,
             json={
                 "id": "chatcmpl-85eqK3CCNTHQcTN0ZoWqL5B0OO5ip",
                 "object": "chat.completion",
@@ -270,9 +269,9 @@ def test_openai_instrumentor_includes_function_call_message_attributes(
     model = "gpt-4"
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(
-            200,
+            status_code=200,
             json={
-                "id": "chatcmpl-85euch0n5ruhawemogmak8cdwyqcb",
+                "id": "chatcmpl-85euCH0n5RuhAWEmogmak8cDwyQcb",
                 "object": "chat.completion",
                 "created": 1696359572,
                 "model": "gpt-4-0613",
@@ -283,7 +282,7 @@ def test_openai_instrumentor_includes_function_call_message_attributes(
                             "role": "assistant",
                             "content": (
                                 "The current weather in Boston is sunny "
-                                "with a temperature of 22 degrees celsius."
+                                "with a temperature of 22 degrees Celsius."
                             ),
                         },
                         "finish_reason": "stop",
@@ -337,7 +336,7 @@ def test_openai_instrumentor_records_authentication_error(
     OpenAIInstrumentor(tracer).instrument()
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(
-            401,
+            status_code=401,
             json={
                 "error": {
                     "message": "error-message",
@@ -377,7 +376,7 @@ def test_openai_instrumentor_does_not_interfere_with_completions_api(
     prompt = "Who won the World Cup in 2018?"
     respx_mock.post("https://api.openai.com/v1/completions").mock(
         return_value=Response(
-            200,
+            status_code=200,
             json={
                 "id": "cmpl-85hqvKwCud3s3DWc80I0OeNmkfjSM",
                 "object": "text_completion",
@@ -395,7 +394,6 @@ def test_openai_instrumentor_does_not_interfere_with_completions_api(
             },
         )
     )
-
     response = client.completions.create(model=model, prompt=prompt)
     response_text = response.choices[0].text
     spans = list(tracer.get_spans())
@@ -415,7 +413,7 @@ def test_openai_instrumentor_instrument_method_is_idempotent(
     messages = [{"role": "user", "content": "Who won the World Cup in 2018?"}]
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
         return_value=Response(
-            200,
+            status_code=200,
             json={
                 "id": "chatcmpl-85evOVGg6afU8iqiUsRtYQ5lYnGwn",
                 "object": "chat.completion",

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -77,7 +77,7 @@ def test_openai_instrumentor_includes_llm_attributes_on_chat_completion_success(
     temperature = 0.23
     expected_response_text = "France won the World Cup in 2018."
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             200,
             json={
                 "id": "chatcmpl-85eo7phshROhvmDvNeMVatGolg9JV",
@@ -166,7 +166,7 @@ def test_openai_instrumentor_includes_function_call_attributes(
     model = "gpt-4"
 
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             200,
             json={
                 "id": "chatcmpl-85eqK3CCNTHQcTN0ZoWqL5B0OO5ip",
@@ -269,7 +269,7 @@ def test_openai_instrumentor_includes_function_call_message_attributes(
     ]
     model = "gpt-4"
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             200,
             json={
                 "id": "chatcmpl-85euch0n5ruhawemogmak8cdwyqcb",
@@ -336,7 +336,7 @@ def test_openai_instrumentor_records_authentication_error(
     tracer = Tracer()
     OpenAIInstrumentor(tracer).instrument()
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             401,
             json={
                 "error": {
@@ -376,7 +376,7 @@ def test_openai_instrumentor_does_not_interfere_with_completions_api(
     model = "gpt-3.5-turbo-instruct"
     prompt = "Who won the World Cup in 2018?"
     respx_mock.post("https://api.openai.com/v1/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             200,
             json={
                 "id": "cmpl-85hqvKwCud3s3DWc80I0OeNmkfjSM",
@@ -414,7 +414,7 @@ def test_openai_instrumentor_instrument_method_is_idempotent(
     model = "gpt-4"
     messages = [{"role": "user", "content": "Who won the World Cup in 2018?"}]
     respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
-        side_effect=lambda request, route: Response(
+        return_value=Response(
             200,
             json={
                 "id": "chatcmpl-85evOVGg6afU8iqiUsRtYQ5lYnGwn",

--- a/tutorials/evals/evaluate_code_readability_classifications.ipynb
+++ b/tutorials/evals/evaluate_code_readability_classifications.ipynb
@@ -759,7 +759,9 @@
    ],
    "source": [
     "# Let's view the data\n",
-    "merged_df = pd.merge(small_df_sample, readability_classifications_df, left_index=True, right_index=True)\n",
+    "merged_df = pd.merge(\n",
+    "    small_df_sample, readability_classifications_df, left_index=True, right_index=True\n",
+    ")\n",
     "merged_df[[\"query\", \"code\", \"label\", \"explanation\"]].head()"
    ]
   },
@@ -800,7 +802,9 @@
     "readability_classifications = llm_classify(\n",
     "    dataframe=df,\n",
     "    template=CODE_READABILITY_PROMPT_TEMPLATE_STR,\n",
-    "    model=OpenAIModel(model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20, max_retries=0),\n",
+    "    model=OpenAIModel(\n",
+    "        model_name=\"gpt-3.5-turbo\", temperature=0.0, request_timeout=20, max_retries=0\n",
+    "    ),\n",
     "    rails=rails,\n",
     ")[\"label\"]"
    ]

--- a/tutorials/evals/evaluate_hallucination_classifications.ipynb
+++ b/tutorials/evals/evaluate_hallucination_classifications.ipynb
@@ -620,7 +620,9 @@
    ],
    "source": [
     "# Let's view the data\n",
-    "merged_df = pd.merge(small_df_sample, hallucination_classifications_df, left_index=True, right_index=True)\n",
+    "merged_df = pd.merge(\n",
+    "    small_df_sample, hallucination_classifications_df, left_index=True, right_index=True\n",
+    ")\n",
     "merged_df[[\"query\", \"reference\", \"response\", \"is_hallucination\", \"label\", \"explanation\"]].head()"
    ]
   },

--- a/tutorials/evals/evaluate_relevance_classifications.ipynb
+++ b/tutorials/evals/evaluate_relevance_classifications.ipynb
@@ -645,7 +645,9 @@
    ],
    "source": [
     "# Let's view the data\n",
-    "merged_df = pd.merge(small_df_sample, relevance_classifications_df, left_index=True, right_index=True)\n",
+    "merged_df = pd.merge(\n",
+    "    small_df_sample, relevance_classifications_df, left_index=True, right_index=True\n",
+    ")\n",
     "merged_df[[\"query\", \"reference\", \"label\", \"explanation\"]].head()"
    ]
   },

--- a/tutorials/tracing/openai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/openai_tracing_tutorial.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"openai<1\" arize-phoenix jsonschema"
+    "!pip install \"openai>=1.0.0\" arize-phoenix jsonschema"
    ]
   },
   {
@@ -72,9 +72,9 @@
     "from typing import Any, Dict, Literal, TypedDict\n",
     "\n",
     "import jsonschema\n",
-    "import openai\n",
     "import pandas as pd\n",
     "import phoenix as px\n",
+    "from openai import OpenAI\n",
     "from phoenix.trace.exporter import HttpExporter\n",
     "from phoenix.trace.openai import OpenAIInstrumentor\n",
     "from phoenix.trace.tracer import Tracer\n",
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Configure Your OpenAI API Key\n",
+    "## 2. Configure Your OpenAI API Key and Instantiate Your OpenAI Client\n",
     "\n",
     "Set your OpenAI API key if it is not already set as an environment variable."
    ]
@@ -104,8 +104,7 @@
    "source": [
     "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
     "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
-    "openai.api_key = openai_api_key\n",
-    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+    "client = OpenAI(api_key=openai_api_key)"
    ]
   },
   {
@@ -225,9 +224,13 @@
     "\n",
     "@retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))\n",
     "def extract_raw_travel_request_attributes_string(\n",
-    "    travel_request: str, function_schema: Dict[str, Any], system_message: str, model: str = \"gpt-4\"\n",
+    "    travel_request: str,\n",
+    "    function_schema: Dict[str, Any],\n",
+    "    system_message: str,\n",
+    "    client: OpenAI,\n",
+    "    model: str = \"gpt-4\",\n",
     ") -> str:\n",
-    "    response = openai.ChatCompletion.create(\n",
+    "    chat_completion = client.chat.completions.create(\n",
     "        model=model,\n",
     "        messages=[\n",
     "            {\"role\": \"system\", \"content\": system_message},\n",
@@ -238,8 +241,8 @@
     "        # The line below forces the LLM to call the function so that the output conforms to the schema.\n",
     "        function_call={\"name\": function_schema[\"name\"]},\n",
     "    )\n",
-    "    function_call_data = response[\"choices\"][0][\"message\"][\"function_call\"]\n",
-    "    return function_call_data[\"arguments\"]"
+    "    function_call = chat_completion.choices[0].message.function_call\n",
+    "    return function_call.arguments"
    ]
   },
   {
@@ -262,7 +265,7 @@
     "    print(travel_request)\n",
     "    print()\n",
     "    raw_travel_attributes = extract_raw_travel_request_attributes_string(\n",
-    "        travel_request, function_schema, system_message\n",
+    "        travel_request, function_schema, system_message, client\n",
     "    )\n",
     "    raw_travel_attributes_column.append(raw_travel_attributes)\n",
     "    print(\"Raw Travel Attributes:\")\n",


### PR DESCRIPTION
- updates `OpenAIInstrumentor` to support `openai>=1.0.0`
- deprecates support for `openai<1.0.0`
- improves test fixtures to instantiate client from reloaded modules (necessary since the originally imported modules are patched by `OpenAIInstrumentor.instrument`)
- updates structured data extraction tutorial notebook and pins `openai>=1.0.0`