### PR TITLE
feat: Add `phoenix.evals` bridge to `phoenix` and add `evals` extra install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ dev = [
   "google-cloud-aiplatform>=1.3",
   "anthropic",
 ]
+evals = [
+  "arize-phoenix-evals",
+]
 experimental = [
   "tenacity",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
   "anthropic",
 ]
 evals = [
-  "arize-phoenix-evals",
+  "arize-phoenix-evals>=0.0.3",
 ]
 experimental = [
   "tenacity",

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -7,6 +7,7 @@ from .session.session import NotebookEnvironment, Session, active_session, close
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
 from .version import __version__
+import phoenix._evals as evals
 
 # module level doc-string
 __doc__ = """

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,6 +1,8 @@
 import sys
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
+from types import ModuleType
+from typing import Any, Optional
 
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
@@ -50,17 +52,17 @@ __all__ = [
 
 
 class PhoenixEvalsFinder(MetaPathFinder):
-    def find_spec(self, fullname, path, target=None):
+    def find_spec(self, fullname: Any, path: Any, target: Any = None) -> Optional[ModuleSpec]:
         if fullname == "phoenix.evals":
             return ModuleSpec(fullname, PhoenixEvalsLoader())
         return None
 
 
 class PhoenixEvalsLoader(Loader):
-    def create_module(self, spec):
+    def create_module(self, spec: ModuleSpec) -> None:
         return None
 
-    def exec_module(self, module):
+    def exec_module(self, module: ModuleType) -> None:
         raise ImportError(
             "The optional `phoenix.evals` package is not installed. "
             "Please install `phoenix` with the `evals` extra: `pip install 'arize-phoenix[evals]'`."

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -2,7 +2,6 @@ import sys
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 
-# import phoenix._evals as evals
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
 from .datasets.schema import EmbeddingColumnNames, RetrievalEmbeddingColumnNames, Schema
@@ -59,14 +58,12 @@ class PhoenixEvalsFinder(MetaPathFinder):
 
 class PhoenixEvalsLoader(Loader):
     def create_module(self, spec):
-        # Return None to indicate Python should create a new module
         return None
 
     def exec_module(self, module):
-        # Instead of executing any code, raise an ImportError with your message
         raise ImportError(
             "The optional `phoenix.evals` package is not installed. "
-            "Please install `phoenix` with the `evals` extra: `pip install phoenix[evals]`."
+            "Please install `phoenix` with the `evals` extra: `pip install 'arize-phoenix[evals]'`."
         )
 
 

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,5 +1,8 @@
-import phoenix._evals as evals
+import sys
+from importlib.abc import Loader, MetaPathFinder
+from importlib.machinery import ModuleSpec
 
+# import phoenix._evals as evals
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
 from .datasets.schema import EmbeddingColumnNames, RetrievalEmbeddingColumnNames, Schema
@@ -45,3 +48,26 @@ __all__ = [
     "Client",
     "evals",
 ]
+
+
+class PhoenixEvalsFinder(MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "phoenix.evals":
+            return ModuleSpec(fullname, PhoenixEvalsLoader())
+        return None
+
+
+class PhoenixEvalsLoader(Loader):
+    def create_module(self, spec):
+        # Return None to indicate Python should create a new module
+        return None
+
+    def exec_module(self, module):
+        # Instead of executing any code, raise an ImportError with your message
+        raise ImportError(
+            "The optional `phoenix.evals` package is not installed. "
+            "Please install `phoenix` with the `evals` extra: `pip install phoenix[evals]`."
+        )
+
+
+sys.meta_path.append(PhoenixEvalsFinder())

--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,3 +1,5 @@
+import phoenix._evals as evals
+
 from .datasets.dataset import Dataset
 from .datasets.fixtures import ExampleDatasets, load_example
 from .datasets.schema import EmbeddingColumnNames, RetrievalEmbeddingColumnNames, Schema
@@ -7,7 +9,6 @@ from .session.session import NotebookEnvironment, Session, active_session, close
 from .trace.fixtures import load_example_traces
 from .trace.trace_dataset import TraceDataset
 from .version import __version__
-import phoenix._evals as evals
 
 # module level doc-string
 __doc__ = """
@@ -42,4 +43,5 @@ __all__ = [
     "NotebookEnvironment",
     "log_evaluations",
     "Client",
+    "evals",
 ]

--- a/src/phoenix/_evals.py
+++ b/src/phoenix/_evals.py
@@ -1,0 +1,8 @@
+try:
+    # Attempt to import the actual phoenix.evals package/module
+    from phoenix.evals import *
+except ImportError:
+    raise ImportError(
+        "The optional `phoenix.evals` package is not installed. Please install `phoenix` with the "
+        "`evals` extra: `pip install phoenix[evals]`."
+    )

--- a/src/phoenix/_evals.py
+++ b/src/phoenix/_evals.py
@@ -1,6 +1,6 @@
 try:
     # Attempt to import the actual phoenix.evals package/module
-    from phoenix.evals import *
+    from phoenix.evals import *  # noqa: F403
 except ImportError:
     raise ImportError(
         "The optional `phoenix.evals` package is not installed. Please install `phoenix` with the "

--- a/src/phoenix/_evals.py
+++ b/src/phoenix/_evals.py
@@ -1,8 +1,0 @@
-try:
-    # Attempt to import the actual phoenix.evals package/module
-    from phoenix.evals import *  # noqa: F403
-except ImportError:
-    raise ImportError(
-        "The optional `phoenix.evals` package is not installed. Please install `phoenix` with the "
-        "`evals` extra: `pip install phoenix[evals]`."
-    )


### PR DESCRIPTION
resolves #2368 

- Adds `phoenix.evals` as an optional extra install for `phoenix`
- Imports from `phoenix.evals` will either warn a user about the missing dependency or forward the import

<img width="1141" alt="Screenshot 2024-02-23 at 7 08 05 PM" src="https://github.com/Arize-ai/phoenix/assets/1688064/2d615f87-14c5-485b-894b-4a76de4add76">

