### PR TITLE
span templates

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__init__.py
@@ -20,6 +20,8 @@ from .default_templates import (
     TOXICITY_PROMPT_TEMPLATE,
     USER_FRUSTRATION_PROMPT_RAILS_MAP,
     USER_FRUSTRATION_PROMPT_TEMPLATE,
+    HALLUCINATION_SPAN_PROMPT_TEMPLATE,
+    QA_SPAN_PROMPT_TEMPLATE
 )
 from .evaluators import (
     HallucinationEvaluator,
@@ -88,4 +90,6 @@ __all__ = [
     "RelevanceEvaluator",
     "SummarizationEvaluator",
     "ToxicityEvaluator",
+    "HALLUCINATION_SPAN_PROMPT_TEMPLATE",
+    "QA_SPAN_PROMPT_TEMPLATE",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/default_templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/default_templates.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from enum import Enum
+from phoenix.evals.span_templates import HALLUCINATION_SPAN_PROMPT_TEMPLATE, QA_SPAN_PROMPT_TEMPLATE
 
 from phoenix.evals.templates import ClassificationTemplate
 
@@ -713,3 +714,5 @@ class EvalCriteria(Enum):
     SQL_GEN_EVAL = SQL_GEN_EVAL_PROMPT_TEMPLATE
     CODE_FUNCTIONALITY = CODE_FUNCTIONALITY_PROMPT_TEMPLATE
     USER_FRUSTRATION = USER_FRUSTRATION_PROMPT_TEMPLATE
+    HALLUCINATION_SPAN_LEVEL = HALLUCINATION_SPAN_PROMPT_TEMPLATE
+    QA_SPAN_LEVEL = QA_SPAN_PROMPT_TEMPLATE

--- a/packages/phoenix-evals/src/phoenix/evals/span_templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/span_templates.py
@@ -1,0 +1,181 @@
+from collections import OrderedDict
+from enum import Enum
+
+from phoenix.evals.templates import ClassificationTemplate
+
+### These templates are designed to be used with span level callbacks ###
+
+HALLUCINATION_SPAN_PROMPT_BASE_TEMPLATE = """
+    You are a "EVAL assistant" evaluating prompts and responses for hallucinations. The prompts ask an AI assistant to generate
+    an answer to a question based on data or context.
+
+    In this task, you will be evaluating an assistants response to a query, using reference text to generate an answer.
+    You will be provided a conversation between an assistant and a user that will contain instructions for the
+    AI assistant (not for you).
+    The answer is generated to the question based on the reference text. The answer may contain false information, you
+    must use the reference text to determine if the answer to the question contains false information,
+    if the answer is a hallucination of facts. Your objective is to determine whether the reference text
+    contains factual information and is not a hallucination. A 'hallucination' in this context refers to
+    an answer that is not based on the reference text or assumes information that is not available in
+    the reference text. Your response should be a single word: either "factual" or "hallucinated", and
+    it should not include any other text or characters. "hallucinated" indicates that the answer
+    provides factually inaccurate information to the query based on the reference text. "factual"
+    indicates that the answer to the question is correct relative to the reference text, and does not
+    contain made up information. Please read the query and reference text carefully before determining
+    your response.
+
+        [BEGIN DATA]
+        ************
+        [Input Question, System message and Context to AI Assistant]:
+        {system_message}
+
+        {user_message}
+        ************
+        [AI Assistant Answer]:
+        {output}
+        ************
+        [END DATA]
+    """
+
+HALLUCINATION_SPAN_PROMPT_TEMPLATE_WITH_EXPLANATION = """
+    You are a "EVAL assistant" evaluating prompts and responses for hallucinations. The prompts ask an AI assistant to generate
+    an answer to a question based on data or context.
+
+    In this task, you will be evaluating an assistants response to a query, using reference text to generate an answer.
+    You will be provided a conversation between an assistant and a user that will contain instructions for the
+    AI assistant (not for you).
+    The answer is generated to the question based on the reference text. The answer may contain false information, you
+    must use the reference text to determine if the answer to the question contains false information,
+    if the answer is a hallucination of facts. Your objective is to determine whether the reference text
+    contains factual information and is not a hallucination. A 'hallucination' in this context refers to
+    an answer that is not based on the reference text or assumes information that is not available in
+    the reference text. Your response should be a single word: either "factual" or "hallucinated", and
+    it should not include any other text or characters. "hallucinated" indicates that the answer
+    provides factually inaccurate information to the query based on the reference text. "factual"
+    indicates that the answer to the question is correct relative to the reference text, and does not
+    contain made up information. Please read the query and reference text carefully before determining
+    your response.
+
+        [BEGIN DATA]
+        ************
+        [Input Question, System message and Context to AI Assistant]:
+        {system_message}
+
+        {user_message}
+        ************
+        [AI Assistant Answer]:
+        {output}
+        ************
+        [END DATA]
+
+    Please read the query, reference text and answer carefully, then write out in a step by step manner
+    an EXPLANATION to show how to determine if the answer is "factual" or "hallucinated". Avoid simply
+    stating the correct answer at the outset. Your response LABEL should be a single word: either
+    "factual" or "hallucinated", and it should not include any other text or characters. "hallucinated"
+    indicates that the answer provides factually inaccurate information to the query based on the
+    reference text. "factual" indicates that the answer to the question is correct relative to the
+    reference text, and does not contain made up information.
+
+    Example response:
+    ************
+    EXPLANATION: An explanation of your reasoning for why the label is "factual" or "hallucinated"
+    LABEL: "factual" or "hallucinated"
+    ************
+
+    EXPLANATION:
+    """
+
+HALLUCINATION_SPAN_PROMPT_RAILS_MAP = OrderedDict({True: "hallucinated", False: "factual"})
+
+
+QA_SPAN_PROMPT_BASE_TEMPLATE = """
+    You are a EVAL assistant evaluating prompts and responses for Question and Answer (Q&A) correcntess. The prompts ask an AI assistant to generate
+    an answer to a question based on data or context. Your job is to evaluate whether the question was answered correctly
+    based on the reference data.
+
+    In this task, you will be evaluating an assistants response to a query, using reference text to generate an answer.
+    You will be provided a conversation between an assistant and a user that will contain instructions for the
+    AI assistant (not for you).
+    The answer is generated to the question based on the reference text. You are given a question, an answer and reference text.
+    You must determine whether the given answer correctly answers the question based on the reference text.
+    Your response must be a single word, either "correct" or "incorrect",
+    and should not contain any text or characters aside from that word.
+    "correct" means that the question is correctly and fully answered by the answer.
+    "incorrect" means that the question is not correctly or only partially answered by the
+    answer.
+
+        [BEGIN DATA]
+        ************
+        [Input Question, System message and Context to AI Assistant]:
+        {system_message}
+
+        {user_message}
+        ************
+        [AI Assistant Answer]:
+        {output}
+        ************
+        [END DATA]
+    """
+
+QA_SPAN_PROMPT_TEMPLATE_WITH_EXPLANATION = """
+    You are a EVAL assistant evaluating prompts and responses for Question and Answer (Q&A) correcntess. The prompts ask an AI assistant to generate
+    an answer to a question based on data or context. Your job is to evaluate whether the question was answered correctly
+    based on the reference data.
+
+    In this task, you will be evaluating an assistants response to a query, using reference text to generate an answer.
+    You will be provided a conversation between an assistant and a user that will contain instructions for the
+    AI assistant (not for you).
+    The answer is generated to the question based on the reference text. You are given a question, an answer and reference text.
+    You must determine whether the given answer correctly answers the question based on the reference text.
+    Your response must be a single word, either "correct" or "incorrect",
+    and should not contain any text or characters aside from that word.
+    "correct" means that the question is correctly and fully answered by the answer.
+    "incorrect" means that the question is not correctly or only partially answered by the
+    answer.
+
+        [BEGIN DATA]
+        ************
+        [Input Question, System message and Context to AI Assistant]:
+        {system_message}
+
+        {user_message}
+        ************
+        [AI Assistant Answer]:
+        {output}
+        ************
+        [END DATA]
+    Please read the query, reference text and answer carefully, then write out in a step by step manner
+    an EXPLANATION to show how to determine if the answer is "correct" or "incorrect". Avoid simply
+    stating the correct answer at the outset. Your response LABEL must be a single word, either
+    "correct" or "incorrect", and should not contain any text or characters aside from that word.
+    "correct" means that the question is correctly and fully answered by the answer.
+    "incorrect" means that the question is not correctly or only partially answered by the
+    answer.
+
+    Example response:
+    ************
+    EXPLANATION: An explanation of your reasoning for why the label is "correct" or "incorrect"
+    LABEL: "correct" or "incorrect"
+    ************
+
+    EXPLANATION:
+    """
+
+QA_SPAN_PROMPT_RAILS_MAP = OrderedDict({True: "correct", False: "incorrect"})
+
+
+HALLUCINATION_SPAN_PROMPT_TEMPLATE = ClassificationTemplate(
+    rails=list(HALLUCINATION_SPAN_PROMPT_RAILS_MAP.values()),
+    template=HALLUCINATION_SPAN_PROMPT_BASE_TEMPLATE,
+    explanation_template=HALLUCINATION_SPAN_PROMPT_TEMPLATE_WITH_EXPLANATION,
+    scores=[1, 0],
+)
+
+QA_SPAN_PROMPT_TEMPLATE = ClassificationTemplate(
+    rails=list(QA_SPAN_PROMPT_RAILS_MAP.values()),
+    template=HALLUCINATION_SPAN_PROMPT_BASE_TEMPLATE,
+    explanation_template=QA_SPAN_PROMPT_TEMPLATE_WITH_EXPLANATION,
+    scores=[1, 0],
+)
+
+


### PR DESCRIPTION
Added versions of Halluc and QA that can be run on the LLM spans.

THis is instead of needing reference + Question + Answer from retriever and chain spans. You can just filter and work on LLM spans.