### PR TITLE
chore: fix pandas linting for python 3.9+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,8 +166,7 @@ dependencies = [
 dependencies = [
   "mypy==1.10.0",
   "tenacity",
-  "pandas-stubs==2.2.2.240603; python_version>='3.9'",
-  "pandas-stubs==2.0.3.230814; python_version<'3.9'",
+  "pandas-stubs==2.0.3.230814",
   "types-psutil",
   "types-tqdm",
   "types-requests",
@@ -189,11 +188,17 @@ dependencies = [
   "strawberry-graphql[opentelemetry]==0.235.0",  # need to pin version because we're monkey-patching
 ]
 
+[[tool.hatch.envs.type.matrix]]
+python = ["3.8", "3.9", "3.12"]
+
 [tool.hatch.envs.style]
 detached = true
 dependencies = [
   "ruff==0.4.9",
 ]
+
+[[tool.hatch.envs.style.matrix]]
+python = ["3.8", "3.9", "3.12"]
 
 [tool.hatch.envs.notebooks]
 detached = true


### PR DESCRIPTION
The latest [pandas](https://pypi.org/project/pandas/) has dropped support for 3.8, so there may be linting errors not visible on 3.8.

`pandas-stubs==2.0.3.230814` is the last version supporting python 3.8.