### PR TITLE
ci: run tests on python 3.11

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -61,14 +61,15 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, windows-latest, ubuntu-latest]
-                python-version: ["3.8"]
         steps:
             - name: Checkout Repository
               uses: actions/checkout@v3
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: |
+                      3.8
+                      3.11
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip==${{ env.pip-version }}

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -15,3 +15,4 @@ def test_exporter(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "https://my-phoenix-server.com/")
     exporter = HttpExporter()
     assert exporter._base_url == "https://my-phoenix-server.com"
+    assert True


### PR DESCRIPTION
We are already doing so [locally](https://github.com/Arize-ai/phoenix/blob/a2732cd115dad011c3856819fd2abf2a80ca2154/pyproject.toml#L153). This PR adds it to the CI.

### Before
> Skipped 1 incompatible environment:
> test.py3.11 -> cannot locate Python: 3.11
<img width="404" alt="Screenshot 2023-11-27 at 2 06 20 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/931de72d-96e7-417e-bceb-8e61aa924e05">

### After
> ============================= test session starts ==============================
> platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
<img width="455" alt="Screenshot 2023-11-27 at 2 05 42 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/bba1b319-3e56-42c2-bc7a-b2a561f4a2ec">
