### PR TITLE
fix: disable client-side sorting on trace/span tables

### DIFF
--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -348,6 +348,7 @@ export function SpansTable(props: SpansTableProps) {
       sorting,
       columnVisibility,
     },
+    manualSorting: true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -456,6 +456,7 @@ export function TracesTable(props: TracesTableProps) {
     columns,
     data: tableData,
     onExpandedChange: setExpanded,
+    manualSorting: true,
     getSubRows: (row) => row.children,
     state: {
       sorting,


### PR DESCRIPTION
resolves #2927 

Disables JS sorting and relies entirely on server-side sorting.