### PR TITLE
chore: remove tokenizer warnings

### DIFF
--- a/src/phoenix/experimental/evals/models/anthropic.py
+++ b/src/phoenix/experimental/evals/models/anthropic.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -7,8 +6,6 @@ from phoenix.experimental.evals.models.rate_limiters import RateLimiter
 
 if TYPE_CHECKING:
     from tiktoken import Encoding
-
-logger = logging.getLogger(__name__)
 
 MODEL_TOKEN_LIMIT_MAPPING = {
     "claude-2.1": 200000,

--- a/src/phoenix/experimental/evals/models/anthropic.py
+++ b/src/phoenix/experimental/evals/models/anthropic.py
@@ -80,7 +80,6 @@ class AnthropicModel(BaseEvalModel):
         try:
             encoding = self._tiktoken.encoding_for_model(self.model)
         except KeyError:
-            logger.warning("Warning: model not found. Using cl100k_base encoding.")
             encoding = self._tiktoken.get_encoding("cl100k_base")
         self._tiktoken_encoding = encoding
 

--- a/src/phoenix/experimental/evals/models/bedrock.py
+++ b/src/phoenix/experimental/evals/models/bedrock.py
@@ -87,7 +87,6 @@ class BedrockModel(BaseEvalModel):
         try:
             encoding = self._tiktoken.encoding_for_model(self.model_id)
         except KeyError:
-            logger.warning("Warning: model not found. Using cl100k_base encoding.")
             encoding = self._tiktoken.get_encoding("cl100k_base")
         self._tiktoken_encoding = encoding
 


### PR DESCRIPTION
Removes warnings when a tokenizer cannot be loaded for a non-openai model. These warnings were causing confusion.