### PR TITLE
chore(traces): update calculator agent fixture

### DIFF
--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -59,7 +59,7 @@ llama_index_rag_fixture = TracesFixture(
 llama_index_calculator_agent_fixture = TracesFixture(
     name="llama_index_calculator_agent",
     description="Traces from running the llama_index with calculator tools.",
-    file_name="llama_index_calculator_agent_v2.jsonl",
+    file_name="llama_index_calculator_agent_v3.jsonl",
 )
 
 llama_index_rag_fixture_with_davinci = TracesFixture(


### PR DESCRIPTION
The previous fixture had deprecated semantic conventions, causing the fixture to not load (see #2012) This simply updates the fixture to the up to date messages conventions