### PR TITLE
fix: Bypass signal handler if running in a thread

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -259,11 +259,13 @@ class SyncExecutor(Executor):
     def _signal_handler(self, signum: int, frame: Any) -> None:
         tqdm.write("Process was interrupted. The return value will be incomplete...")
         self._TERMINATE = True
-    
-    def _set_signal_handler(self, signum: Optional[int], handler: Callable[[int, Any], None]) -> None:
+
+    def _set_signal_handler(
+        self, signum: Optional[int], handler: Callable[[int, Any], None]
+    ) -> None:
         if signum is not None:
             signal.signal(signum, handler)
-    
+
     def _reset_signal_handler(self, signum: Optional[int]) -> None:
         if signum is not None:
             signal.signal(signum, signal.SIG_DFL)

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -339,7 +339,7 @@ def get_executor_on_sync_context(
             termination_signal=None,
         )
 
-    if run_sync is False:
+    if run_sync is True:
         return SyncExecutor(
             sync_fn,
             tqdm_bar_format=tqdm_bar_format,

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -5,7 +5,19 @@ import logging
 import signal
 import threading
 import traceback
-from typing import Any, Callable, Coroutine, List, Optional, Protocol, Sequence, Tuple, Union
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Generator,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from phoenix.evals.exceptions import PhoenixException
 from tqdm.auto import tqdm
@@ -169,7 +181,7 @@ class AsyncExecutor(Executor):
             termination_event.set()
             tqdm.write("Process was interrupted. The return value will be incomplete...")
 
-        signal.signal(self.termination_signal, termination_handler)
+        original_handler = signal.signal(self.termination_signal, termination_handler)
         outputs = [self.fallback_return_value] * len(inputs)
         progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
 
@@ -210,7 +222,7 @@ class AsyncExecutor(Executor):
             termination_event_watcher.cancel()
 
         # reset the SIGTERM handler
-        signal.signal(self.termination_signal, signal.SIG_DFL)  # reset the SIGTERM handler
+        signal.signal(self.termination_signal, original_handler)  # reset the SIGTERM handler
         return outputs
 
     def run(self, inputs: Sequence[Any]) -> List[Any]:
@@ -260,45 +272,46 @@ class SyncExecutor(Executor):
         tqdm.write("Process was interrupted. The return value will be incomplete...")
         self._TERMINATE = True
 
-    def _set_signal_handler(
-        self, signum: Optional[int], handler: Callable[[int, Any], None]
-    ) -> None:
+    @contextmanager
+    def _executor_signal_handling(self, signum: Optional[int]) -> Generator[None, None, None]:
+        original_handler = None
         if signum is not None:
-            signal.signal(signum, handler)
-
-    def _reset_signal_handler(self, signum: Optional[int]) -> None:
-        if signum is not None:
-            signal.signal(signum, signal.SIG_DFL)
+            original_handler = signal.signal(signum, self._signal_handler)
+            try:
+                yield
+            finally:
+                signal.signal(signum, original_handler)
+        else:
+            yield
 
     def run(self, inputs: Sequence[Any]) -> List[Any]:
-        self._set_signal_handler(self.termination_signal, self._signal_handler)
-        outputs = [self.fallback_return_value] * len(inputs)
-        progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
+        with self._executor_signal_handling(self.termination_signal):
+            outputs = [self.fallback_return_value] * len(inputs)
+            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
 
-        for index, input in enumerate(inputs):
-            try:
-                for attempt in range(self.max_retries + 1):
-                    if self._TERMINATE:
+            for index, input in enumerate(inputs):
+                try:
+                    for attempt in range(self.max_retries + 1):
+                        if self._TERMINATE:
+                            return outputs
+                        try:
+                            result = self.generate(input)
+                            outputs[index] = result
+                            progress_bar.update()
+                            break
+                        except Exception as exc:
+                            is_phoenix_exception = isinstance(exc, PhoenixException)
+                            if attempt >= self.max_retries or is_phoenix_exception:
+                                raise exc
+                            else:
+                                tqdm.write(f"Exception in worker on attempt {attempt + 1}: {exc}")
+                                tqdm.write("Retrying...")
+                except Exception as exc:
+                    tqdm.write(f"Exception in worker: {exc}")
+                    if self.exit_on_error:
                         return outputs
-                    try:
-                        result = self.generate(input)
-                        outputs[index] = result
+                    else:
                         progress_bar.update()
-                        break
-                    except Exception as exc:
-                        is_phoenix_exception = isinstance(exc, PhoenixException)
-                        if attempt >= self.max_retries or is_phoenix_exception:
-                            raise exc
-                        else:
-                            tqdm.write(f"Exception in worker on attempt {attempt + 1}: {exc}")
-                            tqdm.write("Retrying...")
-            except Exception as exc:
-                tqdm.write(f"Exception in worker: {exc}")
-                if self.exit_on_error:
-                    return outputs
-                else:
-                    progress_bar.update()
-        self._reset_signal_handler(self.termination_signal)
         return outputs
 
 

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -1,7 +1,9 @@
 import asyncio
 import os
 import platform
+import queue
 import signal
+import threading
 import time
 from unittest.mock import AsyncMock, Mock
 
@@ -343,3 +345,95 @@ def test_executor_factory_returns_sync_in_sync_context_if_asked():
 
     executor = executor_in_sync_context()
     assert isinstance(executor, SyncExecutor)
+
+
+def test_executor_factory_returns_sync_in_threads():
+    def sync_fn():
+        pass
+
+    async def async_fn():
+        pass
+
+    exception_log = queue.Queue()
+
+    def run_test():
+        try:
+            executor = get_executor_on_sync_context(
+                sync_fn,
+                async_fn,
+                run_sync=True,  # request a sync_executor
+            )
+            assert isinstance(executor, SyncExecutor)
+            assert executor.termination_signal is None
+        except Exception as e:
+            exception_log.put(e)
+
+    test_thread = threading.Thread(target=run_test)
+    test_thread.start()
+    test_thread.join()
+    if not exception_log.empty():
+        raise exception_log.get()
+
+
+async def test_executor_factory_returns_sync_in_threads_even_if_async_context():
+    def sync_fn():
+        pass
+
+    async def async_fn():
+        pass
+
+    exception_log = queue.Queue()
+
+    async def run_test():
+        nest_asyncio.apply()
+        try:
+            executor = get_executor_on_sync_context(
+                sync_fn,
+                async_fn,
+            )
+            assert isinstance(executor, SyncExecutor)
+            assert executor.termination_signal is None
+        except Exception as e:
+            exception_log.put(e)
+
+    def async_task(loop):
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(run_test())
+
+    loop = asyncio.new_event_loop()
+    test_thread = threading.Thread(target=async_task, args=(loop,))
+    test_thread.start()
+    test_thread.join()
+
+    if not exception_log.empty():
+        raise exception_log.get()
+
+
+def test_executor_factory_returns_async_not_in_thread_if_async_context():
+    def sync_fn():
+        pass
+
+    async def async_fn():
+        pass
+
+    exception_log = queue.Queue()
+
+    async def run_test():
+        nest_asyncio.apply()
+        try:
+            executor = get_executor_on_sync_context(
+                sync_fn,
+                async_fn,
+            )
+            assert isinstance(executor, AsyncExecutor)
+            assert executor.termination_signal is not None
+        except Exception as e:
+            exception_log.put(e)
+
+    def async_task():
+        asyncio.run(run_test())
+
+    async_task()
+
+    if not exception_log.empty():
+        raise exception_log.get()

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -244,6 +244,33 @@ def test_sync_executor_sigint_handling():
     assert results.count("test") > 100, "most inputs should not have been processed"
 
 
+def test_sync_executor_defaults_sigint_handling():
+    def sync_fn(x):
+        return signal.getsignal(signal.SIGINT)
+
+    executor = SyncExecutor(
+        sync_fn,
+        max_retries=0,
+        fallback_return_value="test",
+    )
+    res = executor.run(["test"])
+    assert res[0] != signal.default_int_handler
+
+
+def test_sync_executor_bypasses_sigint_handling_if_none():
+    def sync_fn(x):
+        return signal.getsignal(signal.SIGINT)
+
+    executor = SyncExecutor(
+        sync_fn,
+        max_retries=0,
+        fallback_return_value="test",
+        termination_signal=None,
+    )
+    res = executor.run(["test"])
+    assert res[0] == signal.default_int_handler
+
+
 def test_sync_executor_retries():
     mock_generate = Mock(side_effect=RuntimeError("Test exception"))
     executor = SyncExecutor(mock_generate, max_retries=3)


### PR DESCRIPTION
- Refactor of #3240 
- enables full sync compatibility if `run_sync=True`
- Falls back to sync executor if running `llm_classify` not in the main thread