### PR TITLE
chore: rename "retrieval_documents" to "documents" in examples

### DIFF
--- a/src/phoenix/server/api/helpers/dataset_helpers.py
+++ b/src/phoenix/server/api/helpers/dataset_helpers.py
@@ -117,7 +117,7 @@ def _get_retriever_span_output(
     The output is extracted from the retrieval documents (if present).
     """
     if retrieval_documents is not None:
-        return {"retrieval_documents": retrieval_documents}
+        return {"documents": retrieval_documents}
     return _get_generic_io_value(io_value=output_value, mime_type=output_mime_type, kind="output")
 
 

--- a/tests/server/api/helpers/test_dataset_helpers.py
+++ b/tests/server/api/helpers/test_dataset_helpers.py
@@ -271,7 +271,7 @@ def test_get_dataset_example_input(span: MockSpan, expected_input_value: Dict[st
                 llm_output_messages=None,
                 retrieval_documents=[{"id": "1", "score": 0.5, "content": "document-content"}],
             ),
-            {"retrieval_documents": [{"id": "1", "score": 0.5, "content": "document-content"}]},
+            {"documents": [{"id": "1", "score": 0.5, "content": "document-content"}]},
             id="retriever-span-with-retrieval-documents",
         ),
         pytest.param(

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -244,7 +244,7 @@ async def test_add_span_to_dataset(
                                 "revision": {
                                     "input": {"input": "retriever-span-input"},
                                     "output": {
-                                        "retrieval_documents": [
+                                        "documents": [
                                             {
                                                 "document": {
                                                     "content": "retrieved-document-content",


### PR DESCRIPTION
resolves #3574
