### PR TITLE
feat: allow Prometheus to be configured via an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ EXPOSE 9090
 # Run the Phoenix server. Note that the ENTRYPOINT of the base image invokes
 # Python, so no explicit invocation of Python is needed here. See
 # https://github.com/GoogleContainerTools/distroless/blob/16dc4a6a33838006fe956e4c19f049ece9c18a8d/python3/BUILD#L55
-CMD ["-m", "phoenix.server.main", "--host", "0.0.0.0", "--port", "6006", "--enable-prometheus", "True", "serve"]
+CMD ["-m", "phoenix.server.main", "--host", "0.0.0.0", "--port", "6006", "serve"]

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -38,6 +38,11 @@ Note that if you plan on using SQLite, it's advised to to use a persistent volum
 and simply point the PHOENIX_WORKING_DIR to that volume.
 """
 
+ENV_PHOENIX_ENABLE_PROMETHEUS = "PHOENIX_ENABLE_PROMETHEUS"
+"""
+Whether to enable Prometheus. Defaults to false.
+"""
+
 # Phoenix server OpenTelemetry instrumentation environment variables
 ENV_PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT = (
     "PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT"
@@ -181,6 +186,19 @@ def get_env_database_connection_str() -> str:
         working_dir = get_working_dir()
         return f"sqlite:///{working_dir}/phoenix.db"
     return env_url
+
+
+def get_env_enable_prometheus() -> bool:
+    if (enable_promotheus := os.getenv(ENV_PHOENIX_ENABLE_PROMETHEUS)) is None or (
+        enable_promotheus_lower := enable_promotheus.lower()
+    ) == "false":
+        return False
+    if enable_promotheus_lower == "true":
+        return True
+    raise ValueError(
+        f"Invalid value for environment variable {ENV_PHOENIX_ENABLE_PROMETHEUS}: "
+        f"{enable_promotheus}. Value values are 'TRUE' and 'FALSE' (case-insensitive)."
+    )
 
 
 class SpanStorageType(Enum):

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import os
+import warnings
 from argparse import ArgumentParser
 from pathlib import Path
 from threading import Thread
@@ -14,6 +15,7 @@ import phoenix.trace.v1 as pb
 from phoenix.config import (
     EXPORT_DIR,
     get_env_database_connection_str,
+    get_env_enable_prometheus,
     get_env_host,
     get_env_port,
     get_pids_path,
@@ -210,7 +212,17 @@ if __name__ == "__main__":
     )
     read_only = args.read_only
     logger.info(f"Server umap params: {umap_params}")
-    if enable_prometheus := args.enable_prometheus:
+    if enable_prometheus := (
+        get_env_enable_prometheus() or (cli_enable_prometheus := args.enable_prometheus)
+    ):
+        if cli_enable_prometheus:
+            warnings.warn(
+                "The --enable-prometheus command line argument is being deprecated "
+                "and will be removed in an upcoming release. "
+                "Please set the PHOENIX_ENABLE_PROMETHEUS environment variable to TRUE.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         from phoenix.server.prometheus import start_prometheus
 
         start_prometheus()


### PR DESCRIPTION
- add support for a `PHOENIX_ENABLE_PROMETHEUS` environment variable
- add a deprecation warning for the existing `--enable-prometheus` command line argument

resolves #2712
