### PR TITLE
fix(traces): convert (non-list) iterables to lists during protobuf construction due to potential presence of ndarray when reading from parquet files

### DIFF
--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -16,7 +16,7 @@ from typing import (
 from uuid import UUID
 
 from google.protobuf.json_format import MessageToDict
-from google.protobuf.struct_pb2 import Struct
+from google.protobuf.struct_pb2 import ListValue, Struct
 from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf.wrappers_pb2 import BoolValue, BytesValue, FloatValue, StringValue
 
@@ -521,8 +521,13 @@ def _maybe_timestamp(obj: Optional[datetime]) -> Optional[Timestamp]:
 def _as_struct(obj: Mapping[str, Any]) -> Struct:
     struct = Struct()
     for key, value in obj.items():
-        if isinstance(value, Iterable) and not isinstance(value, (str, list, Mapping)):
-            value = list(value)
+        if value is not None and not isinstance(
+            value, (str, int, float, bool, list, dict, Struct, ListValue)
+        ):
+            if isinstance(value, Mapping):
+                value = dict(value)
+            elif isinstance(value, Iterable):
+                value = list(value)
         struct[key] = value
     return struct
 

--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -521,7 +521,7 @@ def _maybe_timestamp(obj: Optional[datetime]) -> Optional[Timestamp]:
 def _as_struct(obj: Mapping[str, Any]) -> Struct:
     struct = Struct()
     for key, value in obj.items():
-        if isinstance(value, Iterable) and not isinstance(value, (str, dict, list)):
+        if isinstance(value, Iterable) and not isinstance(value, (str, list, Mapping)):
             value = list(value)
         struct[key] = value
     return struct

--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -520,7 +520,10 @@ def _maybe_timestamp(obj: Optional[datetime]) -> Optional[Timestamp]:
 
 def _as_struct(obj: Mapping[str, Any]) -> Struct:
     struct = Struct()
-    struct.update(obj)
+    for key, value in obj.items():
+        if isinstance(value, Iterable) and not isinstance(value, (str, dict, list)):
+            value = list(value)
+        struct[key] = value
     return struct
 
 

--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -521,6 +521,9 @@ def _maybe_timestamp(obj: Optional[datetime]) -> Optional[Timestamp]:
 def _as_struct(obj: Mapping[str, Any]) -> Struct:
     struct = Struct()
     for key, value in obj.items():
+        # The type check below is based on _SetStructValue in protobuf 3.20
+        # see https://github.com/protocolbuffers/protobuf/blob/5a3dac894157bf3618b2c906a8b9073b4cad62b6/python/google/protobuf/internal/well_known_types.py#L733C42  # noqa: E501
+        # An example is when we have numpy.ndarray as a value, which can come from pyarrow.
         if value is not None and not isinstance(
             value, (str, int, float, bool, list, dict, Struct, ListValue)
         ):

--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -523,7 +523,8 @@ def _as_struct(obj: Mapping[str, Any]) -> Struct:
     for key, value in obj.items():
         # The type check below is based on _SetStructValue in protobuf 3.20
         # see https://github.com/protocolbuffers/protobuf/blob/5a3dac894157bf3618b2c906a8b9073b4cad62b6/python/google/protobuf/internal/well_known_types.py#L733C42  # noqa: E501
-        # An example is when we have numpy.ndarray as a value, which can come from pyarrow.
+        # A use-case is when we have numpy.ndarray as a value, which can come from pyarrow.
+        # Note that this doesn't handle numpy.ndarray with more than one dimension.
         if value is not None and not isinstance(
             value, (str, int, float, bool, list, dict, Struct, ListValue)
         ):

--- a/src/phoenix/trace/v1/utils.py
+++ b/src/phoenix/trace/v1/utils.py
@@ -528,6 +528,8 @@ def _as_struct(obj: Mapping[str, Any]) -> Struct:
                 value = dict(value)
             elif isinstance(value, Iterable):
                 value = list(value)
+            else:
+                raise TypeError(f"Unsupported type {type(value)} for key {key}")
         struct[key] = value
     return struct
 


### PR DESCRIPTION
resolves #1758

based on the types found in [_SetStructValue](https://github.com/protocolbuffers/protobuf/blob/5a3dac894157bf3618b2c906a8b9073b4cad62b6/python/google/protobuf/internal/well_known_types.py#L733C42) which is shown below

Note that our protobuf version (3.20) does not accept `tuple`, so we have to convert it to list.

```python
def _SetStructValue(struct_value, value):
  if value is None:
    struct_value.null_value = 0
  elif isinstance(value, bool):
    # Note: this check must come before the number check because in Python
    # True and False are also considered numbers.
    struct_value.bool_value = value
  elif isinstance(value, str):
    struct_value.string_value = value
  elif isinstance(value, (int, float)):
    struct_value.number_value = value
  elif isinstance(value, (dict, Struct)):
    struct_value.struct_value.Clear()
    struct_value.struct_value.update(value)
  elif isinstance(value, (list, ListValue)):
    struct_value.list_value.Clear()
    struct_value.list_value.extend(value)
  else:
    raise ValueError('Unexpected type')
```