### PR TITLE
fix: Resolves Bedrock model compatibility issues

### DIFF
--- a/src/phoenix/experimental/evals/models/bedrock.py
+++ b/src/phoenix/experimental/evals/models/bedrock.py
@@ -165,7 +165,7 @@ class BedrockModel(BaseEvalModel):
                     "temperature": self.temperature,
                     "topP": self.top_p,
                     "maxTokens": self.max_tokens,
-                    "stopSequences": [self.stop_sequences],
+                    "stopSequences": self.stop_sequences,
                 },
                 **self.extra_parameters,
             }

--- a/src/phoenix/experimental/evals/models/bedrock.py
+++ b/src/phoenix/experimental/evals/models/bedrock.py
@@ -204,6 +204,9 @@ class BedrockModel(BaseEvalModel):
         elif self.model_id.startswith("anthropic"):
             body = json.loads(response.get("body").read().decode())
             return body.get("completion")
+        elif self.model_id.startswith("amazon"):
+            body = json.loads(response.get("body").read())
+            return body.get("results")[0].get("outputText")
         else:
             body = json.loads(response.get("body").read())
             return body.get("results")[0].get("data").get("outputText")


### PR DESCRIPTION
Resolves #2113

- Properly formats input payload for ai21 Jurassic models
- Properly parses Amazon Titan model outputs