### PR TITLE
chore(evals): soft deprecate model_name param

### DIFF
--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -64,8 +64,10 @@ class OpenAIModel(BaseEvalModel):
     An optional base URL to use for the OpenAI API. If not provided, will default
     to what's configured in OpenAI
     """
-    model_name: str = "gpt-4"
-    """Model name to use. In of azure, this is the deployment name such as gpt-35-instant"""
+    model: str = "gpt-4"
+    """
+    Model name to use. In of azure, this is the deployment name such as gpt-35-instant
+    """
     temperature: float = 0.0
     """What sampling temperature to use."""
     max_tokens: int = 256
@@ -106,7 +108,15 @@ class OpenAIModel(BaseEvalModel):
     azure_ad_token: Optional[str] = field(default=None)
     azure_ad_token_provider: Optional[Callable[[], str]] = field(default=None)
 
+    # Deprecated fields
+    model_name: Optional[str] = field(default=None)
+    """
+    .. deprecated:: 3.0.0
+       use `model` instead. This will be removed
+    """
+
     def __post_init__(self) -> None:
+        self._migrate_model_name()
         self._init_environment()
         self._init_open_ai()
         self._init_tiktoken()
@@ -114,6 +124,17 @@ class OpenAIModel(BaseEvalModel):
 
     def reload_client(self) -> None:
         self._init_open_ai()
+
+    def _migrate_model_name(self) -> None:
+        if self.model_name:
+            warning_message = "The `model_name` field is deprecated. Use `model` instead. \
+                This will be removed in a future release."
+            print(
+                warning_message,
+                DeprecationWarning,
+            )
+            self.model = self.model_name
+            self.model_name = None
 
     def _init_environment(self) -> None:
         try:
@@ -141,9 +162,7 @@ class OpenAIModel(BaseEvalModel):
         # For Azure, you need to provide the endpoint and the endpoint
         self._is_azure = bool(self.azure_endpoint)
 
-        self._model_uses_legacy_completion_api = self.model_name.startswith(
-            LEGACY_COMPLETION_API_MODELS
-        )
+        self._model_uses_legacy_completion_api = self.model.startswith(LEGACY_COMPLETION_API_MODELS)
         if self.api_key is None:
             api_key = os.getenv(OPENAI_API_KEY_ENVVAR_NAME)
             if api_key is None:
@@ -203,7 +222,7 @@ class OpenAIModel(BaseEvalModel):
 
     def _init_tiktoken(self) -> None:
         try:
-            encoding = self._tiktoken.encoding_for_model(self.model_name)
+            encoding = self._tiktoken.encoding_for_model(self.model)
         except KeyError:
             encoding = self._tiktoken.get_encoding("cl100k_base")
         self._tiktoken_encoding = encoding
@@ -333,20 +352,20 @@ class OpenAIModel(BaseEvalModel):
 
     @property
     def max_context_size(self) -> int:
-        model_name = self.model_name
+        model = self.model
         # handling finetuned models
-        if "ft-" in model_name:
-            model_name = self.model_name.split(":")[0]
-        if model_name == "gpt-4":
+        if "ft-" in model:
+            model = self.model.split(":")[0]
+        if model == "gpt-4":
             # Map gpt-4 to the current default
-            model_name = "gpt-4-0613"
+            model = "gpt-4-0613"
 
-        context_size = MODEL_TOKEN_LIMIT_MAPPING.get(model_name, None)
+        context_size = MODEL_TOKEN_LIMIT_MAPPING.get(model, None)
 
         if context_size is None:
             raise ValueError(
                 "Can't determine maximum context size. An unknown model name was "
-                f"used: {model_name}. Please provide a valid OpenAI model name. "
+                f"used: {model}. Please provide a valid OpenAI model name. "
                 "Known models are: " + ", ".join(MODEL_TOKEN_LIMIT_MAPPING.keys())
             )
 
@@ -355,7 +374,7 @@ class OpenAIModel(BaseEvalModel):
     @property
     def public_invocation_params(self) -> Dict[str, Any]:
         return {
-            **({"model": self.model_name}),
+            **({"model": self.model}),
             **self._default_params,
             **self.model_kwargs,
         }
@@ -388,8 +407,8 @@ class OpenAIModel(BaseEvalModel):
 
         Official documentation: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
         """  # noqa
-        model_name = self.model_name
-        if model_name == "gpt-3.5-turbo-0301":
+        model = self.model
+        if model == "gpt-3.5-turbo-0301":
             tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
             tokens_per_name = -1  # if there's a name, the role is omitted
         else:

--- a/src/phoenix/experimental/evals/models/openai.py
+++ b/src/phoenix/experimental/evals/models/openai.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from dataclasses import dataclass, field, fields
 from typing import (
     TYPE_CHECKING,
@@ -131,8 +132,8 @@ class OpenAIModel(BaseEvalModel):
                 This will be removed in a future release."
             print(
                 warning_message,
-                DeprecationWarning,
             )
+            warnings.warn(warning_message, DeprecationWarning)
             self.model = self.model_name
             self.model_name = None
 

--- a/src/phoenix/experimental/evals/models/vertexai.py
+++ b/src/phoenix/experimental/evals/models/vertexai.py
@@ -1,3 +1,5 @@
+import logging
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -6,6 +8,7 @@ from phoenix.experimental.evals.models.base import BaseEvalModel
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials  # type:ignore
 
+logger = logging.getLogger(__name__)
 
 MINIMUM_VERTEX_AI_VERSION = "1.33.0"
 
@@ -18,9 +21,9 @@ class VertexAIModel(BaseEvalModel):
     "location (str): The default location to use when making API calls. If not "
     "set defaults to us-central-1."
     credentials: Optional["Credentials"] = None
-    model_name: str = "text-bison"
-    tuned_model_name: Optional[str] = None
-    "The name of a tuned model. If provided, model_name is ignored."
+    model: str = "text-bison"
+    tuned_model: Optional[str] = None
+    "The name of a tuned model. If provided, model is ignored."
     max_retries: int = 6
     """Maximum number of retries to make when generating."""
     retry_min_seconds: int = 10
@@ -40,10 +43,49 @@ class VertexAIModel(BaseEvalModel):
     "How the model selects tokens for output, the next token is selected from "
     "among the top-k most probable tokens. Top-k is ignored for Codey models."
 
+    # Deprecated fields
+    model_name: Optional[str] = None
+    """
+    .. deprecated:: 3.0.0
+       use `model` instead. This will be removed in a future release.
+    """
+    tuned_model_name: Optional[str] = None
+    """
+    .. deprecated:: 3.0.0
+       use `tuned_model` instead. This will be removed in a future release.
+    """
+
     def __post_init__(self) -> None:
+        self._migrate_model_name()
         self._init_environment()
         self._init_vertex_ai()
         self._instantiate_model()
+
+    def _migrate_model_name(self) -> None:
+        if self.model_name is not None:
+            warning_message = (
+                "The `model_name` field is deprecated. Use `model` instead. "
+                + "This will be removed in a future release."
+            )
+            warnings.warn(
+                warning_message,
+                DeprecationWarning,
+            )
+            print(warning_message)
+            self.model = self.model_name
+            self.model_name = None
+        if self.tuned_model_name is not None:
+            warning_message = (
+                "`tuned_model_name` field is deprecated. Use `tuned_model` instead. "
+                + "This will be removed in a future release."
+            )
+            warnings.warn(
+                warning_message,
+                DeprecationWarning,
+            )
+            print(warning_message)
+            self.tuned_model = self.tuned_model_name
+            self.tuned_model_name = None
 
     def _init_environment(self) -> None:
         try:
@@ -72,10 +114,10 @@ class VertexAIModel(BaseEvalModel):
 
             model = TextGenerationModel
 
-        if self.tuned_model_name:
-            self._model = model.get_tuned_model(self.tuned_model_name)
+        if self.tuned_model:
+            self._model = model.get_tuned_model(self.tuned_model)
         else:
-            self._model = model.from_pretrained(self.model_name)
+            self._model = model.from_pretrained(self.model)
 
     def verbose_generation_info(self) -> str:
         return f"VertexAI invocation parameters: {self.invocation_params}"
@@ -93,7 +135,7 @@ class VertexAIModel(BaseEvalModel):
 
     @property
     def is_codey_model(self) -> bool:
-        return is_codey_model(self.tuned_model_name or self.model_name)
+        return is_codey_model(self.tuned_model or self.model)
 
     @property
     def _init_params(self) -> Dict[str, Any]:

--- a/tests/experimental/evals/functions/test_generate.py
+++ b/tests/experimental/evals/functions/test_generate.py
@@ -272,7 +272,7 @@ def test_litellm_model_llm_generate(monkeypatch: pytest.MonkeyPatch):
         "Given {query} and a golden answer {reference}, generate an answer that returns True."
     )
 
-    model = LiteLLMModel(model_name="gpt-3.5-turbo", model_kwargs={"mock_response": True})
+    model = LiteLLMModel(model="gpt-3.5-turbo", model_kwargs={"mock_response": True})
 
     generated = llm_generate(dataframe=dataframe, template=template, model=model)
     assert generated.iloc[:, 0].tolist() == responses

--- a/tests/experimental/evals/models/test_openai.py
+++ b/tests/experimental/evals/models/test_openai.py
@@ -13,9 +13,9 @@ def test_openai_model(monkeypatch):
     """
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
-        model = OpenAIModel(model_name="gpt-4-turbo-preview")
+        model = OpenAIModel(model="gpt-4-turbo-preview")
 
-    assert model.model_name == "gpt-4-turbo-preview"
+    assert model.model == "gpt-4-turbo-preview"
     assert isinstance(model._client, OpenAI)
 
 
@@ -55,7 +55,7 @@ def test_azure_supports_function_calling(monkeypatch):
 
     with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
         model = OpenAIModel(
-            model_name="gpt-4-turbo-preview",
+            model="gpt-4-turbo-preview",
             api_version="2023-06-01-preview",
             azure_endpoint="https://example-endpoint.openai.azure.com",
         )

--- a/tests/experimental/evals/models/test_openai.py
+++ b/tests/experimental/evals/models/test_openai.py
@@ -23,7 +23,7 @@ def test_azure_openai_model(monkeypatch):
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
         model = OpenAIModel(
-            model_name="gpt-4-turbo-preview",
+            model="gpt-4-turbo-preview",
             api_version="2023-07-01-preview",
             azure_endpoint="https://example-endpoint.openai.azure.com",
         )
@@ -37,7 +37,7 @@ def test_azure_fails_when_missing_options(monkeypatch):
         ValueError, match="Option 'api_version' must be set when using Azure OpenAI"
     ):
         OpenAIModel(
-            model_name="gpt-4-turbo-preview",
+            model="gpt-4-turbo-preview",
             azure_endpoint="https://example-endpoint.openai.azure.com",
         )
 
@@ -46,7 +46,7 @@ def test_azure_supports_function_calling(monkeypatch):
     monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     with patch.object(OpenAIModel, "_init_tiktoken", return_value=None):
         model = OpenAIModel(
-            model_name="gpt-4-turbo-preview",
+            model="gpt-4-turbo-preview",
             api_version="2023-07-01-preview",
             azure_endpoint="https://example-endpoint.openai.azure.com",
         )
@@ -61,3 +61,11 @@ def test_azure_supports_function_calling(monkeypatch):
         )
     assert isinstance(model._client, AzureOpenAI)
     assert model.supports_function_calling is False
+
+
+def test_model_name_deprecation(monkeypatch):
+    monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
+    with pytest.warns(DeprecationWarning, match="The `model_name` field is deprecated"):
+        model = OpenAIModel(model_name="gpt-4-turbo-preview")
+    assert model.model == "gpt-4-turbo-preview"
+    assert model.model_name is None


### PR DESCRIPTION
resolves #2252 

Soft-deprecates the model_name param in favor of model which is the common param name for openAI and other SDKs.