### PR TITLE
feat(experiments): full-text toggle for experiments table

### DIFF
--- a/app/src/components/code/JSONText.tsx
+++ b/app/src/components/code/JSONText.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo } from "react";
+import { css } from "@emotion/react";
 
 import { isObject } from "@phoenix/typeUtils";
 
+const preCSS = css`
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+`;
 /**
  * Truncates the text if it is too long.
  * @param {string} text The text to truncate
@@ -17,12 +23,17 @@ function formatText(text: string, maxLength: number) {
 export function JSONText({
   json,
   maxLength,
+  space = 0,
 }: {
   json: unknown;
   maxLength?: number;
+  space?: number;
 }) {
   const hasMaxLength = typeof maxLength === "number";
-  const fullValue = useMemo(() => JSON.stringify(json), [json]);
+  const fullValue = useMemo(
+    () => JSON.stringify(json, null, space),
+    [json, space]
+  );
   if (!isObject(json)) {
     // Just show text and log a warning
     // eslint-disable-next-line no-console
@@ -42,5 +53,11 @@ export function JSONText({
     }
   }
   const textValue = hasMaxLength ? formatText(fullValue, maxLength) : fullValue;
-  return <span title={fullValue}>{textValue}</span>;
+  const Element = hasMaxLength ? "span" : "pre";
+  const cssStyles = hasMaxLength ? undefined : preCSS;
+  return (
+    <Element title={fullValue} css={cssStyles}>
+      {textValue}
+    </Element>
+  );
 }

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -30,7 +30,7 @@ const sideNavCSS = css`
   height: 100vh;
   position: fixed;
   width: var(--px-nav-collapsed-width);
-  z-index: 3;
+  z-index: 100; // Above the content
   transition:
     width 0.15s cubic-bezier(0, 0.57, 0.21, 0.99),
     box-shadow 0.15s cubic-bezier(0, 0.57, 0.21, 0.99);

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -128,6 +128,6 @@ export function getCommonPinningStyles<Row>(
     opacity: isPinned ? 0.95 : 1,
     position: isPinned ? "sticky" : "relative",
     width: column.getSize() + "px",
-    zIndex: isPinned ? 3 : 0,
+    zIndex: isPinned ? 1 : 0,
   };
 }

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -42,7 +42,7 @@ export const tableCSS = (theme: Theme) => css`
           right: 0;
           top: 0;
           cursor: grab;
-          z-index: 2;
+          z-index: 4;
           touch-action: none;
           &.isResizing,
           &:hover {
@@ -127,7 +127,7 @@ export function getCommonPinningStyles<Row>(
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     opacity: isPinned ? 0.95 : 1,
     position: isPinned ? "sticky" : "relative",
-    width: column.getSize(),
-    zIndex: isPinned ? 1 : 0,
+    width: column.getSize() + "px",
+    zIndex: isPinned ? 3 : 0,
   };
 }

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -1,8 +1,8 @@
-import React, { startTransition, Suspense } from "react";
+import React, { startTransition, Suspense, useState } from "react";
 import { useLoaderData, useSearchParams } from "react-router-dom";
 import { css } from "@emotion/react";
 
-import { Alert, Flex, Heading, View } from "@arizeai/components";
+import { Alert, Flex, Heading, Switch, View } from "@arizeai/components";
 
 import { Loading } from "@phoenix/components";
 
@@ -12,6 +12,8 @@ import { ExperimentMultiSelector } from "./ExperimentMultiSelector";
 
 export function ExperimentComparePage() {
   const data = useLoaderData() as experimentCompareLoaderQuery$data;
+  // The text of most is too long, so we need to make this optional
+  const [displayFullText, setDisplayFullText] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const experimentIds = searchParams.getAll("experimentId");
   const experimentIdsSelected = experimentIds.length > 0;
@@ -32,20 +34,31 @@ export function ExperimentComparePage() {
       >
         <Flex direction="column" gap="size-100">
           <Heading level={1}>Compare Experiments</Heading>
-          <ExperimentMultiSelector
-            dataset={data.dataset}
-            selectedExperimentIds={experimentIds}
-            label="experiments"
-            onChange={(newExperimentIds) => {
-              startTransition(() => {
-                searchParams.delete("experimentId");
-                newExperimentIds.forEach((id) => {
-                  searchParams.append("experimentId", id);
+          <Flex direction="row" justifyContent="space-between" alignItems="end">
+            <ExperimentMultiSelector
+              dataset={data.dataset}
+              selectedExperimentIds={experimentIds}
+              label="experiments"
+              onChange={(newExperimentIds) => {
+                startTransition(() => {
+                  searchParams.delete("experimentId");
+                  newExperimentIds.forEach((id) => {
+                    searchParams.append("experimentId", id);
+                  });
+                  setSearchParams(searchParams);
                 });
-                setSearchParams(searchParams);
-              });
-            }}
-          />
+              }}
+            />
+            <Switch
+              onChange={(isSelected) => {
+                setDisplayFullText(isSelected);
+              }}
+              defaultSelected={false}
+              labelPlacement="start"
+            >
+              Full Text
+            </Switch>
+          </Flex>
         </Flex>
       </View>
       {experimentIdsSelected ? (
@@ -53,6 +66,7 @@ export function ExperimentComparePage() {
           <ExperimentCompareTable
             datasetId={data.dataset.id}
             experimentIds={experimentIds}
+            displayFullText={displayFullText}
           />
         </Suspense>
       ) : (

--- a/app/src/pages/experiment/ExperimentComparePage.tsx
+++ b/app/src/pages/experiment/ExperimentComparePage.tsx
@@ -12,7 +12,7 @@ import { ExperimentMultiSelector } from "./ExperimentMultiSelector";
 
 export function ExperimentComparePage() {
   const data = useLoaderData() as experimentCompareLoaderQuery$data;
-  // The text of most is too long, so we need to make this optional
+  // The text of most IO is too long so default to showing truncated text
   const [displayFullText, setDisplayFullText] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const experimentIds = searchParams.getAll("experimentId");


### PR DESCRIPTION
resolves #3547 

Adds a toggle to let you view the full-text in the table view
<img width="2560" alt="Screenshot 2024-06-17 at 5 13 41 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/8d648f3f-df36-4164-94a9-37e1c35fd487">
