### PR TITLE
chore: update tables for human annotations on experiment runs

### DIFF
--- a/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
+++ b/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
@@ -220,7 +220,7 @@ def upgrade() -> None:
             "annotator_kind",
             sa.String,
             sa.CheckConstraint(
-                "annotator_kind IN ('LLM', 'HUMAN')",
+                "annotator_kind IN ('LLM', 'CODE', 'HUMAN')",
                 name="valid_annotator_kind",
             ),
             nullable=False,

--- a/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
+++ b/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
@@ -202,7 +202,7 @@ def upgrade() -> None:
         ),
     )
     op.create_table(
-        "experiment_evaluations",
+        "experiment_annotations",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
             "experiment_run_id",
@@ -214,6 +214,15 @@ def upgrade() -> None:
         sa.Column(
             "name",
             sa.String,
+            nullable=False,
+        ),
+        sa.Column(
+            "annotator_kind",
+            sa.String,
+            sa.CheckConstraint(
+                "annotator_kind IN ('LLM', 'HUMAN')",
+                name="valid_annotator_kind",
+            ),
             nullable=False,
         ),
         sa.Column(

--- a/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
+++ b/src/phoenix/db/migrations/versions/10460e46d750_datasets.py
@@ -257,7 +257,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("experiment_evaluations")
+    op.drop_table("experiment_annotations")
     op.drop_table("experiment_runs")
     op.drop_table("experiments")
     op.drop_table("dataset_example_revisions")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -538,14 +538,17 @@ class ExperimentRun(Base):
     error: Mapped[Optional[str]]
 
 
-class ExperimentEvaluation(Base):
-    __tablename__ = "experiment_evaluations"
+class ExperimentAnnotation(Base):
+    __tablename__ = "experiment_annotations"
     id: Mapped[int] = mapped_column(primary_key=True)
     experiment_run_id: Mapped[int] = mapped_column(
         ForeignKey("experiment_runs.id", ondelete="CASCADE"),
         index=True,
     )
     name: Mapped[str]
+    annotator_kind: Mapped[str] = mapped_column(
+        CheckConstraint("annotator_kind IN ('LLM', 'HUMAN')", name="valid_annotator_kind"),
+    )
     label: Mapped[Optional[str]]
     score: Mapped[Optional[float]]
     explanation: Mapped[Optional[str]]

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -547,7 +547,7 @@ class ExperimentAnnotation(Base):
     )
     name: Mapped[str]
     annotator_kind: Mapped[str] = mapped_column(
-        CheckConstraint("annotator_kind IN ('LLM', 'HUMAN')", name="valid_annotator_kind"),
+        CheckConstraint("annotator_kind IN ('LLM', 'CODE', 'HUMAN')", name="valid_annotator_kind"),
     )
     label: Mapped[Optional[str]]
     score: Mapped[Optional[float]]

--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -31,9 +31,10 @@ async def create_experiment_evaluation(request: Request) -> Response:
     start_time = payload["start_time"]
     end_time = payload["end_time"]
     async with request.app.state.db() as session:
-        experiment_evaluation = models.ExperimentEvaluation(
+        experiment_evaluation = models.ExperimentAnnotation(
             experiment_run_id=experiment_run_id,
             name=name,
+            annotator_kind="LLM",
             label=label,
             score=score,
             explanation=explanation,

--- a/tests/server/api/conftest.py
+++ b/tests/server/api/conftest.py
@@ -483,10 +483,11 @@ async def dataset_with_experiments_and_runs(session, dataset_with_experiments_wi
 
 @pytest.fixture
 async def dataset_with_experiments_runs_and_evals(session, dataset_with_experiments_and_runs):
-    experiment_evaluation_0 = models.ExperimentEvaluation(
+    experiment_evaluation_0 = models.ExperimentAnnotation(
         id=0,
         experiment_run_id=0,
         name="test",
+        annotator_kind="LLM",
         label="test",
         score=0.8,
         explanation="test",
@@ -498,10 +499,11 @@ async def dataset_with_experiments_runs_and_evals(session, dataset_with_experime
     session.add(experiment_evaluation_0)
     await session.flush()
 
-    experiment_evaluation_1 = models.ExperimentEvaluation(
+    experiment_evaluation_1 = models.ExperimentAnnotation(
         id=1,
         experiment_run_id=1,
         name="test",
+        annotator_kind="LLM",
         label="test",
         score=0.9,
         explanation="test",
@@ -513,10 +515,11 @@ async def dataset_with_experiments_runs_and_evals(session, dataset_with_experime
     session.add(experiment_evaluation_1)
     await session.flush()
 
-    experiment_evaluation_2 = models.ExperimentEvaluation(
+    experiment_evaluation_2 = models.ExperimentAnnotation(
         id=2,
         experiment_run_id=2,
         name="second experiment",
+        annotator_kind="LLM",
         label="test2",
         score=1,
         explanation="test",
@@ -528,10 +531,11 @@ async def dataset_with_experiments_runs_and_evals(session, dataset_with_experime
     session.add(experiment_evaluation_2)
     await session.flush()
 
-    experiment_evaluation_3 = models.ExperimentEvaluation(
+    experiment_evaluation_3 = models.ExperimentAnnotation(
         id=3,
         experiment_run_id=3,
         name="experiment",
+        annotator_kind="LLM",
         label="test2",
         score=None,
         explanation="test",


### PR DESCRIPTION
- Renames `experiment_evaluations` table to `experiment_annotations`.
- Adds `annotator_kind` column with a check constraint.
- Updates source and tests.

resolves #3425
