### PR TITLE
refactor: use TTL for project cache for dataloaders

### DIFF
--- a/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
@@ -12,7 +12,7 @@ from typing import (
 
 import numpy as np
 from aioitertools.itertools import groupby
-from cachetools import LFUCache
+from cachetools import LFUCache, TTLCache
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.dataloader import AbstractCache, DataLoader
@@ -54,7 +54,10 @@ _SubKey: TypeAlias = Tuple[TimeInterval, FilterCondition]
 
 class DocumentEvaluationSummaryCache(
     TwoTierCache[Key, Result, _Section, _SubKey],
-    main_cache_factory=lambda: LFUCache(maxsize=64 * 16),
+    # TTL=3600 (1-hour) because time intervals are always moving forward, but
+    # interval endpoints are rounded down to the hour by the UI, so anything
+    # older than an hour most likely won't be a cache-hit anyway.
+    main_cache_factory=lambda: TTLCache(maxsize=64 * 32, ttl=3600),
     sub_cache_factory=lambda: LFUCache(maxsize=2 * 2),
 ):
     def _cache_keys(self, key: Key) -> Tuple[_Section, _SubKey]:

--- a/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
+++ b/src/phoenix/server/api/dataloaders/latency_ms_quantile.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from cachetools import LFUCache
+from cachetools import LFUCache, TTLCache
 from sqlalchemy import (
     ARRAY,
     Float,
@@ -70,7 +70,10 @@ _SubKey: TypeAlias = Tuple[TimeInterval, FilterCondition, Kind, Probability]
 
 class LatencyMsQuantileCache(
     TwoTierCache[Key, Result, _Section, _SubKey],
-    main_cache_factory=lambda: LFUCache(maxsize=64),
+    # TTL=3600 (1-hour) because time intervals are always moving forward, but
+    # interval endpoints are rounded down to the hour by the UI, so anything
+    # older than an hour most likely won't be a cache-hit anyway.
+    main_cache_factory=lambda: TTLCache(maxsize=64, ttl=3600),
     sub_cache_factory=lambda: LFUCache(maxsize=2 * 2 * 2 * 16),
 ):
     def _cache_keys(self, key: Key) -> Tuple[_Section, _SubKey]:

--- a/src/phoenix/server/api/dataloaders/record_counts.py
+++ b/src/phoenix/server/api/dataloaders/record_counts.py
@@ -11,7 +11,7 @@ from typing import (
     Tuple,
 )
 
-from cachetools import LFUCache
+from cachetools import LFUCache, TTLCache
 from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.dataloader import AbstractCache, DataLoader
@@ -51,7 +51,10 @@ _SubKey: TypeAlias = Tuple[TimeInterval, FilterCondition, Kind]
 
 class RecordCountCache(
     TwoTierCache[Key, Result, _Section, _SubKey],
-    main_cache_factory=lambda: LFUCache(maxsize=64),
+    # TTL=3600 (1-hour) because time intervals are always moving forward, but
+    # interval endpoints are rounded down to the hour by the UI, so anything
+    # older than an hour most likely won't be a cache-hit anyway.
+    main_cache_factory=lambda: TTLCache(maxsize=64, ttl=3600),
     sub_cache_factory=lambda: LFUCache(maxsize=2 * 2 * 2),
 ):
     def _cache_keys(self, key: Key) -> Tuple[_Section, _SubKey]:


### PR DESCRIPTION
Set TTL=3600 (1-hour) because time intervals are always moving forward, but interval endpoints are [rounded down](https://github.com/Arize-ai/phoenix/pull/3079) to the hour by the UI, so anything older than an hour most likely won't be a cache-hit anyway.