### PR TITLE
fix: cast message to string in vertexai model

### DIFF
--- a/src/phoenix/experimental/evals/models/vertex.py
+++ b/src/phoenix/experimental/evals/models/vertex.py
@@ -168,14 +168,14 @@ class GeminiModel(BaseEvalModel):
                     printif(
                         self._verbose, "The 'candidates' object does not have a 'text' attribute."
                     )
-                    printif(self._verbose, response.candidates[0])
+                    printif(self._verbose, str(response.candidates[0]))
                     candidate = ""
             else:
                 printif(
                     self._verbose,
                     "The 'candidates' attribute of 'response' is either not a list or is empty.",
                 )
-                printif(self._verbose, response)
+                printif(self._verbose, str(response))
                 candidate = ""
         else:
             printif(self._verbose, "The 'response' object does not have a 'candidates' attribute.")


### PR DESCRIPTION
Small bug fix, we were printing a non string object, need to cast it to a string. This is blocking large runs with vertex that hit this error.