### PR TITLE
feat(persistence): clear project

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -486,6 +486,7 @@ type Mutation {
   """
   exportClusters(clusters: [ClusterInput!]!, fileName: String): ExportedFile!
   deleteProject(id: GlobalID!): Query!
+  clearProject(id: GlobalID!): Query!
 }
 
 """A node in the graph with a globally unique ID"""

--- a/cspell.json
+++ b/cspell.json
@@ -41,6 +41,7 @@
         "RERANKER",
         "respx",
         "rgba",
+        "rowid",
         "seafoam",
         "sqlalchemy",
         "Starlette",

--- a/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
+++ b/src/phoenix/db/migrations/versions/cf03bd6bae1d_init.py
@@ -88,8 +88,6 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        # TODO(mikeldking): might not be the right place for this
-        sa.Column("session_id", sa.String, nullable=True),
         sa.Column("trace_id", sa.String, nullable=False, unique=True),
         sa.Column("start_time", sa.TIMESTAMP(timezone=True), nullable=False, index=True),
         sa.Column("end_time", sa.TIMESTAMP(timezone=True), nullable=False),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -152,7 +152,6 @@ class Trace(Base):
         ForeignKey("projects.id", ondelete="CASCADE"),
         index=True,
     )
-    session_id: Mapped[Optional[str]]
     trace_id: Mapped[str]
     start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Set, Union
 import numpy as np
 import numpy.typing as npt
 import strawberry
-from sqlalchemy import delete, query, select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import load_only
 from strawberry import ID, UNSET
 from strawberry.types import Info
@@ -266,13 +266,9 @@ class Mutation(ExportEventsMutation):
     @strawberry.mutation
     async def clear_project(self, info: Info[Context, None], id: GlobalID) -> Query:
         project_id = from_global_id_with_expected_type(str(id), "Project")
-        delete_statement = delete(models.Span).where(
-            models.Span.trace_rowid.in_(
-                query(models.Trace.id).filter(models.Trace.project_rowid == project_id)
-            )
-        )
+        delete_statement = delete(models.Trace).where(models.Trace.project_rowid == project_id)
         async with info.context.db() as session:
-            await session.delete(delete_statement)
+            await session.execute(delete_statement)
         return Query()
 
 

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Set, Union
 import numpy as np
 import numpy.typing as npt
 import strawberry
-from sqlalchemy import select
+from sqlalchemy import delete, query, select
 from sqlalchemy.orm import load_only
 from strawberry import ID, UNSET
 from strawberry.types import Info
@@ -261,6 +261,18 @@ class Mutation(ExportEventsMutation):
             if project.name == DEFAULT_PROJECT_NAME:
                 raise ValueError(f"Cannot delete the {DEFAULT_PROJECT_NAME} project")
             await session.delete(project)
+        return Query()
+
+    @strawberry.mutation
+    async def clear_project(self, info: Info[Context, None], id: GlobalID) -> Query:
+        project_id = from_global_id_with_expected_type(str(id), "Project")
+        delete_statement = delete(models.Span).where(
+            models.Span.trace_rowid.in_(
+                query(models.Trace.id).filter(models.Trace.project_rowid == project_id)
+            )
+        )
+        async with info.context.db() as session:
+            await session.delete(delete_statement)
         return Query()
 
 


### PR DESCRIPTION
resolves #2539

Adds the ability to clear traces from the DB. Currently doesn't include a time range but can in the future.

```graphql
mutation {
  clearProject(id: "UHJvamVjdDox") {
    projects {
      edges {
        node {
          ... on Project {
            name
            traceCount
          }
        }
      }
    }
  }
}
```