### PR TITLE
feat: graphql api for document evaluations

### DIFF
--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -11,13 +11,14 @@ from strawberry.dataloader import DataLoader
 from phoenix.core.model_schema import Model
 from phoenix.core.traces import Traces
 from phoenix.server.api.input_types.TimeRange import TimeRange
-from phoenix.server.api.types.Evaluation import SpanEvaluation
+from phoenix.server.api.types.Evaluation import DocumentEvaluation, SpanEvaluation
 
 
 @dataclass
 class DataLoaders:
     latency_ms_quantile: DataLoader[Tuple[str, Optional[TimeRange], float], Optional[float]]
     span_evaluations: DataLoader[int, List[SpanEvaluation]]
+    document_evaluations: DataLoader[int, List[DocumentEvaluation]]
 
 
 @dataclass

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -1,7 +1,9 @@
+from .document_evaluations import DocumentEvaluationsDataLoader
 from .latency_ms_quantile import LatencyMsQuantileDataLoader
 from .span_evaluations import SpanEvaluationsDataLoader
 
 __all__ = [
+    "DocumentEvaluationsDataLoader",
     "LatencyMsQuantileDataLoader",
     "SpanEvaluationsDataLoader",
 ]

--- a/src/phoenix/server/api/dataloaders/document_evaluations.py
+++ b/src/phoenix/server/api/dataloaders/document_evaluations.py
@@ -1,0 +1,39 @@
+from collections import defaultdict
+from typing import (
+    AsyncContextManager,
+    Callable,
+    DefaultDict,
+    List,
+)
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.api.types.Evaluation import DocumentEvaluation
+
+Key: TypeAlias = int
+
+
+class DocumentEvaluationsDataLoader(DataLoader[Key, List[DocumentEvaluation]]):
+    def __init__(self, db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: List[Key]) -> List[List[DocumentEvaluation]]:
+        document_evaluations_by_id: DefaultDict[Key, List[DocumentEvaluation]] = defaultdict(list)
+        async with self._db() as session:
+            for document_evaluation in await session.scalars(
+                select(models.DocumentAnnotation).where(
+                    and_(
+                        models.DocumentAnnotation.span_rowid.in_(keys),
+                        models.DocumentAnnotation.annotator_kind == "LLM",
+                    )
+                )
+            ):
+                document_evaluations_by_id[document_evaluation.span_rowid].append(
+                    DocumentEvaluation.from_sql_document_annotation(document_evaluation)
+                )
+        return [document_evaluations_by_id[key] for key in keys]

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -158,12 +158,8 @@ class Span:
         "a list, and each evaluation is identified by its document's (zero-based) "
         "index in that list."
     )  # type: ignore
-    def document_evaluations(self) -> List[DocumentEvaluation]:
-        span_id = SpanID(str(self.context.span_id))
-        return [
-            DocumentEvaluation.from_pb_evaluation(evaluation)
-            for evaluation in self.project.get_document_evaluations_by_span_id(span_id)
-        ]
+    async def document_evaluations(self, info: Info[Context, None]) -> List[DocumentEvaluation]:
+        return await info.context.data_loaders.document_evaluations.load(self.span_rowid)
 
     @strawberry.field(
         description="Retrieval metrics: NDCG@K, Precision@K, Reciprocal Rank, etc.",

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -45,6 +45,7 @@ from phoenix.db.engines import create_engine
 from phoenix.pointcloud.umap_parameters import UMAPParameters
 from phoenix.server.api.context import Context, DataLoaders
 from phoenix.server.api.dataloaders import (
+    DocumentEvaluationsDataLoader,
     LatencyMsQuantileDataLoader,
     SpanEvaluationsDataLoader,
 )
@@ -151,6 +152,7 @@ class GraphQLWithContext(GraphQL):  # type: ignore
             data_loaders=DataLoaders(
                 latency_ms_quantile=LatencyMsQuantileDataLoader(self.db),
                 span_evaluations=SpanEvaluationsDataLoader(self.db),
+                document_evaluations=DocumentEvaluationsDataLoader(self.db),
             ),
         )
 


### PR DESCRIPTION
GraphQL API reads document evaluations from database using a dataloader.

resolves #2777
