### PR TITLE
fix: set global session to None if it fails to start

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -477,6 +477,7 @@ def launch_app(
             f"port {port} is not occupied by another process) or file an issue "
             f"with us at https://github.com/Arize-ai/phoenix"
         )
+        _session = None
         return None
 
     print(f"🌍 To view the Phoenix app in your browser, visit {_session.url}")

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -490,7 +490,9 @@ def active_session() -> Optional[Session]:
     """
     Returns the active session if one exists, otherwise returns None
     """
-    return _session
+    if _session and _session.active:
+        return _session
+    return None
 
 
 def close_app() -> None:


### PR DESCRIPTION
So that `px.Client()` doesn't use the failed session (or one that has ended).