### PR TITLE
refactor: run_evals returns list of dataframes rather than a single dataframe

### DIFF
--- a/src/phoenix/experimental/evals/evaluators.py
+++ b/src/phoenix/experimental/evals/evaluators.py
@@ -20,7 +20,6 @@ class LLMEvaluator:
         self,
         model: BaseEvalModel,
         template: ClassificationTemplate,
-        name: str,
         verbose: bool = False,
     ) -> None:
         """Initializer for LLMEvaluator.
@@ -28,12 +27,10 @@ class LLMEvaluator:
         Args:
             model (BaseEvalModel): The LLM model to use for evaluation.
             template (ClassificationTemplate): The evaluation template.
-            name (str): The name of the evaluator.
             verbose (bool, optional): Whether to print verbose output.
         """
         self._model = model
         self._template = template
-        self.name = name
         self._verbose = verbose
 
     def evaluate(self, record: Record) -> str:


### PR DESCRIPTION
Updates the behavior of `run_evals` so that it returns a list of dataframes, one for each input evaluator, rather than a single dataframe.