### PR TITLE
feat: project archiving and deletion

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -485,8 +485,8 @@ type Mutation {
   Given a list of clusters, export the corresponding data subset in Parquet format. File name is optional, but if specified, should be without file extension. By default the exported file name is current timestamp.
   """
   exportClusters(clusters: [ClusterInput!]!, fileName: String): ExportedFile!
-  deleteProject(id: GlobalID!): Void
-  archiveProject(id: GlobalID!): Void
+  deleteProject(id: GlobalID!): Query!
+  archiveProject(id: GlobalID!): Query!
 }
 
 """A node in the graph with a globally unique ID"""
@@ -821,6 +821,3 @@ type ValidationResult {
 enum VectorDriftMetric {
   euclideanDistance
 }
-
-"""Represents NULL values"""
-scalar Void

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -485,6 +485,8 @@ type Mutation {
   Given a list of clusters, export the corresponding data subset in Parquet format. File name is optional, but if specified, should be without file extension. By default the exported file name is current timestamp.
   """
   exportClusters(clusters: [ClusterInput!]!, fileName: String): ExportedFile!
+  deleteProject(id: GlobalID!): Void
+  archiveProject(id: GlobalID!): Void
 }
 
 """A node in the graph with a globally unique ID"""
@@ -819,3 +821,6 @@ type ValidationResult {
 enum VectorDriftMetric {
   euclideanDistance
 }
+
+"""Represents NULL values"""
+scalar Void

--- a/src/phoenix/core/project.py
+++ b/src/phoenix/core/project.py
@@ -91,6 +91,7 @@ class Project:
     def __init__(self) -> None:
         self._spans = _Spans()
         self._evals = _Evals()
+        self._is_archived = False
 
     @property
     def last_updated_at(self) -> Optional[datetime]:
@@ -191,6 +192,13 @@ class Project:
 
     def export_evaluations(self) -> List[Evaluations]:
         return self._evals.export_evaluations()
+
+    def archive(self) -> None:
+        self._is_archived = True
+
+    @property
+    def is_archived(self) -> bool:
+        return self._is_archived
 
 
 class _Spans:

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -34,14 +34,6 @@ class Traces:
         )
         self._start_consumers()
 
-    def archive_project(self, id: int) -> Optional["Project"]:
-        with self._lock:
-            for project_id, _, project in self.get_projects():
-                if id == project_id:
-                    project.archive()
-                    return project
-        return None
-
     def get_project(self, project_name: str) -> Optional["Project"]:
         with self._lock:
             return self._projects.get(project_name)
@@ -52,6 +44,14 @@ class Traces:
                 if project.is_archived:
                     continue
                 yield project_id, project_name, project
+
+    def archive_project(self, id: int) -> Optional["Project"]:
+        with self._lock:
+            for project_id, _, project in self.get_projects():
+                if id == project_id:
+                    project.archive()
+                    return project
+        return None
 
     def put(
         self,

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -47,10 +47,16 @@ class Traces:
 
     def archive_project(self, id: int) -> Optional["Project"]:
         with self._lock:
-            for project_id, _, project in self.get_projects():
-                if id == project_id:
-                    project.archive()
-                    return project
+            active_projects = {
+                project_id: project
+                for project_id, _, project in self.get_projects()
+                if not project.is_archived
+            }
+            if len(active_projects) <= 1:
+                return None
+            if project := active_projects.get(id):
+                project.archive()
+                return project
         return None
 
     def put(

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -229,22 +229,24 @@ class Query:
 @strawberry.type
 class Mutation(ExportEventsMutation):
     @strawberry.mutation
-    def delete_project(self, info: Info[Context, None], id: GlobalID) -> None:
+    def delete_project(self, info: Info[Context, None], id: GlobalID) -> Query:
         if (traces := info.context.traces) is None:
-            return
+            return Query()
         type_name, node_id = from_global_id(str(id))
         if type_name != "Project":
-            return
+            return Query()
         traces.archive_project(node_id)
+        return Query()
 
     @strawberry.mutation
-    def archive_project(self, info: Info[Context, None], id: GlobalID) -> None:
+    def archive_project(self, info: Info[Context, None], id: GlobalID) -> Query:
         if (traces := info.context.traces) is None:
-            return
+            return Query()
         type_name, node_id = from_global_id(str(id))
         if type_name != "Project":
-            return
+            return Query()
         traces.archive_project(node_id)
+        return Query()
 
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -56,8 +56,8 @@ class Query:
             []
             if (traces := info.context.traces) is None
             else [
-                Project(id_attr=i, name=name, project=project)
-                for i, (name, project) in enumerate(traces.get_projects())
+                Project(id_attr=project_id, name=project_name, project=project)
+                for project_id, project_name, project in traces.get_projects()
             ]
         )
         return connection_from_list(data=data, args=args)
@@ -86,8 +86,11 @@ class Query:
             return to_gql_embedding_dimension(node_id, embedding_dimension)
         elif type_name == "Project":
             if (traces := info.context.traces) is not None:
-                projects = list(traces.get_projects())
-                if node_id < len(projects):
+                projects = {
+                    project_id: (project_name, project)
+                    for project_id, project_name, project in traces.get_projects()
+                }
+                if node_id in projects:
                     name, project = projects[node_id]
                     return Project(id_attr=node_id, name=name, project=project)
             raise Exception(f"Unknown project: {id}")
@@ -224,7 +227,24 @@ class Query:
 
 
 @strawberry.type
-class Mutation(ExportEventsMutation): ...
+class Mutation(ExportEventsMutation):
+    @strawberry.mutation
+    def delete_project(self, info: Info[Context, None], id: GlobalID) -> None:
+        if (traces := info.context.traces) is None:
+            return
+        type_name, node_id = from_global_id(str(id))
+        if type_name != "Project":
+            return
+        traces.archive_project(node_id)
+
+    @strawberry.mutation
+    def archive_project(self, info: Info[Context, None], id: GlobalID) -> None:
+        if (traces := info.context.traces) is None:
+            return
+        type_name, node_id = from_global_id(str(id))
+        if type_name != "Project":
+            return
+        traces.archive_project(node_id)
 
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)


### PR DESCRIPTION
Adds `deleteProject` and `archiveProject` mutations. No deletion currently happens, we simply mark the project as archived and don't return it from the `projects` field on `Query`.