### PR TITLE
fix(traces): handle AIMessageChunk in langchain tracer by matching prefix in name

### DIFF
--- a/src/phoenix/trace/langchain/tracer.py
+++ b/src/phoenix/trace/langchain/tracer.py
@@ -133,15 +133,15 @@ def _output_messages(run_outputs: Mapping[str, Any]) -> Iterator[Tuple[str, List
 def _parse_message_data(message_data: Mapping[str, Any]) -> Message:
     """Parses message data to grab message role, content, etc."""
     message_class_name = message_data["id"][-1]
-    if message_class_name == "HumanMessage":
+    if message_class_name.startswith("HumanMessage"):
         role = "user"
-    elif message_class_name == "AIMessage":
+    elif message_class_name.startswith("AIMessage"):
         role = "assistant"
-    elif message_class_name == "SystemMessage":
+    elif message_class_name.startswith("SystemMessage"):
         role = "system"
-    elif message_class_name == "FunctionMessage":
+    elif message_class_name.startswith("FunctionMessage"):
         role = "function"
-    elif message_class_name == "ChatMessage":
+    elif message_class_name.startswith("ChatMessage"):
         role = message_data["kwargs"]["role"]
     else:
         raise ValueError(f"Cannot parse message of type: {message_class_name}")


### PR DESCRIPTION
resolves #1719 

## Notes and Caveats
Matching prefix is effectively the same as calling [`isinstance`](https://github.com/langchain-ai/langchain/blob/58da6e0d476d3b3554c30d68c847ce93b5194924/libs/langchain/langchain/schema/messages.py#L43). It's not totally clear what's specifically distinct about [`AIMessageChunk`](https://github.com/langchain-ai/langchain/blob/58da6e0d476d3b3554c30d68c847ce93b5194924/libs/langchain/langchain/schema/messages.py#L207). All we know right now is that it's a subclass of `AIMessage`.