### PR TITLE
feat: support instrumentation for openai synchronous streaming

### DIFF
--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -179,9 +179,7 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
             self._process_chat_completion(response)
         elif isinstance(response, Stream):
             self.end_time = None  # set end time to None to indicate that the stream is still open
-            response = self._process_stream(
-                response
-            )  # reassign to response to return an instrumented stream object
+            response = StreamWrapper(stream=response, context=self)
         elif hasattr(response, "parse") and callable(
             response.parse
         ):  # handle raw response by converting them to chat completions
@@ -204,18 +202,6 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
         ) in _CHAT_COMPLETION_ATTRIBUTE_FUNCTIONS.items():
             if (attribute_value := get_chat_completion_attribute_fn(chat_completion)) is not None:
                 self.attributes[attribute_name] = attribute_value
-
-    def _process_stream(self, stream: Stream[ChatCompletionChunk]) -> Stream[ChatCompletionChunk]:
-        """
-        Instruments a stream of chat completion chunks and returns an instrumented stream.
-
-        Args:
-            stream (Stream[ChatCompletionChunk]): The input stream.
-
-        Returns:
-            Stream[ChatCompletionChunk]: The instrumented stream.
-        """
-        return StreamWrapper(stream=stream, context=self)
 
     def _process_parameters(self, parameters: Parameters) -> None:
         """

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -35,7 +35,6 @@ from phoenix.trace.schemas import (
     SpanException,
     SpanKind,
     SpanStatusCode,
-    SpanStreamEvent,
 )
 from phoenix.trace.semantic_conventions import (
     INPUT_MIME_TYPE,
@@ -563,11 +562,11 @@ def _parameters(bound_arguments: BoundArguments) -> Parameters:
     return cast(Parameters, bound_arguments.arguments["options"].json_data)
 
 
-def _span_stream_event(chat_completion_chunk: ChatCompletionChunk) -> SpanStreamEvent:
+def _span_stream_event(chat_completion_chunk: ChatCompletionChunk) -> SpanEvent:
     """
     Converts a chat completion chunk to a span stream event.
     """
-    return SpanStreamEvent(
+    return SpanEvent(
         name="OpenAI Chat Completion Server-Sent Event",
         timestamp=datetime.now(),
         attributes={

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -178,6 +178,7 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
         if isinstance(response, ChatCompletion):
             self._process_chat_completion(response)
         elif isinstance(response, Stream):
+            self.end_time = None  # set end time to None to indicate that the stream is still open
             response = self._process_stream(
                 response
             )  # reassign to response to return an instrumented stream object
@@ -322,6 +323,7 @@ class StreamWrapper(ObjectProxy):  # type: ignore
                     },
                     status_code=self._self_context.status_code,
                     events=span.events,
+                    end_time=datetime.now(),
                 )
                 self._self_context.tracer.add_span(span)
 

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -138,7 +138,6 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
         self.events: List[SpanEvent] = []
         self.attributes: SpanAttributes = dict()
         self._process_parameters(_parameters(bound_arguments))
-        self._is_streaming_request = _is_streaming_request(bound_arguments)
 
     def __enter__(self) -> "ChatCompletionContext":
         self.start_time = datetime.now()

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -142,6 +142,13 @@ class StreamWrapper(ObjectProxy):  # type: ignore
             self.__context.tracer.add_span(span)
             raise
 
+    def __iter__(self) -> Iterator[ChatCompletionChunk]:
+        """
+        This bypasses the wrapped class' __iter__ method so that __iter__ is
+        automatically instrumented using __next__.
+        """
+        return self
+
 
 class StreamProcessor:
     def __init__(self, context: "ChatCompletionContext") -> None:

--- a/src/phoenix/trace/schemas.py
+++ b/src/phoenix/trace/schemas.py
@@ -91,16 +91,6 @@ class SpanEvent(Dict[str, Any]):
 
 
 @dataclass(frozen=True)
-class SpanStreamEvent(SpanEvent):
-    """
-    An event to contain the contents of an individual chunk of a stream (e.g.,
-    of server-sent events) when using a streaming API.
-    """
-
-    ...
-
-
-@dataclass(frozen=True)
 class SpanException(SpanEvent):
     """
     A Span Exception is a special type of Span Event that denotes an error

--- a/src/phoenix/trace/schemas.py
+++ b/src/phoenix/trace/schemas.py
@@ -91,6 +91,11 @@ class SpanEvent(Dict[str, Any]):
 
 
 @dataclass(frozen=True)
+class SpanStreamEvent(SpanEvent):
+    ...
+
+
+@dataclass(frozen=True)
 class SpanException(SpanEvent):
     """
     A Span Exception is a special type of Span Event that denotes an error

--- a/src/phoenix/trace/schemas.py
+++ b/src/phoenix/trace/schemas.py
@@ -92,6 +92,11 @@ class SpanEvent(Dict[str, Any]):
 
 @dataclass(frozen=True)
 class SpanStreamEvent(SpanEvent):
+    """
+    An event to contain the contents of an individual chunk of a stream (e.g.,
+    of server-sent events) when using a streaming API.
+    """
+
     ...
 
 

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -100,13 +100,17 @@ class Tracer:
             conversation=conversation,
         )
 
+        self.add_span(span)
+
+        return span
+
+    def add_span(self, span: Span) -> None:
         if self._exporter:
             self._exporter.export(span)
         self.span_buffer.append(span)
 
         if self.on_append is not None:
             self.on_append(self.span_buffer)
-        return span
 
     def get_spans(self) -> Iterator[Span]:
         """

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -102,16 +102,6 @@ class Tracer:
             conversation=conversation,
         )
 
-        self.add_span(span)
-
-        return span
-
-    def add_span(self, span: Span) -> None:
-        """Adds a span to the tracer.
-
-        Args:
-            span (Span): The span to be add to the tracer.
-        """
         if self._exporter:
             self._exporter.export(span)
 
@@ -120,6 +110,7 @@ class Tracer:
 
         if self.on_append is not None:
             self.on_append(self.span_buffer)
+        return span
 
     def get_spans(self) -> Iterator[Span]:
         """

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -105,6 +105,11 @@ class Tracer:
         return span
 
     def add_span(self, span: Span) -> None:
+        """Adds a span to the tracer.
+
+        Args:
+            span (Span): The span to be add to the tracer.
+        """
         if self._exporter:
             self._exporter.export(span)
         self.span_buffer.append(span)

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from threading import RLock
 from typing import Any, Callable, Iterator, List, Optional, Protocol
 from uuid import UUID, uuid4
 
@@ -55,6 +56,7 @@ class Tracer:
         self.span_buffer = []
         self.on_append = on_append
         self._exporter: Optional[SpanExporter] = exporter
+        self._lock = RLock()
         super().__init__(*args, **kwargs)
 
     def create_span(
@@ -112,7 +114,9 @@ class Tracer:
         """
         if self._exporter:
             self._exporter.export(span)
-        self.span_buffer.append(span)
+
+        with self._lock:
+            self.span_buffer.append(span)
 
         if self.on_append is not None:
             self.on_append(self.span_buffer)

--- a/tests/trace/llama_index/test_callback.py
+++ b/tests/trace/llama_index/test_callback.py
@@ -177,7 +177,7 @@ def test_callback_streaming_response_produces_correct_result(
     ]
     expected_response = "".join(expected_response_tokens)
     mock_data = []
-    for token in expected_response_tokens:
+    for token_index, token in enumerate(expected_response_tokens):
         response_body = {
             "object": "chat.completion.chunk",
             "created": 1701722737,
@@ -185,7 +185,7 @@ def test_callback_streaming_response_produces_correct_result(
             "choices": [
                 {
                     "delta": {"role": "assistant", "content": token},
-                    "finish_reason": None,
+                    "finish_reason": "stop" if token_index == len(expected_response) - 1 else None,
                 }
             ],
         }

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from datetime import datetime
 from importlib import reload
 from types import ModuleType
 from typing import Iterator
@@ -649,6 +650,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
+    assert span.end_time is None  # the end time should be None until the stream is consumed
     assert span.events == []
     assert attributes[LLM_INPUT_MESSAGES] == [
         {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
@@ -683,6 +685,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
+    assert isinstance(span.end_time, datetime)
     assert len(span.events) == len(expected_response_tokens)
     span_stream_event = span.events[0]
     assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
@@ -779,6 +782,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
+    assert span.end_time is None  # the end time should be None until the stream is consumed
     assert span.events == []
     assert attributes[LLM_INPUT_MESSAGES] == [
         {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
@@ -806,6 +810,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
+    assert isinstance(span.end_time, datetime)
     assert len(span.events) == len(expected_response_tokens)
     span_stream_event = span.events[0]
     assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
@@ -890,6 +895,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
+    assert span.end_time is None  # the end time should be None until the stream is consumed
     assert span.events == []
     assert attributes[LLM_INPUT_MESSAGES] == [
         {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
@@ -921,6 +927,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.ERROR
+    assert isinstance(span.end_time, datetime)
     assert (
         len(span.events) == len(response_tokens_before_error) + 1
     )  # there should be an exception event in addition to each span stream event

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -9,7 +9,7 @@ import pytest
 from httpx import Response
 from openai import AsyncOpenAI, AuthenticationError, OpenAI, Stream
 from phoenix.trace.openai.instrumentor import OpenAIInstrumentor
-from phoenix.trace.schemas import SpanException, SpanKind, SpanStatusCode, SpanStreamEvent
+from phoenix.trace.schemas import SpanException, SpanKind, SpanStatusCode
 from phoenix.trace.semantic_conventions import (
     EXCEPTION_MESSAGE,
     EXCEPTION_STACKTRACE,
@@ -684,7 +684,6 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
     assert len(span.events) == len(expected_response_tokens)
-    assert all(isinstance(event, SpanStreamEvent) for event in span.events)
     span_stream_event = span.events[0]
     assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
@@ -808,7 +807,6 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
     assert len(span.events) == len(expected_response_tokens)
-    assert all(isinstance(event, SpanStreamEvent) for event in span.events)
     span_stream_event = span.events[0]
     assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
@@ -926,7 +924,6 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
     assert (
         len(span.events) == len(response_tokens_before_error) + 1
     )  # there should be an exception event in addition to each span stream event
-    assert all(isinstance(event, SpanStreamEvent) for event in span.events[:-1])
     span_stream_event = span.events[0]
     assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -859,7 +859,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_records_exceptio
     response_text_before_error = "".join(response_tokens_before_error)
 
     def mock_stream() -> Iterator[bytes]:
-        for token in response_tokens_before_error[:5]:
+        for token in response_tokens_before_error:
             response_body = {
                 "object": "chat.completion.chunk",
                 "created": 1701722737,
@@ -922,7 +922,9 @@ def test_openai_instrumentor_sync_streaming_response_with_error_records_exceptio
 
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.ERROR
-    assert len(span.events) == len(response_tokens_before_error)
+    assert (
+        len(span.events) == len(response_tokens_before_error) + 1
+    )  # there should be an exception event in addition to each span stream event
     assert all(isinstance(event, SpanStreamEvent) for event in span.events[:-1])
     assert isinstance(span.events[-1], SpanException)
     assert attributes[LLM_INPUT_MESSAGES] == [


### PR DESCRIPTION
Overview
- adds support for openai synchronous streaming
- for synchronous streams, returns an instrumented stream that records span stream events and updates the original span when the stream is exhausted or when an exception is encountered midstream
- adds corresponding unit tests

Future Work
- plumb everything through the ui
- implement support for asynchronous streaming
- implement support for streaming function calls and tool calls