### PR TITLE
fix(persistence): postgres down migration and url support

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
         "alimit",
         "arize",
         "asyncio",
+        "asyncpg",
         "chatbot",
         "codemirror",
         "Colab",

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -38,7 +38,16 @@ def get_async_db_url(connection_str: str) -> URL:
     if "sqlite" in url.drivername:
         return get_db_url(driver="sqlite+aiosqlite", database=url.database)
     if "postgresql" in url.drivername:
-        return url.set(drivername="postgresql+asyncpg")
+        print(f"URL: {url}")
+        url = url.set(drivername="postgresql+asyncpg")
+        # For some reason username and password cannot be parsed from the typical slot
+        # So we need to parse them out manually
+        if url.username and url.password:
+            url = url.set(
+                query={"user": url.username, "password": url.password}, password=None, username=None
+            )
+        print(f"URL: {url.render_as_string(hide_password=False)}")
+        return url
     raise ValueError(f"Unsupported driver: {url.drivername}")
 
 
@@ -81,7 +90,7 @@ def aio_postgresql_engine(
     echo: bool = False,
 ) -> AsyncEngine:
     # Swap out the engine
-    async_url = url.set(drivername="postgresql+asyncpg")
+    async_url = get_async_db_url(url.render_as_string(hide_password=False))
     engine = create_async_engine(url=async_url, echo=echo, json_serializer=_dumps)
     # TODO(persistence): figure out the postgres pragma
     # event.listen(engine.sync_engine, "connect", set_pragma)

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -38,7 +38,6 @@ def get_async_db_url(connection_str: str) -> URL:
     if "sqlite" in url.drivername:
         return get_db_url(driver="sqlite+aiosqlite", database=url.database)
     if "postgresql" in url.drivername:
-        print(f"URL: {url}")
         url = url.set(drivername="postgresql+asyncpg")
         # For some reason username and password cannot be parsed from the typical slot
         # So we need to parse them out manually
@@ -46,7 +45,7 @@ def get_async_db_url(connection_str: str) -> URL:
             url = url.set(
                 query={"user": url.username, "password": url.password}, password=None, username=None
             )
-        print(f"URL: {url.render_as_string(hide_password=False)}")
+
         return url
     raise ValueError(f"Unsupported driver: {url.drivername}")
 

--- a/src/phoenix/db/migrations/env.py
+++ b/src/phoenix/db/migrations/env.py
@@ -66,7 +66,9 @@ def run_migrations_online() -> None:
         config = context.config.get_section(context.config.config_ini_section) or {}
         if "sqlalchemy.url" not in config:
             connection_str = get_env_database_connection_str()
-            config["sqlalchemy.url"] = str(get_async_db_url(connection_str))
+            config["sqlalchemy.url"] = get_async_db_url(connection_str).render_as_string(
+                hide_password=False
+            )
         connectable = AsyncEngine(
             engine_from_config(
                 config,

--- a/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
+++ b/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
@@ -244,9 +244,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("projects")
-    op.drop_table("traces")
-    op.drop_table("spans")
     op.drop_table("span_annotations")
     op.drop_table("trace_annotations")
     op.drop_table("document_annotations")
+    op.drop_table("spans")
+    op.drop_table("traces")
+    op.drop_table("projects")

--- a/tests/db/test_engines.py
+++ b/tests/db/test_engines.py
@@ -1,0 +1,29 @@
+from phoenix.db.engines import get_async_db_url
+
+
+def test_get_async_sqlite_db_url():
+    connection_str = "sqlite:///phoenix.db"
+    url = get_async_db_url(connection_str)
+    assert url.drivername == "sqlite+aiosqlite"
+    assert url.database == "phoenix.db"
+
+
+def test_get_async_postgresql_db_url():
+    # Test credentials as url params
+    connection_str = "postgresql://@localhost:5432/phoenix?user=user&password=password"
+    url = get_async_db_url(connection_str)
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.database == "phoenix"
+    assert url.host == "localhost"
+    assert url.query["user"] == "user"
+    assert url.query["password"] == "password"
+
+    # Test credentials as part of the url
+    connection_str = "postgresql://user:password@localhost:5432/phoenix"
+    url = get_async_db_url(connection_str)
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.database == "phoenix"
+    assert url.host == "localhost"
+    # NB(mikeldking): No idea why this fails to authenticate
+    assert url.query["user"] == "user"
+    assert url.query["password"] == "password"


### PR DESCRIPTION
Ensures that the postgres URL is properly formed for authentication and so that down migrations run in the proper order