### PR TITLE
feat: openai async streaming instrumentation

### DIFF
--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -305,7 +305,7 @@ class AsyncStreamWrapper(ObjectProxy):  # type: ignore
             ChatCompletionChunk: The forwarded chat completion chunk.
         """
         with self._self_context as context:
-            chat_completion_chunk = await anext(self.__wrapped__)
+            chat_completion_chunk = await self.__wrapped__.__anext__()
             context.process_chat_completion_chunk(chat_completion_chunk)
             return cast(ChatCompletionChunk, chat_completion_chunk)
 

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -236,7 +236,7 @@ class ChatCompletionContext(ContextManager["ChatCompletionContext"]):
 
 class StreamWrapper(ObjectProxy):  # type: ignore
     """
-    A wrapper for  streams of chat completion chunks that records events and
+    A wrapper for streams of chat completion chunks that records events and
     creates the span upon completion of the stream or upon an exception.
     """
 
@@ -309,14 +309,25 @@ class AsyncStreamWrapper(ObjectProxy):  # type: ignore
 
     def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
         """
-        A __aiter__ method that bypasses the wrapped class' __aiter__ method so
+        An __aiter__ method that bypasses the wrapped class' __aiter__ method so
         that __aiter__ is automatically instrumented using __anext__.
         """
         return self
 
 
 class ChatCompletionStreamEventContext(ContextManager["ChatCompletionStreamEventContext"]):
+    """
+    A context manager that surrounds stream events in a stream of chat
+    completions and processes each chat completion chunk.
+    """
+
     def __init__(self, chat_completion_context: ChatCompletionContext) -> None:
+        """Initializes the context manager.
+
+        Args:
+            chat_completion_context (ChatCompletionContext): The chat completion
+            context storing span fields and attributes.
+        """
         self._chat_completion_context = chat_completion_context
         self._chunks: List[ChatCompletionChunk] = []
         self._finished_streaming = False
@@ -355,6 +366,12 @@ class ChatCompletionStreamEventContext(ContextManager["ChatCompletionStreamEvent
             self._chat_completion_context.create_span()
 
     def process_chat_completion_chunk(self, chat_completion_chunk: ChatCompletionChunk) -> None:
+        """
+        Processes a chat completion chunk and adds relevant information to the context.
+
+        Args:
+            chat_completion_chunk (ChatCompletionChunk): _description_
+        """
         if not self._chunks:
             self._chat_completion_context.events.append(
                 SpanEvent(

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -1543,7 +1543,7 @@ async def test_openai_instrumentor_async_streaming_creates_span_when_iterated_wi
     tokens = []
     while True:
         try:
-            chunk = await anext(response)
+            chunk = await response.__anext__()
             tokens.append(chunk.choices[0].delta.content)
         except StopAsyncIteration:
             break
@@ -1741,10 +1741,10 @@ async def test_openai_instrumentor_async_streaming_with_error_midstream_records_
     # iterate over the stream until hitting the error
     tokens = []
     for _ in range(len(response_tokens_before_error)):
-        chunk = await anext(response)
+        chunk = await response.__anext__()
         tokens.append(chunk.choices[0].delta.content)
     with pytest.raises(RuntimeError, match="error-message"):
-        await anext(response)
+        await response.__anext__()
 
     spans = list(tracer.get_spans())
     assert len(spans) == 1
@@ -1855,6 +1855,6 @@ async def test_openai_instrumentor_async_streaming_creates_span_only_once(
 
     # ensure that further attempts to iterate over the exhausted stream do not create new spans
     with pytest.raises(StopAsyncIteration):
-        await anext(response)
+        await response.__anext__()
     spans = list(tracer.get_spans())
     assert len(spans) == 1

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -594,7 +594,7 @@ def test_openai_instrumentor_sync_works_with_chat_completion_with_raw_response(
     assert "france" in response_content.lower() or "french" in response_content.lower()
 
 
-def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_next(
+def test_openai_instrumentor_sync_streaming_creates_span_when_iterated_with_next(
     sync_client: OpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -628,24 +628,24 @@ def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_next
         "",
     ]
     expected_response_text = "".join(expected_response_tokens)
-    mock_stream = []
+    byte_stream = []
     for token_index, token in enumerate(expected_response_tokens):
         response_body = {
             "choices": [
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }
             ],
         }
-        mock_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
-    mock_stream.append(b"data: [DONE]\n")
+        byte_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
+    byte_stream.append(b"data: [DONE]\n")
     respx_mock.post("https://api.openai.com/v1/chat/completions").respond(
         status_code=200,
-        stream=mock_stream,
+        stream=byte_stream,
     )
     response = sync_client.chat.completions.create(
         model=model, messages=messages, temperature=temperature, stream=True
@@ -702,7 +702,7 @@ def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_next
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
 
-def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_for_loop(
+def test_openai_instrumentor_sync_streaming_creates_span_when_iterated_with_for_loop(
     sync_client: OpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -736,25 +736,25 @@ def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_for_
         "",
     ]
     expected_response_text = "".join(expected_response_tokens)
-    mock_stream = []
+    byte_stream = []
     for token_index, token in enumerate(expected_response_tokens):
         response_body = {
             "choices": [
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }
             ],
         }
-        mock_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
-    mock_stream.append(b"data: [DONE]\n")
+        byte_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
+    byte_stream.append(b"data: [DONE]\n")
     url = "https://api.openai.com/v1/chat/completions"
     respx_mock.post(url).respond(
         status_code=200,
-        stream=mock_stream,
+        stream=byte_stream,
     )
     response = sync_client.chat.completions.create(
         model=model, messages=messages, temperature=temperature, stream=True
@@ -825,7 +825,7 @@ def test_openai_instrumentor_sync_streaming_with_error_midstream_records_excepti
     ]
     response_text_before_error = "".join(response_tokens_before_error)
 
-    def mock_stream() -> Iterator[bytes]:
+    def byte_stream() -> Iterator[bytes]:
         for token in response_tokens_before_error:
             response_body = {
                 "object": "chat.completion.chunk",
@@ -844,7 +844,7 @@ def test_openai_instrumentor_sync_streaming_with_error_midstream_records_excepti
 
     respx_mock.post("https://api.openai.com/v1/chat/completions").respond(
         status_code=200,
-        stream=mock_stream(),
+        stream=byte_stream(),
     )
     response = sync_client.chat.completions.create(
         model=model, messages=messages, temperature=temperature, stream=True
@@ -936,26 +936,25 @@ def test_openai_instrumentor_sync_streaming_creates_span_only_once(
         ".",
         "",
     ]
-    expected_response_text = "".join(expected_response_tokens)
-    mock_stream = []
+    byte_stream = []
     for token_index, token in enumerate(expected_response_tokens):
         response_body = {
             "choices": [
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }
             ],
         }
-        mock_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
-    mock_stream.append(b"data: [DONE]\n")
+        byte_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
+    byte_stream.append(b"data: [DONE]\n")
     url = "https://api.openai.com/v1/chat/completions"
     respx_mock.post(url).respond(
         status_code=200,
-        stream=mock_stream,
+        stream=byte_stream,
     )
     response = sync_client.chat.completions.create(
         model=model, messages=messages, temperature=temperature, stream=True
@@ -1480,7 +1479,7 @@ async def test_openai_instrumentor_async_works_with_chat_completion_with_raw_res
     assert "france" in response_content.lower() or "french" in response_content.lower()
 
 
-async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_with_anext(
+async def test_openai_instrumentor_async_streaming_creates_span_when_iterated_with_anext(
     async_client: AsyncOpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -1521,7 +1520,7 @@ async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_wi
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }
@@ -1588,7 +1587,7 @@ async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_wi
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
 
-async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_with_async_for_loop(
+async def test_openai_instrumentor_async_streaming_creates_span_when_iterated_with_async_for_loop(
     async_client: AsyncOpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -1629,7 +1628,7 @@ async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_wi
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }
@@ -1822,7 +1821,6 @@ async def test_openai_instrumentor_async_streaming_creates_span_only_once(
         ".",
         "",
     ]
-    expected_response_text = "".join(expected_response_tokens)
     byte_stream = []
     for token_index, token in enumerate(expected_response_tokens):
         response_body = {
@@ -1830,7 +1828,7 @@ async def test_openai_instrumentor_async_streaming_creates_span_only_once(
                 {
                     "delta": {"role": "assistant", "content": token},
                     "finish_reason": "stop"
-                    if token_index == len(expected_response_text) - 1
+                    if token_index == len(expected_response_tokens) - 1
                     else None,
                     "index": 0,
                 }

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -1856,7 +1856,7 @@ async def test_openai_instrumentor_async_streaming_creates_span_only_once(
     assert len(spans) == 1
 
     # ensure that further attempts to iterate over the exhausted stream do not create new spans
-    with pytest.raises(StopIteration):
+    with pytest.raises(StopAsyncIteration):
         await anext(response)
     spans = list(tracer.get_spans())
     assert len(spans) == 1

--- a/tests/trace/openai/test_instrumentor.py
+++ b/tests/trace/openai/test_instrumentor.py
@@ -3,12 +3,12 @@ import sys
 from datetime import datetime
 from importlib import reload
 from types import ModuleType
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
 import openai
 import pytest
-from httpx import Response
-from openai import AsyncOpenAI, AuthenticationError, OpenAI, Stream
+from httpx import AsyncByteStream, Response
+from openai import AsyncOpenAI, AsyncStream, AuthenticationError, OpenAI, Stream
 from phoenix.trace.openai.instrumentor import OpenAIInstrumentor
 from phoenix.trace.schemas import SpanException, SpanKind, SpanStatusCode
 from phoenix.trace.semantic_conventions import (
@@ -38,6 +38,15 @@ from phoenix.trace.semantic_conventions import (
 )
 from phoenix.trace.tracer import Tracer
 from respx import MockRouter
+
+
+class MockAsyncByteStream(AsyncByteStream):
+    def __init__(self, byte_stream: Iterator[bytes]):
+        self._byte_stream = byte_stream
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for byte_string in self._byte_stream:
+            yield byte_string
 
 
 @pytest.fixture
@@ -585,7 +594,7 @@ def test_openai_instrumentor_sync_works_with_chat_completion_with_raw_response(
     assert "france" in response_content.lower() or "french" in response_content.lower()
 
 
-def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_with_next(
+def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_next(
     sync_client: OpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -693,7 +702,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
 
-def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_with_for_loop(
+def test_openai_instrumentor_sync_streaming_updates_span_when_iterated_with_for_loop(
     sync_client: OpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -795,7 +804,7 @@ def test_openai_instrumentor_sync_streaming_response_updates_span_when_iterated_
     assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
 
 
-def test_openai_instrumentor_sync_streaming_response_with_error_midstream_records_exception_event(
+def test_openai_instrumentor_sync_streaming_with_error_midstream_records_exception(
     sync_client: OpenAI,
     respx_mock: MockRouter,
 ) -> None:
@@ -1469,3 +1478,312 @@ async def test_openai_instrumentor_async_works_with_chat_completion_with_raw_res
     assert len(choices) == 1
     response_content = choices[0]["message"]["content"]
     assert "france" in response_content.lower() or "french" in response_content.lower()
+
+
+async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_with_anext(
+    async_client: AsyncOpenAI,
+    respx_mock: MockRouter,
+) -> None:
+    tracer = Tracer()
+    OpenAIInstrumentor(tracer).instrument()
+    model = "gpt-4"
+    messages = [{"role": "user", "content": "What are the seven wonders of the world?"}]
+    temperature = 0.23
+    expected_response_tokens = [
+        "",
+        "The",
+        " seven",
+        " wonders",
+        " of",
+        " the",
+        " world",
+        " include",
+        " the",
+        " Great",
+        " Pyramid",
+        " of",
+        " G",
+        "iza",
+        " and",
+        " the",
+        " Hanging",
+        " Gardens",
+        " of",
+        " Babylon",
+        ".",
+        "",
+    ]
+    expected_response_text = "".join(expected_response_tokens)
+    byte_stream = []
+    for token_index, token in enumerate(expected_response_tokens):
+        response_body = {
+            "choices": [
+                {
+                    "delta": {"role": "assistant", "content": token},
+                    "finish_reason": "stop"
+                    if token_index == len(expected_response_text) - 1
+                    else None,
+                    "index": 0,
+                }
+            ],
+        }
+        byte_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
+    byte_stream.append(b"data: [DONE]\n")
+    respx_mock.post("https://api.openai.com/v1/chat/completions").respond(
+        status_code=200,
+        stream=MockAsyncByteStream(byte_stream),
+    )
+    response = await async_client.chat.completions.create(
+        model=model, messages=messages, temperature=temperature, stream=True
+    )
+    assert isinstance(response, AsyncStream)
+    spans = list(tracer.get_spans())
+    assert len(spans) == 0
+
+    # consume the stream to trigger span creation
+    tokens = []
+    while True:
+        try:
+            chunk = await anext(response)
+            tokens.append(chunk.choices[0].delta.content)
+        except StopAsyncIteration:
+            break
+    response_text = "".join(tokens)
+    assert response_text == expected_response_text
+
+    spans = list(tracer.get_spans())
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = span.attributes
+
+    assert span.span_kind is SpanKind.LLM
+    assert span.status_code == SpanStatusCode.OK
+    assert isinstance(span.end_time, datetime)
+    assert len(span.events) == 1
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
+
+    assert attributes[LLM_INPUT_MESSAGES] == [
+        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
+    ]
+    assert (
+        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
+        == json.loads(attributes[INPUT_VALUE])
+        == {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": True,
+        }
+    )
+    output_messages = attributes[LLM_OUTPUT_MESSAGES]
+    assert len(output_messages) == 1
+    assert output_messages[0] == {
+        MESSAGE_ROLE: "assistant",
+        MESSAGE_CONTENT: expected_response_text,
+    }
+    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
+    chunks = json.loads(attributes[OUTPUT_VALUE])
+    assert len(chunks) == len(expected_response_tokens)
+    assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
+
+
+async def test_openai_instrumentor_async_streaming_updates_span_when_iterated_with_async_for_loop(
+    async_client: AsyncOpenAI,
+    respx_mock: MockRouter,
+) -> None:
+    tracer = Tracer()
+    OpenAIInstrumentor(tracer).instrument()
+    model = "gpt-4"
+    messages = [{"role": "user", "content": "What are the seven wonders of the world?"}]
+    temperature = 0.23
+    expected_response_tokens = [
+        "",
+        "The",
+        " seven",
+        " wonders",
+        " of",
+        " the",
+        " world",
+        " include",
+        " the",
+        " Great",
+        " Pyramid",
+        " of",
+        " G",
+        "iza",
+        " and",
+        " the",
+        " Hanging",
+        " Gardens",
+        " of",
+        " Babylon",
+        ".",
+        "",
+    ]
+    expected_response_text = "".join(expected_response_tokens)
+    byte_stream = []
+    for token_index, token in enumerate(expected_response_tokens):
+        response_body = {
+            "choices": [
+                {
+                    "delta": {"role": "assistant", "content": token},
+                    "finish_reason": "stop"
+                    if token_index == len(expected_response_text) - 1
+                    else None,
+                    "index": 0,
+                }
+            ],
+        }
+        byte_stream.append(f"data: {json.dumps(response_body)}\n\n".encode("utf-8"))
+    byte_stream.append(b"data: [DONE]\n")
+    url = "https://api.openai.com/v1/chat/completions"
+    respx_mock.post(url).respond(
+        status_code=200,
+        stream=MockAsyncByteStream(byte_stream),
+    )
+    response = await async_client.chat.completions.create(
+        model=model, messages=messages, temperature=temperature, stream=True
+    )
+    assert isinstance(response, AsyncStream)
+    spans = list(tracer.get_spans())
+    assert len(spans) == 0
+
+    # iterate over the stream to trigger span creation
+    response_text = "".join([chunk.choices[0].delta.content async for chunk in response])
+    assert response_text == expected_response_text
+
+    spans = list(tracer.get_spans())
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = span.attributes
+
+    assert span.span_kind is SpanKind.LLM
+    assert span.status_code == SpanStatusCode.OK
+    assert isinstance(span.end_time, datetime)
+    assert len(span.events) == 1
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
+
+    assert attributes[LLM_INPUT_MESSAGES] == [
+        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
+    ]
+    assert (
+        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
+        == json.loads(attributes[INPUT_VALUE])
+        == {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": True,
+        }
+    )
+    output_messages = attributes[LLM_OUTPUT_MESSAGES]
+    assert len(output_messages) == 1
+    assert output_messages[0] == {
+        MESSAGE_ROLE: "assistant",
+        MESSAGE_CONTENT: expected_response_text,
+    }
+    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
+    chunks = json.loads(attributes[OUTPUT_VALUE])
+    assert len(chunks) == len(expected_response_tokens)
+    assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON
+
+
+async def test_openai_instrumentor_async_streaming_with_error_midstream_records_exception(
+    async_client: AsyncOpenAI,
+    respx_mock: MockRouter,
+) -> None:
+    tracer = Tracer()
+    OpenAIInstrumentor(tracer).instrument()
+    model = "gpt-4"
+    messages = [{"role": "user", "content": "What are the seven wonders of the world?"}]
+    temperature = 0.23
+    response_tokens_before_error = [
+        "",
+        "The",
+        " seven",
+        " wonders",
+        " of",
+        " the",
+        " world",
+        " include",
+    ]
+    response_text_before_error = "".join(response_tokens_before_error)
+
+    def byte_stream() -> Iterator[bytes]:
+        for token in response_tokens_before_error:
+            response_body = {
+                "object": "chat.completion.chunk",
+                "created": 1701722737,
+                "model": "gpt-4-0613",
+                "choices": [
+                    {
+                        "delta": {"role": "assistant", "content": token},
+                        "finish_reason": None,
+                        "index": 0,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(response_body)}\n\n".encode("utf-8")
+        raise RuntimeError("error-message")
+
+    respx_mock.post("https://api.openai.com/v1/chat/completions").respond(
+        status_code=200,
+        stream=MockAsyncByteStream(byte_stream()),
+    )
+    response = await async_client.chat.completions.create(
+        model=model, messages=messages, temperature=temperature, stream=True
+    )
+    assert isinstance(response, AsyncStream)
+    spans = list(tracer.get_spans())
+    assert len(spans) == 0
+
+    # iterate over the stream until hitting the error
+    tokens = []
+    for _ in range(len(response_tokens_before_error)):
+        chunk = await anext(response)
+        tokens.append(chunk.choices[0].delta.content)
+    with pytest.raises(RuntimeError, match="error-message"):
+        await anext(response)
+
+    spans = list(tracer.get_spans())
+    assert len(spans) == 1
+    span = spans[0]
+    attributes = span.attributes
+
+    assert span.span_kind is SpanKind.LLM
+    assert span.status_code == SpanStatusCode.ERROR
+    assert isinstance(span.end_time, datetime)
+    assert len(span.events) == 2
+    first_token_event = span.events[0]
+    assert "first token" in first_token_event.name.lower()
+    span_exception = span.events[-1]
+    assert isinstance(span_exception, SpanException)
+    assert span_exception.attributes[EXCEPTION_TYPE] == "RuntimeError"
+    assert span_exception.attributes[EXCEPTION_MESSAGE] == "error-message"
+    assert "Traceback" in span_exception.attributes[EXCEPTION_STACKTRACE]
+
+    assert attributes[LLM_INPUT_MESSAGES] == [
+        {MESSAGE_ROLE: "user", MESSAGE_CONTENT: "What are the seven wonders of the world?"}
+    ]
+    assert (
+        json.loads(attributes[LLM_INVOCATION_PARAMETERS])
+        == json.loads(attributes[INPUT_VALUE])
+        == {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": True,
+        }
+    )
+    output_messages = attributes[LLM_OUTPUT_MESSAGES]
+    assert len(output_messages) == 1
+    assert output_messages[0] == {
+        MESSAGE_ROLE: "assistant",
+        MESSAGE_CONTENT: response_text_before_error,
+    }
+    assert attributes[INPUT_MIME_TYPE] == MimeType.JSON
+    chunks = json.loads(attributes[OUTPUT_VALUE])
+    assert len(chunks) == len(response_tokens_before_error)
+    assert attributes[OUTPUT_MIME_TYPE] == MimeType.JSON

--- a/tutorials/internal/openai_request_types.ipynb
+++ b/tutorials/internal/openai_request_types.ipynb
@@ -129,7 +129,7 @@
     "response = sync_client.chat.completions.create(\n",
     "    messages=[\n",
     "        {\n",
-    "            \"content\": \"Hello world! I am making an synchronous streaming request.\",\n",
+    "            \"content\": \"Hello world! I am making a synchronous streaming request.\",\n",
     "            \"role\": \"user\",\n",
     "        }\n",
     "    ],\n",
@@ -145,6 +145,43 @@
    "outputs": [],
    "source": [
     "for chunk in response:\n",
+    "    choice = chunk.choices[0]\n",
+    "    if choice.finish_reason is None:\n",
+    "        print(choice.delta.content, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Asynchronous Streaming Request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await async_client.chat.completions.create(\n",
+    "    messages=[\n",
+    "        {\n",
+    "            \"content\": \"Hello world! I am making an asynchronous streaming request.\",\n",
+    "            \"role\": \"user\",\n",
+    "        }\n",
+    "    ],\n",
+    "    model=model,\n",
+    "    stream=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async for chunk in response:\n",
     "    choice = chunk.choices[0]\n",
     "    if choice.finish_reason is None:\n",
     "        print(choice.delta.content, end=\"\")"


### PR DESCRIPTION
- adds support to `OpenAIInstrumentor` for asynchronous streaming LLM requests
- refactors logic that previously resided in StreamWrapper into a context manager for reusability across synchronous and asynchronous contexts
- adds corresponding unit tests
- adds corresponding section in the openai request types notebook
