### PR TITLE
chore: update relay-compiler to v16

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       hooks:
           - id: eslint
             additional_dependencies:
-                - eslint@8.31.0
-                - eslint-plugin-react@7.31.11
+                - eslint@8.56.0
+                - eslint-plugin-react@7.33.2
                 - eslint-plugin-react-hooks@4.6.0
                 - eslint-plugin-simple-import-sort@10.0.0

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -69,7 +69,7 @@
         "graphql": "^16.8.1",
         "jest": "^29.7.0",
         "prettier": "^3.2.4",
-        "relay-compiler": "^15.0.0",
+        "relay-compiler": "^16.2.0",
         "rimraf": "^5.0.5",
         "ts-jest": "^29.1.2",
         "typescript": "5.4"
@@ -8728,9 +8728,9 @@
       }
     },
     "node_modules/relay-compiler": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
-      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-16.2.0.tgz",
+      "integrity": "sha512-KuyzUBKL9PZRNtIZWNlWEOl7OliUxaGJ2d+3mkiWEiGCEuGnNTxqEg4kJyL341aIGZC4gSqEpfvRTcMqnSM4qQ==",
       "dev": true,
       "bin": {
         "relay-compiler": "cli.js"

--- a/app/package.json
+++ b/app/package.json
@@ -66,7 +66,7 @@
     "graphql": "^16.8.1",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
-    "relay-compiler": "^15.0.0",
+    "relay-compiler": "^16.2.0",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.2",
     "typescript": "5.4"

--- a/app/relay.config.js
+++ b/app/relay.config.js
@@ -5,9 +5,10 @@ module.exports = {
   schema: "./schema.graphql",
   exclude: ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"],
   noFutureProofEnums: true,
-  customScalars: {
+  customScalarTypes: {
     GlobalID: "string",
     DateTime: "string",
     UUID: "string",
   },
+  typescriptExcludeUndefinedFromNullableUnion: true,
 };

--- a/app/src/components/form/__generated__/DimensionPickerQuery.graphql.ts
+++ b/app/src/components/form/__generated__/DimensionPickerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<606285a493f8754bd9bd14cbf56a51a5>>
+ * @generated SignedSource<<e1b9ec2115d4d844de08733e98b4b001>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest, Query } from 'relay-runtime';
 export type DimensionDataType = "categorical" | "numeric";
 export type DimensionType = "actual" | "feature" | "prediction" | "tag";
-export type DimensionPickerQuery$variables = {};
+export type DimensionPickerQuery$variables = Record<PropertyKey, never>;
 export type DimensionPickerQuery$data = {
   readonly model: {
     readonly dimensions: {

--- a/app/src/pages/__generated__/ModelRootQuery.graphql.ts
+++ b/app/src/pages/__generated__/ModelRootQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<083ba2eb212036ac9357be1a0300ed8d>>
+ * @generated SignedSource<<df662386f58467849411bb66b59ea668>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type ModelRootQuery$variables = {};
+export type ModelRootQuery$variables = Record<PropertyKey, never>;
 export type ModelRootQuery$data = {
   readonly model: {
     readonly corpusDataset: {

--- a/app/src/pages/embedding/__generated__/EmbeddingPageModelQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/EmbeddingPageModelQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4a8bd4197880c4cc52531fc9bde7c3a5>>
+ * @generated SignedSource<<c1c1ddc4e1064fa3fb7ae65dfe48eada>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type EmbeddingPageModelQuery$variables = {};
+export type EmbeddingPageModelQuery$variables = Record<PropertyKey, never>;
 export type EmbeddingPageModelQuery$data = {
   readonly model: {
     readonly " $fragmentSpreads": FragmentRefs<"MetricSelector_dimensions">;

--- a/app/src/pages/embedding/__generated__/ExportSelectionButtonExportsQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/ExportSelectionButtonExportsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f7ee9d3574969ba690b28c0473c3959f>>
+ * @generated SignedSource<<28eea2320d6b7e29ea9d04c777c2fbc8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type ExportSelectionButtonExportsQuery$variables = {};
+export type ExportSelectionButtonExportsQuery$variables = Record<PropertyKey, never>;
 export type ExportSelectionButtonExportsQuery$data = {
   readonly model: {
     readonly exportedFiles: ReadonlyArray<{

--- a/app/src/pages/home/__generated__/homeLoaderQuery.graphql.ts
+++ b/app/src/pages/home/__generated__/homeLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e3048861c5e55f2679f7a8ee3fe10b80>>
+ * @generated SignedSource<<fd029bdb4d270e271279fce055881bec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type homeLoaderQuery$variables = {};
+export type homeLoaderQuery$variables = Record<PropertyKey, never>;
 export type homeLoaderQuery$data = {
   readonly functionality: {
     readonly modelInferences: boolean;

--- a/app/src/pages/project/__generated__/DocumentEvaluationSummaryValueFragment.graphql.ts
+++ b/app/src/pages/project/__generated__/DocumentEvaluationSummaryValueFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fab02541ae0d031779d474322c75e4f>>
+ * @generated SignedSource<<19c61ceac4056cca0c2bff5682151edc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -41,7 +41,10 @@ const node: ReaderFragment = {
         "node"
       ],
       "operation": require('./DocumentEvaluationSummaryValueQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "DocumentEvaluationSummaryValueFragment",

--- a/app/src/pages/project/__generated__/EvaluationSummaryValueFragment.graphql.ts
+++ b/app/src/pages/project/__generated__/EvaluationSummaryValueFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14afc41c1acf9b4706d6f096affa7151>>
+ * @generated SignedSource<<5e5050afba9dd8829f06272a77edb108>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,7 +42,10 @@ const node: ReaderFragment = {
         "node"
       ],
       "operation": require('./EvaluationSummaryValueQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "EvaluationSummaryValueFragment",

--- a/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<be91bef1354011680eb90dfb7a005548>>
+ * @generated SignedSource<<655195ee2a990f0154d96938251c2da0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,7 +35,10 @@ const node: ReaderFragment = {
         "node"
       ],
       "operation": require('./ProjectPageHeaderQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "ProjectPageHeader_stats",

--- a/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7f4ad0f33e1ac0edcd6008a44ce15006>>
+ * @generated SignedSource<<0b2861c5a2cc6e2f649c1564ee5f256d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -137,7 +137,10 @@ return {
         "node"
       ],
       "operation": require('./SpansTableSpansQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "SpansTable_spans",

--- a/app/src/pages/project/__generated__/StreamToggle_data.graphql.ts
+++ b/app/src/pages/project/__generated__/StreamToggle_data.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f0657e3c6c1e4c08c7c88f0fc67c6ed>>
+ * @generated SignedSource<<8f6740670ce6512aed19576112040735>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,7 +30,10 @@ const node: ReaderFragment = {
         "node"
       ],
       "operation": require('./StreamToggleRefetchQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "StreamToggle_data",

--- a/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<669fadd557967601f1d3d6e603c65b08>>
+ * @generated SignedSource<<95617f92540c861c4d8cc55a7b6132df>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -305,7 +305,10 @@ return {
         "node"
       ],
       "operation": require('./TracesTableQuery.graphql'),
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "TracesTable_spans",

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2c9707b0817fb1bc0e644965182e5929>>
+ * @generated SignedSource<<a11a4115d282f83774109ca2b565cfdb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ProjectsPageProjectsQuery$variables = {};
+export type ProjectsPageProjectsQuery$variables = Record<PropertyKey, never>;
 export type ProjectsPageProjectsQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"ProjectsPageProjectsFragment">;
 };

--- a/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9f79904b7377a8ede887d780c96232af>>
+ * @generated SignedSource<<59e92b9a89860706c2a220c48b2eeb84>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ProjectsPageQuery$variables = {};
+export type ProjectsPageQuery$variables = Record<PropertyKey, never>;
 export type ProjectsPageQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"ProjectsPageProjectsFragment">;
 };


### PR DESCRIPTION
- updates `relay-compiler` to 16.2.0
- updates eslint versions used in pre-commit hooks to match the lower bounds defined in `package.json`
- migrates `relay.config.js`
    - `customScalars` -> `customScalarTypes` (https://github.com/facebook/relay/releases/tag/v16.2.0)
    - adds `"typescriptExcludeUndefinedFromNullableUnion": true` to preserve generation of nullable types pre v16.0.0. (https://github.com/facebook/relay/releases/tag/v16.0.0)

resolves #2651
