### PR TITLE
chore: Add LlamaIndex streaming notebook

### DIFF
--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -135,7 +135,6 @@ def test_callback_llm_span_contains_template_attributes(
     assert isinstance(span.attributes[LLM_PROMPT_TEMPLATE_VARIABLES], dict)
 
 
-@pytest.mark.xfail(reason="Span status code is incorrect after llama index update")
 def test_callback_llm_internal_error_has_exception_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -20,7 +20,7 @@ from llama_index.llms import (
 from llama_index.llms.base import llm_completion_callback
 from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.schema import Document, TextNode
-from openai import RateLimitError
+from openai import InternalServerError
 from phoenix.experimental.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 from phoenix.trace.exporter import NoOpExporter
 from phoenix.trace.llama_index import OpenInferenceTraceCallbackHandler
@@ -135,7 +135,8 @@ def test_callback_llm_span_contains_template_attributes(
     assert isinstance(span.attributes[LLM_PROMPT_TEMPLATE_VARIABLES], dict)
 
 
-def test_callback_llm_rate_limit_error_has_exception_event(
+@pytest.mark.xfail(reason="Span status code is incorrect after llama index update")
+def test_callback_llm_internal_error_has_exception_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
@@ -149,14 +150,14 @@ def test_callback_llm_rate_limit_error_has_exception_event(
     query_engine = index.as_query_engine(service_context=service_context)
 
     with patch.object(llm._client.chat.completions, "create") as mocked_chat_completion_create:
-        mocked_chat_completion_create.side_effect = RateLimitError(
+        mocked_chat_completion_create.side_effect = InternalServerError(
             "message",
             response=httpx.Response(
                 429, request=httpx.Request(method="post", url="https://api.openai.com/")
             ),
             body={},
         )
-        with pytest.raises(RateLimitError):
+        with pytest.raises(InternalServerError):
             query_engine.query(query)
 
     spans = list(callback_handler.get_spans())
@@ -170,7 +171,7 @@ def test_callback_llm_rate_limit_error_has_exception_event(
     assert isinstance(event, SpanException)
     assert isinstance(event.timestamp, datetime)
     assert len(event.attributes) == 3
-    assert event.attributes[EXCEPTION_TYPE] == "RateLimitError"
+    assert event.attributes[EXCEPTION_TYPE] == "InternalServerError"
     assert event.attributes[EXCEPTION_MESSAGE] == "message"
     assert isinstance(event.attributes[EXCEPTION_STACKTRACE], str)
 

--- a/tutorials/internal/llama_index_tracing_stream_example.ipynb
+++ b/tutorials/internal/llama_index_tracing_stream_example.ipynb
@@ -1,0 +1,289 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n",
+    "<h1 align=\"center\">Tracing and Evaluating a LlamaIndex Application</h1>\n",
+    "\n",
+    "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
+    "\n",
+    "In this tutorial, you will:\n",
+    "- Build a simple query engine using LlamaIndex that uses retrieval-augmented generation to answer questions over the Arize documentation,\n",
+    "- Record trace data in [OpenInference tracing](https://github.com/Arize-ai/open-inference-spec/blob/main/trace/spec/traces.md) format using the global `arize_phoenix` handler\n",
+    "- Inspect the traces and spans of your application to identify sources of latency and cost,\n",
+    "- Export your trace data as a pandas dataframe and run an [LLM Evals](https://docs.arize.com/phoenix/concepts/llm-evals) to measure the precision@k of the query engine's retrieval step.\n",
+    "\n",
+    "ℹ️ This notebook requires an OpenAI API key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install Dependencies and Import Libraries\n",
+    "\n",
+    "Install Phoenix, LlamaIndex, and OpenAI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"arize-phoenix[experimental,llama-index]\" \"openai>=1\" gcsfs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "from getpass import getpass\n",
+    "from urllib.request import urlopen\n",
+    "\n",
+    "import openai\n",
+    "import pandas as pd\n",
+    "import phoenix as px\n",
+    "from gcsfs import GCSFileSystem\n",
+    "from llama_index import (\n",
+    "    ServiceContext,\n",
+    "    StorageContext,\n",
+    "    load_index_from_storage,\n",
+    "    set_global_handler,\n",
+    ")\n",
+    "from llama_index.embeddings import OpenAIEmbedding\n",
+    "from llama_index.graph_stores.simple import SimpleGraphStore\n",
+    "from llama_index.llms import OpenAI\n",
+    "from phoenix.experimental.evals import (\n",
+    "    OpenAIModel,\n",
+    "    compute_precisions_at_k,\n",
+    "    run_relevance_eval,\n",
+    ")\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "pd.set_option(\"display.max_colwidth\", 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Launch Phoenix\n",
+    "\n",
+    "You can run Phoenix in the background to collect trace data emitted by any LlamaIndex application that has been instrumented with the `OpenInferenceTraceCallbackHandler`. Phoenix supports LlamaIndex's [one-click observability](https://gpt-index.readthedocs.io/en/latest/end_to_end_tutorials/one_click_observability.html) which will automatically instrument your LlamaIndex application! You can consult our [integration guide](https://docs.arize.com/phoenix/integrations/llamaindex) for a more detailed explanation of how to instrument your LlamaIndex application.\n",
+    "\n",
+    "Launch Phoenix and follow the instructions in the cell output to open the Phoenix UI (the UI should be empty because we have yet to run the LlamaIndex application)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = px.launch_app()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Configure Your OpenAI API Key\n",
+    "\n",
+    "Set your OpenAI API key if it is not already set as an environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "openai.api_key = openai_api_key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Build Your LlamaIndex Application"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example uses a `RetrieverQueryEngine` over a pre-built index of the Arize documentation, but you can use whatever LlamaIndex application you like.\n",
+    "\n",
+    "Download our pre-built index of the Arize docs from cloud storage and instantiate your storage context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_system = GCSFileSystem(project=\"public-assets-275721\")\n",
+    "index_path = \"arize-assets/phoenix/datasets/unstructured/llm/llama-index/arize-docs/index/\"\n",
+    "storage_context = StorageContext.from_defaults(\n",
+    "    fs=file_system,\n",
+    "    persist_dir=index_path,\n",
+    "    graph_store=SimpleGraphStore(),  # prevents unauthorized request to GCS\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Enable Phoenix tracing within LlamaIndex by setting `arize_phoenix` as the global handler. This will mount Phoenix's [OpenInferenceTraceCallback](https://docs.arize.com/phoenix/integrations/llamaindex) as the global handler. Phoenix uses OpenInference traces - an open-source standard for capturing and storing LLM application traces that enables LLM applications to seamlessly integrate with LLM observability solutions such as Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set_global_handler(\"arize_phoenix\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are now ready to instantiate our query engine that will perform retrieval-augmented generation (RAG). Query engine is a generic interface in LlamaIndex that allows you to ask question over your data. A query engine takes in a natural language query, and returns a rich response. It is built on top of Retrievers. You can compose multiple query engines to achieve more advanced capability  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service_context = ServiceContext.from_defaults(\n",
+    "    llm=OpenAI(model=\"gpt-4\", temperature=0.0),\n",
+    "    embed_model=OpenAIEmbedding(model=\"text-embedding-ada-002\"),\n",
+    ")\n",
+    "index = load_index_from_storage(\n",
+    "    storage_context,\n",
+    "    service_context=service_context,\n",
+    ")\n",
+    "query_engine = index.as_query_engine(streaming=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run Your Query Engine and View Your Traces in Phoenix\n",
+    "\n",
+    "We've compiled a list of commonly asked questions about Arize. Let's download the sample queries and take a look."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "queries_url = \"http://storage.googleapis.com/arize-assets/phoenix/datasets/unstructured/llm/context-retrieval/arize_docs_queries.jsonl\"\n",
+    "queries = []\n",
+    "with urlopen(queries_url) as response:\n",
+    "    for line in response:\n",
+    "        line = line.decode(\"utf-8\").strip()\n",
+    "        data = json.loads(line)\n",
+    "        queries.append(data[\"query\"])\n",
+    "queries[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's run the first 10 queries and view the traces in Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the response streams are correctly logged to phoenix\n",
+    "\n",
+    "for query in queries[:10]:\n",
+    "    query_engine.query(query).print_response_stream()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And just for fun, ask your own question and print the streamed response!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# however, the response generator does not yield live results\n",
+    "\n",
+    "for query in queries[:10]:\n",
+    "    response = query_engine.query(query)\n",
+    "    for result in response.response_gen:\n",
+    "        print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev38",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/internal/llama_index_tracing_stream_example.ipynb
+++ b/tutorials/internal/llama_index_tracing_stream_example.ipynb
@@ -77,12 +77,6 @@
     "from llama_index.embeddings import OpenAIEmbedding\n",
     "from llama_index.graph_stores.simple import SimpleGraphStore\n",
     "from llama_index.llms import OpenAI\n",
-    "from phoenix.experimental.evals import (\n",
-    "    OpenAIModel,\n",
-    "    compute_precisions_at_k,\n",
-    "    run_relevance_eval,\n",
-    ")\n",
-    "from tqdm import tqdm\n",
     "\n",
     "pd.set_option(\"display.max_colwidth\", 1000)"
    ]

--- a/tutorials/internal/llama_index_tracing_stream_example.ipynb
+++ b/tutorials/internal/llama_index_tracing_stream_example.ipynb
@@ -260,22 +260,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
research for #1572 

Adds a notebook that uses llama-index `query_engine` streaming. Demonstrates that while we successfully log queries, the streaming generator has already been consumed and will not yield results.