### PR TITLE
ci: fix type checks

### DIFF
--- a/src/phoenix/trace/langchain/instrumentor.py
+++ b/src/phoenix/trace/langchain/instrumentor.py
@@ -34,4 +34,4 @@ class LangChainInstrumentor:
             source_init(self, *args, **kwargs)
             self.add_handler(tracer, True)
 
-        BaseCallbackManager.__init__ = patched_init  # type: ignore
+        BaseCallbackManager.__init__ = patched_init

--- a/src/phoenix/trace/langchain/tracer.py
+++ b/src/phoenix/trace/langchain/tracer.py
@@ -283,7 +283,7 @@ def _chat_model_start_fallback(
     pass
 
 
-class OpenInferenceTracer(Tracer, BaseTracer):
+class OpenInferenceTracer(Tracer, BaseTracer):  # type: ignore
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._exporter = self._exporter or HttpExporter()


### PR DESCRIPTION
> src/phoenix/trace/langchain/tracer.py:286: error: Class cannot subclass "BaseTracer" (has type "Any")  [misc]
> src/phoenix/trace/langchain/instrumentor.py:37: error: Unused "type: ignore" comment  [unused-ignore]