### PR TITLE
ci: add missing `api_key` fixtures in unit tests

### DIFF
--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -158,6 +158,7 @@ def test_executor_factory_returns_async_in_sync_context():
 
 @pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions")
 def test_llm_classify(
+    api_key: str,
     classification_dataframe: DataFrame,
     respx_mock: respx.mock,
 ):
@@ -387,7 +388,7 @@ def test_llm_classify_prints_to_stdout_with_verbose_flag(
     assert "sk-0123456789" not in out, "Credentials should not be printed out in cleartext"
 
 
-def test_llm_classify_shows_retry_info(capfd: pytest.CaptureFixture[str]):
+def test_llm_classify_shows_retry_info(api_key: str, capfd: pytest.CaptureFixture[str]):
     dataframe = pd.DataFrame(
         [
             {
@@ -547,6 +548,7 @@ def test_run_relevance_eval_standard_dataframe(
 
 @pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions", assert_all_called=False)
 def test_classify_tolerance_to_exceptions(
+    api_key: str,
     classification_dataframe: pd.DataFrame,
     classification_responses: List[str],
     classification_template: str,
@@ -579,6 +581,7 @@ def test_classify_tolerance_to_exceptions(
 
 
 def test_run_relevance_eval_openinference_dataframe(
+    api_key: str,
     respx_mock: respx.mock,
 ):
     dataframe = pd.DataFrame(


### PR DESCRIPTION
this fixes the following errors

> FAILED tests/experimental/evals/functions/test_classify.py::test_llm_classify - RuntimeError: OpenAI's API key not provided. Pass it as an argument to 'api_key' or set it in your environment: 'export OPENAI_API_KEY=sk-****'
FAILED tests/experimental/evals/functions/test_classify.py::test_llm_classify_shows_retry_info - RuntimeError: OpenAI's API key not provided. Pass it as an argument to 'api_key' or set it in your environment: 'export OPENAI_API_KEY=sk-****'
FAILED tests/experimental/evals/functions/test_classify.py::test_classify_tolerance_to_exceptions - RuntimeError: OpenAI's API key not provided. Pass it as an argument to 'api_key' or set it in your environment: 'export OPENAI_API_KEY=sk-****'
FAILED tests/experimental/evals/functions/test_classify.py::test_run_relevance_eval_openinference_dataframe - RuntimeError: OpenAI's API key not provided. Pass it as an argument to 'api_key' or set it in your environment: 'export OPENAI_API_KEY=sk-****'