### PR TITLE
chore: log level control over migrations

### DIFF
--- a/src/phoenix/db/alembic.ini
+++ b/src/phoenix/db/alembic.ini
@@ -104,7 +104,7 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+level = WARN
 handlers =
 qualname = alembic
 

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -1,33 +1,19 @@
 import logging
-from contextlib import contextmanager
 from pathlib import Path
 from threading import Thread
-from typing import Any, Iterator, List
 
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import URL
 
-
-@contextmanager
-def using_log_level(new_level: int, logger_names: List[str]) -> Iterator[Any]:
-    original_levels = {}
-    try:
-        for name in logger_names:
-            logger = logging.getLogger(name)
-            # Save the original log level
-            original_levels[name] = logger.level
-            # Set the new log level
-            logger.setLevel(new_level)
-        yield
-    finally:
-        # Revert log levels to their original states
-        for name, level in original_levels.items():
-            logger = logging.getLogger(name)
-            logger.setLevel(level)
-
+from phoenix.settings import Settings
 
 logger = logging.getLogger(__name__)
+
+
+def printif(condition: bool, text: str) -> None:
+    if condition:
+        print(text)
 
 
 def migrate(url: URL) -> None:
@@ -38,8 +24,9 @@ def migrate(url: URL) -> None:
     Args:
         url: The database URL.
     """
-    print("🏃‍♀️‍➡️ Running migrations on the database.")
-    print("---------------------------")
+    log_migrations = Settings.log_migrations
+    printif(log_migrations, "🏃‍♀️‍➡️ Running migrations on the database.")
+    printif(log_migrations, "---------------------------")
     config_path = str(Path(__file__).parent.resolve() / "alembic.ini")
     alembic_cfg = Config(config_path)
 
@@ -47,11 +34,9 @@ def migrate(url: URL) -> None:
     scripts_location = str(Path(__file__).parent.resolve() / "migrations")
     alembic_cfg.set_main_option("script_location", scripts_location)
     alembic_cfg.set_main_option("sqlalchemy.url", str(url))
-
-    with using_log_level(logging.DEBUG, ["sqlalchemy", "alembic"]):
-        command.upgrade(alembic_cfg, "head")
-    print("---------------------------")
-    print("✅ Migrations complete.")
+    command.upgrade(alembic_cfg, "head")
+    printif(log_migrations, "---------------------------")
+    printif(log_migrations, "✅ Migrations complete.")
 
 
 def migrate_in_thread(url: URL) -> None:

--- a/src/phoenix/db/migrations/env.py
+++ b/src/phoenix/db/migrations/env.py
@@ -5,6 +5,7 @@ from alembic import context
 from phoenix.config import get_env_database_connection_str
 from phoenix.db.engines import get_async_db_url
 from phoenix.db.models import Base
+from phoenix.settings import Settings
 from sqlalchemy import Connection, engine_from_config, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -71,6 +72,7 @@ def run_migrations_online() -> None:
                 prefix="sqlalchemy.",
                 poolclass=pool.NullPool,
                 future=True,
+                echo=Settings.log_migrations,
             )
         )
 

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -30,6 +30,7 @@ from phoenix.pointcloud.umap_parameters import (
     UMAPParameters,
 )
 from phoenix.server.app import create_app
+from phoenix.settings import Settings
 from phoenix.storage.span_store import SpanStore
 from phoenix.trace.fixtures import (
     TRACES_FIXTURES,
@@ -119,6 +120,9 @@ if __name__ == "__main__":
     primary_dataset: Dataset = EMPTY_DATASET
     reference_dataset: Optional[Dataset] = None
     corpus_dataset: Optional[Dataset] = None
+
+    # Initialize the settings for the Server
+    Settings.log_migrations = True
 
     # automatically remove the pid file when the process is being gracefully terminated
     atexit.register(_remove_pid_file)

--- a/src/phoenix/settings.py
+++ b/src/phoenix/settings.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Settings:
+    """Settings for Phoenix, lazily initialized."""
+
+    # By default, don't log migrations
+    log_migrations: bool = field(default=False)
+
+
+# Singleton instance of the settings
+Settings = _Settings()


### PR DESCRIPTION
resolves #2856 

Lets you control the settings so that migrations only get logged when running in container mode.