### PR TITLE
fix: support numpy arrays in span to json encoder

### DIFF
--- a/src/phoenix/trace/span_json_encoder.py
+++ b/src/phoenix/trace/span_json_encoder.py
@@ -5,6 +5,8 @@ from enum import Enum
 from typing import Any, List
 from uuid import UUID
 
+import numpy as np
+
 from phoenix.trace.schemas import (
     Span,
     SpanContext,
@@ -45,6 +47,12 @@ class SpanJSONEncoder(json.JSONEncoder):
             }
         elif isinstance(obj, SpanConversationAttributes):
             return {"conversation_id": str(obj.conversation_id)}
+        elif isinstance(obj, np.ndarray):
+            return list(obj)
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
         return super().default(obj)
 
 

--- a/tests/trace/test_span_json_encoder.py
+++ b/tests/trace/test_span_json_encoder.py
@@ -1,0 +1,51 @@
+import json
+from datetime import datetime, timezone
+
+import numpy as np
+from phoenix.trace.schemas import Span, SpanContext, SpanKind, SpanStatusCode
+from phoenix.trace.span_json_encoder import span_to_json
+
+
+def test_span_to_json() -> None:
+    start_time = datetime.now(timezone.utc)
+    end_time = datetime.now(timezone.utc)
+    span = Span(
+        name="test",
+        context=SpanContext(
+            trace_id="1234",
+            span_id="5678",
+        ),
+        span_kind=SpanKind.UNKNOWN,
+        parent_id=None,
+        start_time=start_time,
+        end_time=end_time,
+        status_code=SpanStatusCode.ERROR,
+        status_message="error",
+        attributes={
+            "key": "value",
+            "integers": np.array([1, 2, 3]),
+            "floats": np.array([0.1, 0.2, 0.3]),
+        },
+        events=[],
+        conversation=None,
+    )
+    assert json.loads(span_to_json(span)) == {
+        "name": "test",
+        "context": {
+            "trace_id": "1234",
+            "span_id": "5678",
+        },
+        "span_kind": "UNKNOWN",
+        "parent_id": None,
+        "start_time": start_time.isoformat(),
+        "end_time": end_time.isoformat(),
+        "status_code": "ERROR",
+        "status_message": "error",
+        "attributes": {
+            "key": "value",
+            "integers": [1, 2, 3],
+            "floats": [0.1, 0.2, 0.3],
+        },
+        "events": [],
+        "conversation": None,
+    }


### PR DESCRIPTION
numpy arrays in spans can exist when user loads data from a parquet file that's generated from pyarrow, which turns lists into ndarrays. In order to export spans containing these numpy elements via `get_spans_dataframe`, we need convert these numpy objects in the span to json encoder.