### PR TITLE
fix: normalize telemetry url before setup

### DIFF
--- a/src/phoenix/server/telemetry.py
+++ b/src/phoenix/server/telemetry.py
@@ -15,19 +15,21 @@ logger = getLogger(__name__)
 
 def normalize_http_collector_endpoint(endpoint: str) -> str:
     normalized_endpoint = endpoint
-    if not endpoint.startswith("http://") and not endpoint.startswith("https://"):
+    if not normalized_endpoint.startswith("http://") and not normalized_endpoint.startswith(
+        "https://"
+    ):
         logger.warning(
             "HTTP collector endpoint should include the protocol (http:// or https://)."
             "Assuming http."
         )
         # assume http if no protocol is provided
         normalized_endpoint = f"http://{endpoint}"
-    if endpoint.endswith("/v1/traces"):
+    if normalized_endpoint.endswith("/v1/traces"):
         logger.warning(
             "HTTP collector endpoint should not include the /v1/traces path. Removing it."
         )
         # remove the /v1/traces path
-        normalized_endpoint = endpoint[: -len("/v1/traces")]
+        normalized_endpoint = normalized_endpoint[: -len("/v1/traces")]
     # remove trailing slashes
     normalized_endpoint = normalized_endpoint.rstrip("/")
     return normalized_endpoint

--- a/src/phoenix/server/telemetry.py
+++ b/src/phoenix/server/telemetry.py
@@ -1,16 +1,16 @@
 import os
 from typing import TYPE_CHECKING
 
+from phoenix.config import (
+    ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_GRPC_ENDPOINT,
+    ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT,
+)
+
 if TYPE_CHECKING:
     from opentelemetry.trace import TracerProvider
 from logging import getLogger
 
 logger = getLogger(__name__)
-
-from phoenix.config import (  # noqa: E402
-    ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_GRPC_ENDPOINT,
-    ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT,
-)
 
 
 def normalize_http_collector_endpoint(endpoint: str) -> str:
@@ -35,7 +35,6 @@ def normalize_http_collector_endpoint(endpoint: str) -> str:
 
 def initialize_opentelemetry_tracer_provider() -> "TracerProvider":
     logger.info("Initializing OpenTelemetry tracer provider")
-    from opentelemetry import trace as trace_api
     from opentelemetry.sdk import trace as trace_sdk
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 

--- a/src/phoenix/server/telemetry.py
+++ b/src/phoenix/server/telemetry.py
@@ -45,7 +45,7 @@ def initialize_opentelemetry_tracer_provider() -> "TracerProvider":
         ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT
     ):
         logger.info(f"Using HTTP collector endpoint: {http_endpoint}")
-        http_endpoint = normalize_http_collector_endpoint(http_endpoint + "/v1/traces")
+        http_endpoint = normalize_http_collector_endpoint(http_endpoint) + "/v1/traces"
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter as HttpExporter,
         )

--- a/tests/server/test_telemetry.py
+++ b/tests/server/test_telemetry.py
@@ -1,0 +1,16 @@
+from phoenix.server.telemetry import normalize_http_collector_endpoint
+
+
+def test_normalize_http_collector_endpoint():
+    assert normalize_http_collector_endpoint("http://localhost:4317") == "http://localhost:4317"
+    assert normalize_http_collector_endpoint("https://localhost:4317") == "https://localhost:4317"
+    assert normalize_http_collector_endpoint("localhost:4317") == "http://localhost:4317"
+    assert (
+        normalize_http_collector_endpoint("http://localhost:4317/v1/traces")
+        == "http://localhost:4317"
+    )
+    assert (
+        normalize_http_collector_endpoint("https://localhost:4317/v1/traces")
+        == "https://localhost:4317"
+    )
+    assert normalize_http_collector_endpoint("localhost:4317/v1/traces") == "http://localhost:4317"


### PR DESCRIPTION
Makes sure that the URL doesn't include irrelevant info or trailing /v1/traces

resolves #2997 