### PR TITLE
fix: make alert icon for exceptions visible

### DIFF
--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1426,7 +1426,7 @@ function SpanEventsList({ events }: { events: Span["events"] }) {
         return (
           <ListItem key={idx}>
             <Flex direction="row" alignItems="center" gap="size-100">
-              <View>
+              <View overflow="visible">
                 <div
                   data-event-type={isException ? "exception" : "info"}
                   css={(theme) => css`

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1426,7 +1426,7 @@ function SpanEventsList({ events }: { events: Span["events"] }) {
         return (
           <ListItem key={idx}>
             <Flex direction="row" alignItems="center" gap="size-100">
-              <View overflow="visible">
+              <View flex="none">
                 <div
                   data-event-type={isException ? "exception" : "info"}
                   css={(theme) => css`


### PR DESCRIPTION
Ensures that the alerts icon for exception events is visible. The issue appears to be caused by the fact that the `View` component from the Arize component library has `overflow: hidden`.

 https://github.com/Arize-ai/ui-components/blob/adb81aab5ca9cc686a2b73aeabae20726b336e4f/src/view/View.tsx#L35