### PR TITLE
chore: exclude `packages` folder from source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ artifacts = ["src/phoenix/server/static"]
 only-packages = true
 
 [tool.hatch.build.targets.sdist]
+packages = ["src/phoenix"]
 artifacts = ["src/phoenix/server/static"]
 
 [tool.hatch.envs.default]


### PR DESCRIPTION
for reference: https://hatch.pypa.io/1.9/config/build/#packages
> The packages option is semantically equivalent to only-include (which takes precedence) except that the shipped path will be collapsed to only include the final component.