### PR TITLE
fix: update tracer for llama-index 0.9.0

### DIFF
--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -918,7 +918,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
         backgroundColor: "indigo-100",
         borderColor: "indigo-700",
       };
-    } else if (role === "function") {
+    } else if (["function", "tool"].includes(role)) {
       return {
         backgroundColor: "yellow-100",
         borderColor: "yellow-700",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dev = [
 experimental = [
   "tenacity",
 ]
+llama-index = [
+  "llama-index~=0.9.0",
+]
 
 [project.urls]
 Documentation = "https://docs.arize.com/phoenix/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
   "strawberry-graphql[debug-server]==0.208.2",
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
-  "llama-index>=0.8.64",
+  "llama-index>=0.9.0",
   "langchain>=0.0.334",
 ]
 experimental = [
@@ -92,7 +92,7 @@ dependencies = [
   "pytest-lazy-fixture",
   "arize",
   "langchain>=0.0.334",
-  "llama-index>=0.8.63.post2",
+  "llama-index>=0.9.0",
   "openai>=1.0.0",
   "tenacity",
   "nltk==3.8.1",
@@ -110,7 +110,7 @@ dependencies = [
 [tool.hatch.envs.type]
 dependencies = [
   "mypy==1.5.1",
-  "llama-index>=0.8.64",
+  "llama-index>=0.9.0",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "types-psutil",
   "types-tqdm",

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -29,6 +29,7 @@ from typing import (
 )
 from uuid import uuid4
 
+import llama_index
 from llama_index.callbacks.base_handler import BaseCallbackHandler
 from llama_index.callbacks.schema import (
     TIMESTAMP_FORMAT,
@@ -88,9 +89,10 @@ from phoenix.trace.semantic_conventions import (
     MimeType,
 )
 from phoenix.trace.tracer import SpanExporter, Tracer
-from phoenix.trace.utils import get_stacktrace
+from phoenix.trace.utils import extract_version_triplet, get_stacktrace
 from phoenix.utilities.error_handling import graceful_fallback
 
+LLAMA_INDEX_MINIMUM_VERSION_TRIPLET = (0, 9, 0)
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -160,9 +162,9 @@ def payload_to_semantic_attributes(
             attributes[INPUT_VALUE] = _message_payload_to_str(messages[0])
     if response := (payload.get(EventPayload.RESPONSE) or payload.get(EventPayload.COMPLETION)):
         attributes.update(_get_response_output(response))
-        if (raw := getattr(response, "raw", None)) is not None:
+        if raw := getattr(response, "raw", None):
             attributes.update(_get_output_messages(raw))
-            if (usage := getattr(raw, "usage", None)) is not None:
+            if usage := raw.get("usage"):
                 # OpenAI token counts are available on raw.usage but can also be
                 # found in additional_kwargs. Thus the duplicate handling.
                 attributes.update(_get_token_counts(usage))
@@ -191,7 +193,7 @@ def payload_to_semantic_attributes(
         tool_metadata = cast(ToolMetadata, payload.get(EventPayload.TOOL))
         attributes[TOOL_NAME] = tool_metadata.name
         attributes[TOOL_DESCRIPTION] = tool_metadata.description
-        attributes[TOOL_PARAMETERS] = tool_metadata.to_openai_function()["parameters"]
+        attributes[TOOL_PARAMETERS] = tool_metadata.to_openai_tool()["function"]["parameters"]
     if EventPayload.SERIALIZED in payload:
         serialized = payload[EventPayload.SERIALIZED]
         if event_type is CBEventType.EMBEDDING:
@@ -226,6 +228,15 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         callback: Optional[Callable[[List[Span]], None]] = None,
         exporter: Optional[SpanExporter] = None,
     ) -> None:
+        if (
+            hasattr(llama_index, "__version__")
+            and (version_triplet := extract_version_triplet(llama_index.__version__))
+            and version_triplet < LLAMA_INDEX_MINIMUM_VERSION_TRIPLET
+        ):
+            raise NotImplementedError(
+                f"minimum supported version of llama-index is "
+                f"{'.'.join(map(str, LLAMA_INDEX_MINIMUM_VERSION_TRIPLET))}"
+            )
         super().__init__(event_starts_to_ignore=[], event_ends_to_ignore=[])
         self._tracer = Tracer(on_append=callback, exporter=exporter or HttpExporter())
         self._event_id_to_event_data: EventData = defaultdict(lambda: CBEventData())
@@ -437,10 +448,18 @@ def _message_payload_to_attributes(message: Any) -> Dict[str, Optional[str]]:
         # NB: these additional kwargs exist both for 'agent' and 'function' roles
         if "name" in message.additional_kwargs:
             message_attributes[MESSAGE_NAME] = message.additional_kwargs["name"]
-        if "function_call" in message.additional_kwargs:
-            function_call = message.additional_kwargs["function_call"]
-            message_attributes[MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON] = function_call.arguments
-            message_attributes[MESSAGE_FUNCTION_CALL_NAME] = function_call.name
+        if tool_calls := message.additional_kwargs.get("tool_calls"):
+            assert isinstance(
+                tool_calls, Iterable
+            ), f"tool_calls must be Iterable, found {type(tool_calls)}"
+            tool_call = next(iter(tool_calls), None)
+            function = getattr(tool_call, "function", None)
+            if name := getattr(function, "name", None):
+                assert isinstance(name, str), f"name must be str, found {type(name)}"
+                message_attributes[MESSAGE_FUNCTION_CALL_NAME] = name
+            if arguments := getattr(function, "arguments", None):
+                assert isinstance(arguments, str), f"arguments must be str, found {type(arguments)}"
+                message_attributes[MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON] = arguments
         return message_attributes
 
     return {
@@ -457,6 +476,16 @@ def _message_payload_to_str(message: Any) -> Optional[str]:
     return str(message)
 
 
+class _CustomJSONEncoder(json.JSONEncoder):
+    def default(self, obj: object) -> Any:
+        try:
+            return super().default(obj)
+        except TypeError:
+            if callable(as_dict := getattr(obj, "dict", None)):
+                return as_dict()
+            raise
+
+
 def _get_response_output(response: Any) -> Iterator[Tuple[str, Any]]:
     """
     Gets output from response objects. This is needed since the string representation of some
@@ -470,7 +499,7 @@ def _get_response_output(response: Any) -> Iterator[Tuple[str, Any]]:
             yield OUTPUT_VALUE, content
             yield OUTPUT_MIME_TYPE, MimeType.TEXT
         else:
-            yield OUTPUT_VALUE, json.dumps(message.additional_kwargs)
+            yield OUTPUT_VALUE, json.dumps(message.additional_kwargs, cls=_CustomJSONEncoder)
             yield OUTPUT_MIME_TYPE, MimeType.JSON
     else:
         yield OUTPUT_VALUE, str(response)
@@ -516,19 +545,25 @@ def _get_message(message: object) -> Iterator[Tuple[str, Any]]:
     if content := getattr(message, "content", None):
         assert isinstance(content, str), f"content must be str, found {type(content)}"
         yield MESSAGE_CONTENT, content
-    if (function_call := getattr(message, "function_call", None)) is not None:
-        if name := getattr(function_call, "name", None):
+    if tool_calls := getattr(message, "tool_calls", None):
+        assert isinstance(
+            tool_calls, Iterable
+        ), f"tool_calls must be Iterable, found {type(tool_calls)}"
+        tool_call = next(iter(tool_calls), None)
+        function = getattr(tool_call, "function", None)
+        if name := getattr(function, "name", None):
             assert isinstance(name, str), f"name must be str, found {type(name)}"
             yield MESSAGE_FUNCTION_CALL_NAME, name
-        if arguments := getattr(function_call, "arguments", None):
+        if arguments := getattr(function, "arguments", None):
             assert isinstance(arguments, str), f"arguments must be str, found {type(arguments)}"
             yield MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON, arguments
 
 
-def _get_output_messages(raw: object) -> Iterator[Tuple[str, Any]]:
-    if not (choices := getattr(raw, "choices", None)):
+def _get_output_messages(raw: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
+    assert isinstance(raw, Iterable), f"raw must be Mapping, found {type(raw)}"
+    if not (choices := raw.get("choices")):
         return
-    assert isinstance(choices, Iterable), f"expected Iterable, found {type(choices)}"
+    assert isinstance(choices, Iterable), f"choices must be Iterable, found {type(choices)}"
     messages = [
         dict(_get_message(message))
         for choice in choices

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -163,7 +163,7 @@ def payload_to_semantic_attributes(
     if response := (payload.get(EventPayload.RESPONSE) or payload.get(EventPayload.COMPLETION)):
         attributes.update(_get_response_output(response))
         if raw := getattr(response, "raw", None):
-            assert isinstance(raw, Mapping), f"raw must be Mapping, found {type(raw)}"
+            assert hasattr(raw, "get"), f"raw must be Mapping, found {type(raw)}"
             attributes.update(_get_output_messages(raw))
             if usage := raw.get("usage"):
                 # OpenAI token counts are available on raw.usage but can also be
@@ -236,7 +236,11 @@ class OpenInferenceTraceCallbackHandler(BaseCallbackHandler):
         ):
             raise NotImplementedError(
                 f"minimum supported version of llama-index is "
-                f"{'.'.join(map(str, LLAMA_INDEX_MINIMUM_VERSION_TRIPLET))}"
+                f"{'.'.join(map(str, LLAMA_INDEX_MINIMUM_VERSION_TRIPLET))}, "
+                f"but yours is {llama_index.__version__}. "
+                f"you can update to the latest using `pip install llama-index --upgrade`, "
+                f"or install the minimum required for Phoenix using "
+                f'`pip install "arize-phoenix[llama-index]"`',
             )
         super().__init__(event_starts_to_ignore=[], event_ends_to_ignore=[])
         self._tracer = Tracer(on_append=callback, exporter=exporter or HttpExporter())
@@ -561,7 +565,7 @@ def _get_message(message: object) -> Iterator[Tuple[str, Any]]:
 
 
 def _get_output_messages(raw: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
-    assert isinstance(raw, Mapping), f"raw must be Mapping, found {type(raw)}"
+    assert hasattr(raw, "get"), f"raw must be Mapping, found {type(raw)}"
     if not (choices := raw.get("choices")):
         return
     assert isinstance(choices, Iterable), f"choices must be Iterable, found {type(choices)}"

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -163,6 +163,7 @@ def payload_to_semantic_attributes(
     if response := (payload.get(EventPayload.RESPONSE) or payload.get(EventPayload.COMPLETION)):
         attributes.update(_get_response_output(response))
         if raw := getattr(response, "raw", None):
+            assert isinstance(raw, Mapping), f"raw must be Mapping, found {type(raw)}"
             attributes.update(_get_output_messages(raw))
             if usage := raw.get("usage"):
                 # OpenAI token counts are available on raw.usage but can also be
@@ -560,7 +561,7 @@ def _get_message(message: object) -> Iterator[Tuple[str, Any]]:
 
 
 def _get_output_messages(raw: Mapping[str, Any]) -> Iterator[Tuple[str, Any]]:
-    assert isinstance(raw, Iterable), f"raw must be Mapping, found {type(raw)}"
+    assert isinstance(raw, Mapping), f"raw must be Mapping, found {type(raw)}"
     if not (choices := raw.get("choices")):
         return
     assert isinstance(choices, Iterable), f"choices must be Iterable, found {type(choices)}"

--- a/src/phoenix/trace/utils.py
+++ b/src/phoenix/trace/utils.py
@@ -66,6 +66,6 @@ _VERSION_TRIPLET_REGEX = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 def extract_version_triplet(version: str) -> Optional[Tuple[int, int, int]]:
     return (
         cast(Tuple[int, int, int], tuple(map(int, match.groups())))
-        if (match := _VERSION_TRIPLET_REGEX.match(version))
+        if (match := _VERSION_TRIPLET_REGEX.search(version))
         else None
     )

--- a/src/phoenix/trace/utils.py
+++ b/src/phoenix/trace/utils.py
@@ -1,8 +1,9 @@
 import importlib
 import json
+import re
 from traceback import format_exception
 from types import ModuleType
-from typing import List, Optional
+from typing import List, Optional, Tuple, cast
 
 import pandas as pd
 
@@ -57,3 +58,14 @@ def import_package(package_name: str, pypi_name: Optional[str] = None) -> Module
             f"The {package_name} package is not installed. "
             f"Install with `pip install {pypi_name or package_name}`."
         )
+
+
+_VERSION_TRIPLET_REGEX = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+def extract_version_triplet(version: str) -> Optional[Tuple[int, int, int]]:
+    return (
+        cast(Tuple[int, int, int], tuple(map(int, match.groups())))
+        if (match := _VERSION_TRIPLET_REGEX.match(version))
+        else None
+    )

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from typing import Any
 from unittest.mock import patch
@@ -38,6 +39,9 @@ from phoenix.trace.semantic_conventions import (
 )
 from phoenix.trace.span_json_decoder import json_string_to_span
 from phoenix.trace.span_json_encoder import span_to_json
+
+# fake openai key so that llama_index doesn't download huggingface embeddings
+os.environ["OPENAI_API_KEY"] = "sk-fake-openai-key"
 
 nodes = [
     Document(


### PR DESCRIPTION
resolves #1747 

# Key Changes
1. Added `tool` as a new message role, because the `function` role is deprecated. (This is the result of the function call that we send back to openai as part of a chat)
2. Check the minimum version for llama-index at `0.9.0` at when initializing the tracer.
3. For the `ToolMetata` object from llama-index, change `tool_metadata.to_openai_function()["parameters"]` to `tool_metadata.to_openai_tool()["function"]["parameters"]` because the former is deprecated, and its underlying dictionary structure has changed.
4. Multiple function calls is now possible in the OpenAI response message (i.e. the new `tool_calls` is a list, the old `function_call`, which is singular, is deprecated). But we're only capturing the first one for now. A follow-up PR will be needed to capture all.