### PR TITLE
fix: remove symbolic links for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN cd /phoenix/app && npm install && npm run build && rm -rf /phoenix/app
 
 FROM builder
 
+# delete symbolic links
+RUN find . -xtype l -delete
+
 # Install any needed packages 
 RUN pip install .
 


### PR DESCRIPTION
resolves #2403

symbolic links [not allowed](https://github.com/moby/moby/issues/1676#issuecomment-23878459)