### PR TITLE
refactor: type check for exhaustive branching (using `assert_never` from typing-extension 4.1.0+)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "psutil",
   "strawberry-graphql==0.208.2",
   "pyarrow",
-  "typing-extensions",
+  "typing-extensions>=4.5, <5",
   "scipy",
   "wrapt",
   "sortedcontainers",

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union
 
 import requests
 from requests import Session
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, assert_never
 
 import phoenix.trace.v1 as pb
 from phoenix.config import get_env_collector_endpoint, get_env_host, get_env_port
@@ -76,6 +76,9 @@ class HttpExporter:
             self._queue.put(encode(item))
         elif isinstance(item, pb.Evaluation):
             self._queue.put(item)
+        else:
+            logger.exception(f"unrecognized item type: {type(item)}")
+            assert_never(item)
 
     def _start_consumer(self) -> None:
         Thread(
@@ -103,7 +106,8 @@ class HttpExporter:
             return f"{self._base_url}/v1/spans"
         if isinstance(message, pb.Evaluation):
             return f"{self._base_url}/v1/evaluations"
-        raise ValueError(f"Unknown message type: {type(message)}")
+        logger.exception(f"unrecognized message type: {type(message)}")
+        assert_never(message)
 
     def _warn_if_phoenix_is_not_running(self) -> None:
         try:


### PR DESCRIPTION
Notes:
1. `assert_never` is only available in typing-extension 4.1.0+. See [here](https://typing.readthedocs.io/en/latest/source/unreachable.html) for more info.
2. strawberry has typing-extension>=4.5 since [0.187.1](https://github.com/strawberry-graphql/strawberry/releases/tag/0.187.1) (6/21/23), so setting it lower by us than that won't change anything
3. colab has typing-extension 4.5.0
4. sagemaker has typing-extension 4.1.1, which will be upgraded when strawberry is installed