### PR TITLE
feat(experiments): experiment error rate column

### DIFF
--- a/app/src/pages/experiments/ErrorRateCell.tsx
+++ b/app/src/pages/experiments/ErrorRateCell.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from "react";
+import { CellContext } from "@tanstack/react-table";
+
+import { Text } from "@arizeai/components";
+
+import { percentFormatter } from "@phoenix/utils/numberFormatUtils";
+/**
+ * A table cell that nicely formats the error rate,
+ * highlighting issues when the number gets high
+ */
+export function ErrorRateCell<TData extends object, TValue>({
+  getValue,
+}: CellContext<TData, TValue>) {
+  const value = getValue() as number;
+  const percent = value * 100;
+  const color = useMemo(() => {
+    if (percent >= 80) {
+      return "red-1100";
+    } else if (percent > 0) {
+      return "orange-1100";
+    } else {
+      return "green-1100";
+    }
+  }, [percent]);
+  return <Text color={color}>{percentFormatter(percent)}</Text>;
+}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -41,6 +41,7 @@ import {
 import { experimentsLoaderQuery$data } from "./__generated__/experimentsLoaderQuery.graphql";
 import type { ExperimentsTableFragment$key } from "./__generated__/ExperimentsTableFragment.graphql";
 import { ExperimentsTableQuery } from "./__generated__/ExperimentsTableQuery.graphql";
+import { ErrorRateCell } from "./ErrorRateCell";
 import { ExperimentSelectionToolbar } from "./ExperimentSelectionToolbar";
 
 const PAGE_SIZE = 100;
@@ -95,6 +96,7 @@ export function ExperimentsTable({
                 description
                 createdAt
                 metadata
+                errorRate
                 project {
                   id
                 }
@@ -233,7 +235,20 @@ export function ExperimentsTable({
       };
     });
 
-  const actionColumns: ColumnDef<TableRow>[] = [
+  const tailColumns: ColumnDef<TableRow>[] = [
+    {
+      header: "error rate",
+      accessorKey: "errorRate",
+      meta: {
+        textAlign: "right",
+      },
+      cell: ErrorRateCell,
+    },
+    {
+      header: "metadata",
+      accessorKey: "metadata",
+      cell: CompactJSONCell,
+    },
     {
       id: "actions",
       cell: ({ row }) => {
@@ -243,7 +258,7 @@ export function ExperimentsTable({
     },
   ];
   const table = useReactTable<TableRow>({
-    columns: [...baseColumns, ...annotationColumns, ...actionColumns],
+    columns: [...baseColumns, ...annotationColumns, ...tailColumns],
     data: tableData,
     getCoreRowModel: getCoreRowModel(),
     state: {

--- a/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a4fef9f01fbe3de31baf91deb0d90b87>>
+ * @generated SignedSource<<81d93ddac7367a87c1a05d542fee3ae9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type ExperimentsTableFragment$data = {
         }>;
         readonly createdAt: string;
         readonly description: string | null;
+        readonly errorRate: number | null;
         readonly id: string;
         readonly metadata: any;
         readonly name: string;
@@ -194,6 +195,13 @@ return {
                 {
                   "alias": null,
                   "args": null,
+                  "kind": "ScalarField",
+                  "name": "errorRate",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
                   "concreteType": "Project",
                   "kind": "LinkedField",
                   "name": "project",
@@ -288,6 +296,6 @@ return {
 };
 })();
 
-(node as any).hash = "0911261e5175626c0a4b4f91d60bc0d9";
+(node as any).hash = "5128648fbcfd8cd6f81ef103cd6a2b14";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<18f2b2f02e1ea6ff12d8a3f9e4625c83>>
+ * @generated SignedSource<<ab3a68a1824b2447817a291d42cab698>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -222,6 +222,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "errorRate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "Project",
                             "kind": "LinkedField",
                             "name": "project",
@@ -322,16 +329,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6c9af409faca7f016950572dc4a7420b",
+    "cacheID": "dc02b7cdde5707c64b467252cbb01740",
     "id": null,
     "metadata": {},
     "name": "ExperimentsTableQuery",
     "operationKind": "query",
-    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0911261e5175626c0a4b4f91d60bc0d9";
+(node as any).hash = "5128648fbcfd8cd6f81ef103cd6a2b14";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0dec2b8f79ed9a1e086561824f148043>>
+ * @generated SignedSource<<3fbfcdf01c2392484cd63e94ee8496e7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -210,6 +210,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "errorRate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "Project",
                             "kind": "LinkedField",
                             "name": "project",
@@ -310,12 +317,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "06b938134f0feffa08111eb8c8f02b7c",
+    "cacheID": "abd247aa0e79038905eda43da809e02d",
     "id": null,
     "metadata": {},
     "name": "experimentsLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentsLoaderQuery(\n  $id: GlobalID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query experimentsLoaderQuery(\n  $id: GlobalID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
resolves #3656 
<img width="178" alt="Screenshot 2024-06-25 at 2 44 18 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/4c1d79cc-c5be-4152-a8d5-0c1af367dedb">

Also displays error traces which were hidden before.
<img width="2008" alt="Screenshot 2024-06-25 at 3 00 58 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/81e7c747-10dc-4bec-926c-a52a5b9f0f38">
<img width="1921" alt="Screenshot 2024-06-25 at 2 58 47 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/95e02165-b442-4228-b6bb-e1b90da0b081">
