### PR TITLE
chore: update kustomize

### DIFF
--- a/kustomize/base/phoenix.yaml
+++ b/kustomize/base/phoenix.yaml
@@ -28,7 +28,7 @@ spec:
                         value: /mnt/data
                       - name: PHOENIX_PORT
                         value: "6006"
-                  image: arizephoenix/phoenix:version-4.0.3
+                  image: arizephoenix/phoenix:version-4.1.1
                   name: phoenix
                   ports:
                       - containerPort: 6006


### PR DESCRIPTION
Updates `kustomize` configuration to use `4.1.1` version of Phoenix, which fixes an issue when running on Postgres 12.