### PR TITLE
fix: Do not retry when context window has been exceeded

### DIFF
--- a/src/phoenix/exceptions.py
+++ b/src/phoenix/exceptions.py
@@ -2,5 +2,5 @@ class PhoenixException(Exception):
     pass
 
 
-class TokenLimitException(PhoenixException):
+class PhoenixContextLimitExceeded(PhoenixException):
     pass

--- a/src/phoenix/exceptions.py
+++ b/src/phoenix/exceptions.py
@@ -1,2 +1,6 @@
 class PhoenixException(Exception):
     pass
+
+
+class TokenLimitException(PhoenixException):
+    pass

--- a/src/phoenix/experimental/evals/models/anthropic.py
+++ b/src/phoenix/experimental/evals/models/anthropic.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from phoenix.exceptions import PhoenixTokenLimitExceededError
+from phoenix.exceptions import PhoenixContextLimitExceeded
 from phoenix.experimental.evals.models.base import BaseEvalModel
 from phoenix.experimental.evals.models.rate_limiters import RateLimiter
 
@@ -145,7 +145,7 @@ class AnthropicModel(BaseEvalModel):
                 return response.completion
             except self._anthropic.BadRequestError as e:
                 if "prompt is too long" in e.args[0]:
-                    raise PhoenixTokenLimitExceededError("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
                 raise e
 
         return _completion_with_retry(**kwargs)
@@ -171,7 +171,7 @@ class AnthropicModel(BaseEvalModel):
                 return response.completion
             except self._anthropic.BadRequestError as e:
                 if "prompt is too long" in e.args[0]:
-                    raise PhoenixTokenLimitExceededError("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
                 raise e
 
         return await _async_completion_with_retry(**kwargs)

--- a/src/phoenix/experimental/evals/models/anthropic.py
+++ b/src/phoenix/experimental/evals/models/anthropic.py
@@ -144,8 +144,9 @@ class AnthropicModel(BaseEvalModel):
                 response = self.client.completions.create(**kwargs)
                 return response.completion
             except self._anthropic.BadRequestError as e:
-                if "prompt is too long" in e.args[0]:
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                exception_message = e.args[0]
+                if exception_message and "prompt is too long" in exception_message:
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 raise e
 
         return _completion_with_retry(**kwargs)
@@ -170,8 +171,9 @@ class AnthropicModel(BaseEvalModel):
                 response = await self.async_client.completions.create(**kwargs)
                 return response.completion
             except self._anthropic.BadRequestError as e:
-                if "prompt is too long" in e.args[0]:
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                exception_message = e.args[0]
+                if exception_message and "prompt is too long" in exception_message:
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 raise e
 
         return await _async_completion_with_retry(**kwargs)

--- a/src/phoenix/experimental/evals/models/bedrock.py
+++ b/src/phoenix/experimental/evals/models/bedrock.py
@@ -147,15 +147,18 @@ class BedrockModel(BaseEvalModel):
                 return self.client.invoke_model(**kwargs)
             except Exception as e:
                 exception_message = e.args[0]
+                if not exception_message:
+                    raise e
+
                 if "Input is too long" in exception_message:
                     # Error from Anthropic models
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 elif "expected maxLength" in exception_message:
                     # Error from Titan models
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 elif "Prompt has too many tokens" in exception_message:
                     # Error from AI21 models
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 raise e
 
         return _completion_with_retry(**kwargs)

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -317,8 +317,9 @@ class OpenAIModel(BaseEvalModel):
                     res = await self._async_client.chat.completions.create(**kwargs)
                 return res.model_dump()
             except self._openai._exceptions.BadRequestError as e:
-                if "maximum context length" in e.args[0]:
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                exception_message = e.args[0]
+                if exception_message and "maximum context length" in exception_message:
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 raise e
 
         return await _completion_with_retry(**kwargs)
@@ -341,8 +342,9 @@ class OpenAIModel(BaseEvalModel):
                     return self._client.completions.create(**kwargs).model_dump()
                 return self._client.chat.completions.create(**kwargs).model_dump()
             except self._openai._exceptions.BadRequestError as e:
-                if "maximum context length" in e.args[0]:
-                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
+                exception_message = e.args[0]
+                if exception_message and "maximum context length" in exception_message:
+                    raise PhoenixContextLimitExceeded(exception_message) from e
                 raise e
 
         return _completion_with_retry(**kwargs)

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -14,7 +14,7 @@ from typing import (
     get_origin,
 )
 
-from phoenix.exceptions import PhoenixTokenLimitExceededError
+from phoenix.exceptions import PhoenixContextLimitExceeded
 from phoenix.experimental.evals.models.base import BaseEvalModel
 from phoenix.experimental.evals.models.rate_limiters import RateLimiter
 
@@ -318,7 +318,7 @@ class OpenAIModel(BaseEvalModel):
                 return res.model_dump()
             except self._openai._exceptions.BadRequestError as e:
                 if "maximum context length" in e.args[0]:
-                    raise PhoenixTokenLimitExceededError("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
                 raise e
 
         return await _completion_with_retry(**kwargs)
@@ -342,7 +342,7 @@ class OpenAIModel(BaseEvalModel):
                 return self._client.chat.completions.create(**kwargs).model_dump()
             except self._openai._exceptions.BadRequestError as e:
                 if "maximum context length" in e.args[0]:
-                    raise PhoenixTokenLimitExceededError("Maximum context length exceeded.")
+                    raise PhoenixContextLimitExceeded("Maximum context length exceeded.")
                 raise e
 
         return _completion_with_retry(**kwargs)


### PR DESCRIPTION
resolves #2065 

Requests to an LLM with a prompt that exceeds the maximum context window will never succeed, so we should stop retrying on these errors.

Due to the lack of concrete errors that are scoped to exceeding the context window size, we match on the error message instead. OpenAI, Anthropic and Bedrock models have been modified to not retry on the context limit window being hit.

I haven't been able to induce a concrete error using a Gemini model (it will simply hang), so a fix hasn't been implemented for Gemini.