### PR TITLE
chore: pin instrumentation versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dependencies = [
   "opentelemetry-sdk",
   "opentelemetry-proto",
   "opentelemetry-exporter-otlp",
-  "openinference-semantic-conventions",
-  "openinference-instrumentation-langchain",
-  "openinference-instrumentation-llama-index",
-  "openinference-instrumentation-openai",
+  "openinference-semantic-conventions>=0.1.4",
+  "openinference-instrumentation-langchain>=0.1.11",
+  "openinference-instrumentation-llama-index>=1.1.1",
+  "openinference-instrumentation-openai>=0.1.3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Put a lower bound on instrumentation versions to ensure users are running on recent versions of our instrumentation