### PR TITLE
refactor: use urljoin for urls

### DIFF
--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -5,6 +5,7 @@ from queue import SimpleQueue
 from threading import Thread
 from types import MethodType
 from typing import Any, Optional, Union
+from urllib.parse import urljoin
 
 import opentelemetry.proto.trace.v1.trace_pb2 as otlp
 import requests
@@ -104,15 +105,15 @@ class HttpExporter:
 
     def _url(self, message: Message) -> str:
         if isinstance(message, otlp.Span):
-            return f"{self._base_url}/v1/spans"
+            return urljoin(self._base_url, "v1/spans")
         if isinstance(message, pb.Evaluation):
-            return f"{self._base_url}/v1/evaluations"
+            return urljoin(self._base_url, "v1/evaluations")
         logger.exception(f"unrecognized message type: {type(message)}")
         assert_never(message)
 
     def _warn_if_phoenix_is_not_running(self) -> None:
         try:
-            requests.get(f"{self._base_url}/arize_phoenix_version").raise_for_status()
+            requests.get(urljoin(self._base_url, "arize_phoenix_version")).raise_for_status()
         except Exception:
             logger.warning(
                 f"Arize Phoenix is not running on {self._base_url}. Launch Phoenix "

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -56,9 +56,9 @@ class HttpExporter:
         """
         self._host = host or get_env_host()
         self._port = port or get_env_port()
-        endpoint = endpoint or get_env_collector_endpoint() or f"http://{self._host}:{self._port}"
-        # Make sure the url does not end with a slash
-        self._base_url = endpoint.rstrip("/")
+        self._base_url = (
+            endpoint or get_env_collector_endpoint() or f"http://{self._host}:{self._port}"
+        )
         self._warn_if_phoenix_is_not_running()
         self._session = Session()
         weakref.finalize(self, self._session.close)

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -9,6 +9,11 @@ def test_exporter(monkeypatch: pytest.MonkeyPatch):
     exporter = HttpExporter()
     assert exporter._base_url == f"http://{HOST}:{PORT}"
 
+    # Test that you can configure host and port
+    host, port = "abcd", 1234
+    exporter = HttpExporter(host=host, port=port)
+    assert exporter._base_url == f"http://{host}:{port}"
+
     # Test that you can configure an endpoint
     endpoint = "https://my-phoenix-server.com/"
     exporter = HttpExporter(endpoint=endpoint)

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -4,7 +4,7 @@ from phoenix.trace.exporter import HttpExporter
 
 def test_exporter(monkeypatch: pytest.MonkeyPatch):
     # Test that it defaults to local
-    monkeypatch.delenv("PHOENIX_COLLECTOR_ENDPOINT")
+    monkeypatch.delenv("PHOENIX_COLLECTOR_ENDPOINT", False)
     exporter = HttpExporter()
     assert exporter._base_url == "http://0.0.0.0:6006"
 

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -4,14 +4,16 @@ from phoenix.trace.exporter import HttpExporter
 
 def test_exporter(monkeypatch: pytest.MonkeyPatch):
     # Test that it defaults to local
+    monkeypatch.delenv("PHOENIX_COLLECTOR_ENDPOINT")
     exporter = HttpExporter()
     assert exporter._base_url == "http://0.0.0.0:6006"
 
     # Test that you can configure an endpoint
-    exporter = HttpExporter(endpoint="https://my-phoenix-server.com/")
-    assert exporter._base_url == "https://my-phoenix-server.com"
+    endpoint = "https://my-phoenix-server.com/"
+    exporter = HttpExporter(endpoint=endpoint)
+    assert exporter._base_url == endpoint
 
     # Test that it supports environment variables
-    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", "https://my-phoenix-server.com/")
+    monkeypatch.setenv("PHOENIX_COLLECTOR_ENDPOINT", endpoint)
     exporter = HttpExporter()
-    assert exporter._base_url == "https://my-phoenix-server.com"
+    assert exporter._base_url == endpoint

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -1,4 +1,5 @@
 import pytest
+from phoenix.config import HOST, PORT
 from phoenix.trace.exporter import HttpExporter
 
 
@@ -6,7 +7,7 @@ def test_exporter(monkeypatch: pytest.MonkeyPatch):
     # Test that it defaults to local
     monkeypatch.delenv("PHOENIX_COLLECTOR_ENDPOINT", False)
     exporter = HttpExporter()
-    assert exporter._base_url == "http://0.0.0.0:6006"
+    assert exporter._base_url == f"http://{HOST}:{PORT}"
 
     # Test that you can configure an endpoint
     endpoint = "https://my-phoenix-server.com/"


### PR DESCRIPTION
This eliminates the problem of double-slash if the `base_url` string has a slash at the end, e.g. `http://localhost:6006//v1/spans`

<img width="346" alt="Screenshot 2024-01-31 at 12 06 00 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/3524332d-a3eb-4d69-93a6-9207ea44ef51">

