### PR TITLE
fix: pin llama-index temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ experimental = [
   "tenacity",
 ]
 llama-index = [
-  "llama-index~=0.9.0",
+  "llama-index~=0.9.0,<=0.9.6.post2"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
   "strawberry-graphql[debug-server]==0.208.2",
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
-  "llama-index>=0.9.0",
+  "llama-index>=0.9.0,<0.9.8",
   "langchain>=0.0.334",
   "litellm>=1.0.3"
 ]
@@ -64,7 +64,7 @@ experimental = [
   "tenacity",
 ]
 llama-index = [
-  "llama-index<0.9.7"
+  "llama-index>=0.9.0,<0.9.8"
 ]
 
 [project.urls]
@@ -98,7 +98,7 @@ dependencies = [
   "arize",
   "langchain>=0.0.334",
   "litellm>=1.0.3",
-  "llama-index>=0.9.0",
+  "llama-index>=0.9.0,<0.9.8",
   "openai>=1.0.0",
   "tenacity",
   "nltk==3.8.1",
@@ -117,7 +117,7 @@ dependencies = [
 [tool.hatch.envs.type]
 dependencies = [
   "mypy==1.5.1",
-  "llama-index>=0.9.0",
+  "llama-index>=0.9.0,<0.9.8",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "types-psutil",
   "types-tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ experimental = [
   "tenacity",
 ]
 llama-index = [
-  "llama-index~=0.9.0,<=0.9.6.post2"
+  "llama-index<0.9.7"
 ]
 
 [project.urls]


### PR DESCRIPTION
LlamaIndex recently updated their callback system so that exceptions are attached to the same. This PR pins the version of LlamaIndex below this most recent change until we've updated the callbacks to reflect the change.

Related PRs and issues:
- https://github.com/run-llama/llama_index/issues/9070
- https://github.com/Arize-ai/phoenix/issues/1618