### PR TITLE
fix: add tiebreak to versions resolver

### DIFF
--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 import strawberry
-from sqlalchemy import and_, desc, func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.sql.functions import count
 from strawberry import UNSET
 from strawberry.relay import Connection, GlobalID, Node, NodeID
@@ -54,10 +54,10 @@ class Dataset(Node):
             if sort:
                 # For now assume the the column names match 1:1 with the enum values
                 sort_col = getattr(models.DatasetVersion, sort.col.value)
-                sort_expr = sort_col
                 if sort.dir is SortDir.desc:
-                    sort_expr = desc(sort_col)
-                stmt = stmt.order_by(sort_expr)
+                    stmt = stmt.order_by(sort_col.desc()).order_by(models.DatasetVersion.id.desc())
+                else:
+                    stmt = stmt.order_by(sort_col.asc()).order_by(models.DatasetVersion.id.asc())
             else:
                 stmt = stmt.order_by(models.DatasetVersion.created_at.desc())
             versions = await session.scalars(stmt)

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -65,7 +65,7 @@ class Dataset(Node):
             DatasetVersion(
                 id_attr=version.id,
                 description=version.description,
-                metadata=version.metadata,
+                metadata=version.metadata_,
                 created_at=version.created_at,
             )
             for version in versions

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -55,9 +55,9 @@ class Dataset(Node):
                 # For now assume the the column names match 1:1 with the enum values
                 sort_col = getattr(models.DatasetVersion, sort.col.value)
                 if sort.dir is SortDir.desc:
-                    stmt = stmt.order_by(sort_col.desc()).order_by(models.DatasetVersion.id.desc())
+                    stmt = stmt.order_by(sort_col.desc(), models.DatasetVersion.id.desc())
                 else:
-                    stmt = stmt.order_by(sort_col.asc()).order_by(models.DatasetVersion.id.asc())
+                    stmt = stmt.order_by(sort_col.asc(), models.DatasetVersion.id.asc())
             else:
                 stmt = stmt.order_by(models.DatasetVersion.created_at.desc())
             versions = await session.scalars(stmt)

--- a/tests/server/api/types/test_Dataset.py
+++ b/tests/server/api/types/test_Dataset.py
@@ -474,7 +474,7 @@ async def test_versions_resolver_returns_versions_in_correct_order(
     sort_direction, expected_versions, test_client, dataset_with_three_versions
 ):
     query = """
-      query compare($datasetId: GlobalID!, $dir: SortDir!, $col: DatasetVersionColumn!) {
+      query ($datasetId: GlobalID!, $dir: SortDir!, $col: DatasetVersionColumn!) {
         dataset: node(id: $datasetId) {
           ... on Dataset {
             versions(sort: {dir: $dir, col: $col}) {

--- a/tests/server/api/types/test_Dataset.py
+++ b/tests/server/api/types/test_Dataset.py
@@ -420,22 +420,22 @@ class TestDatasetExamplesResolver:
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(1))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-1-description",
+                        "metadata": {"version-1-metadata-key": "version-1-metadata-value"},
                     }
                 },
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(2))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-2-description",
+                        "metadata": {"version-2-metadata-key": "version-2-metadata-value"},
                     }
                 },
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(3))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-3-description",
+                        "metadata": {"version-3-metadata-key": "version-3-metadata-value"},
                     }
                 },
             ],
@@ -447,22 +447,22 @@ class TestDatasetExamplesResolver:
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(3))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-3-description",
+                        "metadata": {"version-3-metadata-key": "version-3-metadata-value"},
                     }
                 },
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(2))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-2-description",
+                        "metadata": {"version-2-metadata-key": "version-2-metadata-value"},
                     }
                 },
                 {
                     "version": {
                         "id": str(GlobalID("DatasetVersion", str(1))),
-                        "description": None,
-                        "metadata": {},
+                        "description": "version-1-description",
+                        "metadata": {"version-1-metadata-key": "version-1-metadata-value"},
                     }
                 },
             ],
@@ -666,8 +666,8 @@ async def dataset_with_three_versions(session):
     dataset_version_1 = models.DatasetVersion(
         id=1,
         dataset_id=1,
-        description=None,
-        metadata_={},
+        description="version-1-description",
+        metadata_={"version-1-metadata-key": "version-1-metadata-value"},
         created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
     )
     session.add(dataset_version_1)
@@ -688,8 +688,8 @@ async def dataset_with_three_versions(session):
     dataset_version_2 = models.DatasetVersion(
         id=2,
         dataset_id=1,
-        description=None,
-        metadata_={},
+        description="version-2-description",
+        metadata_={"version-2-metadata-key": "version-2-metadata-value"},
         created_at=datetime(
             year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
         ),  # same created_at as version 1
@@ -700,8 +700,8 @@ async def dataset_with_three_versions(session):
     dataset_version_3 = models.DatasetVersion(
         id=3,
         dataset_id=1,
-        description=None,
-        metadata_={},
+        description="version-3-description",
+        metadata_={"version-3-metadata-key": "version-3-metadata-value"},
         created_at=datetime(
             year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc
         ),  # created one minute after version 2


### PR DESCRIPTION
If the sort column is tied, use the row ID as a tiebreak

resolves #3485
