### PR TITLE
fix: turn span_kind enums into string because it's not serializable by pyarrow

### DIFF
--- a/src/phoenix/trace/dsl/query.py
+++ b/src/phoenix/trace/dsl/query.py
@@ -38,14 +38,9 @@ _ALIASES = {
     "trace_id": "context.trace_id",
 }
 
-# Because UUIDs is not convertible to Parquet,
-# they need to be converted to string.
-_CONVERT_TO_STRING = (
-    "context.span_id",
-    "context.trace_id",
-    "parent_id",
-    "span_kind",
-)
+# Because span_kind is an enum, it needs to be converted to string,
+# so it's serializable by pyarrow.
+_CONVERT_TO_STRING = ("span_kind",)
 
 
 def _unalias(key: str) -> str:

--- a/src/phoenix/trace/dsl/query.py
+++ b/src/phoenix/trace/dsl/query.py
@@ -44,6 +44,7 @@ _CONVERT_TO_STRING = (
     "context.span_id",
     "context.trace_id",
     "parent_id",
+    "span_kind",
 )
 
 

--- a/tests/trace/dsl/test_query.py
+++ b/tests/trace/dsl/test_query.py
@@ -256,7 +256,7 @@ def test_join(spans):
 def spans():
     return (
         Span(
-            context=Context(span_id=0, trace_id=99),
+            context=Context(span_id="0", trace_id="99"),
             parent_id=None,
             attributes={
                 INPUT_VALUE: "000",
@@ -264,8 +264,8 @@ def spans():
             },
         ),
         Span(
-            context=Context(span_id=1, trace_id=99),
-            parent_id=0,
+            context=Context(span_id="1", trace_id="99"),
+            parent_id="0",
             attributes={
                 RETRIEVAL_DOCUMENTS: [
                     {
@@ -276,8 +276,8 @@ def spans():
             },
         ),
         Span(
-            context=Context(span_id=2, trace_id=99),
-            parent_id=1,
+            context=Context(span_id="2", trace_id="99"),
+            parent_id="1",
             attributes={
                 "12": [1, 2],
                 OUTPUT_VALUE: "222",


### PR DESCRIPTION
resolves #2437 

```python
import phoenix as px
from phoenix.trace.dsl.query import SpanQuery

px.Client().query_spans(SpanQuery().select("parent_id", "span_kind", "trace_id"))
```

<img width="800" alt="Screenshot 2024-03-04 at 6 56 55 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/b9a2ac73-29c5-4e7e-a1aa-19255c2b1a1c">
