### PR TITLE
feat(experiments): navigation to experiments view

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -18,6 +18,7 @@ import {
   ExamplePage,
   examplesLoader,
   ExamplesPage,
+  experimentCompareLoader,
   ExperimentComparePage,
   experimentsLoader,
   ExperimentsPage,
@@ -120,6 +121,7 @@ const router = createBrowserRouter(
             handle={{
               crumb: () => "compare",
             }}
+            loader={experimentCompareLoader}
             element={<ExperimentComparePage />}
           />
         </Route>

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
-import { Icon, Icons, Text } from "@arizeai/components";
+import { Icon, Icons } from "@arizeai/components";
 
 import { Link } from "@phoenix/components";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
@@ -83,13 +83,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
         header: "name",
         accessorKey: "name",
         cell: ({ row }) => {
-          return (
-            <Link to={`${row.original.id}`}>
-              <Text textSize="xlarge" color="inherit">
-                {row.original.name}
-              </Text>
-            </Link>
-          );
+          return <Link to={`${row.original.id}`}>{row.original.name}</Link>;
         },
       },
       {

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -24,7 +24,7 @@ export function ExperimentComparePage() {
             selectedExperimentIds={experimentIds}
             label="experiments"
             onChange={(newExperimentIds) => {
-              searchParams.delete("experimentIds");
+              searchParams.delete("experimentId");
               newExperimentIds.forEach((id) => {
                 searchParams.append("experimentId", id);
               });

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -1,5 +1,32 @@
 import React from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { Flex, View } from "@arizeai/components";
+
+import { ExperimentMultiSelector } from "./ExperimentMultiSelector";
 
 export function ExperimentComparePage() {
-  return <main>Compare 1 or more experiments</main>;
+  const [searchParams] = useSearchParams();
+  const experimentIds = searchParams.getAll("experimentIds");
+  return (
+    <main>
+      <View
+        padding="size-200"
+        borderBottomColor="dark"
+        borderBottomWidth="thin"
+      >
+        <Flex direction="column" gap="size-100">
+          {/* <Heading level={1}>Comparing Experiments</Heading> */}
+          <ExperimentMultiSelector
+            experiments={experimentIds}
+            selectedExperimentIds={experimentIds}
+            label="experiments"
+            onChange={() => {
+              // searchParams.set("experimentIds", selectedExperimentIds);
+            }}
+          />
+        </Flex>
+      </View>
+    </main>
+  );
 }

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -9,7 +9,7 @@ import { ExperimentMultiSelector } from "./ExperimentMultiSelector";
 export function ExperimentComparePage() {
   const data = useLoaderData() as experimentCompareLoaderQuery$data;
   const [searchParams, setSearchParams] = useSearchParams();
-  const experimentIds = searchParams.getAll("experimentIds");
+  const experimentIds = searchParams.getAll("experimentId");
   return (
     <main>
       <View
@@ -26,7 +26,7 @@ export function ExperimentComparePage() {
             onChange={(newExperimentIds) => {
               searchParams.delete("experimentIds");
               newExperimentIds.forEach((id) => {
-                searchParams.append("experimentIds", id);
+                searchParams.append("experimentId", id);
               });
               setSearchParams(searchParams);
             }}

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLoaderData, useSearchParams } from "react-router-dom";
 
-import { Flex, View } from "@arizeai/components";
+import { Flex, Heading, View } from "@arizeai/components";
 
+import { experimentCompareLoaderQuery$data } from "./__generated__/experimentCompareLoaderQuery.graphql";
 import { ExperimentMultiSelector } from "./ExperimentMultiSelector";
 
 export function ExperimentComparePage() {
-  const [searchParams] = useSearchParams();
+  const data = useLoaderData() as experimentCompareLoaderQuery$data;
+  const [searchParams, setSearchParams] = useSearchParams();
   const experimentIds = searchParams.getAll("experimentIds");
   return (
     <main>
@@ -16,13 +18,17 @@ export function ExperimentComparePage() {
         borderBottomWidth="thin"
       >
         <Flex direction="column" gap="size-100">
-          {/* <Heading level={1}>Comparing Experiments</Heading> */}
+          <Heading level={1}>Compare Experiments</Heading>
           <ExperimentMultiSelector
-            experiments={experimentIds}
+            dataset={data.dataset}
             selectedExperimentIds={experimentIds}
             label="experiments"
-            onChange={() => {
-              // searchParams.set("experimentIds", selectedExperimentIds);
+            onChange={(newExperimentIds) => {
+              searchParams.delete("experimentIds");
+              newExperimentIds.forEach((id) => {
+                searchParams.append("experimentIds", id);
+              });
+              setSearchParams(searchParams);
             }}
           />
         </Flex>

--- a/app/src/pages/experiment/ExperimentMultiSelector.tsx
+++ b/app/src/pages/experiment/ExperimentMultiSelector.tsx
@@ -95,10 +95,9 @@ export function ExperimentMultiSelector(
                 <Flex direction="column" gap="size-50">
                   <Flex direction="row" gap="size-100">
                     <Label color="yellow-1000">
-                      {experiment.sequenceNumber}
+                      #{experiment.sequenceNumber}
                     </Label>
                     <Text>
-                      {" "}
                       {new Date(experiment.createdAt).toLocaleDateString()}
                     </Text>
                   </Flex>

--- a/app/src/pages/experiment/ExperimentMultiSelector.tsx
+++ b/app/src/pages/experiment/ExperimentMultiSelector.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from "react";
+
+import {
+  Dropdown,
+  DropdownProps,
+  Field,
+  FieldProps,
+  Item,
+  ListBox,
+} from "@arizeai/components";
+
+export function ExperimentMultiSelector(
+  props: Omit<DropdownProps, "menu" | "children"> &
+    Pick<
+      FieldProps,
+      "label" | "validationState" | "description" | "errorMessage"
+    > & {
+      label: string;
+      experiments: string[];
+      selectedExperimentIds: string[];
+      onChange: (selectedColumns: string[]) => void;
+    }
+) {
+  const {
+    experiments,
+    selectedExperimentIds,
+    onChange,
+    label,
+    validationState,
+    description,
+    errorMessage,
+    ...restProps
+  } = props;
+  const noColumns = experiments.length === 0;
+  const displayText = useMemo(() => {
+    if (noColumns) {
+      return "No experiments";
+    }
+    const numExperiments = selectedExperimentIds.length;
+    return numExperiments > 0
+      ? `${numExperiments} experiment${numExperiments > 1 ? "s" : ""}`
+      : "No experiments selected";
+  }, [selectedExperimentIds, noColumns]);
+  return (
+    <Field
+      label={label}
+      isDisabled={noColumns}
+      validationState={validationState}
+      description={description}
+      errorMessage={errorMessage}
+    >
+      <Dropdown
+        isDisabled={noColumns}
+        {...restProps}
+        menu={
+          <ListBox
+            selectionMode="multiple"
+            onSelectionChange={(keys) => {
+              onChange(Array.from(keys) as string[]);
+            }}
+            selectedKeys={new Set(selectedExperimentIds)}
+          >
+            {experiments.map((column) => (
+              <Item key={column}>{column}</Item>
+            ))}
+          </ListBox>
+        }
+        triggerProps={{
+          placement: "bottom end",
+        }}
+      >
+        {displayText}
+      </Dropdown>
+    </Field>
+  );
+}

--- a/app/src/pages/experiment/__generated__/ExperimentMultiSelector__experiments.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentMultiSelector__experiments.graphql.ts
@@ -1,0 +1,105 @@
+/**
+ * @generated SignedSource<<a81c0a2ee236e6086d88c36111e6e1cf>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ExperimentMultiSelector__experiments$data = {
+  readonly experiments: {
+    readonly edges: ReadonlyArray<{
+      readonly experiment: {
+        readonly createdAt: string;
+        readonly description: string | null;
+        readonly id: string;
+        readonly sequenceNumber: number;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "ExperimentMultiSelector__experiments";
+};
+export type ExperimentMultiSelector__experiments$key = {
+  readonly " $data"?: ExperimentMultiSelector__experiments$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ExperimentMultiSelector__experiments">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ExperimentMultiSelector__experiments",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExperimentConnection",
+      "kind": "LinkedField",
+      "name": "experiments",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ExperimentEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "experiment",
+              "args": null,
+              "concreteType": "Experiment",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "sequenceNumber",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Dataset",
+  "abstractKey": null
+};
+
+(node as any).hash = "8794d5b225c97e3f92451bfe596190e6";
+
+export default node;

--- a/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
@@ -1,0 +1,127 @@
+/**
+ * @generated SignedSource<<aca355ef40ec50583ebaeddbd46d2f77>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type experimentCompareLoaderQuery$variables = {
+  id: string;
+};
+export type experimentCompareLoaderQuery$data = {
+  readonly dataset: {
+    readonly id: string;
+    readonly name?: string;
+  };
+};
+export type experimentCompareLoaderQuery = {
+  response: experimentCompareLoaderQuery$data;
+  variables: experimentCompareLoaderQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Dataset",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "experimentCompareLoaderQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "experimentCompareLoaderQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "85e475c414364ce22901dbbe3ea8c9c7",
+    "id": null,
+    "metadata": {},
+    "name": "experimentCompareLoaderQuery",
+    "operationKind": "query",
+    "text": "query experimentCompareLoaderQuery(\n  $id: GlobalID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "df0a23466864a36752ab01e4f8dab942";
+
+export default node;

--- a/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aca355ef40ec50583ebaeddbd46d2f77>>
+ * @generated SignedSource<<ea9ee9906471bdd22f057fa896ff768c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type experimentCompareLoaderQuery$variables = {
   id: string;
 };
@@ -16,6 +17,7 @@ export type experimentCompareLoaderQuery$data = {
   readonly dataset: {
     readonly id: string;
     readonly name?: string;
+    readonly " $fragmentSpreads": FragmentRefs<"ExperimentMultiSelector__experiments">;
   };
 };
 export type experimentCompareLoaderQuery = {
@@ -46,18 +48,11 @@ v2 = {
   "storageKey": null
 },
 v3 = {
-  "kind": "InlineFragment",
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    }
-  ],
-  "type": "Dataset",
-  "abstractKey": null
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -75,7 +70,19 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          (v3/*: any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ExperimentMultiSelector__experiments"
+              }
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
@@ -105,23 +112,85 @@ return {
             "storageKey": null
           },
           (v2/*: any*/),
-          (v3/*: any*/)
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ExperimentConnection",
+                "kind": "LinkedField",
+                "name": "experiments",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ExperimentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "experiment",
+                        "args": null,
+                        "concreteType": "Experiment",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "sequenceNumber",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "85e475c414364ce22901dbbe3ea8c9c7",
+    "cacheID": "ea5c76e30df3df4e33e075e6e7dab73b",
     "id": null,
     "metadata": {},
     "name": "experimentCompareLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentCompareLoaderQuery(\n  $id: GlobalID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n    }\n  }\n}\n"
+    "text": "query experimentCompareLoaderQuery(\n  $id: GlobalID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n      ...ExperimentMultiSelector__experiments\n    }\n  }\n}\n\nfragment ExperimentMultiSelector__experiments on Dataset {\n  experiments {\n    edges {\n      experiment: node {\n        id\n        sequenceNumber\n        description\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "df0a23466864a36752ab01e4f8dab942";
+(node as any).hash = "fa02088830fd16688f0f2fba9a0009eb";
 
 export default node;

--- a/app/src/pages/experiment/experimentCompareLoader.ts
+++ b/app/src/pages/experiment/experimentCompareLoader.ts
@@ -19,6 +19,7 @@ export async function experimentCompareLoader(args: LoaderFunctionArgs) {
           ... on Dataset {
             id
             name
+            ...ExperimentMultiSelector__experiments
           }
         }
       }

--- a/app/src/pages/experiment/experimentCompareLoader.ts
+++ b/app/src/pages/experiment/experimentCompareLoader.ts
@@ -1,0 +1,30 @@
+import { fetchQuery, graphql } from "react-relay";
+import { LoaderFunctionArgs } from "react-router-dom";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import { experimentCompareLoaderQuery } from "./__generated__/experimentCompareLoaderQuery.graphql";
+
+/**
+ * Loads in the necessary page data for the compare experiment page
+ */
+export async function experimentCompareLoader(args: LoaderFunctionArgs) {
+  const { datasetId } = args.params;
+  return await fetchQuery<experimentCompareLoaderQuery>(
+    RelayEnvironment,
+    graphql`
+      query experimentCompareLoaderQuery($id: GlobalID!) {
+        dataset: node(id: $id) {
+          id
+          ... on Dataset {
+            id
+            name
+          }
+        }
+      }
+    `,
+    {
+      id: datasetId as string,
+    }
+  ).toPromise();
+}

--- a/app/src/pages/experiment/index.tsx
+++ b/app/src/pages/experiment/index.tsx
@@ -1,1 +1,2 @@
 export * from "./ExperimentComparePage";
+export * from "./experimentCompareLoader";

--- a/app/src/pages/experiments/ExperimentSelectionToolbar.tsx
+++ b/app/src/pages/experiments/ExperimentSelectionToolbar.tsx
@@ -1,0 +1,76 @@
+import React, { ReactNode, useState } from "react";
+import { useNavigate } from "react-router";
+import { css } from "@emotion/react";
+
+import { Button, DialogContainer, Flex, Text, View } from "@arizeai/components";
+
+interface SelectedExperiment {
+  id: string;
+}
+
+type ExperimentSelectionToolbarProps = {
+  datasetId: string;
+  selectedExperiments: SelectedExperiment[];
+  onClearSelection: () => void;
+};
+
+export function ExperimentSelectionToolbar(
+  props: ExperimentSelectionToolbarProps
+) {
+  const navigate = useNavigate();
+  const [dialog, setDialog] = useState<ReactNode>(null);
+  const { datasetId, selectedExperiments, onClearSelection } = props;
+
+  const isPlural = selectedExperiments.length !== 1;
+
+  return (
+    <div
+      css={css`
+        position: absolute;
+        bottom: var(--ac-global-dimension-size-400);
+        left: 50%;
+        transform: translateX(-50%);
+      `}
+    >
+      <View
+        backgroundColor="light"
+        padding="size-200"
+        borderColor="light"
+        borderWidth="thin"
+        borderRadius="medium"
+        minWidth="size-6000"
+      >
+        <Flex
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Text>{`${selectedExperiments.length} experiment${isPlural ? "s" : ""} selected`}</Text>
+          <Flex direction="row" gap="size-100">
+            <Button variant="default" size="compact" onClick={onClearSelection}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => {
+                navigate(
+                  `/datasets/${datasetId}/compare?${selectedExperiments.map((experiment) => `experimentId=${experiment.id}`).join("&")}`
+                );
+              }}
+            >
+              Compare Experiments
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+      <DialogContainer
+        onDismiss={() => {
+          setDialog(null);
+        }}
+      >
+        {dialog}
+      </DialogContainer>
+    </div>
+  );
+}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -123,7 +123,7 @@ export function ExperimentsTable({
         const experimentId = row.original.id;
         return (
           <Link
-            to={`/datasets/${dataset.id}/compare?experimentIds=${experimentId}`}
+            to={`/datasets/${dataset.id}/compare?experimentId=${experimentId}`}
           >
             {getValue() as string}
           </Link>

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useRef } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
+import { useNavigate } from "react-router";
 // import { useNavigate } from "react-router";
 import {
   ColumnDef,
@@ -9,7 +10,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
-// import { Link } from "@phoenix/components/Link";
+import { Link } from "@phoenix/components/Link";
 import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
@@ -111,10 +112,14 @@ export function ExperimentsTable({
     {
       header: "id",
       accessorKey: "id",
-      //   cell: ({ getValue, row }) => {
-      //     const experimentId = row.original.id;
-      //     return <Link to={`experiments/${experimentId}`}>{getValue() as string}</Link>;
-      //   },
+      cell: ({ getValue, row }) => {
+        const experimentId = row.original.id;
+        return (
+          <Link to={`compare?experimentIds=${experimentId}`}>
+            {getValue() as string}
+          </Link>
+        );
+      },
     },
     {
       header: "description",
@@ -154,7 +159,7 @@ export function ExperimentsTable({
     },
     [hasNext, isLoadingNext, loadNext]
   );
-  //   const navigate = useNavigate();
+  const navigate = useNavigate();
   return (
     <div
       css={css`
@@ -188,9 +193,9 @@ export function ExperimentsTable({
             {rows.map((row) => (
               <tr
                 key={row.id}
-                // onClick={() => {
-                //   navigate(`experiments/${row.original.id}`);
-                // }}
+                onClick={() => {
+                  navigate(`compare?experimentsIds=${row.original.id}`);
+                }}
               >
                 {row.getVisibleCells().map((cell) => {
                   return (

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -10,6 +10,8 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
+import { Label } from "@arizeai/components";
+
 import { Link } from "@phoenix/components/Link";
 import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
@@ -108,6 +110,9 @@ export function ExperimentsTable({
     {
       header: "#",
       accessorKey: "sequenceNumber",
+      cell: ({ getValue }) => {
+        return <Label color="yellow-1000">{getValue() as number}</Label>;
+      },
     },
     {
       header: "id",
@@ -115,7 +120,9 @@ export function ExperimentsTable({
       cell: ({ getValue, row }) => {
         const experimentId = row.original.id;
         return (
-          <Link to={`compare?experimentIds=${experimentId}`}>
+          <Link
+            to={`/datasets/${dataset.id}/compare?experimentIds=${experimentId}`}
+          >
             {getValue() as string}
           </Link>
         );
@@ -194,7 +201,9 @@ export function ExperimentsTable({
               <tr
                 key={row.id}
                 onClick={() => {
-                  navigate(`compare?experimentsIds=${row.original.id}`);
+                  navigate(
+                    `/datasets/${dataset.id}/compare?experimentsIds=${row.original.id}`
+                  );
                 }}
               >
                 {row.getVisibleCells().map((cell) => {


### PR DESCRIPTION
Just adds the navigation to the experiment comparison view. A pre-cursor to building out the table
<img width="2559" alt="Screenshot 2024-06-13 at 5 12 32 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/75d4bf13-4e64-42ec-be9d-66c02ef8ca28">
<img width="2555" alt="Screenshot 2024-06-13 at 5 12 51 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/839920b8-b433-4081-a6ec-ef03dab456fa">
