### PR TITLE
fix(ui): broken context for markdown

### DIFF
--- a/app/src/markdown/MarkdownDisplayContext.tsx
+++ b/app/src/markdown/MarkdownDisplayContext.tsx
@@ -17,12 +17,14 @@ export type MarkdownDisplayContextType = {
 export const MarkdownDisplayContext =
   createContext<MarkdownDisplayContextType | null>(null);
 
-export function useMarkdownMode() {
-  const context = useContext(MarkdownDisplayContext);
+export function useMarkdownMode(): MarkdownDisplayContextType {
+  let context = useContext(MarkdownDisplayContext);
   if (context === null) {
-    throw new Error(
+    // eslint-disable-next-line no-console
+    console.warn(
       "useMarkdownMode must be used within a MarkdownDisplayProvider"
     );
+    context = { mode: "text", setMode: () => {} };
   }
   return context;
 }

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -681,9 +681,22 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
           ) : null}
           {hasInput ? (
             <TabPane name="Input" hidden={!hasInput}>
-              <CopyToClipboard text={input.value}>
-                <CodeBlock {...input} />
-              </CopyToClipboard>
+              <View padding="size-200">
+                <MarkdownDisplayProvider>
+                  <Card
+                    {...defaultCardProps}
+                    title="LLM Input"
+                    extra={
+                      <Flex direction="row" gap="size-100">
+                        <ConnectedMarkdownModeRadioGroup />
+                        <CopyToClipboardButton text={input.value} />
+                      </Flex>
+                    }
+                  >
+                    <CodeBlock {...input} />
+                  </Card>
+                </MarkdownDisplayProvider>
+              </View>
             </TabPane>
           ) : null}
           {hasPromptTemplateObject ? (
@@ -752,9 +765,8 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
                 <View padding="size-200">
                   <MarkdownDisplayProvider>
                     <Card
+                      {...defaultCardProps}
                       title="LLM Output"
-                      collapsible
-                      variant="compact"
                       extra={
                         <Flex direction="row" gap="size-100">
                           <ConnectedMarkdownModeRadioGroup />


### PR DESCRIPTION
Had broken context when using markdown that was causing an error to throw. Made the context fault tolerent.