### PR TITLE
refactor: use string for span and trace id in protos

### DIFF
--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
     cast,
 )
-from uuid import UUID
 
 from ddsketch import DDSketch
 from sortedcontainers import SortedKeyList
@@ -231,14 +230,14 @@ class Traces:
                 self._process_span(item)
 
     def _process_span(self, span: pb.Span) -> None:
-        span_id = UUID(bytes=span.context.span_id)
+        span_id = SpanID(span.context.span_id)
         existing_span = self._spans.get(span_id)
         if existing_span and existing_span.end_time:
             # Reject updates if span has ended.
             return
         is_root_span = not span.HasField("parent_span_id")
         if not is_root_span:
-            parent_span_id = UUID(bytes=span.parent_span_id.value)
+            parent_span_id = SpanID(span.parent_span_id.value)
             if parent_span_id not in self._spans:
                 # Span can't be processed before its parent.
                 self._orphan_spans[parent_span_id].append(span)
@@ -258,7 +257,7 @@ class Traces:
         if is_root_span and end_time:
             self._latency_sorted_root_span_ids.add(span_id)
         if not existing_span:
-            trace_id = UUID(bytes=span.context.trace_id)
+            trace_id = TraceID(span.context.trace_id)
             self._traces[trace_id].append(span_id)
             if is_root_span:
                 self._start_time_sorted_root_span_ids.add(span_id)

--- a/src/phoenix/proto/trace/v1/trace.proto
+++ b/src/phoenix/proto/trace/v1/trace.proto
@@ -8,11 +8,11 @@ import "google/protobuf/wrappers.proto";
 message Span {
   google.protobuf.Struct attributes = 1;
   message Context {
-    bytes trace_id = 1;
-    bytes span_id = 2;
+    string trace_id = 1;
+    string span_id = 2;
   }
   Context context = 2;
-  google.protobuf.BytesValue parent_span_id = 3;
+  google.protobuf.StringValue parent_span_id = 3;
   string name = 4;
   google.protobuf.Timestamp start_time = 5;
   google.protobuf.Timestamp end_time = 6;

--- a/src/phoenix/trace/v1/trace_pb2.py
+++ b/src/phoenix/trace/v1/trace_pb2.py
@@ -16,7 +16,7 @@ from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 from google.protobuf import wrappers_pb2 as google_dot_protobuf_dot_wrappers__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14trace/v1/trace.proto\x12\x16phoenix.proto.trace.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xa2\x0b\n\x04Span\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x35\n\x07\x63ontext\x18\x02 \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.Context\x12\x33\n\x0eparent_span_id\x18\x03 \x01(\x0b\x32\x1b.google.protobuf.BytesValue\x12\x0c\n\x04name\x18\x04 \x01(\t\x12.\n\nstart_time\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x33\n\x06status\x18\x07 \x01(\x0b\x32#.phoenix.proto.trace.v1.Span.Status\x12\x32\n\x06\x65vents\x18\x08 \x03(\x0b\x32\".phoenix.proto.trace.v1.Span.Event\x12:\n\nexceptions\x18\t \x03(\x0b\x32&.phoenix.proto.trace.v1.Span.Exception\x12\x33\n\x05input\x18\n \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.IOValue\x12\x34\n\x06output\x18\x0b \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.IOValue\x12\x0c\n\x04kind\x18\x0c \x01(\t\x12\x34\n\tretrieval\x18\r \x01(\x0b\x32!.phoenix.proto.trace.v1.Retrieval\x12\x34\n\tembedding\x18\x0e \x01(\x0b\x32!.phoenix.proto.trace.v1.Embedding\x12(\n\x03llm\x18\x0f \x01(\x0b\x32\x1b.phoenix.proto.trace.v1.LLM\x12*\n\x04tool\x18\x10 \x01(\x0b\x32\x1c.phoenix.proto.trace.v1.Tool\x1a,\n\x07\x43ontext\x12\x10\n\x08trace_id\x18\x01 \x01(\x0c\x12\x0f\n\x07span_id\x18\x02 \x01(\x0c\x1a\x95\x01\n\x06Status\x12\x36\n\x04\x63ode\x18\x01 \x01(\x0e\x32(.phoenix.proto.trace.v1.Span.Status.Code\x12-\n\x07message\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"$\n\x04\x43ode\x12\t\n\x05UNSET\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x1aq\n\x05\x45vent\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x0c\n\x04name\x18\x02 \x01(\t\x12-\n\ttimestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a\xa1\x02\n\tException\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12-\n\x07message\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12*\n\x04type\x18\x03 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12+\n\x07\x65scaped\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x12\x30\n\nstacktrace\x18\x05 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12-\n\ttimestamp\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1aX\n\x07IOValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12-\n\njson_value\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x42\x06\n\x04kind\"\xdf\x02\n\tRetrieval\x12=\n\tdocuments\x18\x01 \x03(\x0b\x32*.phoenix.proto.trace.v1.Retrieval.Document\x1a\x92\x02\n\x08\x44ocument\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12(\n\x02id\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12*\n\x05score\x18\x03 \x01(\x0b\x32\x1b.google.protobuf.FloatValue\x12-\n\x07\x63ontent\x18\x04 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12)\n\x08metadata\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12)\n\x04hash\x18\x06 \x01(\x0b\x32\x1b.google.protobuf.BytesValue\"\xf4\x01\n\tEmbedding\x12?\n\nembeddings\x18\x01 \x03(\x0b\x32+.phoenix.proto.trace.v1.Embedding.Embedding\x12\x30\n\nmodel_name\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x1at\n\tEmbedding\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12*\n\x04text\x18\x03 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"2\n\x03LLM\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"3\n\x04Tool\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Structb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14trace/v1/trace.proto\x12\x16phoenix.proto.trace.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xa3\x0b\n\x04Span\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x35\n\x07\x63ontext\x18\x02 \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.Context\x12\x34\n\x0eparent_span_id\x18\x03 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12\x0c\n\x04name\x18\x04 \x01(\t\x12.\n\nstart_time\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x33\n\x06status\x18\x07 \x01(\x0b\x32#.phoenix.proto.trace.v1.Span.Status\x12\x32\n\x06\x65vents\x18\x08 \x03(\x0b\x32\".phoenix.proto.trace.v1.Span.Event\x12:\n\nexceptions\x18\t \x03(\x0b\x32&.phoenix.proto.trace.v1.Span.Exception\x12\x33\n\x05input\x18\n \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.IOValue\x12\x34\n\x06output\x18\x0b \x01(\x0b\x32$.phoenix.proto.trace.v1.Span.IOValue\x12\x0c\n\x04kind\x18\x0c \x01(\t\x12\x34\n\tretrieval\x18\r \x01(\x0b\x32!.phoenix.proto.trace.v1.Retrieval\x12\x34\n\tembedding\x18\x0e \x01(\x0b\x32!.phoenix.proto.trace.v1.Embedding\x12(\n\x03llm\x18\x0f \x01(\x0b\x32\x1b.phoenix.proto.trace.v1.LLM\x12*\n\x04tool\x18\x10 \x01(\x0b\x32\x1c.phoenix.proto.trace.v1.Tool\x1a,\n\x07\x43ontext\x12\x10\n\x08trace_id\x18\x01 \x01(\t\x12\x0f\n\x07span_id\x18\x02 \x01(\t\x1a\x95\x01\n\x06Status\x12\x36\n\x04\x63ode\x18\x01 \x01(\x0e\x32(.phoenix.proto.trace.v1.Span.Status.Code\x12-\n\x07message\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"$\n\x04\x43ode\x12\t\n\x05UNSET\x10\x00\x12\x06\n\x02OK\x10\x01\x12\t\n\x05\x45RROR\x10\x02\x1aq\n\x05\x45vent\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x0c\n\x04name\x18\x02 \x01(\t\x12-\n\ttimestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1a\xa1\x02\n\tException\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12-\n\x07message\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12*\n\x04type\x18\x03 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12+\n\x07\x65scaped\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\x12\x30\n\nstacktrace\x18\x05 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12-\n\ttimestamp\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x1aX\n\x07IOValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12-\n\njson_value\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x42\x06\n\x04kind\"\xdf\x02\n\tRetrieval\x12=\n\tdocuments\x18\x01 \x03(\x0b\x32*.phoenix.proto.trace.v1.Retrieval.Document\x1a\x92\x02\n\x08\x44ocument\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12(\n\x02id\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12*\n\x05score\x18\x03 \x01(\x0b\x32\x1b.google.protobuf.FloatValue\x12-\n\x07\x63ontent\x18\x04 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x12)\n\x08metadata\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\x12)\n\x04hash\x18\x06 \x01(\x0b\x32\x1b.google.protobuf.BytesValue\"\xf4\x01\n\tEmbedding\x12?\n\nembeddings\x18\x01 \x03(\x0b\x32+.phoenix.proto.trace.v1.Embedding.Embedding\x12\x30\n\nmodel_name\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.StringValue\x1at\n\tEmbedding\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12*\n\x04text\x18\x03 \x01(\x0b\x32\x1c.google.protobuf.StringValue\"2\n\x03LLM\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"3\n\x04Tool\x12+\n\nattributes\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Structb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'trace.v1.trace_pb2', globals())
@@ -24,29 +24,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   _SPAN._serialized_start=144
-  _SPAN._serialized_end=1586
-  _SPAN_CONTEXT._serialized_start=893
-  _SPAN_CONTEXT._serialized_end=937
-  _SPAN_STATUS._serialized_start=940
-  _SPAN_STATUS._serialized_end=1089
-  _SPAN_STATUS_CODE._serialized_start=1053
-  _SPAN_STATUS_CODE._serialized_end=1089
-  _SPAN_EVENT._serialized_start=1091
-  _SPAN_EVENT._serialized_end=1204
-  _SPAN_EXCEPTION._serialized_start=1207
-  _SPAN_EXCEPTION._serialized_end=1496
-  _SPAN_IOVALUE._serialized_start=1498
-  _SPAN_IOVALUE._serialized_end=1586
-  _RETRIEVAL._serialized_start=1589
-  _RETRIEVAL._serialized_end=1940
-  _RETRIEVAL_DOCUMENT._serialized_start=1666
-  _RETRIEVAL_DOCUMENT._serialized_end=1940
-  _EMBEDDING._serialized_start=1943
-  _EMBEDDING._serialized_end=2187
-  _EMBEDDING_EMBEDDING._serialized_start=2071
-  _EMBEDDING_EMBEDDING._serialized_end=2187
-  _LLM._serialized_start=2189
-  _LLM._serialized_end=2239
-  _TOOL._serialized_start=2241
-  _TOOL._serialized_end=2292
+  _SPAN._serialized_end=1587
+  _SPAN_CONTEXT._serialized_start=894
+  _SPAN_CONTEXT._serialized_end=938
+  _SPAN_STATUS._serialized_start=941
+  _SPAN_STATUS._serialized_end=1090
+  _SPAN_STATUS_CODE._serialized_start=1054
+  _SPAN_STATUS_CODE._serialized_end=1090
+  _SPAN_EVENT._serialized_start=1092
+  _SPAN_EVENT._serialized_end=1205
+  _SPAN_EXCEPTION._serialized_start=1208
+  _SPAN_EXCEPTION._serialized_end=1497
+  _SPAN_IOVALUE._serialized_start=1499
+  _SPAN_IOVALUE._serialized_end=1587
+  _RETRIEVAL._serialized_start=1590
+  _RETRIEVAL._serialized_end=1941
+  _RETRIEVAL_DOCUMENT._serialized_start=1667
+  _RETRIEVAL_DOCUMENT._serialized_end=1941
+  _EMBEDDING._serialized_start=1944
+  _EMBEDDING._serialized_end=2188
+  _EMBEDDING_EMBEDDING._serialized_start=2072
+  _EMBEDDING_EMBEDDING._serialized_end=2188
+  _LLM._serialized_start=2190
+  _LLM._serialized_end=2240
+  _TOOL._serialized_start=2242
+  _TOOL._serialized_end=2293
 # @@protoc_insertion_point(module_scope)

--- a/src/phoenix/trace/v1/trace_pb2.pyi
+++ b/src/phoenix/trace/v1/trace_pb2.pyi
@@ -31,13 +31,13 @@ class Span(google.protobuf.message.Message):
 
         TRACE_ID_FIELD_NUMBER: builtins.int
         SPAN_ID_FIELD_NUMBER: builtins.int
-        trace_id: builtins.bytes
-        span_id: builtins.bytes
+        trace_id: builtins.str
+        span_id: builtins.str
         def __init__(
             self,
             *,
-            trace_id: builtins.bytes = ...,
-            span_id: builtins.bytes = ...,
+            trace_id: builtins.str = ...,
+            span_id: builtins.str = ...,
         ) -> None: ...
         def ClearField(self, field_name: typing_extensions.Literal["span_id", b"span_id", "trace_id", b"trace_id"]) -> None: ...
 
@@ -171,7 +171,7 @@ class Span(google.protobuf.message.Message):
     @property
     def context(self) -> global___Span.Context: ...
     @property
-    def parent_span_id(self) -> google.protobuf.wrappers_pb2.BytesValue: ...
+    def parent_span_id(self) -> google.protobuf.wrappers_pb2.StringValue: ...
     name: builtins.str
     @property
     def start_time(self) -> google.protobuf.timestamp_pb2.Timestamp: ...
@@ -201,7 +201,7 @@ class Span(google.protobuf.message.Message):
         *,
         attributes: google.protobuf.struct_pb2.Struct | None = ...,
         context: global___Span.Context | None = ...,
-        parent_span_id: google.protobuf.wrappers_pb2.BytesValue | None = ...,
+        parent_span_id: google.protobuf.wrappers_pb2.StringValue | None = ...,
         name: builtins.str = ...,
         start_time: google.protobuf.timestamp_pb2.Timestamp | None = ...,
         end_time: google.protobuf.timestamp_pb2.Timestamp | None = ...,

--- a/tests/trace/test_schemas.py
+++ b/tests/trace/test_schemas.py
@@ -1,6 +1,5 @@
 import json
 import math
-from base64 import b64encode
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
@@ -76,9 +75,6 @@ def test_span_with_exception():
 
 def test_pb_span_encode_decode():
     trace_id, span_id, parent_span_id = uuid4(), uuid4(), uuid4()
-    trace_id_base64 = b64encode(trace_id.bytes).decode("utf-8")
-    span_id_base64 = b64encode(span_id.bytes).decode("utf-8")
-    parent_span_id_base64 = b64encode(parent_span_id.bytes).decode("utf-8")
     start_time = datetime.now(timezone.utc) - timedelta(weeks=1)
     start_time_rfc3339 = start_time.astimezone(timezone.utc).isoformat()[:-6] + "Z"
     event1_time = datetime.now(pytz.timezone("Asia/Kolkata")) - timedelta(days=1)
@@ -157,8 +153,8 @@ def test_pb_span_encode_decode():
         ],
     )
     desired_dict = {
-        "context": {"traceId": trace_id_base64, "spanId": span_id_base64},
-        "parentSpanId": parent_span_id_base64,
+        "context": {"traceId": str(trace_id), "spanId": str(span_id)},
+        "parentSpanId": str(parent_span_id),
         "name": "test",
         "startTime": start_time_rfc3339,
         "status": {"code": "OK"},
@@ -219,8 +215,8 @@ def test_pb_span_encode_decode():
     # Default values should not break.
     empty_pb_span = pb.Span(
         context=pb.Span.Context(
-            span_id=uuid4().bytes,
-            trace_id=uuid4().bytes,
+            span_id=str(uuid4()),
+            trace_id=str(uuid4()),
         )
     )
     assert decode(empty_pb_span) == decode(encode(decode(empty_pb_span)))


### PR DESCRIPTION
I think it was a mistake to use bytes to begin with, since string is much simpler overall. It's also much more readable as string when it's converted to JSON.