### PR TITLE
feat(ui): display input and output for tool spans

### DIFF
--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1065,13 +1065,14 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
     () => spanAttributes[SemanticAttributePrefixes.tool] || {},
     [spanAttributes]
   );
+  const hasToolAttributes = Object.keys(toolAttributes).length > 0;
   const toolName = toolAttributes[ToolAttributePostfixes.name];
   const toolDescription = toolAttributes[ToolAttributePostfixes.description];
   const toolParameters = toolAttributes[ToolAttributePostfixes.parameters];
   if (
     (!input || input.value == null) &&
     (!output || output.value == null) &&
-    !toolAttributes
+    !hasToolAttributes
   ) {
     return null;
   }
@@ -1111,7 +1112,7 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
           </Card>
         </MarkdownDisplayProvider>
       ) : null}
-      {toolAttributes ? (
+      {hasToolAttributes ? (
         <Card
           title={"Tool" + (typeof toolName === "string" ? `: ${toolName}` : "")}
           {...defaultCardProps}

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1057,7 +1057,10 @@ function EmbeddingSpanInfo(props: {
 }
 
 function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
-  const { spanAttributes } = props;
+  const { span, spanAttributes } = props;
+  const { input, output } = span;
+  const inputIsText = input?.mimeType === "text";
+  const outputIsText = output?.mimeType === "text";
   const toolAttributes = useMemo<AttributeTool>(
     () => spanAttributes[SemanticAttributePrefixes.tool] || {},
     [spanAttributes]
@@ -1071,6 +1074,40 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
   const toolParameters = toolAttributes[ToolAttributePostfixes.parameters];
   return (
     <Flex direction="column" gap="size-200">
+      {input && input.value != null ? (
+        <MarkdownDisplayProvider>
+          <Card
+            title="Input"
+            {...defaultCardProps}
+            extra={
+              <Flex direction="row" gap="size-100">
+                {inputIsText ? <ConnectedMarkdownModeRadioGroup /> : null}
+                <CopyToClipboardButton text={input.value} />
+              </Flex>
+            }
+          >
+            <CodeBlock {...input} />
+          </Card>
+        </MarkdownDisplayProvider>
+      ) : null}
+      {output && output.value != null ? (
+        <MarkdownDisplayProvider>
+          <Card
+            title="Output"
+            {...defaultCardProps}
+            backgroundColor="green-100"
+            borderColor="green-700"
+            extra={
+              <Flex direction="row" gap="size-100">
+                {outputIsText ? <ConnectedMarkdownModeRadioGroup /> : null}
+                <CopyToClipboardButton text={output.value} />
+              </Flex>
+            }
+          >
+            <CodeBlock {...output} />
+          </Card>
+        </MarkdownDisplayProvider>
+      ) : null}
       <Card
         title={"Tool" + (typeof toolName === "string" ? `: ${toolName}` : "")}
         {...defaultCardProps}

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1059,8 +1059,8 @@ function EmbeddingSpanInfo(props: {
 function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
   const { span, spanAttributes } = props;
   const { input, output } = span;
-  const hasInput = typeof input?.value == "string";
-  const hasOutput = typeof output?.value == "string";
+  const hasInput = typeof input?.value === "string";
+  const hasOutput = typeof output?.value === "string";
   const inputIsText = input?.mimeType === "text";
   const outputIsText = output?.mimeType === "text";
   const toolAttributes = useMemo<AttributeTool>(

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1065,13 +1065,16 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
     () => spanAttributes[SemanticAttributePrefixes.tool] || {},
     [spanAttributes]
   );
-  const hasToolAttributes = Object.keys(toolAttributes).length > 0;
-  if (!hasToolAttributes) {
-    return null;
-  }
   const toolName = toolAttributes[ToolAttributePostfixes.name];
   const toolDescription = toolAttributes[ToolAttributePostfixes.description];
   const toolParameters = toolAttributes[ToolAttributePostfixes.parameters];
+  if (
+    (!input || input.value == null) &&
+    (!output || output.value == null) &&
+    !toolAttributes
+  ) {
+    return null;
+  }
   return (
     <Flex direction="column" gap="size-200">
       {input && input.value != null ? (
@@ -1108,50 +1111,52 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
           </Card>
         </MarkdownDisplayProvider>
       ) : null}
-      <Card
-        title={"Tool" + (typeof toolName === "string" ? `: ${toolName}` : "")}
-        {...defaultCardProps}
-      >
-        <Flex direction="column">
-          {toolDescription != null ? (
-            <View
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              paddingTop="size-100"
-              paddingBottom="size-100"
-              borderBottomColor="dark"
-              borderBottomWidth="thin"
-              backgroundColor="light"
-            >
-              <Flex direction="column" alignItems="start" gap="size-50">
-                <Text color="text-700" fontStyle="italic">
-                  Description
-                </Text>
-                <Text>{toolDescription as string}</Text>
-              </Flex>
-            </View>
-          ) : null}
-          {toolParameters != null ? (
-            <View
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              paddingTop="size-100"
-              paddingBottom="size-100"
-              borderBottomColor="dark"
-              borderBottomWidth="thin"
-            >
-              <Flex direction="column" alignItems="start" width="100%">
-                <Text color="text-700" fontStyle="italic">
-                  Parameters
-                </Text>
-                <JSONBlock>
-                  {JSON.stringify(toolParameters) as string}
-                </JSONBlock>
-              </Flex>
-            </View>
-          ) : null}
-        </Flex>
-      </Card>
+      {toolAttributes ? (
+        <Card
+          title={"Tool" + (typeof toolName === "string" ? `: ${toolName}` : "")}
+          {...defaultCardProps}
+        >
+          <Flex direction="column">
+            {toolDescription != null ? (
+              <View
+                paddingStart="size-200"
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderBottomColor="dark"
+                borderBottomWidth="thin"
+                backgroundColor="light"
+              >
+                <Flex direction="column" alignItems="start" gap="size-50">
+                  <Text color="text-700" fontStyle="italic">
+                    Description
+                  </Text>
+                  <Text>{toolDescription as string}</Text>
+                </Flex>
+              </View>
+            ) : null}
+            {toolParameters != null ? (
+              <View
+                paddingStart="size-200"
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderBottomColor="dark"
+                borderBottomWidth="thin"
+              >
+                <Flex direction="column" alignItems="start" width="100%">
+                  <Text color="text-700" fontStyle="italic">
+                    Parameters
+                  </Text>
+                  <JSONBlock>
+                    {JSON.stringify(toolParameters) as string}
+                  </JSONBlock>
+                </Flex>
+              </View>
+            ) : null}
+          </Flex>
+        </Card>
+      ) : null}
     </Flex>
   );
 }

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1059,6 +1059,8 @@ function EmbeddingSpanInfo(props: {
 function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
   const { span, spanAttributes } = props;
   const { input, output } = span;
+  const hasInput = typeof input?.value == "string";
+  const hasOutput = typeof output?.value == "string";
   const inputIsText = input?.mimeType === "text";
   const outputIsText = output?.mimeType === "text";
   const toolAttributes = useMemo<AttributeTool>(
@@ -1069,16 +1071,12 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
   const toolName = toolAttributes[ToolAttributePostfixes.name];
   const toolDescription = toolAttributes[ToolAttributePostfixes.description];
   const toolParameters = toolAttributes[ToolAttributePostfixes.parameters];
-  if (
-    (!input || input.value == null) &&
-    (!output || output.value == null) &&
-    !hasToolAttributes
-  ) {
+  if (!hasInput && !hasOutput && !hasToolAttributes) {
     return null;
   }
   return (
     <Flex direction="column" gap="size-200">
-      {input && input.value != null ? (
+      {hasInput ? (
         <MarkdownDisplayProvider>
           <Card
             title="Input"
@@ -1094,7 +1092,7 @@ function ToolSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
           </Card>
         </MarkdownDisplayProvider>
       ) : null}
-      {output && output.value != null ? (
+      {hasOutput ? (
         <MarkdownDisplayProvider>
           <Card
             title="Output"


### PR DESCRIPTION
<img width="800" alt="Screenshot 2024-06-05 at 4 52 32 PM" src="https://github.com/Arize-ai/phoenix/assets/80478925/e8c35f83-2d27-43c7-a189-e0a7641d2dec">
