### PR TITLE
fix: json input and output values are properly parsed when adding examples

### DIFF
--- a/src/phoenix/server/api/helpers/dataset_helpers.py
+++ b/src/phoenix/server/api/helpers/dataset_helpers.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, Literal, Mapping, Optional, Protocol
 
 from openinference.semconv.trace import (
@@ -128,14 +129,14 @@ def _get_generic_io_value(
     Makes a best-effort attempt to extract the input or output value from a span
     and returns it as a dictionary.
     """
-    if isinstance(io_value, str) and (
-        mime_type == OpenInferenceMimeTypeValues.TEXT.value or mime_type is None
-    ):
+    if mime_type == OpenInferenceMimeTypeValues.JSON.value:
+        parsed_value = json.loads(io_value)
+        if isinstance(parsed_value, dict):
+            return parsed_value
+        else:
+            return {kind: parsed_value}
+    if isinstance(io_value, str):
         return {kind: io_value}
-    if isinstance(io_value, dict) and (
-        mime_type == OpenInferenceMimeTypeValues.JSON.value or mime_type is None
-    ):
-        return io_value
     return {}
 
 

--- a/tests/server/api/helpers/test_dataset_helpers.py
+++ b/tests/server/api/helpers/test_dataset_helpers.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -152,7 +153,7 @@ class MockSpan:
         pytest.param(
             MockSpan(
                 span_kind="LLM",
-                input_value={"llm-span-input": "llm-input"},
+                input_value=json.dumps({"llm-span-input": "llm-input"}),
                 input_mime_type="application/json",
                 output_value="plain-text-output",
                 output_mime_type="text/plain",
@@ -186,7 +187,7 @@ class MockSpan:
         pytest.param(
             MockSpan(
                 span_kind="CHAIN",
-                input_value={"chain_input": "chain-input"},
+                input_value=json.dumps({"chain_input": "chain-input"}),
                 input_mime_type="application/json",
                 output_value="plain-text-output",
                 output_mime_type="text/plain",
@@ -249,7 +250,7 @@ def test_get_dataset_example_input(span: MockSpan, expected_input_value: Dict[st
                 span_kind="LLM",
                 input_value="plain-text-input",
                 input_mime_type="text/plain",
-                output_value={"llm-span-output": "value"},
+                output_value=json.dumps({"llm-span-output": "value"}),
                 output_mime_type="application/json",
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,
@@ -292,9 +293,9 @@ def test_get_dataset_example_input(span: MockSpan, expected_input_value: Dict[st
         pytest.param(
             MockSpan(
                 span_kind="RETRIEVER",
-                input_value={"retriever-input": "retriever-input"},
+                input_value=json.dumps({"retriever-input": "retriever-input"}),
                 input_mime_type="application/json",
-                output_value={"retriever_output": "retriever-output"},
+                output_value=json.dumps({"retriever_output": "retriever-output"}),
                 output_mime_type="application/json",
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,
@@ -322,9 +323,9 @@ def test_get_dataset_example_input(span: MockSpan, expected_input_value: Dict[st
         pytest.param(
             MockSpan(
                 span_kind="CHAIN",
-                input_value={"chain_input": "chain-input"},
+                input_value=json.dumps({"chain_input": "chain-input"}),
                 input_mime_type="application/json",
-                output_value={"chain_output": "chain-output"},
+                output_value=json.dumps({"chain_output": "chain-output"}),
                 output_mime_type="application/json",
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,


### PR DESCRIPTION
resolves #3625
