### PR TITLE
feat(traces): configurable endpoint for the exporter

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -84,4 +84,4 @@ def get_env_host() -> str:
 
 
 def get_env_collector_endpoint() -> Optional[str]:
-    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or None
+    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_HOST = "PHOENIX_HOST"
 ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
+ENV_TRACE_ENDPOINT = "PHOENIX_TRACE_ENDPOINT"
 
 
 def _get_temp_path() -> Path:
@@ -76,3 +77,7 @@ def get_env_port() -> int:
 
 def get_env_host() -> str:
     return os.getenv(ENV_PHOENIX_HOST) or HOST
+
+
+def get_env_trace_endpoint() -> Optional[str]:
+    return os.getenv(ENV_TRACE_ENDPOINT) or None

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -7,7 +7,11 @@ from typing import List, Optional
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_HOST = "PHOENIX_HOST"
 ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
-ENV_TRACE_ENDPOINT = "PHOENIX_TRACE_ENDPOINT"
+ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
+"""
+The endpoint traces and evals are sent to. This must be set if the Phoenix
+server is running on a remote instance.
+"""
 
 
 def _get_temp_path() -> Path:
@@ -79,5 +83,5 @@ def get_env_host() -> str:
     return os.getenv(ENV_PHOENIX_HOST) or HOST
 
 
-def get_env_trace_endpoint() -> Optional[str]:
-    return os.getenv(ENV_TRACE_ENDPOINT) or None
+def get_env_collector_endpoint() -> Optional[str]:
+    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or None

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -11,7 +11,7 @@ from requests import Session
 from typing_extensions import TypeAlias
 
 import phoenix.trace.v1 as pb
-from phoenix.config import get_env_host, get_env_port, get_env_trace_endpoint
+from phoenix.config import get_env_collector_endpoint, get_env_host, get_env_port
 from phoenix.trace.schemas import Span
 from phoenix.trace.v1.utils import encode
 
@@ -43,7 +43,8 @@ class HttpExporter:
         endpoint: Optional[str]
             The endpoint of the Phoenix server (collector). This should be set if the Phoenix
             server is running on a remote instance. It can also be set using environment
-            variable `PHOENIX_TRACES_ENDPOINT`, otherwise it defaults to `http://127.0.0.1:6006`
+            variable `PHOENIX_COLLECTOR_ENDPOINT`, otherwise it defaults to `http://127.0.0.1:6006`
+            Note, this parameter supersedes `host` and `port`.
         host: Optional[str]
             The host of the Phoenix server. It can also be set using environment
             variable `PHOENIX_HOST`, otherwise it defaults to `127.0.0.1`.
@@ -53,7 +54,7 @@ class HttpExporter:
         """
         self._host = host or get_env_host()
         self._port = port or get_env_port()
-        endpoint = endpoint or get_env_trace_endpoint() or f"http://{self._host}:{self._port}"
+        endpoint = endpoint or get_env_collector_endpoint() or f"http://{self._host}:{self._port}"
         # Make sure the url does not end with a slash
         self._base_url = endpoint.rstrip("/")
         self._warn_if_phoenix_is_not_running()

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -11,7 +11,7 @@ from requests import Session
 from typing_extensions import TypeAlias
 
 import phoenix.trace.v1 as pb
-from phoenix.config import get_env_host, get_env_port
+from phoenix.config import get_env_host, get_env_port, get_env_trace_endpoint
 from phoenix.trace.schemas import Span
 from phoenix.trace.v1.utils import encode
 
@@ -31,6 +31,7 @@ class NoOpExporter:
 class HttpExporter:
     def __init__(
         self,
+        endpoint: Optional[str] = None,
         host: Optional[str] = None,
         port: Optional[int] = None,
     ) -> None:
@@ -39,6 +40,10 @@ class HttpExporter:
 
         Parameters
         ----------
+        endpoint: Optional[str]
+            The endpoint of the Phoenix server (collector). This should be set if the Phoenix
+            server is running on a remote instance. It can also be set using environment
+            variable `PHOENIX_TRACES_ENDPOINT`, otherwise it defaults to `http://127.0.0.1:6006`
         host: Optional[str]
             The host of the Phoenix server. It can also be set using environment
             variable `PHOENIX_HOST`, otherwise it defaults to `127.0.0.1`.
@@ -48,7 +53,9 @@ class HttpExporter:
         """
         self._host = host or get_env_host()
         self._port = port or get_env_port()
-        self._base_url = f"http://{self._host}:{self._port}"
+        endpoint = endpoint or get_env_trace_endpoint() or f"http://{self._host}:{self._port}"
+        # Make sure the url does not end with a slash
+        self._base_url = endpoint.rstrip("/")
         self._warn_if_phoenix_is_not_running()
         self._session = Session()
         weakref.finalize(self, self._session.close)

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -1,0 +1,17 @@
+import pytest
+from phoenix.trace.exporter import HttpExporter
+
+
+def test_exporter(monkeypatch: pytest.MonkeyPatch):
+    # Test that it defaults to local
+    exporter = HttpExporter()
+    assert exporter._base_url == "http://127.0.0.1:6006"
+
+    # Test that you can configure an endpoint
+    exporter = HttpExporter(endpoint="https://my-phoenix-server.com/")
+    assert exporter._base_url == "https://my-phoenix-server.com"
+
+    # Test that it supports environment variables
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "https://my-phoenix-server.com/")
+    exporter = HttpExporter()
+    assert exporter._base_url == "https://my-phoenix-server.com"


### PR DESCRIPTION
resolves #1793 

This PR introduces an `endpoint` config for the exporter so that we don't assume that the phoenix server is running locally. This is needed for various use-cases:

Phoenix can now be running on an EC2 instance or other
Phoenix might have to be running in Sagemaker studio in a separate process (Networking failing right now but in theory this might be the configuration)