### PR TITLE
feat(traces): Trace page header with latency, status, and evaluations

### DIFF
--- a/app/src/components/trace/SpanStatusCodeIcon.tsx
+++ b/app/src/components/trace/SpanStatusCodeIcon.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
-import { ColorValue, Icon, Icons } from "@arizeai/components";
+import { Icon, Icons } from "@arizeai/components";
 
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { SpanStatusCodeType } from "./types";
+import { useSpanStatusCodeColor } from "./useSpanStatusCodeColor";
 
 export function SpanStatusCodeIcon<TCode extends SpanStatusCodeType>({
   statusCode,
@@ -12,15 +13,13 @@ export function SpanStatusCodeIcon<TCode extends SpanStatusCodeType>({
   statusCode: TCode;
 }) {
   let iconSVG = <Icons.MinusCircleOutline />;
-  let color: ColorValue = "grey-500";
+  const color = useSpanStatusCodeColor(statusCode);
   switch (statusCode) {
     case "OK":
       iconSVG = <Icons.CheckmarkCircleOutline />;
-      color = "success";
       break;
     case "ERROR":
       iconSVG = <Icons.AlertCircleOutline />;
-      color = "danger";
       break;
     case "UNSET":
       iconSVG = <Icons.MinusCircleOutline />;

--- a/app/src/components/trace/useSpanStatusCodeColor.ts
+++ b/app/src/components/trace/useSpanStatusCodeColor.ts
@@ -1,0 +1,22 @@
+import { ColorValue } from "@arizeai/components";
+
+import { assertUnreachable } from "@phoenix/typeUtils";
+
+import { SpanStatusCodeType } from "./types";
+
+export function useSpanStatusCodeColor(
+  statusCode: SpanStatusCodeType
+): ColorValue {
+  switch (statusCode) {
+    case "OK":
+      return "success";
+
+    case "ERROR":
+      return "danger";
+      break;
+    case "UNSET":
+      return "grey-500";
+    default:
+      assertUnreachable(statusCode);
+  }
+}

--- a/app/src/pages/tracing/TracingHomePageHeader.tsx
+++ b/app/src/pages/tracing/TracingHomePageHeader.tsx
@@ -57,7 +57,7 @@ export function TracingHomePageHeader(props: {
     <View
       paddingStart="size-200"
       paddingEnd="size-200"
-      paddingTop="size-100"
+      paddingTop="size-200"
       paddingBottom="size-50"
       flex="none"
     >

--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,7 @@
         "tiktoken",
         "tracedataset",
         "UMAP",
+        "xlarge",
         "Zustand"
     ],
     "flagWords": [


### PR DESCRIPTION
resolves #1827 

Adds a header to the trace page to show the trace level info, notably shows the evaluations that correl
ate with the entire trace.

<img width="2056" alt="Screenshot 2023-11-29 at 9 18 42 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/9920f55f-6f81-4127-83da-7e84dba385a8">