### PR TITLE
docs: Update Langchain dependencies in notebook tutorials

### DIFF
--- a/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.0.334\" \"openai>=1\" numexpr arize-phoenix"
+    "!pip install \"langchain>=0.0.334,<0.2.0\" \"openai>=1\" numexpr arize-phoenix"
    ]
   },
   {

--- a/tutorials/tracing/langchain_google_palm_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_google_palm_tracing_tutorial.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install arize-phoenix google-generativeai langchain"
+    "!pip install arize-phoenix google-generativeai \"langchain<0.2.0\""
    ]
   },
   {

--- a/tutorials/tracing/langchain_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_tracing_tutorial.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.1.0\" langchain-openai \"openai>=1\" \"arize-phoenix[evals]\" tiktoken nest-asyncio"
+    "!pip install \"langchain>=0.1.0,<0.2.0\" langchain-openai \"openai>=1\" \"arize-phoenix[evals]\" tiktoken nest-asyncio"
    ]
   },
   {

--- a/tutorials/tracing/langchain_vertex_ai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_vertex_ai_tracing_tutorial.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"arize-phoenix[evals]\" google-api-python-client \"google-cloud-aiplatform[preview]\" langchain nest-asyncio"
+    "!pip install \"arize-phoenix[evals]\" google-api-python-client \"google-cloud-aiplatform[preview]\" \"langchain<0.2.0\" nest-asyncio"
    ]
   },
   {


### PR DESCRIPTION
Temporary fix for #3317 
Resolves breaking changes in langchain tutorials with langchain >= 0.2.0