### PR TITLE
fix: ensure welcome message urls are valid

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -2,11 +2,10 @@ import atexit
 import logging
 import os
 from argparse import ArgumentParser
-from pathlib import Path
+from pathlib import Path, PosixPath
 from threading import Thread
 from time import sleep, time
 from typing import List, Optional
-from urllib.parse import urljoin
 
 import pkg_resources
 from uvicorn import Config, Server
@@ -251,9 +250,9 @@ if __name__ == "__main__":
     print(
         _WELCOME_MESSAGE.format(
             version=phoenix_version,
-            ui_path=urljoin(f"http://{host}:{port}", host_root_path),
+            ui_path=PosixPath(f"http://{host}:{port}", host_root_path),
             grpc_path=f"http://{host}:{get_env_grpc_port()}",
-            http_path=urljoin(f"http://{host}:{port}/{host_root_path}", "/v1/traces"),
+            http_path=PosixPath(f"http://{host}:{port}", host_root_path, "v1/traces"),
             storage=get_printable_db_url(db_connection_str),
         )
     )

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from threading import Thread
 from time import sleep, time
 from typing import List, Optional
+from urllib.parse import urljoin
 
 import pkg_resources
 from uvicorn import Config, Server
@@ -67,10 +68,10 @@ _WELCOME_MESSAGE = """
 |  https://docs.arize.com/phoenix
 |
 |  🚀 Phoenix Server 🚀
-|  Phoenix UI: http://{host}:{port}/{root_path}
+|  Phoenix UI: {ui_path}
 |  Log traces:
-|    - gRPC: http://{host}:{grpc_port}
-|    - HTTP: http://{host}:{port}/{root_path}/v1/traces
+|    - gRPC: {grpc_path}
+|    - HTTP: {http_path}
 |  Storage: {storage}
 """
 
@@ -247,15 +248,15 @@ if __name__ == "__main__":
 
     # Print information about the server
     phoenix_version = pkg_resources.get_distribution("arize-phoenix").version
-    config = {
-        "version": phoenix_version,
-        "host": display_host,
-        "port": port,
-        "root_path": host_root_path.strip("/"),
-        "grpc_port": get_env_grpc_port(),
-        "storage": get_printable_db_url(db_connection_str),
-    }
-    print(_WELCOME_MESSAGE.format(**config))
+    print(
+        _WELCOME_MESSAGE.format(
+            version=phoenix_version,
+            ui_path=urljoin(f"http://{host}:{port}", host_root_path),
+            grpc_path=f"http://{host}:{get_env_grpc_port()}",
+            http_path=urljoin(f"http://{host}:{port}/{host_root_path}", "/v1/traces"),
+            storage=get_printable_db_url(db_connection_str),
+        )
+    )
 
     # Start the server
     server.run()


### PR DESCRIPTION
**No Host Root Path**

Ensures welcome message URLs are valid and do not have unnecessary trailing slashes.

*Before*

```
|  🚀 Phoenix Server 🚀
|  Phoenix UI: http://0.0.0.0:6006/
|  Log traces:
|    - gRPC: http://0.0.0.0:4317
|    - HTTP: http://0.0.0.0:6006//v1/traces
|  Storage: sqlite:////Users/xandersong/.phoenix/phoenix.db
```

*After*

```
|  🚀 Phoenix Server 🚀
|  Phoenix UI: http:/0.0.0.0:6006
|  Log traces:
|    - gRPC: http://0.0.0.0:4317
|    - HTTP: http:/0.0.0.0:6006/v1/traces
|  Storage: sqlite:////Users/xandersong/.phoenix/phoenix.db
```

**WIth Host Root Path**

(no changes)

*Before*

```
|  🚀 Phoenix Server 🚀
|  Phoenix UI: http://0.0.0.0:6006/test
|  Log traces:
|    - gRPC: http://0.0.0.0:4317
|    - HTTP: http://0.0.0.0:6006/test/v1/traces
|  Storage: sqlite:////Users/xandersong/.phoenix/phoenix.db
```

*After*

```
|  🚀 Phoenix Server 🚀
|  Phoenix UI: http:/0.0.0.0:6006/test
|  Log traces:
|    - gRPC: http://0.0.0.0:4317
|    - HTTP: http:/0.0.0.0:6006/test/v1/traces
|  Storage: sqlite:////Users/xandersong/.phoenix/phoenix.db
```

resolves #3459