### PR TITLE
docs: Add SQL retriever tracing tutorial

### DIFF
--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -293,7 +293,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This query asked for specific details about a camera, and routed to the SQL retriever to get context for the response."
+    "This query asked for specific details about a camera, and routed to the SQL retriever to get context for the response. The LLM-generated SQL can be seen in a Phoenix span.\n",
+    "\n",
+    "![A view of the Phoenix UI showing SQL retrieval](https://storage.googleapis.com/arize-phoenix-assets/assets/docs/notebooks/tracing/llama-index-sql-retrieval-tutorial/sql-retrieval.png)"
    ]
   },
   {
@@ -310,7 +312,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "More general queries are routed to the vector index."
+    "More general queries are routed to the vector index.\n",
+    "\n",
+    "![A view of the Phoenix UI showing vector retrieval](https://storage.googleapis.com/arize-phoenix-assets/assets/docs/notebooks/tracing/llama-index-sql-retrieval-tutorial/vectorstoreindex-retrieval.png)"
    ]
   },
   {

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -57,6 +57,7 @@
     "from getpass import getpass\n",
     "\n",
     "import openai\n",
+    "import pandas as pd\n",
     "\n",
     "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
     "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
@@ -82,6 +83,17 @@
     "    Integer,\n",
     "    select,\n",
     "    column,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_info = pd.read_parquet(\n",
+    "    \"https://storage.googleapis.com/arize-phoenix-assets/datasets/structured/camera-info/cameras.parquet\"\n",
     ")"
    ]
   },

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -20,9 +20,20 @@
     "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
     "\n",
     "In this tutorial, you will:\n",
-    "- Build a simple query engine using LlamaIndex that uses a SQL retriever\n",
+    "- Build a query engine that uses both a SQL retriever and a VectorStoreIndex using LlamaIndex\n",
+    "- Record trace data in [OpenInference tracing](https://github.com/Arize-ai/openinference) format using the global `arize_phoenix` handler\n",
+    "- Observe how a more complex LlamaIndex application might perform retrieval\n",
     "\n",
     "ℹ️ This notebook requires an OpenAI API key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install Dependencies and Import Libraries\n",
+    "\n",
+    "Install Phoenix, LlamaIndex, and OpenAI."
    ]
   },
   {
@@ -36,18 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import nest_asyncio\n",
-    "\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,48 +58,86 @@
     "\n",
     "import openai\n",
     "import pandas as pd\n",
+    "import phoenix as px\n",
+    "import wikipedia\n",
     "\n",
     "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
     "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
     "\n",
-    "# from llama_index.core import VectorStoreIndex, SQLDatabase\n",
+    "from llama_index.core import Document, set_global_handler\n",
     "from llama_index.core.indices import VectorStoreIndex\n",
+    "from llama_index.core.query_engine import NLSQLTableQueryEngine\n",
+    "from llama_index.core.tools import QueryEngineTool\n",
     "from llama_index.core.utilities.sql_wrapper import SQLDatabase\n",
-    "from llama_index.legacy.readers.wikipedia import WikipediaReader"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from sqlalchemy import (\n",
     "    create_engine,\n",
-    "    MetaData,\n",
-    "    Table,\n",
-    "    Column,\n",
-    "    String,\n",
-    "    Integer,\n",
-    "    select,\n",
-    "    column,\n",
-    ")"
+    "    text,\n",
+    ")\n",
+    "\n",
+    "pd.set_option(\"display.max_colwidth\", 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Launch Phoenix\n",
+    "\n",
+    "You can run Phoenix in the background to collect trace data emitted by any LlamaIndex application that has been instrumented with the `OpenInferenceTraceCallbackHandler`. Phoenix supports LlamaIndex's [one-click observability](https://gpt-index.readthedocs.io/en/latest/end_to_end_tutorials/one_click_observability.html) which will automatically instrument your LlamaIndex application! You can consult our [integration guide](https://docs.arize.com/phoenix/integrations/llamaindex) for a more detailed explanation of how to instrument your LlamaIndex application.\n",
+    "\n",
+    "Launch Phoenix and follow the instructions in the cell output to open the Phoenix UI (the UI should be empty because we have yet to run the LlamaIndex application)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:phoenix.session.session:Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
+      "Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
+      "Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
+      "🌍 To view the Phoenix app in your browser, visit http://localhost:6006/\n",
+      "📺 To view the Phoenix app in a notebook, run `px.active_session().view()`\n",
+      "📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix\n"
+     ]
+    }
+   ],
+   "source": [
+    "session = px.launch_app()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Enable Phoenix tracing within LlamaIndex by setting `arize_phoenix` as the global handler. This will mount Phoenix's [OpenInferenceTraceCallback](https://docs.arize.com/phoenix/integrations/llamaindex) as the global handler. Phoenix uses OpenInference traces - an open-source standard for capturing and storing LLM application traces that enables LLM applications to seamlessly integrate with LLM observability solutions such as Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "camera_info = pd.read_parquet(\n",
-    "    \"https://storage.googleapis.com/arize-phoenix-assets/datasets/structured/camera-info/cameras.parquet\"\n",
-    ")"
+    "set_global_handler(\"arize_phoenix\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Configure Your OpenAI API Key\n",
+    "\n",
+    "Set your OpenAI API key if it is not already set as an environment variable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,120 +148,318 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "engine = create_engine(\"sqlite:///:memory:\", future=True)\n",
-    "metadata_obj = MetaData()\n",
-    "\n",
-    "# create city SQL table\n",
-    "table_name = \"city_stats\"\n",
-    "city_stats_table = Table(\n",
-    "    table_name,\n",
-    "    metadata_obj,\n",
-    "    Column(\"city_name\", String(16), primary_key=True),\n",
-    "    Column(\"population\", Integer),\n",
-    "    Column(\"country\", String(16), nullable=False),\n",
-    ")\n",
-    "\n",
-    "metadata_obj.create_all(engine)\n",
-    "metadata_obj.tables.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sqlalchemy import insert\n",
-    "\n",
-    "rows = [\n",
-    "    {\"city_name\": \"Toronto\", \"population\": 2930000, \"country\": \"Canada\"},\n",
-    "    {\"city_name\": \"Tokyo\", \"population\": 13960000, \"country\": \"Japan\"},\n",
-    "    {\"city_name\": \"Berlin\", \"population\": 3645000, \"country\": \"Germany\"},\n",
-    "]\n",
-    "for row in rows:\n",
-    "    stmt = insert(city_stats_table).values(**row)\n",
-    "    with engine.begin() as connection:\n",
-    "        cursor = connection.execute(stmt)\n",
-    "\n",
-    "with engine.connect() as connection:\n",
-    "    cursor = connection.exec_driver_sql(\"SELECT * FROM city_stats\")\n",
-    "    print(cursor.fetchall())"
+    "## 3. Prepare reference data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load Data\n"
+    "First, we'll download a dataset that contains technical details of various digital cameras and convert it into an in-memory SQL database. This dataset is provided by Kaggle and more details can be found [here](https://www.kaggle.com/datasets/crawford/1000-cameras-dataset)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cities = [\"Toronto\", \"Berlin\", \"Tokyo\"]\n",
-    "wiki_docs = WikipediaReader().load_data(pages=cities)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Build Database"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sql_database = SQLDatabase(engine, include_tables=[\"city_stats\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.core.query_engine import NLSQLTableQueryEngine\n",
-    "\n",
-    "sql_query_engine = NLSQLTableQueryEngine(\n",
-    "    sql_database=sql_database,\n",
-    "    tables=[\"city_stats\"],\n",
+    "camera_info = pd.read_parquet(\n",
+    "    \"https://storage.googleapis.com/arize-phoenix-assets/datasets/structured/camera-info/cameras.parquet\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Model</th>\n",
+       "      <th>Release date</th>\n",
+       "      <th>Max resolution</th>\n",
+       "      <th>Low resolution</th>\n",
+       "      <th>Effective pixels</th>\n",
+       "      <th>Zoom wide (W)</th>\n",
+       "      <th>Zoom tele (T)</th>\n",
+       "      <th>Normal focus range</th>\n",
+       "      <th>Macro focus range</th>\n",
+       "      <th>Storage included</th>\n",
+       "      <th>Weight (inc. batteries)</th>\n",
+       "      <th>Dimensions</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Agfa ePhoto 1280</td>\n",
+       "      <td>1997</td>\n",
+       "      <td>1024.0</td>\n",
+       "      <td>640.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>114.0</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>420.0</td>\n",
+       "      <td>95.0</td>\n",
+       "      <td>179.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Agfa ePhoto 1680</td>\n",
+       "      <td>1998</td>\n",
+       "      <td>1280.0</td>\n",
+       "      <td>640.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>114.0</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>420.0</td>\n",
+       "      <td>158.0</td>\n",
+       "      <td>179.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Agfa ePhoto CL18</td>\n",
+       "      <td>2000</td>\n",
+       "      <td>640.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>179.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Agfa ePhoto CL30</td>\n",
+       "      <td>1999</td>\n",
+       "      <td>1152.0</td>\n",
+       "      <td>640.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>269.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Agfa ePhoto CL30 Clik!</td>\n",
+       "      <td>1999</td>\n",
+       "      <td>1152.0</td>\n",
+       "      <td>640.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>300.0</td>\n",
+       "      <td>128.0</td>\n",
+       "      <td>1299.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    Model  Release date  Max resolution  Low resolution  \\\n",
+       "0        Agfa ePhoto 1280          1997          1024.0           640.0   \n",
+       "1        Agfa ePhoto 1680          1998          1280.0           640.0   \n",
+       "2        Agfa ePhoto CL18          2000           640.0             0.0   \n",
+       "3        Agfa ePhoto CL30          1999          1152.0           640.0   \n",
+       "4  Agfa ePhoto CL30 Clik!          1999          1152.0           640.0   \n",
+       "\n",
+       "   Effective pixels  Zoom wide (W)  Zoom tele (T)  Normal focus range  \\\n",
+       "0               0.0           38.0          114.0                70.0   \n",
+       "1               1.0           38.0          114.0                50.0   \n",
+       "2               0.0           45.0           45.0                 0.0   \n",
+       "3               0.0           35.0           35.0                 0.0   \n",
+       "4               0.0           43.0           43.0                50.0   \n",
+       "\n",
+       "   Macro focus range  Storage included  Weight (inc. batteries)  Dimensions  \\\n",
+       "0               40.0               4.0                    420.0        95.0   \n",
+       "1                0.0               4.0                    420.0       158.0   \n",
+       "2                0.0               2.0                      0.0         0.0   \n",
+       "3                0.0               4.0                      0.0         0.0   \n",
+       "4                0.0              40.0                    300.0       128.0   \n",
+       "\n",
+       "    Price  \n",
+       "0   179.0  \n",
+       "1   179.0  \n",
+       "2   179.0  \n",
+       "3   269.0  \n",
+       "4  1299.0  "
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "camera_info.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1038"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "engine = create_engine(\"sqlite:///:memory:\", future=True)\n",
+    "camera_info.to_sql(\"cameras\", engine, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Agfa ePhoto 1280', 1997, 1024.0, 640.0, 0.0, 38.0, 114.0, 70.0, 40.0, 4.0, 420.0, 95.0, 179.0)\n",
+      "('Agfa ePhoto 1680', 1998, 1280.0, 640.0, 1.0, 38.0, 114.0, 50.0, 0.0, 4.0, 420.0, 158.0, 179.0)\n",
+      "('Agfa ePhoto CL18', 2000, 640.0, 0.0, 0.0, 45.0, 45.0, 0.0, 0.0, 2.0, 0.0, 0.0, 179.0)\n",
+      "('Agfa ePhoto CL30', 1999, 1152.0, 640.0, 0.0, 35.0, 35.0, 0.0, 0.0, 4.0, 0.0, 0.0, 269.0)\n",
+      "('Agfa ePhoto CL30 Clik!', 1999, 1152.0, 640.0, 0.0, 43.0, 43.0, 50.0, 0.0, 40.0, 300.0, 128.0, 1299.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "with engine.connect() as connection:\n",
+    "    result = connection.execute(text(\"SELECT * FROM cameras LIMIT 5\")).all()\n",
+    "\n",
+    "    for row in result:\n",
+    "        print(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, for more general queries about digital cameras, we'll download the Wikipedia page on Digital Cameras using the `wikipedia` SDK. We will convert this document into a LlamaIndex `VectorStoreIndex`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load the Digital Camera wikipedia page\n",
+    "page = wikipedia.page(pageid=52797)\n",
+    "doc = Document(id_=page.pageid, text=page.content)\n",
+    "\n",
+    "vector_indices = []\n",
+    "vector_index = VectorStoreIndex.from_documents([doc])\n",
+    "vector_indices.append(vector_index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Build LlamaIndex Application\n",
+    "\n",
+    "Let's use a simple `RouterQueryEngine` using multiple query engine tools. We will either route to the SQL retriever or the vector index built over the \"Digital Camera\" Wikipedia page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.tools import QueryEngineTool\n",
+    "sql_database = SQLDatabase(engine, include_tables=[\"cameras\"])\n",
     "\n",
-    "\n",
+    "sql_query_engine = NLSQLTableQueryEngine(\n",
+    "    sql_database=sql_database,\n",
+    "    tables=[\"cameras\"],\n",
+    ")\n",
     "sql_tool = QueryEngineTool.from_defaults(\n",
     "    query_engine=sql_query_engine,\n",
     "    description=(\n",
     "        \"Useful for translating a natural language query into a SQL query over\"\n",
-    "        \" a table containing: city_stats, containing the population/country of\"\n",
-    "        \" each city\"\n",
+    "        \" a table containing technical details about various digital camera models: Model,\"\n",
+    "        \" Release date, Max resolution, Low resolution, Effective pixels, Zoom wide (W),\"\n",
+    "        \" Zoom tele (T), Normal focus range, Macro focus range, Storage included,\"\n",
+    "        \" Weight (inc. batteries), Dimensions, Price\"\n",
     "    ),\n",
-    ")"
+    ")\n",
+    "\n",
+    "vector_query_engines = [index.as_query_engine() for index in vector_indices]\n",
+    "vector_tools = []\n",
+    "for query_engine in vector_query_engines:\n",
+    "    vector_tool = QueryEngineTool.from_defaults(\n",
+    "        query_engine=query_engine,\n",
+    "        description=\"Useful for answering generic questions about digital cameras.\",\n",
+    "    )\n",
+    "    vector_tools.append(vector_tool)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,26 +468,104 @@
     "\n",
     "query_engine = RouterQueryEngine(\n",
     "    selector=LLMSingleSelector.from_defaults(),\n",
-    "    query_engine_tools=([sql_tool]),\n",
+    "    query_engine_tools=([sql_tool] + vector_tools),\n",
     ")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "response = query_engine.query(\"Which city has the highest population?\")\n",
-    "print(str(response))"
+    "## 5. Make Queries and Use Phoenix to view Spans"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:llama_index.core.query_engine.router_query_engine:Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
+      "Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
+      "Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
+      "INFO:llama_index.core.indices.struct_store.sql_retriever:> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
+      "> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
+      "> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "The Canon EOS-1Ds Mark III model digital camera has the most effective pixels, with 21.0 pixels.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = query_engine.query(\"Which model digital camera has the most effective pixels?\")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This query asked for specific details about a camera, and routed to the SQL retriever to get context for the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:llama_index.core.query_engine.router_query_engine:Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
+      "Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
+      "Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "The charge-coupled device (CCD) was the first semiconductor image sensor, invented in 1969 at Bell Labs. The NMOS active-pixel sensor was later developed in 1985, leading to the CMOS active-pixel sensor in 1993. In the 1970s, digital cameras were mainly used for military and scientific purposes before expanding into medical and news applications. The first fully digital camera, the FUJIX DS-1P, was introduced in 1988, recording images on a semiconductor memory card. Toshiba's 40 MB flash memory card was adopted for digital cameras in 1996. The first commercial camera phone, the Kyocera Visual Phone VP-210, was released in Japan in 1999, storing digital images and capable of sending them over email or cellular networks.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = query_engine.query(\"Tell me about the history of digital camera sensors.\")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More general queries are routed to the vector index."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Final Thoughts\n",
+    "\n",
+    "LLM Traces and the accompanying OpenInference Tracing specification is designed to be a category of telemetry data that is used to understand the execution of LLMs and the surrounding application context. This is especially useful when understanding the behavior of more complex RAG applications that might make use of multiple context retrieval strategies, such as mixing a SQL retriever with more-common vector indexes.\n",
+    "\n",
+    "For more details on Phoenix, LLM Tracing, and LLM Evals, checkout our [documentation](https://docs.arize.com/phoenix/)."
+   ]
   }
  ],
  "metadata": {

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,19 +86,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🌍 To view the Phoenix app in your browser, visit http://localhost:6006/\n",
-      "📺 To view the Phoenix app in a notebook, run `px.active_session().view()`\n",
-      "📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "session = px.launch_app()"
    ]
@@ -112,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,185 +157,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Model</th>\n",
-       "      <th>Release date</th>\n",
-       "      <th>Max resolution</th>\n",
-       "      <th>Low resolution</th>\n",
-       "      <th>Effective pixels</th>\n",
-       "      <th>Zoom wide (W)</th>\n",
-       "      <th>Zoom tele (T)</th>\n",
-       "      <th>Normal focus range</th>\n",
-       "      <th>Macro focus range</th>\n",
-       "      <th>Storage included</th>\n",
-       "      <th>Weight (inc. batteries)</th>\n",
-       "      <th>Dimensions</th>\n",
-       "      <th>Price</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Agfa ePhoto 1280</td>\n",
-       "      <td>1997</td>\n",
-       "      <td>1024.0</td>\n",
-       "      <td>640.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>38.0</td>\n",
-       "      <td>114.0</td>\n",
-       "      <td>70.0</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>420.0</td>\n",
-       "      <td>95.0</td>\n",
-       "      <td>179.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Agfa ePhoto 1680</td>\n",
-       "      <td>1998</td>\n",
-       "      <td>1280.0</td>\n",
-       "      <td>640.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>38.0</td>\n",
-       "      <td>114.0</td>\n",
-       "      <td>50.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>420.0</td>\n",
-       "      <td>158.0</td>\n",
-       "      <td>179.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Agfa ePhoto CL18</td>\n",
-       "      <td>2000</td>\n",
-       "      <td>640.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>45.0</td>\n",
-       "      <td>45.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>179.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Agfa ePhoto CL30</td>\n",
-       "      <td>1999</td>\n",
-       "      <td>1152.0</td>\n",
-       "      <td>640.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>35.0</td>\n",
-       "      <td>35.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>269.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Agfa ePhoto CL30 Clik!</td>\n",
-       "      <td>1999</td>\n",
-       "      <td>1152.0</td>\n",
-       "      <td>640.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>43.0</td>\n",
-       "      <td>50.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>300.0</td>\n",
-       "      <td>128.0</td>\n",
-       "      <td>1299.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                    Model  Release date  Max resolution  Low resolution  \\\n",
-       "0        Agfa ePhoto 1280          1997          1024.0           640.0   \n",
-       "1        Agfa ePhoto 1680          1998          1280.0           640.0   \n",
-       "2        Agfa ePhoto CL18          2000           640.0             0.0   \n",
-       "3        Agfa ePhoto CL30          1999          1152.0           640.0   \n",
-       "4  Agfa ePhoto CL30 Clik!          1999          1152.0           640.0   \n",
-       "\n",
-       "   Effective pixels  Zoom wide (W)  Zoom tele (T)  Normal focus range  \\\n",
-       "0               0.0           38.0          114.0                70.0   \n",
-       "1               1.0           38.0          114.0                50.0   \n",
-       "2               0.0           45.0           45.0                 0.0   \n",
-       "3               0.0           35.0           35.0                 0.0   \n",
-       "4               0.0           43.0           43.0                50.0   \n",
-       "\n",
-       "   Macro focus range  Storage included  Weight (inc. batteries)  Dimensions  \\\n",
-       "0               40.0               4.0                    420.0        95.0   \n",
-       "1                0.0               4.0                    420.0       158.0   \n",
-       "2                0.0               2.0                      0.0         0.0   \n",
-       "3                0.0               4.0                      0.0         0.0   \n",
-       "4                0.0              40.0                    300.0       128.0   \n",
-       "\n",
-       "    Price  \n",
-       "0   179.0  \n",
-       "1   179.0  \n",
-       "2   179.0  \n",
-       "3   269.0  \n",
-       "4  1299.0  "
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "camera_info.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1038"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "engine = create_engine(\"sqlite:///:memory:\", future=True)\n",
     "camera_info.to_sql(\"cameras\", engine, index=False)"
@@ -353,21 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('Agfa ePhoto 1280', 1997, 1024.0, 640.0, 0.0, 38.0, 114.0, 70.0, 40.0, 4.0, 420.0, 95.0, 179.0)\n",
-      "('Agfa ePhoto 1680', 1998, 1280.0, 640.0, 1.0, 38.0, 114.0, 50.0, 0.0, 4.0, 420.0, 158.0, 179.0)\n",
-      "('Agfa ePhoto CL18', 2000, 640.0, 0.0, 0.0, 45.0, 45.0, 0.0, 0.0, 2.0, 0.0, 0.0, 179.0)\n",
-      "('Agfa ePhoto CL30', 1999, 1152.0, 640.0, 0.0, 35.0, 35.0, 0.0, 0.0, 4.0, 0.0, 0.0, 269.0)\n",
-      "('Agfa ePhoto CL30 Clik!', 1999, 1152.0, 640.0, 0.0, 43.0, 43.0, 50.0, 0.0, 40.0, 300.0, 128.0, 1299.0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with engine.connect() as connection:\n",
     "    result = connection.execute(text(\"SELECT * FROM cameras LIMIT 5\")).all()\n",
@@ -385,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,17 +281,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The most expensive digital camera is the Canon EOS-1Ds, priced at $7999.00.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "response = query_engine.query(\"What is the most expensive digital camera?\")\n",
     "print(str(response))"
@@ -495,23 +298,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The history of digital camera sensors began with the invention of the first semiconductor image sensor, the charge-coupled device (CCD), by Willard S. Boyle and George E. Smith at Bell Labs in 1969. This was based on MOS capacitor technology. Later, in 1985, the NMOS active-pixel sensor was invented by Tsutomu Nakamura's team at Olympus, leading to the development of the CMOS active-pixel sensor (CMOS sensor) at the NASA Jet Propulsion Laboratory in 1993. \n",
-      "\n",
-      "In the early days, digital cameras were used mainly for military, scientific, medical, and news applications. The first fully digital camera, which recorded digital images using a semiconductor memory card, was introduced by Fujifilm at Photokina 1988. This camera's memory card had a capacity of 2 MB of SRAM and could hold up to ten photographs. \n",
-      "\n",
-      "The first commercial camera phone was the Kyocera Visual Phone VP-210, released in Japan in May 1999. It had a 110,000-pixel front-facing camera and could store up to 20 JPEG digital images. By the mid-2000s, higher-end cell phones had an integrated digital camera, and by the early 2010s, almost all smartphones had an integrated digital camera.\n",
-      "\n",
-      "The two major types of digital image sensors are CCD and CMOS. A CCD sensor has one amplifier for all the pixels, while each pixel in a CMOS active-pixel sensor has its own amplifier. Compared to CCDs, CMOS sensors use less power. Cameras with a small sensor use a back-side-illuminated CMOS (BSI-CMOS) sensor. The image processing capabilities of the camera determine the outcome of the final image quality much more than the sensor type.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "response = query_engine.query(\"Tell me about the history of digital camera sensors.\")\n",
     "print(str(response))"
@@ -537,22 +326,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -47,28 +47,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
     "import os\n",
-    "import sys\n",
     "from getpass import getpass\n",
     "\n",
     "import openai\n",
     "import pandas as pd\n",
     "import phoenix as px\n",
     "import wikipedia\n",
-    "\n",
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
-    "\n",
-    "from llama_index.core import Document, set_global_handler\n",
+    "from llama_index.core import Document, Settings, set_global_handler\n",
     "from llama_index.core.indices import VectorStoreIndex\n",
-    "from llama_index.core.query_engine import NLSQLTableQueryEngine\n",
+    "from llama_index.core.query_engine import NLSQLTableQueryEngine, RouterQueryEngine\n",
+    "from llama_index.core.selectors import LLMSingleSelector\n",
     "from llama_index.core.tools import QueryEngineTool\n",
     "from llama_index.core.utilities.sql_wrapper import SQLDatabase\n",
+    "from llama_index.llms.openai import OpenAI\n",
     "from sqlalchemy import (\n",
     "    create_engine,\n",
     "    text,\n",
@@ -90,16 +86,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:phoenix.session.session:Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
-      "Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
-      "Existing running Phoenix instance detected! Shutting it down and starting a new instance...\n",
       "🌍 To view the Phoenix app in your browser, visit http://localhost:6006/\n",
       "📺 To view the Phoenix app in a notebook, run `px.active_session().view()`\n",
       "📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix\n"
@@ -119,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -328,7 +321,7 @@
        "4  1299.0  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -339,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -348,7 +341,7 @@
        "1038"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -360,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -392,19 +385,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load the Digital Camera wikipedia page\n",
     "page = wikipedia.page(pageid=52797)\n",
@@ -426,7 +409,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Settings.llm = OpenAI(temperature=0.0, model=\"gpt-4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +432,7 @@
     "    query_engine=sql_query_engine,\n",
     "    description=(\n",
     "        \"Useful for translating a natural language query into a SQL query over\"\n",
-    "        \" a table containing technical details about various digital camera models: Model,\"\n",
+    "        \" a table containing technical details about specific digital camera models: Model,\"\n",
     "        \" Release date, Max resolution, Low resolution, Effective pixels, Zoom wide (W),\"\n",
     "        \" Zoom tele (T), Normal focus range, Macro focus range, Storage included,\"\n",
     "        \" Weight (inc. batteries), Dimensions, Price\"\n",
@@ -459,13 +451,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.query_engine import RouterQueryEngine\n",
-    "from llama_index.core.selectors import LLMSingleSelector\n",
-    "\n",
     "query_engine = RouterQueryEngine(\n",
     "    selector=LLMSingleSelector.from_defaults(),\n",
     "    query_engine_tools=([sql_tool] + vector_tools),\n",
@@ -481,34 +470,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "INFO:llama_index.core.query_engine.router_query_engine:Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
-      "Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
-      "Selecting query engine 0: Choice 1 is most relevant as it provides detailed technical information about digital camera models, including the number of effective pixels which can be used to determine which model has the most effective pixels..\n",
-      "INFO:llama_index.core.indices.struct_store.sql_retriever:> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
-      "> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
-      "> Table desc str: Table 'cameras' has columns: Model (TEXT), Release date (BIGINT), Max resolution (FLOAT), Low resolution (FLOAT), Effective pixels (FLOAT), Zoom wide (W) (FLOAT), Zoom tele (T) (FLOAT), Normal focus range (FLOAT), Macro focus range (FLOAT), Storage included (FLOAT), Weight (inc. batteries) (FLOAT), Dimensions (FLOAT), Price (FLOAT), and foreign keys: .\n",
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "The Canon EOS-1Ds Mark III model digital camera has the most effective pixels, with 21.0 pixels.\n"
+      "The most expensive digital camera is the Canon EOS-1Ds, priced at $7999.00.\n"
      ]
     }
    ],
    "source": [
-    "response = query_engine.query(\"Which model digital camera has the most effective pixels?\")\n",
+    "response = query_engine.query(\"What is the most expensive digital camera?\")\n",
     "print(str(response))"
    ]
   },
@@ -521,26 +495,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "INFO:llama_index.core.query_engine.router_query_engine:Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
-      "Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
-      "Selecting query engine 1: Choice 2 is more relevant as it is focused on answering generic questions about digital cameras, which may include information about the history of digital camera sensors..\n",
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "The charge-coupled device (CCD) was the first semiconductor image sensor, invented in 1969 at Bell Labs. The NMOS active-pixel sensor was later developed in 1985, leading to the CMOS active-pixel sensor in 1993. In the 1970s, digital cameras were mainly used for military and scientific purposes before expanding into medical and news applications. The first fully digital camera, the FUJIX DS-1P, was introduced in 1988, recording images on a semiconductor memory card. Toshiba's 40 MB flash memory card was adopted for digital cameras in 1996. The first commercial camera phone, the Kyocera Visual Phone VP-210, was released in Japan in 1999, storing digital images and capable of sending them over email or cellular networks.\n"
+      "The history of digital camera sensors began with the invention of the first semiconductor image sensor, the charge-coupled device (CCD), by Willard S. Boyle and George E. Smith at Bell Labs in 1969. This was based on MOS capacitor technology. Later, in 1985, the NMOS active-pixel sensor was invented by Tsutomu Nakamura's team at Olympus, leading to the development of the CMOS active-pixel sensor (CMOS sensor) at the NASA Jet Propulsion Laboratory in 1993. \n",
+      "\n",
+      "In the early days, digital cameras were used mainly for military, scientific, medical, and news applications. The first fully digital camera, which recorded digital images using a semiconductor memory card, was introduced by Fujifilm at Photokina 1988. This camera's memory card had a capacity of 2 MB of SRAM and could hold up to ten photographs. \n",
+      "\n",
+      "The first commercial camera phone was the Kyocera Visual Phone VP-210, released in Japan in May 1999. It had a 110,000-pixel front-facing camera and could store up to 20 JPEG digital images. By the mid-2000s, higher-end cell phones had an integrated digital camera, and by the early 2010s, almost all smartphones had an integrated digital camera.\n",
+      "\n",
+      "The two major types of digital image sensors are CCD and CMOS. A CCD sensor has one amplifier for all the pixels, while each pixel in a CMOS active-pixel sensor has its own amplifier. Compared to CCDs, CMOS sensors use less power. Cameras with a small sensor use a back-side-illuminated CMOS (BSI-CMOS) sensor. The image processing capabilities of the camera determine the outcome of the final image quality much more than the sensor type.\n"
      ]
     }
    ],

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-phoenix-assets/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n",
+    "<h1 align=\"center\">SQL Router Query Engine Example</h1>\n",
+    "\n",
+    "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
+    "\n",
+    "In this tutorial, you will:\n",
+    "- Build a simple query engine using LlamaIndex that uses a SQL retriever\n",
+    "\n",
+    "ℹ️ This notebook requires an OpenAI API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"arize-phoenix[evals]\" \"openai>=1\" gcsfs nest-asyncio \"llama-index>=0.10.3\" \"llama-index-core\" \"openinference-instrumentation-llama-index>=1.0.0\" \"llama-index-callbacks-arize-phoenix>=0.1.2\" \"llama-index-readers-wikipedia\" \"sqlalchemy\" wikipedia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import os\n",
+    "import sys\n",
+    "from getpass import getpass\n",
+    "\n",
+    "import openai\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "# from llama_index.core import VectorStoreIndex, SQLDatabase\n",
+    "from llama_index.core.indices import VectorStoreIndex\n",
+    "from llama_index.core.utilities.sql_wrapper import SQLDatabase\n",
+    "from llama_index.legacy.readers.wikipedia import WikipediaReader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import (\n",
+    "    create_engine,\n",
+    "    MetaData,\n",
+    "    Table,\n",
+    "    Column,\n",
+    "    String,\n",
+    "    Integer,\n",
+    "    select,\n",
+    "    column,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "openai.api_key = openai_api_key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = create_engine(\"sqlite:///:memory:\", future=True)\n",
+    "metadata_obj = MetaData()\n",
+    "\n",
+    "# create city SQL table\n",
+    "table_name = \"city_stats\"\n",
+    "city_stats_table = Table(\n",
+    "    table_name,\n",
+    "    metadata_obj,\n",
+    "    Column(\"city_name\", String(16), primary_key=True),\n",
+    "    Column(\"population\", Integer),\n",
+    "    Column(\"country\", String(16), nullable=False),\n",
+    ")\n",
+    "\n",
+    "metadata_obj.create_all(engine)\n",
+    "metadata_obj.tables.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import insert\n",
+    "\n",
+    "rows = [\n",
+    "    {\"city_name\": \"Toronto\", \"population\": 2930000, \"country\": \"Canada\"},\n",
+    "    {\"city_name\": \"Tokyo\", \"population\": 13960000, \"country\": \"Japan\"},\n",
+    "    {\"city_name\": \"Berlin\", \"population\": 3645000, \"country\": \"Germany\"},\n",
+    "]\n",
+    "for row in rows:\n",
+    "    stmt = insert(city_stats_table).values(**row)\n",
+    "    with engine.begin() as connection:\n",
+    "        cursor = connection.execute(stmt)\n",
+    "\n",
+    "with engine.connect() as connection:\n",
+    "    cursor = connection.exec_driver_sql(\"SELECT * FROM city_stats\")\n",
+    "    print(cursor.fetchall())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load Data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cities = [\"Toronto\", \"Berlin\", \"Tokyo\"]\n",
+    "wiki_docs = WikipediaReader().load_data(pages=cities)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build Database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_database = SQLDatabase(engine, include_tables=[\"city_stats\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.query_engine import NLSQLTableQueryEngine\n",
+    "\n",
+    "sql_query_engine = NLSQLTableQueryEngine(\n",
+    "    sql_database=sql_database,\n",
+    "    tables=[\"city_stats\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.tools import QueryEngineTool\n",
+    "\n",
+    "\n",
+    "sql_tool = QueryEngineTool.from_defaults(\n",
+    "    query_engine=sql_query_engine,\n",
+    "    description=(\n",
+    "        \"Useful for translating a natural language query into a SQL query over\"\n",
+    "        \" a table containing: city_stats, containing the population/country of\"\n",
+    "        \" each city\"\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.query_engine import RouterQueryEngine\n",
+    "from llama_index.core.selectors import LLMSingleSelector\n",
+    "\n",
+    "query_engine = RouterQueryEngine(\n",
+    "    selector=LLMSingleSelector.from_defaults(),\n",
+    "    query_engine_tools=([sql_tool]),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = query_engine.query(\"Which city has the highest population?\")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev38",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Resolves #1654 

Adds a tutorial on tracing a more complex LlamaIndex RAG application that uses a router to pick between a SQL retriever and VectorStoreIndex.

![image](https://github.com/Arize-ai/phoenix/assets/1688064/4f29b7f6-fbc3-40f2-a154-1970c35ed4f4)
