### PR TITLE
feat(datasets): multi-select on span / traces tables

### DIFF
--- a/app/src/components/dataset/CreateDatasetForm.tsx
+++ b/app/src/components/dataset/CreateDatasetForm.tsx
@@ -24,7 +24,7 @@ type CreateDatasetParams = {
 
 export type CreateDatasetFormProps = {
   onDatasetCreated: (
-    dataset: CreateDatasetFormMutation$data["createDataset"]
+    dataset: CreateDatasetFormMutation$data["createDataset"]["dataset"]
   ) => void;
   onDatasetCreateError: (error: Error) => void;
 };
@@ -64,7 +64,7 @@ export function CreateDatasetForm(props: CreateDatasetFormProps) {
       commit({
         variables: params,
         onCompleted: (response) => {
-          onDatasetCreated(response["createDataset"]);
+          onDatasetCreated(response["createDataset"]["dataset"]);
         },
         onError: (error) => {
           // TODO(datasets): cleanup error handling to show human friendly error

--- a/app/src/components/dataset/__generated__/CreateDatasetFormMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateDatasetFormMutation.graphql.ts
@@ -1,0 +1,152 @@
+/**
+ * @generated SignedSource<<6cdeb954351fb1678084ff14e016ce3e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type CreateDatasetFormMutation$variables = {
+  description?: string | null;
+  metadata?: any | null;
+  name: string;
+};
+export type CreateDatasetFormMutation$data = {
+  readonly createDataset: {
+    readonly dataset: {
+      readonly description: string | null;
+      readonly id: string;
+      readonly name: string;
+    };
+  };
+};
+export type CreateDatasetFormMutation = {
+  response: CreateDatasetFormMutation$data;
+  variables: CreateDatasetFormMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "description"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "metadata"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "description",
+            "variableName": "description"
+          },
+          {
+            "kind": "Variable",
+            "name": "metadata",
+            "variableName": "metadata"
+          },
+          {
+            "kind": "Variable",
+            "name": "name",
+            "variableName": "name"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "CreateDatasetPayload",
+    "kind": "LinkedField",
+    "name": "createDataset",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dataset",
+        "kind": "LinkedField",
+        "name": "dataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CreateDatasetFormMutation",
+    "selections": (v3/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "CreateDatasetFormMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "d2aeec21cead6fee265f4e80c330cf18",
+    "id": null,
+    "metadata": {},
+    "name": "CreateDatasetFormMutation",
+    "operationKind": "mutation",
+    "text": "mutation CreateDatasetFormMutation(\n  $name: String!\n  $description: String = null\n  $metadata: JSON = null\n) {\n  createDataset(input: {name: $name, description: $description, metadata: $metadata}) {\n    dataset {\n      id\n      name\n      description\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "06eeac5ef68e9533c4881faad4b4e07d";
+
+export default node;

--- a/app/src/components/table/IndeterminateCheckboxCell.tsx
+++ b/app/src/components/table/IndeterminateCheckboxCell.tsx
@@ -1,0 +1,37 @@
+import React, { HTMLProps, useRef } from "react";
+import { css } from "@emotion/react";
+
+/**
+ * A checkbox that can be in an indeterminate state.
+ * Borrowed from tanstack/react-table example code.
+ */
+export function IndeterminateCheckboxCell({
+  indeterminate,
+  ...passThroughProps
+}: { indeterminate?: boolean } & HTMLProps<HTMLInputElement>) {
+  const ref = useRef<HTMLInputElement>(null!);
+
+  React.useEffect(() => {
+    if (typeof indeterminate === "boolean") {
+      ref.current.indeterminate = !passThroughProps.checked && indeterminate;
+    }
+  }, [ref, indeterminate, passThroughProps.checked]);
+
+  return (
+    <div
+      onClick={(e) => {
+        // prevent conflicts with the table row click event
+        e.stopPropagation();
+      }}
+    >
+      <input
+        type="checkbox"
+        ref={ref}
+        css={css`
+          cursor: pointer;
+        `}
+        {...passThroughProps}
+      />
+    </div>
+  );
+}

--- a/app/src/pages/datasets/DatasetsPage.tsx
+++ b/app/src/pages/datasets/DatasetsPage.tsx
@@ -12,10 +12,10 @@ import {
 } from "@arizeai/components";
 
 import { Loading } from "@phoenix/components";
+import { CreateDatasetForm } from "@phoenix/components/dataset/CreateDatasetForm";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 
 import { DatasetsPageQuery } from "./__generated__/DatasetsPageQuery.graphql";
-import { CreateDatasetForm } from "./CreateDatasetForm";
 import { DatasetsTable } from "./DatasetsTable";
 
 export function DatasetsPage() {
@@ -74,14 +74,14 @@ function CreateDatasetButton({ onDatasetCreated }: CreateDatasetButtonProps) {
     setDialog(
       <Dialog size="S" title="New Dataset">
         <CreateDatasetForm
-          onDatasetCreated={(payload) => {
+          onDatasetCreated={(newDataset) => {
             notifySuccess({
               title: "Dataset created",
-              message: `${payload.dataset.name} has been successfully created.`,
+              message: `${newDataset.name} has been successfully created.`,
               action: {
                 text: "Go to Dataset",
                 onClick: () => {
-                  navigate(`/datasets/${payload.dataset.id}`);
+                  navigate(`/datasets/${newDataset.id}`);
                 },
               },
             });

--- a/app/src/pages/project/DatasetSelectorPopoverContent.tsx
+++ b/app/src/pages/project/DatasetSelectorPopoverContent.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo, useState } from "react";
+import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { css } from "@emotion/react";
+
+import {
+  Button,
+  Card,
+  Flex,
+  Icon,
+  Icons,
+  Item,
+  ListBox,
+  Text,
+  TextField,
+  View,
+} from "@arizeai/components";
+
+import { DatasetSelectorPopoverContent_datasets$key } from "./__generated__/DatasetSelectorPopoverContent_datasets.graphql";
+import { DatasetSelectorPopoverContentQuery } from "./__generated__/DatasetSelectorPopoverContentQuery.graphql";
+
+export type DatasetSelectorPopoverContentProps = {
+  onCreateNewDataset: () => void;
+  onDatasetSelected: (datasetId: string) => void;
+};
+export function DatasetSelectorPopoverContent(
+  props: DatasetSelectorPopoverContentProps
+) {
+  const { onCreateNewDataset, onDatasetSelected } = props;
+  const [search, setSearch] = useState<string>("");
+  const data = useLazyLoadQuery<DatasetSelectorPopoverContentQuery>(
+    graphql`
+      query DatasetSelectorPopoverContentQuery {
+        ...DatasetSelectorPopoverContent_datasets
+      }
+    `,
+    {},
+    { fetchPolicy: "network-only" }
+  );
+  return (
+    <Card
+      title="Add to Dataset"
+      variant="compact"
+      backgroundColor="light"
+      borderColor="light"
+      bodyStyle={{ padding: 0 }}
+      extra={
+        <Button variant="default" size="compact" onClick={onCreateNewDataset}>
+          New Dataset
+        </Button>
+      }
+    >
+      <View padding="size-100">
+        <TextField
+          type="search"
+          placeholder="Search datasets"
+          addonBefore={<Icon svg={<Icons.Search />} />}
+          onChange={(newSearch) => {
+            setSearch(newSearch);
+          }}
+        />
+      </View>
+      <View borderTopWidth="thin" borderColor="light">
+        <div
+          css={css`
+            height: 400px;
+            overflow-y: auto;
+          `}
+        >
+          <DatasetsListBox
+            query={data}
+            search={search}
+            onDatasetSelected={onDatasetSelected}
+          />
+        </div>
+      </View>
+    </Card>
+  );
+}
+
+function DatasetsListBox(props: {
+  search: string;
+  query: DatasetSelectorPopoverContent_datasets$key;
+  onDatasetSelected: (datasetId: string) => void;
+}) {
+  const { search, onDatasetSelected } = props;
+  const [data] = useRefetchableFragment(
+    graphql`
+      fragment DatasetSelectorPopoverContent_datasets on Query
+      @refetchable(queryName: "DatasetSelectorPopoverContentDatasetsQuery") {
+        datasets {
+          edges {
+            dataset: node {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    props.query
+  );
+  const datasets = useMemo(() => {
+    let datasets = data.datasets.edges.map((edge) => edge.dataset);
+    if (search) {
+      datasets = datasets.filter((dataset) =>
+        dataset.name.toLowerCase().includes(search.toLowerCase())
+      );
+    }
+    return datasets;
+  }, [search, data]);
+
+  const isEmpty = datasets.length === 0;
+  if (isEmpty) {
+    return (
+      <Flex
+        direction="column"
+        justifyContent="center"
+        alignItems="center"
+        flex="1 1 auto"
+      >
+        <Text>No datasets found</Text>
+      </Flex>
+    );
+  }
+  return (
+    <ListBox
+      selectionMode="single"
+      onSelectionChange={(selection) => {
+        if (typeof selection === "object") {
+          const selectedDatasetIds = Array.from(selection);
+          onDatasetSelected(selectedDatasetIds[0] as string);
+        }
+      }}
+    >
+      {datasets.map((ds) => (
+        <Item key={ds.id}>{ds.name}</Item>
+      ))}
+    </ListBox>
+  );
+}

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -1,0 +1,174 @@
+import React, { ReactNode, Suspense, useCallback, useState } from "react";
+import { graphql, useMutation } from "react-relay";
+import { useNavigate } from "react-router";
+import { css } from "@emotion/react";
+
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  Flex,
+  Icon,
+  Icons,
+  PopoverTrigger,
+  Text,
+  View,
+} from "@arizeai/components";
+
+import { CreateDatasetForm } from "@phoenix/components/dataset/CreateDatasetForm";
+import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+
+import { DatasetSelectorPopoverContent } from "./DatasetSelectorPopoverContent";
+
+interface SelectedSpan {
+  id: string;
+}
+
+type SpanSelectionToolbarProps = {
+  selectedSpans: SelectedSpan[];
+  onClearSelection: () => void;
+};
+
+export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
+  const [dialog, setDialog] = useState<ReactNode>(null);
+  const notifySuccess = useNotifySuccess();
+  const notifyError = useNotifyError();
+  const [isDatasetPopoverOpen, setIsDatasetPopoverOpen] = useState(false);
+  const { selectedSpans, onClearSelection } = props;
+  const [commitSpansToDataset, isAddingSpansToDataset] = useMutation(graphql`
+    mutation SpanSelectionToolbarAddSpansToDatasetMutation(
+      $input: AddSpansToDatasetInput!
+    ) {
+      addSpansToDataset(input: $input) {
+        dataset {
+          id
+        }
+      }
+    }
+  `);
+  const isPlural = selectedSpans.length !== 1;
+  const onAddSpansToDataset = useCallback(
+    (datasetId: string) => {
+      commitSpansToDataset({
+        variables: {
+          input: {
+            datasetId,
+            spanIds: selectedSpans.map((span) => span.id),
+          },
+        },
+        onCompleted: () => {
+          notifySuccess({
+            title: "Examples added to dataset",
+            message: `${selectedSpans.length} example${isPlural ? "s" : ""} have been added to the dataset.`,
+          });
+          // Clear the selection
+          onClearSelection();
+        },
+        onError: (error) => {
+          notifyError({
+            title: "An error occurred",
+            message: `Failed to add spans to dataset: ${error.message}`,
+          });
+        },
+      });
+    },
+    [
+      commitSpansToDataset,
+      isPlural,
+      notifyError,
+      notifySuccess,
+      selectedSpans,
+      onClearSelection,
+    ]
+  );
+  return (
+    <div
+      css={css`
+        position: absolute;
+        bottom: var(--ac-global-dimension-size-400);
+        left: 50%;
+        transform: translateX(-50%);
+      `}
+    >
+      <View
+        backgroundColor="light"
+        padding="size-200"
+        borderColor="light"
+        borderWidth="thin"
+        borderRadius="medium"
+        minWidth="size-6000"
+      >
+        <Flex
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Text>{`${selectedSpans.length} span${isPlural ? "s" : ""} selected`}</Text>
+          <Flex direction="row" gap="size-100">
+            <Button variant="default" size="compact" onClick={onClearSelection}>
+              Cancel
+            </Button>
+            <PopoverTrigger
+              placement="top end"
+              crossOffset={300}
+              isOpen={isDatasetPopoverOpen}
+              onOpenChange={(isOpen) => {
+                setIsDatasetPopoverOpen(isOpen);
+              }}
+            >
+              <Button
+                variant="primary"
+                size="compact"
+                icon={<Icon svg={<Icons.DatabaseOutline />} />}
+                loading={isAddingSpansToDataset}
+                disabled={isAddingSpansToDataset}
+              >
+                {isAddingSpansToDataset
+                  ? "Adding to dataset"
+                  : "Add to dataset"}
+              </Button>
+              <Suspense>
+                <DatasetSelectorPopoverContent
+                  onDatasetSelected={(datasetId) => {
+                    onAddSpansToDataset(datasetId);
+                    setIsDatasetPopoverOpen(false);
+                  }}
+                  onCreateNewDataset={() => {
+                    setIsDatasetPopoverOpen(false);
+                    setDialog(
+                      <Dialog title="New Dataset">
+                        <CreateDatasetForm
+                          onDatasetCreateError={() => {
+                            notifyError({
+                              title: "Dataset creation failed",
+                              message: "Failed to create dataset.",
+                            });
+                          }}
+                          onDatasetCreated={(dataset) => {
+                            setDialog(null);
+                            notifySuccess({
+                              title: "Dataset created",
+                              message: `${dataset.name} has been successfully created.`,
+                            });
+                            setIsDatasetPopoverOpen(true);
+                          }}
+                        />
+                      </Dialog>
+                    );
+                  }}
+                />
+              </Suspense>
+            </PopoverTrigger>
+          </Flex>
+        </Flex>
+      </View>
+      <DialogContainer
+        onDismiss={() => {
+          setDialog(null);
+        }}
+      >
+        {dialog}
+      </DialogContainer>
+    </div>
+  );
+}

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode, Suspense, useCallback, useState } from "react";
 import { graphql, useMutation } from "react-relay";
-import { useNavigate } from "react-router";
 import { css } from "@emotion/react";
 
 import {

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, {
   startTransition,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -24,6 +25,7 @@ import { Flex, Icon, Icons, View } from "@arizeai/components";
 
 import { Link } from "@phoenix/components/Link";
 import { TextCell } from "@phoenix/components/table";
+import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TableExpandButton } from "@phoenix/components/table/TableExpandButton";
@@ -45,6 +47,7 @@ import { EvaluationLabel } from "./EvaluationLabel";
 import { RetrievalEvaluationLabel } from "./RetrievalEvaluationLabel";
 import { SpanColumnSelector } from "./SpanColumnSelector";
 import { SpanFilterConditionField } from "./SpanFilterConditionField";
+import { SpanSelectionToolbar } from "./SpanSelectionToolbar";
 import { spansTableCSS } from "./styles";
 import {
   DEFAULT_SORT,
@@ -88,6 +91,7 @@ function spanTreeToNestedSpanTableRows<TSpan extends ISpanItem>(
 export function TracesTable(props: TracesTableProps) {
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const [rowSelection, setRowSelection] = useState({});
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
   const navigate = useNavigate();
@@ -117,6 +121,7 @@ export function TracesTable(props: TracesTableProps) {
           ) @connection(key: "TracesTable_rootSpans") {
             edges {
               rootSpan: node {
+                id
                 spanKind
                 name
                 metadata
@@ -149,6 +154,7 @@ export function TracesTable(props: TracesTableProps) {
                   hit
                 }
                 descendants {
+                  id
                   spanKind
                   name
                   statusCode: propagatedStatusCode
@@ -296,6 +302,20 @@ export function TracesTable(props: TracesTableProps) {
   ];
 
   const columns: ColumnDef<TableRow>[] = [
+    {
+      id: "select",
+      maxSize: 10,
+      cell: ({ row }) => (
+        <IndeterminateCheckboxCell
+          {...{
+            checked: row.getIsSelected(),
+            disabled: !row.getCanSelect(),
+            indeterminate: row.getIsSomeSelected(),
+            onChange: row.getToggleSelectedHandler(),
+          }}
+        />
+      ),
+    },
     {
       header: () => {
         return (
@@ -462,13 +482,21 @@ export function TracesTable(props: TracesTableProps) {
       sorting,
       expanded,
       columnVisibility,
+      rowSelection,
     },
+    onRowSelectionChange: setRowSelection,
+    enableSubRowSelection: false,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
   });
   const rows = table.getRowModel().rows;
+  const selectedRows = table.getSelectedRowModel().rows;
+  const selectedSpans = selectedRows.map((row) => row.original);
+  const clearSelection = useCallback(() => {
+    setRowSelection({});
+  }, [setRowSelection]);
   const isEmpty = rows.length === 0;
   const computedColumns = table.getAllColumns().filter((column) => {
     // Filter out columns that are eval groupings
@@ -571,6 +599,12 @@ export function TracesTable(props: TracesTableProps) {
           )}
         </table>
       </div>
+      {selectedRows.length ? (
+        <SpanSelectionToolbar
+          selectedSpans={selectedSpans}
+          onClearSelection={clearSelection}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/src/pages/project/__generated__/DatasetSelectorPopoverContentDatasetsQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/DatasetSelectorPopoverContentDatasetsQuery.graphql.ts
@@ -1,0 +1,105 @@
+/**
+ * @generated SignedSource<<0c4cf53dd4a0183ff8d2eb436d18b2f9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetSelectorPopoverContentDatasetsQuery$variables = Record<PropertyKey, never>;
+export type DatasetSelectorPopoverContentDatasetsQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetSelectorPopoverContent_datasets">;
+};
+export type DatasetSelectorPopoverContentDatasetsQuery = {
+  response: DatasetSelectorPopoverContentDatasetsQuery$data;
+  variables: DatasetSelectorPopoverContentDatasetsQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DatasetSelectorPopoverContentDatasetsQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "DatasetSelectorPopoverContent_datasets"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "DatasetSelectorPopoverContentDatasetsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "DatasetConnection",
+        "kind": "LinkedField",
+        "name": "datasets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "dataset",
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6d459b61a36b99979f025742892941f9",
+    "id": null,
+    "metadata": {},
+    "name": "DatasetSelectorPopoverContentDatasetsQuery",
+    "operationKind": "query",
+    "text": "query DatasetSelectorPopoverContentDatasetsQuery {\n  ...DatasetSelectorPopoverContent_datasets\n}\n\nfragment DatasetSelectorPopoverContent_datasets on Query {\n  datasets {\n    edges {\n      dataset: node {\n        id\n        name\n      }\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "40d5267ad0ec2335a73ff2a4d05bbed1";
+
+export default node;

--- a/app/src/pages/project/__generated__/DatasetSelectorPopoverContentQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/DatasetSelectorPopoverContentQuery.graphql.ts
@@ -1,0 +1,105 @@
+/**
+ * @generated SignedSource<<fed518c0b30d6d9dac45653f93c43a63>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetSelectorPopoverContentQuery$variables = Record<PropertyKey, never>;
+export type DatasetSelectorPopoverContentQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetSelectorPopoverContent_datasets">;
+};
+export type DatasetSelectorPopoverContentQuery = {
+  response: DatasetSelectorPopoverContentQuery$data;
+  variables: DatasetSelectorPopoverContentQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DatasetSelectorPopoverContentQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "DatasetSelectorPopoverContent_datasets"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "DatasetSelectorPopoverContentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "DatasetConnection",
+        "kind": "LinkedField",
+        "name": "datasets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "dataset",
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5fb28a402f330dd235295da21efea58b",
+    "id": null,
+    "metadata": {},
+    "name": "DatasetSelectorPopoverContentQuery",
+    "operationKind": "query",
+    "text": "query DatasetSelectorPopoverContentQuery {\n  ...DatasetSelectorPopoverContent_datasets\n}\n\nfragment DatasetSelectorPopoverContent_datasets on Query {\n  datasets {\n    edges {\n      dataset: node {\n        id\n        name\n      }\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "7cd8a13144d97d2b5294f2a09c9e1351";
+
+export default node;

--- a/app/src/pages/project/__generated__/DatasetSelectorPopoverContent_datasets.graphql.ts
+++ b/app/src/pages/project/__generated__/DatasetSelectorPopoverContent_datasets.graphql.ts
@@ -1,0 +1,95 @@
+/**
+ * @generated SignedSource<<a94c3d84b46672b56d631c5e77c3cf2e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetSelectorPopoverContent_datasets$data = {
+  readonly datasets: {
+    readonly edges: ReadonlyArray<{
+      readonly dataset: {
+        readonly id: string;
+        readonly name: string;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "DatasetSelectorPopoverContent_datasets";
+};
+export type DatasetSelectorPopoverContent_datasets$key = {
+  readonly " $data"?: DatasetSelectorPopoverContent_datasets$data;
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetSelectorPopoverContent_datasets">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./DatasetSelectorPopoverContentDatasetsQuery.graphql')
+    }
+  },
+  "name": "DatasetSelectorPopoverContent_datasets",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DatasetConnection",
+      "kind": "LinkedField",
+      "name": "datasets",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DatasetEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "dataset",
+              "args": null,
+              "concreteType": "Dataset",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "40d5267ad0ec2335a73ff2a4d05bbed1";
+
+export default node;

--- a/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<807e42f8533ba556d148c124ec4e469f>>
+ * @generated SignedSource<<8281c7e64e43a60aeebe2292a8304e40>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,11 +56,18 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
   "kind": "Literal",
   "name": "first",
   "value": 100
 },
-v4 = {
+v5 = {
   "kind": "Literal",
   "name": "sort",
   "value": {
@@ -68,52 +75,52 @@ v4 = {
     "dir": "desc"
   }
 },
-v5 = {
+v6 = {
   "kind": "Variable",
   "name": "timeRange",
   "variableName": "timeRange"
 },
-v6 = [
-  (v3/*: any*/),
+v7 = [
   (v4/*: any*/),
-  (v5/*: any*/)
+  (v5/*: any*/),
+  (v6/*: any*/)
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanKind",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "metadata",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanContext",
@@ -138,7 +145,7 @@ v12 = {
   ],
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "alias": "value",
     "args": null,
@@ -147,27 +154,27 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v13/*: any*/),
+  "selections": (v14/*: any*/),
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v13/*: any*/),
+  "selections": (v14/*: any*/),
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanEvaluation",
@@ -175,7 +182,7 @@ v16 = {
   "name": "spanEvaluations",
   "plural": true,
   "selections": [
-    (v8/*: any*/),
+    (v9/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -193,7 +200,7 @@ v16 = {
   ],
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -232,14 +239,14 @@ v17 = {
   ],
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "Span",
@@ -251,7 +258,7 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -276,31 +283,31 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = [
-  (v3/*: any*/),
+v22 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "rootSpansOnly",
     "value": true
   },
-  (v4/*: any*/),
-  (v5/*: any*/)
+  (v5/*: any*/),
+  (v6/*: any*/)
 ],
-v22 = {
+v23 = {
   "alias": "statusCode",
   "args": null,
   "kind": "ScalarField",
   "name": "propagatedStatusCode",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v24 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -309,8 +316,8 @@ v24 = [
     "storageKey": null
   }
 ],
-v25 = [
-  (v5/*: any*/)
+v26 = [
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -373,13 +380,7 @@ return {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
+          (v3/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -392,7 +393,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -414,9 +415,10 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v3/*: any*/),
                           (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -424,8 +426,8 @@ return {
                             "name": "statusCode",
                             "storageKey": null
                           },
-                          (v10/*: any*/),
                           (v11/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -447,26 +449,26 @@ return {
                             "name": "tokenCountCompletion",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
-                          (v14/*: any*/),
+                          (v13/*: any*/),
                           (v15/*: any*/),
                           (v16/*: any*/),
-                          (v17/*: any*/)
+                          (v17/*: any*/),
+                          (v18/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v18/*: any*/),
-                      (v19/*: any*/)
+                      (v19/*: any*/),
+                      (v20/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v21/*: any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v7/*: any*/),
                 "filters": [
                   "sort",
                   "filterCondition",
@@ -479,7 +481,7 @@ return {
               },
               {
                 "alias": "rootSpans",
-                "args": (v21/*: any*/),
+                "args": (v22/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -501,12 +503,13 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v3/*: any*/),
                           (v8/*: any*/),
                           (v9/*: any*/),
-                          (v22/*: any*/),
                           (v10/*: any*/),
+                          (v23/*: any*/),
                           (v11/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -528,12 +531,12 @@ return {
                             "name": "cumulativeTokenCountCompletion",
                             "storageKey": null
                           },
-                          (v23/*: any*/),
-                          (v14/*: any*/),
+                          (v24/*: any*/),
                           (v15/*: any*/),
-                          (v12/*: any*/),
                           (v16/*: any*/),
+                          (v13/*: any*/),
                           (v17/*: any*/),
+                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -542,12 +545,13 @@ return {
                             "name": "descendants",
                             "plural": true,
                             "selections": [
-                              (v7/*: any*/),
+                              (v3/*: any*/),
                               (v8/*: any*/),
-                              (v22/*: any*/),
-                              (v10/*: any*/),
-                              (v11/*: any*/),
+                              (v9/*: any*/),
                               (v23/*: any*/),
+                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              (v24/*: any*/),
                               {
                                 "alias": "cumulativeTokenCountTotal",
                                 "args": null,
@@ -576,7 +580,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "input",
                                 "plural": false,
-                                "selections": (v24/*: any*/),
+                                "selections": (v25/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -586,30 +590,30 @@ return {
                                 "kind": "LinkedField",
                                 "name": "output",
                                 "plural": false,
-                                "selections": (v24/*: any*/),
+                                "selections": (v25/*: any*/),
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
-                              (v16/*: any*/),
-                              (v17/*: any*/)
+                              (v13/*: any*/),
+                              (v17/*: any*/),
+                              (v18/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v18/*: any*/),
-                      (v19/*: any*/)
+                      (v19/*: any*/),
+                      (v20/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v21/*: any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": "rootSpans",
-                "args": (v21/*: any*/),
+                "args": (v22/*: any*/),
                 "filters": [
                   "sort",
                   "rootSpansOnly",
@@ -623,14 +627,14 @@ return {
               },
               {
                 "alias": null,
-                "args": (v25/*: any*/),
+                "args": (v26/*: any*/),
                 "kind": "ScalarField",
                 "name": "traceCount",
                 "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v25/*: any*/),
+                "args": (v26/*: any*/),
                 "kind": "ScalarField",
                 "name": "tokenCountTotal",
                 "storageKey": null
@@ -643,7 +647,7 @@ return {
                     "name": "probability",
                     "value": 0.5
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "kind": "ScalarField",
                 "name": "latencyMsQuantile",
@@ -657,7 +661,7 @@ return {
                     "name": "probability",
                     "value": 0.99
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "kind": "ScalarField",
                 "name": "latencyMsQuantile",
@@ -687,12 +691,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b36eff80e4b1f8a62276ecd93ac4ec47",
+    "cacheID": "f91a1a2f14ed08ee58a7f39925bac3c8",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: 100, sort: {col: startTime, dir: desc}, timeRange: $timeRange) {\n    edges {\n      span: node {\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanEvaluationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: 100, sort: {col: startTime, dir: desc}, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: 100, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          id\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/__generated__/SpanSelectionToolbarAddSpansToDatasetMutation.graphql.ts
+++ b/app/src/pages/project/__generated__/SpanSelectionToolbarAddSpansToDatasetMutation.graphql.ts
@@ -1,0 +1,108 @@
+/**
+ * @generated SignedSource<<27e425354d9a6193c25a09cbe1d7d460>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AddSpansToDatasetInput = {
+  datasetId: string;
+  datasetVersionDescription?: string | null;
+  datasetVersionMetadata?: any | null;
+  spanIds: ReadonlyArray<string>;
+};
+export type SpanSelectionToolbarAddSpansToDatasetMutation$variables = {
+  input: AddSpansToDatasetInput;
+};
+export type SpanSelectionToolbarAddSpansToDatasetMutation$data = {
+  readonly addSpansToDataset: {
+    readonly dataset: {
+      readonly id: string;
+    };
+  };
+};
+export type SpanSelectionToolbarAddSpansToDatasetMutation = {
+  response: SpanSelectionToolbarAddSpansToDatasetMutation$data;
+  variables: SpanSelectionToolbarAddSpansToDatasetMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AddSpansToDatasetPayload",
+    "kind": "LinkedField",
+    "name": "addSpansToDataset",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Dataset",
+        "kind": "LinkedField",
+        "name": "dataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SpanSelectionToolbarAddSpansToDatasetMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SpanSelectionToolbarAddSpansToDatasetMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "1c694540190478b8fba8ef3c0cacf30c",
+    "id": null,
+    "metadata": {},
+    "name": "SpanSelectionToolbarAddSpansToDatasetMutation",
+    "operationKind": "mutation",
+    "text": "mutation SpanSelectionToolbarAddSpansToDatasetMutation(\n  $input: AddSpansToDatasetInput!\n) {\n  addSpansToDataset(input: $input) {\n    dataset {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5e3aef907285081a06c0e0360045e865";
+
+export default node;

--- a/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3b5d830da1c30a7b5e84543eaa26eec>>
+ * @generated SignedSource<<e8be7057253b134c8b01970cd9616d43>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,7 +112,14 @@ v11 = {
   "name": "__typename",
   "storageKey": null
 },
-v12 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v13 = [
   (v7/*: any*/),
   (v8/*: any*/),
   (v9/*: any*/),
@@ -123,14 +130,14 @@ v12 = [
     "variableName": "timeRange"
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": "value",
     "args": null,
@@ -204,13 +211,7 @@ return {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
+          (v12/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -223,7 +224,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v12/*: any*/),
+                "args": (v13/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -245,6 +246,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -252,7 +254,7 @@ return {
                             "name": "spanKind",
                             "storageKey": null
                           },
-                          (v13/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -334,7 +336,7 @@ return {
                             "kind": "LinkedField",
                             "name": "input",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -344,7 +346,7 @@ return {
                             "kind": "LinkedField",
                             "name": "output",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -355,7 +357,7 @@ return {
                             "name": "spanEvaluations",
                             "plural": true,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -467,7 +469,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v12/*: any*/),
+                "args": (v13/*: any*/),
                 "filters": [
                   "sort",
                   "filterCondition",
@@ -488,16 +490,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "06dfd950503b65c9d0ce14a43780d0c3",
+    "cacheID": "2413f18f0d411113ca2ad6117d901511",
     "id": null,
     "metadata": {},
     "name": "SpansTableSpansQuery",
     "operationKind": "query",
-    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans_1XEuU on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: $first, after: $after, sort: $sort, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      span: node {\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment SpansTable_spans_1XEuU on Project {\n  ...SpanColumnSelector_evaluations\n  spans(first: $first, after: $after, sort: $sort, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        context {\n          spanId\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ba5d821b72675bc6ea380d9f0f36e8b7";
+(node as any).hash = "78738e3d457d0b4140c9bb4f4dc1180a";
 
 export default node;

--- a/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92417fd62f18f55233ff6dcadb92e2a0>>
+ * @generated SignedSource<<d0e1796f70c8fa6099732ff98c20df11>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -27,6 +27,7 @@ export type SpansTable_spans$data = {
           readonly ndcg: number | null;
           readonly precision: number | null;
         }>;
+        readonly id: string;
         readonly input: {
           readonly value: string;
         } | null;
@@ -66,10 +67,17 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v2 = [
+v3 = [
   {
     "alias": "value",
     "args": null,
@@ -184,6 +192,7 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -191,7 +200,7 @@ return {
                   "name": "spanKind",
                   "storageKey": null
                 },
-                (v1/*: any*/),
+                (v2/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -273,7 +282,7 @@ return {
                   "kind": "LinkedField",
                   "name": "input",
                   "plural": false,
-                  "selections": (v2/*: any*/),
+                  "selections": (v3/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -283,7 +292,7 @@ return {
                   "kind": "LinkedField",
                   "name": "output",
                   "plural": false,
-                  "selections": (v2/*: any*/),
+                  "selections": (v3/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -294,7 +303,7 @@ return {
                   "name": "spanEvaluations",
                   "plural": true,
                   "selections": [
-                    (v1/*: any*/),
+                    (v2/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -410,19 +419,13 @@ return {
       ],
       "storageKey": null
     },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "id",
-      "storageKey": null
-    }
+    (v1/*: any*/)
   ],
   "type": "Project",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "ba5d821b72675bc6ea380d9f0f36e8b7";
+(node as any).hash = "78738e3d457d0b4140c9bb4f4dc1180a";
 
 export default node;

--- a/app/src/pages/project/__generated__/TracesTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<989e3ee43a2807856fd1239125d83dfa>>
+ * @generated SignedSource<<6e4d1c5341bc49d250c97a667a770e56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,7 +112,14 @@ v11 = {
   "name": "__typename",
   "storageKey": null
 },
-v12 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v13 = [
   (v7/*: any*/),
   (v8/*: any*/),
   (v9/*: any*/),
@@ -128,49 +135,49 @@ v12 = [
     "variableName": "timeRange"
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanKind",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": "statusCode",
   "args": null,
   "kind": "ScalarField",
   "name": "propagatedStatusCode",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v19 = [
+v20 = [
   {
     "alias": "value",
     "args": null,
@@ -179,7 +186,7 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanContext",
@@ -204,7 +211,7 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanEvaluation",
@@ -212,7 +219,7 @@ v21 = {
   "name": "spanEvaluations",
   "plural": true,
   "selections": [
-    (v14/*: any*/),
+    (v15/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -230,7 +237,7 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -269,7 +276,7 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = [
+v24 = [
   {
     "alias": null,
     "args": null,
@@ -343,13 +350,7 @@ return {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
+          (v12/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -362,7 +363,7 @@ return {
               },
               {
                 "alias": "rootSpans",
-                "args": (v12/*: any*/),
+                "args": (v13/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -384,8 +385,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
+                          (v12/*: any*/),
                           (v14/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -393,9 +395,9 @@ return {
                             "name": "metadata",
                             "storageKey": null
                           },
-                          (v15/*: any*/),
                           (v16/*: any*/),
                           (v17/*: any*/),
+                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -417,7 +419,7 @@ return {
                             "name": "cumulativeTokenCountCompletion",
                             "storageKey": null
                           },
-                          (v18/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -425,7 +427,7 @@ return {
                             "kind": "LinkedField",
                             "name": "input",
                             "plural": false,
-                            "selections": (v19/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -435,12 +437,12 @@ return {
                             "kind": "LinkedField",
                             "name": "output",
                             "plural": false,
-                            "selections": (v19/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
-                          (v20/*: any*/),
                           (v21/*: any*/),
                           (v22/*: any*/),
+                          (v23/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -449,12 +451,13 @@ return {
                             "name": "descendants",
                             "plural": true,
                             "selections": [
-                              (v13/*: any*/),
+                              (v12/*: any*/),
                               (v14/*: any*/),
                               (v15/*: any*/),
                               (v16/*: any*/),
                               (v17/*: any*/),
                               (v18/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": "cumulativeTokenCountTotal",
                                 "args": null,
@@ -483,7 +486,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "input",
                                 "plural": false,
-                                "selections": (v23/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -493,12 +496,12 @@ return {
                                 "kind": "LinkedField",
                                 "name": "output",
                                 "plural": false,
-                                "selections": (v23/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               },
-                              (v20/*: any*/),
                               (v21/*: any*/),
-                              (v22/*: any*/)
+                              (v22/*: any*/),
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -557,7 +560,7 @@ return {
               },
               {
                 "alias": "rootSpans",
-                "args": (v12/*: any*/),
+                "args": (v13/*: any*/),
                 "filters": [
                   "sort",
                   "rootSpansOnly",
@@ -579,16 +582,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "53ca67e938a89bb469bf35d8623a1788",
+    "cacheID": "82574e0f30ec618a7a89afd7c4664347",
     "id": null,
     "metadata": {},
     "name": "TracesTableQuery",
     "operationKind": "query",
-    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...TracesTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment TracesTable_spans_1XEuU on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 100\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...TracesTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_evaluations on Project {\n  spanEvaluationNames\n}\n\nfragment TracesTable_spans_1XEuU on Project {\n  ...SpanColumnSelector_evaluations\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanEvaluations {\n          name\n          label\n          score\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          id\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value\n          }\n          output {\n            value\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanEvaluations {\n            name\n            label\n            score\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "567d631d2187a62101bff2abba20d240";
+(node as any).hash = "b8e7c42b9731568c7e348cf191017d06";
 
 export default node;

--- a/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6d59c2a06cc578894102874c2eb1f1e3>>
+ * @generated SignedSource<<8fcec1f707fe453a191ba2f7b079be0c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,6 +38,7 @@ export type TracesTable_spans$data = {
             readonly ndcg: number | null;
             readonly precision: number | null;
           }>;
+          readonly id: string;
           readonly input: {
             readonly value: string;
           } | null;
@@ -62,6 +63,7 @@ export type TracesTable_spans$data = {
           readonly ndcg: number | null;
           readonly precision: number | null;
         }>;
+        readonly id: string;
         readonly input: {
           readonly value: string;
         } | null;
@@ -99,45 +101,52 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "spanKind",
+  "name": "id",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "spanKind",
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
   "alias": "statusCode",
   "args": null,
   "kind": "ScalarField",
   "name": "propagatedStatusCode",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "alias": "value",
     "args": null,
@@ -146,7 +155,7 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanContext",
@@ -171,7 +180,7 @@ v8 = {
   ],
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanEvaluation",
@@ -179,7 +188,7 @@ v9 = {
   "name": "spanEvaluations",
   "plural": true,
   "selections": [
-    (v2/*: any*/),
+    (v3/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -197,7 +206,7 @@ v9 = {
   ],
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -236,7 +245,7 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -358,6 +367,7 @@ return {
               "selections": [
                 (v1/*: any*/),
                 (v2/*: any*/),
+                (v3/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -365,9 +375,9 @@ return {
                   "name": "metadata",
                   "storageKey": null
                 },
-                (v3/*: any*/),
                 (v4/*: any*/),
                 (v5/*: any*/),
+                (v6/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -389,7 +399,7 @@ return {
                   "name": "cumulativeTokenCountCompletion",
                   "storageKey": null
                 },
-                (v6/*: any*/),
+                (v7/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -397,7 +407,7 @@ return {
                   "kind": "LinkedField",
                   "name": "input",
                   "plural": false,
-                  "selections": (v7/*: any*/),
+                  "selections": (v8/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -407,12 +417,12 @@ return {
                   "kind": "LinkedField",
                   "name": "output",
                   "plural": false,
-                  "selections": (v7/*: any*/),
+                  "selections": (v8/*: any*/),
                   "storageKey": null
                 },
-                (v8/*: any*/),
                 (v9/*: any*/),
                 (v10/*: any*/),
+                (v11/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -427,6 +437,7 @@ return {
                     (v4/*: any*/),
                     (v5/*: any*/),
                     (v6/*: any*/),
+                    (v7/*: any*/),
                     {
                       "alias": "cumulativeTokenCountTotal",
                       "args": null,
@@ -455,7 +466,7 @@ return {
                       "kind": "LinkedField",
                       "name": "input",
                       "plural": false,
-                      "selections": (v11/*: any*/),
+                      "selections": (v12/*: any*/),
                       "storageKey": null
                     },
                     {
@@ -465,12 +476,12 @@ return {
                       "kind": "LinkedField",
                       "name": "output",
                       "plural": false,
-                      "selections": (v11/*: any*/),
+                      "selections": (v12/*: any*/),
                       "storageKey": null
                     },
-                    (v8/*: any*/),
                     (v9/*: any*/),
-                    (v10/*: any*/)
+                    (v10/*: any*/),
+                    (v11/*: any*/)
                   ],
                   "storageKey": null
                 }
@@ -533,19 +544,13 @@ return {
       ],
       "storageKey": null
     },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "id",
-      "storageKey": null
-    }
+    (v1/*: any*/)
   ],
   "type": "Project",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "567d631d2187a62101bff2abba20d240";
+(node as any).hash = "b8e7c42b9731568c7e348cf191017d06";
 
 export default node;


### PR DESCRIPTION
resolves #3202 

Adds the ability to add spans as examples to a dataset from the tables
<img width="2056" alt="Screenshot 2024-05-20 at 5 24 54 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/f638e8f3-2fa8-4fdd-8ee7-f2c75ab92b8b">
