### PR TITLE
feat(projects): add support for the PHOENIX_PROJECT_NAME param

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -3,8 +3,6 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-from phoenix.core.project import DEFAULT_PROJECT_NAME
-
 # Phoenix environment variables
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_HOST = "PHOENIX_HOST"
@@ -122,4 +120,4 @@ def get_env_collector_endpoint() -> Optional[str]:
 
 
 def get_env_project_name() -> str:
-    return os.getenv(ENV_PHOENIX_PROJECT_NAME) or DEFAULT_PROJECT_NAME
+    return os.getenv(ENV_PHOENIX_PROJECT_NAME) or "config"

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -120,4 +120,4 @@ def get_env_collector_endpoint() -> Optional[str]:
 
 
 def get_env_project_name() -> str:
-    return os.getenv(ENV_PHOENIX_PROJECT_NAME) or "config"
+    return os.getenv(ENV_PHOENIX_PROJECT_NAME) or "default"

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -3,6 +3,8 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
+from phoenix.core.project import DEFAULT_PROJECT_NAME
+
 # Phoenix environment variables
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_HOST = "PHOENIX_HOST"
@@ -16,6 +18,10 @@ ENV_PHOENIX_WORKING_DIR = "PHOENIX_WORKING_DIR"
 """
 The directory in which to save, load, and export datasets. This directory must
 be accessible by both the Phoenix server and the notebook environment.
+"""
+ENV_PHOENIX_PROJECT_NAME = "PHOENIX_PROJECT_NAME"
+"""
+The project name to use when logging traces and evals. defaults to 'default'.
 """
 
 
@@ -113,3 +119,7 @@ def get_env_host() -> str:
 
 def get_env_collector_endpoint() -> Optional[str]:
     return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)
+
+
+def get_env_project_name() -> str:
+    return os.getenv(ENV_PHOENIX_PROJECT_NAME) or DEFAULT_PROJECT_NAME

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -11,7 +11,12 @@ from pyarrow import ArrowInvalid
 from requests import Session
 
 import phoenix as px
-from phoenix.config import get_env_collector_endpoint, get_env_host, get_env_port
+from phoenix.config import (
+    get_env_collector_endpoint,
+    get_env_host,
+    get_env_port,
+    get_env_project_name,
+)
 from phoenix.session.data_extractor import TraceDataExtractor
 from phoenix.trace import Evaluations
 from phoenix.trace.dsl import SpanQuery
@@ -59,6 +64,7 @@ class Client(TraceDataExtractor):
         root_spans_only: Optional[bool] = None,
         project_name: Optional[str] = None,
     ) -> Optional[Union[pd.DataFrame, List[pd.DataFrame]]]:
+        project_name = project_name or get_env_project_name()
         if not queries:
             queries = (SpanQuery(),)
         if self._use_active_session_if_available and (session := px.active_session()):
@@ -102,6 +108,7 @@ class Client(TraceDataExtractor):
         self,
         project_name: Optional[str] = None,
     ) -> List[Evaluations]:
+        project_name = project_name or get_env_project_name()
         if self._use_active_session_if_available and (session := px.active_session()):
             return session.get_evaluations(project_name=project_name)
         response = self._session.get(

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -349,7 +349,7 @@ class ThreadSession(Session):
             root_spans_only : boolean, optional
                 whether to include only root spans in the results.
 
-            project_name : (string, optional)
+            project_name : string, optional
                 name of the project to query. Defaults to the project name set
                 in the environment variable `PHOENIX_PROJECT_NAME` or 'default' if not set.
 

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -334,19 +334,28 @@ class ThreadSession(Session):
         """
         Queries the spans in the project based on the provided parameters.
 
-        Args:
-            queries: Variable-length argument list of SpanQuery objects
-            representing the queries to be executed. start_time: Optional
-            datetime object representing the start time of the query. stop_time:
-            Optional datetime object representing the stop time of the query.
-            root_spans_only: Optional boolean indicating whether to include only
-            root spans in the results. project_name: Optional string
-            representing the name of the project to query. Defaults to the project name
-            set in the environment variable `PHOENIX_PROJECT_NAME` or 'default' if not set.
+        Parameters
+        ----------
+            queries : *SpanQuery
+                Variable-length argument list of SpanQuery objects representing
+                the queries to be executed.
+
+            start_time : datetime, optional
+                 datetime representing the start time of the query.
+
+            stop_time : datetime, optional
+                datetime representing the stop time of the query.
+
+            root_spans_only : boolean, optional
+                whether to include only root spans in the results.
+
+            project_name : (string, optional)
+                name of the project to query. Defaults to the project name set
+                in the environment variable `PHOENIX_PROJECT_NAME` or 'default' if not set.
 
         Returns:
-            Optional pandas DataFrame or list of DataFrames containing the query
-            results.
+            results : DataFrame
+                DataFrame or list of DataFrames containing the query results.
         """
         if not (traces := self.traces) or not (
             project := traces.get_project(project_name or get_env_project_name())
@@ -382,13 +391,17 @@ class ThreadSession(Session):
         """
         Get the evaluations for a project.
 
-        Args:
-            project_name (str, optional): The name of the project. If not
-            provided, the project name set in the environment variable
-            `PHOENIX_PROJECT_NAME` will be used. Otherwise, 'default' will be used.
+        Parameters
+        ----------
+            project_name :  str, optional
+                The name of the project. If not provided, the project name set
+                in the environment variable `PHOENIX_PROJECT_NAME` will be used.
+                Otherwise, 'default' will be used.
 
-        Returns:
-            List[Evaluations]: A list of evaluations for the specified project.
+        Returns
+        -------
+            evaluations : List[Evaluations]
+                A list of evaluations for the specified project.
 
         """
         project_name = project_name or get_env_project_name()

--- a/src/phoenix/trace/langchain/instrumentor.py
+++ b/src/phoenix/trace/langchain/instrumentor.py
@@ -4,9 +4,12 @@ from importlib.util import find_spec
 from typing import Any
 
 from openinference.instrumentation.langchain import LangChainInstrumentor as Instrumentor
+from openinference.semconv.resource import ResourceAttributes
 from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
+from phoenix.config import get_env_project_name
 from phoenix.trace.exporter import _OpenInferenceExporter
 from phoenix.trace.tracer import _show_deprecation_warnings
 
@@ -26,6 +29,8 @@ class LangChainInstrumentor(Instrumentor):
         super().__init__()
 
     def instrument(self) -> None:
-        tracer_provider = trace_sdk.TracerProvider()
+        tracer_provider = trace_sdk.TracerProvider(
+            resource=Resource({ResourceAttributes.PROJECT_NAME: get_env_project_name()})
+        )
         tracer_provider.add_span_processor(SimpleSpanProcessor(_OpenInferenceExporter()))
         super().instrument(skip_dep_check=True, tracer_provider=tracer_provider)

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -3,10 +3,13 @@ from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
 from typing import Any
 
+from openinference.semconv.resource import ResourceAttributes
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
+from phoenix.config import get_env_project_name
 from phoenix.trace.errors import IncompatibleLibraryVersionError
 from phoenix.trace.exporter import _OpenInferenceExporter
 from phoenix.trace.tracer import _show_deprecation_warnings
@@ -72,6 +75,8 @@ class OpenInferenceTraceCallbackHandler(_OpenInferenceTraceCallbackHandler):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         _show_deprecation_warnings(self, *args, **kwargs)
-        tracer_provider = trace_sdk.TracerProvider()
+        tracer_provider = trace_sdk.TracerProvider(
+            resource=Resource({ResourceAttributes.PROJECT_NAME: get_env_project_name()})
+        )
         tracer_provider.add_span_processor(SimpleSpanProcessor(_OpenInferenceExporter()))
         super().__init__(trace_api.get_tracer(__name__, __version__, tracer_provider))

--- a/src/phoenix/trace/openai/instrumentor.py
+++ b/src/phoenix/trace/openai/instrumentor.py
@@ -4,9 +4,12 @@ from importlib.util import find_spec
 from typing import Any
 
 from openinference.instrumentation.openai import OpenAIInstrumentor as Instrumentor
+from openinference.semconv.resource import ResourceAttributes
 from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
+from phoenix.config import get_env_project_name
 from phoenix.trace.exporter import _OpenInferenceExporter
 from phoenix.trace.tracer import _show_deprecation_warnings
 
@@ -21,6 +24,8 @@ class OpenAIInstrumentor(Instrumentor):
         super().__init__()
 
     def instrument(self) -> None:
-        tracer_provider = trace_sdk.TracerProvider()
+        tracer_provider = trace_sdk.TracerProvider(
+            resource=Resource({ResourceAttributes.PROJECT_NAME: get_env_project_name()})
+        )
         tracer_provider.add_span_processor(SimpleSpanProcessor(_OpenInferenceExporter()))
         super().instrument(skip_dep_check=True, tracer_provider=tracer_provider)


### PR DESCRIPTION
resolves #2377 

Adds the ability to set the project name via an environment variable so that all the instrumentation goes to one project across instrumentations and so that loading evals and dataframes just works out of the box.

<img width="906" alt="Screenshot 2024-03-08 at 5 36 31 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/daad0be8-8dd8-4fd4-85a8-66a44bf527ee">
