### PR TITLE
refactor: materialize fixtures before loading by thread

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     traces = Traces()
     evals = Evals()
     if trace_dataset_name is not None:
-        fixture_spans = (
+        fixture_spans = list(
             encode(json_string_to_span(json_span))
             for json_span in _download_traces_fixture(
                 _get_trace_fixture_by_name(trace_dataset_name)
@@ -160,7 +160,7 @@ if __name__ == "__main__":
             args=(traces, fixture_spans, simulate_streaming),
             daemon=True,
         ).start()
-        fixture_evals = get_evals_from_fixture(trace_dataset_name)
+        fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
         Thread(
             target=_load_items,
             args=(evals, fixture_evals, simulate_streaming),


### PR DESCRIPTION
If a network error prevent the fixtures from being read, it should be a fatal error, and the app should not launch.