### PR TITLE
fix: enhance llama-index callback support for exception events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
   "strawberry-graphql[debug-server]==0.208.2",
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
-  "llama-index~=0.9.8",
+  "llama-index>=0.9.8",
   "langchain>=0.0.334",
   "litellm>=1.0.3"
 ]
@@ -64,7 +64,7 @@ experimental = [
   "tenacity",
 ]
 llama-index = [
-  "llama-index~=0.9.8",
+  "llama-index>=0.9.8",
 ]
 
 [project.urls]
@@ -98,7 +98,7 @@ dependencies = [
   "arize",
   "langchain>=0.0.334",
   "litellm>=1.0.3",
-  "llama-index~=0.9.8",
+  "llama-index>=0.9.8",
   "openai>=1.0.0",
   "tenacity",
   "nltk==3.8.1",
@@ -117,7 +117,7 @@ dependencies = [
 [tool.hatch.envs.type]
 dependencies = [
   "mypy==1.5.1",
-  "llama-index~=0.9.8",
+  "llama-index>=0.9.8",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "types-psutil",
   "types-tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
   "strawberry-graphql[debug-server]==0.208.2",
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
-  "llama-index>=0.9.0,<0.9.8",
+  "llama-index~=0.9.8",
   "langchain>=0.0.334",
   "litellm>=1.0.3"
 ]
@@ -64,7 +64,7 @@ experimental = [
   "tenacity",
 ]
 llama-index = [
-  "llama-index>=0.9.0,<0.9.8"
+  "llama-index~=0.9.8",
 ]
 
 [project.urls]
@@ -98,7 +98,7 @@ dependencies = [
   "arize",
   "langchain>=0.0.334",
   "litellm>=1.0.3",
-  "llama-index>=0.9.0,<0.9.8",
+  "llama-index~=0.9.8",
   "openai>=1.0.0",
   "tenacity",
   "nltk==3.8.1",
@@ -117,7 +117,7 @@ dependencies = [
 [tool.hatch.envs.type]
 dependencies = [
   "mypy==1.5.1",
-  "llama-index>=0.9.0,<0.9.8",
+  "llama-index~=0.9.8",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "types-psutil",
   "types-tqdm",

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -23,7 +23,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Sequence,
     Tuple,
     Union,
     cast,
@@ -511,7 +510,7 @@ def _get_end_time(event_data: CBEventData, span_events: Iterable[SpanEvent]) -> 
     return _tz_naive_to_tz_aware_datetime(tz_naive_end_time)
 
 
-def _get_span_exceptions(event_data: CBEventData, start_time: datetime) -> Sequence[SpanException]:
+def _get_span_exceptions(event_data: CBEventData, start_time: datetime) -> List[SpanException]:
     """Collects exceptions from the start and end events, if present."""
     span_exceptions = []
     for event in [event_data.start_event, event_data.end_event]:

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -494,7 +494,7 @@ def _get_response_output(response: Any) -> Iterator[Tuple[str, Any]]:
         yield OUTPUT_MIME_TYPE, MimeType.TEXT
 
 
-def _get_end_time(event_data: CBEventData, span_events: Sequence[SpanEvent]) -> Optional[datetime]:
+def _get_end_time(event_data: CBEventData, span_events: Iterable[SpanEvent]) -> Optional[datetime]:
     """
     A best-effort attempt to get the end time of an event.
 

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -515,18 +515,15 @@ def _get_span_exceptions(event_data: CBEventData, start_time: datetime) -> Seque
     """Collects exceptions from the start and end events, if present."""
     span_exceptions = []
     for event in [event_data.start_event, event_data.end_event]:
-        if event is None:
-            continue
-        if payload := event.payload:
-            if error := payload.get(EventPayload.EXCEPTION):
-                span_exceptions.append(
-                    SpanException(
-                        message=str(error),
-                        timestamp=start_time,
-                        exception_type=type(error).__name__,
-                        exception_stacktrace=get_stacktrace(error),
-                    )
+        if event and (payload := event.payload) and (error := payload.get(EventPayload.EXCEPTION)):
+            span_exceptions.append(
+                SpanException(
+                    message=str(error),
+                    timestamp=start_time,
+                    exception_type=type(error).__name__,
+                    exception_stacktrace=get_stacktrace(error),
                 )
+            )
     return span_exceptions
 
 

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -93,7 +93,7 @@ from phoenix.trace.tracer import SpanExporter, Tracer
 from phoenix.trace.utils import extract_version_triplet, get_stacktrace
 from phoenix.utilities.error_handling import graceful_fallback
 
-LLAMA_INDEX_MINIMUM_VERSION_TRIPLET = (0, 9, 0)
+LLAMA_INDEX_MINIMUM_VERSION_TRIPLET = (0, 9, 8)
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -518,13 +518,13 @@ def _get_span_exceptions(event_data: CBEventData, start_time: datetime) -> Seque
         if event is None:
             continue
         if payload := event.payload:
-            if exception := payload.get(EventPayload.EXCEPTION):
+            if error := payload.get(EventPayload.EXCEPTION):
                 span_exceptions.append(
                     SpanException(
-                        message=str(exception),
+                        message=str(error),
                         timestamp=start_time,
-                        exception_type=type(exception).__name__,
-                        exception_stacktrace=get_stacktrace(exception),
+                        exception_type=type(error).__name__,
+                        exception_stacktrace=get_stacktrace(error),
                     )
                 )
     return span_exceptions

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -183,8 +183,8 @@ def test_callback_exception_event_produces_root_chain_span_with_exception_events
     )
     query_engine = index.as_query_engine(service_context=service_context)
 
-    # mock the _query method to raise an exception before on_event_start is
-    # called for any method
+    # mock the _query method to raise an exception before any event has begun
+    # to produce an independent exception event
     with patch.object(query_engine, "_query") as mocked_query:
         mocked_query.side_effect = Exception("message")
         with pytest.raises(Exception):

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -160,10 +160,8 @@ def test_callback_llm_rate_limit_error_has_exception_event(
             query_engine.query(query)
 
     spans = list(callback_handler.get_spans())
-    assert all(
-        span.status_code == SpanStatusCode.OK for span in spans if span.span_kind != SpanKind.LLM
-    )
-    span = next(span for span in spans if span.span_kind == SpanKind.LLM)
+    assert all(span.status_code == SpanStatusCode.OK for span in spans if span.name != "synthesize")
+    span = next(span for span in spans if span.name == "synthesize")
     assert span.status_code == SpanStatusCode.ERROR
     events = span.events
     event = events[0]

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -135,7 +135,7 @@ def test_callback_llm_span_contains_template_attributes(
     assert isinstance(span.attributes[LLM_PROMPT_TEMPLATE_VARIABLES], dict)
 
 
-def test_callback_llm_rate_limit_error_has_exception_event(
+def test_callback_rate_limit_error_has_exception_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
@@ -169,6 +169,39 @@ def test_callback_llm_rate_limit_error_has_exception_event(
     assert isinstance(event.timestamp, datetime)
     assert len(event.attributes) == 3
     assert event.attributes[EXCEPTION_TYPE] == "RateLimitError"
+    assert event.attributes[EXCEPTION_MESSAGE] == "message"
+    assert isinstance(event.attributes[EXCEPTION_STACKTRACE], str)
+
+
+def test_callback_exception_event_produces_root_chain_span_with_exception_events() -> None:
+    llm = OpenAI(model="gpt-3.5-turbo", max_retries=1)
+    query = "What are the seven wonders of the world?"
+    callback_handler = OpenInferenceTraceCallbackHandler(exporter=NoOpExporter())
+    index = ListIndex(nodes)
+    service_context = ServiceContext.from_defaults(
+        llm=llm, callback_manager=CallbackManager([callback_handler])
+    )
+    query_engine = index.as_query_engine(service_context=service_context)
+
+    # mock the _query method to raise an exception before on_event_start is
+    # called for any method
+    with patch.object(query_engine, "_query") as mocked_query:
+        mocked_query.side_effect = Exception("message")
+        with pytest.raises(Exception):
+            query_engine.query(query)
+
+    spans = list(callback_handler.get_spans())
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.span_kind == SpanKind.CHAIN
+    assert span.status_code == SpanStatusCode.ERROR
+    assert span.name == "exception"
+    events = span.events
+    event = events[0]
+    assert isinstance(event, SpanException)
+    assert isinstance(event.timestamp, datetime)
+    assert len(event.attributes) == 3
+    assert event.attributes[EXCEPTION_TYPE] == "Exception"
     assert event.attributes[EXCEPTION_MESSAGE] == "message"
     assert isinstance(event.attributes[EXCEPTION_STACKTRACE], str)
 

--- a/tutorials/internal/llama_index_tracing_example.ipynb
+++ b/tutorials/internal/llama_index_tracing_example.ipynb
@@ -54,7 +54,7 @@
     "from llama_index.callbacks import CallbackManager\n",
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.graph_stores.simple import SimpleGraphStore\n",
-    "from llama_index.indices.postprocessor.cohere_rerank import CohereRerank\n",
+    "from llama_index.postprocessor.cohere_rerank import CohereRerank\n",
     "from phoenix.trace.llama_index import (\n",
     "    OpenInferenceTraceCallbackHandler,\n",
     ")\n",


### PR DESCRIPTION
LlamaIndex recently changed the way their callback system handles exception information. Previously, exceptions always resulted in independent exception callback events. Now, whenever possible, exception information is passed via the `on_event_end` callback hook for the callback event that caused the exception. When that is not possible (e.g., when the exception arises outside of any event), the callback system produces an independent exception event containing the exception information. This latter scenario should be rare and indicates that there is a bug in LlamaIndex itself.

This PR adjusts our callback handler to accommodate these changes. In particular, it searches each callback event payload for an `EventPayload.EXCEPTION` key, and if present, grabs the exception information from that key. In the infrequent but possible event that the LlamaIndex callback system registers an independent exception callback event, we create a span of span kind "chain" and attach the exception information to this span.

Note that LlamaIndex is currently incorrectly passing the exception information for failed LLM calls (e.g., due to rate limit errors) to the parent synthesis span in the case of query engines. I've adjusted the unit tests accordingly for now. I've noted to the LlamaIndex team [here](https://github.com/run-llama/llama_index/issues/9070#issuecomment-1829187065).

<img width="586" alt="Screenshot 2023-11-27 at 9 39 58 PM" src="https://github.com/Arize-ai/phoenix/assets/15664869/e6e3d0a2-597f-43b5-92df-d988ddb49ed0">

I will handle percolating exceptions up the span tree in a subsequent PR.

Relevant issues:

- https://github.com/Arize-ai/phoenix/pull/1814/files
- https://github.com/run-llama/llama_index/issues/9070