### PR TITLE
refactor(traces): log span and document evaluations

### DIFF
--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,6 +1,7 @@
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
 from .datasets.schema import EmbeddingColumnNames, RetrievalEmbeddingColumnNames, Schema
+from .session.evaluation import log_evaluations
 from .session.session import NotebookEnvironment, Session, active_session, close_app, launch_app
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
@@ -37,4 +38,5 @@ __all__ = [
     "load_example_traces",
     "TraceDataset",
     "NotebookEnvironment",
+    "log_evaluations",
 ]

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -73,6 +73,9 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
     eval_name: str  # The name for the evaluation, e.g. 'toxicity'
     dataframe: pd.DataFrame = field(repr=False)
 
+    def __len__(self) -> int:
+        return len(self.dataframe)
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(eval_name={self.eval_name!r}, "

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -1,12 +1,160 @@
-import pandas as pd
+from abc import ABC
+from dataclasses import dataclass, field
+from itertools import product
+from types import MappingProxyType
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Set, Tuple
 
-EVALUATIONS_INDEX_NAME = "context.span_id"
-RESULTS_COLUMN_NAMES = ["score", "label", "explanation"]
+import pandas as pd
+from pandas.api.types import is_integer_dtype, is_numeric_dtype, is_string_dtype
 
 EVAL_NAME_COLUMN_PREFIX = "eval."
 
 
-class SpanEvaluations:
+class NeedsNamedIndex(ABC):
+    index_names: Mapping[Tuple[str, ...], Callable[[Any], bool]]
+    all_valid_index_name_sorted_combos: Set[Tuple[str, ...]]
+
+    @classmethod
+    def preferred_names(cls) -> List[str]:
+        return [choices[0] for choices in cls.index_names.keys()]
+
+    @classmethod
+    def aliases(cls) -> Mapping[str, str]:
+        return {alias: choices[0] for choices in cls.index_names.keys() for alias in choices[1:]}
+
+    @classmethod
+    def unalias(cls, name: str) -> str:
+        return cls.aliases().get(name, name)
+
+    @classmethod
+    def is_valid_index_names(cls, names: Sequence[str]) -> bool:
+        return (
+            len(names) == len(cls.index_names)
+            and tuple(sorted(names)) in cls.all_valid_index_name_sorted_combos
+        )
+
+    @classmethod
+    def find_valid_index_names(cls, dtypes: "pd.Series[Any]") -> Optional[List[str]]:
+        valid_names = []
+        for names, check_type in cls.index_names.items():
+            for name in names:
+                if name in dtypes.index and check_type(dtypes[name]):
+                    valid_names.append(name)
+                    break
+            else:
+                return None
+        return valid_names
+
+
+class NeedsResultColumns(ABC):
+    result_column_names: Mapping[str, Callable[[Any], bool]] = MappingProxyType(
+        {
+            "score": is_numeric_dtype,
+            "label": is_string_dtype,
+            "explanation": is_string_dtype,
+        }
+    )
+
+    @classmethod
+    def is_valid_result_columns(cls, dtypes: "pd.Series[Any]") -> bool:
+        names = cls.result_column_names.keys()
+        intersection = dtypes.index.intersection(names)  # type: ignore
+        if not len(intersection):
+            return False
+        for name in intersection:
+            check_type = cls.result_column_names[name]
+            if not check_type(dtypes[name]):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
+    eval_name: str  # The name for the evaluation, e.g. 'toxicity'
+    dataframe: pd.DataFrame = field(repr=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(eval_name={self.eval_name!r}, "
+            f"dataframe=<rows: {len(self.dataframe)!r}>)"
+        )
+
+    def __dir__(self) -> List[str]:
+        return ["get_dataframe"]
+
+    def get_dataframe(self, prefix_columns_with_name: bool = True) -> pd.DataFrame:
+        """
+        Returns a copy of the dataframe with the evaluation annotations
+
+        Parameters
+        __________
+        prefix_columns_with_name: bool
+            if True, the columns will be prefixed with the eval_name, e.g. 'eval.toxicity.value'
+        """
+        if prefix_columns_with_name:
+            prefix = f"{EVAL_NAME_COLUMN_PREFIX}{self.eval_name}."
+            return self.dataframe.add_prefix(prefix)
+        return self.dataframe.copy(deep=False)
+
+    def __bool__(self) -> bool:
+        return not self.dataframe.empty
+
+    def __post_init__(self) -> None:
+        dataframe = (
+            pd.DataFrame() if self.dataframe.empty else self._clean_dataframe(self.dataframe)
+        )
+        object.__setattr__(self, "dataframe", dataframe)
+
+    def _clean_dataframe(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        # Ensure column names are strings.
+        column_names = dataframe.columns.astype(str)
+        dataframe = dataframe.set_axis(column_names, axis=1)
+
+        # If the dataframe contains the index columns, set the index to those columns
+        if not self.is_valid_index_names(dataframe.index.names) and (
+            index_names := self.find_valid_index_names(dataframe.dtypes)
+        ):
+            dataframe = dataframe.set_index(index_names)
+
+        # Validate that the dataframe is indexed correctly.
+        if not self.is_valid_index_names(dataframe.index.names):
+            raise ValueError(
+                f"The dataframe index must be {self.preferred_names()} but was "
+                f"'{dataframe.index.name or dataframe.index.names}'"
+            )
+
+        # Validate that the dataframe contains result columns of appropriate types.
+        if not self.is_valid_result_columns(dataframe.dtypes):
+            raise ValueError(
+                f"The dataframe must contain one of these columns with appropriate "
+                f"value types: {self.result_column_names.keys()} "
+            )
+
+        # Un-alias to the preferred names.
+        preferred_names = [self.unalias(name) for name in dataframe.index.names]
+        dataframe = dataframe.rename_axis(preferred_names, axis=0)
+
+        # Drop the unnecessary columns.
+        result_column_names = dataframe.columns.intersection(self.result_column_names.keys())  # type: ignore
+        return dataframe.loc[:, result_column_names]  # type: ignore
+
+    def __init_subclass__(
+        cls,
+        index_names: Mapping[Tuple[str, ...], Callable[[Any], bool]],
+        **kwargs: Any,
+    ) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.index_names = index_names
+        cls.all_valid_index_name_sorted_combos = set(
+            tuple(sorted(prod)) for prod in product(*cls.index_names.keys())
+        )
+
+
+@dataclass(frozen=True)
+class SpanEvaluations(
+    Evaluations,
+    index_names=MappingProxyType({("context.span_id", "span_id"): is_string_dtype}),
+):
     """
     SpanEvaluations is a set of evaluation annotations for a set of spans.
     SpanEvaluations encompasses the evaluation annotations for a single evaluation task
@@ -18,7 +166,7 @@ class SpanEvaluations:
     Parameters
     __________
     eval_name: str
-        the name of the evaluation, e.x. 'toxicity'
+        the name of the evaluation, e.g. 'toxicity'
     dataframe: pandas.DataFrame
         the pandas dataframe containing the evaluation annotations Each row
         represents the evaluations on a span.
@@ -35,38 +183,52 @@ class SpanEvaluations:
     | span_3  | 1                  | toxic              | discrimination     |
     """
 
-    dataframe: pd.DataFrame
 
-    eval_name: str  # The name for the evaluation, e.x. 'toxicity'
+@dataclass(frozen=True)
+class DocumentEvaluations(
+    Evaluations,
+    index_names=MappingProxyType(
+        {
+            ("context.span_id", "span_id"): is_string_dtype,
+            ("document_position", "position"): is_integer_dtype,
+        }
+    ),
+):
+    """
+    DocumentEvaluations is a set of evaluation annotations for a set of documents.
+    DocumentEvaluations encompasses the evaluation annotations for a single evaluation task
+    such as relevance.
 
-    def __init__(self, eval_name: str, dataframe: pd.DataFrame):
-        self.eval_name = eval_name
+    Parameters
+    __________
+    eval_name: str
+        the name of the evaluation, e.g. 'relevance'
+    dataframe: pandas.DataFrame
+        the pandas dataframe containing the evaluation annotations. Each row
+        represents the evaluations on a document.
 
-        # If the dataframe contains the index column, set the index to that column
-        if EVALUATIONS_INDEX_NAME in dataframe.columns:
-            dataframe = dataframe.set_index(EVALUATIONS_INDEX_NAME)
+    Example
+    _______
 
-        # validate that the dataframe is indexed by context.span_id
-        if dataframe.index.name != EVALUATIONS_INDEX_NAME:
-            raise ValueError(
-                f"The dataframe index must be '{EVALUATIONS_INDEX_NAME}' but was "
-                f"'{dataframe.index.name}'"
-            )
+    DataFrame of document evaluations for relevance may look like:
 
-        # Drop the unnecessary columns
-        extra_column_names = dataframe.columns.difference(RESULTS_COLUMN_NAMES)
-        self.dataframe = dataframe.drop(extra_column_names, axis=1)
+    | span_id | position | score | label      | explanation  |
+    |---------|----------|-------|------------|--------------|
+    | span_1  | 0        | 1     | relevant   | it's apropos |
+    | span_1  | 1        | 1     | relevant   | it's germane |
+    | span_2  | 0        | 0     | irrelevant | it's rubbish |
+    """
 
-    def get_dataframe(self, prefix_columns_with_name: bool = True) -> pd.DataFrame:
-        """
-        Returns a copy of the dataframe with the evaluation annotations
+    def _clean_dataframe(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        dataframe = super()._clean_dataframe(dataframe)
+        if dataframe.index.names != self.preferred_names():
+            return dataframe.swaplevel()
+        return dataframe
 
-        Parameters
-        __________
-        prefix_columns_with_name: bool
-            if True, the columns will be prefixed with the eval_name, e.x. 'eval.toxicity.value'
-        """
-        if prefix_columns_with_name:
-            prefix = f"{EVAL_NAME_COLUMN_PREFIX}{self.eval_name}."
-            return self.dataframe.add_prefix(prefix)
-        return self.dataframe.copy()
+
+@dataclass(frozen=True)
+class TraceEvaluations(
+    Evaluations,
+    index_names=MappingProxyType({("context.trace_id", "trace_id"): is_string_dtype}),
+):
+    ...

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -16,7 +16,7 @@ from .semantic_conventions import (
     RERANKER_OUTPUT_DOCUMENTS,
     RETRIEVAL_DOCUMENTS,
 )
-from .span_evaluations import EVALUATIONS_INDEX_NAME, SpanEvaluations
+from .span_evaluations import Evaluations, SpanEvaluations
 from .span_json_decoder import json_to_span
 from .span_json_encoder import span_to_json
 
@@ -93,14 +93,14 @@ class TraceDataset:
 
     name: str
     dataframe: pd.DataFrame
-    evaluations: List[SpanEvaluations] = []
+    evaluations: List[Evaluations] = []
     _data_file_name: str = "data.parquet"
 
     def __init__(
         self,
         dataframe: DataFrame,
         name: Optional[str] = None,
-        evaluations: Iterable[SpanEvaluations] = (),
+        evaluations: Iterable[Evaluations] = (),
     ):
         """
         Constructs a TraceDataset from a dataframe of spans. Optionally takes in
@@ -199,7 +199,7 @@ class TraceDataset:
             coerce_timestamps="ms",
         )
 
-    def append_evaluations(self, evaluations: SpanEvaluations) -> None:
+    def append_evaluations(self, evaluations: Evaluations) -> None:
         """adds an evaluation to the traces"""
         # Append the evaluations to the list of evaluations
         self.evaluations.append(evaluations)
@@ -209,7 +209,11 @@ class TraceDataset:
         Creates a flat dataframe of all the evaluations for the dataset.
         """
         return pd.concat(
-            [evals.get_dataframe(prefix_columns_with_name=True) for evals in self.evaluations],
+            [
+                evals.get_dataframe(prefix_columns_with_name=True)
+                for evals in self.evaluations
+                if isinstance(evals, SpanEvaluations)
+            ],
             axis=1,
         )
 
@@ -227,5 +231,5 @@ class TraceDataset:
             return self.dataframe.copy()
         evals_df = self.get_evals_dataframe()
         # Make sure the index is set to the span_id
-        df = self.dataframe.set_index(EVALUATIONS_INDEX_NAME, drop=False)
+        df = self.dataframe.set_index("context.span_id", drop=False)
         return pd.concat([df, evals_df], axis=1)

--- a/tests/trace/test_span_evaluations.py
+++ b/tests/trace/test_span_evaluations.py
@@ -1,5 +1,14 @@
+from itertools import chain, combinations
+from random import random
+
 import pandas as pd
-from phoenix.trace.span_evaluations import SpanEvaluations
+import pytest
+from pandas.testing import assert_frame_equal
+from phoenix.trace.span_evaluations import (
+    EVAL_NAME_COLUMN_PREFIX,
+    DocumentEvaluations,
+    SpanEvaluations,
+)
 
 
 def test_span_evaluations_construction():
@@ -11,7 +20,7 @@ def test_span_evaluations_construction():
         dataframe=pd.DataFrame(
             {
                 "context.span_id": span_ids,
-                "label": [index for index in range(num_records)],
+                "label": [str(index) for index in range(num_records)],
                 "score": [index for index in range(num_records)],
                 "random_column": [index for index in range(num_records)],
             }
@@ -22,3 +31,67 @@ def test_span_evaluations_construction():
     assert "context.span_id" not in eval_ds.dataframe.columns
     assert "random_column" not in eval_ds.dataframe.columns
     assert "score" in eval_ds.dataframe.columns
+
+
+def power_set(s):
+    for result in chain.from_iterable(combinations(s, r) for r in range(len(s) + 1)):
+        yield dict(result)
+
+
+RESULTS = list(power_set(list({"score": 0, "label": "1", "explanation": "2"}.items())))
+BAD_RESULTS = list(power_set(list({"score": "0", "label": 1, "explanation": 2}.items())))
+
+
+@pytest.mark.parametrize("span_id", [None, "span_id", "context.span_id"])
+@pytest.mark.parametrize("position", [None, "position", "document_position"])
+@pytest.mark.parametrize("result", RESULTS)
+def test_document_evaluations_construction(span_id, position, result):
+    eval_name = "my_eval"
+    rand1, rand2 = random(), random()
+    df = pd.DataFrame([{**result, **{span_id: "x", position: 0, rand1: rand1, rand2: rand2}}])
+    if not result or not span_id or not position:
+        with pytest.raises(ValueError):
+            DocumentEvaluations(eval_name=eval_name, dataframe=df)
+        return
+    desired = (
+        df.drop([rand1, rand2], axis=1, errors="ignore")
+        .set_index([span_id, position])
+        .rename_axis(["context.span_id", "document_position"])
+        .add_prefix(f"{EVAL_NAME_COLUMN_PREFIX}{eval_name}.")
+    )
+    for idx in (
+        [],
+        [rand1],
+        [span_id],
+        [position],
+        [span_id, position],
+        [position, span_id],
+        [span_id, position, rand1],
+    ):
+        doc_evals = DocumentEvaluations(
+            eval_name=eval_name,
+            dataframe=df.set_index(idx, drop=False) if idx else df,
+        )
+        assert bool(doc_evals)
+        assert doc_evals.eval_name == eval_name
+        actual = doc_evals.get_dataframe(prefix_columns_with_name=True)
+        assert_frame_equal(actual, desired)
+
+
+@pytest.mark.parametrize("result", BAD_RESULTS)
+def test_document_evaluations_bad_results(result):
+    eval_name = "my_eval"
+    df = pd.DataFrame([{**result, **{"span_id": "x", "position": 0}}])
+    with pytest.raises(ValueError):
+        DocumentEvaluations(eval_name=eval_name, dataframe=df)
+
+
+def test_document_evaluations_edge_cases():
+    eval_name = "my_eval"
+    # empty should be fine
+    df = pd.DataFrame()
+    doc_evals = DocumentEvaluations(eval_name=eval_name, dataframe=df)
+    assert not bool(doc_evals)
+    assert doc_evals.eval_name == eval_name
+    actual = doc_evals.get_dataframe()
+    assert actual.shape == (0, 0)

--- a/tutorials/internal/trace_eval_ingestion_testing.ipynb
+++ b/tutorials/internal/trace_eval_ingestion_testing.ipynb
@@ -31,8 +31,9 @@
     "    RAG_RELEVANCY_PROMPT_RAILS_MAP,\n",
     "    RAG_RELEVANCY_PROMPT_TEMPLATE,\n",
     ")\n",
-    "from phoenix.session.evaluation import add_evaluations, get_retrieved_documents\n",
+    "from phoenix.session.evaluation import get_retrieved_documents, log_evaluations\n",
     "from phoenix.trace.exporter import HttpExporter\n",
+    "from phoenix.trace.span_evaluations import DocumentEvaluations, SpanEvaluations\n",
     "from sklearn.metrics import ndcg_score"
    ]
   },
@@ -222,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = OpenAIModel(model_name=\"gpt-4-1106-preview\")\n",
+    "model = OpenAIModel(model_name=\"gpt-3.5-turbo\")\n",
     "model(\"hi\")"
    ]
   },
@@ -299,36 +300,6 @@
     "    \"llama_index_rag_with_rerank.documents_eval.parquet\"\n",
     ")  # not required\n",
     "retrieved_documents_eval"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c6425c50d95f5340",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "### Evaluation Results are Ready to be Ingested. Dataframe Index is the Subject Identifier. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c2fd98885acf66d9",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Each set of evaluations should specify a name, which is an arbitrary string. Evaluations with the same name will be grouped together when computing aggregate metrics. The name is also used to identify different evaluations for the same subject when they are displayed in the UI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "495a5e74b469a660",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "add_evaluations(exporter, retrieved_documents_eval, \"Relevance\")"
    ]
   },
   {
@@ -439,36 +410,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2efd0431fe6b0e48",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "### Evaluation Results are Ready to be Ingested. Dataframe Index is the Subject Identifier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c3f119177a425b7c",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Each set of evaluations should specify a name, which is an arbitrary string. Evaluations with the same name will be grouped together when computing aggregate metrics. The name is also used to identify different evaluations for the same subject when they are displayed in the UI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20cc931d1529f84c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "add_evaluations(exporter, ndcg_at_2, \"NDCG@2\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "e8d5816954fbaa4d",
    "metadata": {
     "collapsed": false
@@ -525,36 +466,6 @@
     "    \"llama_index_rag_with_rerank.precision_at_3.parquet\"\n",
     ")  # not required\n",
     "precision_at_3"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "84ef28fd8cd65363",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "### Evaluation Results are Ready to be Ingested. Dataframe Index is the Subject Identifier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1da4d5b65e4ff68f",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Each set of evaluations should specify a name, which is an arbitrary string. Evaluations with the same name will be grouped together when computing aggregate metrics. The name is also used to identify different evaluations for the same subject when they are displayed in the UI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eb48a5daae9d5bcb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "add_evaluations(exporter, precision_at_3, \"Precision@3\")"
    ]
   },
   {
@@ -656,36 +567,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb1b19bfb4fcebd2",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "### Evaluation Results are Ready to be Ingested. Dataframe Index is the Subject Identifier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "36bfbbdce171a476",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Each set of evaluations should specify a name, which is an arbitrary string. Evaluations with the same name will be grouped together when computing aggregate metrics. The name is also used to identify different evaluations for the same subject when they are displayed in the UI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "848420ee90e10f62",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "add_evaluations(exporter, qa_correctness_eval, \"Q&A Correctness\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a88f90ea9c24832b",
    "metadata": {
     "collapsed": false
@@ -750,33 +631,29 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f9abd277dfbf1981",
-   "metadata": {
-    "collapsed": false
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baea4ca8",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "### Evaluation Results are Ready to be Ingested. Dataframe Index is the Subject Identifier."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "59e296d827a0b66c",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Each set of evaluations should specify a name, which is an arbitrary string. Evaluations with the same name will be grouped together when computing aggregate metrics. The name is also used to identify different evaluations for the same subject when they are displayed in the UI."
+    "evaluations = [\n",
+    "    DocumentEvaluations(eval_name=\"Relevance\", dataframe=retrieved_documents_eval),\n",
+    "    SpanEvaluations(eval_name=\"Hallucination\", dataframe=hallucination_eval),\n",
+    "    SpanEvaluations(eval_name=\"Q&A Correctness\", dataframe=qa_correctness_eval),\n",
+    "    SpanEvaluations(eval_name=\"ndcg@2\", dataframe=ndcg_at_2),\n",
+    "    SpanEvaluations(eval_name=\"precision@3\", dataframe=precision_at_3),\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c03dde5802ed98a3",
+   "id": "28e44983",
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_evaluations(exporter, hallucination_eval, \"Hallucination\")"
+    "log_evaluations(*evaluations)"
    ]
   },
   {
@@ -795,15 +672,11 @@
    "outputs": [],
    "source": [
     "from phoenix.trace import TraceDataset\n",
-    "from phoenix.trace.span_evaluations import SpanEvaluations\n",
     "\n",
     "trace_dataframe = px.active_session().get_spans_dataframe()\n",
     "trace_ds = TraceDataset(\n",
     "    trace_dataframe,\n",
-    "    evaluations=[\n",
-    "        SpanEvaluations(eval_name=\"hallucination\", dataframe=hallucination_eval),\n",
-    "        SpanEvaluations(eval_name=\"qa_correctness\", dataframe=qa_correctness_eval),\n",
-    "    ],\n",
+    "    evaluations=evaluations,\n",
     ")"
    ]
   },


### PR DESCRIPTION
resolves #1701 

# Changes
1. Add `DocumentEvaluations` alongside `SpanEvaluations`
    - Improve validation mechanics 
2. Add `log_evaluations`, which uses an internal `HttpExporter`. This is not ideal, but works for now.

## log_evaluations

https://github.com/Arize-ai/phoenix/assets/80478925/b73ab200-dfa3-4836-b03b-a34a3f0bd113