### PR TITLE
fix: Rate limiter will sometimes tank request rate with many concurrent requests

### DIFF
--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -141,7 +141,7 @@ class AsyncExecutor:
                 termination_signal_task = asyncio.create_task(self._TERMINATE.wait())
                 done, pending = await asyncio.wait(
                     [generate_task, termination_signal_task],
-                    timeout=60,
+                    timeout=20,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if generate_task in done:

--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -63,7 +63,7 @@ class AdaptiveTokenBucket:
 
     def on_rate_limit_error(self, request_start_time: float, verbose: bool = False) -> None:
         now = time.time()
-        if self.cooldown > abs(request_start_time - self.last_error):
+        if request_start_time < (self.last_error + self.cooldown):
             # do not reduce the rate for concurrent requests
             return
 

--- a/tests/experimental/evals/models/test_rate_limiters.py
+++ b/tests/experimental/evals/models/test_rate_limiters.py
@@ -281,6 +281,29 @@ def test_token_bucket_does_not_increase_rate_past_maximum():
         bucket.wait_until_ready()
         assert isclose(bucket.rate, rate * 2)
 
+def test_token_bucket_resets_rate_after_inactivity():
+    start = time.time()
+
+    with freeze_time(start):
+        rate = 0.1
+        bucket = AdaptiveTokenBucket(
+            initial_per_second_request_rate=rate,
+            maximum_per_second_request_rate=rate * 2,
+            enforcement_window_minutes=1,
+            rate_reduction_factor=1,
+            rate_increase_factor=100,
+            cooldown_seconds=5,
+        )
+
+    with warp_time(start + 5):
+        assert bucket.available_requests() == 0.5, "should have accumulated half a request"
+        bucket.wait_until_ready()
+        assert isclose(bucket.rate, rate * 2)
+
+    with warp_time(start + 100):
+        bucket.wait_until_ready()
+        assert isclose(bucket.rate, rate)
+
 
 def test_token_bucket_decreases_rate():
     start = time.time()
@@ -326,34 +349,5 @@ def test_token_bucket_decreases_rate_once_per_cooldown_period():
         assert isclose(bucket.rate, 25), "requests before the rate limited request are ignored"
 
     with warp_time(start + 6):
-        # mock "available_requests" to simulate full usage
-        mock_available_requests = mock.MagicMock()
-        mock_available_requests.return_value = 0
-        bucket.available_requests = mock_available_requests
         bucket.on_rate_limit_error(request_start_time=time.time())
         assert isclose(bucket.rate, 6.25)
-
-
-def test_token_bucket_decreases_rate_depending_on_usage():
-    start = time.time()
-
-    with warp_time(start):
-        rate = 100
-        bucket = AdaptiveTokenBucket(
-            initial_per_second_request_rate=rate,
-            maximum_per_second_request_rate=rate * 2,
-            enforcement_window_minutes=1,
-            rate_reduction_factor=0.25,
-            rate_increase_factor=0.01,
-            cooldown_seconds=5,
-        )
-        # mock "available_requests" to simulate actual usage
-        mock_available_requests = mock.MagicMock()
-        mock_available_requests.return_value = rate * 30
-        bucket.available_requests = mock_available_requests
-
-        effective_rate = rate * 30 / 60
-        expected_rate = effective_rate * 0.25
-
-        bucket.on_rate_limit_error(request_start_time=time.time())
-        assert isclose(bucket.rate, expected_rate)

--- a/tests/experimental/evals/models/test_rate_limiters.py
+++ b/tests/experimental/evals/models/test_rate_limiters.py
@@ -321,6 +321,10 @@ def test_token_bucket_decreases_rate_once_per_cooldown_period():
         bucket.on_rate_limit_error(request_start_time=time.time())
         assert isclose(bucket.rate, 25), "3 seconds is still within the cooldown period"
 
+    with warp_time(start - 6):
+        bucket.on_rate_limit_error(request_start_time=time.time())
+        assert isclose(bucket.rate, 25), "requests before the rate limited request are ignored"
+
     with warp_time(start + 6):
         # mock "available_requests" to simulate full usage
         mock_available_requests = mock.MagicMock()


### PR DESCRIPTION
resolves #1851

This makes a few changes to our client-side rate limiting / async submission strategy. Older requests that come in late can now no longer cause our feedback mechanism to throttle our internal rate limit. Furthermore we're decreasing the frozen request timeout from 60 seconds to 20 seconds.

Last, the internal rate limit is now reset after a period of inactivity.