### PR TITLE
feat(datasets): delete examples mutation

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -175,6 +175,12 @@ type DatasetVersionEdge {
 """Date with time (isoformat)"""
 scalar DateTime
 
+input DeleteDatasetExamplesInput {
+  exampleIds: [GlobalID!]!
+  datasetVersionDescription: String
+  datasetVersionMetadata: JSON
+}
+
 type Dimension implements Node {
   """The Globally Unique ID of this object"""
   id: GlobalID!
@@ -624,6 +630,7 @@ type Mutation {
   createDataset(input: CreateDatasetInput!): DatasetMutationPayload!
   addSpansToDataset(input: AddSpansToDatasetInput!): DatasetMutationPayload!
   addExamplesToDataset(input: AddExamplesToDatasetInput!): DatasetMutationPayload!
+  deleteDatasetExamples(input: DeleteDatasetExamplesInput!): DatasetMutationPayload!
 
   """
   Given a list of event ids, export the corresponding data subset in Parquet format. File name is optional, but if specified, should be without file extension. By default the exported file name is current timestamp.

--- a/src/phoenix/server/api/input_types/DeleteDatasetExamplesInput.py
+++ b/src/phoenix/server/api/input_types/DeleteDatasetExamplesInput.py
@@ -1,0 +1,13 @@
+from typing import List, Optional
+
+import strawberry
+from strawberry import UNSET
+from strawberry.relay import GlobalID
+from strawberry.scalars import JSON
+
+
+@strawberry.input
+class DeleteDatasetExamplesInput:
+    example_ids: List[GlobalID]
+    dataset_version_description: Optional[str] = UNSET
+    dataset_version_metadata: Optional[JSON] = UNSET


### PR DESCRIPTION
resolves #3301 

Adds the ability to delete dataset examples

```graphql
mutation delteExamples($input: DeleteDatasetExamplesInput!) {
  deleteDatasetExamples(input: $input) {
    dataset {
      id
    }
  }
}
```

```json
{
  "input": {
    "exampleIds": ["RGF0YXNldEV4YW1wbGU6MQ=="],
    "datasetVersionDescription": "mikyo-foo"
  }
}

```