### PR TITLE
feat: openai streaming spans show up in the ui

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
             files: \.ipynb$
             stages: [commit]
             language: system
-            entry: nbqa ruff --fix --ignore=E402 --ignore=E501
+            entry: nbqa ruff --fix --ignore=E402 --ignore=E501 --ignore=F704 
     - repo: https://github.com/pre-commit/mirrors-prettier
       rev: "6f3cb139ef36133b6f903b97facc57b07cef57c9"
       hooks:

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -262,7 +262,7 @@ class Traces:
     def _process_span(self, span: pb.Span) -> None:
         span_id = SpanID(span.context.span_id)
         existing_span = self._spans.get(span_id)
-        if existing_span and existing_span.end_time:
+        if existing_span and existing_span.HasField("end_time"):
             # Reject updates if span has ended.
             return
         is_root_span = not span.HasField("parent_span_id")

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -180,7 +180,7 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
             self._process_chat_completion(response)
         elif isinstance(response, Stream):
             self.end_time = None  # set end time to None to indicate that the stream is still open
-            response = StreamWrapper(stream=response, context=self)
+            return StreamWrapper(stream=response, context=self)
         elif hasattr(response, "parse") and callable(
             response.parse
         ):  # handle raw response by converting them to chat completions

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -297,9 +297,7 @@ class StreamWrapper(ObjectProxy):  # type: ignore
                     LLM_OUTPUT_MESSAGES: _accumulate_messages(
                         chunks=self._self_chunks, num_choices=self._self_context.num_choices
                     ),  # type: ignore
-                    OUTPUT_VALUE: json.dumps(
-                        {"chat_completion_chunks": [chunk.dict() for chunk in self._self_chunks]}
-                    ),
+                    OUTPUT_VALUE: json.dumps([chunk.dict() for chunk in self._self_chunks]),
                     OUTPUT_MIME_TYPE: MimeType.JSON,  # type: ignore
                 }
                 self._self_context.create_span()

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -265,7 +265,7 @@ class StreamWrapper(ObjectProxy):  # type: ignore
             if not self._self_chunks:
                 self._self_context.events.append(
                     SpanEvent(
-                        name="First Token Event",
+                        name="First Token Stream Event",
                         timestamp=datetime.now(tz=timezone.utc),
                         attributes={},
                     )

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -72,7 +72,6 @@ class Tracer:
         attributes: Optional[SpanAttributes] = None,
         events: Optional[List[SpanEvent]] = None,
         conversation: Optional[SpanConversationAttributes] = None,
-        span_id: Optional[SpanID] = None,
     ) -> Span:
         """
         create_span creates a new span with the given name and options.
@@ -91,7 +90,7 @@ class Tracer:
 
         span = Span(
             name=name,
-            context=SpanContext(trace_id=trace_id, span_id=span_id or uuid4()),
+            context=SpanContext(trace_id=trace_id, span_id=uuid4()),
             span_kind=span_kind,
             parent_id=parent_id,
             start_time=start_time,

--- a/src/phoenix/trace/tracer.py
+++ b/src/phoenix/trace/tracer.py
@@ -72,6 +72,7 @@ class Tracer:
         attributes: Optional[SpanAttributes] = None,
         events: Optional[List[SpanEvent]] = None,
         conversation: Optional[SpanConversationAttributes] = None,
+        span_id: Optional[SpanID] = None,
     ) -> Span:
         """
         create_span creates a new span with the given name and options.
@@ -90,7 +91,7 @@ class Tracer:
 
         span = Span(
             name=name,
-            context=SpanContext(trace_id=trace_id, span_id=uuid4()),
+            context=SpanContext(trace_id=trace_id, span_id=span_id or uuid4()),
             span_kind=span_kind,
             parent_id=parent_id,
             start_time=start_time,

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -688,10 +688,9 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
     assert isinstance(span.end_time, datetime)
-    assert len(span.events) == len(expected_response_tokens)
-    span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
-    assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
+    assert len(span.events) == 1
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
 
     assert attributes[LLM_INPUT_MESSAGES] == [
         {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
@@ -815,10 +814,9 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.OK
     assert isinstance(span.end_time, datetime)
-    assert len(span.events) == len(expected_response_tokens)
-    span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
-    assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
+    assert len(span.events) == 1
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
 
     assert attributes[LLM_INPUT_MESSAGES] == [
         {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
@@ -934,12 +932,9 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
     assert span.span_kind is SpanKind.LLM
     assert span.status_code == SpanStatusCode.ERROR
     assert isinstance(span.end_time, datetime)
-    assert (
-        len(span.events) == len(response_tokens_before_error) + 1
-    )  # there should be an exception event in addition to each span stream event
-    span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
-    assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
+    assert len(span.events) == 2
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
     span_exception = span.events[-1]
     assert isinstance(span_exception, SpanException)
     assert span_exception.attributes[EXCEPTION_TYPE] == "RuntimeError"

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -680,6 +680,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes
 
@@ -688,7 +689,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert isinstance(span.end_time, datetime)
     assert len(span.events) == len(expected_response_tokens)
     span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
+    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
 
     assert attributes[LLM_INPUT_MESSAGES] == [
@@ -711,7 +712,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         MESSAGE_CONTENT: expected_response_text,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])
+    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
     assert len(chunks) == len(expected_response_tokens)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
@@ -805,6 +806,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes
 
@@ -813,7 +815,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert isinstance(span.end_time, datetime)
     assert len(span.events) == len(expected_response_tokens)
     span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
+    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
 
     assert attributes[LLM_INPUT_MESSAGES] == [
@@ -836,7 +838,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         MESSAGE_CONTENT: expected_response_text,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])
+    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
     assert len(chunks) == len(expected_response_tokens)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
@@ -922,6 +924,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes
 
@@ -932,7 +935,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
         len(span.events) == len(response_tokens_before_error) + 1
     )  # there should be an exception event in addition to each span stream event
     span_stream_event = span.events[0]
-    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
+    assert span_stream_event.attributes[OUTPUT_MIME_TYPE] == MimeType.JSON.value
     assert isinstance(span_stream_event.attributes[OUTPUT_VALUE], str)
     span_exception = span.events[-1]
     assert isinstance(span_exception, SpanException)
@@ -960,7 +963,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
         MESSAGE_CONTENT: response_text_before_error,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])
+    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
     assert len(chunks) == len(response_tokens_before_error)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -642,32 +642,10 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         model=model, messages=messages, temperature=temperature, stream=True
     )
     assert isinstance(response, Stream)
-
     spans = list(tracer.get_spans())
-    assert len(spans) == 1
-    span = spans[0]
-    attributes = span.attributes
+    assert len(spans) == 0
 
-    assert span.span_kind is SpanKind.LLM
-    assert span.status_code == SpanStatusCode.OK
-    assert span.end_time is None  # the end time should be None until the stream is consumed
-    assert span.events == []
-    assert attributes[LLM_INPUT_MESSAGES] == [
-        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
-    ]
-    assert (
-        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
-        == json.loads(attributes[INPUT_VALUE])
-        == {
-            "model": model,
-            "messages": messages,
-            "temperature": temperature,
-            "stream": True,
-        }
-    )
-    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-
-    # consume the stream to trigger the span update
+    # consume the stream to trigger span creation
     tokens = []
     while True:
         try:
@@ -679,10 +657,8 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert response_text == expected_response_text
 
     spans = list(tracer.get_spans())
-    assert len(spans) == 2
-    assert spans[0].context.trace_id == spans[1].context.trace_id
-    assert spans[0].context.span_id == spans[1].context.span_id
-    span = spans[-1]
+    assert len(spans) == 1
+    span = spans[0]
     attributes = span.attributes
 
     assert span.span_kind is SpanKind.LLM
@@ -775,40 +751,16 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         model=model, messages=messages, temperature=temperature, stream=True
     )
     assert isinstance(response, Stream)
-
     spans = list(tracer.get_spans())
-    assert len(spans) == 1
-    span = spans[0]
-    attributes = span.attributes
+    assert len(spans) == 0
 
-    assert span.span_kind is SpanKind.LLM
-    assert span.status_code == SpanStatusCode.OK
-    assert span.end_time is None  # the end time should be None until the stream is consumed
-    assert span.events == []
-    assert attributes[LLM_INPUT_MESSAGES] == [
-        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
-    ]
-    assert (
-        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
-        == json.loads(attributes[INPUT_VALUE])
-        == {
-            "model": model,
-            "messages": messages,
-            "temperature": temperature,
-            "stream": True,
-        }
-    )
-    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-
-    # iterate over the stream to trigger the span update
+    # iterate over the stream to trigger span creation
     response_text = "".join([chunk.choices[0].delta.content for chunk in response])
     assert response_text == expected_response_text
 
     spans = list(tracer.get_spans())
-    assert len(spans) == 2
-    assert spans[0].context.trace_id == spans[1].context.trace_id
-    assert spans[0].context.span_id == spans[1].context.span_id
-    span = spans[-1]
+    assert len(spans) == 1
+    span = spans[0]
     attributes = span.attributes
 
     assert span.span_kind is SpanKind.LLM
@@ -889,32 +841,10 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
         model=model, messages=messages, temperature=temperature, stream=True
     )
     assert isinstance(response, Stream)
-
     spans = list(tracer.get_spans())
-    assert len(spans) == 1
-    span = spans[0]
-    attributes = span.attributes
+    assert len(spans) == 0
 
-    assert span.span_kind is SpanKind.LLM
-    assert span.status_code == SpanStatusCode.OK
-    assert span.end_time is None  # the end time should be None until the stream is consumed
-    assert span.events == []
-    assert attributes[LLM_INPUT_MESSAGES] == [
-        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
-    ]
-    assert (
-        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
-        == json.loads(attributes[INPUT_VALUE])
-        == {
-            "model": model,
-            "messages": messages,
-            "temperature": temperature,
-            "stream": True,
-        }
-    )
-    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-
-    # iterate over the stream until hitting the RuntimeError
+    # iterate over the stream until hitting the error
     tokens = []
     for _ in range(len(response_tokens_before_error)):
         chunk = next(response)
@@ -923,10 +853,8 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
         next(response)
 
     spans = list(tracer.get_spans())
-    assert len(spans) == 2
-    assert spans[0].context.trace_id == spans[1].context.trace_id
-    assert spans[0].context.span_id == spans[1].context.span_id
-    span = spans[-1]
+    assert len(spans) == 1
+    span = spans[0]
     attributes = span.attributes
 
     assert span.span_kind is SpanKind.LLM

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -680,6 +680,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.trace_id == spans[1].context.trace_id
     assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes
@@ -806,6 +807,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.trace_id == spans[1].context.trace_id
     assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes
@@ -924,6 +926,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
 
     spans = list(tracer.get_spans())
     assert len(spans) == 2
+    assert spans[0].context.trace_id == spans[1].context.trace_id
     assert spans[0].context.span_id == spans[1].context.span_id
     span = spans[-1]
     attributes = span.attributes

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -688,7 +688,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         MESSAGE_CONTENT: expected_response_text,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
+    chunks = json.loads(attributes[OUTPUT_VALUE])
     assert len(chunks) == len(expected_response_tokens)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
@@ -790,7 +790,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
         MESSAGE_CONTENT: expected_response_text,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
+    chunks = json.loads(attributes[OUTPUT_VALUE])
     assert len(chunks) == len(expected_response_tokens)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
@@ -889,7 +889,7 @@ def test_openai_instrumentor_sync_streaming_response_with_error_midstream_record
         MESSAGE_CONTENT: response_text_before_error,
     }
     assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
-    chunks = json.loads(attributes[OUTPUT_VALUE])["chat_completion_chunks"]
+    chunks = json.loads(attributes[OUTPUT_VALUE])
     assert len(chunks) == len(response_tokens_before_error)
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 

--- a/tutorials/internal/openai_request_types.ipynb
+++ b/tutorials/internal/openai_request_types.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenAI Instrumentation\n",
+    "\n",
+    "This notebook tests out various request configurations using instrumented OpenAI clients, including:\n",
+    "\n",
+    "- sync vs. async\n",
+    "- streaming vs. non-streaming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import phoenix as px\n",
+    "from openai import AsyncOpenAI, OpenAI\n",
+    "from phoenix.trace.exporter import HttpExporter\n",
+    "from phoenix.trace.openai import OpenAIInstrumentor\n",
+    "from phoenix.trace.tracer import Tracer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instrument OpenAI clients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tracer = Tracer(exporter=HttpExporter())\n",
+    "OpenAIInstrumentor(tracer).instrument()\n",
+    "sync_client = OpenAI()\n",
+    "async_client = AsyncOpenAI()\n",
+    "model = \"gpt-4\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Launch Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.launch_app()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Synchronous Non-Streaming Request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = sync_client.chat.completions.create(\n",
+    "    messages=[\n",
+    "        {\n",
+    "            \"content\": \"Hello world! I am making a synchronous non-streaming request.\",\n",
+    "            \"role\": \"user\",\n",
+    "        }\n",
+    "    ],\n",
+    "    model=model,\n",
+    ")\n",
+    "response_text = response.choices[0].message.content\n",
+    "response_text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Asynchronous Non-Streaming Request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await async_client.chat.completions.create(\n",
+    "    messages=[\n",
+    "        {\n",
+    "            \"content\": \"Hello world! I am making an asynchronous non-streaming request.\",\n",
+    "            \"role\": \"user\",\n",
+    "        }\n",
+    "    ],\n",
+    "    model=model,\n",
+    ")\n",
+    "response_text = response.choices[0].message.content\n",
+    "response_text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Synchronous Streaming Request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = sync_client.chat.completions.create(\n",
+    "    messages=[\n",
+    "        {\n",
+    "            \"content\": \"Hello world! I am making an synchronous streaming request.\",\n",
+    "            \"role\": \"user\",\n",
+    "        }\n",
+    "    ],\n",
+    "    model=model,\n",
+    "    stream=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for chunk in response:\n",
+    "    choice = chunk.choices[0]\n",
+    "    if choice.finish_reason == \"stop\":\n",
+    "        break\n",
+    "    print(choice.delta.content, end=\"\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/internal/openai_request_types.ipynb
+++ b/tutorials/internal/openai_request_types.ipynb
@@ -146,9 +146,8 @@
    "source": [
     "for chunk in response:\n",
     "    choice = chunk.choices[0]\n",
-    "    if choice.finish_reason == \"stop\":\n",
-    "        break\n",
-    "    print(choice.delta.content, end=\"\")"
+    "    if choice.finish_reason is None:\n",
+    "        print(choice.delta.content, end=\"\")"
    ]
   }
  ],


### PR DESCRIPTION
- creates a new span only once upon end of iteration
- only creates an event for the first streaming token event, not for each event (otherwise, there are too many events to make sense)
- fix bug preventing span updates, although span updates are not used in this PR
- add notebook for running openai sdk requests of various request types

Trace

<img width="1723" alt="Screenshot 2023-12-07 at 11 10 21 AM" src="https://github.com/Arize-ai/phoenix/assets/15664869/d401858b-065c-4101-a24d-b8d7e8d769a6">

First Token Event

<img width="1040" alt="Screenshot 2023-12-07 at 11 11 00 AM" src="https://github.com/Arize-ai/phoenix/assets/15664869/b427d371-ebf3-41d8-b896-e57668cd25d6">
