### PR TITLE
chore: pin pydantic version for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dependencies = [
 [tool.hatch.envs.type]
 dependencies = [
   "mypy==1.5.1",
+  "pydantic==v1.10.14",  # for mypy
   "llama-index>=0.9.14",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
   "types-psutil",


### PR DESCRIPTION
This fixes following mypy error on github CI. Potential [cause](https://github.com/pydantic/pydantic/pull/8666).
> /home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/openai/_models.py:408: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Traceback (most recent call last):
Please report a bug at https://github.com/python/mypy/issues
  File "mypy/semanal.py", line 6475, in accept
version: 1.5.1
/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/openai/_models.py:408: : note: use --pdb to drop into pdb
  File "mypy/nodes.py", line 1141, in accept
  File "mypy/semanal.py", line 1600, in visit_class_def
  File "mypy/semanal.py", line 1685, in analyze_class
  File "mypy/semanal.py", line 1714, in analyze_class_body_common
  File "mypy/semanal.py", line 1801, in apply_class_plugin_hooks
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 187, in _pydantic_model_class_maker_callback
    return transformer.transform()
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 478, in transform
    self.add_initializer(fields, config, is_settings, is_root_model)
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 856, in add_initializer
    args = self.get_field_arguments(
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 1038, in get_field_arguments
    arguments = [
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 1039, in <listcomp>
    field.to_argument(
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 346, in to_argument
    variable=self.to_var(current_info, use_alias),
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 373, in to_var
    return Var(name, self.expand_type(current_info))
  File "/home/runner/.local/share/hatch/env/virtual/arize-phoenix/C8K4HrkP/type/lib/python3.8/site-packages/pydantic/mypy.py", line 362, in expand_type
    raise _DeferAnalysis()
_DeferAnalysis: 
Error: Process completed with exit code 2.