### PR TITLE
fix: default collector endpoint breaks on windows

### DIFF
--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -48,14 +48,18 @@ class HttpExporter:
             Note, this parameter supersedes `host` and `port`.
         host: Optional[str]
             The host of the Phoenix server. It can also be set using environment
-            variable `PHOENIX_HOST`, otherwise it defaults to `127.0.0.1`.
+            variable `PHOENIX_HOST`, otherwise it defaults to `0.0.0.0`.
         port: Optional[int]
             The port of the Phoenix server. It can also be set using environment
             variable `PHOENIX_PORT`, otherwise it defaults to `6006`.
         """
         self._host = host or get_env_host()
         self._port = port or get_env_port()
-        endpoint = endpoint or get_env_collector_endpoint() or f"http://{self._host}:{self._port}"
+        endpoint = (
+            endpoint
+            or get_env_collector_endpoint()
+            or f"http://{'127.0.0.1' if self._host == '0.0.0.0' else self._host}:{self._port}"
+        )
         # Make sure the url does not end with a slash
         self._base_url = endpoint.rstrip("/")
         self._warn_if_phoenix_is_not_running()

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -43,10 +43,11 @@ class HttpExporter:
         Parameters
         ----------
         endpoint: Optional[str]
-            The endpoint of the Phoenix server (collector). This should be set if the Phoenix
-            server is running on a remote instance. It can also be set using environment
-            variable `PHOENIX_COLLECTOR_ENDPOINT`, otherwise it defaults to `http://127.0.0.1:6006`
-            Note, this parameter supersedes `host` and `port`.
+            The endpoint of the Phoenix server (collector). This should be set
+            if the Phoenix server is running on a remote instance. It can also
+            be set using environment variable `PHOENIX_COLLECTOR_ENDPOINT`,
+            otherwise it defaults to `http://<host>:<port>`. Note, this
+            parameter supersedes `host` and `port`.
         host: Optional[str]
             The host of the Phoenix server. It can also be set using environment
             variable `PHOENIX_HOST`, otherwise it defaults to `0.0.0.0`.

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -5,7 +5,7 @@ from phoenix.trace.exporter import HttpExporter
 def test_exporter(monkeypatch: pytest.MonkeyPatch):
     # Test that it defaults to local
     exporter = HttpExporter()
-    assert exporter._base_url == "http://0.0.0.0:6006"
+    assert exporter._base_url == "http://127.0.0.0:6006"
 
     # Test that you can configure an endpoint
     exporter = HttpExporter(endpoint="https://my-phoenix-server.com/")

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -5,7 +5,7 @@ from phoenix.trace.exporter import HttpExporter
 def test_exporter(monkeypatch: pytest.MonkeyPatch):
     # Test that it defaults to local
     exporter = HttpExporter()
-    assert exporter._base_url == "http://127.0.0.0:6006"
+    assert exporter._base_url == "http://127.0.0.1:6006"
 
     # Test that you can configure an endpoint
     exporter = HttpExporter(endpoint="https://my-phoenix-server.com/")


### PR DESCRIPTION
We recently changed the default Phoenix port to `0.0.0.0`. The default collector endpoint was implicitly changed to `http://0.0.0.0:6006`. This appears to work fine on Mac, but breaks on Windows. This PR sets the collector endpoint to `http://127.0.0.1:6006` if the Phoenix port is set to `0.0.0.0`.