### PR TITLE
feat: add gradient start/end to projects table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -538,6 +538,8 @@ type Point3D {
 type Project implements Node {
   id: GlobalID!
   name: String!
+  gradientStartColor: String!
+  gradientEndColor: String!
   startTime: DateTime
   endTime: DateTime
   recordCount(timeRange: TimeRange): Int!

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -72,6 +72,8 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
             project: node {
               id
               name
+              gradientStartColor
+              gradientEndColor
               traceCount(timeRange: $timeRange)
               endTime
               latencyMsP50: latencyMsQuantile(
@@ -155,7 +157,13 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
   );
 }
 
-function ProjectIcon() {
+function ProjectIcon({
+  gradientStartColor,
+  gradientEndColor,
+}: {
+  gradientStartColor: string;
+  gradientEndColor: string;
+}) {
   return (
     <div
       css={css`
@@ -164,8 +172,8 @@ function ProjectIcon() {
         height: 32px;
         background: linear-gradient(
           136.27deg,
-          rgb(91, 219, 255) 14.03%,
-          rgb(28, 118, 252) 84.38%
+          ${gradientStartColor} 14.03%,
+          ${gradientEndColor} 84.38%
         );
         flex-shrink: 0;
       `}
@@ -182,7 +190,14 @@ function ProjectItem({
   canDelete,
   onProjectDelete,
 }: ProjectItemProps) {
-  const { endTime, traceCount, tokenCountTotal, latencyMsP50 } = project;
+  const {
+    endTime,
+    traceCount,
+    tokenCountTotal,
+    latencyMsP50,
+    gradientStartColor,
+    gradientEndColor,
+  } = project;
   const lastUpdatedText = useMemo(() => {
     if (endTime) {
       return `Last updated  ${formatDistance(new Date(endTime), new Date(), { addSuffix: true })}`;
@@ -209,7 +224,10 @@ function ProjectItem({
     >
       <Flex direction="row" justifyContent="space-between" alignItems="start">
         <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
-          <ProjectIcon />
+          <ProjectIcon
+            gradientStartColor={gradientStartColor}
+            gradientEndColor={gradientEndColor}
+          />
           <Flex direction="column" minWidth={0}>
             <Heading
               level={2}

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<260c2f50f9cb857944f365304ec667e3>>
+ * @generated SignedSource<<4b18018d5ea6f754fd9c0b1591bcc4a2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,8 @@ export type ProjectsPageProjectsFragment$data = {
     readonly edges: ReadonlyArray<{
       readonly project: {
         readonly endTime: string | null;
+        readonly gradientEndColor: string;
+        readonly gradientStartColor: string;
         readonly id: string;
         readonly latencyMsP50: number | null;
         readonly name: string;
@@ -96,6 +98,20 @@ return {
                 },
                 {
                   "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "gradientStartColor",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "gradientEndColor",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
                   "args": (v1/*: any*/),
                   "kind": "ScalarField",
                   "name": "traceCount",
@@ -144,6 +160,6 @@ return {
 };
 })();
 
-(node as any).hash = "80cfac4a7e56fc862924dce5da4ed971";
+(node as any).hash = "eed3bc970f109d273b6235f9eb0811ae";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<72f2e8a0e846252624ba834ea2739ade>>
+ * @generated SignedSource<<2a8c4f4e6dc6baf963fd2dd708dc5909>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -103,6 +103,20 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "gradientStartColor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "gradientEndColor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
                     "args": (v2/*: any*/),
                     "kind": "ScalarField",
                     "name": "traceCount",
@@ -148,16 +162,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "84f80c7e08a0397a97091aa2b4d45ae8",
+    "cacheID": "b7b294ef46695c71a41287c42ec9392f",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageProjectsQuery(\n  $timeRange: TimeRange\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectsPageProjectsQuery(\n  $timeRange: TimeRange\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "80cfac4a7e56fc862924dce5da4ed971";
+(node as any).hash = "eed3bc970f109d273b6235f9eb0811ae";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9258370758fe1af08d6cb85665285247>>
+ * @generated SignedSource<<2c9bcedff081a32e9f8aeb4d472a624d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -103,6 +103,20 @@ return {
                   },
                   {
                     "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "gradientStartColor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "gradientEndColor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
                     "args": (v2/*: any*/),
                     "kind": "ScalarField",
                     "name": "traceCount",
@@ -148,12 +162,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "991909413909af281a75c58c2cd6996b",
+    "cacheID": "9e5408cfa88c6d82157f9979960611bd",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageQuery(\n  $timeRange: TimeRange!\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n    }\n  }\n}\n"
+    "text": "query ProjectsPageQuery(\n  $timeRange: TimeRange!\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
+++ b/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
@@ -33,6 +33,18 @@ def upgrade() -> None:
         sa.Column("name", sa.String, nullable=False, unique=True),
         sa.Column("description", sa.String, nullable=True),
         sa.Column(
+            "gradient_start_color",
+            sa.String,
+            nullable=False,
+            server_default=sa.text("'#5bdbff'"),
+        ),
+        sa.Column(
+            "gradient_end_color",
+            sa.String,
+            nullable=False,
+            server_default=sa.text("'#1c76fc'"),
+        ),
+        sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
             nullable=False,

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     MetaData,
+    String,
     TypeDecorator,
     UniqueConstraint,
     func,
@@ -93,6 +94,15 @@ class Project(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
     description: Mapped[Optional[str]]
+    gradient_start_color: Mapped[str] = mapped_column(
+        String,
+        server_default=func.text("'#5bdbff'"),
+    )
+
+    gradient_end_color: Mapped[str] = mapped_column(
+        String,
+        server_default=func.text("'#1c76fc'"),
+    )
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
     insert,
+    text,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -96,12 +97,12 @@ class Project(Base):
     description: Mapped[Optional[str]]
     gradient_start_color: Mapped[str] = mapped_column(
         String,
-        server_default=func.text("'#5bdbff'"),
+        server_default=text("'#5bdbff'"),
     )
 
     gradient_end_color: Mapped[str] = mapped_column(
         String,
-        server_default=func.text("'#1c76fc'"),
+        server_default=text("'#1c76fc'"),
     )
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -71,6 +71,8 @@ class Query:
             Project(
                 id_attr=project.id,
                 name=project.name,
+                gradient_start_color=project.gradient_start_color,
+                gradient_end_color=project.gradient_end_color,
                 project=info.context.traces.get_project(project.name),  # type: ignore
             )
             for project in projects
@@ -109,6 +111,8 @@ class Query:
             return Project(
                 id_attr=project.id,
                 name=project.name,
+                gradient_start_color=project.gradient_start_color,
+                gradient_end_color=project.gradient_end_color,
                 project=info.context.traces.get_project(project.name),  # type: ignore
             )
         raise Exception(f"Unknown node type: {type_name}")

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -36,6 +36,8 @@ from phoenix.trace.schemas import SpanID
 @strawberry.type
 class Project(Node):
     name: str
+    gradient_start_color: str
+    gradient_end_color: str
     project: strawberry.Private[CoreProject]
 
     @strawberry.field


### PR DESCRIPTION
resolves #2926 

MVP of wiring up project gradient colors. This is done just to avoid a migration in the future.

<img width="319" alt="Screenshot 2024-04-23 at 12 28 09 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/7dc83093-704c-4b37-8e0f-5eb6a7330e3e">
