### PR TITLE
fix: ensure llamaindex spans are correctly encoded

### DIFF
--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -396,10 +396,10 @@ def _encode_value(value: AttributeValue) -> AnyValue:
         return AnyValue(int_value=value)
     if isinstance(value, float):
         return AnyValue(double_value=value)
-    if isinstance(value, Sequence):
-        return AnyValue(array_value=ArrayValue(values=map(_encode_value, value)))
     if isinstance(value, bytes):
         return AnyValue(bytes_value=value)
+    if isinstance(value, Sequence):
+        return AnyValue(array_value=ArrayValue(values=map(_encode_value, value)))
     raise AssertionError(f"Unexpected attribute value {value} with type {type(value)}.")
 
 

--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -400,7 +400,7 @@ def _encode_value(value: AttributeValue) -> AnyValue:
         return AnyValue(array_value=ArrayValue(values=map(_encode_value, value)))
     if isinstance(value, bytes):
         return AnyValue(bytes_value=value)
-    assert_never(value)
+    raise AssertionError(f"Unexpected attribute value {value} with type {type(value)}.")
 
 
 __all__ = [

--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -400,7 +400,7 @@ def _encode_value(value: AttributeValue) -> AnyValue:
         return AnyValue(bytes_value=value)
     if isinstance(value, Sequence):
         return AnyValue(array_value=ArrayValue(values=map(_encode_value, value)))
-    raise AssertionError(f"Unexpected attribute value {value} with type {type(value)}.")
+    raise ValueError(f"Unexpected attribute value {value} with type {type(value)}.")
 
 
 __all__ = [


### PR DESCRIPTION
- Fixes a bug in the LlamaIndex trace callback that was causing bytes to fail to be encoded.
- Improves log messages for uncaught types.