### PR TITLE
feat: change docker base image to distroless

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ Dockerfile
 **/node_modules/
 **/.venv/
 **/__pycache__/
+src/phoenix/server/static/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,4 @@
-*
-!Dockerfile
-!app
-!src
-!README.md
-!LICENSE
-!IP_NOTICE
-!pyproject.toml
+Dockerfile
+**/node_modules/
+**/.venv/
+**/__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,16 @@ RUN pip install --target ./env .[container]
 #
 # https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#debug-images
 #
-# Append :debug to the following line to use the debug image.
-FROM python:3.11-bullseye
+# Append :debug to the following line to build the debug image.
+FROM gcr.io/distroless/python3-debian12
 WORKDIR /phoenix
-COPY --from=backend-builder /phoenix/env/ ./
+COPY --from=backend-builder /phoenix/env/ ./env
+ENV PYTHONPATH="/phoenix/env:$PYTHONPATH"
 # Export the Phoenix port.
 EXPOSE 6006
 # Export the Prometheus port.
 EXPOSE 9090
-# Run the Phoenix server.
-CMD ["python", "-m", "phoenix.server.main", "--host", "0.0.0.0", "--port", "6006", "--enable-prometheus", "True", "serve"]
+# Run the Phoenix server. Note that the ENTRYPOINT of the base image invokes
+# Python, so no explicit invocation of Python is needed here. See
+# https://github.com/GoogleContainerTools/distroless/blob/16dc4a6a33838006fe956e4c19f049ece9c18a8d/python3/BUILD#L55
+CMD ["-m", "phoenix.server.main", "--host", "0.0.0.0", "--port", "6006", "--enable-prometheus", "True", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ FROM node:20-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
-COPY ./ /phoenix/
 WORKDIR /phoenix/app/
+COPY ./app /phoenix/app
 RUN pnpm install
 RUN pnpm run build
 
@@ -33,7 +33,7 @@ RUN pnpm run build
 FROM python:3.11-bullseye as backend-builder
 WORKDIR /phoenix
 COPY ./ /phoenix/
-COPY --from=frontend-builder /phoenix/ /phoenix/
+COPY --from=frontend-builder /phoenix/src/phoenix/server/static/ /phoenix/src/phoenix/server/static/
 # Delete symbolic links used during development.
 RUN find src/ -xtype l -delete  
 RUN pip install --target ./env .[container]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 # This Dockerfile is provided for convenience if you wish to run Phoenix in a
-# container or sidecar. To use this Dockerfile, you must first build the Phoenix
-# image using the following command:
+# container or sidecar. To build the image, run the following commmand:
 # 
 # > docker build -t phoenix
 #
-# You can then run the image with the following command:
+# You can then run the image in the background with:
 #
 # > docker run -d --name phoenix -p 6006:6006 phoenix
+#
+# or in the foreground with:
+#
+# > docker run -it -p 6006:6006 phoenix
 # 
-# If you have a production use-case for phoenix, please get in touch!
-
+# How are you using Phoenix in production? Let us know!
+#
+# To get support or provide feedback, contact the team in the #phoenix-support
+# channel in the Arize AI Slack community or file an issue on GitHub:
+#
+# - https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q
+# - https://github.com/Arize-ai/phoenix/issues
 
 # This Dockerfile is a multi-stage build. The first stage builds the frontend.
 FROM node:20-slim AS frontend-builder
@@ -37,7 +45,7 @@ RUN pip install --target ./env .[container]
 #
 # > docker run --entrypoint=sh -it phoenix
 #
-# For more information, see:
+# to enter a shell. For more information, see:
 #
 # https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#debug-images
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,53 @@
-# This dockerfile is provided for convenience if you wish to run
-# Phoenix in a docker container / sidecar.
-# To use this dockerfile, you must first build the phoenix image
-# using the following command:
-# > docker build -t phoenix .
-# You can then run that image with the following command:
+# This Dockerfile is provided for convenience if you wish to run Phoenix in a
+# container or sidecar. To use this Dockerfile, you must first build the Phoenix
+# image using the following command:
+# 
+# > docker build -t phoenix
+#
+# You can then run the image with the following command:
+#
 # > docker run -d --name phoenix -p 6006:6006 phoenix
+# 
 # If you have a production use-case for phoenix, please get in touch!
 
-# Use an official Python runtime as a parent image
-FROM python:3.10-slim as builder
 
-# Install nodejs
-RUN apt-get update && apt-get upgrade -y &&\
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&\
-    apt-get install -y nodejs npm
+# This Dockerfile is a multi-stage build. The first stage builds the frontend.
+FROM node:20-slim AS frontend-builder
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+COPY ./ /phoenix/
+WORKDIR /phoenix/app/
+RUN pnpm install
+RUN pnpm run build
 
-# Set the phoenix directory in the container to /phoenix
+# The second stage builds the backend.
+FROM python:3.11-bullseye as backend-builder
 WORKDIR /phoenix
+COPY ./ /phoenix/
+COPY --from=frontend-builder /phoenix/ /phoenix/
+# Delete symbolic links used during development.
+RUN find src/ -xtype l -delete  
+RUN pip install --target ./env .[container]
 
-# Add the current directory contents into the container at /phoenix
-ADD . /phoenix
-
-
-# Install the app by building the typescript package
-RUN cd /phoenix/app && npm install && npm run build && rm -rf /phoenix/app
-
-FROM builder
-
-# delete symbolic links
-RUN find . -xtype l -delete
-
-# Install any needed packages
-RUN pip install .[container]
-
-# Make port 6006 available to the world outside this container
+# The production image is distroless, meaning that it is a minimal image that
+# contains only the necessary dependencies to run the application. This is
+# useful for security and performance reasons. If you need to debug the
+# container, you can build from the debug image instead and run
+#
+# > docker run --entrypoint=sh -it phoenix
+#
+# For more information, see:
+#
+# https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#debug-images
+#
+# Append :debug to the following line to use the debug image.
+FROM python:3.11-bullseye
+WORKDIR /phoenix
+COPY --from=backend-builder /phoenix/env/ ./
+# Export the Phoenix port.
 EXPOSE 6006
-
-# Prometheus
+# Export the Prometheus port.
 EXPOSE 9090
-
-# Run server.py when the container launches
-CMD ["python", "src/phoenix/server/main.py", "--host", "0.0.0.0", "--port", "6006", "--enable-prometheus", "True", "serve"]
+# Run the Phoenix server.
+CMD ["python", "-m", "phoenix.server.main", "--host", "0.0.0.0", "--port", "6006", "--enable-prometheus", "True", "serve"]


### PR DESCRIPTION
- Changes production image to distroless. This makes the image more lightweight and secure.
- Converts docker to use `pnpm`.
- Uses multi-stage builds.
- Switches up `.dockerignore` to enable better caching by ignoring `Dockerfile`. Also, since we're doing multi-stage builds, there's no need to ignore all the files, since only the built packages will wind up in the production stage.