### PR TITLE
feat: Update `AnthropicModel` to use `messages` API

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "anthropic",
+  "anthropic>0.18.0",
   "boto3",
   "litellm>=1.0.3",
   "openai>=1.0.0",
@@ -40,7 +40,7 @@ test = [
   "pandas",
   "tqdm",
   "typing-extensions>=4.5, <5",
-  "anthropic",
+  "anthropic>=0.18.0",
   "boto3",
   "litellm>=1.0.3",
   "openai>=1.0.0",

--- a/packages/phoenix-evals/src/phoenix/evals/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__init__.py
@@ -24,7 +24,14 @@ from .evaluators import (
     ToxicityEvaluator,
 )
 from .generate import llm_generate
-from .models import BedrockModel, LiteLLMModel, OpenAIModel, VertexAIModel
+from .models import (
+    AnthropicModel,
+    BedrockModel,
+    GeminiModel,
+    LiteLLMModel,
+    OpenAIModel,
+    VertexAIModel,
+)
 from .retrievals import compute_precisions_at_k
 from .templates import (
     ClassificationTemplate,
@@ -38,6 +45,8 @@ __all__ = [
     "llm_classify",
     "llm_generate",
     "OpenAIModel",
+    "AnthropicModel",
+    "GeminiModel",
     "VertexAIModel",
     "BedrockModel",
     "LiteLLMModel",

--- a/packages/phoenix-evals/src/phoenix/evals/models/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/__init__.py
@@ -1,14 +1,18 @@
+from .anthropic import AnthropicModel
 from .base import BaseModel, set_verbosity
 from .bedrock import BedrockModel
 from .litellm import LiteLLMModel
 from .openai import OpenAIModel
+from .vertex import GeminiModel
 from .vertexai import VertexAIModel
 
 __all__ = [
-    "BedrockModel",
+    "set_verbosity",
     "BaseModel",
+    "AnthropicModel",
+    "BedrockModel",
     "LiteLLMModel",
     "OpenAIModel",
+    "GeminiModel",
     "VertexAIModel",
-    "set_verbosity",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -8,7 +8,7 @@ from phoenix.evals.models.rate_limiters import RateLimiter
 MINIMUM_ANTHROPIC_VERSION = "0.18.0"
 
 
-def anthropic_version(version_str: str) -> Tuple:
+def anthropic_version(version_str: str) -> Tuple[int, ...]:
     return tuple(map(int, version_str.split(".")))
 
 
@@ -136,7 +136,7 @@ class AnthropicModel(BaseModel):
 
         return await _async_completion(**kwargs)
 
-    def _format_prompt_for_claude(self, prompt: str) -> str:
+    def _format_prompt_for_claude(self, prompt: str) -> List[Dict[str, str]]:
         # the Anthropic messages API expects a list of messages
         return [
             {"role": "user", "content": prompt},

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -1,9 +1,15 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
+
+MINIMUM_ANTHROPIC_VERSION = "0.18.0"
+
+
+def anthropic_version(version_str: str) -> Tuple:
+    return tuple(map(int, version_str.split(".")))
 
 
 @dataclass
@@ -36,14 +42,25 @@ class AnthropicModel(BaseModel):
     def _init_client(self) -> None:
         try:
             import anthropic
-
-            self._anthropic = anthropic
-            self.client = self._anthropic.Anthropic()
-            self.async_client = self._anthropic.AsyncAnthropic()
         except ImportError:
             self._raise_import_error(
                 package_name="anthropic",
+                package_min_version=MINIMUM_ANTHROPIC_VERSION,
             )
+
+        installed_version = anthropic_version(anthropic.__version__)
+        minimum_version = anthropic_version(MINIMUM_ANTHROPIC_VERSION)
+
+        if installed_version <= minimum_version:
+            raise ImportError(
+                "The installed version of `anthropic` is no longer supported. "
+                "Please upgrade to the latest version with "
+                f"`pip install -U anthropic>={MINIMUM_ANTHROPIC_VERSION}`"
+            )
+
+        self._anthropic = anthropic
+        self.client = self._anthropic.Anthropic()
+        self.async_client = self._anthropic.AsyncAnthropic()
 
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
@@ -56,7 +73,7 @@ class AnthropicModel(BaseModel):
 
     def invocation_parameters(self) -> Dict[str, Any]:
         return {
-            "max_tokens_to_sample": self.max_tokens,
+            "max_tokens": self.max_tokens,
             "stop_sequences": self.stop_sequences,
             "temperature": self.temperature,
             "top_p": self.top_p,
@@ -71,7 +88,7 @@ class AnthropicModel(BaseModel):
         invocation_parameters.update(kwargs)
         response = self._rate_limited_completion(
             model=self.model,
-            prompt=self._format_prompt_for_claude(prompt),
+            messages=self._format_prompt_for_claude(prompt),
             **invocation_parameters,
         )
 
@@ -81,8 +98,8 @@ class AnthropicModel(BaseModel):
         @self._rate_limiter.limit
         def _completion(**kwargs: Any) -> Any:
             try:
-                response = self.client.completions.create(**kwargs)
-                return response.completion
+                response = self.client.messages.create(**kwargs)
+                return response.content[0].text
             except self._anthropic.BadRequestError as e:
                 exception_message = e.args[0]
                 if exception_message and "prompt is too long" in exception_message:
@@ -99,7 +116,7 @@ class AnthropicModel(BaseModel):
         invocation_parameters.update(kwargs)
         response = await self._async_rate_limited_completion(
             model=self.model,
-            prompt=self._format_prompt_for_claude(prompt),
+            messages=self._format_prompt_for_claude(prompt),
             **invocation_parameters,
         )
 
@@ -109,8 +126,8 @@ class AnthropicModel(BaseModel):
         @self._rate_limiter.alimit
         async def _async_completion(**kwargs: Any) -> Any:
             try:
-                response = await self.async_client.completions.create(**kwargs)
-                return response.completion
+                response = await self.async_client.messages.create(**kwargs)
+                return response.content[0].text
             except self._anthropic.BadRequestError as e:
                 exception_message = e.args[0]
                 if exception_message and "prompt is too long" in exception_message:
@@ -120,5 +137,7 @@ class AnthropicModel(BaseModel):
         return await _async_completion(**kwargs)
 
     def _format_prompt_for_claude(self, prompt: str) -> str:
-        # Claude requires prompt in the format of Human: ... Assistant:
-        return f"{self._anthropic.HUMAN_PROMPT} {prompt} {self._anthropic.AI_PROMPT}"
+        # the Anthropic messages API expects a list of messages
+        return [
+            {"role": "user", "content": prompt},
+        ]


### PR DESCRIPTION
Resolves #2488 

Updates the `AnthropicModel` wrapper to use the new `messages` API. This also enables the use of `claude-3` models.