### PR TITLE
chore: default spans limit

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -27,6 +27,8 @@ from phoenix.server.api.types.Trace import Trace
 from phoenix.server.api.types.ValidationResult import ValidationResult
 from phoenix.trace.dsl import SpanFilter
 
+SPANS_LIMIT = 1000
+
 
 @strawberry.type
 class Project(Node):
@@ -194,6 +196,8 @@ class Project(Node):
             stmt = span_filter(stmt)
         if sort:
             stmt = sort.update_orm_expr(stmt)
+        # todo: remove this after adding pagination https://github.com/Arize-ai/phoenix/issues/3003
+        stmt = stmt.limit(SPANS_LIMIT)
         async with info.context.db() as session:
             spans = await session.scalars(stmt)
         data = [to_gql_span(span) for span in spans]

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import strawberry
 from openinference.semconv.trace import SpanAttributes
-from sqlalchemy import and_, distinct, select
+from sqlalchemy import and_, desc, distinct, select
 from sqlalchemy.orm import contains_eager
 from strawberry import ID, UNSET
 from strawberry.types import Info
@@ -196,6 +196,8 @@ class Project(Node):
             stmt = span_filter(stmt)
         if sort:
             stmt = sort.update_orm_expr(stmt)
+        else:
+            stmt = stmt.order_by(desc(models.Span.id))
         # todo: remove this after adding pagination https://github.com/Arize-ai/phoenix/issues/3003
         stmt = stmt.limit(SPANS_LIMIT)
         async with info.context.db() as session:

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -198,8 +198,9 @@ class Project(Node):
             stmt = sort.update_orm_expr(stmt)
         else:
             stmt = stmt.order_by(desc(models.Span.id))
-        # todo: remove this after adding pagination https://github.com/Arize-ai/phoenix/issues/3003
-        stmt = stmt.limit(SPANS_LIMIT)
+        stmt = stmt.limit(
+            SPANS_LIMIT
+        )  # todo: remove this after adding pagination https://github.com/Arize-ai/phoenix/issues/3003
         async with info.context.db() as session:
             spans = await session.scalars(stmt)
         data = [to_gql_span(span) for span in spans]


### PR DESCRIPTION
add a default limit of 1000 to the spans resolver. this is hard-coded and is purely for testing purposes until we get pagination out.
