### PR TITLE
fix(dataset): get metadata as `{}` when its value is `None` in JSON

### DIFF
--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -27,7 +27,7 @@ async def create_experiment_evaluation(request: Request) -> Response:
     score = payload["score"]
     explanation = payload["explanation"]
     error = payload.get("error")
-    metadata = payload.get("metadata", {})
+    metadata = payload.get("metadata") or {}
     start_time = payload["start_time"]
     end_time = payload["end_time"]
     async with request.app.state.db() as session:

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -34,7 +34,7 @@ async def create_experiment(request: Request) -> Response:
 
     payload = await request.json()
     repetitions = payload.get("repetitions", 1)
-    metadata = payload.get("metadata", {})
+    metadata = payload.get("metadata") or {}
     dataset_version_globalid_str = payload.get("version-id")
     if dataset_version_globalid_str is not None:
         try:


### PR DESCRIPTION
metadata can be `None` in the JSON payload