### PR TITLE
feat: add ability to save and load TraceDatasets

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -242,7 +242,7 @@ class ProcessSession(Session):
         if isinstance(corpus_dataset, Dataset):
             corpus_dataset.to_disc()
         if isinstance(trace_dataset, TraceDataset):
-            trace_dataset.to_parquet()
+            trace_dataset.to_disc()
         umap_params_str = (
             f"{self.umap_parameters.min_dist},"
             f"{self.umap_parameters.n_neighbors},"

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -242,7 +242,7 @@ class ProcessSession(Session):
         if isinstance(corpus_dataset, Dataset):
             corpus_dataset.to_disc()
         if isinstance(trace_dataset, TraceDataset):
-            trace_dataset.to_disc()
+            trace_dataset.to_parquet()
         umap_params_str = (
             f"{self.umap_parameters.min_dist},"
             f"{self.umap_parameters.n_neighbors},"

--- a/src/phoenix/trace/errors.py
+++ b/src/phoenix/trace/errors.py
@@ -1,0 +1,5 @@
+from phoenix.exceptions import PhoenixException
+
+
+class InvalidParquetMetadataError(PhoenixException):
+    pass

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -317,13 +317,11 @@ def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, Type[Evaluations]
     try:
         metadata = schema.metadata
         arize_metadata = json.loads(metadata[b"arize"])
-        evaluations_classes = {
-            subclass.__name__: subclass for subclass in Evaluations.__subclasses__()
-        }
+        eval_classes = {subclass.__name__: subclass for subclass in Evaluations.__subclasses__()}
         eval_id = UUID(arize_metadata["eval_id"])
         if not isinstance((eval_name := arize_metadata["eval_name"]), str):
             raise ValueError('Arize metadata must contain a string value for key "eval_name"')
-        evaluations_cls = evaluations_classes[arize_metadata["eval_type"]]
+        evaluations_cls = eval_classes[arize_metadata["eval_type"]]
         return eval_id, eval_name, evaluations_cls
     except Exception as err:
         raise InvalidParquetMetadataError(

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -303,13 +303,13 @@ def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, Type[Evaluations]
     """
     try:
         metadata = schema.metadata
-        arize_metadata_json = metadata[b"arize"]
-        arize_metadata = json.loads(arize_metadata_json)
+        arize_metadata = json.loads(metadata[b"arize"])
         evaluations_classes = {
             subclass.__name__: subclass for subclass in Evaluations.__subclasses__()
         }
         eval_id = UUID(arize_metadata["eval_id"])
-        eval_name = arize_metadata["eval_name"]
+        if not isinstance((eval_name := arize_metadata["eval_name"]), str):
+            raise ValueError('Arize metadata must contain a string value for key "eval_name"')
         evaluations_cls = evaluations_classes[arize_metadata["eval_type"]]
         return eval_id, eval_name, evaluations_cls
     except Exception as err:

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -214,6 +214,11 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
         path = Path(directory) / EVAL_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema)
+        if id != eval_id:
+            raise InvalidParquetMetadataError(
+                f"The input id {id} does not match the id {eval_id} in the parquet metadata. "
+                "Ensure that you have not renamed the parquet file."
+            )
         table = parquet.read_table(path)
         dataframe = table.to_pandas()
         evaluations = evaluations_cls(eval_name=eval_name, dataframe=dataframe)

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -161,18 +161,18 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             tuple(sorted(prod)) for prod in product(*cls.index_names.keys())
         )
 
-    def to_parquet(self, directory: Optional[Union[str, Path]] = None) -> UUID:
+    def save(self, directory: Optional[Union[str, Path]] = None) -> UUID:
         """
-        Persists the evaluations to a parquet file.
+        Persists the evaluations to disk.
 
         Args:
             directory (Optional[Union[str, Path]], optional): An optional path
-            to a directory where the parquet file will be saved. If not
-            provided, the parquet file will be saved to a default location.
+            to a directory where the data will be saved. If not provided, the
+            data will be saved to a default location.
 
         Returns:
             UUID: The ID of the evaluations, which can be used as a key to load
-            the evaluations from disk using `from_parquet`.
+            the evaluations from disk using `load`.
         """
         directory = Path(directory) if directory else TRACE_DATASET_DIR
         path = directory / EVAL_PARQUET_FILE_NAME.format(id=self.id)
@@ -194,17 +194,17 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
         return self.id
 
     @classmethod
-    def from_parquet(cls, id: UUID, directory: Optional[Union[str, Path]] = None) -> "Evaluations":
+    def load(cls, id: UUID, directory: Optional[Union[str, Path]] = None) -> "Evaluations":
         """
-        Loads the evaluations from a parquet file.
+        Loads the evaluations from disk.
 
         Args:
             id (UUID): The ID of the evaluations to load.
 
             directory(Optional[Union[str, Path]], optional): The path to the
-            directory containing the persisted evaluations parquet file. If not
-            provided, the parquet file will be loaded from the same default
-            location used by `to_parquet`.
+            directory containing the persisted evaluations. If not provided, the
+            parquet file will be loaded from the same default location used by
+            `save`.
 
         Returns:
             Evaluations: The loaded evaluations. The type of the returned

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -211,7 +211,7 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             evaluations will be the same as the type of the evaluations that
             were originally persisted.
         """
-        path = Path(directory) / EVAL_PARQUET_FILE_NAME.format(id=id)
+        path = Path(directory or TRACE_DATASET_DIR) / EVAL_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema)
         if id != eval_id:

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 from itertools import product
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
 from uuid import UUID, uuid4
 
 import pandas as pd
 from pandas.api.types import is_integer_dtype, is_numeric_dtype, is_string_dtype
-from pyarrow import Table, parquet
+from pyarrow import Schema, Table, parquet
 
 from phoenix.config import TRACE_DATASET_DIR
 from phoenix.trace.errors import InvalidParquetMetadataError
@@ -205,7 +205,7 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             were originally persisted.
         """
         schema = parquet.read_schema(path)
-        eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema.metadata)
+        eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema)
         table = parquet.read_table(path)
         dataframe = table.to_pandas()
         evaluations = evaluations_cls(eval_name=eval_name, dataframe=dataframe)
@@ -297,48 +297,22 @@ class TraceEvaluations(
     ...
 
 
-def _parse_schema_metadata(metadata: Dict[bytes, Any]) -> Tuple[UUID, str, Type[Evaluations]]:
-    """Validates and parses the schema metadata. Raises an exception if the
-    metadata is invalid.
-
-    Args:
-        metadata (Dict[bytes, Any]): A dictionary of schema metadata from a
-        parquet file.
-
-    Returns:
-        Tuple[str, ModuleType]: The evaluation name and the evaluations class.
+def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, Type[Evaluations]]:
     """
-    if not (arize_metadata_json := metadata.get(b"arize")):
-        raise InvalidParquetMetadataError('Schema metadata is missing "arize" key')
+    Validates and parses the pyarrow schema metadata.
+    """
     try:
+        metadata = schema.metadata
+        arize_metadata_json = metadata[b"arize"]
         arize_metadata = json.loads(arize_metadata_json)
-    except json.JSONDecodeError as err:
+        evaluations_classes = {
+            subclass.__name__: subclass for subclass in Evaluations.__subclasses__()
+        }
+        eval_id = UUID(arize_metadata["eval_id"])
+        eval_name = arize_metadata["eval_name"]
+        evaluations_cls = evaluations_classes[arize_metadata["eval_type"]]
+        return eval_id, eval_name, evaluations_cls
+    except Exception as err:
         raise InvalidParquetMetadataError(
-            'Encountered invalid JSON string under "arize" key'
+            "An error occurred while parsing parquet schema metadata"
         ) from err
-    evaluations_classes = {subclass.__name__: subclass for subclass in Evaluations.__subclasses__()}
-    if not (
-        isinstance(arize_metadata, dict)
-        and (eval_id := _to_uuid(arize_metadata.get("eval_id")))
-        and isinstance(eval_name := arize_metadata.get("eval_name"), str)
-        and (eval_type := arize_metadata.get("eval_type"))
-        and (evaluations_cls := evaluations_classes.get(eval_type))
-    ):
-        raise InvalidParquetMetadataError(f"Invalid Arize metadata: {arize_metadata}")
-    return eval_id, eval_name, evaluations_cls
-
-
-def _to_uuid(value: Any) -> Optional[UUID]:
-    """
-    Converts an input to a UUID if possible, otherwise returns None.
-
-    Args:
-        value (Any): The value to convert to a UUID.
-
-    Returns:
-        Optional[UUID]: A UUID if the value could be converted, otherwise None.
-    """
-    try:
-        return UUID(value)
-    except Exception:
-        return None

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -15,6 +15,7 @@ from phoenix.config import TRACE_DATASET_DIR
 from phoenix.trace.errors import InvalidParquetMetadataError
 
 EVAL_NAME_COLUMN_PREFIX = "eval."
+EVAL_PARQUET_FILE_NAME = "evaluations-{id}.parquet"
 
 
 class NeedsNamedIndex(ABC):
@@ -174,7 +175,7 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             the evaluations from disk using `from_parquet`.
         """
         directory = Path(directory) if directory else TRACE_DATASET_DIR
-        path = directory / f"evaluations-{self.id}.parquet"
+        path = directory / EVAL_PARQUET_FILE_NAME.format(id=self.id)
         table = Table.from_pandas(self.dataframe)
         table = table.replace_schema_metadata(
             {
@@ -210,7 +211,7 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             evaluations will be the same as the type of the evaluations that
             were originally persisted.
         """
-        path = Path(directory) / f"evaluations-{id}.parquet"
+        path = Path(directory) / EVAL_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema)
         table = parquet.read_table(path)

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -194,12 +194,14 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
         return self.id
 
     @classmethod
-    def load(cls, id: UUID, directory: Optional[Union[str, Path]] = None) -> "Evaluations":
+    def load(
+        cls, id: Union[str, UUID], directory: Optional[Union[str, Path]] = None
+    ) -> "Evaluations":
         """
         Loads the evaluations from disk.
 
         Args:
-            id (UUID): The ID of the evaluations to load.
+            id (Union[str, UUID]): The ID of the evaluations to load.
 
             directory(Optional[Union[str, Path]], optional): The path to the
             directory containing the persisted evaluations. If not provided, the
@@ -211,6 +213,8 @@ class Evaluations(NeedsNamedIndex, NeedsResultColumns, ABC):
             evaluations will be the same as the type of the evaluations that
             were originally persisted.
         """
+        if not isinstance(id, UUID):
+            id = UUID(id)
         path = Path(directory or TRACE_DATASET_DIR) / EVAL_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         eval_id, eval_name, evaluations_cls = _parse_schema_metadata(schema)

--- a/src/phoenix/trace/span_evaluations.py
+++ b/src/phoenix/trace/span_evaluations.py
@@ -12,13 +12,9 @@ from pandas.api.types import is_integer_dtype, is_numeric_dtype, is_string_dtype
 from pyarrow import Table, parquet
 
 from phoenix.config import TRACE_DATASET_DIR
-from phoenix.exceptions import PhoenixException
+from phoenix.trace.errors import InvalidParquetMetadataError
 
 EVAL_NAME_COLUMN_PREFIX = "eval."
-
-
-class InvalidParquetMetadataError(PhoenixException):
-    pass
 
 
 class NeedsNamedIndex(ABC):

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -249,13 +249,15 @@ class TraceDataset:
         return self._id
 
     @classmethod
-    def load(cls, id: UUID, directory: Optional[Union[str, Path]] = None) -> "TraceDataset":
+    def load(
+        cls, id: Union[str, UUID], directory: Optional[Union[str, Path]] = None
+    ) -> "TraceDataset":
         """
         Reads in a trace dataset from disk. Any associated evaluations will
         automatically be read from disk and attached to the trace dataset.
 
         Args:
-            id (UUID): The ID of the trace dataset to be loaded.
+            id (Union[str, UUID]): The ID of the trace dataset to be loaded.
 
             directory (Optional[Union[str, Path]], optional): The path to the
             directory containing the persisted trace dataset parquet file. If
@@ -265,6 +267,8 @@ class TraceDataset:
         Returns:
             TraceDataset: The loaded trace dataset.
         """
+        if not isinstance(id, UUID):
+            id = UUID(id)
         path = Path(directory or TRACE_DATASET_DIR) / TRACE_DATASET_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         dataset_id, dataset_name, eval_ids = _parse_schema_metadata(schema)

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -204,29 +204,29 @@ class TraceDataset:
             coerce_timestamps="ms",
         )
 
-    def to_parquet(self, path: Optional[Union[str, Path]] = None) -> Path:
+    def to_parquet(self, directory: Optional[Union[str, Path]] = None) -> Path:
         """
         Writes the trace dataset to a parquet file. If any evaluations have been
         appended to the dataset, those evaluations will be written to separate
         parquet files in the same directory.
 
         Args:
-            path (Optional[Union[str, Path]], optional): An optional path to a
-            directory where the data will be written. If not provided, the data
-            will be written to a default location.
+            directory (Optional[Union[str, Path]], optional): An optional path
+            to a directory where the data will be written. If not provided, the
+            data will be written to a default location.
 
         Returns:
             Path: The path to the saved parquet file. The file name is
             automatically generated.
         """
-        directory = Path(path or TRACE_DATASET_DIR)
+        directory = Path(directory or TRACE_DATASET_DIR)
         directory.mkdir(parents=True, exist_ok=True)
         for evals in self.evaluations:
             evals.to_parquet(directory)
-        path = directory / f"trace_dataset-{self._id}.parquet"
+        directory = directory / f"trace_dataset-{self._id}.parquet"
         dataframe = get_serializable_spans_dataframe(self.dataframe)
         dataframe.to_parquet(
-            path,
+            directory,
             allow_truncated_timestamps=True,
             coerce_timestamps="ms",
         )
@@ -244,8 +244,8 @@ class TraceDataset:
                 ).encode("utf-8"),
             }
         )
-        parquet.write_table(table, path)
-        return path
+        parquet.write_table(table, directory)
+        return directory
 
     @classmethod
     def from_parquet(cls, path: Union[str, Path]) -> "TraceDataset":

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -47,6 +47,8 @@ DOCUMENT_COLUMNS = [
     RERANKER_OUTPUT_DOCUMENTS_COLUMN_NAME,
 ]
 
+TRACE_DATASET_PARQUET_FILE_NAME = "trace_dataset-{id}.parquet"
+
 
 def normalize_dataframe(dataframe: DataFrame) -> "DataFrame":
     """Makes the dataframe have appropriate data types"""
@@ -222,7 +224,7 @@ class TraceDataset:
         directory.mkdir(parents=True, exist_ok=True)
         for evals in self.evaluations:
             evals.save(directory)
-        directory = directory / f"trace_dataset-{self._id}.parquet"
+        directory = directory / TRACE_DATASET_PARQUET_FILE_NAME.format(id=self._id)
         dataframe = get_serializable_spans_dataframe(self.dataframe)
         dataframe.to_parquet(
             directory,
@@ -263,7 +265,7 @@ class TraceDataset:
         Returns:
             TraceDataset: The loaded trace dataset.
         """
-        path = Path(directory or TRACE_DATASET_DIR) / f"trace_dataset-{id}.parquet"
+        path = Path(directory or TRACE_DATASET_DIR) / TRACE_DATASET_PARQUET_FILE_NAME.format(id=id)
         schema = parquet.read_schema(path)
         dataset_id, dataset_name, eval_ids = _parse_schema_metadata(schema)
         if id != dataset_id:

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -261,7 +261,7 @@ class TraceDataset:
         schema = parquet.read_schema(path)
         dataset_id, dataset_name, eval_ids = _parse_schema_metadata(schema)
         evaluations = [
-            Evaluations.from_parquet(TRACE_DATASET_DIR / f"evaluations-{eval_id}.parquet")
+            Evaluations.from_parquet(path.parent / f"evaluations-{eval_id}.parquet")
             for eval_id in eval_ids
         ]
         table = parquet.read_table(path)

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -267,6 +267,11 @@ class TraceDataset:
         path = Path(directory or TRACE_DATASET_DIR) / f"trace_dataset-{id}.parquet"
         schema = parquet.read_schema(path)
         dataset_id, dataset_name, eval_ids = _parse_schema_metadata(schema)
+        if id != dataset_id:
+            raise InvalidParquetMetadataError(
+                f"The input id {id} does not match the id {dataset_id} in the parquet metadata. "
+                "Ensure that you have not renamed the parquet file."
+            )
         evaluations = []
         for eval_id in eval_ids:
             try:

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -209,7 +209,8 @@ class TraceDataset:
     def save(self, directory: Optional[Union[str, Path]] = None) -> UUID:
         """
         Writes the trace dataset to disk. If any evaluations have been appended
-        to the dataset, those evaluations will be saved to the same directory.
+        to the dataset, those evaluations will be saved to separate files within
+        the same directory.
 
         Args:
             directory (Optional[Union[str, Path]], optional): An optional path
@@ -221,13 +222,12 @@ class TraceDataset:
             the dataset from disk using `load`.
         """
         directory = Path(directory or TRACE_DATASET_DIR)
-        directory.mkdir(parents=True, exist_ok=True)
         for evals in self.evaluations:
             evals.save(directory)
-        directory = directory / TRACE_DATASET_PARQUET_FILE_NAME.format(id=self._id)
+        path = directory / TRACE_DATASET_PARQUET_FILE_NAME.format(id=self._id)
         dataframe = get_serializable_spans_dataframe(self.dataframe)
         dataframe.to_parquet(
-            directory,
+            path,
             allow_truncated_timestamps=True,
             coerce_timestamps="ms",
         )
@@ -245,7 +245,7 @@ class TraceDataset:
                 ).encode("utf-8"),
             }
         )
-        parquet.write_table(table, directory)
+        parquet.write_table(table, path)
         return self._id
 
     @classmethod

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -261,14 +261,11 @@ class TraceDataset:
         """
         schema = parquet.read_schema(path)
         dataset_id, dataset_name, eval_ids = _parse_schema_metadata(schema)
-        evaluations = []
-        for eval_id in eval_ids:
-            try:
-                evaluations.append(
-                    Evaluations.from_parquet(path.parent / f"evaluations-{eval_id}.parquet")
-                )
-            except Exception:
-                warn(f'Failed to load evaluations with id: "{eval_id}"')
+        evaluations = [
+            evals
+            for eval_id in eval_ids
+            if (evals := _load_eval(directory=path.parent, eval_id=eval_id))
+        ]
         table = parquet.read_table(path)
         dataframe = table.to_pandas()
         ds = cls(dataframe, dataset_name, evaluations)
@@ -311,7 +308,7 @@ class TraceDataset:
         return pd.concat([df, evals_df], axis=1)
 
 
-def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, List[str]]:
+def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, List[UUID]]:
     """
     Returns parsed metadata from a parquet schema or raises an exception if the
     metadata is invalid.
@@ -322,11 +319,17 @@ def _parse_schema_metadata(schema: Schema) -> Tuple[UUID, str, List[str]]:
         dataset_id = UUID(arize_metadata["dataset_id"])
         if not isinstance(dataset_name := arize_metadata["dataset_name"], str):
             raise ValueError("Arize metadata must contain a dataset_name key with string value")
-        eval_ids = arize_metadata["eval_ids"]
-        if not all(isinstance(eval_id, str) for eval_id in eval_ids):
-            raise ValueError(
-                "Arize metadata must contain an eval_ids key with a list of strings as a value"
-            )
+        eval_ids = list(map(UUID, arize_metadata["eval_ids"]))
         return dataset_id, dataset_name, eval_ids
     except Exception as err:
         raise InvalidParquetMetadataError("Unable to parse parquet metadata") from err
+
+
+def _load_eval(directory: Path, eval_id: UUID) -> Optional[Evaluations]:
+    """
+    Loads a set of evaluations from disk.
+    """
+    try:
+        return Evaluations.from_parquet(directory / f"evaluations-{eval_id}.parquet")
+    except Exception:
+        warn(f'Failed to load evaluations with id: "{eval_id}"')

--- a/tests/trace/test_span_evaluations.py
+++ b/tests/trace/test_span_evaluations.py
@@ -115,24 +115,21 @@ def test_span_evaluations_to_and_from_parquet_preserves_data(tmp_path):
         eval_name="eval-name",
         dataframe=dataframe,
     )
-    path = evals.to_parquet(tmp_path)
-    table = parquet.read_table(path)
+    eval_id = evals.to_parquet(tmp_path)
+    table = parquet.read_table(tmp_path / f"evaluations-{eval_id}.parquet")
     arize_metadata = json.loads(table.schema.metadata[b"arize"])
 
-    assert path.resolve().parent == tmp_path.resolve()
-    assert path.exists()
     assert_frame_equal(table.to_pandas(), evals.dataframe)
     assert set(arize_metadata.keys()) == {"eval_id", "eval_name", "eval_type"}
     assert arize_metadata["eval_name"] == "eval-name"
     assert arize_metadata["eval_type"] == "SpanEvaluations"
     assert arize_metadata["eval_id"] == str(evals.id)
 
-    read_evals = Evaluations.from_parquet(path)
+    read_evals = Evaluations.from_parquet(eval_id, tmp_path)
     assert isinstance(read_evals, SpanEvaluations)
     assert_frame_equal(read_evals.dataframe, dataframe)
     assert read_evals.eval_name == "eval-name"
     assert read_evals.id == evals.id
-    assert path.stem.endswith(str(read_evals.id))
 
 
 def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
@@ -149,23 +146,20 @@ def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
         eval_name="eval-name",
         dataframe=dataframe,
     )
-    path = evals.to_parquet(tmp_path)
-    table = parquet.read_table(path)
+    eval_id = evals.to_parquet(tmp_path)
+    table = parquet.read_table(tmp_path / f"evaluations-{eval_id}.parquet")
     arize_metadata = json.loads(table.schema.metadata[b"arize"])
 
-    assert path.resolve().parent == tmp_path.resolve()
-    assert path.exists()
     assert_frame_equal(table.to_pandas(), evals.dataframe)
     assert arize_metadata["eval_name"] == "eval-name"
     assert arize_metadata["eval_type"] == "DocumentEvaluations"
     assert arize_metadata["eval_id"] == str(evals.id)
 
-    read_evals = Evaluations.from_parquet(path)
+    read_evals = Evaluations.from_parquet(eval_id, tmp_path)
     assert isinstance(read_evals, DocumentEvaluations)
     assert_frame_equal(read_evals.dataframe, dataframe)
     assert read_evals.eval_name == "eval-name"
     assert read_evals.id == evals.id
-    assert path.stem.endswith(str(read_evals.id))
 
 
 def test_parse_schema_metadata_raise_error_on_invalid_metadata():

--- a/tests/trace/test_span_evaluations.py
+++ b/tests/trace/test_span_evaluations.py
@@ -168,24 +168,20 @@ def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "metadata,error_message_fragment",
+    "metadata",
     [
-        pytest.param({}, 'missing "arize" key', id="empty-metadata"),
+        pytest.param({}, id="empty-metadata"),
         pytest.param(
             {"pandas": "some-pandas-metadata"},
-            'missing "arize" key',
             id="metadata-missing-arize-key",
         ),
-        pytest.param(
-            {b"arize": '{"invalid_json": "value"'}, "invalid JSON string", id="invalid-json"
-        ),
+        pytest.param({b"arize": '{"invalid_json": "value"'}, id="invalid-json"),
         pytest.param(
             {
                 b"arize": json.dumps(
                     {"eval_id": "2956d001-e2e1-4f22-8e32-1b4930510803", "eval_name": "eval-name"}
                 )
             },
-            "Invalid Arize metadata",
             id="missing-key-inside-arize-metadata",
         ),
         pytest.param(
@@ -194,7 +190,6 @@ def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
                     {"eval_id": "1234", "eval_name": 10, "eval_type": "SpanEvaluations"}
                 )
             },
-            "Invalid Arize metadata",
             id="eval-id-not-uuid",
         ),
         pytest.param(
@@ -207,7 +202,6 @@ def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
                     }
                 )
             },
-            "Invalid Arize metadata",
             id="incorrect-eval-name-type",
         ),
         pytest.param(
@@ -220,12 +214,10 @@ def test_document_evaluations_to_and_from_parquet_preserves_data(tmp_path):
                     }
                 )
             },
-            "Invalid Arize metadata",
             id="incorrect-eval-type",
         ),
     ],
 )
-def test_parse_schema_metadata(metadata, error_message_fragment):
-    with pytest.raises(InvalidParquetMetadataError) as exc_info:
+def test_parse_schema_metadata(metadata):
+    with pytest.raises(InvalidParquetMetadataError):
         _parse_schema_metadata(metadata)
-    assert error_message_fragment in str(exc_info.value)

--- a/tests/trace/test_trace_dataset.py
+++ b/tests/trace/test_trace_dataset.py
@@ -203,7 +203,7 @@ def test_trace_dataset_construction_with_evaluations():
     assert "context.span_id" in df_with_evals.columns
 
 
-def test_trace_dataset_to_parquet_and_from_parquet_preserve_values() -> None:
+def test_trace_dataset_to_parquet_and_from_parquet_preserve_values(tmp_path) -> None:
     num_records = 5
     traces_df = pd.DataFrame(
         {
@@ -238,7 +238,7 @@ def test_trace_dataset_to_parquet_and_from_parquet_preserve_values() -> None:
 
     ds.append_evaluations(eval_ds)
 
-    path = ds.to_parquet()
+    path = ds.to_parquet(tmp_path)
 
     assert os.path.exists(path)
     assert os.path.exists(path.parent / f"evaluations-{eval_ds.id}.parquet")


### PR DESCRIPTION
## Save and Load Trace Datasets

1. Adds ability to read and write `TraceDataset` instances to parquet while automatically reading and writing any appended evaluations.

Usage with user-specified directory:

```python
dataset = TraceDataset(...)
dataset_id = dataset.save(directory)
loaded_dataset = TraceDataset.load(dataset_id, directory)
```

Usage with default directory:

```python
dataset = TraceDataset(...)
dataset_id = dataset.save()
loaded_dataset = TraceDataset.load(dataset_id)
```

2. Changes API of `Evaluations`. Previously, there were `to_parquet` and `from_parquet` methods uses paths as inputs and outputs. The API has been changed to `save` and `load` methods similar to `TraceDataset`.

Usage with user-specified directory:

```python
evals = SpanEvaluations(...)
eval_id = evals.save(directory)
loaded_evals = TraceDataset.load(eval_id, directory)
```

Usage with default directory:

```python
evals = SpanEvaluations(...)
eval_id = evals.save()
loaded_evals = TraceDataset.load(eval_id)
```

3. Adds corresponding tests
4. Simplifies implementation and tests for parsing of schema metadata for `Evaluations`