### PR TITLE
chore: add a read-only mode

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -163,6 +163,7 @@ def create_app(
     traces: Optional[Traces] = None,
     evals: Optional[Evals] = None,
     debug: bool = False,
+    read_only: bool = False,
 ) -> Starlette:
     graphql = GraphQLWithContext(
         schema=schema,
@@ -180,7 +181,7 @@ def create_app(
         debug=debug,
         routes=(
             []
-            if traces is None
+            if traces is None or read_only
             else [
                 Route(
                     "/v1/spans",
@@ -194,7 +195,7 @@ def create_app(
         )
         + (
             []
-            if evals is None
+            if evals is None or read_only
             else [
                 Route(
                     "/v1/evaluations",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -93,6 +93,7 @@ if __name__ == "__main__":
     parser.add_argument("--export_path")
     parser.add_argument("--host", type=str, required=False)
     parser.add_argument("--port", type=int, required=False)
+    parser.add_argument("--read-only", type=bool, default=False)
     parser.add_argument("--no-internet", action="store_true")
     parser.add_argument("--umap_params", type=str, required=False, default=DEFAULT_UMAP_PARAMS_STR)
     parser.add_argument("--debug", action="store_false")
@@ -172,6 +173,7 @@ if __name__ == "__main__":
         n_neighbors=int(umap_params_list[1]),
         n_samples=int(umap_params_list[2]),
     )
+    read_only = args.read_only
     logger.info(f"Server umap params: {umap_params}")
     app = create_app(
         export_path=export_path,
@@ -181,6 +183,7 @@ if __name__ == "__main__":
         evals=evals,
         corpus=None if corpus_dataset is None else create_model_from_datasets(corpus_dataset),
         debug=args.debug,
+        read_only=read_only,
     )
     host = args.host or get_env_host()
     port = args.port or get_env_port()


### PR DESCRIPTION
Create a read-only mode flag so that phoenix can be hosted on data but reject appending spans and evals to it. Needed for a demo site.