### PR TITLE
PHOENIX_WORKING_DIR default value documentation

### DIFF
--- a/docs/deployment/persistence.md
+++ b/docs/deployment/persistence.md
@@ -8,7 +8,7 @@ Persistence is only available for 'arize-phoenix>=4.0.0'
 
 ## SQLite
 
-By default Phoenix uses SQLite so that it runs with no external dependancies. This SQLite instance is by default mounted in the directory specified by the **PHOENIX\_WORKING\_DIR** environment variable. The easiest way to make Phoenix to persist data is to back this working directory to a mounted volume. Attach the mounted volume to the phoenix pod and point **PHOENIX\_WORKING\_DIR** to that volume (e.x. `/mnt/volume`)\
+By default Phoenix uses SQLite so that it runs with no external dependancies. This SQLite instance is by default mounted in the directory specified by the **PHOENIX\_WORKING\_DIR** environment variable (default value in your home directory, e.x. ` ~/.phoenix/`). The easiest way to make Phoenix to persist data is to back this working directory to a mounted volume. Attach the mounted volume to the phoenix pod and point **PHOENIX\_WORKING\_DIR** to that volume (e.x. `/mnt/volume`)\
 
 
 ## PostgreSQL

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -24,8 +24,8 @@ The following environment variables will control how your phoenix server runs.
 
 * **PHOENIX\_PORT:** The port to run the phoenix web server. Defaults to 6006.
 * **PHOENIX\_GRPC\_PORT:** The port to run the gRPC OTLP trace collector. Defaults to 4317.
-* &#x20;**PHOENIX\_HOST:** The host to run the phoenix server. Defaults to 0.0.0.0&#x20;
-* &#x20;**PHOENIX\_WORKING\_DIR:** The directory in which to save, load, and export datasets. This directory must be accessible by both the Phoenix server and the notebook environment.&#x20;
+* **PHOENIX\_HOST:** The host to run the phoenix server. Defaults to 0.0.0.0
+* **PHOENIX\_WORKING\_DIR:** The directory in which to save, load, and export datasets. This directory must be accessible by both the Phoenix server and the notebook environment. Defaults to `~/.phoenix/`
 * **PHOENIX\_SQL\_DATABASE\_URL:** The SQL database URL to use when logging traces and evals. if you plan on using SQLite, it's advised to to use a persistent volume and simply point the `PHOENIX_WORKING_DIR` to that volume. If URL is not specified, by default Phoenix starts with a file-based SQLite database in a temporary folder, the location of which will be shown at startup. Phoenix also supports PostgresSQL as shown below:
   * PostgreSQL, e.g. `postgresql://@host/dbname?user=user&password=password` or `postgresql://user:password@host/dbname`
   * SQLite, e.g. `sqlite:///path/to/database.db`


### PR DESCRIPTION
Hey :)
I'm opening this MR to update the docs relatively to the default value for `PHOENIX_WORKING_DIR`. It would be nice to know where the default folder for tracing is (e.g. to delete the files or to load the sqlite db in a different tool), so I added it in the documentation.
Open to feedback!

Best,
Martino