### PR TITLE
feat(datasets): UI to edit a dataset example

### DIFF
--- a/app/src/pages/ErrorElement.tsx
+++ b/app/src/pages/ErrorElement.tsx
@@ -50,7 +50,7 @@ function NotFoundContent() {
         <h1>Server disconnected</h1>
       </Flex>
       <p>
-        We are unable to reach the phoenix server. Please ensure that phoenix is
+        We are unable to reach the Phoenix server. Please ensure that Phoenix is
         running and try again.
       </p>
     </>

--- a/app/src/pages/ErrorElement.tsx
+++ b/app/src/pages/ErrorElement.tsx
@@ -50,9 +50,8 @@ function NotFoundContent() {
         <h1>Server disconnected</h1>
       </Flex>
       <p>
-        We are unable to reach the phoenix server. This is most likely due to
-        the notebook runtime being no longer active. Please restart phoenix by
-        re-running the initialization cell.
+        We are unable to reach the phoenix server. Please ensure that phoenix is
+        running and try again.
       </p>
     </>
   );

--- a/app/src/pages/dataset/DatasetExamplePage.tsx
+++ b/app/src/pages/dataset/DatasetExamplePage.tsx
@@ -20,6 +20,7 @@ import { CopyToClipboardButton } from "@phoenix/components";
 import { useTheme } from "@phoenix/contexts";
 
 import type { DatasetExamplePageQuery } from "./__generated__/DatasetExamplePageQuery.graphql";
+import { EditDatasetExampleButton } from "./EditDatasetExampleButton";
 
 /**
  * A page that shows the details of a dataset example.
@@ -31,6 +32,7 @@ export function DatasetExamplePage() {
       query DatasetExamplePageQuery($exampleId: GlobalID!) {
         example: node(id: $exampleId) {
           ... on DatasetExample {
+            id
             latestRevision: revision {
               input
               output
@@ -42,7 +44,7 @@ export function DatasetExamplePage() {
     `,
     { exampleId: exampleId as string }
   );
-  const { input, output, metadata } = useMemo(() => {
+  const revision = useMemo(() => {
     const revision = data.example.latestRevision;
     return {
       input: JSON.stringify(revision?.input),
@@ -50,6 +52,7 @@ export function DatasetExamplePage() {
       metadata: JSON.stringify(revision?.metadata),
     };
   }, [data]);
+  const { input, output, metadata } = revision;
   const navigate = useNavigate();
   return (
     <DialogContainer
@@ -57,7 +60,16 @@ export function DatasetExamplePage() {
       isDismissable
       onDismiss={() => navigate(`/datasets/${datasetId}`)}
     >
-      <Dialog size="XL" title={`Example: ${datasetId}`}>
+      <Dialog
+        size="XL"
+        title={`Example: ${exampleId}`}
+        extra={
+          <EditDatasetExampleButton
+            exampleId={exampleId as string}
+            currentRevision={revision}
+          />
+        }
+      >
         <div
           css={css`
             overflow-y: auto;

--- a/app/src/pages/dataset/DatasetExamplePage.tsx
+++ b/app/src/pages/dataset/DatasetExamplePage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { useNavigate, useParams } from "react-router";
 import { json } from "@codemirror/lang-json";
@@ -27,6 +27,7 @@ import { EditDatasetExampleButton } from "./EditDatasetExampleButton";
  */
 export function DatasetExamplePage() {
   const { datasetId, exampleId } = useParams();
+  const [fetchKey, setFetchKey] = useState(0);
   const data = useLazyLoadQuery<DatasetExamplePageQuery>(
     graphql`
       query DatasetExamplePageQuery($exampleId: GlobalID!) {
@@ -42,14 +43,15 @@ export function DatasetExamplePage() {
         }
       }
     `,
-    { exampleId: exampleId as string }
+    { exampleId: exampleId as string },
+    { fetchKey, fetchPolicy: "store-and-network" }
   );
   const revision = useMemo(() => {
     const revision = data.example.latestRevision;
     return {
-      input: JSON.stringify(revision?.input),
-      output: JSON.stringify(revision?.output),
-      metadata: JSON.stringify(revision?.metadata),
+      input: JSON.stringify(revision?.input, null, 2),
+      output: JSON.stringify(revision?.output, null, 2),
+      metadata: JSON.stringify(revision?.metadata, null, 2),
     };
   }, [data]);
   const { input, output, metadata } = revision;
@@ -67,6 +69,9 @@ export function DatasetExamplePage() {
           <EditDatasetExampleButton
             exampleId={exampleId as string}
             currentRevision={revision}
+            onCompleted={() => {
+              setFetchKey((key) => key + 1);
+            }}
           />
         }
       >

--- a/app/src/pages/dataset/EditDatasetExampleButton.tsx
+++ b/app/src/pages/dataset/EditDatasetExampleButton.tsx
@@ -7,11 +7,9 @@ import {
   EditDatasetExampleDialogProps,
 } from "./EditDatasetExampleDialog";
 
-type EditDatasetExampleButtonProps = Omit<
-  EditDatasetExampleDialogProps,
-  "onCompleted"
->;
+type EditDatasetExampleButtonProps = EditDatasetExampleDialogProps;
 export function EditDatasetExampleButton(props: EditDatasetExampleButtonProps) {
+  const { onCompleted, ...dialogProps } = props;
   const [dialog, setDialog] = useState<ReactNode>(null);
   return (
     <>
@@ -22,9 +20,10 @@ export function EditDatasetExampleButton(props: EditDatasetExampleButtonProps) {
         onClick={() =>
           setDialog(
             <EditDatasetExampleDialog
-              {...props}
+              {...dialogProps}
               onCompleted={() => {
                 setDialog(null);
+                onCompleted();
               }}
             />
           )

--- a/app/src/pages/dataset/EditDatasetExampleButton.tsx
+++ b/app/src/pages/dataset/EditDatasetExampleButton.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, useState } from "react";
+
+import { Button, DialogContainer, Icon, Icons } from "@arizeai/components";
+
+import {
+  EditDatasetExampleDialog,
+  EditDatasetExampleDialogProps,
+} from "./EditDatasetExampleDialog";
+
+type EditDatasetExampleButtonProps = Omit<
+  EditDatasetExampleDialogProps,
+  "onCompleted"
+>;
+export function EditDatasetExampleButton(props: EditDatasetExampleButtonProps) {
+  const [dialog, setDialog] = useState<ReactNode>(null);
+  return (
+    <>
+      <Button
+        variant="default"
+        size="compact"
+        icon={<Icon svg={<Icons.EditOutline />} />}
+        onClick={() =>
+          setDialog(
+            <EditDatasetExampleDialog
+              {...props}
+              onCompleted={() => {
+                setDialog(null);
+              }}
+            />
+          )
+        }
+      >
+        Edit Example
+      </Button>
+      <DialogContainer
+        type="slideOver"
+        isDismissable
+        onDismiss={() => setDialog(null)}
+      >
+        {dialog}
+      </DialogContainer>
+    </>
+  );
+}

--- a/app/src/pages/dataset/EditDatasetExampleDialog.tsx
+++ b/app/src/pages/dataset/EditDatasetExampleDialog.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { css } from "@emotion/react";
+
+import {
+  Alert,
+  Button,
+  Card,
+  CardProps,
+  Dialog,
+  Flex,
+  View,
+} from "@arizeai/components";
+
+import { JSONEditor } from "@phoenix/components/code";
+
+type DatasetExamplePatch = {
+  input: string;
+  output: string;
+  metadata: string;
+};
+
+export type EditDatasetExampleDialogProps = {
+  exampleId: string;
+  currentRevision: DatasetExamplePatch;
+  onCompleted: () => void;
+};
+
+const defaultCardProps: Partial<CardProps> = {
+  backgroundColor: "light",
+  borderColor: "light",
+  collapsible: true,
+  bodyStyle: { padding: 0 },
+};
+
+export function EditDatasetExampleDialog(props: EditDatasetExampleDialogProps) {
+  const { exampleId } = props;
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const {
+    control,
+    setError,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<DatasetExamplePatch>({
+    defaultValues: props.currentRevision,
+  });
+
+  return (
+    <Dialog
+      size="fullscreen"
+      title={`Edit Example: ${exampleId}`}
+      extra={
+        <Button variant="primary" size="compact">
+          Save Changes
+        </Button>
+      }
+    >
+      <div
+        css={css`
+          overflow-y: auto;
+          padding: var(--ac-global-dimension-size-400);
+          /* Make widths configurable */
+          .dataset-picker {
+            width: 100%;
+            .ac-dropdown--picker,
+            .ac-dropdown-button {
+              width: 100%;
+            }
+          }
+        `}
+      >
+        <Flex direction="row" justifyContent="center">
+          <View width="900px" paddingStart="auto" paddingEnd="auto">
+            <Flex direction="column" gap="size-200">
+              {submitError ? (
+                <Alert variant="danger">{submitError}</Alert>
+              ) : null}
+
+              <Controller
+                control={control}
+                name={"input"}
+                render={({
+                  field: { onChange, onBlur, value },
+                  fieldState: { invalid, error },
+                }) => (
+                  <Card
+                    title="Input"
+                    subTitle="The input to the LLM, retriever, program, etc."
+                    {...defaultCardProps}
+                  >
+                    {invalid ? (
+                      <Alert variant="danger" banner>
+                        {error?.message}
+                      </Alert>
+                    ) : null}
+                    <JSONEditor
+                      value={value}
+                      onChange={onChange}
+                      onBlur={onBlur}
+                    />
+                  </Card>
+                )}
+              />
+              <Controller
+                control={control}
+                name={"output"}
+                render={({
+                  field: { onChange, onBlur, value },
+                  fieldState: { invalid, error },
+                }) => (
+                  <Card
+                    title="Output"
+                    subTitle="The output of the LLM or program to be used as an expected output"
+                    {...defaultCardProps}
+                    backgroundColor="green-100"
+                    borderColor="green-700"
+                  >
+                    {invalid ? (
+                      <Alert variant="danger" banner>
+                        {error?.message}
+                      </Alert>
+                    ) : null}
+                    <JSONEditor
+                      value={value}
+                      onChange={onChange}
+                      onBlur={onBlur}
+                    />
+                  </Card>
+                )}
+              />
+              <Controller
+                control={control}
+                name={"metadata"}
+                render={({
+                  field: { onChange, onBlur, value },
+                  fieldState: { invalid, error },
+                }) => (
+                  <Card
+                    title="Metadata"
+                    subTitle="All data from the span to use during experimentation or evaluation"
+                    {...defaultCardProps}
+                  >
+                    {invalid ? (
+                      <Alert variant="danger" banner>
+                        {error?.message}
+                      </Alert>
+                    ) : null}
+                    <JSONEditor
+                      value={value}
+                      onChange={onChange}
+                      onBlur={onBlur}
+                    />
+                  </Card>
+                )}
+              />
+            </Flex>
+          </View>
+        </Flex>
+      </div>
+    </Dialog>
+  );
+}

--- a/app/src/pages/dataset/__generated__/DatasetExamplePageQuery.graphql.ts
+++ b/app/src/pages/dataset/__generated__/DatasetExamplePageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1603f54723deee980b6705470ce34c4f>>
+ * @generated SignedSource<<f015cbabef07d6563a8392f9a4696372>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type DatasetExamplePageQuery$variables = {
 };
 export type DatasetExamplePageQuery$data = {
   readonly example: {
+    readonly id?: string;
     readonly latestRevision?: {
       readonly input: any;
       readonly metadata: any;
@@ -42,43 +43,43 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": "latestRevision",
+  "args": null,
+  "concreteType": "DatasetExampleRevision",
+  "kind": "LinkedField",
+  "name": "revision",
+  "plural": false,
   "selections": [
     {
-      "alias": "latestRevision",
+      "alias": null,
       "args": null,
-      "concreteType": "DatasetExampleRevision",
-      "kind": "LinkedField",
-      "name": "revision",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "input",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "output",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "metadata",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "input",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "output",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "metadata",
       "storageKey": null
     }
   ],
-  "type": "DatasetExample",
-  "abstractKey": null
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -95,7 +96,15 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "type": "DatasetExample",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -124,17 +133,18 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v2/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
+          (v2/*: any*/),
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/)
+            ],
+            "type": "DatasetExample",
+            "abstractKey": null
           }
         ],
         "storageKey": null
@@ -142,16 +152,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "57efff08a8a2b555f02a8af5fcaea308",
+    "cacheID": "93fbebc2d9ffcd7cf2d9c97a29b81abf",
     "id": null,
     "metadata": {},
     "name": "DatasetExamplePageQuery",
     "operationKind": "query",
-    "text": "query DatasetExamplePageQuery(\n  $exampleId: GlobalID!\n) {\n  example: node(id: $exampleId) {\n    __typename\n    ... on DatasetExample {\n      latestRevision: revision {\n        input\n        output\n        metadata\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query DatasetExamplePageQuery(\n  $exampleId: GlobalID!\n) {\n  example: node(id: $exampleId) {\n    __typename\n    ... on DatasetExample {\n      id\n      latestRevision: revision {\n        input\n        output\n        metadata\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "df42938b9353ee8729d3ff079d009fe3";
+(node as any).hash = "04e6568e5b36514aee41eb38d5c66166";
 
 export default node;

--- a/app/src/pages/dataset/__generated__/EditDatasetExampleDialogMutation.graphql.ts
+++ b/app/src/pages/dataset/__generated__/EditDatasetExampleDialogMutation.graphql.ts
@@ -1,0 +1,100 @@
+/**
+ * @generated SignedSource<<85f8cd17d4d969e99a0ce88dbad4d27f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type PatchDatasetExamplesInput = {
+  patches: ReadonlyArray<DatasetExamplePatch>;
+  versionDescription?: string | null;
+  versionMetadata?: any | null;
+};
+export type DatasetExamplePatch = {
+  exampleId: string;
+  input?: any | null;
+  metadata?: any | null;
+  output?: any | null;
+};
+export type EditDatasetExampleDialogMutation$variables = {
+  input: PatchDatasetExamplesInput;
+};
+export type EditDatasetExampleDialogMutation$data = {
+  readonly patchDatasetExamples: {
+    readonly __typename: "DatasetMutationPayload";
+  };
+};
+export type EditDatasetExampleDialogMutation = {
+  response: EditDatasetExampleDialogMutation$data;
+  variables: EditDatasetExampleDialogMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DatasetMutationPayload",
+    "kind": "LinkedField",
+    "name": "patchDatasetExamples",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditDatasetExampleDialogMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditDatasetExampleDialogMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "5b7537a09214878e93804f19af2a3701",
+    "id": null,
+    "metadata": {},
+    "name": "EditDatasetExampleDialogMutation",
+    "operationKind": "mutation",
+    "text": "mutation EditDatasetExampleDialogMutation(\n  $input: PatchDatasetExamplesInput!\n) {\n  patchDatasetExamples(input: $input) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e8c0c5c882dad5264f4f7ddcbe1777e1";
+
+export default node;

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -144,7 +144,11 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
                   onCreateNewDataset={() => {
                     setIsDatasetPopoverOpen(false);
                     setDialog(
-                      <Dialog title="New Dataset">
+                      <Dialog
+                        title="New Dataset"
+                        isDismissable
+                        onDismiss={() => setDialog(null)}
+                      >
                         <CreateDatasetForm
                           onDatasetCreateError={() => {
                             notifyError({

--- a/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
+++ b/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { css } from "@emotion/react";
@@ -41,7 +41,7 @@ export function SpanToDatasetExampleDialog({
   spanId: string;
   onCompleted: () => void;
 }) {
-  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const {
     span: { revision },
     datasets,


### PR DESCRIPTION
resolves #3368 

Adds a slide-over UI to edit a dataset example

<img width="1488" alt="Screenshot 2024-06-05 at 10 31 17 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/9dff0b14-ae3c-48fc-9a78-656b6e98110c">
