### PR TITLE
fix: Update Dockerfile to work with ARM64 chips.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@
 # - https://github.com/Arize-ai/phoenix/issues
 
 ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot
+# To deploy it on an arm64, like Raspberry Pi or Apple-Silicon, chose this image instead:
+# ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot-arm64
 
 # This Dockerfile is a multi-stage build. The first stage builds the frontend.
 FROM node:20-slim AS frontend-builder


### PR DESCRIPTION
- **Purpose**: Update Dockerfile to support ARM64 architecture.
- **Change**:
   - Added a comment and an option to use gcr.io/distroless/python3-debian12:nonroot-arm64 for ARM64 deployments.
- **Use Case**: Enables deployment on devices like Raspberry Pi and Apple Silicon.

This change ensures compatibility with ARM64 architecture, enhancing the flexibility of the Phoenix project to run on various hardware platforms.