### PR TITLE
fix(projects): the home page should direct you to the projects page if there are multiple projects with data

### DIFF
--- a/app/src/pages/home/homeLoader.ts
+++ b/app/src/pages/home/homeLoader.ts
@@ -34,11 +34,23 @@ export async function homeLoader(_args: LoaderFunctionArgs) {
   if (data?.functionality.modelInferences) {
     return redirect("/model");
   } else if (data?.projects.edges?.length) {
+    // Detect if there is only a single project with data. If that's the case, redirect to that project
+    let numProjectsWithData = 0,
+      projectIdWithData = null;
     for (const { project } of data.projects.edges) {
       if (project.endTime != null) {
-        return redirect(`/projects/${project.id}`);
+        numProjectsWithData++;
+        projectIdWithData = project.id;
       }
     }
+    if (numProjectsWithData > 1) {
+      // There are multiple projects with data, redirect to projects
+      return redirect("/projects");
+    } else if (numProjectsWithData === 1 && projectIdWithData != null) {
+      // There is only one project with data, redirect to that project
+      return redirect(`/projects/${projectIdWithData}`);
+    }
+    // Fallback to the default project
     const projectId = data?.projects.edges[0].project.id;
     return redirect(`/projects/${projectId}`);
   } else {


### PR DESCRIPTION
resolves #2568

It doesn't make too much sense to direct the user to a specific project when there are multiple projects with data. For example if you run indexing first, you will keep getting redirected to that project even though you want to see all.