### PR TITLE
fix: commit insert into alembic_version at the end of migration

### DIFF
--- a/src/phoenix/db/migrations/env.py
+++ b/src/phoenix/db/migrations/env.py
@@ -107,6 +107,7 @@ def run_migrations(connection: Connection) -> None:
             transaction_per_migration=True,
         )
         context.run_migrations()
+        transaction.commit()
     except Exception:
         transaction.rollback()
         raise


### PR DESCRIPTION
## Before
```
INFO  [sqlalchemy.engine.Engine] INSERT INTO alembic_version (version_num) VALUES ('cf03bd6bae1d') RETURNING version_num
INFO  [sqlalchemy.engine.Engine] [generated in 0.00034s] ()
INFO  [sqlalchemy.engine.Engine] ROLLBACK
```

## After
```
INFO  [sqlalchemy.engine.Engine] INSERT INTO alembic_version (version_num) VALUES ('cf03bd6bae1d') RETURNING version_num
INFO  [sqlalchemy.engine.Engine] [generated in 0.00010s] ()
INFO  [sqlalchemy.engine.Engine] COMMIT
```