### PR TITLE
feat: Allow skipping on template mapping errors, returning debug info

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -217,7 +217,7 @@ def llm_classify(
         fallback_return_value=fallback_return_value,
     )
 
-    results, exceptions = executor.run([row_tuple[1] for row_tuple in dataframe.iterrows()])
+    results, statuses = executor.run([row_tuple[1] for row_tuple in dataframe.iterrows()])
     labels, explanations, responses, prompts = zip(*results)
 
     return pd.DataFrame(
@@ -226,7 +226,7 @@ def llm_classify(
             **({"explanation": explanations} if provide_explanation else {}),
             **({"prompt": prompts} if include_prompt else {}),
             **({"response": responses} if include_response else {}),
-            **({"exception": exceptions} if include_exceptions else {}),
+            **({"exception": [s.exceptions for s in statuses]} if include_exceptions else {}),
         },
         index=dataframe.index,
     )

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -64,6 +64,7 @@ def llm_classify(
     include_prompt: bool = False,
     include_response: bool = False,
     include_exceptions: bool = False,
+    max_retries: int = 10,
     run_sync: bool = False,
     concurrency: Optional[int] = None,
 ) -> pd.DataFrame:
@@ -107,6 +108,9 @@ def llm_classify(
 
         include_exceptions (bool, default=False): if True, includes a column named `exception` in
         the output dataframe containing any exceptions that occurred during the classification.
+
+        max_retries (int, optional): The maximum number of times to retry on exceptions. Defaults to
+        10.
 
         run_sync (bool, default=False): If True, forces synchronous request submission. Otherwise
         evaluations will be run asynchronously if possible.
@@ -208,6 +212,7 @@ def llm_classify(
         run_sync=run_sync,
         concurrency=concurrency,
         tqdm_bar_format=tqdm_bar_format,
+        max_retries=max_retries,
         exit_on_error=True,
         fallback_return_value=fallback_return_value,
     )

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -50,7 +50,7 @@ Record: TypeAlias = Mapping[str, Any]
 Index: TypeAlias = int
 
 # snapped_response, explanation, response
-ParsedLLMResponse: TypeAlias = Tuple[Optional[str], Optional[str], str]
+ParsedLLMResponse: TypeAlias = Tuple[Optional[str], Optional[str], str, str]
 
 
 class ClassificationStatus(Enum):
@@ -167,7 +167,7 @@ def llm_classify(
     if generation_info := model.verbose_generation_info():
         printif(verbose, generation_info)
 
-    def _map_template(data: pd.Series) -> str:
+    def _map_template(data: pd.Series[Any]) -> str:
         try:
             variables = {var: data[var] for var in eval_template.variables}
             empty_keys = [k for k, v in variables.items() if v is None]
@@ -200,7 +200,7 @@ def llm_classify(
             unrailed_label, explanation = parse_openai_function_call(response)
         return snap_to_rail(unrailed_label, rails, verbose=verbose), explanation
 
-    async def _run_llm_classification_async(input_data: pd.Series) -> ParsedLLMResponse:
+    async def _run_llm_classification_async(input_data: pd.Series[Any]) -> ParsedLLMResponse:
         with set_verbosity(model, verbose) as verbose_model:
             prompt = _map_template(input_data)
             response = await verbose_model._async_generate(
@@ -209,7 +209,7 @@ def llm_classify(
         inference, explanation = _process_response(response)
         return inference, explanation, response, prompt
 
-    def _run_llm_classification_sync(input_data: pd.Series) -> ParsedLLMResponse:
+    def _run_llm_classification_sync(input_data: pd.Series[Any]) -> ParsedLLMResponse:
         with set_verbosity(model, verbose) as verbose_model:
             prompt = _map_template(input_data)
             response = verbose_model._generate(

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -181,15 +181,16 @@ def llm_classify(
         inference, explanation = _process_response(response)
         return inference, explanation, response, prompt
 
-    def _run_llm_classification_sync(prompt: str) -> ParsedLLMResponse:
+    def _run_llm_classification_sync(input_data: pd.Series) -> ParsedLLMResponse:
         with set_verbosity(model, verbose) as verbose_model:
+            prompt = _map_template(input_data)
             response = verbose_model._generate(
                 prompt, instruction=system_instruction, **model_kwargs
             )
         inference, explanation = _process_response(response)
         return inference, explanation, response, prompt
 
-    fallback_return_value: ParsedLLMResponse = (None, None, "")
+    fallback_return_value: ParsedLLMResponse = (None, None, "", "")
 
     executor = get_executor_on_sync_context(
         _run_llm_classification_sync,

--- a/packages/phoenix-evals/src/phoenix/evals/exceptions.py
+++ b/packages/phoenix-evals/src/phoenix/evals/exceptions.py
@@ -4,3 +4,7 @@ class PhoenixException(Exception):
 
 class PhoenixContextLimitExceeded(PhoenixException):
     pass
+
+
+class PhoenixTemplateMappingError(PhoenixException):
+    pass

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -40,25 +40,25 @@ class ExecutionStatus(Enum):
 
 
 class ExecutionDetails:
-    def __init__(self):
-        self.exceptions = []
+    def __init__(self) -> None:
+        self.exceptions: List[Exception] = []
         self.status = ExecutionStatus.DID_NOT_RUN
 
-    def fail(self):
+    def fail(self) -> None:
         self.status = ExecutionStatus.FAILED
 
-    def complete(self):
+    def complete(self) -> None:
         if self.exceptions:
             self.status = ExecutionStatus.COMPLETED_WITH_RETRIES
         else:
             self.status = ExecutionStatus.COMPLETED
 
-    def log_exception(self, exc: Exception):
+    def log_exception(self, exc: Exception) -> None:
         self.exceptions.append(exc)
 
 
 class Executor(Protocol):
-    def run(self, inputs: Sequence[Any]) -> List[Any]: ...
+    def run(self, inputs: Sequence[Any]) -> Tuple[List[Any], List[ExecutionDetails]]: ...
 
 
 class AsyncExecutor(Executor):
@@ -264,7 +264,7 @@ class AsyncExecutor(Executor):
         signal.signal(self.termination_signal, original_handler)  # reset the SIGTERM handler
         return outputs, execution_details
 
-    def run(self, inputs: Sequence[Any]) -> Tuple[List[Any], List[Any]]:
+    def run(self, inputs: Sequence[Any]) -> Tuple[List[Any], List[ExecutionDetails]]:
         return asyncio.run(self.execute(inputs))
 
 

--- a/packages/phoenix-evals/src/phoenix/evals/generate.py
+++ b/packages/phoenix-evals/src/phoenix/evals/generate.py
@@ -133,5 +133,5 @@ def llm_generate(
         exit_on_error=True,
         fallback_return_value=fallback_return_value,
     )
-    results = executor.run(list(enumerate(prompts.tolist())))
+    results, _ = executor.run(list(enumerate(prompts.tolist())))
     return pd.DataFrame.from_records(results, index=dataframe.index)

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -392,6 +392,7 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
             template=RAG_RELEVANCY_PROMPT_TEMPLATE,
             model=model,
             rails=["relevant", "unrelated"],
+            max_retries=10,
         )
 
     out, _ = capfd.readouterr()
@@ -405,8 +406,8 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
     assert "Exception in worker on attempt 8" in out, "Retry information should be printed"
     assert "Exception in worker on attempt 9" in out, "Retry information should be printed"
     assert "Exception in worker on attempt 10" in out, "Retry information should be printed"
-    assert "Exception in worker on attempt 11" in out, "Retry information should be printed"
-    assert "Exception in worker on attempt 12" not in out, "Maximum retries should not be exceeded"
+    assert "Exception in worker on attempt 11" not in out, "Maximum retires should not be exceeded"
+    assert "Retries exhausted after 11 attempts" in out, "Retry information should be printed"
 
 
 @pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions", assert_all_called=False)

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -16,6 +16,7 @@ from phoenix.evals import (
     llm_classify,
 )
 from phoenix.evals.classify import (
+    ClassificationStatus,
     run_evals,
 )
 from phoenix.evals.default_templates import (
@@ -23,6 +24,7 @@ from phoenix.evals.default_templates import (
     TOXICITY_PROMPT_TEMPLATE,
 )
 from phoenix.evals.evaluators import LLMEvaluator
+from phoenix.evals.executors import Status
 from phoenix.evals.utils import _EXPLANATION, _FUNCTION_NAME, _RESPONSE
 from respx.patterns import M
 
@@ -439,6 +441,107 @@ def test_classify_tolerance_to_exceptions(
 
     assert classification_df is not None
     # Make sure there is a logger.error output
+    captured = capfd.readouterr()
+    assert "Exception in worker" in captured.out
+
+
+@pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions", assert_all_called=False)
+def test_classify_exits_on_missing_input(
+    openai_api_key: str,
+    classification_dataframe: pd.DataFrame,
+    classification_responses: List[str],
+    classification_template: str,
+    respx_mock: respx.mock,
+):
+    model = OpenAIModel()
+    queries = classification_dataframe["input"].tolist()
+    for query, response in zip(queries, classification_responses):
+        matcher = M(content__contains=query)
+        # Simulate an error on the second query
+        if query == "What is C++?":
+            response = httpx.Response(500, json={"error": "Internal Server Error"})
+        else:
+            response = httpx.Response(200, json={"choices": [{"message": {"content": response}}]})
+        respx_mock.route(matcher).mock(return_value=response)
+
+    # remove an input to cause a template mapping exception
+    classification_dataframe["input"][2] = None
+
+    classification_df = llm_classify(
+        dataframe=classification_dataframe,
+        template=classification_template,
+        model=model,
+        rails=["relevant", "unrelated"],
+        include_exceptions=True,
+        max_retries=4,
+        exit_on_error=True,
+        run_sync=True,  # run synchronously to ensure ordering
+    )
+
+    assert classification_df["execution_status"].tolist() == [
+        ClassificationStatus.COMPLETED,
+        ClassificationStatus.COMPLETED,
+        ClassificationStatus.MISSING_INPUT,
+        ClassificationStatus.DID_NOT_RUN,
+    ]
+
+    exceptions = classification_df["exceptions"].tolist()
+    assert [len(excs) for excs in exceptions] == [
+        0,
+        0,
+        1,  # one failure due to missing input
+        0,  # never runs, so no exceptions
+    ]
+
+
+@pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions", assert_all_called=False)
+def test_classify_skips_missing_input_with_when_exit_on_error_false(
+    openai_api_key: str,
+    classification_dataframe: pd.DataFrame,
+    classification_responses: List[str],
+    classification_template: str,
+    respx_mock: respx.mock,
+    capfd,
+):
+    model = OpenAIModel()
+    queries = classification_dataframe["input"].tolist()
+    for query, response in zip(queries, classification_responses):
+        matcher = M(content__contains=query)
+        # Simulate an error on the second query
+        if query == "What is C++?":
+            response = httpx.Response(500, json={"error": "Internal Server Error"})
+        else:
+            response = httpx.Response(200, json={"choices": [{"message": {"content": response}}]})
+        respx_mock.route(matcher).mock(return_value=response)
+
+    # remove an input to cause a template mapping exception
+    classification_dataframe["input"][2] = None
+
+    classification_df = llm_classify(
+        dataframe=classification_dataframe,
+        template=classification_template,
+        model=model,
+        rails=["relevant", "unrelated"],
+        include_exceptions=True,
+        max_retries=4,
+        exit_on_error=False,
+    )
+
+    assert classification_df["execution_status"].tolist() == [
+        ClassificationStatus.COMPLETED,
+        ClassificationStatus.COMPLETED,
+        ClassificationStatus.MISSING_INPUT,
+        ClassificationStatus.FAILED,
+    ]
+
+    exceptions = classification_df["exceptions"].tolist()
+    assert [len(excs) for excs in exceptions] == [
+        0,
+        0,
+        1,  # one failure due to missing input
+        5,  # first attempt + 4 retries
+    ]
+
     captured = capfd.readouterr()
     assert "Exception in worker" in captured.out
 
@@ -1028,3 +1131,7 @@ def test_run_evals_with_empty_evaluators_returns_empty_list() -> None:
         evaluators=[],
     )
     assert eval_dfs == []
+
+
+def test_classification_status_is_superset_of_execution_status() -> None:
+    assert {item.value for item in ClassificationStatus}.issuperset({item.value for item in Status})

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -408,7 +408,7 @@ def test_llm_classify_shows_retry_info(openai_api_key: str, capfd: pytest.Captur
     assert "Exception in worker on attempt 8" in out, "Retry information should be printed"
     assert "Exception in worker on attempt 9" in out, "Retry information should be printed"
     assert "Exception in worker on attempt 10" in out, "Retry information should be printed"
-    assert "Exception in worker on attempt 11" not in out, "Maximum retires should not be exceeded"
+    assert "Exception in worker on attempt 11" not in out, "Maximum retries should not be exceeded"
     assert "Retries exhausted after 11 attempts" in out, "Retry information should be printed"
 
 
@@ -425,7 +425,6 @@ def test_classify_tolerance_to_exceptions(
     queries = classification_dataframe["input"].tolist()
     for query, response in zip(queries, classification_responses):
         matcher = M(content__contains=query)
-        # Simulate an error on the second query
         if query == "What is C++?":
             response = httpx.Response(500, json={"error": "Internal Server Error"})
         else:
@@ -457,7 +456,6 @@ def test_classify_exits_on_missing_input(
     queries = classification_dataframe["input"].tolist()
     for query, response in zip(queries, classification_responses):
         matcher = M(content__contains=query)
-        # Simulate an error on the second query
         if query == "What is C++?":
             response = httpx.Response(500, json={"error": "Internal Server Error"})
         else:
@@ -507,7 +505,6 @@ def test_classify_skips_missing_input_with_when_exit_on_error_false(
     queries = classification_dataframe["input"].tolist()
     for query, response in zip(queries, classification_responses):
         matcher = M(content__contains=query)
-        # Simulate an error on the second query
         if query == "What is C++?":
             response = httpx.Response(500, json={"error": "Internal Server Error"})
         else:

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -24,7 +24,7 @@ from phoenix.evals.default_templates import (
     TOXICITY_PROMPT_TEMPLATE,
 )
 from phoenix.evals.evaluators import LLMEvaluator
-from phoenix.evals.executors import Status
+from phoenix.evals.executors import ExecutionStatus
 from phoenix.evals.utils import _EXPLANATION, _FUNCTION_NAME, _RESPONSE
 from respx.patterns import M
 
@@ -1131,4 +1131,6 @@ def test_run_evals_with_empty_evaluators_returns_empty_list() -> None:
 
 
 def test_classification_status_is_superset_of_execution_status() -> None:
-    assert {item.value for item in ClassificationStatus}.issuperset({item.value for item in Status})
+    assert {item.value for item in ClassificationStatus}.issuperset(
+        {item.value for item in ExecutionStatus}
+    )

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -11,7 +11,7 @@ import nest_asyncio
 import pytest
 from phoenix.evals.executors import (
     AsyncExecutor,
-    Status,
+    ExecutionStatus,
     SyncExecutor,
     get_executor_on_sync_context,
 )
@@ -85,11 +85,11 @@ def test_async_executor_run_exits_early_on_error():
         0,
     ], "one exception raised, then exits"
     assert status_types == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.FAILED,
-        Status.DID_NOT_RUN,
-        Status.DID_NOT_RUN,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.FAILED,
+        ExecutionStatus.DID_NOT_RUN,
+        ExecutionStatus.DID_NOT_RUN,
     ]
     assert all(isinstance(exc, ValueError) for exc in exceptions[2])
 
@@ -116,11 +116,11 @@ async def test_async_executor_can_continue_on_error():
         0,
     ], "two exceptions due to retries"
     assert status_types == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.FAILED,
-        Status.COMPLETED,
-        Status.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.FAILED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
     ]
     assert all(isinstance(exc, ValueError) for exc in exceptions[2])
 
@@ -143,11 +143,11 @@ async def test_async_executor_marks_completed_with_retries_status():
     outputs, execution_details = await executor.execute(inputs)
     assert outputs == [0, 1, 2, 3, 4], "input 3 should only fail twice"
     assert [status.status for status in execution_details] == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.COMPLETED_WITH_RETRIES,
-        Status.COMPLETED,
-        Status.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED_WITH_RETRIES,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
     ]
 
 
@@ -259,11 +259,11 @@ def test_sync_executor_run_exits_early_on_error():
         0,
     ], "one exception raised, then exits"
     assert status_types == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.FAILED,
-        Status.DID_NOT_RUN,
-        Status.DID_NOT_RUN,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.FAILED,
+        ExecutionStatus.DID_NOT_RUN,
+        ExecutionStatus.DID_NOT_RUN,
     ]
     assert all(isinstance(exc, ValueError) for exc in exceptions[2])
 
@@ -288,11 +288,11 @@ def test_sync_executor_can_continue_on_error():
         0,
     ], "two exceptions due to retries"
     assert status_types == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.FAILED,
-        Status.COMPLETED,
-        Status.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.FAILED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
     ]
     assert all(isinstance(exc, ValueError) for exc in exceptions[2])
 
@@ -313,11 +313,11 @@ def test_sync_executor_marks_completed_with_retries_status():
     outputs, execution_details = executor.run(inputs)
     assert outputs == [0, 1, 2, 3, 4], "input 3 should only fail twice"
     assert [status.status for status in execution_details] == [
-        Status.COMPLETED,
-        Status.COMPLETED,
-        Status.COMPLETED_WITH_RETRIES,
-        Status.COMPLETED,
-        Status.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED_WITH_RETRIES,
+        ExecutionStatus.COMPLETED,
+        ExecutionStatus.COMPLETED,
     ]
 
 

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -140,9 +140,9 @@ async def test_async_executor_marks_completed_with_retries_status():
         dummy_fn, concurrency=1, max_retries=3, exit_on_error=False, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs, statuses = await executor.execute(inputs)
+    outputs, execution_details = await executor.execute(inputs)
     assert outputs == [0, 1, 2, 3, 4], "input 3 should only fail twice"
-    assert [status.status for status in statuses] == [
+    assert [status.status for status in execution_details] == [
         Status.COMPLETED,
         Status.COMPLETED,
         Status.COMPLETED_WITH_RETRIES,
@@ -247,9 +247,9 @@ def test_sync_executor_run_exits_early_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=True, fallback_return_value=52, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs, statuses = executor.run(inputs)
-    exceptions = [status.exceptions for status in statuses]
-    status_types = [status.status for status in statuses]
+    outputs, execution_details = executor.run(inputs)
+    exceptions = [status.exceptions for status in execution_details]
+    status_types = [status.status for status in execution_details]
     assert outputs == [0, 1, 52, 52, 52]
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,
@@ -276,9 +276,9 @@ def test_sync_executor_can_continue_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=False, fallback_return_value=52, max_retries=1)
     inputs = [1, 2, 3, 4, 5]
-    outputs, statuses = executor.run(inputs)
-    exceptions = [status.exceptions for status in statuses]
-    status_types = [status.status for status in statuses]
+    outputs, execution_details = executor.run(inputs)
+    exceptions = [status.exceptions for status in execution_details]
+    status_types = [status.status for status in execution_details]
     assert outputs == [0, 1, 52, 3, 4]
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,
@@ -310,9 +310,9 @@ def test_sync_executor_marks_completed_with_retries_status():
 
     executor = SyncExecutor(dummy_fn, max_retries=3, exit_on_error=False, fallback_return_value=52)
     inputs = [1, 2, 3, 4, 5]
-    outputs, statuses = executor.run(inputs)
+    outputs, execution_details = executor.run(inputs)
     assert outputs == [0, 1, 2, 3, 4], "input 3 should only fail twice"
-    assert [status.status for status in statuses] == [
+    assert [status.status for status in execution_details] == [
         Status.COMPLETED,
         Status.COMPLETED,
         Status.COMPLETED_WITH_RETRIES,

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -72,7 +72,8 @@ def test_async_executor_run_exits_early_on_error():
         dummy_fn, concurrency=1, max_retries=0, exit_on_error=True, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs, exceptions = executor.run(inputs)
+    outputs, statuses = executor.run(inputs)
+    exceptions = [status.exceptions for status in statuses]
     assert outputs == [0, 1, 52, 52, 52]
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,
@@ -94,7 +95,8 @@ async def test_async_executor_can_continue_on_error():
         dummy_fn, concurrency=1, max_retries=1, exit_on_error=False, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs, exceptions = await executor.execute(inputs)
+    outputs, statuses = await executor.execute(inputs)
+    exceptions = [status.exceptions for status in statuses]
     assert outputs == [0, 1, 52, 3, 4], "failed tasks use the fallback value"
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,
@@ -202,7 +204,8 @@ def test_sync_executor_run_exits_early_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=True, fallback_return_value=52, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs, exceptions = executor.run(inputs)
+    outputs, statuses = executor.run(inputs)
+    exceptions = [status.exceptions for status in statuses]
     assert outputs == [0, 1, 52, 52, 52]
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,
@@ -222,7 +225,8 @@ def test_sync_executor_can_continue_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=False, fallback_return_value=52, max_retries=1)
     inputs = [1, 2, 3, 4, 5]
-    outputs, exceptions = executor.run(inputs)
+    outputs, statuses = executor.run(inputs)
+    exceptions = [status.exceptions for status in statuses]
     assert outputs == [0, 1, 52, 3, 4]
     assert [len(excs) if excs else 0 for excs in exceptions] == [
         0,

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -24,7 +24,7 @@ async def test_async_executor_executes():
 
     executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs = await executor.execute(inputs)
+    outputs, _ = await executor.execute(inputs)
     assert outputs == [0, 1, 2, 3, 4]
 
 
@@ -34,7 +34,7 @@ async def test_async_executor_executes_many_tasks():
 
     executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
     inputs = [x for x in range(100)]
-    outputs = await executor.execute(inputs)
+    outputs, _ = await executor.execute(inputs)
     assert outputs == inputs
 
 
@@ -44,7 +44,7 @@ def test_async_executor_runs_synchronously():
 
     executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == [-1, 0, 1, 2, 3]
 
 
@@ -58,7 +58,7 @@ async def test_async_executor_execute_exits_early_on_error():
         dummy_fn, concurrency=1, max_retries=0, exit_on_error=True, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs = await executor.execute(inputs)
+    outputs, _ = await executor.execute(inputs)
     assert outputs == [0, 1, 52, 52, 52]
 
 
@@ -72,7 +72,7 @@ def test_async_executor_run_exits_early_on_error():
         dummy_fn, concurrency=1, max_retries=0, exit_on_error=True, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == [0, 1, 52, 52, 52]
 
 
@@ -86,7 +86,7 @@ async def test_async_executor_can_continue_on_error():
         dummy_fn, concurrency=1, max_retries=0, exit_on_error=False, fallback_return_value=52
     )
     inputs = [1, 2, 3, 4, 5]
-    outputs = await executor.execute(inputs)
+    outputs, _ = await executor.execute(inputs)
     assert outputs == [0, 1, 52, 3, 4]
 
 
@@ -132,7 +132,7 @@ async def test_async_executor_sigint_handling():
     )
     task = asyncio.create_task(executor.execute(InterruptingIterator(sigint_index, result_length)))
 
-    results = await task
+    results, _ = await task
     assert len(results) == result_length
     assert results.count("test") > 100, "most inputs should not have been processed"
 
@@ -155,7 +155,7 @@ def test_sync_executor_runs_many_tasks():
 
     executor = SyncExecutor(dummy_fn, max_retries=0)
     inputs = [x for x in range(1000)]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == inputs
 
 
@@ -174,7 +174,7 @@ def test_sync_executor_runs():
 
     executor = SyncExecutor(dummy_fn, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == [-1, 0, 1, 2, 3]
 
 
@@ -186,7 +186,7 @@ def test_sync_executor_run_exits_early_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=True, fallback_return_value=52, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == [0, 1, 52, 52, 52]
 
 
@@ -198,7 +198,7 @@ def test_sync_executor_can_continue_on_error():
 
     executor = SyncExecutor(dummy_fn, exit_on_error=False, fallback_return_value=52, max_retries=0)
     inputs = [1, 2, 3, 4, 5]
-    outputs = executor.run(inputs)
+    outputs, _ = executor.run(inputs)
     assert outputs == [0, 1, 52, 3, 4]
 
 
@@ -241,7 +241,7 @@ def test_sync_executor_sigint_handling():
         fallback_return_value="test",
         termination_signal=signal.SIGUSR1,
     )
-    results = executor.run(InterruptingIterator(sigint_index, result_length))
+    results, _ = executor.run(InterruptingIterator(sigint_index, result_length))
     assert len(results) == result_length
     assert results.count("test") > 100, "most inputs should not have been processed"
 
@@ -255,7 +255,7 @@ def test_sync_executor_defaults_sigint_handling():
         max_retries=0,
         fallback_return_value="test",
     )
-    res = executor.run(["test"])
+    res, _ = executor.run(["test"])
     assert res[0] != signal.default_int_handler
 
 
@@ -269,7 +269,7 @@ def test_sync_executor_bypasses_sigint_handling_if_none():
         fallback_return_value="test",
         termination_signal=None,
     )
-    res = executor.run(["test"])
+    res, _ = executor.run(["test"])
     assert res[0] == signal.default_int_handler
 
 


### PR DESCRIPTION
resolves #3313 

- Adds `exit_on_error` flag to `llm_classify` that will optionally continue to process evals, even if one fails
- Adds `include_exceptions` flag to `llm_classify` that optionally returns an `exceptions` column that logs errors running evals on each row and an `execution_status` column that summarizes whether or not each eval completed