### PR TITLE
fix: close delete modal on delete

### DIFF
--- a/app/src/pages/projects/ProjectActionMenu.tsx
+++ b/app/src/pages/projects/ProjectActionMenu.tsx
@@ -91,7 +91,13 @@ export function ProjectActionMenu({
           borderTopWidth="thin"
         >
           <Flex direction="row" justifyContent="end">
-            <Button variant="danger" onClick={handleDelete}>
+            <Button
+              variant="danger"
+              onClick={() => {
+                handleDelete();
+                setConfirmDialog(null);
+              }}
+            >
               Delete Project
             </Button>
           </Flex>


### PR DESCRIPTION
resolves #3058 

The issue here is that deleting a project while the project is receiving spans really doesn't do anything but clear the traces as the project gets immediately reconstructed. I filed #3068 to figure out what the right solution is there.