### PR TITLE
fix: `run_evals` correctly falls back to default responses on error

### DIFF
--- a/src/phoenix/experimental/evals/functions/classify.py
+++ b/src/phoenix/experimental/evals/functions/classify.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections import defaultdict
+from itertools import product
 from typing import (
     Any,
     DefaultDict,
@@ -54,8 +55,7 @@ Label: TypeAlias = str
 Score: TypeAlias = Optional[float]
 Explanation: TypeAlias = Optional[str]
 Record: TypeAlias = Mapping[str, Any]
-EvaluatorIndex: TypeAlias = int
-RowIndex: TypeAlias = Any
+RowIndex: TypeAlias = int
 
 # snapped_response, explanation, response
 ParsedLLMResponse: TypeAlias = Tuple[Optional[str], Optional[str], str]
@@ -343,8 +343,6 @@ def _get_contents_from_openinference_documents(documents: Iterable[Any]) -> List
 
 
 class RunEvalsPayload(NamedTuple):
-    evaluator_index: EvaluatorIndex
-    row_index: RowIndex
     evaluator: LLMEvaluator
     record: Record
 
@@ -404,23 +402,21 @@ def run_evals(
 
     async def _arun_eval(
         payload: RunEvalsPayload,
-    ) -> Tuple[EvaluatorIndex, RowIndex, Label, Score, Explanation]:
-        label, score, explanation = await payload.evaluator.aevaluate(
+    ) -> Tuple[Label, Score, Explanation]:
+        return await payload.evaluator.aevaluate(
             payload.record,
             provide_explanation=provide_explanation,
             use_function_calling_if_available=use_function_calling_if_available,
         )
-        return payload.evaluator_index, payload.row_index, label, score, explanation
 
     def _run_eval(
         payload: RunEvalsPayload,
-    ) -> Tuple[EvaluatorIndex, RowIndex, Label, Score, Explanation]:
-        label, score, explanation = payload.evaluator.evaluate(
+    ) -> Tuple[Label, Score, Explanation]:
+        return payload.evaluator.evaluate(
             payload.record,
             provide_explanation=provide_explanation,
             use_function_calling_if_available=use_function_calling_if_available,
         )
-        return payload.evaluator_index, payload.row_index, label, score, explanation
 
     executor = get_executor_on_sync_context(
         _run_eval,
@@ -428,24 +424,20 @@ def run_evals(
         concurrency=concurrency,
         tqdm_bar_format=get_tqdm_progress_bar_formatter("run_evals"),
         exit_on_error=True,
-        fallback_return_value=(None, None),
+        fallback_return_value=(None, None, None),
     )
+
+    total_records = len(dataframe)
     payloads = [
-        RunEvalsPayload(
-            evaluator_index=evaluator_index,
-            row_index=row_index,
-            evaluator=evaluator,
-            record=row.to_dict(),
-        )
-        # use the position of the row rather than the dataframe index, which is used
-        # to ensure the output dataframe has the same row order as the input dataframe
-        for row_index, (_, row) in enumerate(dataframe.iterrows())
-        for evaluator_index, evaluator in enumerate(evaluators)
+        RunEvalsPayload(evaluator=evaluator, record=row)
+        for evaluator, (_, row) in product(evaluators, dataframe.iterrows())
     ]
     eval_results: List[DefaultDict[RowIndex, Dict[ColumnName, Union[Label, Explanation]]]] = [
         defaultdict(dict) for _ in range(len(evaluators))
     ]
-    for evaluator_index, row_index, label, score, explanation in executor.run(payloads):
+    for index, (label, score, explanation) in enumerate(executor.run(payloads)):
+        evaluator_index = index // total_records
+        row_index = index % total_records
         eval_results[evaluator_index][row_index]["label"] = label
         eval_results[evaluator_index][row_index]["score"] = score
         if provide_explanation:

--- a/tests/experimental/evals/functions/test_classify.py
+++ b/tests/experimental/evals/functions/test_classify.py
@@ -1193,6 +1193,62 @@ def test_run_evals_produces_expected_output_when_llm_outputs_unexpected_data(
     )
 
 
+@pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions")
+def test_run_evals_fails_gracefully_on_error(
+    respx_mock: respx.mock,
+    relevance_evaluator: LLMEvaluator,
+) -> None:
+    for matcher, response in [
+        (
+            M(content__contains="Paris is the capital of France."),
+            "relevant-explanation\nrelevant",  # missing delimiter
+        ),
+        (
+            M(content__contains="Munich is the capital of Germany."),
+            "some-explanation\nLABEL: unparseable-label",  # unparseable-label
+        ),
+        (
+            M(content__contains="Washington, D.C. is the capital of the USA."),
+            "unrelated-explanation\nLABEL: unrelated",  # normal
+        ),
+    ]:
+        respx_mock.route(matcher).mock(side_effect=Exception("spurious test error"))
+
+    df = pd.DataFrame(
+        [
+            {
+                "input": "What is the capital of France?",
+                "reference": "Paris is the capital of France.",
+            },
+            {
+                "input": "What is the capital of France?",
+                "reference": "Munich is the capital of Germany.",
+            },
+            {
+                "input": "What is the capital of France?",
+                "reference": "Washington, D.C. is the capital of the USA.",
+            },
+        ],
+    )
+    eval_dfs = run_evals(
+        dataframe=df,
+        evaluators=[relevance_evaluator],
+        provide_explanation=True,
+        use_function_calling_if_available=False,
+    )
+    assert len(eval_dfs) == 1
+    assert_frame_equal(
+        pd.DataFrame(
+            {
+                "label": [None, None, None],
+                "score": [None, None, None],
+                "explanation": [None, None, None],
+            },
+        ),
+        eval_dfs[0],
+    )
+
+
 def test_run_evals_with_empty_evaluators_returns_empty_list() -> None:
     eval_dfs = run_evals(
         dataframe=pd.DataFrame(),


### PR DESCRIPTION
resolves #2216

We internally refactor `run_evals` to not require a dynamic fallback value then return fallback values in case a particular eval failed to run.