### PR TITLE
fix: evaluators no longer have incorrect type hints

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -199,24 +199,6 @@ class RelevanceEvaluator(LLMEvaluator):
         super().__init__(model=model, template=EvalCriteria.RELEVANCE.value)
 
 
-class ToxicityEvaluator(LLMEvaluator):
-    """
-    Leverages an LLM to evaluate whether the string stored under the "input"
-    column contains racist, sexist, chauvinistic, biased, or otherwise toxic
-    content.
-    """
-
-    def __init__(self, model: BaseModel) -> None:
-        """
-        Initializer for ToxicityEvaluator.
-
-        Args:
-            model (BaseEvalModel): The LLM model to use for evaluation.
-        """
-
-        super().__init__(model=model, template=EvalCriteria.TOXICITY.value)
-
-
 class QAEvaluator(LLMEvaluator):
     """
     Leverages an LLM to evaluate whether a response (stored under an "output"
@@ -234,6 +216,24 @@ class QAEvaluator(LLMEvaluator):
         """
 
         super().__init__(model=model, template=EvalCriteria.QA.value)
+
+
+class ToxicityEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether the string stored under the "input"
+    column contains racist, sexist, chauvinistic, biased, or otherwise toxic
+    content.
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for ToxicityEvaluator.
+
+        Args:
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
+
+        super().__init__(model=model, template=EvalCriteria.TOXICITY.value)
 
 
 class SummarizationEvaluator(LLMEvaluator):

--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -1,5 +1,4 @@
-from textwrap import indent
-from typing import List, Mapping, Optional, Tuple, Type
+from typing import List, Mapping, Optional, Tuple
 
 from phoenix.evals.default_templates import EvalCriteria
 from phoenix.evals.models import BaseModel, OpenAIModel, set_verbosity
@@ -164,76 +163,95 @@ class LLMEvaluator:
         return label, score, explanation
 
 
-def _create_llm_evaluator_subclass(
-    class_name: str, template: ClassificationTemplate, docstring: str
-) -> Type[LLMEvaluator]:
-    """A factory method that dynamically creates subclasses of LLMEvaluator.
-
-    Args:
-        class_name (str): Name of the class to be created (should match the name
-        of the assignment variable).
-
-        template (ClassificationTemplate): The classification template to use
-        for evaluation.
-
-        docstring (str): The docstring that will be attached to the subclass.
-
-    Returns:
-        Type[LLMEvaluator]: The dynamically created subclass.
+class HallucinationEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether a response (stored under an "output"
+    column) is a hallucination given a query (stored under an "input" column)
+    and one or more retrieved documents (stored under a "reference" column).
     """
 
-    def __init__(self: LLMEvaluator, model: BaseModel) -> None:
-        LLMEvaluator.__init__(self, model, template)
-
-    __init__.__doc__ = f"""
-        Initializer for {class_name}.
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for HallucinationEvaluator.
 
         Args:
-            model (BaseEvalModel): The LLM model to use for evaluation."""
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
 
-    docstring += f" Outputs railed classes {', '.join(template.rails)}."
-    docstring += "\n\nThe template used for evaluation (without explanation) is:\n\n"
-    docstring += indent(template.template, 2 * _TAB)
-
-    return type(class_name, (LLMEvaluator,), {"__init__": __init__, "__doc__": docstring})
+        super().__init__(self, model=model, template=EvalCriteria.HALLUCINATION.value)
 
 
-(
-    HallucinationEvaluator,
-    RelevanceEvaluator,
-    ToxicityEvaluator,
-    QAEvaluator,
-    SummarizationEvaluator,
-) = map(
-    lambda args: _create_llm_evaluator_subclass(*args),
-    (
-        (
-            "HallucinationEvaluator",
-            EvalCriteria.HALLUCINATION.value,
-            'Leverages an LLM to evaluate whether a response (stored under an "output" column) is a hallucination given a query (stored under an "input" column) and one or more retrieved documents (stored under a "reference" column).',  # noqa: E501
-        ),
-        (
-            "RelevanceEvaluator",
-            EvalCriteria.RELEVANCE.value,
-            'Leverages an LLM to evaluate whether a retrieved document (stored under a "reference" column) is relevant or irrelevant to the corresponding query (stored under the "input" column).',  # noqa: E501
-        ),
-        (
-            "ToxicityEvaluator",
-            EvalCriteria.TOXICITY.value,
-            'Leverages an LLM to evaluate whether the string stored under the "input" column contains racist, sexist, chauvinistic, biased, or otherwise toxic content.',  # noqa: E501
-        ),
-        (
-            "QAEvaluator",
-            EvalCriteria.QA.value,
-            'Leverages an LLM to evaluate whether a response (stored under an "output" column) is correct or incorrect given a query (stored under an "input" column) and one or more retrieved documents (stored under a "reference" column).',  # noqa: E501
-        ),
-        (
-            "SummarizationEvaluator",
-            EvalCriteria.SUMMARIZATION.value,
-            'Leverages an LLM to evaluate whether a summary (stored under an "output" column) provides an accurate synopsis of an input document (stored under a "input" column).',  # noqa: E501
-        ),
-    ),
-)
+class RelevanceEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether a retrieved document (stored under a
+    "reference" column) is relevant or irrelevant to the corresponding query
+    (stored under the "input" column).
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for RelevanceEvaluator.
+
+        Args:
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
+
+        super().__init__(self, model=model, template=EvalCriteria.RELEVANCE.value)
+
+
+class ToxicityEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether the string stored under the "input"
+    column contains racist, sexist, chauvinistic, biased, or otherwise toxic
+    content.
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for ToxicityEvaluator.
+
+        Args:
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
+
+        super().__init__(self, model=model, template=EvalCriteria.TOXICITY.value)
+
+
+class QAEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether a response (stored under an "output"
+    column) is correct or incorrect given a query (stored under an "input"
+    column) and one or more retrieved documents (stored under a "reference"
+    column).
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for QAEvaluator.
+
+        Args:
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
+
+        super().__init__(self, model=model, template=EvalCriteria.QA.value)
+
+
+class SummarizationEvaluator(LLMEvaluator):
+    """
+    Leverages an LLM to evaluate whether a summary (stored under an
+    "output" column) provides an accurate synopsis of an input document
+    (stored under a "input" column).
+    """
+
+    def __init__(self, model: BaseModel) -> None:
+        """
+        Initializer for SummarizationEvaluator.
+
+        Args:
+            model (BaseEvalModel): The LLM model to use for evaluation.
+        """
+
+        super().__init__(self, model=model, template=EvalCriteria.SUMMARIZATION.value)
 
 
 class MapReducer:

--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -178,7 +178,7 @@ class HallucinationEvaluator(LLMEvaluator):
             model (BaseEvalModel): The LLM model to use for evaluation.
         """
 
-        super().__init__(self, model=model, template=EvalCriteria.HALLUCINATION.value)
+        super().__init__(model=model, template=EvalCriteria.HALLUCINATION.value)
 
 
 class RelevanceEvaluator(LLMEvaluator):
@@ -196,7 +196,7 @@ class RelevanceEvaluator(LLMEvaluator):
             model (BaseEvalModel): The LLM model to use for evaluation.
         """
 
-        super().__init__(self, model=model, template=EvalCriteria.RELEVANCE.value)
+        super().__init__(model=model, template=EvalCriteria.RELEVANCE.value)
 
 
 class ToxicityEvaluator(LLMEvaluator):
@@ -214,7 +214,7 @@ class ToxicityEvaluator(LLMEvaluator):
             model (BaseEvalModel): The LLM model to use for evaluation.
         """
 
-        super().__init__(self, model=model, template=EvalCriteria.TOXICITY.value)
+        super().__init__(model=model, template=EvalCriteria.TOXICITY.value)
 
 
 class QAEvaluator(LLMEvaluator):
@@ -233,7 +233,7 @@ class QAEvaluator(LLMEvaluator):
             model (BaseEvalModel): The LLM model to use for evaluation.
         """
 
-        super().__init__(self, model=model, template=EvalCriteria.QA.value)
+        super().__init__(model=model, template=EvalCriteria.QA.value)
 
 
 class SummarizationEvaluator(LLMEvaluator):
@@ -251,7 +251,7 @@ class SummarizationEvaluator(LLMEvaluator):
             model (BaseEvalModel): The LLM model to use for evaluation.
         """
 
-        super().__init__(self, model=model, template=EvalCriteria.SUMMARIZATION.value)
+        super().__init__(model=model, template=EvalCriteria.SUMMARIZATION.value)
 
 
 class MapReducer:

--- a/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
@@ -172,27 +172,27 @@ def test_llm_evaluator_evaluate_makes_best_effort_attempt_to_parse_invalid_funct
         pytest.param(
             HallucinationEvaluator,
             "hallucinated",
-            id="HallucinationEvaluator",
+            id="hallucination-evaluator",
         ),
         pytest.param(
             RelevanceEvaluator,
             "relevant",
-            id="RelevanceEvaluator",
+            id="relevance-evaluator",
         ),
         pytest.param(
             QAEvaluator,
             "correct",
-            id="QAEvaluator",
+            id="qa-evaluator",
         ),
         pytest.param(
             ToxicityEvaluator,
             "toxic",
-            id="ToxicityEvaluator",
+            id="toxicity-evaluator",
         ),
         pytest.param(
             SummarizationEvaluator,
             "good",
-            id="SummarizationEvaluator",
+            id="summarization-evaluator",
         ),
     ],
 )

--- a/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
@@ -6,9 +6,13 @@ from phoenix.evals import (
     NOT_PARSABLE,
     RAG_RELEVANCY_PROMPT_TEMPLATE,
     ClassificationTemplate,
+    HallucinationEvaluator,
     LLMEvaluator,
     OpenAIModel,
+    QAEvaluator,
     RelevanceEvaluator,
+    SummarizationEvaluator,
+    ToxicityEvaluator,
 )
 from phoenix.evals.utils import _EXPLANATION, _RESPONSE
 
@@ -162,19 +166,52 @@ def test_llm_evaluator_evaluate_makes_best_effort_attempt_to_parse_invalid_funct
     assert explanation is None
 
 
-def test_relevance_evaluator_evaluate_outputs_label_when_model_produces_expected_output(
+@pytest.mark.parametrize(
+    "evaluator_cls, expected_label",
+    [
+        pytest.param(
+            HallucinationEvaluator,
+            "hallucinated",
+            id="HallucinationEvaluator",
+        ),
+        pytest.param(
+            RelevanceEvaluator,
+            "relevant",
+            id="RelevanceEvaluator",
+        ),
+        pytest.param(
+            QAEvaluator,
+            "correct",
+            id="QAEvaluator",
+        ),
+        pytest.param(
+            ToxicityEvaluator,
+            "toxic",
+            id="ToxicityEvaluator",
+        ),
+        pytest.param(
+            SummarizationEvaluator,
+            "good",
+            id="SummarizationEvaluator",
+        ),
+    ],
+)
+def test_evaluator_evaluate_outputs_expected_label_when_model_produces_expected_output(
+    evaluator_cls: LLMEvaluator,
+    expected_label: str,
     openai_model: OpenAIModel,
 ) -> None:
-    openai_model._generate = MagicMock(return_value="relevant")
-    evaluator = RelevanceEvaluator(openai_model)
+    openai_model._generate = MagicMock(return_value=expected_label)
+    evaluator = evaluator_cls(openai_model)
     label, score, explanation = evaluator.evaluate(
         {
-            "input": "What is the capital of California?",
-            "reference": "Sacramento is the capital of California.",
+            "input": "input-text",
+            "reference": "reference-text",
+            "output": "output-text",
         },
         use_function_calling_if_available=False,
     )
-    assert label == "relevant"
+    assert label == expected_label
     assert math.isclose(score, 1.0)
     assert explanation is None
 


### PR DESCRIPTION
The way I previously did the factory method for instantiating evaluators was overly complex and led to incorrect type hints for end users.

resolves #2638
