### PR TITLE
feat: make graphql api for span evaluations read from database

### DIFF
--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncContextManager, Callable, Optional, Tuple, Union
+from typing import AsyncContextManager, Callable, List, Optional, Tuple, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
@@ -11,11 +11,13 @@ from strawberry.dataloader import DataLoader
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
 from phoenix.server.api.input_types.TimeRange import TimeRange
+from phoenix.server.api.types.Evaluation import SpanEvaluation
 
 
 @dataclass
 class DataLoaders:
     latency_ms_quantile: DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]
+    span_evaluations: DataLoader[int, List[SpanEvaluation]]
 
 
 @dataclass

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -1,0 +1,7 @@
+from .latency_ms_quantile import LatencyMsQuantileDataLoader
+from .span_evaluations import SpanEvaluationsDataLoader
+
+__all__ = [
+    "LatencyMsQuantileDataLoader",
+    "SpanEvaluationsDataLoader",
+]

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -11,12 +11,13 @@ from typing import (
 )
 
 from ddsketch.ddsketch import DDSketch
-from phoenix.db import models
-from phoenix.server.api.input_types.TimeRange import TimeRange
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.api.input_types.TimeRange import TimeRange
 
 ProjectName: TypeAlias = str
 TimeInterval: TypeAlias = Tuple[Optional[datetime], Optional[datetime]]

--- a/src/phoenix/server/api/dataloaders/span_evaluations.py
+++ b/src/phoenix/server/api/dataloaders/span_evaluations.py
@@ -25,15 +25,14 @@ class SpanEvaluationsDataLoader(DataLoader[Key, List[SpanEvaluation]]):
     async def _load_fn(self, keys: List[Key]) -> List[List[SpanEvaluation]]:
         span_evaluations_by_id: DefaultDict[Key, List[SpanEvaluation]] = defaultdict(list)
         async with self._db() as session:
-            span_evaluations = await session.scalars(
+            for span_evaluation in await session.scalars(
                 select(models.SpanAnnotation).where(
                     and_(
                         models.SpanAnnotation.span_rowid.in_(keys),
                         models.SpanAnnotation.annotator_kind == "LLM",
                     )
                 )
-            )
-            for span_evaluation in span_evaluations:
+            ):
                 span_evaluations_by_id[span_evaluation.span_rowid].append(
                     SpanEvaluation.from_sql_span_annotation(span_evaluation)
                 )

--- a/src/phoenix/server/api/dataloaders/span_evaluations.py
+++ b/src/phoenix/server/api/dataloaders/span_evaluations.py
@@ -19,7 +19,7 @@ Key: TypeAlias = int
 
 class SpanEvaluationsDataLoader(DataLoader[Key, List[SpanEvaluation]]):
     def __init__(self, db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
-        super().__init__(load_fn=self._load_fn, max_batch_size=1000)
+        super().__init__(load_fn=self._load_fn)
         self._db = db
 
     async def _load_fn(self, keys: List[Key]) -> List[List[SpanEvaluation]]:

--- a/src/phoenix/server/api/dataloaders/span_evaluations.py
+++ b/src/phoenix/server/api/dataloaders/span_evaluations.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+from typing import (
+    AsyncContextManager,
+    Callable,
+    DefaultDict,
+    List,
+)
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.api.types.Evaluation import SpanEvaluation
+
+Key: TypeAlias = int
+
+
+class SpanEvaluationsDataLoader(DataLoader[Key, List[SpanEvaluation]]):
+    def __init__(self, db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+        super().__init__(load_fn=self._load_fn, max_batch_size=1000)
+        self._db = db
+
+    async def _load_fn(self, keys: List[Key]) -> List[List[SpanEvaluation]]:
+        span_evaluations_by_id: DefaultDict[Key, List[SpanEvaluation]] = defaultdict(list)
+        async with self._db() as session:
+            span_evaluations = await session.scalars(
+                select(models.SpanAnnotation).where(
+                    and_(
+                        models.SpanAnnotation.span_rowid.in_(keys),
+                        models.SpanAnnotation.annotator_kind == "LLM",
+                    )
+                )
+            )
+            for span_evaluation in span_evaluations:
+                span_evaluations_by_id[span_evaluation.span_rowid].append(
+                    SpanEvaluation.from_sql_span_annotation(span_evaluation)
+                )
+        return [span_evaluations_by_id[key] for key in keys]

--- a/src/phoenix/server/api/types/Evaluation.py
+++ b/src/phoenix/server/api/types/Evaluation.py
@@ -3,6 +3,7 @@ from typing import Optional
 import strawberry
 
 import phoenix.trace.v1 as pb
+from phoenix.db.models import SpanAnnotation
 from phoenix.trace.schemas import SpanID, TraceID
 
 
@@ -46,21 +47,26 @@ class TraceEvaluation(Evaluation):
 
 @strawberry.type
 class SpanEvaluation(Evaluation):
-    span_id: strawberry.Private[SpanID]
-
     @staticmethod
     def from_pb_evaluation(evaluation: pb.Evaluation) -> "SpanEvaluation":
         result = evaluation.result
         score = result.score.value if result.HasField("score") else None
         label = result.label.value if result.HasField("label") else None
         explanation = result.explanation.value if result.HasField("explanation") else None
-        span_id = SpanID(evaluation.subject_id.span_id)
         return SpanEvaluation(
             name=evaluation.name,
             score=score,
             label=label,
             explanation=explanation,
-            span_id=span_id,
+        )
+
+    @staticmethod
+    def from_sql_span_annotation(annotation: "SpanAnnotation") -> "SpanEvaluation":
+        return SpanEvaluation(
+            name=annotation.name,
+            score=annotation.score,
+            label=annotation.label,
+            explanation=annotation.explanation,
         )
 
 

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -148,9 +148,8 @@ class Span:
         "respect to its input."
     )  # type: ignore
     async def span_evaluations(self, info: Info[Context, None]) -> List[SpanEvaluation]:
-        span_id = SpanID(str(self.context.span_id))
         async with info.context.db() as session:
-            span_evaluations = await session.scalars(
+            span_annotations = await session.scalars(
                 select(models.SpanAnnotation).where(
                     and_(
                         models.SpanAnnotation.span_rowid == self.span_rowid,
@@ -158,11 +157,8 @@ class Span:
                     )
                 )
             )
-            for span_evaluation in span_evaluations:
-                print(span_evaluation.name)
         return [
-            SpanEvaluation.from_pb_evaluation(evaluation)
-            for evaluation in self.project.get_evaluations_by_span_id(span_id)
+            SpanEvaluation.from_sql_span_annotation(annotation) for annotation in span_annotations
         ]
 
     @strawberry.field(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -44,8 +44,9 @@ from phoenix.db.bulk_inserter import BulkInserter
 from phoenix.db.engines import create_engine
 from phoenix.pointcloud.umap_parameters import UMAPParameters
 from phoenix.server.api.context import Context, DataLoaders
-from phoenix.server.api.dataloaders.latency_ms_quantile import (
+from phoenix.server.api.dataloaders import (
     LatencyMsQuantileDataLoader,
+    SpanEvaluationsDataLoader,
 )
 from phoenix.server.api.routers.evaluation_handler import EvaluationHandler
 from phoenix.server.api.routers.span_handler import SpanHandler
@@ -149,6 +150,7 @@ class GraphQLWithContext(GraphQL):  # type: ignore
             export_path=self.export_path,
             data_loaders=DataLoaders(
                 latency_ms_quantile=LatencyMsQuantileDataLoader(self.db),
+                span_evaluations=SpanEvaluationsDataLoader(self.db),
             ),
         )
 


### PR DESCRIPTION
Makes the GraphQL resolver for span evaluations read from the database, using a data loader.

resolves #2777

Coauthored-by: Mikyo King mikeldking@gmail.com