### PR TITLE
fix(traces): make column selector sync'd between tabs

### DIFF
--- a/app/src/contexts/TracingContext.tsx
+++ b/app/src/contexts/TracingContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, PropsWithChildren, useRef } from "react";
+import { useZustand } from "use-zustand";
+
+import {
+  createTracingStore,
+  TracingProps,
+  TracingState,
+  TracingStore,
+} from "@phoenix/store/tracingStore";
+
+export const TracingContext = createContext<TracingStore | null>(null);
+
+export function TracingProvider({
+  children,
+  ...props
+}: PropsWithChildren<Partial<TracingProps>>) {
+  const storeRef = useRef<TracingStore>();
+  if (!storeRef.current) {
+    storeRef.current = createTracingStore(props);
+  }
+  return (
+    <TracingContext.Provider value={storeRef.current}>
+      {children}
+    </TracingContext.Provider>
+  );
+}
+
+export function useTracingContext<T>(
+  selector: (state: TracingState) => T,
+  equalityFn?: (left: T, right: T) => boolean
+): T {
+  const store = React.useContext(TracingContext);
+  if (!store) throw new Error("Missing TracingContext.Provider in the tree");
+  return useZustand(store, selector, equalityFn);
+}

--- a/app/src/pages/TracingRoot.tsx
+++ b/app/src/pages/TracingRoot.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { Outlet } from "react-router";
 
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
+import { TracingProvider } from "@phoenix/contexts/TracingContext";
 
 export function TracingRoot() {
   return (
-    <StreamStateProvider>
-      <Outlet />
-    </StreamStateProvider>
+    <TracingProvider>
+      <StreamStateProvider>
+        <Outlet />
+      </StreamStateProvider>
+    </TracingProvider>
   );
 }

--- a/app/src/pages/tracing/SpanColumnSelector.tsx
+++ b/app/src/pages/tracing/SpanColumnSelector.tsx
@@ -1,8 +1,10 @@
 import React, { ChangeEvent, useCallback, useMemo } from "react";
-import { Column, VisibilityState } from "@tanstack/react-table";
+import { Column } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
 import { Dropdown, Flex, Icon, Icons, View } from "@arizeai/components";
+
+import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
 const UN_HIDABLE_COLUMN_IDS = ["spanKind", "name"];
 
@@ -14,14 +16,6 @@ type SpanColumnSelectorProps = {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   columns: Column<any>[];
-  /**
-   * Map of the column id to the visibility state
-   */
-  columnVisibility: VisibilityState;
-  /*
-   * Callback to set the visibility state of a column
-   */
-  onColumnVisibilityChange: (visibilityState: VisibilityState) => void;
 };
 
 export function SpanColumnSelector(props: SpanColumnSelectorProps) {
@@ -51,12 +45,12 @@ const columCheckboxItemCSS = css`
 `;
 
 function ColumnSelectorMenu(props: SpanColumnSelectorProps) {
-  const {
-    columns: propsColumns,
-    columnVisibility,
-    onColumnVisibilityChange,
-  } = props;
+  const { columns: propsColumns } = props;
 
+  const columnVisibility = useTracingContext((state) => state.columnVisibility);
+  const setColumnVisibility = useTracingContext(
+    (state) => state.setColumnVisibility
+  );
   const columns = useMemo(() => {
     return propsColumns.filter((column) => {
       return !UN_HIDABLE_COLUMN_IDS.includes(column.id);
@@ -74,9 +68,9 @@ function ColumnSelectorMenu(props: SpanColumnSelectorProps) {
   const onCheckboxChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const { name, checked } = event.target;
-      onColumnVisibilityChange({ ...columnVisibility, [name]: checked });
+      setColumnVisibility({ ...columnVisibility, [name]: checked });
     },
-    [columnVisibility, onColumnVisibilityChange]
+    [columnVisibility, setColumnVisibility]
   );
 
   const onToggleAll = useCallback(
@@ -85,9 +79,9 @@ function ColumnSelectorMenu(props: SpanColumnSelectorProps) {
       const newVisibilityState = columns.reduce((acc, column) => {
         return { ...acc, [column.id]: checked };
       }, {});
-      onColumnVisibilityChange(newVisibilityState);
+      setColumnVisibility(newVisibilityState);
     },
-    [columns, onColumnVisibilityChange]
+    [columns, setColumnVisibility]
   );
 
   return (

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -29,6 +29,7 @@ import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
+import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
 import {
   SpansTable_spans$key,
@@ -57,7 +58,7 @@ export function SpansTable(props: SpansTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const navigate = useNavigate();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<SpansTableSpansQuery, SpansTable_spans$key>(
@@ -235,6 +236,7 @@ export function SpansTable(props: SpansTableProps) {
     data: tableData,
     state: {
       sorting,
+      columnVisibility,
     },
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
@@ -255,11 +257,7 @@ export function SpansTable(props: SpansTableProps) {
       >
         <Flex direction="row" gap="size-100" width="100%" alignItems="center">
           <SpanFilterConditionField onValidCondition={setFilterCondition} />
-          <SpanColumnSelector
-            columns={computedColumns}
-            columnVisibility={columnVisibility}
-            onColumnVisibilityChange={setColumnVisibility}
-          />
+          <SpanColumnSelector columns={computedColumns} />
         </Flex>
       </View>
       <div

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -14,7 +14,6 @@ import {
   getSortedRowModel,
   SortingState,
   useReactTable,
-  VisibilityState,
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -120,9 +120,9 @@ export function TracesTable(props: TracesTableProps) {
                 statusCode
                 startTime
                 latencyMs
-                cumulativeTokenCountTotal
-                cumulativeTokenCountPrompt
-                cumulativeTokenCountCompletion
+                tokenCountTotal: cumulativeTokenCountTotal
+                tokenCountPrompt: cumulativeTokenCountPrompt
+                tokenCountCompletion: cumulativeTokenCountCompletion
                 parentId
                 input {
                   value
@@ -141,9 +141,9 @@ export function TracesTable(props: TracesTableProps) {
                   startTime
                   latencyMs
                   parentId
-                  cumulativeTokenCountTotal: tokenCountTotal # this switcheroo is to allow descendant Rows to unfurl in the same Table while displaying a different value under the same Column
-                  cumulativeTokenCountPrompt: tokenCountPrompt
-                  cumulativeTokenCountCompletion: tokenCountCompletion
+                  tokenCountTotal
+                  tokenCountPrompt
+                  tokenCountCompletion
                   input {
                     value
                   }
@@ -261,7 +261,7 @@ export function TracesTable(props: TracesTableProps) {
     },
     {
       header: "total tokens",
-      accessorKey: "cumulativeTokenCountTotal",
+      accessorKey: "tokenCountTotal",
       cell: ({ row, getValue }) => {
         const value = getValue();
         if (value === null) {
@@ -270,10 +270,8 @@ export function TracesTable(props: TracesTableProps) {
         return (
           <TokenCount
             tokenCountTotal={value as number}
-            tokenCountPrompt={row.original.cumulativeTokenCountPrompt || 0}
-            tokenCountCompletion={
-              row.original.cumulativeTokenCountCompletion || 0
-            }
+            tokenCountPrompt={row.original.tokenCountPrompt || 0}
+            tokenCountCompletion={row.original.tokenCountCompletion || 0}
           />
         );
       },

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -17,7 +17,6 @@ import {
   getSortedRowModel,
   SortingState,
   useReactTable,
-  VisibilityState,
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
@@ -35,6 +34,7 @@ import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon
 import { ISpanItem } from "@phoenix/components/trace/types";
 import { createSpanTree, SpanTreeNode } from "@phoenix/components/trace/utils";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
+import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
 import {
   SpanStatusCode,
@@ -327,7 +327,7 @@ export function TracesTable(props: TracesTableProps) {
     [hasNext, isLoadingNext, loadNext]
   );
   const [expanded, setExpanded] = useState<ExpandedState>({});
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const table = useReactTable<TableRow>({
     columns,
     data: tableData,
@@ -359,11 +359,7 @@ export function TracesTable(props: TracesTableProps) {
       >
         <Flex direction="row" gap="size-100" width="100%" alignItems="center">
           <SpanFilterConditionField onValidCondition={setFilterCondition} />
-          <SpanColumnSelector
-            columns={computedColumns}
-            columnVisibility={columnVisibility}
-            onColumnVisibilityChange={setColumnVisibility}
-          />
+          <SpanColumnSelector columns={computedColumns} />
         </Flex>
       </View>
       <div

--- a/app/src/pages/tracing/__generated__/TracesTableQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracesTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84dba557735ef51ceef7db0c334eab1a>>
+ * @generated SignedSource<<f50050fcce0dc13af22f690bdb37e872>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -240,21 +240,21 @@ return {
                   (v9/*: any*/),
                   (v10/*: any*/),
                   {
-                    "alias": null,
+                    "alias": "tokenCountTotal",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountTotal",
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "tokenCountPrompt",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountPrompt",
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "tokenCountCompletion",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountCompletion",
@@ -279,21 +279,21 @@ return {
                       (v10/*: any*/),
                       (v11/*: any*/),
                       {
-                        "alias": "cumulativeTokenCountTotal",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "tokenCountTotal",
                         "storageKey": null
                       },
                       {
-                        "alias": "cumulativeTokenCountPrompt",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "tokenCountPrompt",
                         "storageKey": null
                       },
                       {
-                        "alias": "cumulativeTokenCountCompletion",
+                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "tokenCountCompletion",
@@ -380,16 +380,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b789bd2511cdd3d727cc8d5dd722ca19",
+    "cacheID": "d4ab1d47415433043982e3a5fd4cef26",
     "id": null,
     "metadata": {},
     "name": "TracesTableQuery",
     "operationKind": "query",
-    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...TracesTable_spans_1XEuU\n}\n\nfragment TracesTable_spans_1XEuU on Query {\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...TracesTable_spans_1XEuU\n}\n\nfragment TracesTable_spans_1XEuU on Query {\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "db7fc63729aa46c828716aef5c7e9693";
+(node as any).hash = "bef7f02af9f00db54d9294f27ee3c302";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<da24c5f08b2aff47a06f93788283e3f0>>
+ * @generated SignedSource<<df319ec22ad1efe3e709d46fd1890f41>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,17 +20,11 @@ export type TracesTable_spans$data = {
           readonly spanId: string;
           readonly traceId: string;
         };
-        readonly cumulativeTokenCountCompletion: number | null;
-        readonly cumulativeTokenCountPrompt: number | null;
-        readonly cumulativeTokenCountTotal: number | null;
         readonly descendants: ReadonlyArray<{
           readonly context: {
             readonly spanId: string;
             readonly traceId: string;
           };
-          readonly cumulativeTokenCountCompletion: number | null;
-          readonly cumulativeTokenCountPrompt: number | null;
-          readonly cumulativeTokenCountTotal: number | null;
           readonly input: {
             readonly value: string;
           } | null;
@@ -43,6 +37,9 @@ export type TracesTable_spans$data = {
           readonly spanKind: SpanKind;
           readonly startTime: string;
           readonly statusCode: SpanStatusCode;
+          readonly tokenCountCompletion: number | null;
+          readonly tokenCountPrompt: number | null;
+          readonly tokenCountTotal: number | null;
         }>;
         readonly input: {
           readonly value: string;
@@ -56,6 +53,9 @@ export type TracesTable_spans$data = {
         readonly spanKind: SpanKind;
         readonly startTime: string;
         readonly statusCode: SpanStatusCode;
+        readonly tokenCountCompletion: number | null;
+        readonly tokenCountPrompt: number | null;
+        readonly tokenCountTotal: number | null;
       };
     }>;
   };
@@ -263,21 +263,21 @@ return {
                 (v4/*: any*/),
                 (v5/*: any*/),
                 {
-                  "alias": null,
+                  "alias": "tokenCountTotal",
                   "args": null,
                   "kind": "ScalarField",
                   "name": "cumulativeTokenCountTotal",
                   "storageKey": null
                 },
                 {
-                  "alias": null,
+                  "alias": "tokenCountPrompt",
                   "args": null,
                   "kind": "ScalarField",
                   "name": "cumulativeTokenCountPrompt",
                   "storageKey": null
                 },
                 {
-                  "alias": null,
+                  "alias": "tokenCountCompletion",
                   "args": null,
                   "kind": "ScalarField",
                   "name": "cumulativeTokenCountCompletion",
@@ -302,21 +302,21 @@ return {
                     (v5/*: any*/),
                     (v6/*: any*/),
                     {
-                      "alias": "cumulativeTokenCountTotal",
+                      "alias": null,
                       "args": null,
                       "kind": "ScalarField",
                       "name": "tokenCountTotal",
                       "storageKey": null
                     },
                     {
-                      "alias": "cumulativeTokenCountPrompt",
+                      "alias": null,
                       "args": null,
                       "kind": "ScalarField",
                       "name": "tokenCountPrompt",
                       "storageKey": null
                     },
                     {
-                      "alias": "cumulativeTokenCountCompletion",
+                      "alias": null,
                       "args": null,
                       "kind": "ScalarField",
                       "name": "tokenCountCompletion",
@@ -393,6 +393,6 @@ return {
 };
 })();
 
-(node as any).hash = "db7fc63729aa46c828716aef5c7e9693";
+(node as any).hash = "bef7f02af9f00db54d9294f27ee3c302";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/TracingHomePageQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracingHomePageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5bd93b218dbad867dfbcffca19c7730>>
+ * @generated SignedSource<<5e93a0c14112bb044a93e42227466a49>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,6 +82,20 @@ v8 = {
 v9 = {
   "alias": null,
   "args": null,
+  "kind": "ScalarField",
+  "name": "tokenCountPrompt",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "tokenCountCompletion",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
   "concreteType": "SpanContext",
   "kind": "LinkedField",
   "name": "context",
@@ -104,15 +118,15 @@ v9 = {
   ],
   "storageKey": null
 },
-v10 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "value",
   "storageKey": null
 },
-v11 = [
-  (v10/*: any*/),
+v13 = [
+  (v12/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -121,14 +135,14 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v13 = {
+v15 = {
   "alias": null,
   "args": null,
   "concreteType": "Span",
@@ -146,7 +160,7 @@ v13 = {
   ],
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -171,50 +185,50 @@ v14 = {
   ],
   "storageKey": null
 },
-v15 = {
+v17 = {
   "kind": "Literal",
   "name": "rootSpansOnly",
   "value": true
 },
-v16 = [
+v18 = [
   (v0/*: any*/),
-  (v15/*: any*/),
+  (v17/*: any*/),
   (v1/*: any*/)
 ],
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v18 = [
-  (v10/*: any*/)
+v20 = [
+  (v12/*: any*/)
 ],
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v18/*: any*/),
+  "selections": (v20/*: any*/),
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v18/*: any*/),
+  "selections": (v20/*: any*/),
   "storageKey": null
 },
-v21 = [
-  (v15/*: any*/)
+v23 = [
+  (v17/*: any*/)
 ],
-v22 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -301,21 +315,9 @@ return {
                   (v6/*: any*/),
                   (v7/*: any*/),
                   (v8/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "tokenCountPrompt",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "tokenCountCompletion",
-                    "storageKey": null
-                  },
                   (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -323,7 +325,7 @@ return {
                     "kind": "LinkedField",
                     "name": "input",
                     "plural": false,
-                    "selections": (v11/*: any*/),
+                    "selections": (v13/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -333,18 +335,18 @@ return {
                     "kind": "LinkedField",
                     "name": "output",
                     "plural": false,
-                    "selections": (v11/*: any*/),
+                    "selections": (v13/*: any*/),
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v12/*: any*/),
-              (v13/*: any*/)
+              (v14/*: any*/),
+              (v15/*: any*/)
             ],
             "storageKey": null
           },
-          (v14/*: any*/)
+          (v16/*: any*/)
         ],
         "storageKey": "spans(first:100,sort:{\"col\":\"startTime\",\"dir\":\"desc\"})"
       },
@@ -362,7 +364,7 @@ return {
       },
       {
         "alias": "rootSpans",
-        "args": (v16/*: any*/),
+        "args": (v18/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
@@ -390,30 +392,30 @@ return {
                   (v6/*: any*/),
                   (v7/*: any*/),
                   {
-                    "alias": null,
+                    "alias": "tokenCountTotal",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountTotal",
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "tokenCountPrompt",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountPrompt",
                     "storageKey": null
                   },
                   {
-                    "alias": null,
+                    "alias": "tokenCountCompletion",
                     "args": null,
                     "kind": "ScalarField",
                     "name": "cumulativeTokenCountCompletion",
                     "storageKey": null
                   },
-                  (v17/*: any*/),
                   (v19/*: any*/),
-                  (v20/*: any*/),
-                  (v9/*: any*/),
+                  (v21/*: any*/),
+                  (v22/*: any*/),
+                  (v11/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -427,49 +429,31 @@ return {
                       (v5/*: any*/),
                       (v6/*: any*/),
                       (v7/*: any*/),
-                      (v17/*: any*/),
-                      {
-                        "alias": "cumulativeTokenCountTotal",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "tokenCountTotal",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cumulativeTokenCountPrompt",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "tokenCountPrompt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cumulativeTokenCountCompletion",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "tokenCountCompletion",
-                        "storageKey": null
-                      },
                       (v19/*: any*/),
-                      (v20/*: any*/),
-                      (v9/*: any*/)
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v21/*: any*/),
+                      (v22/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v12/*: any*/),
-              (v13/*: any*/)
+              (v14/*: any*/),
+              (v15/*: any*/)
             ],
             "storageKey": null
           },
-          (v14/*: any*/)
+          (v16/*: any*/)
         ],
         "storageKey": "spans(first:100,rootSpansOnly:true,sort:{\"col\":\"startTime\",\"dir\":\"desc\"})"
       },
       {
         "alias": "rootSpans",
-        "args": (v16/*: any*/),
+        "args": (v18/*: any*/),
         "filters": [
           "sort",
           "rootSpansOnly",
@@ -482,12 +466,12 @@ return {
       },
       {
         "alias": "totalTraces",
-        "args": (v21/*: any*/),
+        "args": (v23/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
         "plural": false,
-        "selections": (v22/*: any*/),
+        "selections": (v24/*: any*/),
         "storageKey": "spans(rootSpansOnly:true)"
       },
       {
@@ -526,23 +510,23 @@ return {
       },
       {
         "alias": "traceCount",
-        "args": (v21/*: any*/),
+        "args": (v23/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
         "plural": false,
-        "selections": (v22/*: any*/),
+        "selections": (v24/*: any*/),
         "storageKey": "spans(rootSpansOnly:true)"
       }
     ]
   },
   "params": {
-    "cacheID": "46ac777207a95172a83162f50ac2d22d",
+    "cacheID": "c6ade5ea24cf7c92b41252beca473730",
     "id": null,
     "metadata": {},
     "name": "TracingHomePageQuery",
     "operationKind": "query",
-    "text": "query TracingHomePageQuery {\n  ...SpansTable_spans\n  ...TracesTable_spans\n  ...TracingHomePageHeader_stats\n  ...StreamToggle_data\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment StreamToggle_data on Query {\n  traceCount: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n}\n\nfragment TracesTable_spans on Query {\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TracingHomePageHeader_stats on Query {\n  totalTraces: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n  traceDatasetInfo {\n    startTime\n    endTime\n    tokenCountTotal\n    latencyMsP50\n    latencyMsP99\n  }\n}\n"
+    "text": "query TracingHomePageQuery {\n  ...SpansTable_spans\n  ...TracesTable_spans\n  ...TracingHomePageHeader_stats\n  ...StreamToggle_data\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment StreamToggle_data on Query {\n  traceCount: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n}\n\nfragment TracesTable_spans on Query {\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TracingHomePageHeader_stats on Query {\n  totalTraces: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n  traceDatasetInfo {\n    startTime\n    endTime\n    tokenCountTotal\n    latencyMsP50\n    latencyMsP99\n  }\n}\n"
   }
 };
 })();

--- a/app/src/store/index.tsx
+++ b/app/src/store/index.tsx
@@ -1,1 +1,2 @@
 export * from "./pointCloudStore";
+export * from "./tracingStore";

--- a/app/src/store/tracingStore.tsx
+++ b/app/src/store/tracingStore.tsx
@@ -1,0 +1,32 @@
+import { create, StateCreator } from "zustand";
+import { devtools } from "zustand/middleware";
+
+type VisibilityState = Record<string, boolean>;
+export interface TracingProps {
+  /**
+   * Map of the column id to the visibility state
+   */
+  columnVisibility: VisibilityState;
+}
+
+export interface TracingState extends TracingProps {
+  /**
+   * Sets the visibility state of a column
+   * @param columnVisibility
+   * @returns
+   */
+  setColumnVisibility: (columnVisibility: VisibilityState) => void;
+}
+
+export const createTracingStore = (initialProps?: Partial<TracingProps>) => {
+  const tracingStore: StateCreator<TracingState> = (set) => ({
+    ...initialProps,
+    columnVisibility: {},
+    setColumnVisibility: (columnVisibility) => {
+      set({ columnVisibility });
+    },
+  });
+  return create<TracingState>()(devtools(tracingStore));
+};
+
+export type TracingStore = ReturnType<typeof createTracingStore>;

--- a/cspell.json
+++ b/cspell.json
@@ -28,7 +28,8 @@
         "tensorboard",
         "tiktoken",
         "tracedataset",
-        "UMAP"
+        "UMAP",
+        "Zustand"
     ],
     "flagWords": [
         "hte"


### PR DESCRIPTION
resolves #1807 

Makes the column selector work on the spans tab and keeps the visibility state in sync across the two tabs by creating a central zustand store (which will be extended).