### PR TITLE
feat: sagemaker nobebook support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # using the following command:
 # > docker build -t phoenix .
 # You can then run that image with the following command:
-# > docker run -d --name phoenix -p 6060:6060 phoenix
+# > docker run -d --name phoenix -p 6006:6006 phoenix
 # If you have a production use-case for phoenix, please get in touch!
 
 # Use an official Python runtime as a parent image
@@ -26,8 +26,8 @@ RUN cd /phoenix/app && npm install && npm run build
 # Install any needed packages 
 RUN pip install .
 
-# Make port 6060 available to the world outside this container
-EXPOSE 6060
+# Make port 6006 available to the world outside this container
+EXPOSE 6006
 
 # Run server.py when the container launches
-CMD ["python", "src/phoenix/server/main.py", "--host", "0.0.0.0", "--port", "6060", "serve"]
+CMD ["python", "src/phoenix/server/main.py", "--host", "0.0.0.0", "--port", "6006", "serve"]

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -6,13 +6,14 @@ import {
   Store,
 } from "relay-runtime";
 
+const graphQLPath = window.Config.basename + "/graphql";
 /**
  * Relay requires developers to configure a "fetch" function that tells Relay how to load
  * the results of GraphQL queries from your server (or other data source). See more at
  * https://relay.dev/docs/en/quick-start-guide#relay-environment.
  */
 const fetchRelay: FetchFunction = async (params, variables, _cacheConfig) => {
-  const response = await fetch("/graphql", {
+  const response = await fetch(graphQLPath, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -65,7 +65,10 @@ const router = createBrowserRouter(
         </Route>
       </Route>
     </Route>
-  )
+  ),
+  {
+    basename: window.Config.basename,
+  }
 );
 
 export function AppRoutes() {

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -3,6 +3,9 @@ export {};
 declare global {
   interface Window {
     Config: {
+      // basename for the app. This can be the proxy path for
+      // Remote notebooks like SageMaker
+      basename: string;
       hasCorpus: boolean;
       UMAP: {
         minDist: number;

--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
         "RERANKER",
         "respx",
         "rgba",
+        "tensorboard",
         "tiktoken",
         "tracedataset",
         "UMAP"

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -5,7 +5,7 @@ from .session.session import Session, active_session, close_app, launch_app
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
 
-__version__ = "1.1.1"
+__version__ = "1.1.2-rc7"
 
 # module level doc-string
 __doc__ = """

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -39,7 +39,7 @@ SERVER_DIR = PHOENIX_DIR / "server"
 # The host the server will run on after launch_app is called
 HOST = "127.0.0.1"
 # The port the server will run on after launch_app is called
-PORT = 6060
+PORT = 6006
 # The prefix of datasets that are auto-assigned a name
 GENERATED_DATASET_NAME_PREFIX = "phoenix_dataset_"
 

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <title>Phoenix</title>
-    <link rel="icon" href="{{base_url}}/favicon.ico" type="image/x-icon"></link>
+    <link rel="icon" href="{{basename}}/favicon.ico" type="image/x-icon"></link>
     <meta charset="UTF-8" />
     <meta name="description" content="Explore, Analyze, Curate" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
-    <link rel="stylesheet" src="{{base_url}}/index.css"></link>
+    <link rel="stylesheet" src="{{basename}}/index.css"></link>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap"
     />
-    <script src="{{base_url}}/modernizr.js"></script>
+    <script src="{{basename}}/modernizr.js"></script>
   </head>
   <body>
     <div id="root"></div>
@@ -22,6 +22,7 @@
             // E.g. default UMAP parameters etc. that needs to be
             // injected into the client before React runs
             value: Object.freeze({
+                basename: "{{basename}}",
                 hasCorpus: Boolean("{{has_corpus}}"),
                 UMAP: {
                   minDist: parseFloat("{{min_dist}}"),
@@ -32,6 +33,6 @@
             writable: false
         });
     })()</script>
-    <script type="module" src="/index.js"></script>
+    <script type="module" src="{{basename}}/index.js"></script>
   </body>
 </html>

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <title>Phoenix</title>
-    <link rel="icon" href="/favicon.ico" type="image/x-icon"></link>
+    <link rel="icon" href="{{base_url}}/favicon.ico" type="image/x-icon"></link>
     <meta charset="UTF-8" />
     <meta name="description" content="Explore, Analyze, Curate" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
-    <link rel="stylesheet" src="/index.css"></link>
+    <link rel="stylesheet" src="{{base_url}}/index.css"></link>
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap"
     />
-    <script src="/modernizr.js"></script>
+    <script src="{{base_url}}/modernizr.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -451,7 +451,7 @@ def _get_notebook_environment() -> NotebookEnvironment:
 
 def _get_sagemaker_notebook_base_url() -> str:
     """
-    Returns the name of the SageMaker notebook
+    Returns base url of the sagemaker notebook by parsing the Arn
     src: https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/blob/62c44aa5e69f4266955476f24647b99d9b597aaf/scripts/auto-stop-idle/autostop.py#L79
     """
     log_path = "/opt/ml/metadata/resource-metadata.json"

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -435,7 +435,7 @@ def _is_sagemaker() -> bool:
     except ImportError:
         return False
     try:
-        from IPython.core.getipython import get_ipython  # type: ignore
+        from IPython.core.getipython import get_ipython
     except ImportError:
         return False
     return get_ipython() is not None

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -3,6 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import UserList
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -44,6 +45,12 @@ else:
     _BaseList = UserList
 
 
+class NotebookEnvironment(Enum):
+    COLAB = "colab"
+    LOCAL = "local"
+    SAGEMAKER = "sagemaker"
+
+
 class ExportedData(_BaseList):
     def __init__(self) -> None:
         self.paths: Set[Path] = set()
@@ -68,6 +75,8 @@ class Session(ABC):
 
     trace_dataset: Optional[TraceDataset]
     traces: Optional[Traces]
+    nb_env: NotebookEnvironment
+    """The notebook environment that the session is running in."""
 
     def __dir__(self) -> List[str]:
         return ["exports", "view", "url"]
@@ -111,7 +120,7 @@ class Session(ABC):
         self.export_path = Path(self.temp_dir.name) / "exports"
         self.export_path.mkdir(parents=True, exist_ok=True)
         self.exported_data = ExportedData()
-        self.is_colab = _is_colab()
+        self.nb_env = _get_notebook_environment()
 
     @abstractmethod
     def end(self) -> None:
@@ -150,7 +159,7 @@ class Session(ABC):
     @property
     def url(self) -> str:
         """Returns the url for the phoenix app"""
-        return _get_url(self.host, self.port, self.is_colab)
+        return _get_url(self.host, self.port, self.nb_env)
 
     def get_spans_dataframe(
         self,
@@ -312,7 +321,7 @@ def launch_app(
     port: int, optional
         The port on which the server listens. When using traces this should not be
         used and should instead set the environment variable `PHOENIX_PORT`.
-        Defaults to 6060.
+        Defaults to 6006.
     run_in_thread: bool, optional, default=True
         Whether the server should run in a Thread or Process.
     default_umap_parameters: Dict[str, Union[int, float]], optional, default=None
@@ -394,13 +403,15 @@ def close_app() -> None:
     logger.info("Session closed")
 
 
-def _get_url(host: str, port: int, is_colab: bool) -> str:
+def _get_url(host: str, port: int, nb_env: NotebookEnvironment) -> str:
     """Determines the IFrame URL based on whether this is in a Colab or in a local notebook"""
-    if is_colab:
+    if nb_env == NotebookEnvironment.COLAB:
         from google.colab.output import eval_js  # type: ignore
 
         return str(eval_js(f"google.colab.kernel.proxyPort({port}, {{'cache': true}})"))
-
+    if nb_env == NotebookEnvironment.SAGEMAKER:
+        # NB: Sagemaker notebooks only work with port 6006 - which is used by tensorboard
+        return str(f"{_get_sagemaker_notebook_base_url()}/proxy/{port}/")
     return f"http://{host}:{port}/"
 
 
@@ -415,3 +426,40 @@ def _is_colab() -> bool:
     except ImportError:
         return False
     return get_ipython() is not None
+
+
+def _is_sagemaker() -> bool:
+    """Determines whether this is in a SageMaker notebook"""
+    try:
+        import sagemaker  # type: ignore # noqa: F401
+    except ImportError:
+        return False
+    try:
+        from IPython.core.getipython import get_ipython  # type: ignore
+    except ImportError:
+        return False
+    return get_ipython() is not None
+
+
+def _get_notebook_environment() -> NotebookEnvironment:
+    if _is_colab():
+        return NotebookEnvironment.COLAB
+    if _is_sagemaker():
+        return NotebookEnvironment.SAGEMAKER
+    return NotebookEnvironment.LOCAL
+
+
+def _get_sagemaker_notebook_base_url() -> str:
+    """
+    Returns the name of the SageMaker notebook
+    src: https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/blob/62c44aa5e69f4266955476f24647b99d9b597aaf/scripts/auto-stop-idle/autostop.py#L79
+    """
+    log_path = "/opt/ml/metadata/resource-metadata.json"
+    with open(log_path, "r") as logs:
+        logs = json.load(logs)
+    arn = logs["ResourceArn"]  # type: ignore
+    parts = arn.split(":")
+    region = parts[3]
+    notebook_instance_name = parts[5].split("/")[1]
+
+    return f"https://{notebook_instance_name}.notebook.{region}.sagemaker.aws"

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -458,6 +458,9 @@ def _get_sagemaker_notebook_base_url() -> str:
     with open(log_path, "r") as logs:
         logs = json.load(logs)
     arn = logs["ResourceArn"]  # type: ignore
+
+    # Parse the ARN to get the region and notebook instance name
+    # E.x. arn:aws:sagemaker:us-east-2:802164118598:notebook-instance/my-notebook-instance
     parts = arn.split(":")
     region = parts[3]
     notebook_instance_name = parts[5].split("/")[1]

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -41,7 +41,7 @@ class HttpExporter:
             variable `PHOENIX_HOST`, otherwise it defaults to `127.0.0.1`.
         port: Optional[int]
             The port of the Phoenix server. It can also be set using environment
-            variable `PHOENIX_PORT`, otherwise it defaults to `6060`.
+            variable `PHOENIX_PORT`, otherwise it defaults to `6006`.
         """
         self._host = host or get_env_host()
         self._port = port or get_env_port()


### PR DESCRIPTION
resolves: #675 

Adds support for sagemaker by detecting the notebook environment and also adjusting the `basename` of the application to be `/proxy/6006`. It seems 6006 is the port of choice since it's left open for tensorboard so just made the shift to that port.
<img width="2056" alt="Screenshot 2023-11-16 at 11 51 20 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/6313afe7-ef6c-4b56-a46c-145417224955">
