### PR TITLE
feat(persistence): experimental bulk inserter for spans

### DIFF
--- a/src/phoenix/db/alembic.ini
+++ b/src/phoenix/db/alembic.ini
@@ -94,17 +94,17 @@ keys = console
 keys = generic
 
 [logger_root]
-level = DEBUG
+level = WARN
 handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = DEBUG
+level = WARN
 handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = DEBUG
+level = WARN
 handlers =
 qualname = alembic
 

--- a/src/phoenix/db/bulk_inserter.py
+++ b/src/phoenix/db/bulk_inserter.py
@@ -1,0 +1,177 @@
+import asyncio
+import logging
+from itertools import islice
+from time import time
+from typing import Any, AsyncContextManager, Callable, Iterable, List, Optional, Tuple, cast
+
+from openinference.semconv.trace import SpanAttributes
+from sqlalchemy import func, insert, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from phoenix.db import models
+from phoenix.trace.schemas import Span, SpanStatusCode
+
+logger = logging.getLogger(__name__)
+
+
+class SpansBulkInserter:
+    def __init__(
+        self,
+        db: Callable[[], AsyncContextManager[AsyncSession]],
+        initial_batch: Optional[Iterable[Tuple[Span, str]]] = None,
+        sleep_seconds: float = 0.5,
+        max_num_spans_per_transaction: int = 100,
+    ) -> None:
+        self._db = db
+        self._running = False
+        self._sleep_seconds = sleep_seconds
+        self._max_num_spans_per_transaction = max_num_spans_per_transaction
+        self._batch: List[Tuple[Span, str]] = [] if initial_batch is None else list(initial_batch)
+        self._task: Optional[asyncio.Task[None]] = None
+
+    async def __aenter__(self) -> Callable[[Span, str], None]:
+        self._running = True
+        self._task = asyncio.create_task(self._insert_spans())
+        return self._queue_span
+
+    async def __aexit__(self, *args: Any) -> None:
+        self._running = False
+
+    def _queue_span(self, span: Span, project_name: str) -> None:
+        self._batch.append((span, project_name))
+
+    async def _insert_spans(self) -> None:
+        next_run_at = time() + self._sleep_seconds
+        while self._batch or self._running:
+            await asyncio.sleep(next_run_at - time())
+            next_run_at = time() + self._sleep_seconds
+            if not self._batch:
+                continue
+            batch = self._batch
+            self._batch = []
+            for i in range(0, len(batch), self._max_num_spans_per_transaction):
+                try:
+                    async with self._db() as session:
+                        for span, project_name in islice(
+                            batch, i, i + self._max_num_spans_per_transaction
+                        ):
+                            try:
+                                async with session.begin_nested():
+                                    await _insert_span(session, span, project_name)
+                            except Exception:
+                                logger.exception(
+                                    f"Failed to insert span with span_id={span.context.span_id}"
+                                )
+                except Exception:
+                    logger.exception("Failed to insert spans")
+
+
+async def _insert_span(session: AsyncSession, span: Span, project_name: str) -> None:
+    if await session.scalar(select(1).where(models.Span.span_id == span.context.span_id)):
+        # Span already exists
+        return
+    if not (
+        project_rowid := await session.scalar(
+            select(models.Project.id).where(models.Project.name == project_name)
+        )
+    ):
+        project_rowid = await session.scalar(
+            insert(models.Project).values(name=project_name).returning(models.Project.id)
+        )
+    if trace := await session.scalar(
+        select(models.Trace).where(models.Trace.trace_id == span.context.trace_id)
+    ):
+        trace_rowid = trace.id
+        # TODO(persistence): Figure out how to reliably retrieve timezone-aware
+        # datetime from the (sqlite) database, because all datetime in our
+        # programs should be timezone-aware.
+        if span.start_time < trace.start_time or trace.end_time < span.end_time:
+            trace.start_time = min(trace.start_time, span.start_time)
+            trace.end_time = max(trace.end_time, span.end_time)
+            await session.execute(
+                update(models.Trace)
+                .where(models.Trace.id == trace_rowid)
+                .values(
+                    start_time=min(trace.start_time, span.start_time),
+                    end_time=max(trace.end_time, span.end_time),
+                )
+            )
+    else:
+        trace_rowid = cast(
+            int,
+            await session.scalar(
+                insert(models.Trace)
+                .values(
+                    project_rowid=project_rowid,
+                    trace_id=span.context.trace_id,
+                    start_time=span.start_time,
+                    end_time=span.end_time,
+                )
+                .returning(models.Trace.id)
+            ),
+        )
+    cumulative_error_count = int(span.status_code is SpanStatusCode.ERROR)
+    cumulative_llm_token_count_prompt = cast(
+        int, span.attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, 0)
+    )
+    cumulative_llm_token_count_completion = cast(
+        int, span.attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, 0)
+    )
+    if accumulation := (
+        await session.execute(
+            select(
+                func.sum(models.Span.cumulative_error_count),
+                func.sum(models.Span.cumulative_llm_token_count_prompt),
+                func.sum(models.Span.cumulative_llm_token_count_completion),
+            ).where(models.Span.parent_span_id == span.context.span_id)
+        )
+    ).first():
+        cumulative_error_count += cast(int, accumulation[0] or 0)
+        cumulative_llm_token_count_prompt += cast(int, accumulation[1] or 0)
+        cumulative_llm_token_count_completion += cast(int, accumulation[2] or 0)
+    latency_ms = (span.end_time - span.start_time).total_seconds() * 1000
+    session.add(
+        models.Span(
+            span_id=span.context.span_id,
+            trace_rowid=trace_rowid,
+            parent_span_id=span.parent_id,
+            kind=span.span_kind.value,
+            name=span.name,
+            start_time=span.start_time,
+            end_time=span.end_time,
+            attributes=span.attributes,
+            events=span.events,
+            status=span.status_code.value,
+            status_message=span.status_message,
+            latency_ms=latency_ms,
+            cumulative_error_count=cumulative_error_count,
+            cumulative_llm_token_count_prompt=cumulative_llm_token_count_prompt,
+            cumulative_llm_token_count_completion=cumulative_llm_token_count_completion,
+        )
+    )
+    # Propagate cumulative values to ancestors. This is usually a no-op, since
+    # the parent usually arrives after the child. But in the event that a
+    # child arrives after its parent, we need to make sure the all the
+    # ancestors' cumulative values are updated.
+    ancestors = (
+        select(models.Span.id, models.Span.parent_span_id)
+        .where(models.Span.span_id == span.parent_id)
+        .cte(recursive=True)
+    )
+    child = ancestors.alias()
+    ancestors = ancestors.union_all(
+        select(models.Span.id, models.Span.parent_span_id).join(
+            child, models.Span.span_id == child.c.parent_span_id
+        )
+    )
+    await session.execute(
+        update(models.Span)
+        .where(models.Span.id.in_(select(ancestors.c.id)))
+        .values(
+            cumulative_error_count=models.Span.cumulative_error_count + cumulative_error_count,
+            cumulative_llm_token_count_prompt=models.Span.cumulative_llm_token_count_prompt
+            + cumulative_llm_token_count_prompt,
+            cumulative_llm_token_count_completion=models.Span.cumulative_llm_token_count_completion
+            + cumulative_llm_token_count_completion,
+        )
+    )

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -33,7 +33,12 @@ def aiosqlite_engine(
     engine = create_async_engine(url=url, echo=echo, json_serializer=_dumps)
     event.listen(engine.sync_engine, "connect", set_sqlite_pragma)
     if str(database) == ":memory:":
-        asyncio.run(init_models(engine))
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(init_models(engine))
+        else:
+            asyncio.create_task(init_models(engine))
     else:
         migrate(url)
     return engine

--- a/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
+++ b/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
@@ -25,10 +25,15 @@ def upgrade() -> None:
         # TODO does the uniqueness constraint need to be named
         sa.Column("name", sa.String, nullable=False, unique=True),
         sa.Column("description", sa.String, nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
         sa.Column(
             "updated_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.func.now(),
             onupdate=sa.func.now(),
@@ -41,8 +46,8 @@ def upgrade() -> None:
         # TODO(mikeldking): might not be the right place for this
         sa.Column("session_id", sa.String, nullable=True),
         sa.Column("trace_id", sa.String, nullable=False, unique=True),
-        sa.Column("start_time", sa.DateTime(), nullable=False, index=True),
-        sa.Column("end_time", sa.DateTime(), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=False),
     )
 
     op.create_table(
@@ -53,8 +58,8 @@ def upgrade() -> None:
         sa.Column("parent_span_id", sa.String, nullable=True, index=True),
         sa.Column("name", sa.String, nullable=False),
         sa.Column("kind", sa.String, nullable=False),
-        sa.Column("start_time", sa.DateTime(), nullable=False),
-        sa.Column("end_time", sa.DateTime(), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=False),
         sa.Column("attributes", sa.JSON, nullable=False),
         sa.Column("events", sa.JSON, nullable=False),
         sa.Column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import (
 
 class UtcTimeStamp(TypeDecorator[datetime]):
     """TODO(persistence): Figure out how to reliably store and retrieve
-    timezone-aware datetime objects from the (sqlite) database. This is a
+    timezone-aware datetime objects from the (sqlite) database. Below is a
     workaround to guarantee that the timestamps we fetch from the database is
     always timezone-aware, in order to prevent comparisons of timezone-naive
     datetime with timezone-aware datetime, because objects in the rest of our

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -1,12 +1,14 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import (
     JSON,
     CheckConstraint,
     DateTime,
+    Dialect,
     ForeignKey,
     MetaData,
+    TypeDecorator,
     UniqueConstraint,
     func,
     insert,
@@ -19,6 +21,42 @@ from sqlalchemy.orm import (
     mapped_column,
     relationship,
 )
+
+
+class UtcTimeStamp(TypeDecorator[datetime]):
+    """TODO(persistence): Figure out how to reliably store and retrieve
+    timezone-aware datetime objects from the (sqlite) database. This is a
+    workaround to guarantee that the timestamps we fetch from the database is
+    always timezone-aware, in order to prevent comparisons of timezone-naive
+    datetime with timezone-aware datetime, because objects in the rest of our
+    programs are always timezone-aware.
+    """
+
+    cache_ok = True
+    impl = DateTime
+    _LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
+
+    def process_bind_param(
+        self,
+        value: Optional[datetime],
+        dialect: Dialect,
+    ) -> Optional[datetime]:
+        if not value:
+            return None
+        if value.tzinfo is None:
+            value = value.astimezone(self._LOCAL_TIMEZONE)
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(
+        self,
+        value: Optional[Any],
+        dialect: Dialect,
+    ) -> Optional[datetime]:
+        if not isinstance(value, datetime):
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 class Base(DeclarativeBase):
@@ -44,9 +82,9 @@ class Project(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
     description: Mapped[Optional[str]]
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
 
     traces: WriteOnlyMapped["Trace"] = relationship(
@@ -69,8 +107,8 @@ class Trace(Base):
     project_rowid: Mapped[int] = mapped_column(ForeignKey("projects.id"))
     session_id: Mapped[Optional[str]]
     trace_id: Mapped[str]
-    start_time: Mapped[datetime] = mapped_column(DateTime(), index=True)
-    end_time: Mapped[datetime] = mapped_column(DateTime())
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
+    end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
 
     project: Mapped["Project"] = relationship(
         "Project",
@@ -98,8 +136,8 @@ class Span(Base):
     parent_span_id: Mapped[Optional[str]] = mapped_column(index=True)
     name: Mapped[str]
     kind: Mapped[str]
-    start_time: Mapped[datetime] = mapped_column(DateTime())
-    end_time: Mapped[datetime] = mapped_column(DateTime())
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
+    end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
     attributes: Mapped[Dict[str, Any]]
     events: Mapped[List[Dict[str, Any]]]
     status: Mapped[str] = mapped_column(

--- a/src/phoenix/server/api/routers/trace_handler.py
+++ b/src/phoenix/server/api/routers/trace_handler.py
@@ -1,31 +1,25 @@
 import asyncio
 import gzip
 import zlib
-from typing import AsyncContextManager, Callable, Optional, cast
+from typing import Optional
 
 from google.protobuf.message import DecodeError
-from openinference.semconv.trace import SpanAttributes
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
 )
 from opentelemetry.proto.trace.v1.trace_pb2 import TracesData
-from sqlalchemy import func, insert, select, text, update
-from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.status import HTTP_415_UNSUPPORTED_MEDIA_TYPE, HTTP_422_UNPROCESSABLE_ENTITY
 
 from phoenix.core.traces import Traces
-from phoenix.db import models
 from phoenix.storage.span_store import SpanStore
 from phoenix.trace.otel import decode
-from phoenix.trace.schemas import Span, SpanStatusCode
 from phoenix.utilities.project import get_project_name
 
 
 class TraceHandler(HTTPEndpoint):
-    db: Callable[[], AsyncContextManager[AsyncSession]]
     traces: Traces
     store: Optional[SpanStore]
 
@@ -62,109 +56,13 @@ class TraceHandler(HTTPEndpoint):
             for scope_span in resource_spans.scope_spans:
                 for otlp_span in scope_span.spans:
                     span = decode(otlp_span)
-                    async with self.db() as session:
-                        await _insert_span(session, span, project_name)
+                    # TODO(persistence): Decide which one is better: delayed
+                    # bulk-insert or insert each request immediately, i.e. one
+                    # transaction per request. The bulk-insert is more efficient,
+                    # but it queues data in volatile (buffer) memory (for a short
+                    # period of time), so the 200 response is not a genuine
+                    # confirmation of data persistence.
+                    request.state.queue_span_for_bulk_insert(span, project_name)
                     self.traces.put(span, project_name=project_name)
                     await asyncio.sleep(0)
         return Response()
-
-
-async def _insert_span(session: AsyncSession, span: Span, project_name: str) -> None:
-    if not (
-        project_rowid := await session.scalar(
-            select(models.Project.id).filter(models.Project.name == project_name)
-        )
-    ):
-        project_rowid = await session.scalar(
-            insert(models.Project).values(name=project_name).returning(models.Project.id)
-        )
-    if (
-        trace_rowid := await session.scalar(
-            text(
-                """
-                INSERT INTO traces(trace_id, project_rowid, session_id, start_time, end_time)
-                VALUES(:trace_id, :project_rowid, :session_id, :start_time, :end_time)
-                ON CONFLICT DO UPDATE SET
-                start_time = CASE WHEN excluded.start_time < start_time THEN excluded.start_time ELSE start_time END,
-                end_time = CASE WHEN end_time < excluded.end_time THEN excluded.end_time ELSE end_time END
-                WHERE excluded.start_time < start_time OR end_time < excluded.end_time
-                RETURNING rowid;
-                """  # noqa E501
-            ),
-            {
-                "trace_id": span.context.trace_id,
-                "project_rowid": project_rowid,
-                "session_id": None,
-                "start_time": span.start_time,
-                "end_time": span.end_time,
-            },
-        )
-    ) is None:
-        trace_rowid = await session.scalar(
-            select(models.Trace.id).filter(models.Trace.trace_id == span.context.trace_id)
-        )
-    cumulative_error_count = int(span.status_code is SpanStatusCode.ERROR)
-    cumulative_llm_token_count_prompt = cast(
-        int, span.attributes.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, 0)
-    )
-    cumulative_llm_token_count_completion = cast(
-        int, span.attributes.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, 0)
-    )
-    if accumulation := (
-        await session.execute(
-            select(
-                func.sum(models.Span.cumulative_error_count),
-                func.sum(models.Span.cumulative_llm_token_count_prompt),
-                func.sum(models.Span.cumulative_llm_token_count_completion),
-            ).where(models.Span.parent_span_id == span.context.span_id)
-        )
-    ).first():
-        cumulative_error_count += cast(int, accumulation[0] or 0)
-        cumulative_llm_token_count_prompt += cast(int, accumulation[1] or 0)
-        cumulative_llm_token_count_completion += cast(int, accumulation[2] or 0)
-    latency_ms = (span.end_time - span.start_time).total_seconds() * 1000
-    session.add(
-        models.Span(
-            span_id=span.context.span_id,
-            trace_rowid=trace_rowid,
-            parent_span_id=span.parent_id,
-            kind=span.span_kind.value,
-            name=span.name,
-            start_time=span.start_time,
-            end_time=span.end_time,
-            attributes=span.attributes,
-            events=span.events,
-            status=span.status_code.value,
-            status_message=span.status_message,
-            latency_ms=latency_ms,
-            cumulative_error_count=cumulative_error_count,
-            cumulative_llm_token_count_prompt=cumulative_llm_token_count_prompt,
-            cumulative_llm_token_count_completion=cumulative_llm_token_count_completion,
-        )
-    )
-    # Propagate cumulative values to ancestors. This is usually a no-op, since
-    # the parent usually arrives after the child. But in the event that a
-    # child arrives after its parent, we need to make sure the all the
-    # ancestors' cumulative values are updated.
-    ancestors = (
-        select(models.Span.id, models.Span.parent_span_id)
-        .where(models.Span.span_id == span.parent_id)
-        .cte(recursive=True)
-    )
-    child = ancestors.alias()
-    ancestors = ancestors.union_all(
-        select(models.Span.id, models.Span.parent_span_id).join(
-            child, models.Span.span_id == child.c.parent_span_id
-        )
-    )
-    await session.execute(
-        update(models.Span)
-        .where(models.Span.id.in_(select(ancestors.c.id)))
-        .values(
-            cumulative_error_count=models.Span.cumulative_error_count + cumulative_error_count,
-            cumulative_llm_token_count_prompt=models.Span.cumulative_llm_token_count_prompt
-            + cumulative_llm_token_count_prompt,
-            cumulative_llm_token_count_completion=models.Span.cumulative_llm_token_count_completion
-            + cumulative_llm_token_count_completion,
-        )
-    )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -6,8 +6,11 @@ from typing import (
     AsyncContextManager,
     AsyncIterator,
     Callable,
+    Dict,
+    Iterable,
     NamedTuple,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -27,15 +30,16 @@ from starlette.responses import FileResponse, PlainTextResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
-from starlette.types import Scope
+from starlette.types import Scope, StatefulLifespan
 from starlette.websockets import WebSocket
 from strawberry.asgi import GraphQL
 from strawberry.schema import BaseSchema
 
 import phoenix
-from phoenix.config import SERVER_DIR
+from phoenix.config import DEFAULT_PROJECT_NAME, SERVER_DIR
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
+from phoenix.db.bulk_inserter import SpansBulkInserter
 from phoenix.pointcloud.umap_parameters import UMAPParameters
 from phoenix.server.api.context import Context
 from phoenix.server.api.routers.evaluation_handler import EvaluationHandler
@@ -43,6 +47,7 @@ from phoenix.server.api.routers.span_handler import SpanHandler
 from phoenix.server.api.routers.trace_handler import TraceHandler
 from phoenix.server.api.schema import schema
 from phoenix.storage.span_store import SpanStore
+from phoenix.trace.schemas import Span
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +175,18 @@ def _db(engine: AsyncEngine) -> Callable[[], AsyncContextManager[AsyncSession]]:
     return factory
 
 
+def _lifespan(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    initial_batch_of_spans: Optional[Iterable[Tuple[Span, str]]] = None,
+) -> StatefulLifespan[Starlette]:
+    @contextlib.asynccontextmanager
+    async def lifespan(_: Starlette) -> AsyncIterator[Dict[str, Any]]:
+        async with SpansBulkInserter(db, initial_batch_of_spans) as queue_span:
+            yield {"queue_span_for_bulk_insert": queue_span}
+
+    return lifespan
+
+
 def create_app(
     engine: AsyncEngine,
     export_path: Path,
@@ -181,7 +198,16 @@ def create_app(
     debug: bool = False,
     read_only: bool = False,
     enable_prometheus: bool = False,
+    initial_spans: Optional[Iterable[Union[Span, Tuple[Span, str]]]] = None,
 ) -> Starlette:
+    initial_batch_of_spans: Iterable[Tuple[Span, str]] = (
+        ()
+        if initial_spans is None
+        else (
+            ((item, DEFAULT_PROJECT_NAME) if isinstance(item, Span) else item)
+            for item in initial_spans
+        )
+    )
     db = _db(engine)
     graphql = GraphQLWithContext(
         db=db,
@@ -199,6 +225,7 @@ def create_app(
     else:
         prometheus_middlewares = []
     return Starlette(
+        lifespan=_lifespan(db, initial_batch_of_spans),
         middleware=[
             Middleware(HeadersMiddleware),
             *prometheus_middlewares,
@@ -217,7 +244,7 @@ def create_app(
                     type(
                         "TraceEndpoint",
                         (TraceHandler,),
-                        {"db": staticmethod(db), "traces": traces, "store": span_store},
+                        {"traces": traces, "store": span_store},
                     ),
                 ),
                 Route(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -39,7 +39,7 @@ import phoenix
 from phoenix.config import DEFAULT_PROJECT_NAME, SERVER_DIR
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
-from phoenix.db.bulk_inserter import SpansBulkInserter
+from phoenix.db.bulk_inserter import BulkInserter
 from phoenix.pointcloud.umap_parameters import UMAPParameters
 from phoenix.server.api.context import Context
 from phoenix.server.api.routers.evaluation_handler import EvaluationHandler
@@ -181,7 +181,7 @@ def _lifespan(
 ) -> StatefulLifespan[Starlette]:
     @contextlib.asynccontextmanager
     async def lifespan(_: Starlette) -> AsyncIterator[Dict[str, Any]]:
-        async with SpansBulkInserter(db, initial_batch_of_spans) as queue_span:
+        async with BulkInserter(db, initial_batch_of_spans) as queue_span:
             yield {"queue_span_for_bulk_insert": queue_span}
 
     return lifespan
@@ -241,11 +241,7 @@ def create_app(
                 ),
                 Route(
                     "/v1/traces",
-                    type(
-                        "TraceEndpoint",
-                        (TraceHandler,),
-                        {"traces": traces, "store": span_store},
-                    ),
+                    type("TraceEndpoint", (TraceHandler,), {"traces": traces, "store": span_store}),
                 ),
                 Route(
                     "/v1/evaluations",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -1,5 +1,4 @@
 import atexit
-import gzip
 import logging
 import os
 from argparse import ArgumentParser
@@ -10,9 +9,6 @@ from time import sleep, time
 from typing import Iterable, Optional, Protocol, TypeVar
 
 import pkg_resources
-import requests
-from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
-from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans
 from uvicorn import Config, Server
 
 from phoenix.config import (
@@ -42,7 +38,6 @@ from phoenix.trace.fixtures import (
     get_evals_from_fixture,
 )
 from phoenix.trace.otel import decode, encode
-from phoenix.trace.schemas import Span
 from phoenix.trace.span_json_decoder import json_string_to_span
 from phoenix.utilities.span_store import get_span_store, load_traces_data_from_store
 
@@ -113,26 +108,26 @@ def _load_items(
         queue.put(item)
 
 
-def _send_spans(spans: Iterable[Span], url: str) -> None:
-    # TODO(persistence): Ingest fixtures without networking for read-only deployments
-    sleep(5)  # Wait for the server to start
-    session = requests.session()
-    for span in spans:
-        req = ExportTraceServiceRequest(
-            resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=[encode(span)])])]
-        )
-        session.post(
-            url=url,
-            headers={
-                "content-type": "application/x-protobuf",
-                "content-encoding": "gzip",
-            },
-            data=gzip.compress(req.SerializeToString()),
-        )
-        # TODO(persistence): If ingestion rate is too high it can crash the UI, because
-        # sqlite is not designed for high concurrency, especially for disk
-        # persistence.
-        sleep(0.2)
+# TODO(persistence): Delete the commented-out code below
+# def _send_spans(spans: Iterable[Span], url: str) -> None:
+#     sleep(5)  # Wait for the server to start
+#
+#     def _send(span: Span) -> None:
+#         req = ExportTraceServiceRequest(
+#             resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=[encode(span)])])]
+#         )
+#         requests.post(
+#             url=url,
+#             headers={
+#                 "content-type": "application/x-protobuf",
+#                 "content-encoding": "gzip",
+#             },
+#             data=gzip.compress(req.SerializeToString()),
+#         )
+#
+#     # stress test the server by sending multiple spans concurrently
+#     with ThreadPoolExecutor(max_workers=50) as executor:
+#         executor.map(_send, spans)
 
 
 DEFAULT_UMAP_PARAMS_STR = f"{DEFAULT_MIN_DIST},{DEFAULT_N_NEIGHBORS},{DEFAULT_N_SAMPLES}"
@@ -229,6 +224,7 @@ if __name__ == "__main__":
     traces = Traces()
     if span_store := get_span_store():
         Thread(target=load_traces_data_from_store, args=(traces, span_store), daemon=True).start()
+    fixture_spans = []
     if trace_dataset_name is not None:
         fixture_spans = list(
             # Apply `encode` here because legacy jsonl files contains UUIDs as strings.
@@ -243,11 +239,12 @@ if __name__ == "__main__":
             args=(traces, fixture_spans, simulate_streaming),
             daemon=True,
         ).start()
-        Thread(
-            target=_send_spans,
-            args=(fixture_spans, f"http://{host}:{port}/v1/traces"),
-            daemon=True,
-        ).start()
+        # TODO(persistence): Delete the commented-out code below
+        # Thread(
+        #     target=_send_spans,
+        #     args=(fixture_spans, f"http://{host}:{port}/v1/traces"),
+        #     daemon=True,
+        # ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
         Thread(
             target=_load_items,
@@ -280,6 +277,7 @@ if __name__ == "__main__":
         read_only=read_only,
         span_store=span_store,
         enable_prometheus=enable_prometheus,
+        initial_spans=fixture_spans,
     )
     server = Server(config=Config(app, host=host, port=port))
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -109,28 +109,6 @@ def _load_items(
         queue.put(item)
 
 
-# TODO(persistence): Delete the commented-out code below
-# def _send_spans(spans: Iterable[Span], url: str) -> None:
-#     sleep(5)  # Wait for the server to start
-#
-#     def _send(span: Span) -> None:
-#         req = ExportTraceServiceRequest(
-#             resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=[encode(span)])])]
-#         )
-#         requests.post(
-#             url=url,
-#             headers={
-#                 "content-type": "application/x-protobuf",
-#                 "content-encoding": "gzip",
-#             },
-#             data=gzip.compress(req.SerializeToString()),
-#         )
-#
-#     # stress test the server by sending multiple spans concurrently
-#     with ThreadPoolExecutor(max_workers=50) as executor:
-#         executor.map(_send, spans)
-
-
 DEFAULT_UMAP_PARAMS_STR = f"{DEFAULT_MIN_DIST},{DEFAULT_N_NEIGHBORS},{DEFAULT_N_SAMPLES}"
 
 if __name__ == "__main__":
@@ -240,12 +218,6 @@ if __name__ == "__main__":
             args=(traces, fixture_spans, simulate_streaming),
             daemon=True,
         ).start()
-        # TODO(persistence): Delete the commented-out code below
-        # Thread(
-        #     target=_send_spans,
-        #     args=(fixture_spans, f"http://{host}:{port}/v1/traces"),
-        #     daemon=True,
-        # ).start()
         fixture_evals = list(get_evals_from_fixture(trace_dataset_name))
         Thread(
             target=_load_items,

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -317,6 +317,7 @@ class ThreadSession(Session):
             traces=self.traces,
             umap_params=self.umap_parameters,
             span_store=span_store,
+            initial_spans=trace_dataset.to_spans() if trace_dataset else None,
         )
         self.server = ThreadServer(
             app=self.app,


### PR DESCRIPTION
resolves #2806 

This PR implements the queuing method described below.

Two strategies for write transactions:
1. Each request has a separate writer.
    - Pro: Returning a 200 response means data is persisted.
    - Con: Lock contention/starvation, which is probably rare. Granular transactions are less efficient overall.
2. Queue the requests in a buffer and funnel them into a single bulk-writer.
    - Pro: Bulk writing is more efficient, and having a single writer also means no lock contention.
    - Con: Buffer is volatile an can be lost if crashed, so returning a 200 response is not a genuine confirmation of data persistence. Also, transaction errors are not propagated back the client.