### PR TITLE
fix: make the app launchable when nest_asyncio is applied

### DIFF
--- a/src/phoenix/server/thread_server.py
+++ b/src/phoenix/server/thread_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from threading import Thread
 from time import sleep, time
@@ -5,6 +6,19 @@ from typing import Generator
 
 from starlette.applications import Starlette
 from uvicorn import Config, Server
+from uvicorn.config import LoopSetupType
+
+
+def _nest_asyncio_applied() -> bool:
+    """
+    Determines whether nest_asyncio has been applied. This is needed since
+    nest_asyncio affects the runtime of the app. If it is applied, the app must use
+    the "asyncio" loop.
+    see: https://github.com/erdewit/nest_asyncio/blob/a48a68a47e182bd7e1f86c60dfc07d7b8509508b/nest_asyncio.py#L45
+    """
+    if hasattr(asyncio, "_nest_patched"):
+        return True
+    return False
 
 
 class ThreadServer(Server):
@@ -16,12 +30,16 @@ class ThreadServer(Server):
         host: str,
         port: int,
     ) -> None:
+        # Must use asyncio loop if nest_asyncio is applied
+        # Otherwise the app crashes when the server is run in a thread
+        loop: LoopSetupType = "asyncio" if _nest_asyncio_applied() else "auto"
         config = Config(
             app=app,
             host=host,
             port=port,
             # TODO: save logs to file
             log_level=logging.ERROR,
+            loop=loop,
         )
         super().__init__(config=config)
 

--- a/src/phoenix/server/thread_server.py
+++ b/src/phoenix/server/thread_server.py
@@ -16,9 +16,7 @@ def _nest_asyncio_applied() -> bool:
     the "asyncio" loop.
     see: https://github.com/erdewit/nest_asyncio/blob/a48a68a47e182bd7e1f86c60dfc07d7b8509508b/nest_asyncio.py#L45
     """
-    if hasattr(asyncio, "_nest_patched"):
-        return True
-    return False
+    return hasattr(asyncio, "_nest_patched")
 
 
 class ThreadServer(Server):


### PR DESCRIPTION
resolves #1353

This resolves the issue that nest asyncio makes the application fail to launch. Many notebooks, including ones from llamaIndex, have nest_asyncio applied at the top. In these cases the server cannot crash. This makes it so that the server runs via the "asyncio" eventloop when it is applied.

```python
import os
import phoenix as px
import logging
import nest_asyncio

nest_asyncio.apply()
logging.basicConfig(level=logging.INFO)
px.launch_app()
```
```
INFO:phoenix.session.session:Running Phoenix in a process
INFO:phoenix.services:command: [/Users/mikeldking/.virtualenvs/phoenix/bin/python](https://file+.vscode-resource.vscode-cdn.net/Users/mikeldking/.virtualenvs/phoenix/bin/python) main.py --export_path [/var/folders/1s/4vdv59n15b1ghg42frdd8f480000gn/T/tmp1z1xx6_c/exports](https://file+.vscode-resource.vscode-cdn.net/var/folders/1s/4vdv59n15b1ghg42frdd8f480000gn/T/tmp1z1xx6_c/exports) --host 127.0.0.1 --port 6006 --umap_params 0.0,30,500 datasets --primary phoenix_dataset_67bf7bad-1f57-4312-840a-2d32aa6b262a
🌍 To view the Phoenix app in your browser, visit http://127.0.0.1:6006/
📺 To view the Phoenix app in a notebook, run `px.active_session().view()`
📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix
```