### PR TITLE
fix: Handle missing Vertex output

### DIFF
--- a/src/phoenix/experimental/evals/models/litellm.py
+++ b/src/phoenix/experimental/evals/models/litellm.py
@@ -61,14 +61,9 @@ class LiteLLMModel(BaseEvalModel):
 
     def _init_model_encoding(self) -> None:
         from litellm import decode, encode
+        self._encoding = encode
+        self._decoding = decode
 
-        if self.model_name in self._litellm.model_list:
-            self._encoding = encode
-            self._decoding = decode
-        else:
-            raise ValueError(
-                f"Model name not found in the LiteLLM's models list: \n{self._litellm.model_list}"
-            )
 
     @property
     def max_context_size(self) -> int:

--- a/src/phoenix/experimental/evals/models/litellm.py
+++ b/src/phoenix/experimental/evals/models/litellm.py
@@ -61,9 +61,14 @@ class LiteLLMModel(BaseEvalModel):
 
     def _init_model_encoding(self) -> None:
         from litellm import decode, encode
-        self._encoding = encode
-        self._decoding = decode
 
+        if self.model_name in self._litellm.model_list:
+            self._encoding = encode
+            self._decoding = decode
+        else:
+            raise ValueError(
+                f"Model name not found in the LiteLLM's models list: \n{self._litellm.model_list}"
+            )
 
     @property
     def max_context_size(self) -> int:

--- a/src/phoenix/experimental/evals/models/vertex.py
+++ b/src/phoenix/experimental/evals/models/vertex.py
@@ -149,7 +149,23 @@ class GeminiModel(BaseEvalModel):
             response = await self._model.generate_content_async(
                 contents=prompt, generation_config=generation_config, **kwargs
             )
-            candidate = response.candidates[0]
-            return candidate.text
+            if hasattr(response, 'candidates'):
+                if isinstance(response.candidates, list) and len(response.candidates) > 0:
+                    # Access response.candidates[0]
+                    # You can now safely use response.candidates[0] here
+                    try:
+                        candidate = response.candidates[0].text
+                    except ValueError:
+                        print("The 'candidates' object does not have a 'text' attribute.")
+                        print(response.candidates[0])
+                        candidate = "NOT_PARSABLE"
+                else:
+                    print("The 'candidates' attribute of 'response' is either not a list or is empty.")
+                    print(response)
+                    candidate = "NOT_PARSABLE"
+            else:
+                print("The 'response' object does not have a 'candidates' attribute.")
+                candidate = "NOT_PARSABLE"
+            return candidate
 
         return await _completion_with_retry(**kwargs)


### PR DESCRIPTION
We added fixes to the vertex model to handle cases where Vertex does not return a valid result. Gemini blocks for certain content. It happens often enough that its needed to run Eval successfully. 

Only added it to Async, think we need it in sync as well. 

The Haystack analysis runs will not finish with Gemini without this fix.