### PR TITLE
chore: remove outdated option from old release-please version (v3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
         id: release-please
         with:
           release-type: python
-          package-name: arize-phoenix
 
   publish-to-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
v4 uses manifest driven package names