### PR TITLE
feat: convert encoder from tiktoken to anthropic tokenizer

### DIFF
--- a/src/phoenix/experimental/evals/models/anthropic.py
+++ b/src/phoenix/experimental/evals/models/anthropic.py
@@ -45,7 +45,6 @@ class AnthropicModel(BaseEvalModel):
         self._init_client()
         self._init_rate_limiter()
 
-
     def _init_client(self) -> None:
         try:
             import anthropic  # type:ignore
@@ -58,7 +57,6 @@ class AnthropicModel(BaseEvalModel):
             self._raise_import_error(
                 package_name="anthropic",
             )
-
 
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(


### PR DESCRIPTION
The tiktoken encoder has about a 10% difference in token count vs the actual anthropic encoder. May need to implement this for claude models within Bedrock model class as well if satisfied with this implementation.

![image](https://github.com/Arize-ai/phoenix/assets/91354480/52e29666-361c-4043-b7e2-0422ad0a5e0a)
