### PR TITLE
fix: display newlines in explanations

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -79,7 +79,7 @@
     "build:relay": "relay-compiler",
     "watch": "./esbuild.config.mjs dev",
     "test": "jest --config ./jest.config.js",
-    "dev": "npm run dev:server:traces:llama_index_calculator_agent & npm run build:static && npm run watch",
+    "dev": "npm run dev:server:traces:llama_index_rag & npm run build:static && npm run watch",
     "dev:server:mnist": "python3 -m phoenix.server.main --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main fixture fashion_mnist --primary-only true",
     "dev:server:sentiment": "python3 -m phoenix.server.main fixture sentiment_classification_language_drift",

--- a/app/src/components/table/TextCell.tsx
+++ b/app/src/components/table/TextCell.tsx
@@ -26,3 +26,14 @@ export function TextCell<TData extends object, TValue>({
     value != null && typeof value === "string" ? formatText(value) : "--";
   return <span title={String(value)}>{str}</span>;
 }
+
+/**
+ * A table cell that shows pre-formatted text.
+ */
+export function PreformattedTextCell<TData extends object, TValue>({
+  getValue,
+}: CellContext<TData, TValue>) {
+  const value = getValue();
+  const str = value != null && typeof value === "string" ? value : "--";
+  return <pre style={{ whiteSpace: "pre-wrap" }}>{str}</pre>;
+}

--- a/app/src/pages/trace/SpanEvaluationsTable.tsx
+++ b/app/src/pages/trace/SpanEvaluationsTable.tsx
@@ -90,22 +90,16 @@ export function SpanEvaluationsTable(props: {
         <tbody>
           {table.getRowModel().rows.map((row) => (
             <tr key={row.id}>
-              {row.getVisibleCells().map((cell) => {
-                const node = flexRender(
-                  cell.column.columnDef.cell,
-                  cell.getContext()
-                );
-                return (
-                  <td
-                    key={cell.id}
-                    style={{
-                      width: cell.column.getSize(),
-                    }}
-                  >
-                    {node}
-                  </td>
-                );
-              })}
+              {row.getVisibleCells().map((cell) => (
+                <td
+                  key={cell.id}
+                  style={{
+                    width: cell.column.getSize(),
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
             </tr>
           ))}
         </tbody>

--- a/app/src/pages/trace/SpanEvaluationsTable.tsx
+++ b/app/src/pages/trace/SpanEvaluationsTable.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { TextCell } from "@phoenix/components/table";
+import { PreformattedTextCell } from "@phoenix/components/table";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 
@@ -31,7 +31,7 @@ const columns = [
   {
     header: "explanation",
     accessorKey: "explanation",
-    Cell: TextCell,
+    cell: PreformattedTextCell,
     size: 400,
   },
 ];
@@ -90,16 +90,22 @@ export function SpanEvaluationsTable(props: {
         <tbody>
           {table.getRowModel().rows.map((row) => (
             <tr key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <td
-                  key={cell.id}
-                  style={{
-                    width: cell.column.getSize(),
-                  }}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
+              {row.getVisibleCells().map((cell) => {
+                const node = flexRender(
+                  cell.column.columnDef.cell,
+                  cell.getContext()
+                );
+                return (
+                  <td
+                    key={cell.id}
+                    style={{
+                      width: cell.column.getSize(),
+                    }}
+                  >
+                    {node}
+                  </td>
+                );
+              })}
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
Displays newlines in explanations in the UI

![Screenshot 2024-03-11 at 6 45 57 PM](https://github.com/Arize-ai/phoenix/assets/15664869/b82f1233-0cfb-4518-abef-42fa5ddb1f76)

resolves #2529
