### PR TITLE
chore: add open graph tags for sharing phoenix via social media

### DIFF
--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -4,8 +4,12 @@
     <title>Phoenix</title>
     <link rel="icon" href="{{basename}}/favicon.ico" type="image/x-icon"></link>
     <meta charset="UTF-8" />
-    <meta name="description" content="Explore, Analyze, Curate" />
+    <meta name="title" content="Arize Phoenix" />
+    <meta name="description" content="AI Observability & Evaluation" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:title" content="AI Observability & Evaluation" />
+    <meta property="og:description" content="AI Observability & Evaluation" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/socal/social-preview-horizontal.jpg" />
     <meta name="theme-color" content="#ffffff" />
     <link rel="stylesheet" src="{{basename}}/index.css"></link>
     <link

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -7,7 +7,7 @@
     <meta name="title" content="Arize Phoenix" />
     <meta name="description" content="AI Observability & Evaluation" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="AI Observability & Evaluation" />
+    <meta property="og:title" content="Arize Phoenix" />
     <meta property="og:description" content="AI Observability & Evaluation" />
     <meta property="og:image" content="https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/socal/social-preview-horizontal.jpg" />
     <meta name="theme-color" content="#ffffff" />


### PR DESCRIPTION
Now that you can host phoenix, we want to have clear titles and open-graph images.
<img width="415" alt="Screenshot 2023-12-20 at 2 17 03 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/655210df-4ef7-4827-82a2-626f9b73a568">
