### PR TITLE
fix: remove __computed__ attributes from exported dataframe

### DIFF
--- a/src/phoenix/trace/span_json_encoder.py
+++ b/src/phoenix/trace/span_json_encoder.py
@@ -2,10 +2,16 @@ import json
 from dataclasses import asdict
 from datetime import datetime
 from enum import Enum
-from typing import Any, List
+from typing import Any, Dict, List, Mapping
 from uuid import UUID
 
-from phoenix.trace.schemas import Span, SpanContext, SpanConversationAttributes, SpanEvent
+from phoenix.trace.schemas import (
+    COMPUTED_PREFIX,
+    Span,
+    SpanContext,
+    SpanConversationAttributes,
+    SpanEvent,
+)
 
 
 class SpanJSONEncoder(json.JSONEncoder):
@@ -34,7 +40,7 @@ class SpanJSONEncoder(json.JSONEncoder):
                 "end_time": obj.end_time,
                 "status_code": obj.status_code,
                 "status_message": obj.status_message,
-                "attributes": obj.attributes,
+                "attributes": _remove_computed_attributes(obj.attributes),
                 "events": [self.default(event) for event in obj.events],
                 "conversation": obj.conversation,
             }
@@ -49,3 +55,7 @@ def span_to_json(span: Span) -> str:
 
 def spans_to_jsonl(spans: List[Span]) -> str:
     return "\n".join(span_to_json(span) for span in spans)
+
+
+def _remove_computed_attributes(attributes: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in attributes.items() if not key.startswith(COMPUTED_PREFIX)}


### PR DESCRIPTION
resolves #2354 

## before
<img width="545" alt="Screenshot 2024-02-22 at 11 21 36 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/7743bfff-06a0-4c5d-b3da-e735142687dd">

## after
<img width="577" alt="Screenshot 2024-02-22 at 11 20 06 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/4969e5b8-a210-421f-b32c-1a71c22876d3">
