### PR TITLE
feat!: Remove model-level tenacity retries

### DIFF
--- a/src/phoenix/experimental/evals/models/litellm.py
+++ b/src/phoenix/experimental/evals/models/litellm.py
@@ -96,14 +96,14 @@ class LiteLLMModel(BaseEvalModel):
     def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
         messages = self._get_messages_from_prompt(prompt)
         response = self._litellm.completion(
-                model=self.model_name,
-                messages=messages,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-                top_p=self.top_p,
-                num_retries=self.num_retries,
-                request_timeout=self.request_timeout,
-                **self.model_kwargs,
+            model=self.model_name,
+            messages=messages,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            top_p=self.top_p,
+            num_retries=self.num_retries,
+            request_timeout=self.request_timeout,
+            **self.model_kwargs,
         )
         return str(response.choices[0].message.content)
 

--- a/src/phoenix/experimental/evals/models/litellm.py
+++ b/src/phoenix/experimental/evals/models/litellm.py
@@ -95,8 +95,7 @@ class LiteLLMModel(BaseEvalModel):
 
     def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
         messages = self._get_messages_from_prompt(prompt)
-        return str(
-            self._generate_with_retry(
+        response = self._litellm.completion(
                 model=self.model_name,
                 messages=messages,
                 temperature=self.temperature,
@@ -105,14 +104,8 @@ class LiteLLMModel(BaseEvalModel):
                 num_retries=self.num_retries,
                 request_timeout=self.request_timeout,
                 **self.model_kwargs,
-            )
         )
-
-    def _generate_with_retry(self, **kwargs: Any) -> Any:
-        # Using default LiteLLM completion with retries = self.num_retries.
-
-        response = self._litellm.completion(**kwargs)
-        return response.choices[0].message.content
+        return str(response.choices[0].message.content)
 
     def _get_messages_from_prompt(self, prompt: str) -> List[Dict[str, str]]:
         # LiteLLM requires prompts in the format of messages

--- a/src/phoenix/experimental/evals/models/vertexai.py
+++ b/src/phoenix/experimental/evals/models/vertexai.py
@@ -52,18 +52,6 @@ class VertexAIModel(BaseEvalModel):
 
             self._vertexai = vertexai
             self._google_exceptions = google_exceptions
-            self._google_api_retry_errors = [
-                self._google_exceptions.ResourceExhausted,
-                self._google_exceptions.ServiceUnavailable,
-                self._google_exceptions.Aborted,
-                self._google_exceptions.DeadlineExceeded,
-            ]
-            self.retry = self._retry(
-                error_types=self._google_api_retry_errors,
-                min_seconds=self.retry_min_seconds,
-                max_seconds=self.retry_max_seconds,
-                max_retries=self.max_retries,
-            )
         except ImportError:
             self._raise_import_error(
                 package_display_name="VertexAI",
@@ -97,18 +85,11 @@ class VertexAIModel(BaseEvalModel):
 
     def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
         invoke_params = self.invocation_params
-        response = self._generate_with_retry(
+        response = self._model.predict(
             prompt=prompt,
             **invoke_params,
         )
         return str(response.text)
-
-    def _generate_with_retry(self, **kwargs: Any) -> Any:
-        @self.retry
-        def _completion_with_retry(**kwargs: Any) -> Any:
-            return self._model.predict(**kwargs)
-
-        return _completion_with_retry(**kwargs)
 
     @property
     def is_codey_model(self) -> bool:

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -395,12 +395,8 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
         openai_retry_error = model._openai.APITimeoutError("test timeout")
         mock_openai = MagicMock()
         mock_openai.side_effect = openai_retry_error
-        stack.enter_context(
-            patch.object(model, "_generate", mock_openai)
-        )
-        stack.enter_context(
-            patch.object(model, "_async_generate", mock_openai)
-        )
+        stack.enter_context(patch.object(model, "_generate", mock_openai))
+        stack.enter_context(patch.object(model, "_async_generate", mock_openai))
         llm_classify(
             dataframe=dataframe,
             template=RAG_RELEVANCY_PROMPT_TEMPLATE,

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -390,29 +390,16 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
     )
 
     with ExitStack() as stack:
-        waiting_fn = "phoenix.experimental.evals.models.base.wait_random_exponential"
-        stack.enter_context(patch(waiting_fn, return_value=False))
-        model = OpenAIModel(max_retries=4)
+        model = OpenAIModel()
 
-        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
-        openai_retry_errors = [
-            model._openai.APITimeoutError("test timeout"),
-            model._openai.APIError(
-                message="test api error",
-                request=httpx.request,
-                body={},
-            ),
-            model._openai.APIConnectionError(message="test api connection error", request=request),
-            model._openai.InternalServerError(
-                "test internal server error",
-                response=httpx.Response(status_code=500, request=request),
-                body={},
-            ),
-        ]
+        openai_retry_error = model._openai.APITimeoutError("test timeout")
         mock_openai = MagicMock()
-        mock_openai.side_effect = openai_retry_errors
+        mock_openai.side_effect = openai_retry_error
         stack.enter_context(
-            patch.object(model._async_client.chat.completions, "create", mock_openai)
+            patch.object(model, "_generate", mock_openai)
+        )
+        stack.enter_context(
+            patch.object(model, "_async_generate", mock_openai)
         )
         llm_classify(
             dataframe=dataframe,
@@ -422,10 +409,18 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
         )
 
     out, _ = capfd.readouterr()
-    assert "Failed attempt 1" in out, "Retry information should be printed"
-    assert "Failed attempt 2" in out, "Retry information should be printed"
-    assert "Failed attempt 3" in out, "Retry information should be printed"
-    assert "Failed attempt 4" not in out, "Maximum retries should not be exceeded"
+    assert "Exception in worker on attempt 1" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 2" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 3" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 4" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 5" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 6" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 7" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 8" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 9" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 10" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 11" in out, "Retry information should be printed"
+    assert "Exception in worker on attempt 12" not in out, "Maximum retries should not be exceeded"
 
 
 @pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions")


### PR DESCRIPTION
Resolves #2177 

Retries are now handled by `Executors`, and `tenacity` is no longer required as a dependency.