### PR TITLE
fix: show localhost when the notebook is running locally

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -479,6 +479,9 @@ def _get_url(host: str, port: int, notebook_env: NotebookEnvironment) -> str:
     if notebook_env == NotebookEnvironment.DATABRICKS:
         context = _get_databricks_context()
         return f"{_get_databricks_notebook_base_url(context)}/{port}/"
+    if host == "0.0.0.0" or host == "127.0.0.1":
+        # The app is running locally, so use localhost
+        return f"http://localhost:{port}/"
     return f"http://{host}:{port}/"
 
 


### PR DESCRIPTION
For notebook setting like databricks, we have to listen on 0.0.0.0, but the URL constructed is confusing by default so this presents local notebooks as localhost for a simpler, clearer message.