### PR TITLE
feat(auth): universal set of headers to be used by the client

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -32,6 +32,7 @@
         "numpy",
         "openai",
         "openinference",
+        "OTEL",
         "OTLP",
         "postprocessors",
         "pydantic",

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -2,7 +2,9 @@ import os
 import tempfile
 from logging import getLogger
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Mapping, Optional
+
+from .utilities.re import parse_env_headers
 
 logger = getLogger(__name__)
 
@@ -12,6 +14,11 @@ ENV_PHOENIX_GRPC_PORT = "PHOENIX_GRPC_PORT"
 ENV_PHOENIX_HOST = "PHOENIX_HOST"
 ENV_PHOENIX_HOST_ROOT_PATH = "PHOENIX_HOST_ROOT_PATH"
 ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
+ENV_PHOENIX_CLIENT_HEADERS = "PHOENIX_CLIENT_HEADERS"
+"""
+The headers to include in the Phoenix client requests.
+Note: This does not apply to OTEL_EXPORTER_OTLP_HEADERS, which is used for OpenTelemetry.
+"""
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
 """
 The endpoint traces and evals are sent to. This must be set if the Phoenix
@@ -217,6 +224,12 @@ def get_env_enable_prometheus() -> bool:
         f"Invalid value for environment variable {ENV_PHOENIX_ENABLE_PROMETHEUS}: "
         f"{enable_promotheus}. Value values are 'TRUE' and 'FALSE' (case-insensitive)."
     )
+
+
+def get_env_client_headers() -> Optional[Mapping[str, str]]:
+    if headers_str := os.getenv(ENV_PHOENIX_CLIENT_HEADERS):
+        return parse_env_headers(headers_str)
+    return None
 
 
 DEFAULT_PROJECT_NAME = "default"

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -17,7 +17,8 @@ ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
 ENV_PHOENIX_CLIENT_HEADERS = "PHOENIX_CLIENT_HEADERS"
 """
 The headers to include in the Phoenix client requests.
-Note: This does not apply to OTEL_EXPORTER_OTLP_HEADERS, which is used for OpenTelemetry.
+Note: This overrides OTEL_EXPORTER_OTLP_HEADERS in the case where
+phoenix.trace instrumentors are used.
 """
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
 """

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from logging import getLogger
 from pathlib import Path
-from typing import List, Mapping, Optional
+from typing import Dict, List, Optional
 
 from .utilities.re import parse_env_headers
 
@@ -227,7 +227,7 @@ def get_env_enable_prometheus() -> bool:
     )
 
 
-def get_env_client_headers() -> Optional[Mapping[str, str]]:
+def get_env_client_headers() -> Optional[Dict[str, str]]:
     if headers_str := os.getenv(ENV_PHOENIX_CLIENT_HEADERS):
         return parse_env_headers(headers_str)
     return None

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -16,7 +16,7 @@ ENV_PHOENIX_HOST_ROOT_PATH = "PHOENIX_HOST_ROOT_PATH"
 ENV_NOTEBOOK_ENV = "PHOENIX_NOTEBOOK_ENV"
 ENV_PHOENIX_CLIENT_HEADERS = "PHOENIX_CLIENT_HEADERS"
 """
-The headers to include in the Phoenix client requests.
+The headers to include in Phoenix client requests.
 Note: This overrides OTEL_EXPORTER_OTLP_HEADERS in the case where
 phoenix.trace instrumentors are used.
 """

--- a/src/phoenix/datasets/experiments.py
+++ b/src/phoenix/datasets/experiments.py
@@ -23,6 +23,7 @@ from typing import (
 import httpx
 
 from phoenix.config import (
+    get_env_client_headers,
     get_env_collector_endpoint,
     get_env_host,
     get_env_port,
@@ -125,7 +126,8 @@ def _phoenix_client() -> httpx.Client:
     host = get_env_host()
     base_url = get_env_collector_endpoint() or f"http://{host}:{get_env_port()}"
     base_url = base_url if base_url.endswith("/") else base_url + "/"
-    client = httpx.Client(base_url=base_url)
+    headers = get_env_client_headers()
+    client = httpx.Client(base_url=base_url, headers=headers)
     return client
 
 

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -62,10 +62,13 @@ class Client(TraceDataExtractor):
         Client for connecting to a Phoenix server.
 
         Args:
-            endpoint (str, optional): Phoenix server endpoint, e.g. http://localhost:6006. If not
-                provided, the endpoint will be inferred from the environment variables.
-            headers (str, optional): Headers to include in each network request. If not provided,
-                the headers will be inferred from the environment variables or be empty.
+            endpoint (str, optional): Phoenix server endpoint, e.g.
+            http://localhost:6006. If not provided, the endpoint will be
+            inferred from the environment variables.
+
+            headers (Mapping[str, str], optional): Headers to include in each
+            network request. If not provided, the headers will be inferred from
+            the environment variables or be empty.
         """
         if kwargs.pop("use_active_session_if_available", None) is not None:
             print(

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -68,7 +68,7 @@ class Client(TraceDataExtractor):
 
             headers (Mapping[str, str], optional): Headers to include in each
             network request. If not provided, the headers will be inferred from
-            the environment variables or be empty.
+            the environment variables (if present).
         """
         if kwargs.pop("use_active_session_if_available", None) is not None:
             print(

--- a/src/phoenix/trace/exporter.py
+++ b/src/phoenix/trace/exporter.py
@@ -12,7 +12,12 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from typing_extensions import TypeAlias, assert_never
 
 import phoenix.trace.v1 as pb
-from phoenix.config import get_env_collector_endpoint, get_env_host, get_env_port
+from phoenix.config import (
+    get_env_client_headers,
+    get_env_collector_endpoint,
+    get_env_host,
+    get_env_port,
+)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -74,7 +79,8 @@ class HttpExporter:
         )
         self._base_url = base_url if base_url.endswith("/") else base_url + "/"
         _warn_if_phoenix_is_not_running(self._base_url)
-        self._client = httpx.Client()
+        headers = get_env_client_headers()
+        self._client = httpx.Client(headers=headers)
         weakref.finalize(self, self._client.close)
         self._client.headers.update(
             {

--- a/src/phoenix/utilities/re.py
+++ b/src/phoenix/utilities/re.py
@@ -1,0 +1,50 @@
+from logging import getLogger
+from re import compile, split
+from typing import Dict, List, Mapping
+from urllib.parse import unquote
+
+_logger = getLogger(__name__)
+
+# Optional whitespace
+_OWS = r"[ \t]*"
+# A key contains printable US-ASCII characters except: SP and "(),/:;<=>?@[\]{}
+_KEY_FORMAT = r"[\x21\x23-\x27\x2a\x2b\x2d\x2e\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+"
+# A value contains a URL-encoded UTF-8 string. The encoded form can contain any
+# printable US-ASCII characters (0x20-0x7f) other than SP, DEL, and ",;/
+_VALUE_FORMAT = r"[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*"
+# A key-value is key=value, with optional whitespace surrounding key and value
+_KEY_VALUE_FORMAT = rf"{_OWS}{_KEY_FORMAT}{_OWS}={_OWS}{_VALUE_FORMAT}{_OWS}"
+
+_HEADER_PATTERN = compile(_KEY_VALUE_FORMAT)
+_DELIMITER_PATTERN = compile(r"[ \t]*,[ \t]*")
+
+
+def parse_env_headers(s: str) -> Mapping[str, str]:
+    """
+    Parse ``s``, which is a ``str`` instance containing HTTP headers encoded
+    for use in ENV variables per the W3C Baggage HTTP header format at
+    https://www.w3.org/TR/baggage/#baggage-http-header-format, except that
+    additional semi-colon delimited metadata is not supported.
+
+    src: https://github.com/open-telemetry/opentelemetry-python/blob/2d5cd58f33bd8a16f45f30be620a96699bc14297/opentelemetry-api/src/opentelemetry/util/re.py#L52
+    """
+    headers: Dict[str, str] = {}
+    headers_list: List[str] = split(_DELIMITER_PATTERN, s)
+    for header in headers_list:
+        if not header:  # empty string
+            continue
+        match = _HEADER_PATTERN.fullmatch(header.strip())
+        if not match:
+            _logger.warning(
+                "Header format invalid! Header values in environment variables must be "
+                "URL encoded: %s",
+                header,
+            )
+            continue
+        # value may contain any number of `=`
+        name, value = match.string.split("=", 1)
+        name = unquote(name).strip().lower()
+        value = unquote(value).strip()
+        headers[name] = value
+
+    return headers

--- a/src/phoenix/utilities/re.py
+++ b/src/phoenix/utilities/re.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 from re import compile, split
-from typing import Dict, List, Mapping
+from typing import Dict, List
 from urllib.parse import unquote
 
 _logger = getLogger(__name__)
@@ -19,7 +19,7 @@ _HEADER_PATTERN = compile(_KEY_VALUE_FORMAT)
 _DELIMITER_PATTERN = compile(r"[ \t]*,[ \t]*")
 
 
-def parse_env_headers(s: str) -> Mapping[str, str]:
+def parse_env_headers(s: str) -> Dict[str, str]:
     """
     Parse ``s``, which is a ``str`` instance containing HTTP headers encoded
     for use in ENV variables per the W3C Baggage HTTP header format at

--- a/tests/utilities/test_re.py
+++ b/tests/utilities/test_re.py
@@ -3,7 +3,7 @@ from phoenix.utilities.re import parse_env_headers
 
 
 @pytest.mark.parametrize(
-    "case",
+    "headers, expected, warn",
     [
         # invalid header name
         ("=value", [], True),
@@ -43,8 +43,7 @@ from phoenix.utilities.re import parse_env_headers
         ),
     ],
 )
-def test_get_env_client_headers(case, caplog):
-    headers, expected, warn = case
+def test_get_env_client_headers(headers, expected, warn, caplog):
     assert parse_env_headers(headers) == dict(expected)
     if warn:
         with caplog.at_level(level="WARNING"):

--- a/tests/utilities/test_re.py
+++ b/tests/utilities/test_re.py
@@ -1,0 +1,58 @@
+import pytest
+from phoenix.utilities.re import parse_env_headers
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # invalid header name
+        ("=value", [], True),
+        ("}key=value", [], True),
+        ("@key()=value", [], True),
+        ("/key=value", [], True),
+        # invalid header value
+        ("name=\\", [], True),
+        ('name=value"', [], True),
+        ("name=;value", [], True),
+        # different header values
+        ("name=", [("name", "")], False),
+        ("name===value=", [("name", "==value=")], False),
+        # url-encoded headers
+        ("key=value%20with%20space", [("key", "value with space")], False),
+        ("key%21=value", [("key!", "value")], False),
+        ("%20key%20=%20value%20", [("key", "value")], False),
+        # header name case normalization
+        ("Key=Value", [("key", "Value")], False),
+        # mix of valid and invalid headers
+        (
+            "name1=value1,invalidName, name2 =   value2   , name3=value3==",
+            [
+                (
+                    "name1",
+                    "value1",
+                ),
+                ("name2", "value2"),
+                ("name3", "value3=="),
+            ],
+            True,
+        ),
+        (
+            "=name=valu3; key1; key2, content  =  application, red=\tvelvet; cake",
+            [("content", "application")],
+            True,
+        ),
+    ],
+)
+def test_get_env_client_headers(case, caplog):
+    headers, expected, warn = case
+    assert parse_env_headers(headers) == dict(expected)
+    if warn:
+        with caplog.at_level(level="WARNING"):
+            assert parse_env_headers(headers) == dict(expected)
+            assert (
+                "Header format invalid! Header values in environment variables must be URL encoded"
+                in caplog.records[0].message
+            )
+
+    else:
+        assert parse_env_headers(headers) == dict(expected)

--- a/tests/utilities/test_re.py
+++ b/tests/utilities/test_re.py
@@ -44,7 +44,6 @@ from phoenix.utilities.re import parse_env_headers
     ],
 )
 def test_get_env_client_headers(headers, expected, warn, caplog):
-    assert parse_env_headers(headers) == dict(expected)
     if warn:
         with caplog.at_level(level="WARNING"):
             assert parse_env_headers(headers) == dict(expected)

--- a/tests/utilities/test_re.py
+++ b/tests/utilities/test_re.py
@@ -6,25 +6,34 @@ from phoenix.utilities.re import parse_env_headers
     "headers, expected, warn",
     [
         # invalid header name
-        ("=value", [], True),
-        ("}key=value", [], True),
-        ("@key()=value", [], True),
-        ("/key=value", [], True),
+        pytest.param("=value", [], True, id="invalid header name 1"),
+        pytest.param("}key=value", [], True, id="invalid header name 2"),
+        pytest.param("@key()=value", [], True, id="invalid header name 3"),
+        pytest.param("/key=value", [], True, id="invalid header name 4"),
         # invalid header value
-        ("name=\\", [], True),
-        ('name=value"', [], True),
-        ("name=;value", [], True),
+        pytest.param("name=\\", [], True, id="invalid header value 1"),
+        pytest.param('name=value"', [], True, id="invalid header value 2"),
+        pytest.param("name=;value", [], True, id="invalid header value 3"),
         # different header values
-        ("name=", [("name", "")], False),
-        ("name===value=", [("name", "==value=")], False),
+        pytest.param("name=", [("name", "")], False, id="different header values 1"),
+        pytest.param(
+            "name===value=", [("name", "==value=")], False, id="different header values 2"
+        ),
         # url-encoded headers
-        ("key=value%20with%20space", [("key", "value with space")], False),
-        ("key%21=value", [("key!", "value")], False),
-        ("%20key%20=%20value%20", [("key", "value")], False),
+        pytest.param(
+            "key=value%20with%20space",
+            [("key", "value with space")],
+            False,
+            id="url-encoded headers 1",
+        ),
+        pytest.param("key%21=value", [("key!", "value")], False, id="url-encoded headers 2"),
+        pytest.param(
+            "%20key%20=%20value%20", [("key", "value")], False, id="url-encoded headers 3"
+        ),
         # header name case normalization
-        ("Key=Value", [("key", "Value")], False),
+        pytest.param("Key=Value", [("key", "Value")], False, id="header name case normalization"),
         # mix of valid and invalid headers
-        (
+        pytest.param(
             "name1=value1,invalidName, name2 =   value2   , name3=value3==",
             [
                 (
@@ -35,11 +44,13 @@ from phoenix.utilities.re import parse_env_headers
                 ("name3", "value3=="),
             ],
             True,
+            id="mix of valid and invalid headers 1",
         ),
-        (
+        pytest.param(
             "=name=valu3; key1; key2, content  =  application, red=\tvelvet; cake",
             [("content", "application")],
             True,
+            id="mix of valid and invalid headers 2",
         ),
     ],
 )


### PR DESCRIPTION
resolves #2738 

Lets you add auth headers (and anything else you might need) to access phoenix from a client