### PR TITLE
fix(traces): add y scroll on trace tree

### DIFF
--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -255,18 +255,20 @@ export function TracePage() {
             `}
           >
             <Panel defaultSize={30} minSize={10} maxSize={40}>
-              <TraceTree
-                spans={spansList}
-                selectedSpanId={selectedSpanId}
-                onSpanClick={(spanId) => {
-                  setSearchParams(
-                    {
-                      selectedSpanId: spanId,
-                    },
-                    { replace: true }
-                  );
-                }}
-              />
+              <ScrollingPanelContent>
+                <TraceTree
+                  spans={spansList}
+                  selectedSpanId={selectedSpanId}
+                  onSpanClick={(spanId) => {
+                    setSearchParams(
+                      {
+                        selectedSpanId: spanId,
+                      },
+                      { replace: true }
+                    );
+                  }}
+                />
+              </ScrollingPanelContent>
             </Panel>
             <PanelResizeHandle css={resizeHandleCSS} />
             <Panel>
@@ -356,6 +358,20 @@ function ScrollingTabsWrapper({ children }: PropsWithChildren) {
             overflow-y: auto;
           }
         }
+      `}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ScrollingPanelContent({ children }: PropsWithChildren) {
+  return (
+    <div
+      data-testid="scrolling-panel-content"
+      css={css`
+        height: 100%;
+        overflow-y: auto;
       `}
     >
       {children}


### PR DESCRIPTION
resolves #2397 

Adds scrolling to the trace tree for long traces

<img width="678" alt="Screenshot 2024-02-26 at 9 50 50 AM" src="https://github.com/Arize-ai/phoenix/assets/5640648/7a5ba7d2-0cc2-42be-84ed-e0bd98260d50">
