### PR TITLE
feat(trace): display metadata in the trace page UI

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,7 +78,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:chatbot & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -492,7 +492,22 @@ function SpanInfo({ span }: { span: Span }) {
     default:
       content = <SpanIO span={span} />;
   }
-  return <View padding="size-200">{content}</View>;
+
+  return (
+    <View padding="size-200">
+      <Flex direction="column" gap="size-200">
+        {content}
+        {attributesObject?.metadata ? (
+          <Card {...defaultCardProps} title="Metadata">
+            <CodeBlock
+              value={JSON.stringify(attributesObject.metadata)}
+              mimeType="json"
+            />
+          </Card>
+        ) : null}
+      </Flex>
+    </View>
+  );
 }
 
 function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {

--- a/tutorials/tracing/langchain_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_tracing_tutorial.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.0.334\" \"openai>=1\" arize-phoenix tiktoken nest-asyncio"
+    "!pip install \"langchain>=0.1.0\" \"openai>=1\" arize-phoenix tiktoken nest-asyncio"
    ]
   },
   {
@@ -161,6 +161,7 @@
     "    llm=llm,\n",
     "    chain_type=chain_type,\n",
     "    retriever=knn_retriever,\n",
+    "    metadata={\"application_type\": \"question_answering\"},\n",
     ")"
    ]
   },


### PR DESCRIPTION
resolves #2296 

Displays metadata in the trace page. This does not show the metadata in the table (https://github.com/Arize-ai/phoenix/issues/2305) which requires a graphql change.

Also updates the notebook to have metadata

<img width="2001" alt="Screenshot 2024-02-15 at 4 05 57 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/026b4abf-a78f-4f9a-b412-6db99bac40dd">
