### PR TITLE
fix(docs): add the remainder of the sentence to run_evals concurrency

### DIFF
--- a/docs/api/evals.md
+++ b/docs/api/evals.md
@@ -33,7 +33,7 @@ Evaluates a pandas dataframe using a set of user-specified evaluators that asses
 * **provide\_explanation** (bool, optional): If true, each output dataframe will contain an explanation column containing the LLM's reasoning for each evaluation.
 * **use\_function\_calling\_if\_available** (bool, optional): If true, function calling is used (if available) as a means to constrain the LLM outputs. With function calling, the LLM is instructed to provide its response as a structured JSON object, which is easier to parse.
 * **verbose** (bool, optional): If true, prints detailed information such as model invocation parameters, retries on failed requests, etc.
-* **concurrency** (int, optional): The number of concurrent workers if async submission is possible. If
+* **concurrency** (int, optional): The number of concurrent workers if async submission is possible. If not provided, a recommended default concurrency is set on a per-model basis.
 
 ### Returns
 


### PR DESCRIPTION
Noticed this when we were reading the documentation for a work related task. Pulled the rest of the documentation from [this line](https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-evals/src/phoenix/evals/classify.py#L248)