### PR TITLE
chore: give a way to manually set the notebook environment

### DIFF
--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,7 +1,7 @@
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
 from .datasets.schema import EmbeddingColumnNames, RetrievalEmbeddingColumnNames, Schema
-from .session.session import Session, active_session, close_app, launch_app
+from .session.session import NotebookEnvironment, Session, active_session, close_app, launch_app
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
 
@@ -36,4 +36,5 @@ __all__ = [
     "Session",
     "load_example_traces",
     "TraceDataset",
+    "NotebookEnvironment",
 ]

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -3,6 +3,11 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
+# Phoenix environment variables
+ENV_PHOENIX_PORT = "PHOENIX_PORT"
+ENV_PHOENIX_HOST = "PHOENIX_HOST"
+ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
+
 
 def _get_temp_path() -> Path:
     """Get path to  directory in which to store temp phoenix server files."""
@@ -64,10 +69,10 @@ def get_exported_files(directory: Path) -> List[Path]:
 def get_env_port() -> int:
     return (
         int(port)
-        if isinstance(port := os.getenv("PHOENIX_PORT"), str) and port.isnumeric()
+        if isinstance(port := os.getenv(ENV_PHOENIX_PORT), str) and port.isnumeric()
         else PORT
     )
 
 
 def get_env_host() -> str:
-    return os.getenv("PHOENIX_HOST") or HOST
+    return os.getenv(ENV_PHOENIX_HOST) or HOST

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -15,6 +15,7 @@ from typing import (
     Mapping,
     Optional,
     Set,
+    Union,
 )
 
 import pandas as pd
@@ -306,7 +307,7 @@ def launch_app(
     host: Optional[str] = None,
     port: Optional[int] = None,
     run_in_thread: bool = True,
-    notebook_environment: Optional[str] = None,
+    notebook_environment: Optional[Union[NotebookEnvironment, str]] = None,
 ) -> Optional[Session]:
     """
     Launches the phoenix application and returns a session to interact with.


### PR DESCRIPTION
Give a way for the user to set the notebook environment manually so that if the feature detection via imports fails, the user can still declare the notebook environment they are using. sagemaker seems to be failing feature detection.