### PR TITLE
feat: add experiments resolver to DatasetExample gql type

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -120,6 +120,7 @@ type DatasetExample implements Node {
   createdAt: DateTime!
   revision(datasetVersionId: GlobalID): DatasetExampleRevision!
   span: Span
+  experiments: ExperimentConnection!
 }
 
 """A connection to a list of items."""

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -120,7 +120,7 @@ type DatasetExample implements Node {
   createdAt: DateTime!
   revision(datasetVersionId: GlobalID): DatasetExampleRevision!
   span: Span
-  experiments: ExperimentConnection!
+  experiments(first: Int = 50, last: Int, after: String, before: String): ExperimentConnection!
 }
 
 """A connection to a list of items."""

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -83,9 +83,7 @@ class DatasetExample(Node):
             .order_by(models.Experiment.id.asc())
         )
         async with info.context.db() as session:
-            db_experiments = [
-                experiment async for experiment in await session.stream_scalars(query)
-            ]
+            experiments = (await session.scalars(query)).all()
         return connection_from_list(
-            [to_gql_experiment(experiment) for experiment in db_experiments], args
+            [to_gql_experiment(experiment) for experiment in experiments], args
         )

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -71,11 +71,7 @@ class DatasetExample(Node):
             last=last,
             before=before if isinstance(before, CursorString) else None,
         )
-        example_id = (
-            select(models.DatasetExample.id)
-            .where(models.DatasetExample.id == self.id_attr)
-            .scalar_subquery()
-        )
+        example_id = self.id_attr
         query = (
             select(models.Experiment)
             .join(models.ExperimentRun, models.Experiment.id == models.ExperimentRun.experiment_id)

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -3,12 +3,13 @@ from typing import Optional
 
 import strawberry
 from strawberry import UNSET
-from strawberry.relay.types import GlobalID, Node, NodeID
+from strawberry.relay.types import Connection, GlobalID, Node, NodeID
 from strawberry.types import Info
 
 from phoenix.server.api.context import Context
 from phoenix.server.api.types.DatasetExampleRevision import DatasetExampleRevision
 from phoenix.server.api.types.DatasetVersion import DatasetVersion
+from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Span import Span, to_gql_span
 
@@ -47,3 +48,7 @@ class DatasetExample(Node):
             if (span := await info.context.data_loaders.dataset_example_spans.load(self.id_attr))
             else None
         )
+
+    @strawberry.field
+    async def experiments(self, info: Info[Context, None]) -> Connection[Experiment]:
+        raise NotImplementedError("experiments resolver on DatasetExample not implemented")

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -76,7 +76,7 @@ class DatasetExample(Node):
             select(models.Experiment)
             .join(models.ExperimentRun, models.Experiment.id == models.ExperimentRun.experiment_id)
             .where(models.ExperimentRun.dataset_example_id == example_id)
-            .order_by(models.Experiment.id.asc())
+            .order_by(models.Experiment.id.desc())
         )
         async with info.context.db() as session:
             experiments = (await session.scalars(query)).all()

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -80,6 +80,7 @@ class DatasetExample(Node):
             select(models.Experiment)
             .join(models.ExperimentRun, models.Experiment.id == models.ExperimentRun.experiment_id)
             .where(models.ExperimentRun.dataset_example_id == example_id)
+            .order_by(models.Experiment.id.asc())
         )
         async with info.context.db() as session:
             db_experiments = [

--- a/src/phoenix/server/api/types/Experiment.py
+++ b/src/phoenix/server/api/types/Experiment.py
@@ -18,4 +18,13 @@ class Experiment(Node):
 
 
 def to_gql_experiment(experiment: models.Experiment) -> Experiment:
-    raise NotImplementedError("implement to_gql_experiment")
+    """
+    Converts an ORM experiment to a GraphQL Experiment.
+    """
+    return Experiment(
+        id_attr=experiment.id,
+        description=experiment.description,
+        metadata=experiment.metadata_,
+        created_at=experiment.created_at,
+        updated_at=experiment.updated_at,
+    )

--- a/src/phoenix/server/api/types/Experiment.py
+++ b/src/phoenix/server/api/types/Experiment.py
@@ -5,6 +5,8 @@ import strawberry
 from strawberry.relay import Node, NodeID
 from strawberry.scalars import JSON
 
+from phoenix.db import models
+
 
 @strawberry.type
 class Experiment(Node):
@@ -13,3 +15,7 @@ class Experiment(Node):
     metadata: JSON
     created_at: datetime
     updated_at: datetime
+
+
+def to_gql_experiment(experiment: models.Experiment) -> Experiment:
+    raise NotImplementedError("implement to_gql_experiment")

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -88,6 +88,39 @@ async def test_dataset_example_span_resolver(
     }
 
 
+async def test_dataset_example_experiments_resolver(test_client) -> None:
+    query = """
+      query ($exampleId: GlobalID!) {
+        example: node(id: $exampleId) {
+          ... on DatasetExample {
+            experiments {
+              edges {
+                experiment: node {
+                  id
+                  description
+                  metadata
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+    response = await test_client.post(
+        "/graphql",
+        json={
+            "query": query,
+            "variables": {
+                "exampleId": str(GlobalID("DatasetExample", str(1))),
+            },
+        },
+    )
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json.get("errors") is None
+
+
 @pytest.fixture
 async def dataset_with_span_and_nonspan_examples(session):
     """

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -278,12 +278,12 @@ async def dataset_with_example_and_experiment(session) -> None:
         .values(
             dataset_id=dataset_id,
             dataset_version_id=version_id,
-            description="experiment-description",
-            metadata_={"metadata": "experiment-metadata"},
+            description="experiment-1-description",
+            metadata_={"metadata": "experiment-1-metadata"},
         )
     )
 
-    # insert an experiment run
+    # insert an experiment run on the example
     await session.execute(
         insert(models.ExperimentRun).values(
             experiment_id=experiment_id,
@@ -291,5 +291,15 @@ async def dataset_with_example_and_experiment(session) -> None:
             output={"output": "experiment-run-output"},
             start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
             end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+        )
+    )
+
+    # insert an unused experiment
+    await session.execute(
+        insert(models.Experiment).values(
+            dataset_id=dataset_id,
+            dataset_version_id=version_id,
+            description="experiment-2-description",
+            metadata_={"metadata": "experiment-2-metadata"},
         )
     )

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -89,7 +89,7 @@ async def test_dataset_example_span_resolver(
     }
 
 
-async def test_dataset_example_experiments_resolver(
+async def test_dataset_example_experiments_resolver_returns_relevant_experiments(
     test_client, dataset_with_example_and_experiment
 ) -> None:
     query = """
@@ -236,7 +236,8 @@ async def dataset_with_span_and_nonspan_examples(session):
 @pytest.fixture
 async def dataset_with_example_and_experiment(session) -> None:
     """
-    A dataset with a single example and a single version.
+    A dataset with a single example and two experiments, one that uses the
+    example and one that does not.
     """
 
     # insert dataset
@@ -255,7 +256,6 @@ async def dataset_with_example_and_experiment(session) -> None:
         insert(models.DatasetExample)
         .values(
             dataset_id=dataset_id,
-            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
         )
         .returning(models.DatasetExample.id)
     )

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -102,7 +102,6 @@ async def test_dataset_example_experiments_resolver(
                   id
                   description
                   metadata
-                  createdAt
                 }
               }
             }
@@ -122,6 +121,21 @@ async def test_dataset_example_experiments_resolver(
     assert response.status_code == 200
     response_json = response.json()
     assert response_json.get("errors") is None
+    assert response_json["data"] == {
+        "example": {
+            "experiments": {
+                "edges": [
+                    {
+                        "experiment": {
+                            "id": str(GlobalID("Experiment", str(1))),
+                            "description": "experiment-1-description",
+                            "metadata": {"metadata": "experiment-1-metadata"},
+                        }
+                    }
+                ]
+            }
+        }
+    }
 
 
 @pytest.fixture

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+import pytz
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
 from sqlalchemy import insert
@@ -88,7 +89,9 @@ async def test_dataset_example_span_resolver(
     }
 
 
-async def test_dataset_example_experiments_resolver(test_client) -> None:
+async def test_dataset_example_experiments_resolver(
+    test_client, dataset_with_example_and_experiment
+) -> None:
     query = """
       query ($exampleId: GlobalID!) {
         example: node(id: $exampleId) {
@@ -212,5 +215,81 @@ async def dataset_with_span_and_nonspan_examples(session):
             output={"output": "example-2-version-1-output"},
             metadata_={"metadata": "example-2-version-1-metadata"},
             revision_kind="CREATE",
+        )
+    )
+
+
+@pytest.fixture
+async def dataset_with_example_and_experiment(session) -> None:
+    """
+    A dataset with a single example and a single version.
+    """
+
+    # insert dataset
+    dataset_id = await session.scalar(
+        insert(models.Dataset)
+        .returning(models.Dataset.id)
+        .values(
+            name="dataset-name",
+            description=None,
+            metadata_={},
+        )
+    )
+
+    # insert example
+    example_id = await session.scalar(
+        insert(models.DatasetExample)
+        .values(
+            dataset_id=dataset_id,
+            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        )
+        .returning(models.DatasetExample.id)
+    )
+
+    # insert version
+    version_id = await session.scalar(
+        insert(models.DatasetVersion)
+        .returning(models.DatasetVersion.id)
+        .values(
+            dataset_id=dataset_id,
+            description="original-description",
+            metadata_={"metadata": "original-metadata"},
+        )
+    )
+
+    # insert revision
+    await session.scalar(
+        insert(models.DatasetExampleRevision)
+        .returning(models.DatasetExampleRevision.id)
+        .values(
+            dataset_example_id=example_id,
+            dataset_version_id=version_id,
+            input={"input": "first-input"},
+            output={"output": "first-output"},
+            metadata_={"metadata": "first-metadata"},
+            revision_kind="CREATE",
+        )
+    )
+
+    # insert an experiment
+    experiment_id = await session.scalar(
+        insert(models.Experiment)
+        .returning(models.Experiment.id)
+        .values(
+            dataset_id=dataset_id,
+            dataset_version_id=version_id,
+            description="experiment-description",
+            metadata_={"metadata": "experiment-metadata"},
+        )
+    )
+
+    # insert an experiment run
+    await session.execute(
+        insert(models.ExperimentRun).values(
+            experiment_id=experiment_id,
+            dataset_example_id=example_id,
+            output={"output": "experiment-run-output"},
+            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
         )
     )


### PR DESCRIPTION
Adds an `experiments` resolver to the `DatasetExample` type and adds corresponding tests.

resolves #3399
