### PR TITLE
chore: Revert "chore: publish to pypi when a release is published (#1726)"

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,12 +1,11 @@
 name: Publish to PyPI
 
-on:
-  release:
-    types: [published]
+on: create
 
 jobs:
   build:
     name: Build distribution
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 286ac4adb4d0cda7bbd0b20aaa331f4e3df037eb.