### PR TITLE
feat: Add `response_format` argument to `MistralAIModel`

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -28,6 +28,7 @@ class MistralAIModel(BaseModel):
     temperature: float = 0
     top_p: Optional[float] = None
     random_seed: Optional[int] = None
+    response_format: Optional[Dict[str, str]] = None
     safe_mode: bool = False
     safe_prompt: bool = False
 
@@ -71,6 +72,7 @@ class MistralAIModel(BaseModel):
             "random_seed": self.random_seed,
             "safe_mode": self.safe_mode,
             "safe_prompt": self.safe_prompt,
+            "response_format": self.response_format,
         }
         # Mistral is strict about not passing None values to the API
         return {k: v for k, v in params.items() if v is not None}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "scipy",
   "wrapt",
   "sortedcontainers",
-  "protobuf>=3.20, <5.0",
+  "protobuf>=3.20, <6.0",
   "tqdm",
   "requests",
   "opentelemetry-sdk",
@@ -125,7 +125,7 @@ dependencies = [
   "openai>=1.0.0",
   "tenacity",
   "requests",
-  "protobuf==3.20",  # version minimum (for tests)
+  "protobuf>=3.20",  # version minimum (for tests)
   "responses",
   "tiktoken",
   "typing-extensions==4.5.0; python_version<'3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
   "openai>=1.0.0",
   "tenacity",
   "requests",
-  "protobuf>=3.20",  # version minimum (for tests)
+  "protobuf==3.20",  # version minimum (for tests)
   "responses",
   "tiktoken",
   "typing-extensions==4.5.0; python_version<'3.12'",


### PR DESCRIPTION
resolves #2658 

- Enables JSON output format: `MistralAIModel(response_format={"type": "json_object"})`