### PR TITLE
feat(persistence): fetch latency_ms percentiles using sql with dataloaders

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -544,8 +544,7 @@ type Project implements Node {
   recordCount(timeRange: TimeRange): Int!
   traceCount(timeRange: TimeRange): Int!
   tokenCountTotal(timeRange: TimeRange): Int!
-  latencyMsP50: Float
-  latencyMsP99: Float
+  latencyMsQuantile(probability: Float!, timeRange: TimeRange): Float
   trace(traceId: ID!): Trace
   spans(timeRange: TimeRange, first: Int = 50, last: Int, after: String, before: String, sort: SpanSort, rootSpansOnly: Boolean, filterCondition: String): SpanConnection!
 

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -31,8 +31,8 @@ export function ProjectPageHeader(props: {
       @refetchable(queryName: "ProjectPageHeaderQuery") {
         traceCount
         tokenCountTotal
-        latencyMsP50
-        latencyMsP99
+        latencyMsP50: latencyMsQuantile(probability: 0.50)
+        latencyMsP99: latencyMsQuantile(probability: 0.99)
         spanEvaluationNames
         documentEvaluationNames
       }

--- a/app/src/pages/project/__generated__/ProjectPageHeaderQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageHeaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<17a291ff3a779b575dec13cb4a15bbb2>>
+ * @generated SignedSource<<67f3d5d708ee31ce43c3bb4ea3e77795>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,18 +115,30 @@ return {
                 "storageKey": null
               },
               {
-                "alias": null,
-                "args": null,
+                "alias": "latencyMsP50",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "probability",
+                    "value": 0.5
+                  }
+                ],
                 "kind": "ScalarField",
-                "name": "latencyMsP50",
-                "storageKey": null
+                "name": "latencyMsQuantile",
+                "storageKey": "latencyMsQuantile(probability:0.5)"
               },
               {
-                "alias": null,
-                "args": null,
+                "alias": "latencyMsP99",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "probability",
+                    "value": 0.99
+                  }
+                ],
                 "kind": "ScalarField",
-                "name": "latencyMsP99",
-                "storageKey": null
+                "name": "latencyMsQuantile",
+                "storageKey": "latencyMsQuantile(probability:0.99)"
               },
               {
                 "alias": null,
@@ -152,16 +164,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bd4c59adfff0b38f6f4357e861b797de",
+    "cacheID": "badea9b7c017c62c14b05faa2cf3fb41",
     "id": null,
     "metadata": {},
     "name": "ProjectPageHeaderQuery",
     "operationKind": "query",
-    "text": "query ProjectPageHeaderQuery(\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectPageHeader_stats\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount\n  tokenCountTotal\n  latencyMsP50\n  latencyMsP99\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n"
+    "text": "query ProjectPageHeaderQuery(\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectPageHeader_stats\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount\n  tokenCountTotal\n  latencyMsP50: latencyMsQuantile(probability: 0.5)\n  latencyMsP99: latencyMsQuantile(probability: 0.99)\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e18ca825b86a66619e25ff123f147ff4";
+(node as any).hash = "9d1c4be9bade9017039ac1969a3cda40";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<655195ee2a990f0154d96938251c2da0>>
+ * @generated SignedSource<<60ee6d98e42b7ed3d5b54cd1ea624235>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,18 +58,30 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
-      "alias": null,
-      "args": null,
+      "alias": "latencyMsP50",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "probability",
+          "value": 0.5
+        }
+      ],
       "kind": "ScalarField",
-      "name": "latencyMsP50",
-      "storageKey": null
+      "name": "latencyMsQuantile",
+      "storageKey": "latencyMsQuantile(probability:0.5)"
     },
     {
-      "alias": null,
-      "args": null,
+      "alias": "latencyMsP99",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "probability",
+          "value": 0.99
+        }
+      ],
       "kind": "ScalarField",
-      "name": "latencyMsP99",
-      "storageKey": null
+      "name": "latencyMsQuantile",
+      "storageKey": "latencyMsQuantile(probability:0.99)"
     },
     {
       "alias": null,
@@ -97,6 +109,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "e18ca825b86a66619e25ff123f147ff4";
+(node as any).hash = "9d1c4be9bade9017039ac1969a3cda40";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f149717fc7aa75fbb721bce209691f06>>
+ * @generated SignedSource<<fb5ff4cd132fcad786265e5f55fe9a8a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -595,18 +595,30 @@ return {
               },
               (v11/*: any*/),
               {
-                "alias": null,
-                "args": null,
+                "alias": "latencyMsP50",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "probability",
+                    "value": 0.5
+                  }
+                ],
                 "kind": "ScalarField",
-                "name": "latencyMsP50",
-                "storageKey": null
+                "name": "latencyMsQuantile",
+                "storageKey": "latencyMsQuantile(probability:0.5)"
               },
               {
-                "alias": null,
-                "args": null,
+                "alias": "latencyMsP99",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "probability",
+                    "value": 0.99
+                  }
+                ],
                 "kind": "ScalarField",
-                "name": "latencyMsP99",
-                "storageKey": null
+                "name": "latencyMsQuantile",
+                "storageKey": "latencyMsQuantile(probability:0.99)"
               },
               {
                 "alias": null,
@@ -632,12 +644,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "754cc7f87a17b0f1316dc0304935f306",
+    "cacheID": "0b38fd1bb1ddad11cd1022a1311949bd",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount\n  tokenCountTotal\n  latencyMsP50\n  latencyMsP99\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount\n  tokenCountTotal\n  latencyMsP50: latencyMsQuantile(probability: 0.5)\n  latencyMsP99: latencyMsQuantile(probability: 0.99)\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: 100, sort: {col: startTime, dir: desc}) {\n    edges {\n      span: node {\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value\n          mimeType\n        }\n        output {\n          value\n          mimeType\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        tokenCountTotal: cumulativeTokenCountTotal\n        tokenCountPrompt: cumulativeTokenCountPrompt\n        tokenCountCompletion: cumulativeTokenCountCompletion\n        parentId\n        input {\n          value\n        }\n        output {\n          value\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          tokenCountTotal\n          tokenCountPrompt\n          tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -50,7 +50,7 @@ export function ProjectsPage() {
               name
               traceCount
               endTime
-              latencyMsP50
+              latencyMsP50: latencyMsQuantile(probability: 0.5)
               tokenCountTotal
             }
           }

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf61c48e9978674f1d2f927e20eac561>>
+ * @generated SignedSource<<0e05e4abf89531516363c1b9be78fc68>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -95,11 +95,17 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "alias": null,
-                  "args": null,
+                  "alias": "latencyMsP50",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "probability",
+                      "value": 0.5
+                    }
+                  ],
                   "kind": "ScalarField",
-                  "name": "latencyMsP50",
-                  "storageKey": null
+                  "name": "latencyMsQuantile",
+                  "storageKey": "latencyMsQuantile(probability:0.5)"
                 },
                 {
                   "alias": null,
@@ -122,6 +128,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "cda7be8f505b3338d69dea54d66c943f";
+(node as any).hash = "b5474884a04e0ab5cfe6e8662450c2e5";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a11a4115d282f83774109ca2b565cfdb>>
+ * @generated SignedSource<<1856c23f19873995bc6669ccb27148d8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -94,11 +94,17 @@ const node: ConcreteRequest = {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
-                    "args": null,
+                    "alias": "latencyMsP50",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "probability",
+                        "value": 0.5
+                      }
+                    ],
                     "kind": "ScalarField",
-                    "name": "latencyMsP50",
-                    "storageKey": null
+                    "name": "latencyMsQuantile",
+                    "storageKey": "latencyMsQuantile(probability:0.5)"
                   },
                   {
                     "alias": null,
@@ -119,15 +125,15 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "4b63c5c0a8bec80cc1519d844376e760",
+    "cacheID": "fe62b40e1c719139a6a3b0cbf2977048",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageProjectsQuery {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount\n        endTime\n        latencyMsP50\n        tokenCountTotal\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectsPageProjectsQuery {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5)\n        tokenCountTotal\n      }\n    }\n  }\n}\n"
   }
 };
 
-(node as any).hash = "cda7be8f505b3338d69dea54d66c943f";
+(node as any).hash = "b5474884a04e0ab5cfe6e8662450c2e5";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<59e92b9a89860706c2a220c48b2eeb84>>
+ * @generated SignedSource<<ea653eac0415a464a1ceb49f5875a66b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -94,11 +94,17 @@ const node: ConcreteRequest = {
                     "storageKey": null
                   },
                   {
-                    "alias": null,
-                    "args": null,
+                    "alias": "latencyMsP50",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "probability",
+                        "value": 0.5
+                      }
+                    ],
                     "kind": "ScalarField",
-                    "name": "latencyMsP50",
-                    "storageKey": null
+                    "name": "latencyMsQuantile",
+                    "storageKey": "latencyMsQuantile(probability:0.5)"
                   },
                   {
                     "alias": null,
@@ -119,12 +125,12 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "30aa28068072e9061c720934cee3837f",
+    "cacheID": "28f9e8120b370aeaea11dc87f747e6bc",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageQuery {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount\n        endTime\n        latencyMsP50\n        tokenCountTotal\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectsPageQuery {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5)\n        tokenCountTotal\n      }\n    }\n  }\n}\n"
   }
 };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "wrapt",
   "sortedcontainers",
   "protobuf>=3.20, <6.0",
+  "ddsketch",
   "tqdm",
   "requests",
   "opentelemetry-sdk",

--- a/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
+++ b/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
@@ -48,6 +48,7 @@ def upgrade() -> None:
         sa.Column("trace_id", sa.String, nullable=False, unique=True),
         sa.Column("start_time", sa.DateTime(timezone=True), nullable=False, index=True),
         sa.Column("end_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("latency_ms", sa.Float, nullable=False),
     )
 
     op.create_table(
@@ -72,7 +73,7 @@ def upgrade() -> None:
             server_default="UNSET",
         ),
         sa.Column("status_message", sa.String, nullable=False),
-        sa.Column("latency_ms", sa.REAL, nullable=False),
+        sa.Column("latency_ms", sa.Float, nullable=False),
         sa.Column("cumulative_error_count", sa.Integer, nullable=False),
         sa.Column("cumulative_llm_token_count_prompt", sa.Integer, nullable=False),
         sa.Column("cumulative_llm_token_count_completion", sa.Integer, nullable=False),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -109,6 +109,7 @@ class Trace(Base):
     trace_id: Mapped[str]
     start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
+    latency_ms: Mapped[float]
 
     project: Mapped["Project"] = relationship(
         "Project",

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -1,14 +1,21 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncContextManager, Callable, Optional, Union
+from typing import AsyncContextManager, Callable, Optional, Tuple, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.websockets import WebSocket
+from strawberry.dataloader import DataLoader
 
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
+from phoenix.server.api.input_types.TimeRange import TimeRange
+
+
+@dataclass
+class DataLoaders:
+    latency_ms_quantile: DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]
 
 
 @dataclass
@@ -16,6 +23,7 @@ class Context:
     request: Union[Request, WebSocket]
     response: Optional[Response]
     db: Callable[[], AsyncContextManager[AsyncSession]]
+    data_loaders: DataLoaders
     model: Model
     export_path: Path
     corpus: Optional[Model] = None

--- a/src/phoenix/server/api/dataloaders.py
+++ b/src/phoenix/server/api/dataloaders.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+from typing import AsyncContextManager, Callable, DefaultDict, List, Optional, Tuple
+
+from ddsketch import ddsketch
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.dataloader import DataLoader
+
+from phoenix.db import models
+from phoenix.server.api.input_types.TimeRange import TimeRange
+
+
+class LatencyMsQuantile(DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]):
+    def __init__(
+        self,
+        db: Callable[[], AsyncContextManager[AsyncSession]],
+    ) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(
+        self,
+        keys: List[Tuple[str, Optional[TimeRange], float]],
+    ) -> List[Optional[float]]:
+        # We use ddsketch here because sqlite doesn't have percentile functions
+        # unless we compile it with the percentile.c extension, like how it's
+        # done in the Python package https://github.com/nalgeon/sqlean.py
+        results: List[Optional[float]] = [None] * len(keys)
+        arguments: DefaultDict[Tuple[str, Optional[TimeRange]], List[Tuple[int, float]]] = (
+            defaultdict(list)
+        )
+        for i, key in enumerate(keys):
+            name, time_range, probability = key
+            arguments[(name, time_range)].append((i, probability))
+        for (name, time_range), probabilities in arguments.items():
+            stmt = (
+                select(models.Trace.latency_ms)
+                .join(models.Project)
+                .where(models.Project.name == name)
+            )
+            if time_range:
+                stmt = stmt.where(
+                    and_(
+                        time_range.start <= models.Trace.start_time,
+                        models.Trace.start_time < time_range.end,
+                    )
+                )
+            sketch = ddsketch.DDSketch()
+            async with self._db() as session:
+                async for val in await session.stream_scalars(stmt):
+                    sketch.add(val)
+            for i, p in probabilities:
+                results[i] = sketch.get_quantile_value(p)
+        return results

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -2,15 +2,16 @@ from collections import defaultdict
 from typing import AsyncContextManager, Callable, DefaultDict, List, Optional, Tuple
 
 from ddsketch import ddsketch
+from phoenix.db import models
+from phoenix.server.api.input_types.TimeRange import TimeRange
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.dataloader import DataLoader
 
-from phoenix.db import models
-from phoenix.server.api.input_types.TimeRange import TimeRange
 
-
-class LatencyMsQuantile(DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]):
+class LatencyMsQuantileDataLoader(
+    DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]
+):
     def __init__(
         self,
         db: Callable[[], AsyncContextManager[AsyncSession]],

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -58,7 +58,7 @@ class LatencyMsQuantileDataLoader(DataLoader[Key, Optional[QuantileValue]]):
             segment, probability = self._cache_key_fn(key)
             arguments[segment].append((i, probability))
         async with self._db() as session:
-            for time_range_by_name, filter_condition in _get_filter_conditons(arguments.keys()):
+            for time_range_by_name, filter_condition in _get_filter_conditions(arguments.keys()):
                 stmt = (
                     select(models.Project.name, models.Trace.latency_ms)
                     .join(models.Project)
@@ -79,7 +79,7 @@ class LatencyMsQuantileDataLoader(DataLoader[Key, Optional[QuantileValue]]):
         return results
 
 
-def _get_filter_conditons(
+def _get_filter_conditions(
     keys: Iterable[Segment],
 ) -> Iterator[Tuple[Dict[ProjectName, TimeInterval], OrmExpression]]:
     """

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -55,7 +55,9 @@ class LatencyMsQuantileDataLoader(DataLoader[Key, Optional[QuantileValue]]):
         async with self._db() as session:
             for segment, probabilities in arguments.items():
                 stmt = (
-                    select(models.Trace.latency_ms).join(models.Project).where(_get_expr(segment))
+                    select(models.Trace.latency_ms)
+                    .join(models.Project)
+                    .where(_get_filter_condition(segment))
                 )
                 sketch = sketches[segment]
                 async for val in await session.stream_scalars(stmt):
@@ -65,7 +67,7 @@ class LatencyMsQuantileDataLoader(DataLoader[Key, Optional[QuantileValue]]):
         return results
 
 
-def _get_expr(segment: Segment) -> OrmExpression:
+def _get_filter_condition(segment: Segment) -> OrmExpression:
     name, (start_time, stop_time) = segment
     if start_time and stop_time:
         return and_(

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -1,55 +1,125 @@
 from collections import defaultdict
-from typing import AsyncContextManager, Callable, DefaultDict, List, Optional, Tuple
+from datetime import datetime
+from itertools import groupby
+from operator import itemgetter
+from typing import (
+    Any,
+    AsyncContextManager,
+    Callable,
+    DefaultDict,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+)
 
-from ddsketch import ddsketch
+from ddsketch.ddsketch import DDSketch
 from phoenix.db import models
 from phoenix.server.api.input_types.TimeRange import TimeRange
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+ProjectName: TypeAlias = str
+TimeInterval: TypeAlias = Tuple[Optional[datetime], Optional[datetime]]
+Segment: TypeAlias = Tuple[ProjectName, TimeInterval]
+Probability: TypeAlias = float
+Key: TypeAlias = Tuple[ProjectName, Optional[TimeRange], Probability]
+ResultPosition: TypeAlias = int
+QuantileValue: TypeAlias = float
+OrmExpression: TypeAlias = Any
 
 
-class LatencyMsQuantileDataLoader(
-    DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]
-):
-    def __init__(
-        self,
-        db: Callable[[], AsyncContextManager[AsyncSession]],
-    ) -> None:
-        super().__init__(load_fn=self._load_fn)
+class LatencyMsQuantileDataLoader(DataLoader[Key, Optional[QuantileValue]]):
+    def __init__(self, db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+        super().__init__(load_fn=self._load_fn, cache_key_fn=self._cache_key_fn)
         self._db = db
 
-    async def _load_fn(
-        self,
-        keys: List[Tuple[str, Optional[TimeRange], float]],
-    ) -> List[Optional[float]]:
+    @staticmethod
+    def _cache_key_fn(key: Key) -> Tuple[Segment, Probability]:
+        if isinstance(key[1], TimeRange):
+            return (key[0], (key[1].start, key[1].end)), key[2]
+        return (key[0], (None, None)), key[2]
+
+    async def _load_fn(self, keys: List[Key]) -> List[Optional[QuantileValue]]:
         # We use ddsketch here because sqlite doesn't have percentile functions
         # unless we compile it with the percentile.c extension, like how it's
         # done in the Python package https://github.com/nalgeon/sqlean.py
-        results: List[Optional[float]] = [None] * len(keys)
-        arguments: DefaultDict[Tuple[str, Optional[TimeRange]], List[Tuple[int, float]]] = (
-            defaultdict(list)
-        )
+        results: List[Optional[QuantileValue]] = [None] * len(keys)
+        arguments: DefaultDict[
+            Segment,
+            List[Tuple[ResultPosition, Probability]],
+        ] = defaultdict(list)
+        sketches: DefaultDict[Segment, DDSketch] = defaultdict(DDSketch)
         for i, key in enumerate(keys):
-            name, time_range, probability = key
-            arguments[(name, time_range)].append((i, probability))
-        for (name, time_range), probabilities in arguments.items():
-            stmt = (
-                select(models.Trace.latency_ms)
-                .join(models.Project)
-                .where(models.Project.name == name)
-            )
-            if time_range:
-                stmt = stmt.where(
-                    and_(
-                        time_range.start <= models.Trace.start_time,
-                        models.Trace.start_time < time_range.end,
-                    )
+            segment, probability = self._cache_key_fn(key)
+            arguments[segment].append((i, probability))
+        async with self._db() as session:
+            for time_range_by_name, filter_condition in _get_filter_conditons(arguments.keys()):
+                stmt = (
+                    select(models.Project.name, models.Trace.latency_ms)
+                    .join(models.Project)
+                    .where(filter_condition)
+                    .order_by(models.Project.name)
                 )
-            sketch = ddsketch.DDSketch()
-            async with self._db() as session:
-                async for val in await session.stream_scalars(stmt):
+                prev_project_name = None
+                async for project_name, val in await session.stream(stmt):
+                    if project_name != prev_project_name:
+                        segment = (project_name, time_range_by_name[project_name])
+                        sketch = sketches[segment]
+                        prev_project_name = project_name
                     sketch.add(val)
+        for segment, probabilities in arguments.items():
+            sketch = sketches[segment]
             for i, p in probabilities:
                 results[i] = sketch.get_quantile_value(p)
         return results
+
+
+def _get_filter_conditons(
+    keys: Iterable[Segment],
+) -> Iterator[Tuple[Dict[ProjectName, TimeInterval], OrmExpression]]:
+    """
+    The purpose of this function is to group together filters that can be
+    combined. For example, suppose we the following 5 filters:
+        1. a & (1 <= t < 3)
+        2. a & (2 <= t < 4)
+        3. b & (1 <= t < 4)
+        4. c & (2 <= t < 5)
+        5. c & (1 <= t < 6)
+    We can reduce them to 2 filters as follows:
+        1. a & (1 <= t < 3) | b & (1 <= t < 4) | c & (2 <= t < 5)
+        2. a & (2 <= t < 4) | c & (1 <= t < 6)
+    """
+    segments: DefaultDict[int, List[Segment]] = defaultdict(list)
+    expressions: DefaultDict[int, List[OrmExpression]] = defaultdict(list)
+    for _, group in groupby(sorted(keys, key=itemgetter(0)), key=itemgetter(0)):
+        for i, segment in enumerate(group):
+            expressions[i].append(_get_expr(segment))
+            segments[i].append(segment)
+    for i, conditions in expressions.items():
+        yield dict(segments[i]), or_(*conditions)
+
+
+def _get_expr(segment: Segment) -> OrmExpression:
+    name, (start_time, stop_time) = segment
+    if start_time and stop_time:
+        return and_(
+            models.Project.name == name,
+            start_time <= models.Trace.start_time,
+            models.Trace.start_time < stop_time,
+        )
+    if start_time:
+        return and_(
+            models.Project.name == name,
+            start_time <= models.Trace.start_time,
+        )
+    if stop_time:
+        return and_(
+            models.Project.name == name,
+            models.Trace.start_time < stop_time,
+        )
+    return models.Project.name == name

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -138,12 +138,15 @@ class Project(Node):
             return (await session.scalar(stmt)) or 0
 
     @strawberry.field
-    def latency_ms_p50(self) -> Optional[float]:
-        return self.project.root_span_latency_ms_quantiles(0.50)
-
-    @strawberry.field
-    def latency_ms_p99(self) -> Optional[float]:
-        return self.project.root_span_latency_ms_quantiles(0.99)
+    async def latency_ms_quantile(
+        self,
+        info: Info[Context, None],
+        probability: float,
+        time_range: Optional[TimeRange] = UNSET,
+    ) -> Optional[float]:
+        return await info.context.data_loaders.latency_ms_quantile.load(
+            (self.name, time_range, probability)
+        )
 
     @strawberry.field
     def trace(self, trace_id: ID) -> Optional[Trace]:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -41,7 +41,8 @@ from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
 from phoenix.db.bulk_inserter import BulkInserter
 from phoenix.pointcloud.umap_parameters import UMAPParameters
-from phoenix.server.api.context import Context
+from phoenix.server.api.context import Context, DataLoaders
+from phoenix.server.api.dataloaders import LatencyMsQuantile
 from phoenix.server.api.routers.evaluation_handler import EvaluationHandler
 from phoenix.server.api.routers.span_handler import SpanHandler
 from phoenix.server.api.routers.trace_handler import TraceHandler
@@ -142,6 +143,9 @@ class GraphQLWithContext(GraphQL):  # type: ignore
             corpus=self.corpus,
             traces=self.traces,
             export_path=self.export_path,
+            data_loaders=DataLoaders(
+                latency_ms_quantile=LatencyMsQuantile(self.db),
+            ),
         )
 
 

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -42,7 +42,9 @@ from phoenix.core.traces import Traces
 from phoenix.db.bulk_inserter import BulkInserter
 from phoenix.pointcloud.umap_parameters import UMAPParameters
 from phoenix.server.api.context import Context, DataLoaders
-from phoenix.server.api.dataloaders import LatencyMsQuantile
+from phoenix.server.api.dataloaders.latency_ms_quantile import (
+    LatencyMsQuantileDataLoader,
+)
 from phoenix.server.api.routers.evaluation_handler import EvaluationHandler
 from phoenix.server.api.routers.span_handler import SpanHandler
 from phoenix.server.api.routers.trace_handler import TraceHandler
@@ -144,7 +146,7 @@ class GraphQLWithContext(GraphQL):  # type: ignore
             traces=self.traces,
             export_path=self.export_path,
             data_loaders=DataLoaders(
-                latency_ms_quantile=LatencyMsQuantile(self.db),
+                latency_ms_quantile=LatencyMsQuantileDataLoader(self.db),
             ),
         )
 

--- a/tests/server/api/types/conftest.py
+++ b/tests/server/api/types/conftest.py
@@ -43,6 +43,7 @@ def context_factory() -> Callable[[Dataset, Optional[Dataset]], Context]:
             model=create_model_from_datasets(primary_dataset, reference_dataset),
             export_path=Path(TemporaryDirectory().name),
             db=None,  # TODO(persistence): add mock for db
+            data_loaders=None,  # TODO(persistence): add mock for data_loaders
         )
 
     return create_context


### PR DESCRIPTION
resolves #2807

We use ddsketch here because sqlite doesn't have percentile functions unless we compile it with the `percentile.c` extension, like how it's done in the Python package https://github.com/nalgeon/sqlean.py.

<img width="1333" alt="Screenshot 2024-04-09 at 5 02 27 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/13cb07a8-7b32-437f-8b76-657c7a1c1d5a">