### PR TITLE
fix: Remove the retry handling lock

### DIFF
--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -162,9 +162,6 @@ class RateLimiter:
             rate_increase_factor=rate_increase_factor,
             cooldown_seconds=cooldown_seconds,
         )
-        self._rate_limit_handling = asyncio.Event()
-        self._rate_limit_handling.set()  # allow requests to start immediately
-        self._rate_limit_handling_lock = asyncio.Lock()
         self._verbose = verbose
 
     def limit(
@@ -198,27 +195,23 @@ class RateLimiter:
         @wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> GenericType:
             try:
-                await self._rate_limit_handling.wait()
                 await self._throttler.async_wait_until_ready()
                 request_start_time = time.time()
                 return await fn(*args, **kwargs)
             except self._rate_limit_error:
-                async with self._rate_limit_handling_lock:
-                    self._rate_limit_handling.clear()  # prevent new requests from starting
-                    self._throttler.on_rate_limit_error(request_start_time, verbose=self._verbose)
-                    try:
-                        for _attempt in range(self._max_rate_limit_retries):
-                            try:
-                                request_start_time = time.time()
-                                await self._throttler.async_wait_until_ready()
-                                return await fn(*args, **kwargs)
-                            except self._rate_limit_error:
-                                self._throttler.on_rate_limit_error(
-                                    request_start_time, verbose=self._verbose
-                                )
-                                continue
-                    finally:
-                        self._rate_limit_handling.set()  # allow new requests to start
-            raise RateLimitError(f"Exceeded max ({self._max_rate_limit_retries}) retries")
+                self._throttler.on_rate_limit_error(request_start_time, verbose=self._verbose)
+                try:
+                    for _attempt in range(self._max_rate_limit_retries):
+                        try:
+                            request_start_time = time.time()
+                            await self._throttler.async_wait_until_ready()
+                            return await fn(*args, **kwargs)
+                        except self._rate_limit_error:
+                            self._throttler.on_rate_limit_error(
+                                request_start_time, verbose=self._verbose
+                            )
+                            continue
+                finally:
+                    raise RateLimitError(f"Exceeded max ({self._max_rate_limit_retries}) retries")
 
         return wrapper


### PR DESCRIPTION
working with @jlopatec 

In rare cases, the task that unsets the event that allows workers to process requests might be timed out and never unsets, locking up the workers. I don't think the locks are strictly necessary so I'm removing them.