### PR TITLE
refactor: update GET /v1/datasets/{datasetId}/examples to return dataset and version IDs as part of payload

### DIFF
--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -208,18 +208,46 @@ paths:
               schema:
                 properties:
                   data:
-                    items:
-                      properties:
-                        example_id:
-                          type: string
-                        input:
+                    properties:
+                      dataset_id:
+                        description: ID of the dataset
+                        type: string
+                      examples:
+                        items:
+                          properties:
+                            id:
+                              description: ID of the dataset example
+                              type: string
+                            input:
+                              description: Input data of the example
+                              type: object
+                            metadata:
+                              description: Metadata of the example
+                              type: object
+                            output:
+                              description: Output data of the example
+                              type: object
+                            updated_at:
+                              description: ISO formatted timestamp of when the example
+                                was updated
+                              format: date-time
+                              type: string
+                          required:
+                          - id
+                          - input
+                          - output
+                          - metadata
+                          - updated_at
                           type: object
-                        metadata:
-                          type: object
-                        output:
-                          type: object
-                      type: object
-                    type: array
+                        type: array
+                      version_id:
+                        description: ID of the version
+                        type: string
+                    required:
+                    - dataset_id
+                    - version_id
+                    - examples
+                    type: object
                 type: object
           description: Success
         403:

--- a/src/phoenix/server/api/routers/v1/dataset_examples.py
+++ b/src/phoenix/server/api/routers/v1/dataset_examples.py
@@ -129,15 +129,20 @@ async def list_dataset_examples(request: Request) -> Response:
             )
             .order_by(DatasetExample.id.asc())
         )
-        examples = []
-        for example, revision in await session.execute(query):
-            examples.append(
-                {
-                    "id": str(GlobalID("DatasetExample", str(example.id))),
-                    "input": revision.input,
-                    "output": revision.output,
-                    "metadata": revision.metadata_,
-                    "updated_at": revision.created_at.isoformat(),
-                }
-            )
-        return JSONResponse(examples)
+        examples = [
+            {
+                "id": str(GlobalID("DatasetExample", str(example.id))),
+                "input": revision.input,
+                "output": revision.output,
+                "metadata": revision.metadata_,
+                "updated_at": revision.created_at.isoformat(),
+            }
+            async for example, revision in await session.stream(query)
+        ]
+        return JSONResponse(
+            {
+                "dataset_id": str(GlobalID("Dataset", str(resolved_dataset_id))),
+                "version_id": str(GlobalID("DatasetVersion", str(resolved_version_id))),
+                "examples": examples,
+            }
+        )

--- a/src/phoenix/server/api/routers/v1/dataset_examples.py
+++ b/src/phoenix/server/api/routers/v1/dataset_examples.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import HTTP_404_NOT_FOUND
@@ -66,46 +66,72 @@ async def list_dataset_examples(request: Request) -> Response:
         )
 
     async with request.app.state.db() as session:
-        # Subquery to find the maximum created_at for each dataset_example_id
-        # timestamp tiebreaks are resolved by the largest id
-        partial_subquery = select(
-            func.max(DatasetExampleRevision.id).label("max_id"),
-        ).group_by(DatasetExampleRevision.dataset_example_id)
-
-        # if a version_id is provided, filter the subquery to only include revisions from that
-        # version or earlier
-        if version_id is not None:
-            # ensure that the specified version exists
-            matched_version_id = (
-                select(DatasetVersion.id)
-                .where(DatasetVersion.id == int(version_id.node_id))
-                .scalar_subquery()
+        if (
+            resolved_dataset_id := await session.scalar(
+                select(Dataset.id).where(Dataset.id == int(dataset_id.node_id))
             )
-            partial_subquery = partial_subquery.filter(
-                DatasetExampleRevision.dataset_version_id <= matched_version_id
+        ) is None:
+            return Response(
+                content=f"No dataset with id {dataset_id} can be found.",
+                status_code=HTTP_404_NOT_FOUND,
             )
+        if version_id:
+            if (
+                resolved_version_id := await session.scalar(
+                    select(DatasetVersion.id).where(
+                        and_(
+                            DatasetVersion.dataset_id == resolved_dataset_id,
+                            DatasetVersion.id == int(version_id.node_id),
+                        )
+                    )
+                )
+            ) is None:
+                return Response(
+                    content=f"No dataset version with id {version_id} can be found.",
+                    status_code=HTTP_404_NOT_FOUND,
+                )
+        else:
+            if (
+                resolved_version_id := await session.scalar(
+                    select(func.max(DatasetVersion.id)).where(
+                        DatasetVersion.dataset_id == resolved_dataset_id
+                    )
+                )
+            ) is None:
+                return Response(
+                    content="Dataset has no versions.",
+                    status_code=HTTP_404_NOT_FOUND,
+                )
 
-        subquery = partial_subquery.subquery()
-
-        # Query for the most recent example revisions that are not deleted
+        revision_ids = (
+            select(func.max(DatasetExampleRevision.id))
+            .join(DatasetExample, DatasetExample.id == DatasetExampleRevision.dataset_example_id)
+            .where(
+                and_(
+                    DatasetExample.dataset_id == resolved_dataset_id,
+                    DatasetExampleRevision.dataset_version_id <= resolved_version_id,
+                )
+            )
+            .group_by(DatasetExampleRevision.dataset_example_id)
+        )
         query = (
             select(DatasetExample, DatasetExampleRevision)
+            .select_from(DatasetExample)
             .join(
                 DatasetExampleRevision,
-                DatasetExample.id == DatasetExampleRevision.dataset_example_id,
+                DatasetExampleRevision.dataset_example_id == DatasetExample.id,
             )
-            .join(
-                subquery,
-                (subquery.c.max_id == DatasetExampleRevision.id),
+            .where(
+                and_(
+                    DatasetExampleRevision.id.in_(revision_ids),
+                    DatasetExampleRevision.revision_kind != "DELETE",
+                )
             )
-            .filter(DatasetExample.dataset_id == int(dataset_id.node_id))
-            .filter(DatasetExampleRevision.revision_kind != "DELETE")
             .order_by(DatasetExample.id.asc())
         )
-
-        data = []
+        examples = []
         for example, revision in await session.execute(query):
-            data.append(
+            examples.append(
                 {
                     "id": str(GlobalID("DatasetExample", str(example.id))),
                     "input": revision.input,
@@ -114,25 +140,4 @@ async def list_dataset_examples(request: Request) -> Response:
                     "updated_at": revision.created_at.isoformat(),
                 }
             )
-        if not data:
-            # make a additional queries to determine if the specified entities exist
-            dataset = (
-                await session.execute(select(Dataset).where(Dataset.id == int(dataset_id.node_id)))
-            ).all()
-            if not dataset:
-                return Response(
-                    content=f"No dataset with id {dataset_id} can be found.",
-                    status_code=HTTP_404_NOT_FOUND,
-                )
-            if version_id is not None:
-                version = (
-                    await session.execute(
-                        select(DatasetVersion).where(DatasetVersion.id == int(version_id.node_id))
-                    )
-                ).all()
-                if not version:
-                    return Response(
-                        content=f"No dataset version with id {version_id} can be found.",
-                        status_code=HTTP_404_NOT_FOUND,
-                    )
-        return JSONResponse(data)
+        return JSONResponse(examples)

--- a/src/phoenix/server/api/routers/v1/dataset_examples.py
+++ b/src/phoenix/server/api/routers/v1/dataset_examples.py
@@ -141,8 +141,10 @@ async def list_dataset_examples(request: Request) -> Response:
         ]
         return JSONResponse(
             {
-                "dataset_id": str(GlobalID("Dataset", str(resolved_dataset_id))),
-                "version_id": str(GlobalID("DatasetVersion", str(resolved_version_id))),
-                "examples": examples,
+                "data": {
+                    "dataset_id": str(GlobalID("Dataset", str(resolved_dataset_id))),
+                    "version_id": str(GlobalID("DatasetVersion", str(resolved_version_id))),
+                    "examples": examples,
+                }
             }
         )

--- a/src/phoenix/server/api/routers/v1/dataset_examples.py
+++ b/src/phoenix/server/api/routers/v1/dataset_examples.py
@@ -124,6 +124,7 @@ async def list_dataset_examples(request: Request) -> Response:
                     content=f"No dataset version with id {version_id} can be found.",
                     status_code=HTTP_404_NOT_FOUND,
                 )
+            # if a version_id is provided, filter the subquery to only include revisions from that
             partial_subquery = partial_subquery.filter(
                 DatasetExampleRevision.dataset_version_id <= resolved_version_id
             )
@@ -141,6 +142,7 @@ async def list_dataset_examples(request: Request) -> Response:
                 )
 
         subquery = partial_subquery.subquery()
+        # Query for the most recent example revisions that are not deleted
         query = (
             select(DatasetExample, DatasetExampleRevision)
             .join(

--- a/src/phoenix/server/api/routers/v1/dataset_examples.py
+++ b/src/phoenix/server/api/routers/v1/dataset_examples.py
@@ -34,18 +34,45 @@ async def list_dataset_examples(request: Request) -> Response:
               type: object
               properties:
                 data:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      example_id:
-                        type: string
-                      input:
+                  type: object
+                  properties:
+                    dataset_id:
+                      type: string
+                      description: ID of the dataset
+                    version_id:
+                      type: string
+                      description: ID of the version
+                    examples:
+                      type: array
+                      items:
                         type: object
-                      output:
-                        type: object
-                      metadata:
-                        type: object
+                        properties:
+                          id:
+                            type: string
+                            description: ID of the dataset example
+                          input:
+                            type: object
+                            description: Input data of the example
+                          output:
+                            type: object
+                            description: Output data of the example
+                          metadata:
+                            type: object
+                            description: Metadata of the example
+                          updated_at:
+                            type: string
+                            format: date-time
+                            description: ISO formatted timestamp of when the example was updated
+                        required:
+                          - id
+                          - input
+                          - output
+                          - metadata
+                          - updated_at
+                  required:
+                    - dataset_id
+                    - version_id
+                    - examples
       403:
         description: Forbidden
       404:

--- a/tests/server/api/routers/v1/test_dataset_examples.py
+++ b/tests/server/api/routers/v1/test_dataset_examples.py
@@ -42,9 +42,10 @@ async def test_get_simple_dataset_examples(test_client, simple_dataset):
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert result["dataset_id"] == str(GlobalID("Dataset", str(0)))
-    assert result["version_id"] == str(GlobalID("DatasetVersion", str(0)))
-    examples = result["examples"]
+    data = result["data"]
+    assert data["dataset_id"] == str(GlobalID("Dataset", str(0)))
+    assert data["version_id"] == str(GlobalID("DatasetVersion", str(0)))
+    examples = data["examples"]
     assert len(examples) == 1
     expected_examples = [
         {
@@ -70,7 +71,8 @@ async def test_list_simple_dataset_examples_at_each_version(test_client, simple_
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 1
+    data = result["data"]
+    assert len(data["examples"]) == 1
 
 
 async def test_list_empty_dataset_examples(test_client, empty_dataset):
@@ -78,7 +80,8 @@ async def test_list_empty_dataset_examples(test_client, empty_dataset):
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 0
+    data = result["data"]
+    assert len(data["examples"]) == 0
 
 
 async def test_list_empty_dataset_examples_at_each_version(test_client, empty_dataset):
@@ -93,7 +96,8 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 2
+    data = result["data"]
+    assert len(data["examples"]) == 2
 
     # two examples are patched in version 2
     response = await test_client.get(
@@ -101,7 +105,8 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 2
+    data = result["data"]
+    assert len(data["examples"]) == 2
 
     # two examples are deleted in version 3
     response = await test_client.get(
@@ -109,7 +114,8 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 0
+    data = result["data"]
+    assert len(data["examples"]) == 0
 
 
 async def test_list_dataset_with_revisions_examples(test_client, dataset_with_revisions):
@@ -117,9 +123,10 @@ async def test_list_dataset_with_revisions_examples(test_client, dataset_with_re
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert result["dataset_id"] == str(GlobalID("Dataset", str(2)))
-    assert result["version_id"] == str(GlobalID("DatasetVersion", str(9)))
-    examples = result["examples"]
+    data = result["data"]
+    assert data["dataset_id"] == str(GlobalID("Dataset", str(2)))
+    assert data["version_id"] == str(GlobalID("DatasetVersion", str(9)))
+    examples = data["examples"]
     assert len(examples) == 3
     expected_values = [
         {
@@ -164,7 +171,8 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 2
+    data = result["data"]
+    assert len(data["examples"]) == 2
 
     # two examples are patched in version 5
     response = await test_client.get(
@@ -172,7 +180,8 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 3
+    data = result["data"]
+    assert len(data["examples"]) == 3
 
     # one example is added in version 6
     response = await test_client.get(
@@ -180,7 +189,8 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 4
+    data = result["data"]
+    assert len(data["examples"]) == 4
 
     # one example is deleted in version 7
     response = await test_client.get(
@@ -188,7 +198,8 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 3
+    data = result["data"]
+    assert len(data["examples"]) == 3
 
     # one example is added in version 8
     response = await test_client.get(
@@ -196,7 +207,8 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 4
+    data = result["data"]
+    assert len(data["examples"]) == 4
 
     # one example is deleted in version 9
     response = await test_client.get(
@@ -204,4 +216,5 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["examples"]) == 3
+    data = result["data"]
+    assert len(data["examples"]) == 3

--- a/tests/server/api/routers/v1/test_dataset_examples.py
+++ b/tests/server/api/routers/v1/test_dataset_examples.py
@@ -42,8 +42,11 @@ async def test_get_simple_dataset_examples(test_client, simple_dataset):
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 1
-    expected_values = [
+    assert result["dataset_id"] == str(GlobalID("Dataset", str(0)))
+    assert result["version_id"] == str(GlobalID("DatasetVersion", str(0)))
+    examples = result["examples"]
+    assert len(examples) == 1
+    expected_examples = [
         {
             "id": str(GlobalID("DatasetExample", str(0))),
             "input": {"in": "foo"},
@@ -51,7 +54,7 @@ async def test_get_simple_dataset_examples(test_client, simple_dataset):
             "metadata": {"info": "the first reivision"},
         }
     ]
-    for example, expected in zip(result, expected_values):
+    for example, expected in zip(examples, expected_examples):
         assert "updated_at" in example
         example_subset = {k: v for k, v in example.items() if k in expected}
         assert example_subset == expected
@@ -67,7 +70,7 @@ async def test_list_simple_dataset_examples_at_each_version(test_client, simple_
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 1
+    assert len(result["examples"]) == 1
 
 
 async def test_list_empty_dataset_examples(test_client, empty_dataset):
@@ -75,7 +78,7 @@ async def test_list_empty_dataset_examples(test_client, empty_dataset):
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 0
+    assert len(result["examples"]) == 0
 
 
 async def test_list_empty_dataset_examples_at_each_version(test_client, empty_dataset):
@@ -90,7 +93,7 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 2
+    assert len(result["examples"]) == 2
 
     # two examples are patched in version 2
     response = await test_client.get(
@@ -98,7 +101,7 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 2
+    assert len(result["examples"]) == 2
 
     # two examples are deleted in version 3
     response = await test_client.get(
@@ -106,7 +109,7 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 0
+    assert len(result["examples"]) == 0
 
 
 async def test_list_dataset_with_revisions_examples(test_client, dataset_with_revisions):
@@ -114,7 +117,10 @@ async def test_list_dataset_with_revisions_examples(test_client, dataset_with_re
     response = await test_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 3
+    assert result["dataset_id"] == str(GlobalID("Dataset", str(2)))
+    assert result["version_id"] == str(GlobalID("DatasetVersion", str(9)))
+    examples = result["examples"]
+    assert len(examples) == 3
     expected_values = [
         {
             "id": str(GlobalID("DatasetExample", str(3))),
@@ -135,7 +141,7 @@ async def test_list_dataset_with_revisions_examples(test_client, dataset_with_re
             "metadata": {"info": "a new example"},
         },
     ]
-    for example, expected in zip(result, expected_values):
+    for example, expected in zip(examples, expected_values):
         assert "updated_at" in example
         example_subset = {k: v for k, v in example.items() if k in expected}
         assert example_subset == expected
@@ -158,7 +164,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 2
+    assert len(result["examples"]) == 2
 
     # two examples are patched in version 5
     response = await test_client.get(
@@ -166,7 +172,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 3
+    assert len(result["examples"]) == 3
 
     # one example is added in version 6
     response = await test_client.get(
@@ -174,7 +180,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 4
+    assert len(result["examples"]) == 4
 
     # one example is deleted in version 7
     response = await test_client.get(
@@ -182,7 +188,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 3
+    assert len(result["examples"]) == 3
 
     # one example is added in version 8
     response = await test_client.get(
@@ -190,7 +196,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 4
+    assert len(result["examples"]) == 4
 
     # one example is deleted in version 9
     response = await test_client.get(
@@ -198,4 +204,4 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == 3
+    assert len(result["examples"]) == 3

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -25,7 +25,7 @@ async def test_experiments_api(test_client, simple_dataset):
             f"/v1/datasets/{dataset_globalid}/examples",
             params={"version-id": str(version_globalid)},
         )
-    ).json()["examples"]
+    ).json()["data"]["examples"]
 
     # experiments can be read using the GET /experiments route
     experiment = (await test_client.get(f"/v1/experiments/{experiment_globalid}")).json()

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -25,7 +25,7 @@ async def test_experiments_api(test_client, simple_dataset):
             f"/v1/datasets/{dataset_globalid}/examples",
             params={"version-id": str(version_globalid)},
         )
-    ).json()
+    ).json()["examples"]
 
     # experiments can be read using the GET /experiments route
     experiment = (await test_client.get(f"/v1/experiments/{experiment_globalid}")).json()


### PR DESCRIPTION
resolves #3499
