### PR TITLE
feat(traces): show all evaluations in the table"

### DIFF
--- a/app/src/components/trace/types.ts
+++ b/app/src/components/trace/types.ts
@@ -9,10 +9,10 @@ export interface ISpanItem {
   startTime: string;
   parentId: string | null;
   context: ISpanContext;
-  [otherKeys: string]: unknown;
   tokenCountTotal?: number | null;
   tokenCountPrompt?: number | null;
   tokenCountCompletion?: number | null;
+  [otherKeys: string]: unknown;
 }
 
 interface ISpanContext {

--- a/app/src/pages/tracing/EvaluationLabel.tsx
+++ b/app/src/pages/tracing/EvaluationLabel.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { Flex, Label, Text } from "@arizeai/components";
+
+import { formatFloat } from "@phoenix/utils/numberFormatUtils";
+
+interface Evaluation {
+  name: string;
+  label?: string | null;
+  score?: number | null;
+}
+export function EvaluationLabel({ evaluation }: { evaluation: Evaluation }) {
+  const labelValue =
+    evaluation.label ||
+    (typeof evaluation.score == "number" && formatFloat(evaluation.score)) ||
+    "n/a";
+  return (
+    <Label color="cyan-1000">
+      <Flex direction="row" gap="size-50">
+        <Text weight="heavy" textSize="small" color="inherit">
+          {evaluation.name}
+        </Text>
+        <Text textSize="small">{labelValue}</Text>
+      </Flex>
+    </Label>
+  );
+}

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -131,7 +131,7 @@ export function SpansTable(props: SpansTableProps) {
 
       cell: ({ row }) => {
         return (
-          <Flex direction="row" gap="size-50">
+          <Flex direction="row" gap="size-50" wrap="wrap">
             {row.original.spanEvaluations.map((evaluation) => {
               return (
                 <EvaluationLabel

--- a/app/src/pages/tracing/SpansTable.tsx
+++ b/app/src/pages/tracing/SpansTable.tsx
@@ -27,6 +27,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
@@ -38,6 +39,7 @@ import {
   SpanSort,
   SpansTableSpansQuery,
 } from "./__generated__/SpansTableSpansQuery.graphql";
+import { EvaluationLabel } from "./EvaluationLabel";
 import { SpanColumnSelector } from "./SpanColumnSelector";
 import { SpanFilterConditionField } from "./SpanFilterConditionField";
 import { spansTableCSS } from "./styles";
@@ -57,6 +59,7 @@ export function SpansTable(props: SpansTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
+  const isEvalsEnabled = useFeatureFlag("evals");
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const navigate = useNavigate();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -101,6 +104,11 @@ export function SpansTable(props: SpansTableProps) {
                   value
                   mimeType
                 }
+                spanEvaluations {
+                  name
+                  label
+                  score
+                }
               }
             }
           }
@@ -115,6 +123,28 @@ export function SpansTable(props: SpansTableProps) {
     return tableData;
   }, [data]);
   type TableRow = (typeof tableData)[number];
+  const evaluationColumns: ColumnDef<TableRow>[] = [
+    {
+      header: "evaluations",
+      accessorKey: "spanEvaluations",
+      enableSorting: false,
+
+      cell: ({ row }) => {
+        return (
+          <Flex direction="row" gap="size-50">
+            {row.original.spanEvaluations.map((evaluation) => {
+              return (
+                <EvaluationLabel
+                  key={evaluation.name}
+                  evaluation={evaluation}
+                />
+              );
+            })}
+          </Flex>
+        );
+      },
+    },
+  ];
   const columns: ColumnDef<TableRow>[] = [
     {
       header: "kind",
@@ -149,6 +179,7 @@ export function SpansTable(props: SpansTableProps) {
       cell: TextCell,
       enableSorting: false,
     },
+    ...(isEvalsEnabled ? evaluationColumns : []),
     {
       header: "start time",
       accessorKey: "startTime",

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -196,7 +196,7 @@ export function TracesTable(props: TracesTableProps) {
 
       cell: ({ row }) => {
         return (
-          <Flex direction="row" gap="size-50">
+          <Flex direction="row" gap="size-50" wrap="wrap">
             {row.original.spanEvaluations.map((evaluation) => {
               return (
                 <EvaluationLabel

--- a/app/src/pages/tracing/TracesTable.tsx
+++ b/app/src/pages/tracing/TracesTable.tsx
@@ -33,6 +33,7 @@ import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { ISpanItem } from "@phoenix/components/trace/types";
 import { createSpanTree, SpanTreeNode } from "@phoenix/components/trace/utils";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
@@ -44,6 +45,7 @@ import {
   SpanSort,
   TracesTableQuery,
 } from "./__generated__/TracesTableQuery.graphql";
+import { EvaluationLabel } from "./EvaluationLabel";
 import { SpanColumnSelector } from "./SpanColumnSelector";
 import { SpanFilterConditionField } from "./SpanFilterConditionField";
 import { spansTableCSS } from "./styles";
@@ -89,7 +91,7 @@ export function TracesTable(props: TracesTableProps) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
-
+  const isEvalsEnabled = useFeatureFlag("evals");
   const navigate = useNavigate();
   const { fetchKey } = useStreamState();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
@@ -134,6 +136,11 @@ export function TracesTable(props: TracesTableProps) {
                   spanId
                   traceId
                 }
+                spanEvaluations {
+                  name
+                  label
+                  score
+                }
                 descendants {
                   spanKind
                   name
@@ -153,6 +160,11 @@ export function TracesTable(props: TracesTableProps) {
                   context {
                     spanId
                     traceId
+                  }
+                  spanEvaluations {
+                    name
+                    label
+                    score
                   }
                 }
               }
@@ -175,6 +187,29 @@ export function TracesTable(props: TracesTableProps) {
     return tableData;
   }, [data]);
   type TableRow = (typeof tableData)[number];
+
+  const evaluationColumns: ColumnDef<TableRow>[] = [
+    {
+      header: "evaluations",
+      accessorKey: "spanEvaluations",
+      enableSorting: false,
+
+      cell: ({ row }) => {
+        return (
+          <Flex direction="row" gap="size-50">
+            {row.original.spanEvaluations.map((evaluation) => {
+              return (
+                <EvaluationLabel
+                  key={evaluation.name}
+                  evaluation={evaluation}
+                />
+              );
+            })}
+          </Flex>
+        );
+      },
+    },
+  ];
   const columns: ColumnDef<TableRow>[] = [
     {
       header: () => {
@@ -241,6 +276,7 @@ export function TracesTable(props: TracesTableProps) {
       enableSorting: false,
       cell: TextCell,
     },
+    ...(isEvalsEnabled ? evaluationColumns : []),
     {
       header: "start time",
       accessorKey: "startTime",

--- a/app/src/pages/tracing/__generated__/SpansTableSpansQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/SpansTableSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<555e60c1e50edf0279d2bca69d4b24d3>>
+ * @generated SignedSource<<e94385514a5a2513a83fe3b4a7859df0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,7 +78,14 @@ v1 = [
     "variableName": "sort"
   }
 ],
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -147,13 +154,7 @@ return {
                     "name": "spanKind",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "name",
-                    "storageKey": null
-                  },
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -228,7 +229,7 @@ return {
                     "kind": "LinkedField",
                     "name": "input",
                     "plural": false,
-                    "selections": (v2/*: any*/),
+                    "selections": (v3/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -238,7 +239,33 @@ return {
                     "kind": "LinkedField",
                     "name": "output",
                     "plural": false,
-                    "selections": (v2/*: any*/),
+                    "selections": (v3/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SpanEvaluation",
+                    "kind": "LinkedField",
+                    "name": "spanEvaluations",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "label",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "score",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   }
                 ],
@@ -315,16 +342,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6a56ebbed01309933fe919f1c45ad129",
+    "cacheID": "3347b1e5bdb27c6b5987d0063b96ad67",
     "id": null,
     "metadata": {},
     "name": "SpansTableSpansQuery",
     "operationKind": "query",
-    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...SpansTable_spans_1XEuU\n}\n\nfragment SpansTable_spans_1XEuU on Query {\n  spans(first: $first, after: $after, sort: $sort, filterCondition: $filterCondition) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...SpansTable_spans_1XEuU\n}\n\nfragment SpansTable_spans_1XEuU on Query {\n  spans(first: $first, after: $after, sort: $sort, filterCondition: $filterCondition) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "40de558e2a7fe5f6916378af1149cd5a";
+(node as any).hash = "7c37fa575b740f80ce3be0faa9215222";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/tracing/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c79db63dd1d769d7fd694e901cc7df63>>
+ * @generated SignedSource<<17a97d93bce1ec0696a31d6889166a02>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,11 @@ export type SpansTable_spans$data = {
           readonly mimeType: MimeType;
           readonly value: string;
         } | null;
+        readonly spanEvaluations: ReadonlyArray<{
+          readonly label: string | null;
+          readonly name: string;
+          readonly score: number | null;
+        }>;
         readonly spanKind: SpanKind;
         readonly startTime: string;
         readonly statusCode: SpanStatusCode;
@@ -51,7 +56,14 @@ const node: ReaderFragment = (function(){
 var v0 = [
   "spans"
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = [
   {
     "alias": null,
     "args": null,
@@ -160,13 +172,7 @@ return {
                   "name": "spanKind",
                   "storageKey": null
                 },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -241,7 +247,7 @@ return {
                   "kind": "LinkedField",
                   "name": "input",
                   "plural": false,
-                  "selections": (v1/*: any*/),
+                  "selections": (v2/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -251,7 +257,33 @@ return {
                   "kind": "LinkedField",
                   "name": "output",
                   "plural": false,
-                  "selections": (v1/*: any*/),
+                  "selections": (v2/*: any*/),
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SpanEvaluation",
+                  "kind": "LinkedField",
+                  "name": "spanEvaluations",
+                  "plural": true,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "label",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "score",
+                      "storageKey": null
+                    }
+                  ],
                   "storageKey": null
                 }
               ],
@@ -319,6 +351,6 @@ return {
 };
 })();
 
-(node as any).hash = "40de558e2a7fe5f6916378af1149cd5a";
+(node as any).hash = "7c37fa575b740f80ce3be0faa9215222";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/TracesTableQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracesTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f50050fcce0dc13af22f690bdb37e872>>
+ * @generated SignedSource<<32eaa17bdc10fa7efd4f68063092dad0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -182,6 +182,32 @@ v15 = {
     }
   ],
   "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SpanEvaluation",
+  "kind": "LinkedField",
+  "name": "spanEvaluations",
+  "plural": true,
+  "selections": [
+    (v7/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "label",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "score",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -264,6 +290,7 @@ return {
                   (v13/*: any*/),
                   (v14/*: any*/),
                   (v15/*: any*/),
+                  (v16/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -301,7 +328,8 @@ return {
                       },
                       (v13/*: any*/),
                       (v14/*: any*/),
-                      (v15/*: any*/)
+                      (v15/*: any*/),
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -380,16 +408,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d4ab1d47415433043982e3a5fd4cef26",
+    "cacheID": "548b60c4c1410666b4f0533db3394b05",
     "id": null,
     "metadata": {},
     "name": "TracesTableQuery",
     "operationKind": "query",
-    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...TracesTable_spans_1XEuU\n}\n\nfragment TracesTable_spans_1XEuU on Query {\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n) {\n  ...TracesTable_spans_1XEuU\n}\n\nfragment TracesTable_spans_1XEuU on Query {\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bef7f02af9f00db54d9294f27ee3c302";
+(node as any).hash = "601519f525b82c387835d8876bc3eab9";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<df319ec22ad1efe3e709d46fd1890f41>>
+ * @generated SignedSource<<25f062cc55729b3b589d3bacc74dfe3c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,6 +34,11 @@ export type TracesTable_spans$data = {
             readonly value: string;
           } | null;
           readonly parentId: string | null;
+          readonly spanEvaluations: ReadonlyArray<{
+            readonly label: string | null;
+            readonly name: string;
+            readonly score: number | null;
+          }>;
           readonly spanKind: SpanKind;
           readonly startTime: string;
           readonly statusCode: SpanStatusCode;
@@ -50,6 +55,11 @@ export type TracesTable_spans$data = {
           readonly value: string;
         } | null;
         readonly parentId: string | null;
+        readonly spanEvaluations: ReadonlyArray<{
+          readonly label: string | null;
+          readonly name: string;
+          readonly score: number | null;
+        }>;
         readonly spanKind: SpanKind;
         readonly startTime: string;
         readonly statusCode: SpanStatusCode;
@@ -161,6 +171,32 @@ v10 = {
       "args": null,
       "kind": "ScalarField",
       "name": "traceId",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SpanEvaluation",
+  "kind": "LinkedField",
+  "name": "spanEvaluations",
+  "plural": true,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "label",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "score",
       "storageKey": null
     }
   ],
@@ -287,6 +323,7 @@ return {
                 (v8/*: any*/),
                 (v9/*: any*/),
                 (v10/*: any*/),
+                (v11/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -324,7 +361,8 @@ return {
                     },
                     (v8/*: any*/),
                     (v9/*: any*/),
-                    (v10/*: any*/)
+                    (v10/*: any*/),
+                    (v11/*: any*/)
                   ],
                   "storageKey": null
                 }
@@ -393,6 +431,6 @@ return {
 };
 })();
 
-(node as any).hash = "bef7f02af9f00db54d9294f27ee3c302";
+(node as any).hash = "601519f525b82c387835d8876bc3eab9";
 
 export default node;

--- a/app/src/pages/tracing/__generated__/TracingHomePageQuery.graphql.ts
+++ b/app/src/pages/tracing/__generated__/TracingHomePageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5e93a0c14112bb044a93e42227466a49>>
+ * @generated SignedSource<<f2938602f247afaf506af24efd45c585>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -138,11 +138,37 @@ v13 = [
 v14 = {
   "alias": null,
   "args": null,
+  "concreteType": "SpanEvaluation",
+  "kind": "LinkedField",
+  "name": "spanEvaluations",
+  "plural": true,
+  "selections": [
+    (v4/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "label",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "score",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "Span",
@@ -160,7 +186,7 @@ v15 = {
   ],
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -185,50 +211,50 @@ v16 = {
   ],
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "Literal",
   "name": "rootSpansOnly",
   "value": true
 },
-v18 = [
+v19 = [
   (v0/*: any*/),
-  (v17/*: any*/),
+  (v18/*: any*/),
   (v1/*: any*/)
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v20 = [
+v21 = [
   (v12/*: any*/)
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v20/*: any*/),
+  "selections": (v21/*: any*/),
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v20/*: any*/),
+  "selections": (v21/*: any*/),
   "storageKey": null
 },
-v23 = [
-  (v17/*: any*/)
-],
 v24 = [
+  (v18/*: any*/)
+],
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -337,16 +363,17 @@ return {
                     "plural": false,
                     "selections": (v13/*: any*/),
                     "storageKey": null
-                  }
+                  },
+                  (v14/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v14/*: any*/),
-              (v15/*: any*/)
+              (v15/*: any*/),
+              (v16/*: any*/)
             ],
             "storageKey": null
           },
-          (v16/*: any*/)
+          (v17/*: any*/)
         ],
         "storageKey": "spans(first:100,sort:{\"col\":\"startTime\",\"dir\":\"desc\"})"
       },
@@ -364,7 +391,7 @@ return {
       },
       {
         "alias": "rootSpans",
-        "args": (v18/*: any*/),
+        "args": (v19/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
@@ -412,10 +439,11 @@ return {
                     "name": "cumulativeTokenCountCompletion",
                     "storageKey": null
                   },
-                  (v19/*: any*/),
-                  (v21/*: any*/),
+                  (v20/*: any*/),
                   (v22/*: any*/),
+                  (v23/*: any*/),
                   (v11/*: any*/),
+                  (v14/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -429,31 +457,32 @@ return {
                       (v5/*: any*/),
                       (v6/*: any*/),
                       (v7/*: any*/),
-                      (v19/*: any*/),
+                      (v20/*: any*/),
                       (v8/*: any*/),
                       (v9/*: any*/),
                       (v10/*: any*/),
-                      (v21/*: any*/),
                       (v22/*: any*/),
-                      (v11/*: any*/)
+                      (v23/*: any*/),
+                      (v11/*: any*/),
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v14/*: any*/),
-              (v15/*: any*/)
+              (v15/*: any*/),
+              (v16/*: any*/)
             ],
             "storageKey": null
           },
-          (v16/*: any*/)
+          (v17/*: any*/)
         ],
         "storageKey": "spans(first:100,rootSpansOnly:true,sort:{\"col\":\"startTime\",\"dir\":\"desc\"})"
       },
       {
         "alias": "rootSpans",
-        "args": (v18/*: any*/),
+        "args": (v19/*: any*/),
         "filters": [
           "sort",
           "rootSpansOnly",
@@ -466,12 +495,12 @@ return {
       },
       {
         "alias": "totalTraces",
-        "args": (v23/*: any*/),
+        "args": (v24/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
         "plural": false,
-        "selections": (v24/*: any*/),
+        "selections": (v25/*: any*/),
         "storageKey": "spans(rootSpansOnly:true)"
       },
       {
@@ -510,23 +539,23 @@ return {
       },
       {
         "alias": "traceCount",
-        "args": (v23/*: any*/),
+        "args": (v24/*: any*/),
         "concreteType": "SpanConnection",
         "kind": "LinkedField",
         "name": "spans",
         "plural": false,
-        "selections": (v24/*: any*/),
+        "selections": (v25/*: any*/),
         "storageKey": "spans(rootSpansOnly:true)"
       }
     ]
   },
   "params": {
-    "cacheID": "c6ade5ea24cf7c92b41252beca473730",
+    "cacheID": "54108ef1d02b43bca1dc407ab4a8bd80",
     "id": null,
     "metadata": {},
     "name": "TracingHomePageQuery",
     "operationKind": "query",
-    "text": "query TracingHomePageQuery {\n  ...SpansTable_spans\n  ...TracesTable_spans\n  ...TracingHomePageHeader_stats\n  ...StreamToggle_data\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment StreamToggle_data on Query {\n  traceCount: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n}\n\nfragment TracesTable_spans on Query {\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TracingHomePageHeader_stats on Query {\n  totalTraces: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n  traceDatasetInfo {\n    startTime\n    endTime\n    tokenCountTotal\n    latencyMsP50\n    latencyMsP99\n  }\n}\n"
+    "text": "query TracingHomePageQuery {\n  ...SpansTable_spans\n  ...TracesTable_spans\n  ...TracingHomePageHeader_stats\n  ...StreamToggle_data\n}\n\nfragment SpansTable_spans on Query {\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment StreamToggle_data on Query {\n  traceCount: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n}\n\nfragment TracesTable_spans on Query {\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        descendants {\n          spanKind\n          name\n          statusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TracingHomePageHeader_stats on Query {\n  totalTraces: spans(rootSpansOnly: true) {\n    pageInfo {\n      totalCount\n    }\n  }\n  traceDatasetInfo {\n    startTime\n    endTime\n    tokenCountTotal\n    latencyMsP50\n    latencyMsP99\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
resolves #1163 

This PR adds a single "evaluations" column so that you can at a glance view all the evaluations. There will be a follow-up to display each evaluation in it's own column for sorting but this lets you view all the evals at a glance and is MVP ready.
<img width="2556" alt="Screenshot 2023-11-28 at 1 50 25 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/f2415455-28b4-4ad3-bb2c-ca7b245b7919">

