### PR TITLE
fix(trace): return to /tracing url when dismissing trace slide over

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,7 +78,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:image & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -216,7 +216,7 @@ export function TracePage() {
     <DialogContainer
       type="slideOver"
       isDismissable
-      onDismiss={() => navigate(-1)}
+      onDismiss={() => navigate("/tracing")}
     >
       <Dialog size="XL" title="Trace Details">
         <main


### PR DESCRIPTION
resolves #2198 
Rather than relying on browser history, this now always navigates to the tracing view.

https://github.com/Arize-ai/phoenix/assets/5640648/cf169294-a2f9-4e11-82bf-61b063a4db3b

