### PR TITLE
chore: protect default project from deletion

### DIFF
--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -47,16 +47,10 @@ class Traces:
 
     def archive_project(self, id: int) -> Optional["Project"]:
         with self._lock:
-            active_projects = {
-                project_id: project
-                for project_id, _, project in self.get_projects()
-                if not project.is_archived
-            }
-            if len(active_projects) <= 1:
-                return None
-            if project := active_projects.get(id):
-                project.archive()
-                return project
+            for project_id, project_name, project in self.get_projects():
+                if id == project_id and project_name != "default":
+                    project.archive()
+                    return project
         return None
 
     def put(

--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -46,9 +46,11 @@ class Traces:
                 yield project_id, project_name, project
 
     def archive_project(self, id: int) -> Optional["Project"]:
+        if id == 0:
+            raise ValueError("Cannot archive the default project")
         with self._lock:
-            for project_id, project_name, project in self.get_projects():
-                if id == project_id and project_name != "default":
+            for project_id, _, project in self.get_projects():
+                if id == project_id:
                     project.archive()
                     return project
         return None


### PR DESCRIPTION
Previously, we required that at least one project exists at all times, but you could delete the default project if you had at least one other project. Now, we require that the default project in particular is not deleted.
