### PR TITLE
chore: raise exception for unexpected node types for deleteProject and archiveProject mutations

### DIFF
--- a/src/phoenix/core/traces.py
+++ b/src/phoenix/core/traces.py
@@ -47,16 +47,10 @@ class Traces:
 
     def archive_project(self, id: int) -> Optional["Project"]:
         with self._lock:
-            active_projects = {
-                project_id: project
-                for project_id, _, project in self.get_projects()
-                if not project.is_archived
-            }
-            if len(active_projects) <= 1:
-                return None
-            if project := active_projects.get(id):
-                project.archive()
-                return project
+            for project_id, project_name, project in self.get_projects():
+                if id == project_id and project_name != "default":
+                    project.archive()
+                    return project
         return None
 
     def put(

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -31,7 +31,7 @@ from .types.Event import create_event_id, unpack_event_id
 from .types.ExportEventsMutation import ExportEventsMutation
 from .types.Functionality import Functionality
 from .types.Model import Model
-from .types.node import GlobalID, Node, from_global_id
+from .types.node import GlobalID, Node, from_global_id, from_global_id_with_expected_type
 from .types.pagination import Connection, ConnectionArgs, Cursor, connection_from_list
 
 
@@ -230,28 +230,16 @@ class Query:
 class Mutation(ExportEventsMutation):
     @strawberry.mutation
     def delete_project(self, info: Info[Context, None], id: GlobalID) -> Query:
-        if (traces := info.context.traces) is None:
-            return Query()
-        type_name, node_id = from_global_id(str(id))
-        if type_name != "Project":
-            raise ValueError(
-                "The id passed to deleteProject must correspond to a node of type Project, "
-                f"but was passed a node of type: {type_name}"
-            )
-        traces.archive_project(node_id)
+        if (traces := info.context.traces) is not None:
+            node_id = from_global_id_with_expected_type(str(id), "Project")
+            traces.archive_project(node_id)
         return Query()
 
     @strawberry.mutation
     def archive_project(self, info: Info[Context, None], id: GlobalID) -> Query:
-        if (traces := info.context.traces) is None:
-            return Query()
-        type_name, node_id = from_global_id(str(id))
-        if type_name != "Project":
-            raise ValueError(
-                "The id passed to archiveProject must correspond to a node of type Project, "
-                f"but was passed a node of type: {type_name}"
-            )
-        traces.archive_project(node_id)
+        if (traces := info.context.traces) is not None:
+            node_id = from_global_id_with_expected_type(str(id), "Project")
+            traces.archive_project(node_id)
         return Query()
 
 

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -234,7 +234,10 @@ class Mutation(ExportEventsMutation):
             return Query()
         type_name, node_id = from_global_id(str(id))
         if type_name != "Project":
-            return Query()
+            raise ValueError(
+                "The id passed to deleteProject must correspond to a node of type Project, "
+                f"but was passed a node of type: {type_name}"
+            )
         traces.archive_project(node_id)
         return Query()
 
@@ -244,7 +247,10 @@ class Mutation(ExportEventsMutation):
             return Query()
         type_name, node_id = from_global_id(str(id))
         if type_name != "Project":
-            return Query()
+            raise ValueError(
+                "The id passed to archiveProject must correspond to a node of type Project, "
+                f"but was passed a node of type: {type_name}"
+            )
         traces.archive_project(node_id)
         return Query()
 

--- a/src/phoenix/server/api/types/node.py
+++ b/src/phoenix/server/api/types/node.py
@@ -30,6 +30,20 @@ def from_global_id(global_id: str) -> Tuple[str, int]:
     return type_name, int(node_id)
 
 
+def from_global_id_with_expected_type(global_id: str, expected_type_name: str) -> int:
+    """
+    Decodes the given global id and return the id, checking that the type
+    matches the expected type.
+    """
+    type_name, node_id = from_global_id(global_id)
+    if type_name != expected_type_name:
+        raise ValueError(
+            f"The node id must correspond to a node of type {expected_type_name}, "
+            f"but instead corresponds to a node of type: {type_name}"
+        )
+    return node_id
+
+
 class GlobalIDValueError(ValueError):
     """GlobalID value error, usually related to parsing or serialization."""
 


### PR DESCRIPTION
Raises an exception when id passed to deleteProject and archiveProject mutations corresponds to a non-Project node
