### PR TITLE
chore: hide openapi routes that are not usable in the playground

### DIFF
--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -400,7 +400,7 @@ paths:
           description: Not found
       summary: Get evaluations from Phoenix
       tags:
-      - evaluations
+      - private
     post:
       operationId: addEvaluations
       parameters:
@@ -433,7 +433,7 @@ paths:
           description: Request body is invalid
       summary: Add evaluations to a span, trace, or document
       tags:
-      - evaluations
+      - private
   /v1/spans:
     post:
       operationId: querySpans
@@ -493,7 +493,7 @@ paths:
           description: Request body is invalid
       summary: Query spans using query DSL
       tags:
-      - spans
+      - private
   /v1/traces:
     post:
       operationId: addTraces
@@ -515,5 +515,5 @@ paths:
           description: Request body is invalid
       summary: Send traces to Phoenix
       tags:
-      - traces
+      - private
 

--- a/src/phoenix/server/api/routers/v1/evaluations.py
+++ b/src/phoenix/server/api/routers/v1/evaluations.py
@@ -44,7 +44,7 @@ async def post_evaluations(request: Request) -> Response:
     summary: Add evaluations to a span, trace, or document
     operationId: addEvaluations
     tags:
-      - evaluations
+      - private
     parameters:
       - name: project-name
         in: query
@@ -105,7 +105,7 @@ async def get_evaluations(request: Request) -> Response:
     summary: Get evaluations from Phoenix
     operationId: getEvaluation
     tags:
-      - evaluations
+      - private
     parameters:
       - name: project-name
         in: query

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -19,7 +19,7 @@ async def query_spans_handler(request: Request) -> Response:
     summary: Query spans using query DSL
     operationId: querySpans
     tags:
-      - spans
+      - private
     parameters:
       - name: project-name
         in: query

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -24,7 +24,7 @@ async def post_traces(request: Request) -> Response:
     summary: Send traces to Phoenix
     operationId: addTraces
     tags:
-      - traces
+      - private
     requestBody:
       required: true
       content:

--- a/src/phoenix/server/openapi/docs.py
+++ b/src/phoenix/server/openapi/docs.py
@@ -43,6 +43,9 @@ def get_swagger_ui_html(
     <div id="swagger-ui">
     </div>
     <script src="{swagger_js_url}"></script>
+    <style type="text/css">
+    div[id^="operations-private"]{{display:none}} #operations-tag-private{{display:none}}
+    </style>
     <!-- `SwaggerUIBundle` is now available on the page -->
     <script>
     const ui = SwaggerUIBundle({{


### PR DESCRIPTION
This PR hides all non-datasets related routes for now until they are well-documented and ready for consumption