### PR TITLE
docs: example using cron for online phoenix evals

### DIFF
--- a/examples/cron-evals/.gitignore
+++ b/examples/cron-evals/.gitignore
@@ -1,0 +1,1 @@
+vector-store

--- a/examples/cron-evals/.gitignore
+++ b/examples/cron-evals/.gitignore
@@ -1,1 +1,2 @@
 vector-store
+evals.log

--- a/examples/cron-evals/README.md
+++ b/examples/cron-evals/README.md
@@ -1,4 +1,4 @@
-# Running Online Phoenix Evals with Cron
+# Running Evals with Cron
 
 This example demonstrates how to compute and upload evals on a regular schedule using `cron`.
 

--- a/examples/cron-evals/README.md
+++ b/examples/cron-evals/README.md
@@ -1,4 +1,4 @@
-# Running Phoenix Evals with Cron
+# Running Online Phoenix Evals with Cron
 
 This example demonstrates how to compute and upload Phoenix evals on a regular schedule using `cron`.
 
@@ -16,7 +16,7 @@ First, build and persist LangChain Qdrant vector store over the Arize documentat
 python build_vector_store.py
 ```
 
-This script will persist your vector store to the `qdrant` directory.
+This script will persist your vector store to the `vector-store` directory.
 
 Run Phoenix with
 
@@ -32,9 +32,20 @@ python run_chain.py
 
 This script will loop indefinitely while emitting traces to your running instance of Phoenix. At this point, you should confirm that traces are appearing in the Phoenix app.
 
-
-Add the following line to your crontab, replacing the paths witih the actual paths to your Python interpreter and script.
+Add the following line to your crontab, replacing the API key and paths as appropriate.
 
 ```
-0 * * * * /path/to/python /path/to/phoenix/examples/cron-evals/run_evals.py
+* * * * * OPENAI_API_KEY=sk-your-openai-api-key /path/to/python /path/to/phoenix/examples/cron-evals/run_evals.py > /path/to/evals.log 2>&1
 ```
+
+Once per minute, the script will query relevant spans from the past minute and compute and log evaluations to Phoenix. You should verify that evaluations appear as annotations on your spans in the Phoenix app at one-minute intervals.
+
+ℹ️ If you are using a virtual environment, you can find the path to your Python interpreter by running `which python` while the environment is activated.
+
+ℹ️ View logs of your evaluation runs with `tail -f /path/to/evals.log`.
+
+ℹ️ If you don't wish to store your OpenAI API key directly in the crontab, there are [several alternative ways](https://stackoverflow.com/questions/2229825/where-can-i-set-environment-variables-that-crontab-will-use) of making it available to the cronjob depending on your OS.
+
+ℹ️ The `run_evals.py` script is hard-coded to select relevant spans within the past one-minute time range. If you wish to run your evaluations at a different frequency, adjust both the time-window in the script and the cron schedule accordingly.
+
+ℹ️ The evaluations in `run_evals.py` are appropriate for the chain defined in `run_chain.py`. If you wish to run scheduled evals with your own LLM application, ensure that the evals inside of `run_evals.py` are appropriate for your application.

--- a/examples/cron-evals/README.md
+++ b/examples/cron-evals/README.md
@@ -10,7 +10,7 @@ Install project dependencies using
 pip install -r requirements.txt
 ```
 
-First, build and persist LangChain Qdrant vector store over the Arize documentation by running
+Build and persist a LangChain Qdrant vector store over the Arize documentation by running
 
 ```
 python build_vector_store.py
@@ -32,7 +32,7 @@ python run_chain.py
 
 This script will loop indefinitely while emitting traces to your running instance of Phoenix. At this point, you should confirm that traces are appearing in the Phoenix app.
 
-Add the following line to your crontab, replacing the API key and paths as appropriate.
+From a new terminal, add the following line to your crontab using `crontab -e` and replacing the API key and paths as appropriate.
 
 ```
 * * * * * OPENAI_API_KEY=sk-your-openai-api-key /path/to/python /path/to/phoenix/examples/cron-evals/run_evals.py > /path/to/evals.log 2>&1
@@ -44,7 +44,7 @@ Once per minute, the script will query relevant spans from the past minute and c
 
 ℹ️ View logs of your evaluation runs with `tail -f /path/to/evals.log`.
 
-ℹ️ If you don't wish to store your OpenAI API key directly in the crontab, there are [several alternative ways](https://stackoverflow.com/questions/2229825/where-can-i-set-environment-variables-that-crontab-will-use) of making it available to the cronjob depending on your OS.
+ℹ️ If you don't wish to store your OpenAI API key directly in the crontab, there are [alternative ways](https://stackoverflow.com/questions/2229825/where-can-i-set-environment-variables-that-crontab-will-use) of making it available to the cron job depending on your OS.
 
 ℹ️ The `run_evals.py` script is hard-coded to select relevant spans within the past one-minute time range. If you wish to run your evaluations at a different frequency, adjust both the time-window in the script and the cron schedule accordingly.
 

--- a/examples/cron-evals/README.md
+++ b/examples/cron-evals/README.md
@@ -1,0 +1,40 @@
+# Running Phoenix Evals with Cron
+
+This example demonstrates how to compute and upload Phoenix evals on a regular schedule using `cron`.
+
+## Setup
+
+Install project dependencies using
+
+```
+pip install -r requirements.txt
+```
+
+First, build and persist LangChain Qdrant vector store over the Arize documentation by running
+
+```
+python build_vector_store.py
+```
+
+This script will persist your vector store to the `qdrant` directory.
+
+Run Phoenix with
+
+```
+python -m phoenix.server.main serve
+```
+
+In a new terminal, define, instrument, and run a LangChain `RetrievalQA` chain to answer queries over your newly created vector store.
+
+```
+python run_chain.py
+```
+
+This script will loop indefinitely while emitting traces to your running instance of Phoenix. At this point, you should confirm that traces are appearing in the Phoenix app.
+
+
+Add the following line to your crontab, replacing the paths witih the actual paths to your Python interpreter and script.
+
+```
+0 * * * * /path/to/python /path/to/phoenix/examples/cron-evals/run_evals.py
+```

--- a/examples/cron-evals/README.md
+++ b/examples/cron-evals/README.md
@@ -1,6 +1,6 @@
 # Running Online Phoenix Evals with Cron
 
-This example demonstrates how to compute and upload Phoenix evals on a regular schedule using `cron`.
+This example demonstrates how to compute and upload evals on a regular schedule using `cron`.
 
 ## Setup
 

--- a/examples/cron-evals/build_vector_store.py
+++ b/examples/cron-evals/build_vector_store.py
@@ -1,0 +1,22 @@
+"""
+Builds and persists a LangChain Qdrant index over the Arize documentation.
+"""
+
+from langchain_community.document_loaders import GitbookLoader
+from langchain_community.vectorstores import Qdrant
+from langchain_openai import OpenAIEmbeddings
+
+loader = GitbookLoader(
+    "https://docs.arize.com/arize/",
+    load_all_paths=True,
+)
+documents = loader.load()
+embeddings = OpenAIEmbeddings(
+    model="text-embedding-3-large",
+)
+Qdrant.from_documents(
+    documents,
+    embeddings,
+    path="./vector-store",
+    collection_name="arize-documentation",
+)

--- a/examples/cron-evals/build_vector_store.py
+++ b/examples/cron-evals/build_vector_store.py
@@ -1,6 +1,6 @@
 # type: ignore
 """
-Builds and persists a LangChain Qdrant index over the Arize documentation.
+Builds and persists a LangChain Qdrant vector store over the Arize documentation.
 """
 
 from langchain_community.document_loaders import GitbookLoader

--- a/examples/cron-evals/build_vector_store.py
+++ b/examples/cron-evals/build_vector_store.py
@@ -1,3 +1,4 @@
+# type: ignore
 """
 Builds and persists a LangChain Qdrant index over the Arize documentation.
 """

--- a/examples/cron-evals/requirements.txt
+++ b/examples/cron-evals/requirements.txt
@@ -1,0 +1,6 @@
+arize-phoenix-evals
+bs4
+langchain-core
+langchain-openai
+langchain-community
+qdrant-client

--- a/examples/cron-evals/requirements.txt
+++ b/examples/cron-evals/requirements.txt
@@ -1,4 +1,4 @@
-arize-phoenix-evals
+arize-phoenix-evals>=3.16.3
 bs4
 langchain
 langchain-openai

--- a/examples/cron-evals/requirements.txt
+++ b/examples/cron-evals/requirements.txt
@@ -1,6 +1,5 @@
 arize-phoenix-evals
 bs4
-langchain-core
+langchain
 langchain-openai
-langchain-community
 qdrant-client

--- a/examples/cron-evals/run_chain.py
+++ b/examples/cron-evals/run_chain.py
@@ -1,0 +1,84 @@
+"""
+Loads a pre-built Qdrant vector store and defines a simple `RetrievalQA` chain.
+Downloads a set of queries and invokes the chain every 10 seconds indefinitely
+to simulate a production environment.
+
+Note: You must first build the Qdrant vector store using the
+`build_vector_store.py` script before running this script.
+"""
+
+from itertools import cycle
+from time import sleep
+
+import pandas as pd
+from langchain.chains import RetrievalQA
+from langchain_community.vectorstores import Qdrant
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from opentelemetry import trace as trace_api
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from qdrant_client import QdrantClient
+
+
+def get_chain():
+    """
+    Loads a pre-built Qdrant vector store and defines a simple `RetrievalQA` chain.
+    """
+    qdrant_client = QdrantClient(path="./qdrant")
+    embeddings = OpenAIEmbeddings(
+        model="text-embedding-3-large",
+    )
+    vector_store = Qdrant(
+        client=qdrant_client,
+        collection_name="arize-documentation",
+        embeddings=embeddings,
+    )
+    retriever = vector_store.as_retriever(
+        search_type="mmr", search_kwargs={"k": 2}, enable_limit=True
+    )
+    llm = ChatOpenAI(model="gpt-4-turbo-preview", temperature=0.0)
+    return RetrievalQA.from_chain_type(
+        llm=llm,
+        chain_type="stuff",
+        retriever=retriever,
+        metadata={"application_type": "question_answering"},
+    )
+
+
+def instrument_langchain():
+    """
+    Instruments LangChain with OpenInference.
+    """
+    endpoint = "http://127.0.0.1:6006/v1/traces"
+    tracer_provider = trace_sdk.TracerProvider()
+    trace_api.set_tracer_provider(tracer_provider)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+    tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    LangChainInstrumentor().instrument()
+
+
+def load_queries():
+    """
+    Loads a set of queries from a parquet file.
+    """
+    return pd.read_parquet(
+        "http://storage.googleapis.com/arize-phoenix-assets/datasets/unstructured/llm/context-retrieval/langchain-pinecone/langchain_pinecone_query_dataframe_with_user_feedbackv2.parquet"  # noqa E501
+    ).text.to_list()
+
+
+if __name__ == "__main__":
+    queries = load_queries()
+    chain = get_chain()
+    instrument_langchain()
+    for query in cycle(queries):
+        response = chain.invoke(query)
+        print("Query")
+        print("=====")
+        print()
+        print("Response")
+        print("========")
+        print(response)
+        print()
+        sleep(10)

--- a/examples/cron-evals/run_chain.py
+++ b/examples/cron-evals/run_chain.py
@@ -1,3 +1,4 @@
+# type: ignore
 """
 Loads a pre-built Qdrant vector store and defines a simple `RetrievalQA` chain.
 Downloads a set of queries and invokes the chain on loop to simulate a

--- a/examples/cron-evals/run_chain.py
+++ b/examples/cron-evals/run_chain.py
@@ -75,6 +75,7 @@ if __name__ == "__main__":
         response = chain.invoke(query)
         print("Query")
         print("=====")
+        print(query)
         print()
         print("Response")
         print("========")

--- a/examples/cron-evals/run_evals.py
+++ b/examples/cron-evals/run_evals.py
@@ -1,0 +1,45 @@
+"""
+Queries Phoenix for spans within the last minute. Computes and logs evaluations
+back to Phoenix. This script is intended to run once a minute as a cron job.
+"""
+
+from datetime import datetime, timedelta
+
+import phoenix as px
+from phoenix.evals import (
+    HallucinationEvaluator,
+    OpenAIModel,
+    QAEvaluator,
+    RelevanceEvaluator,
+    run_evals,
+)
+from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents
+from phoenix.trace import DocumentEvaluations, SpanEvaluations
+
+phoenix_client = px.Client()
+one_minute_ago = datetime.now() - timedelta(
+    minutes=1, seconds=10
+)  # add a few seconds to ensure all spans are captured
+phoenix_client.get_spans_dataframe(start_time=one_minute_ago)
+qa_spans_df = get_qa_with_reference(phoenix_client, start_time=one_minute_ago)
+retriever_spans_df = get_retrieved_documents(phoenix_client, start_time=one_minute_ago)
+eval_model = OpenAIModel(
+    model_name="gpt-4-turbo-preview",
+)
+hallucination_evaluator = HallucinationEvaluator(eval_model)
+qa_correctness_evaluator = QAEvaluator(eval_model)
+relevance_evaluator = RelevanceEvaluator(eval_model)
+[hallucination_evals_df, qa_correctness_evals_df] = run_evals(
+    qa_spans_df,
+    [hallucination_evaluator, qa_correctness_evaluator],
+)
+relevance_evals_df = run_evals(
+    retriever_spans_df,
+    [relevance_evaluator],
+)[0]
+phoenix_client.log_evaluations(
+    SpanEvaluations(eval_name="Hallucination", dataframe=hallucination_evals_df),
+    SpanEvaluations(eval_name="QA Correctness", dataframe=qa_correctness_evals_df),
+    DocumentEvaluations(eval_name="Relevance", dataframe=relevance_evals_df),
+)
+print("Evaluations logged to Phoenix")

--- a/examples/cron-evals/run_evals.py
+++ b/examples/cron-evals/run_evals.py
@@ -1,3 +1,4 @@
+# type: ignore
 """
 Queries Phoenix for spans within the last minute. Computes and logs evaluations
 back to Phoenix. This script is intended to run once a minute as a cron job.
@@ -17,12 +18,11 @@ from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_docu
 from phoenix.trace import DocumentEvaluations, SpanEvaluations
 
 phoenix_client = px.Client()
-one_minute_ago = datetime.now() - timedelta(
+last_eval_run_time = datetime.now() - timedelta(
     minutes=1, seconds=10
 )  # add a few seconds to ensure all spans are captured
-phoenix_client.get_spans_dataframe(start_time=one_minute_ago)
-qa_spans_df = get_qa_with_reference(phoenix_client, start_time=one_minute_ago)
-retriever_spans_df = get_retrieved_documents(phoenix_client, start_time=one_minute_ago)
+qa_spans_df = get_qa_with_reference(phoenix_client, start_time=last_eval_run_time)
+retriever_spans_df = get_retrieved_documents(phoenix_client, start_time=last_eval_run_time)
 eval_model = OpenAIModel(
     model_name="gpt-4-turbo-preview",
 )


### PR DESCRIPTION
Adds example using `cron` for online Phoenix evals.

resolves #2614 