### PR TITLE
feat: show span as soon as they arrive

### DIFF
--- a/app/src/components/trace/utils.ts
+++ b/app/src/components/trace/utils.ts
@@ -22,7 +22,7 @@ export function createSpanTree<TSpan extends ISpanItem>(
   const rootSpans: SpanTreeNode<TSpan>[] = [];
   for (const span of spans) {
     const spanTreeItem = spanMap.get(span.context.spanId);
-    if (span.parentId === null) {
+    if (span.parentId === null || !spanMap.has(span.parentId)) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       rootSpans.push(spanTreeItem!);
     } else {

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -225,9 +225,10 @@ export function TracePage() {
   const selectedSpan = spansList.find(
     (span) => span.context.spanId === selectedSpanId
   );
-  const rootSpan = useMemo(() => {
-    return spansList.find((span) => span.parentId == null);
-  }, [spansList]);
+  const rootSpan =
+    useMemo(() => {
+      return spansList.find((span) => span.parentId == null);
+    }, [spansList]) || null;
 
   return (
     <DialogContainer
@@ -282,7 +283,7 @@ export function TracePage() {
   );
 }
 
-function TraceHeader({ rootSpan }: { rootSpan: Span | null | undefined }) {
+function TraceHeader({ rootSpan }: { rootSpan?: Span | null }) {
   const { latencyMs, statusCode, spanEvaluations } = rootSpan ?? {
     latencyMs: null,
     statusCode: "UNSET",

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -229,9 +229,6 @@ export function TracePage() {
     return spansList.find((span) => span.parentId == null);
   }, [spansList]);
 
-  if (rootSpan == null) {
-    throw new Error("rootSpan is required to view a trace");
-  }
   return (
     <DialogContainer
       type="slideOver"
@@ -247,7 +244,7 @@ export function TracePage() {
             flex-direction: column;
           `}
         >
-          <TraceHeader rootSpan={rootSpan} />
+          {rootSpan ? <TraceHeader rootSpan={rootSpan} /> : null}
           <PanelGroup
             direction="horizontal"
             autoSaveId="trace-panel-group"

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -216,7 +216,7 @@ export function TracePage() {
     `,
     { traceId: traceId as string },
     {
-      fetchPolicy: "network-only",
+      fetchPolicy: "store-and-network",
     }
   );
   const spansList = data.spans.edges.map((edge) => edge.span);

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -214,7 +214,10 @@ export function TracePage() {
         }
       }
     `,
-    { traceId: traceId as string }
+    { traceId: traceId as string },
+    {
+      fetchPolicy: "network-only",
+    }
   );
   const spansList = data.spans.edges.map((edge) => edge.span);
   const urlSelectedSpanId = searchParams.get("selectedSpanId");

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -244,7 +244,7 @@ export function TracePage() {
             flex-direction: column;
           `}
         >
-          {rootSpan ? <TraceHeader rootSpan={rootSpan} /> : null}
+          <TraceHeader rootSpan={rootSpan} />
           <PanelGroup
             direction="horizontal"
             autoSaveId="trace-panel-group"
@@ -282,8 +282,12 @@ export function TracePage() {
   );
 }
 
-function TraceHeader({ rootSpan }: { rootSpan: Span }) {
-  const { latencyMs, statusCode, spanEvaluations } = rootSpan;
+function TraceHeader({ rootSpan }: { rootSpan: Span | null | undefined }) {
+  const { latencyMs, statusCode, spanEvaluations } = rootSpan ?? {
+    latencyMs: null,
+    statusCode: "UNSET",
+    spanEvaluations: [],
+  };
   const statusColor = useSpanStatusCodeColor(statusCode);
   const hasEvaluations = spanEvaluations.length;
   return (

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -72,6 +72,10 @@ class ReadableSpan(ObjectProxy):  # type: ignore
     @property
     def span(self) -> Span:
         span = decode(self._self_otlp_span)
+        # FIXME: Our legacy files have the __computed__ attributes which interferes
+        # with our ability to add more computations. As a workaround, we discard the computed
+        # attribute if it exists.
+        span.attributes.pop(COMPUTED_PREFIX[:-1], None)
         span.attributes.update(
             cast(phoenix.trace.schemas.SpanAttributes, self._self_computed_values)
         )

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from queue import SimpleQueue
 from threading import RLock, Thread
-from types import MethodType
+from types import MappingProxyType, MethodType
 from typing import (
     Any,
     DefaultDict,
@@ -95,6 +95,12 @@ class ReadableSpan(ObjectProxy):  # type: ignore
             raise KeyError(f"{key} is not a computed value")
         self._self_computed_values[key] = value
 
+    def __eq__(self, other: Any) -> bool:
+        return self is other
+
+    def __hash__(self) -> int:
+        return id(self)
+
 
 ParentSpanID: TypeAlias = SpanID
 ChildSpanID: TypeAlias = SpanID
@@ -108,22 +114,20 @@ class Traces:
         self._lock = RLock()
         self._spans: Dict[SpanID, ReadableSpan] = {}
         self._parent_span_ids: Dict[SpanID, ParentSpanID] = {}
-        self._traces: DefaultDict[TraceID, List[SpanID]] = defaultdict(list)
-        self._child_span_ids: DefaultDict[SpanID, Set[ChildSpanID]] = defaultdict(set)
+        self._traces: DefaultDict[TraceID, Set[ReadableSpan]] = defaultdict(set)
+        self._child_spans: DefaultDict[SpanID, Set[ReadableSpan]] = defaultdict(set)
         self._orphan_spans: DefaultDict[ParentSpanID, List[otlp.Span]] = defaultdict(list)
         self._num_documents: DefaultDict[SpanID, int] = defaultdict(int)
-        self._start_time_sorted_span_ids: SortedKeyList[SpanID] = SortedKeyList(
-            key=lambda span_id: self._spans[span_id].start_time,
+        self._start_time_sorted_spans: SortedKeyList[ReadableSpan] = SortedKeyList(
+            key=lambda span: span.start_time,
         )
-        self._start_time_sorted_root_span_ids: SortedKeyList[SpanID] = SortedKeyList(
-            key=lambda span_id: self._spans[span_id].start_time,
+        self._start_time_sorted_root_spans: SortedKeyList[ReadableSpan] = SortedKeyList(
+            key=lambda span: span.start_time,
         )
-        self._latency_sorted_root_span_ids: SortedKeyList[SpanID] = SortedKeyList(
-            key=lambda span_id: self._spans[span_id][ComputedAttributes.LATENCY_MS.value],
+        self._latency_sorted_root_spans: SortedKeyList[ReadableSpan] = SortedKeyList(
+            key=lambda span: span[ComputedAttributes.LATENCY_MS.value],
         )
         self._root_span_latency_ms_sketch = DDSketch()
-        self._min_start_time: Optional[datetime] = None
-        self._max_start_time: Optional[datetime] = None
         self._token_count_total: int = 0
         self._last_updated_at: Optional[datetime] = None
         self._start_consumer()
@@ -136,10 +140,9 @@ class Traces:
             # make a copy because source data can mutate during iteration
             if not (trace := self._traces.get(trace_id)):
                 return
-            span_ids = tuple(trace)
-        for span_id in span_ids:
-            if span := self[span_id]:
-                yield span
+            spans = tuple(trace)
+        for span in spans:
+            yield span.span
 
     def get_spans(
         self,
@@ -157,32 +160,38 @@ class Traces:
         start_time = start_time or min_start_time
         stop_time = stop_time or max_stop_time
         if span_ids is not None:
-            for span_id in span_ids:
-                if (
-                    (span := self[span_id])
-                    and start_time <= span.start_time < stop_time
-                    and (not root_spans_only or span.parent_id is None)
-                ):
-                    yield span
-            return
-        sorted_span_ids = (
-            self._start_time_sorted_root_span_ids
-            if root_spans_only
-            else self._start_time_sorted_span_ids
-        )
-        with self._lock:
-            # make a copy because source data can mutate during iteration
-            span_ids = tuple(
-                sorted_span_ids.irange_key(
-                    start_time.astimezone(timezone.utc),
-                    stop_time.astimezone(timezone.utc),
-                    inclusive=(True, False),
-                    reverse=True,  # most recent spans first
+            with self._lock:
+                spans = tuple(
+                    span
+                    for span_id in span_ids
+                    if (
+                        (span := self._spans.get(span_id))
+                        and start_time <= span.start_time < stop_time
+                        and (not root_spans_only or span.parent_id is None)
+                    )
                 )
+        else:
+            sorted_spans = (
+                self._start_time_sorted_root_spans
+                if root_spans_only
+                else self._start_time_sorted_spans
             )
-        for span_id in span_ids:
-            if span := self[span_id]:
-                yield span
+            # make a copy because source data can mutate during iteration
+            with self._lock:
+                spans = tuple(
+                    sorted_spans.irange_key(
+                        start_time.astimezone(timezone.utc),
+                        stop_time.astimezone(timezone.utc),
+                        inclusive=(True, False),
+                        reverse=True,  # most recent spans first
+                    )
+                )
+        for span in spans:
+            yield span.span
+
+    def span_exists(self, span_id: SpanID) -> bool:
+        with self._lock:
+            return span_id in self._spans
 
     def get_num_documents(self, span_id: SpanID) -> int:
         with self._lock:
@@ -194,11 +203,11 @@ class Traces:
         latency value as percent of the total count of root spans. E.g., for
         a latency value at the 75th percentile, the result is roughly 75.
         """
-        root_span_ids = self._latency_sorted_root_span_ids
-        if not (n := len(root_span_ids)):
+        root_spans = self._latency_sorted_root_spans
+        if not (n := len(root_spans)):
             return None
         with self._lock:
-            rank = cast(int, root_span_ids.bisect_key_left(latency_ms))
+            rank = cast(int, root_spans.bisect_key_left(latency_ms))
         return rank / n * 100
 
     def root_span_latency_ms_quantiles(self, *probabilities: float) -> Iterator[Optional[float]]:
@@ -210,15 +219,19 @@ class Traces:
             )
         yield from values
 
-    def get_descendant_span_ids(self, span_id: SpanID) -> Iterator[SpanID]:
+    def get_descendant_spans(self, span_id: SpanID) -> Iterator[Span]:
+        for span in self._get_descendant_spans(span_id):
+            yield span.span
+
+    def _get_descendant_spans(self, span_id: SpanID) -> Iterator[ReadableSpan]:
         with self._lock:
             # make a copy because source data can mutate during iteration
-            if not (child_span_ids := self._child_span_ids.get(span_id)):
+            if not (child_spans := self._child_spans.get(span_id)):
                 return
-            span_ids = tuple(child_span_ids)
-        for child_span_id in span_ids:
-            yield child_span_id
-            yield from self.get_descendant_span_ids(child_span_id)
+            spans = tuple(child_spans)
+        for child_span in spans:
+            yield child_span
+            yield from self._get_descendant_spans(child_span.context.span_id)
 
     @property
     def last_updated_at(self) -> Optional[datetime]:
@@ -235,7 +248,14 @@ class Traces:
 
     @property
     def right_open_time_range(self) -> Tuple[Optional[datetime], Optional[datetime]]:
-        return right_open_time_range(self._min_start_time, self._max_start_time)
+        if not self._start_time_sorted_spans:
+            return None, None
+        with self._lock:
+            first_span = self._start_time_sorted_spans[0]
+            last_span = self._start_time_sorted_spans[-1]
+        min_start_time = first_span.start_time
+        max_start_time = last_span.start_time
+        return right_open_time_range(min_start_time, max_start_time)
 
     def __getitem__(self, span_id: SpanID) -> Optional[Span]:
         with self._lock:
@@ -257,97 +277,67 @@ class Traces:
             with self._lock:
                 self._process_span(item)
 
-    def _process_span(self, span: otlp.Span) -> None:
-        new_span = ReadableSpan(span)
-        span_id = new_span.context.span_id
-        existing_span = self._spans.get(span_id)
-        if existing_span and existing_span.end_time:
-            # Reject updates if span has ended.
+    def _process_span(self, otlp_span: otlp.Span) -> None:
+        span = ReadableSpan(otlp_span)
+        span_id = span.context.span_id
+        if span_id in self._spans:
+            # Update is not allowed.
             return
-        is_root_span = not new_span.parent_id
+
+        parent_span_id = span.parent_id
+        is_root_span = parent_span_id is None
         if not is_root_span:
-            parent_span_id = new_span.parent_id
-            if parent_span_id not in self._spans:
-                # Span can't be processed before its parent.
-                self._orphan_spans[parent_span_id].append(span)
-                return
-            self._child_span_ids[parent_span_id].add(span_id)
+            self._child_spans[parent_span_id].add(span)
             self._parent_span_ids[span_id] = parent_span_id
-        start_time = new_span.start_time
-        end_time = new_span.end_time
-        if end_time:
-            new_span[ComputedAttributes.LATENCY_MS.value] = latency = (
-                end_time - start_time
-            ).total_seconds() * 1000
-            if is_root_span:
-                self._root_span_latency_ms_sketch.add(latency)
-        self._spans[span_id] = new_span
-        if is_root_span and end_time:
-            self._latency_sorted_root_span_ids.add(span_id)
-        if not existing_span:
-            trace_id = new_span.context.trace_id
-            self._traces[trace_id].append(span_id)
-            if is_root_span:
-                self._start_time_sorted_root_span_ids.add(span_id)
-            self._start_time_sorted_span_ids.add(span_id)
-            self._min_start_time = (
-                start_time
-                if self._min_start_time is None
-                else min(self._min_start_time, start_time)
-            )
-            self._max_start_time = (
-                start_time
-                if self._max_start_time is None
-                else max(self._max_start_time, start_time)
-            )
-        new_span[ComputedAttributes.ERROR_COUNT.value] = int(
-            new_span.status_code is SpanStatusCode.ERROR
-        )
-        # Update cumulative values for span's ancestors.
-        for attribute_name, cumulative_attribute_name in (
-            (LLM_TOKEN_COUNT_TOTAL, ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_TOTAL.value),
-            (LLM_TOKEN_COUNT_PROMPT, ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_PROMPT.value),
-            (
-                LLM_TOKEN_COUNT_COMPLETION,
-                ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_COMPLETION.value,
-            ),
-            (
-                ComputedAttributes.ERROR_COUNT.value,
-                ComputedAttributes.CUMULATIVE_ERROR_COUNT.value,
-            ),
-        ):
-            existing_value = (existing_span[attribute_name] or 0) if existing_span else 0
-            new_value = new_span[attribute_name] or 0
-            if not (difference := new_value - existing_value):
-                continue
-            existing_cumulative_value = (
-                (existing_span[cumulative_attribute_name] or 0) if existing_span else 0
-            )
-            new_span[cumulative_attribute_name] = difference + existing_cumulative_value
-            self._add_value_to_span_ancestors(
-                span_id,
-                cumulative_attribute_name,
-                difference,
-            )
-        # Update token count total
-        if existing_span:
-            self._token_count_total -= existing_span[LLM_TOKEN_COUNT_TOTAL] or 0
-        self._token_count_total += new_span[LLM_TOKEN_COUNT_TOTAL] or 0
-        # Update number of documents
-        num_documents_update = len(
-            new_span.attributes.get(SpanAttributes.RETRIEVAL_DOCUMENTS) or ()
-        )
-        if existing_span:
-            num_documents_update -= len(
-                existing_span.attributes.get(SpanAttributes.RETRIEVAL_DOCUMENTS) or ()
-            )
-        if num_documents_update:
-            self._num_documents[span_id] += num_documents_update
-        # Process previously orphaned spans, if any.
-        for orphan_span in self._orphan_spans.pop(span_id, ()):
-            self._process_span(orphan_span)
-        # Update last updated timestamp
+
+        # Add computed attributes to span
+        start_time = span.start_time
+        end_time = span.end_time
+        span[ComputedAttributes.LATENCY_MS.value] = latency = (
+            end_time - start_time
+        ).total_seconds() * 1000
+        if is_root_span:
+            self._root_span_latency_ms_sketch.add(latency)
+        span[ComputedAttributes.ERROR_COUNT.value] = int(span.status_code is SpanStatusCode.ERROR)
+
+        # Store the new span (after adding computed attributes)
+        self._spans[span_id] = span
+        self._traces[span.context.trace_id].add(span)
+        self._start_time_sorted_spans.add(span)
+        if is_root_span:
+            self._start_time_sorted_root_spans.add(span)
+            self._latency_sorted_root_spans.add(span)
+        self._propagate_cumulative_values(span)
+        self._update_cached_statistics(span)
+
+        # Update last updated timestamp, letting users know
+        # when they should refresh the page.
         self._last_updated_at = datetime.now(timezone.utc)
+
+    def _update_cached_statistics(self, span: ReadableSpan) -> None:
+        # Update statistics for quick access later
+        span_id = span.context.span_id
+        if token_count_update := span.attributes.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL):
+            self._token_count_total += token_count_update
+        if num_documents_update := len(
+            span.attributes.get(SpanAttributes.RETRIEVAL_DOCUMENTS) or ()
+        ):
+            self._num_documents[span_id] += num_documents_update
+
+    def _propagate_cumulative_values(self, span: ReadableSpan) -> None:
+        for cumulative_attribute, attribute in _CUMULATIVE_ATTRIBUTES.items():
+            span[cumulative_attribute] = span[attribute] or 0
+        self._update_ancestors(span)
+        span_id = span.context.span_id
+        for child_span in self._child_spans[span_id]:
+            self._update_ancestors(child_span)
+
+    def _update_ancestors(self, span: ReadableSpan) -> None:
+        # Add cumulative values to each of the span's ancestors.
+        span_id = span.context.span_id
+        for attribute in _CUMULATIVE_ATTRIBUTES.keys():
+            value = span[attribute] or 0
+            self._add_value_to_span_ancestors(span_id, attribute, value)
 
     def _add_value_to_span_ancestors(
         self,
@@ -356,7 +346,18 @@ class Traces:
         value: float,
     ) -> None:
         while parent_span_id := self._parent_span_ids.get(span_id):
-            parent_span = self._spans[parent_span_id]
+            if not (parent_span := self._spans.get(parent_span_id)):
+                return
             cumulative_value = parent_span[attribute_name] or 0
             parent_span[attribute_name] = cumulative_value + value
             span_id = parent_span_id
+
+
+_CUMULATIVE_ATTRIBUTES = MappingProxyType(
+    {
+        ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_TOTAL.value: LLM_TOKEN_COUNT_TOTAL,
+        ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_PROMPT.value: LLM_TOKEN_COUNT_PROMPT,
+        ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_COMPLETION.value: LLM_TOKEN_COUNT_COMPLETION,
+        ComputedAttributes.CUMULATIVE_ERROR_COUNT.value: ComputedAttributes.ERROR_COUNT.value,
+    }
+)

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -325,12 +325,12 @@ class Traces:
             self._num_documents[span_id] += num_documents_update
 
     def _propagate_cumulative_values(self, span: ReadableSpan) -> None:
+        child_spans: Iterable[ReadableSpan] = self._child_spans.get(span.context.span_id) or ()
         for cumulative_attribute, attribute in _CUMULATIVE_ATTRIBUTES.items():
             span[cumulative_attribute] = span[attribute] or 0
+            for child_span in child_spans:
+                span[cumulative_attribute] += child_span[cumulative_attribute] or 0
         self._update_ancestors(span)
-        span_id = span.context.span_id
-        for child_span in self._child_spans[span_id]:
-            self._update_ancestors(child_span)
 
     def _update_ancestors(self, span: ReadableSpan) -> None:
         # Add cumulative values to each of the span's ancestors.

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -193,10 +193,6 @@ class Traces:
         for span in spans:
             yield span.span
 
-    def span_exists(self, span_id: SpanID) -> bool:
-        with self._lock:
-            return span_id in self._spans
-
     def get_num_documents(self, span_id: SpanID) -> int:
         with self._lock:
             return self._num_documents.get(span_id) or 0

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -169,17 +169,17 @@ if __name__ == "__main__":
                 _get_trace_fixture_by_name(trace_dataset_name)
             )
         )
-        Thread(
-            target=_load_items,
-            args=(traces, fixture_spans, simulate_streaming),
-            daemon=True,
-        ).start()
+        # Thread(
+        #     target=_load_items,
+        #     args=(traces, fixture_spans, simulate_streaming),
+        #     daemon=True,
+        # ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
-        Thread(
-            target=_load_items,
-            args=(evals, fixture_evals, simulate_streaming),
-            daemon=True,
-        ).start()
+    #         Thread(
+    #             target=_load_items,
+    #             args=(evals, fixture_evals, simulate_streaming),
+    #             daemon=True,
+    #         ).start()
     umap_params_list = args.umap_params.split(",")
     umap_params = UMAPParameters(
         min_dist=float(umap_params_list[0]),

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -169,17 +169,17 @@ if __name__ == "__main__":
                 _get_trace_fixture_by_name(trace_dataset_name)
             )
         )
-        # Thread(
-        #     target=_load_items,
-        #     args=(traces, fixture_spans, simulate_streaming),
-        #     daemon=True,
-        # ).start()
+        Thread(
+            target=_load_items,
+            args=(traces, fixture_spans, simulate_streaming),
+            daemon=True,
+        ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
-        # Thread(
-        #     target=_load_items,
-        #     args=(evals, fixture_evals, simulate_streaming),
-        #     daemon=True,
-        # ).start()
+        Thread(
+            target=_load_items,
+            args=(evals, fixture_evals, simulate_streaming),
+            daemon=True,
+        ).start()
     umap_params_list = args.umap_params.split(",")
     umap_params = UMAPParameters(
         min_dist=float(umap_params_list[0]),

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -169,17 +169,17 @@ if __name__ == "__main__":
                 _get_trace_fixture_by_name(trace_dataset_name)
             )
         )
-        Thread(
-            target=_load_items,
-            args=(traces, fixture_spans, simulate_streaming),
-            daemon=True,
-        ).start()
+        # Thread(
+        #     target=_load_items,
+        #     args=(traces, fixture_spans, simulate_streaming),
+        #     daemon=True,
+        # ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
-        Thread(
-            target=_load_items,
-            args=(evals, fixture_evals, simulate_streaming),
-            daemon=True,
-        ).start()
+        # Thread(
+        #     target=_load_items,
+        #     args=(evals, fixture_evals, simulate_streaming),
+        #     daemon=True,
+        # ).start()
     umap_params_list = args.umap_params.split(",")
     umap_params = UMAPParameters(
         min_dist=float(umap_params_list[0]),

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -169,17 +169,17 @@ if __name__ == "__main__":
                 _get_trace_fixture_by_name(trace_dataset_name)
             )
         )
-        # Thread(
-        #     target=_load_items,
-        #     args=(traces, fixture_spans, simulate_streaming),
-        #     daemon=True,
-        # ).start()
+        Thread(
+            target=_load_items,
+            args=(traces, fixture_spans, simulate_streaming),
+            daemon=True,
+        ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
-    #         Thread(
-    #             target=_load_items,
-    #             args=(evals, fixture_evals, simulate_streaming),
-    #             daemon=True,
-    #         ).start()
+        Thread(
+            target=_load_items,
+            args=(evals, fixture_evals, simulate_streaming),
+            daemon=True,
+        ).start()
     umap_params_list = args.umap_params.split(",")
     umap_params = UMAPParameters(
         min_dist=float(umap_params_list[0]),

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -1,7 +1,7 @@
 from binascii import hexlify
 from collections import defaultdict, namedtuple
 from itertools import count, islice, permutations
-from typing import DefaultDict, Iterable, Set, Tuple
+from typing import DefaultDict, Iterable, Iterator, Set, Tuple
 
 import opentelemetry.proto.trace.v1.trace_pb2 as otlp
 import pytest
@@ -125,15 +125,13 @@ def _connected_descendant_ids(
     span_id: str,
     child_ids: DefaultDict[str, Set[str]],
     ingested_ids: Set[str],
-) -> Set[str]:
+) -> Iterator[str]:
     # A descendant is connected if all parents in between have been ingested.
-    ans = set()
     for id_ in child_ids.get(span_id) or ():
         if id_ not in ingested_ids:
             continue
-        ans.add(id_)
-        ans.update(_connected_descendant_ids(id_, child_ids, ingested_ids))
-    return ans
+        yield id_
+        yield from _connected_descendant_ids(id_, child_ids, ingested_ids)
 
 
 def _id_str(id_: bytes) -> str:

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -33,8 +33,8 @@ def test_ingestion(
         assert len(mock._spans) == i + 1, f"{i=}, {s=}"
 
         assert _id_str(otlp_span.span_id) in mock._spans, f"{i=}, {s=}"
-        span = mock._spans[_id_str(otlp_span.span_id)]
-        expected_token_count_total += span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL]
+        latest_span = mock._spans[_id_str(otlp_span.span_id)]
+        expected_token_count_total += latest_span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL]
         assert mock.token_count_total == expected_token_count_total, f"{i=}, {s=}"
 
         ingested_ids = {span.context.span_id for span in mock._spans.values()}

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -41,7 +41,7 @@ def test_ingestion(
 
         # Check that all cumulative values are correct at all times. We do this by summing
         # up values from all connected descendants. A descendant is connected if all parents
-        # in between have been ingested. A disconected descendant does not propagate its value
+        # in between have been ingested. A disconnected descendant does not propagate its value
         # across a missing parent.
         for span_id in ingested_ids.intersection(child_ids.keys()):
             span = mock._spans[span_id]

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -39,7 +39,10 @@ def test_ingestion(
 
         ingested_ids = {span.context.span_id for span in mock._spans.values()}
 
-        # Check that all cumulative values are correct.
+        # Check that all cumulative values are correct at all times. We do this by summing
+        # up values from all connected descendants. A descendant is connected if all parents
+        # in between have been ingested. A disconected descendant does not propagate its value
+        # across a missing parent.
         for span_id in ingested_ids.intersection(child_ids.keys()):
             span = mock._spans[span_id]
             assert span[

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -25,6 +25,7 @@ def test_ingestion(
     mock = MockTraces()
     trace_id = _id_str(otlp_trace[0].trace_id)
     expected_token_count_total = 0
+    ingested_ids = set()
     for i, s in enumerate(permutation):
         otlp_span = otlp_trace[s]
         mock._process_span(otlp_span)
@@ -36,8 +37,7 @@ def test_ingestion(
         latest_span = mock._spans[_id_str(otlp_span.span_id)]
         expected_token_count_total += latest_span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL]
         assert mock.token_count_total == expected_token_count_total, f"{i=}, {s=}"
-
-        ingested_ids = {span.context.span_id for span in mock._spans.values()}
+        ingested_ids.add(latest_span.context.span_id)
 
         # Check that all cumulative values are correct at all times. We do this by summing
         # up values from all connected descendants. A descendant is connected if all parents

--- a/tests/core/test_traces.py
+++ b/tests/core/test_traces.py
@@ -1,8 +1,14 @@
-from uuid import uuid4
+from binascii import hexlify
+from collections import defaultdict, namedtuple
+from itertools import count, islice, permutations
+from typing import DefaultDict, Iterable, Set, Tuple
 
-from phoenix.core.traces import (
-    Traces,
-)
+import opentelemetry.proto.trace.v1.trace_pb2 as otlp
+import pytest
+from openinference.semconv.trace import SpanAttributes
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from phoenix.core.traces import Traces
+from phoenix.trace.schemas import ComputedAttributes
 
 
 class MockTraces(Traces):
@@ -10,19 +16,122 @@ class MockTraces(Traces):
         pass
 
 
-def test_get_descendant_span_ids() -> None:
-    span_ids = [uuid4() for _ in range(6)]
+@pytest.mark.parametrize("permutation", list(permutations(range(5))))
+def test_ingestion(
+    otlp_trace: Tuple[otlp.Span, ...],
+    permutation: Tuple[int, ...],
+    child_ids: DefaultDict[str, Set[str]],
+) -> None:
     mock = MockTraces()
-    mock._child_span_ids.update(
+    trace_id = _id_str(otlp_trace[0].trace_id)
+    expected_token_count_total = 0
+    for i, s in enumerate(permutation):
+        otlp_span = otlp_trace[s]
+        mock._process_span(otlp_span)
+
+        assert len(mock._traces[trace_id]) == i + 1, f"{i=}, {s=}"
+        assert len(mock._spans) == i + 1, f"{i=}, {s=}"
+
+        assert _id_str(otlp_span.span_id) in mock._spans, f"{i=}, {s=}"
+        span = mock._spans[_id_str(otlp_span.span_id)]
+        expected_token_count_total += span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL]
+        assert mock.token_count_total == expected_token_count_total, f"{i=}, {s=}"
+
+        ingested_ids = {span.context.span_id for span in mock._spans.values()}
+
+        # Check that all cumulative values are correct.
+        for span_id in ingested_ids.intersection(child_ids.keys()):
+            span = mock._spans[span_id]
+            assert span[
+                ComputedAttributes.CUMULATIVE_LLM_TOKEN_COUNT_TOTAL.value
+            ] == span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL] + sum(
+                mock._spans[descendant_id].attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL]
+                for descendant_id in _connected_descendant_ids(span_id, child_ids, ingested_ids)
+            ), f"{i=}, {s=}, {span_id=}"
+
+
+def test_get_descendant_span_ids(spans) -> None:
+    spans = list(islice(spans, 6))
+    span_ids = [span.context.span_id for span in spans]
+    mock = MockTraces()
+    mock._child_spans.update(
         {
-            span_ids[1]: [span_ids[2], span_ids[3]],
-            span_ids[2]: [span_ids[4]],
-            span_ids[4]: [span_ids[5]],
+            span_ids[1]: {spans[2], spans[3]},
+            span_ids[2]: {spans[4]},
+            span_ids[4]: {spans[5]},
         }
     )
-    assert set(mock.get_descendant_span_ids(span_ids[0])) == set()
-    assert set(mock.get_descendant_span_ids(span_ids[1])) == set(span_ids[2:])
-    assert set(mock.get_descendant_span_ids(span_ids[2])) == set(span_ids[4:])
-    assert set(mock.get_descendant_span_ids(span_ids[3])) == set()
-    assert set(mock.get_descendant_span_ids(span_ids[4])) == set(span_ids[5:])
-    assert set(mock.get_descendant_span_ids(span_ids[5])) == set()
+    assert set(mock._get_descendant_spans(span_ids[0])) == set()
+    assert set(mock._get_descendant_spans(span_ids[1])) == set(spans[2:])
+    assert set(mock._get_descendant_spans(span_ids[2])) == set(spans[4:])
+    assert set(mock._get_descendant_spans(span_ids[3])) == set()
+    assert set(mock._get_descendant_spans(span_ids[4])) == set(spans[5:])
+    assert set(mock._get_descendant_spans(span_ids[5])) == set()
+
+
+Span = namedtuple("Span", "context")
+Context = namedtuple("Context", "span_id")
+
+
+@pytest.fixture
+def spans():
+    return (Span(context=Context(i)) for i in count())
+
+
+@pytest.fixture(scope="module")
+def otlp_trace() -> Tuple[otlp.Span, ...]:
+    def kwargs(v):
+        return {
+            "start_time_unix_nano": 1_000_000_000,
+            "end_time_unix_nano": 2_000_000_000,
+            "trace_id": b"\x00",
+            "attributes": [
+                KeyValue(
+                    key=SpanAttributes.LLM_TOKEN_COUNT_TOTAL,
+                    value=AnyValue(int_value=v),
+                )
+            ],
+        }
+
+    # parent-child relationship:
+    # span_0
+    # └── span_1
+    #     ├── span_2
+    #     │   └── span_3
+    #     └── span_4
+    span_0 = otlp.Span(span_id=b"\x00", **kwargs(1234))
+    span_1 = otlp.Span(span_id=b"\x01", parent_span_id=span_0.span_id, **kwargs(2345))
+    span_2 = otlp.Span(span_id=b"\x02", parent_span_id=span_1.span_id, **kwargs(3456))
+    span_3 = otlp.Span(span_id=b"\x03", parent_span_id=span_2.span_id, **kwargs(4567))
+    span_4 = otlp.Span(span_id=b"\x04", parent_span_id=span_1.span_id, **kwargs(5678))
+    return span_0, span_1, span_2, span_3, span_4
+
+
+@pytest.fixture(scope="module")
+def child_ids(otlp_trace: Iterable[otlp.Span]) -> DefaultDict[str, Set[str]]:
+    ans = defaultdict(set)
+    for span in otlp_trace:
+        if span.parent_span_id:
+            parent_span_id = _id_str(span.parent_span_id)
+            span_id = _id_str(span.span_id)
+            ans[parent_span_id].add(span_id)
+    return ans
+
+
+def _connected_descendant_ids(
+    span_id: str,
+    child_ids: DefaultDict[str, Set[str]],
+    ingested_ids: Set[str],
+) -> Set[str]:
+    # A descendant is connected if all parents in between have been ingested.
+    ans = set()
+    for id_ in child_ids.get(span_id) or ():
+        if id_ not in ingested_ids:
+            continue
+        ans.add(id_)
+        ans.update(_connected_descendant_ids(id_, child_ids, ingested_ids))
+    return ans
+
+
+def _id_str(id_: bytes) -> str:
+    return hexlify(id_).decode()


### PR DESCRIPTION
resolves #2350 

Spans with incomplete traces will only show up in the Spans tab, and not the Trace tab.

<img width="221" alt="Screenshot 2024-02-22 at 3 42 23 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/6e4f5eb2-9606-452c-9b49-edac4a5ea1d5">


## First screenshot below shows the partial trace.
- The header is is a just placeholder because the true root span is not present.
- All partitions of the tree are shown at the same time. (There are two partitions in the screenshot.)
<img width="553" alt="Screenshot 2024-02-22 at 3 30 10 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/e2149c24-18c6-4dca-8091-be48a96412eb">


## This next screenshot shows how it looks when the trace is finally complete.
- Note that the header is now shown because it displays values based on the root span (i.e. the span whose parent is null)
<img width="524" alt="Screenshot 2024-02-22 at 12 58 54 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/9c076728-bf79-4330-87b1-a505bd9911a3">

## Here's the code used for testing.
- A breakpoint can be placed e.g. at the print() statement.
- Uncomment the raise statement to test exception handling.
```python
import openai
from openinference.instrumentation.openai import OpenAIInstrumentor
from opentelemetry import trace as trace_api
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk import trace as trace_sdk
from opentelemetry.sdk.trace.export import SimpleSpanProcessor

endpoint = "http://127.0.0.1:6006/v1/traces"
tracer_provider = trace_sdk.TracerProvider()
tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint, timeout=10000)))

OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)


if __name__ == "__main__":
    client = openai.OpenAI()
    tracer = trace_api.get_tracer(__name__)
    with tracer.start_as_current_span("root") as span:
        response = client.chat.completions.create(
            model="gpt-3.5-turbo",
            messages=[{"role": "user", "content": "Write a poem."}],
            max_tokens=20,
        )
        with tracer.start_as_current_span("parent") as span:
            response = client.chat.completions.create(
                model="gpt-3.5-turbo",
                messages=[{"role": "user", "content": "Write a haiku."}],
                max_tokens=20,
            )
            # raise ValueError("This is a test error")
            response = client.chat.completions.create(
                model="gpt-3.5-turbo",
                messages=[{"role": "user", "content": "Write a sonnet."}],
                max_tokens=20,
            )
        print()
```