### PR TITLE
refactor: support json string attributes in addition to flattened mappings

### DIFF
--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -1,3 +1,4 @@
+import json
 from binascii import hexlify, unhexlify
 from datetime import datetime, timezone
 from types import MappingProxyType
@@ -36,6 +37,7 @@ from phoenix.trace.schemas import (
     TraceID,
 )
 from phoenix.trace.semantic_conventions import (
+    DOCUMENT_METADATA,
     EXCEPTION_ESCAPED,
     EXCEPTION_MESSAGE,
     EXCEPTION_STACKTRACE,
@@ -43,6 +45,7 @@ from phoenix.trace.semantic_conventions import (
     INPUT_MIME_TYPE,
     OPENINFERENCE_SPAN_KIND,
     OUTPUT_MIME_TYPE,
+    TOOL_PARAMETERS,
 )
 
 
@@ -56,7 +59,7 @@ def decode(otlp_span: otlp.Span) -> Span:
         _decode_unix_nano(otlp_span.end_time_unix_nano) if otlp_span.end_time_unix_nano else None
     )
 
-    attributes = dict(_unflatten(_decode_key_values(otlp_span.attributes)))
+    attributes = dict(_unflatten(_load_json_strings(_decode_key_values(otlp_span.attributes))))
     span_kind = SpanKind(attributes.pop(OPENINFERENCE_SPAN_KIND, None))
 
     for mime_type in (INPUT_MIME_TYPE, OUTPUT_MIME_TYPE):
@@ -141,6 +144,26 @@ def _decode_value(any_value: AnyValue) -> Any:
     if which is None:
         return None
     assert_never(which)
+
+
+_JSON_STRING_ATTRIBUTES = (
+    DOCUMENT_METADATA,
+    TOOL_PARAMETERS,
+)
+
+
+def _load_json_strings(key_values: Iterable[Tuple[str, Any]]) -> Iterator[Tuple[str, Any]]:
+    for key, value in key_values:
+        if key.endswith(_JSON_STRING_ATTRIBUTES):
+            try:
+                dict_value = json.loads(value)
+            except json.JSONDecodeError:
+                yield key, value
+            else:
+                if dict_value:
+                    yield key, dict_value
+        else:
+            yield key, value
 
 
 StatusMessage: TypeAlias = str
@@ -291,7 +314,10 @@ def encode(span: Span) -> otlp.Span:
             attributes.pop(key, None)
         elif isinstance(value, Mapping):
             attributes.pop(key, None)
-            attributes.update(_flatten_mapping(value, key))
+            if key.endswith(_JSON_STRING_ATTRIBUTES):
+                attributes[key] = json.dumps(value)
+            else:
+                attributes.update(_flatten_mapping(value, key))
         elif not isinstance(value, str) and isinstance(value, Sequence) and _has_mapping(value):
             attributes.pop(key, None)
             attributes.update(_flatten_sequence(value, key))
@@ -351,7 +377,10 @@ def _flatten_mapping(
     for key, value in mapping.items():
         prefixed_key = f"{prefix}.{key}"
         if isinstance(value, Mapping):
-            yield from _flatten_mapping(value, prefixed_key)
+            if key.endswith(_JSON_STRING_ATTRIBUTES):
+                yield prefixed_key, json.dumps(value)
+            else:
+                yield from _flatten_mapping(value, prefixed_key)
         elif isinstance(value, Sequence):
             yield from _flatten_sequence(value, prefixed_key)
         elif value is not None:

--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -43,6 +43,7 @@ from phoenix.trace.semantic_conventions import (
     EXCEPTION_STACKTRACE,
     EXCEPTION_TYPE,
     INPUT_MIME_TYPE,
+    LLM_PROMPT_TEMPLATE_VARIABLES,
     OPENINFERENCE_SPAN_KIND,
     OUTPUT_MIME_TYPE,
     TOOL_PARAMETERS,
@@ -148,6 +149,7 @@ def _decode_value(any_value: AnyValue) -> Any:
 
 _JSON_STRING_ATTRIBUTES = (
     DOCUMENT_METADATA,
+    LLM_PROMPT_TEMPLATE_VARIABLES,
     TOOL_PARAMETERS,
 )
 

--- a/tests/trace/test_otel.py
+++ b/tests/trace/test_otel.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import replace
 from datetime import datetime, timezone
 from random import random
@@ -281,36 +282,8 @@ def test_decode_encode_documents(span):
             value=AnyValue(double_value=score),
         ),
         KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m0",
-            value=AnyValue(string_value="111"),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m1",
-            value=AnyValue(bool_value=True),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m2",
-            value=AnyValue(int_value=333),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m3",
-            value=AnyValue(double_value=444.0),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m4",
-            value=AnyValue(array_value=ArrayValue(values=[AnyValue(string_value="1111")])),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m5",
-            value=AnyValue(array_value=ArrayValue(values=[AnyValue(bool_value=True)])),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m6",
-            value=AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=3333)])),
-        ),
-        KeyValue(
-            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}.m7",
-            value=AnyValue(array_value=ArrayValue(values=[AnyValue(double_value=4444.0)])),
+            key=f"{RETRIEVAL_DOCUMENTS}.4.{DOCUMENT_METADATA}",
+            value=AnyValue(string_value=json.dumps(document_metadata)),
         ),
     ]
     assert set(map(MessageToJson, otlp_span.attributes)) == set(map(MessageToJson, otlp_attributes))
@@ -428,36 +401,8 @@ def test_decode_encode_message_tool_parameters(span):
             value=AnyValue(string_value="LLM"),
         ),
         KeyValue(
-            key=f"{TOOL_PARAMETERS}.title",
-            value=AnyValue(string_value="multiply"),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.properties.a.title",
-            value=AnyValue(string_value="A"),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.properties.a.type",
-            value=AnyValue(string_value="integer"),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.properties.b.title",
-            value=AnyValue(string_value="B"),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.properties.b.type",
-            value=AnyValue(string_value="integer"),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.required",
-            value=AnyValue(
-                array_value=ArrayValue(
-                    values=[AnyValue(string_value="a"), AnyValue(string_value="b")]
-                )
-            ),
-        ),
-        KeyValue(
-            key=f"{TOOL_PARAMETERS}.type",
-            value=AnyValue(string_value="object"),
+            key=f"{TOOL_PARAMETERS}",
+            value=AnyValue(string_value=json.dumps(attributes[TOOL_PARAMETERS])),
         ),
     ]
     assert set(map(MessageToJson, otlp_span.attributes)) == set(map(MessageToJson, otlp_attributes))


### PR DESCRIPTION
For the following attributes, support both json strings and flattened mappings (with latter for backward compatibility).

- DOCUMENT_METADATA
- LLM_PROMPT_TEMPLATE_VARIABLES
- TOOL_PARAMETERS