### PR TITLE
fix: Add lock failsafe

### DIFF
--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -160,7 +160,7 @@ class AsyncExecutor:
                 termination_signal_task = asyncio.create_task(self._TERMINATE.wait())
                 done, pending = await asyncio.wait(
                     [generate_task, termination_signal_task],
-                    timeout=120,
+                    timeout=360 * 2,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if generate_task in done:

--- a/src/phoenix/experimental/evals/models/rate_limiters.py
+++ b/src/phoenix/experimental/evals/models/rate_limiters.py
@@ -1,6 +1,5 @@
 import asyncio
 import time
-from contextlib import asynccontextmanager
 from functools import wraps
 from math import exp
 from typing import Any, Callable, Coroutine, Optional, Tuple, Type, TypeVar


### PR DESCRIPTION
This implements a better way of adding a failsafe for deadlocks caused by waiting on an event forever. We also extend the outer loop timeout to 720 seconds (6 minutes).