### PR TITLE
fix: hdbscan incompatibility with numpy 2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: "v0.4.1"
+      rev: "v0.4.9"
       hooks:
           - id: ruff-format
           - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ dev = [
   "jupyter",
   "nbqa",
   "ruff==0.4.9",
-  "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
+  "pandas-stubs==2.2.2.240603; python_version>='3.9'",
+  "pandas-stubs==2.0.3.230814; python_version<'3.9'",
   "pytest==8.2.2",
   "pytest-asyncio",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "scikit-learn",
-  "numpy",
+  "numpy<2",  # https://github.com/scikit-learn-contrib/hdbscan/issues/642
   "pandas",
   "jinja2",
   "umap-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "starlette",
   "uvicorn",
   "psutil",
-  "strawberry-graphql==0.227.2",  # need to pin version because we're monkey-patching
+  "strawberry-graphql==0.235.0",  # need to pin version because we're monkey-patching
   "pyarrow",
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
@@ -66,15 +66,15 @@ dev = [
   "hatch",
   "jupyter",
   "nbqa",
-  "ruff==0.3.0",
+  "ruff==0.4.9",
   "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
-  "pytest==7.4.4",
+  "pytest==8.2.2",
   "pytest-asyncio",
   "pytest-cov",
   "pytest-postgresql",
   "asyncpg",
   "psycopg[binary]",
-  "strawberry-graphql[debug-server,opentelemetry]==0.227.2",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[debug-server,opentelemetry]==0.235.0",  # need to pin version because we're monkey-patching
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
   "llama-index>=0.10.3",
@@ -106,7 +106,7 @@ container = [
   "opentelemetry-instrumentation-sqlalchemy",
   "opentelemetry-instrumentation-grpc",
   "py-grpc-prometheus",
-  "strawberry-graphql[opentelemetry]==0.227.2",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[opentelemetry]==0.235.0",  # need to pin version because we're monkey-patching
   "uvloop; platform_system != 'Windows'",
 ]
 
@@ -136,8 +136,10 @@ artifacts = ["src/phoenix/server/static", "src/phoenix/db/migrations"]
 
 [tool.hatch.envs.default]
 dependencies = [
-  "pandas==1.4.0",
-  "pytest==7.4.4",
+  "numpy",
+  "pandas==2.2.2; python_version>='3.9'",
+  "pandas==1.4.0; python_version<'3.9'",
+  "pytest==8.2.2",
   "pytest-asyncio",
   "pytest-cov",
   "pytest-postgresql",
@@ -161,9 +163,10 @@ dependencies = [
 
 [tool.hatch.envs.type]
 dependencies = [
-  "mypy==1.9.0",
+  "mypy==1.10.0",
   "tenacity",
-  "pandas-stubs<=2.0.2.230605",  # version 2.0.3.230814 is causing a dependency conflict.
+  "pandas-stubs==2.2.2.240603; python_version>='3.9'",
+  "pandas-stubs==2.0.3.230814; python_version<'3.9'",
   "types-psutil",
   "types-tqdm",
   "types-requests",
@@ -182,13 +185,13 @@ dependencies = [
   "opentelemetry-instrumentation-sqlalchemy",
   "opentelemetry-instrumentation-grpc",
   "py-grpc-prometheus",
-  "strawberry-graphql[opentelemetry]==0.227.2",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[opentelemetry]==0.235.0",  # need to pin version because we're monkey-patching
 ]
 
 [tool.hatch.envs.style]
 detached = true
 dependencies = [
-  "ruff==0.4.1",
+  "ruff==0.4.9",
 ]
 
 [tool.hatch.envs.notebooks]
@@ -281,7 +284,7 @@ check = [
 
 [tool.hatch.envs.gql]
 dependencies = [
-  "strawberry-graphql[cli]==0.227.2",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[cli]==0.235.0",  # need to pin version because we're monkey-patching
   "requests",
 ]
 
@@ -371,8 +374,7 @@ target-version = "py38"
 "*.ipynb" = ["E402", "E501"]
 
 [tool.ruff.lint]
-ignore-init-module-imports = true
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "NPY201"]
 
 [tool.ruff.lint.isort]
 force-single-line = false

--- a/src/phoenix/core/model_schema.py
+++ b/src/phoenix/core/model_schema.py
@@ -715,8 +715,8 @@ class Dataset(Events):
         return len(self) == 0
 
     @cached_property
-    def primary_key(self) -> pd.Index:
-        return pd.Index(self[PREDICTION_ID])
+    def primary_key(self) -> "pd.Index[Any]":
+        return cast("pd.Index[Any]", pd.Index(self[PREDICTION_ID]))
 
     @overload
     def __getitem__(self, key: ColumnKey) -> "pd.Series[Any]": ...
@@ -749,7 +749,7 @@ class Model:
     _datasets: Dict[DatasetRole, Dataset]
     _dimensions: Dict[Name, Dimension]
     _dim_names_by_role: Dict[DimensionRole, List[Name]]
-    _original_columns_by_role: Dict[DatasetRole, pd.Index]
+    _original_columns_by_role: Dict[DatasetRole, "pd.Index[Any]"]
     _default_timestamps_factory: _ConstantValueSeriesFactory
     _nan_series_factory: _ConstantValueSeriesFactory
     _dimension_categories_from_all_datasets: _Cache[Name, Tuple[str, ...]]

--- a/src/phoenix/metrics/binning.py
+++ b/src/phoenix/metrics/binning.py
@@ -78,7 +78,7 @@ class IntervalBinning(BinningMethod):
             else pd.IntervalIndex(
                 (
                     pd.Interval(
-                        np.NINF,
+                        -np.inf,
                         np.inf,
                         closed="neither",
                     ),
@@ -208,7 +208,7 @@ class QuantileBinning(IntervalBinning):
         # Extend min and max to infinities, unless len(breaks) < 3,
         # in which case the min is kept and two bins are created.
         breaks = breaks[1:-1] if len(breaks) > 2 else breaks[:1]
-        breaks = [np.NINF] + breaks + [np.inf]
+        breaks = [-np.inf] + breaks + [np.inf]
         return pd.IntervalIndex.from_breaks(
             breaks,
             closed="left",

--- a/src/phoenix/server/api/types/Segments.py
+++ b/src/phoenix/server/api/types/Segments.py
@@ -34,7 +34,7 @@ class IntervalBin:
 
 @dataclass(frozen=True)
 class GqlBinFactory:
-    numeric_lbound: float = np.NINF
+    numeric_lbound: float = -np.inf
     numeric_ubound: float = np.inf
 
     @overload

--- a/tests/metrics/test_binning.py
+++ b/tests/metrics/test_binning.py
@@ -104,7 +104,7 @@ def test_categorical_binning() -> None:
 def test_interval_binning() -> None:
     bins = pd.IntervalIndex(
         (
-            pd.Interval(np.NINF, 1.0, closed="left"),
+            pd.Interval(-np.inf, 1.0, closed="left"),
             pd.Interval(1.0, 2.0, closed="left"),
             pd.Interval(2.0, np.inf, closed="left"),
         )
@@ -124,7 +124,7 @@ def test_quantile_binning() -> None:
     prob = (0.25, 0.5, 0.75)
     bins = pd.IntervalIndex(
         (
-            pd.Interval(np.NINF, 0.0, closed="left"),
+            pd.Interval(-np.inf, 0.0, closed="left"),
             pd.Interval(0.0, 1.0, closed="left"),
             pd.Interval(1.0, 2.0, closed="left"),
             pd.Interval(2.0, np.inf, closed="left"),
@@ -225,7 +225,7 @@ def test_segmented_summary_with_interval_binning(
         [
             [np.nan, np.nan],
             [None, -1],
-            [pd.NA, np.NINF],  # infinities are not null
+            [pd.NA, -np.inf],  # infinities are not null
             [pd.NaT, np.nan],
             [MISSING, np.nan],  # MISSING is not null
             [-4, 5],
@@ -240,7 +240,7 @@ def test_segmented_summary_with_interval_binning(
             ["", np.nan],  # "" is same as NaN due to numeric coercion
             ["nan", np.nan],
             [np.inf, 7],
-            [np.NINF, np.nan],
+            [-np.inf, np.nan],
         ],
         columns=["by", "x"],
     )
@@ -250,7 +250,7 @@ def test_segmented_summary_with_interval_binning(
         (
             pd.Interval(-2, 2, closed="left"),
             pd.Interval(100, 200, closed="left"),  # not found in data
-            pd.Interval(np.NINF, -200, closed="left"),
+            pd.Interval(-np.inf, -200, closed="left"),
         ),
     )
     binning_method = binning.IntervalBinning(
@@ -269,7 +269,7 @@ def test_segmented_summary_with_interval_binning(
             cast(List[Any], [] if dropna else [np.nan])
             + [
                 pd.Interval(-2, 2, closed="left"),
-                pd.Interval(np.NINF, -200, closed="left"),
+                pd.Interval(-np.inf, -200, closed="left"),
             ],
             categories=bins,
             ordered=True,
@@ -341,11 +341,11 @@ def test_segmented_summary_with_categorical_binning(
             [1, np.nan],
             ["", np.nan],
             ["1", 2],  # "1" differs from 1
-            ["1", np.NINF],  # infinities are not null
+            ["1", -np.inf],  # infinities are not null
             ["1", 2],
             ["1", np.nan],
             ["nan", np.nan],
-            [np.NINF, 3],
+            [-np.inf, 3],
         ],
         columns=["by", "x"],
     )
@@ -364,7 +364,7 @@ def test_segmented_summary_with_categorical_binning(
     ).set_axis(
         pd.CategoricalIndex(
             cast(List[Any], [] if dropna else [np.nan])
-            + [MISSING, 0.1, 1, "", "1", "nan", np.NINF],
+            + [MISSING, 0.1, 1, "", "1", "nan", -np.inf],
             ordered=False,
         ),
         axis=0,

--- a/tests/metrics/test_scalar_drift.py
+++ b/tests/metrics/test_scalar_drift.py
@@ -41,7 +41,7 @@ def test_psi_interval_binning():
         binning_method=binning.IntervalBinning(
             bins=pd.IntervalIndex(
                 (
-                    pd.Interval(np.NINF, 1.0, closed="left"),
+                    pd.Interval(-np.inf, 1.0, closed="left"),
                     pd.Interval(1.0, 2.0, closed="left"),
                     pd.Interval(2.0, np.inf, closed="left"),
                 )


### PR DESCRIPTION
resolves #3530 
resolves #2261

Notes
- restrict numpy < 2 because of hdbscan [issue](https://github.com/Arize-ai/phoenix/issues/3530) (although the issue seems intermittent)
- numpy related code changes are done by ruff. see [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin)
- pandas related code changes are due to `pandas-stubs==2.0.3.230814`
- also updated pytest, mypy, and strawberry