### PR TITLE
feat(embeddings): add search by text and ID on selection

### DIFF
--- a/app/src/components/pointcloud/EventItem.tsx
+++ b/app/src/components/pointcloud/EventItem.tsx
@@ -50,6 +50,14 @@ type EventItemProps = {
    */
   onClick?: () => void;
   /**
+   * event handler for when the user hovers on the event item
+   */
+  onMouseOver?: () => void;
+  /**
+   * event handler when the hover ends
+   */
+  onMouseOut?: () => void;
+  /**
    * The event's current grouping (color group)
    */
   group: string;
@@ -130,7 +138,8 @@ function getSecondaryPreviewType(
  * An item that represents a single model event. To be displayed in a grid / list
  */
 export function EventItem(props: EventItemProps) {
-  const { onClick, color, size, datasetName, group } = props;
+  const { onClick, onMouseOver, onMouseOut, color, size, datasetName, group } =
+    props;
   // Prioritize the image preview over raw text
   const primaryPreviewType = getPrimaryPreviewType(props);
   // only show the secondary preview for large size
@@ -170,6 +179,8 @@ export function EventItem(props: EventItemProps) {
         }
       `}
       onClick={onClick}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
     >
       <div
         className="event-item__preview-wrap"

--- a/app/src/components/pointcloud/PointCloudPointHoverHalo.tsx
+++ b/app/src/components/pointcloud/PointCloudPointHoverHalo.tsx
@@ -3,7 +3,7 @@ import { Sphere } from "@react-three/drei";
 
 import { usePointCloudContext } from "@phoenix/contexts";
 
-const POINT_RADIUS_MULTIPLIER = 1.5;
+const POINT_RADIUS_MULTIPLIER = 2;
 
 export function PointCloudPointHoverHalo({
   pointRadius,
@@ -36,7 +36,7 @@ export function PointCloudPointHoverHalo({
       scale={[pointSizeScale, pointSizeScale, pointSizeScale]}
     >
       {/* eslint-disable-next-line react/no-unknown-property */}
-      <meshMatcapMaterial color={color} opacity={0.5} transparent />
+      <meshMatcapMaterial color={color} opacity={0.7} transparent />
     </Sphere>
   );
 }

--- a/app/src/components/pointcloud/SelectionDisplayRadioGroup.tsx
+++ b/app/src/components/pointcloud/SelectionDisplayRadioGroup.tsx
@@ -26,7 +26,6 @@ export function SelectionDisplayRadioGroup(
     <RadioGroup
       defaultValue={props.mode}
       variant="inline-button"
-      size="compact"
       onChange={(v) => {
         if (isSelectionDisplay(v)) {
           props.onChange(v);

--- a/app/src/components/pointcloud/SelectionGridSizeRadioGroup.tsx
+++ b/app/src/components/pointcloud/SelectionGridSizeRadioGroup.tsx
@@ -26,7 +26,6 @@ export function SelectionGridSizeRadioGroup(
     <RadioGroup
       defaultValue={props.size}
       variant="inline-button"
-      size="compact"
       onChange={(v) => {
         if (isSelectionGridSize(v)) {
           props.onChange(v);

--- a/app/src/pages/embedding/PointSelectionGrid.tsx
+++ b/app/src/pages/embedding/PointSelectionGrid.tsx
@@ -24,6 +24,9 @@ export function PointSelectionGrid(props: PointSelectionGridProps) {
   const selectionGridSize = usePointCloudContext(
     (state) => state.selectionGridSize
   );
+  const setHoveredEventId = usePointCloudContext(
+    (state) => state.setHoveredEventId
+  );
 
   return (
     <div
@@ -83,6 +86,12 @@ export function PointSelectionGrid(props: PointSelectionGridProps) {
                 group={group}
                 onClick={() => {
                   onItemSelected(event.id);
+                }}
+                onMouseOver={() => {
+                  setHoveredEventId(event.id);
+                }}
+                onMouseOut={() => {
+                  setHoveredEventId(null);
                 }}
                 color={color}
                 size={selectionGridSize}

--- a/app/src/pages/embedding/PointSelectionPanelContent.tsx
+++ b/app/src/pages/embedding/PointSelectionPanelContent.tsx
@@ -204,8 +204,6 @@ export function PointSelectionPanelContent() {
     return [...primaryEvents, ...referenceEvents, ...corpusEvents];
   }, [data]);
 
-  const numSelectedEvents = allSelectedEvents.length;
-
   const onClose = () => {
     setSelectedEventIds(new Set());
     setSelectedClusterId(null);
@@ -298,6 +296,9 @@ export function PointSelectionPanelContent() {
     return null;
   }, [allData, selectedDetailPointId]);
 
+  const numSelectedEvents = allSelectedEvents.length;
+  const numMatchingEvents = filteredEvents.length;
+
   return (
     <section css={pointSelectionPanelCSS}>
       <div
@@ -323,7 +324,11 @@ export function PointSelectionPanelContent() {
       {/* @ts-expect-error more tabs to come */}
       <Tabs>
         <TabPane name="Selection">
-          <SelectionToolbar numSelectedEvents={numSelectedEvents} />
+          <SelectionToolbar
+            numSelectedEvents={numSelectedEvents}
+            numMatchingEvents={numMatchingEvents}
+            searchText={selectionSearchText}
+          />
           {selectionDisplay === SelectionDisplay.list ? (
             <div
               css={css`
@@ -361,8 +366,18 @@ export function PointSelectionPanelContent() {
 
 function SelectionToolbar({
   numSelectedEvents,
+  numMatchingEvents,
+  searchText,
 }: {
   numSelectedEvents: number;
+  /**
+   * The number of events that match the current search
+   */
+  numMatchingEvents: number;
+  /**
+   * The current search text
+   */
+  searchText: string;
 }) {
   const selectionDisplay = usePointCloudContext(
     (state) => state.selectionDisplay
@@ -379,6 +394,12 @@ function SelectionToolbar({
   const setSelectionSearchText = usePointCloudContext(
     (state) => state.setSelectionSearchText
   );
+  const summaryText = useMemo(() => {
+    if (!searchText) {
+      return `${numSelectedEvents} selected`;
+    }
+    return `${numMatchingEvents}/${numSelectedEvents} match "${searchText}"`;
+  }, [numSelectedEvents, numMatchingEvents, searchText]);
   return (
     <Toolbar
       extra={
@@ -410,7 +431,7 @@ function SelectionToolbar({
         </div>
       }
     >
-      <Text>{`${numSelectedEvents} points selected`}</Text>
+      <Text>{summaryText}</Text>
     </Toolbar>
   );
 }

--- a/app/src/store/pointCloudStore.ts
+++ b/app/src/store/pointCloudStore.ts
@@ -374,6 +374,10 @@ export interface PointCloudProps {
    * The overall metric for the point cloud
    */
   metric: MetricDefinition;
+  /**
+   * Search text for the selection panel
+   */
+  selectionSearchText: string;
 }
 
 export interface PointCloudState extends PointCloudProps {
@@ -488,6 +492,10 @@ export interface PointCloudState extends PointCloudProps {
    * Set the overall metric used in the point-cloud
    */
   setMetric(metric: MetricDefinition): void;
+  /**
+   * Set the selection search text
+   */
+  setSelectionSearchText: (text: string) => void;
 }
 
 const getDefaultColorScheme = () => {
@@ -620,6 +628,7 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
       type: "drift",
       metric: "euclideanDistance",
     },
+    selectionSearchText: "",
   };
 
   const pointCloudStore: StateCreator<PointCloudState> = (set, get) => ({
@@ -712,7 +721,8 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
       const sortedClusters = [...pointCloud.clusters].sort(clusterSortFn(sort));
       set({ clusterSort: sort, clusters: sortedClusters });
     },
-    setSelectedEventIds: (ids) => set({ selectedEventIds: ids }),
+    setSelectedEventIds: (ids) =>
+      set({ selectedEventIds: ids, selectionSearchText: "" }),
     setHoveredEventId: (id) => set({ hoveredEventId: id }),
     setHighlightedClusterId: (id) => set({ highlightedClusterId: id }),
     setSelectedClusterId: (id) =>
@@ -925,6 +935,8 @@ export const createPointCloudStore = (initProps?: Partial<PointCloudProps>) => {
       });
       pointCloud.setClusters(clusters);
     },
+    setSelectionSearchText: (searchText: string) =>
+      set({ selectionSearchText: searchText }),
   });
 
   return create<PointCloudState>()(devtools(pointCloudStore));


### PR DESCRIPTION
resolves #814 

This does not fully resolve #814 but can be used to solve some of the pain points.

Adds a search field in the selection panel and the ability to hover on points in the grid to try to identify a point.

What a user might ultimately want is actually search on all the points displayed - and this most certainly is the case. However this requires a bit more design and thought and this at least lets you narrow down the selection vector space.

<img width="2056" alt="Screenshot 2024-02-06 at 4 23 51 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/e71999a3-eaa1-4199-a5d9-eac5ceabce76">

