### PR TITLE
fix: make dspy notebook work on colab

### DIFF
--- a/tutorials/tracing/dspy_tracing_tutorial.ipynb
+++ b/tutorials/tracing/dspy_tracing_tutorial.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install dspy arize-phoenix openinference-instrumentation-dspy opentelemetry-exporter-otlp"
+    "!pip install dspy-ai arize-phoenix openinference-instrumentation-dspy opentelemetry-exporter-otlp"
    ]
   },
   {

--- a/tutorials/tracing/dspy_tracing_tutorial.ipynb
+++ b/tutorials/tracing/dspy_tracing_tutorial.ipynb
@@ -47,7 +47,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install dspy-ai arize-phoenix openinference-instrumentation-dspy opentelemetry-exporter-otlp"
+    "!pip install \"regex~=2023.10.3\" dspy-ai  # DSPy requires an old version of regex that conflicts with the installed version on Colab\n",
+    "!pip install arize-phoenix openinference-instrumentation-dspy opentelemetry-exporter-otlp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "⚠️ DSPy conflicts with the default version of the `regex` module that comes pre-installed on Google Colab. If you are running this notebook in Google Colab, you will likely need to restart the kernel after running the installation step above and before proceeding to the rest of the notebook, otherwise, your instrumentation will fail."
    ]
   },
   {


### PR DESCRIPTION
A few issues:
- I had the wrong package name in the pip install statement.
- DSPy conflicts with the pre-installed version of `regex` on Google Colab, which breaks our instrumentation. I install a compatible version and add a warning message to restart the kernel on Colab.