### PR TITLE
fix: `_last_insertion_time` should be updated if queue is empty

### DIFF
--- a/src/phoenix/db/bulk_inserter.py
+++ b/src/phoenix/db/bulk_inserter.py
@@ -107,6 +107,7 @@ class BulkInserter:
             next_run_at = self._last_insertion_time + self._run_interval_seconds
             await asyncio.sleep(max(next_run_at - time(), 0))
             if not (self._spans or self._evaluations):
+                self._last_insertion_time = time()
                 continue
             # It's important to grab the buffers at the same time so there's
             # no race condition, since an eval insertion will fail if the span


### PR DESCRIPTION
follow-up to https://github.com/Arize-ai/phoenix/pull/3151/files