### PR TITLE
fix: preserve loggers across migrations

### DIFF
--- a/src/phoenix/db/alembic.ini
+++ b/src/phoenix/db/alembic.ini
@@ -104,7 +104,7 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = WARN
+level = INFO
 handlers =
 qualname = alembic
 

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -9,7 +9,7 @@ from sqlalchemy import URL
 
 
 @contextmanager
-def using_log_level(new_level: int, logger_names: list[str]) -> Generator[Any, Any, Any]:
+def using_log_level(new_level: int, logger_names: list[str]) -> "Generator[Any, Any, Any]":
     original_levels = {}
     try:
         for name in logger_names:

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Generator
 
 from alembic import command
 from alembic.config import Config
@@ -9,7 +9,7 @@ from sqlalchemy import URL
 
 
 @contextmanager
-def using_log_level(new_level: int, logger_names: list[str]) -> "Generator[Any, Any, Any]":
+def using_log_level(new_level: int, logger_names: list[str]) -> Generator[None, None, None]:
     original_levels = {}
     try:
         for name in logger_names:

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from typing import Any, Iterator, List
 
 from alembic import command
 from alembic.config import Config
@@ -9,7 +9,7 @@ from sqlalchemy import URL
 
 
 @contextmanager
-def using_log_level(new_level: int, logger_names: list[str]) -> Generator[None, None, None]:
+def using_log_level(new_level: int, logger_names: List[str]) -> Iterator[Any]:
     original_levels = {}
     try:
         for name in logger_names:

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -1,9 +1,29 @@
 import logging
+from contextlib import contextmanager
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import URL
+
+
+@contextmanager
+def using_log_level(new_level: int, logger_names: list[str]):
+    original_levels = {}
+    try:
+        for name in logger_names:
+            logger = logging.getLogger(name)
+            # Save the original log level
+            original_levels[name] = logger.level
+            # Set the new log level
+            logger.setLevel(new_level)
+        yield
+    finally:
+        # Revert log levels to their original states
+        for name, level in original_levels.items():
+            logger = logging.getLogger(name)
+            logger.setLevel(level)
+
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +36,8 @@ def migrate(url: URL) -> None:
     Args:
         url: The database URL.
     """
-    logger.warning("Running migrations on the database")
+    print("🏃‍♀️‍➡️ Running migrations on the database.")
+    print("---------------------------")
     config_path = str(Path(__file__).parent.resolve() / "alembic.ini")
     alembic_cfg = Config(config_path)
 
@@ -25,4 +46,7 @@ def migrate(url: URL) -> None:
     alembic_cfg.set_main_option("script_location", scripts_location)
     alembic_cfg.set_main_option("sqlalchemy.url", str(url))
 
-    command.upgrade(alembic_cfg, "head")
+    with using_log_level(logging.DEBUG, ["sqlalchemy", "alembic"]):
+        command.upgrade(alembic_cfg, "head")
+    print("---------------------------")
+    print("✅ Migrations complete.")

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any, Generator
 
 from alembic import command
 from alembic.config import Config
@@ -8,7 +9,7 @@ from sqlalchemy import URL
 
 
 @contextmanager
-def using_log_level(new_level: int, logger_names: list[str]):
+def using_log_level(new_level: int, logger_names: list[str]) -> Generator[Any, Any, Any]:
     original_levels = {}
     try:
         for name in logger_names:

--- a/src/phoenix/db/migrations/env.py
+++ b/src/phoenix/db/migrations/env.py
@@ -15,7 +15,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
resolves #2825 

This fixes that logging was permanently broken post migrations. This also increases the log level while running migrations for debugging purposes.

<img width="550" alt="Screenshot 2024-04-09 at 5 42 08 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/d86bb414-d5b3-4564-b8c6-3fcd86fd144a">
