### PR TITLE
fix: support minimal llama-index installations

### DIFF
--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -65,12 +65,11 @@ def _get_version_if_installed(package_name: str) -> Optional[str]:
         return None
 
 
-def _parse_semantic_version(semver_string: str) -> Tuple[int, int, int]:
+def _parse_semantic_version(semver_string: str) -> Tuple[int, ...]:
     """
     Parse a semantic version string into a tuple of integers.
     """
-    major, minor, patch = semver_string.split(".")[:3]
-    return int(major), int(minor), int(patch)
+    return tuple(map(int, semver_string.split(".")[:3]))
 
 
 if _check_instrumentation_compatibility():

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -1,6 +1,6 @@
 import logging
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk import trace as trace_sdk
@@ -17,40 +17,32 @@ INSTRUMENTATION_MODERN_VERSION = (1, 0, 0)
 
 
 def _check_instrumentation_compatibility() -> bool:
-    llama_index_version_str = None
-    try:
-        llama_index_version_str = version("llama-index")
-    except PackageNotFoundError:
-        pass
-
-    llama_index_core_version_str = None
-    try:
-        llama_index_core_version_str = version("llama-index-core")
-    except PackageNotFoundError:
-        pass
-
+    llama_index_version_str = _get_version_if_installed("llama-index")
+    llama_index_installed = llama_index_version_str is not None
+    llama_index_core_version_str = _get_version_if_installed("llama-index-core")
+    llama_index_core_installed = modern_llama_index_installed = (
+        llama_index_core_version_str is not None
+    )
     instrumentation_version_str = version("openinference-instrumentation-llama-index")
     instrumentation_version = _parse_semantic_version(instrumentation_version_str)
 
-    if llama_index_version_str is None:
-        if llama_index_core_version_str is None:
-            raise PackageNotFoundError(
-                "Missing `llama_index`. "
-                "Install with `pip install llama-index` or "
-                "`pip install llama-index-core` for a minimal installation."
-            )
-        if instrumentation_version < INSTRUMENTATION_MODERN_VERSION:
-            raise IncompatibleLibraryVersionError(
-                f"llama-index-core v{llama_index_core_version_str} is not compatible with "
-                f"openinference-instrumentation-llama-index v{instrumentation_version_str}. "
-                "Please upgrade openinference-instrumentation-llama-index to at least 1.0.0 via "
-                "`pip install 'openinference-instrumentation-llama-index>=1.0.0'`."
-            )
-        return True
-
-    llama_index_version = _parse_semantic_version(llama_index_version_str)
-    if (
-        llama_index_version < LLAMA_INDEX_MODERN_VERSION
+    if not llama_index_installed and not llama_index_core_installed:
+        raise PackageNotFoundError(
+            "Missing `llama_index`. "
+            "Install with `pip install llama-index` or "
+            "`pip install llama-index-core` for a minimal installation."
+        )
+    elif modern_llama_index_installed and instrumentation_version < INSTRUMENTATION_MODERN_VERSION:
+        raise IncompatibleLibraryVersionError(
+            f"llama-index-core v{llama_index_core_version_str} is not compatible with "
+            f"openinference-instrumentation-llama-index v{instrumentation_version_str}. "
+            "Please upgrade openinference-instrumentation-llama-index to at least 1.0.0 via "
+            "`pip install 'openinference-instrumentation-llama-index>=1.0.0'`."
+        )
+    elif (
+        llama_index_installed
+        and llama_index_version_str
+        and _parse_semantic_version(llama_index_version_str) < LLAMA_INDEX_MODERN_VERSION
         and instrumentation_version >= INSTRUMENTATION_MODERN_VERSION
     ):
         raise IncompatibleLibraryVersionError(
@@ -60,18 +52,17 @@ def _check_instrumentation_compatibility() -> bool:
             "openinference-instrumentation-llama-index via "
             "`pip install 'openinference-instrumentation-llama-index<1.0.0'`."
         )
-    elif (
-        llama_index_version >= LLAMA_INDEX_MODERN_VERSION
-        and instrumentation_version < INSTRUMENTATION_MODERN_VERSION
-    ):
-        raise IncompatibleLibraryVersionError(
-            f"llama-index v{llama_index_version_str} is not compatible with "
-            f"openinference-instrumentation-llama-index v{instrumentation_version_str}. "
-            "Please upgrade openinference-instrumentation-llama-index to at least 1.0.0 via "
-            "`pip install 'openinference-instrumentation-llama-index>=1.0.0'`."
-        )
-    # if the versions are compatible, return True
     return True
+
+
+def _get_version_if_installed(package_name: str) -> Optional[str]:
+    """
+    Gets the version of the package if it is installed, otherwise, returns None.
+    """
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return None
 
 
 def _parse_semantic_version(semver_string: str) -> Tuple[int, int, int]:

--- a/src/phoenix/trace/llama_index/callback.py
+++ b/src/phoenix/trace/llama_index/callback.py
@@ -17,15 +17,17 @@ INSTRUMENTATION_MODERN_VERSION = (1, 0, 0)
 
 
 def _check_instrumentation_compatibility() -> bool:
+    llama_index_version_str = None
     try:
         llama_index_version_str = version("llama-index")
     except PackageNotFoundError:
-        llama_index_version_str = None
+        pass
 
+    llama_index_core_version_str = None
     try:
         llama_index_core_version_str = version("llama-index-core")
     except PackageNotFoundError:
-        llama_index_core_version_str = None
+        pass
 
     instrumentation_version_str = version("openinference-instrumentation-llama-index")
     instrumentation_version = _parse_semantic_version(instrumentation_version_str)


### PR DESCRIPTION
Adds support for minimal LlamaIndex installations, i.e., when only the `llama-index-core` module is installed but not the full `llama-index` package.

resolves #2509
