### PR TITLE
chore: remove tests from source distribution

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -65,6 +65,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/phoenix"]
 
+[tool.hatch.build]
+only-packages = true
+
 [tool.hatch.envs.publish]
 dependencies = [
   "check-wheel-contents",


### PR DESCRIPTION
parity with phoenix [here](https://github.com/Arize-ai/phoenix/blob/f17c4ba60956895d905c3134e993edf243dec176/pyproject.toml#L103-L104)

before
<img width="200" alt="Screenshot 2024-03-04 at 12 49 14 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/06d62d73-5007-4821-8c72-204643fe3321">

after
<img width="198" alt="Screenshot 2024-03-04 at 12 50 22 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/3c6c6c1c-8dda-4279-954c-aa1c370ffb00">
