### PR TITLE
feat(datasets): allow unrecognized parameters in the evaluator function with default values

### DIFF
--- a/src/phoenix/datasets/evaluators/utils.py
+++ b/src/phoenix/datasets/evaluators/utils.py
@@ -35,7 +35,11 @@ def validate_signature(sig: inspect.Signature) -> None:
         raise ValueError("Evaluation function must have at least one parameter.")
     if len(params) > 1:
         for not_found in set(params) - valid_named_params:
-            if params[not_found].kind is inspect.Parameter.VAR_KEYWORD:
+            param = params[not_found]
+            if (
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                or param.default is not inspect.Parameter.empty
+            ):
                 continue
             raise ValueError(
                 (

--- a/src/phoenix/datasets/evaluators/utils.py
+++ b/src/phoenix/datasets/evaluators/utils.py
@@ -64,8 +64,9 @@ def _bind_signature(sig: inspect.Signature, **kwargs: Any) -> inspect.BoundArgum
             return sig.bind(parameter_mapping[parameter_name])
         else:
             return sig.bind(parameter_mapping["output"])
-    else:
-        return sig.bind_partial(**{name: parameter_mapping[name] for name in params})
+    return sig.bind_partial(
+        **{name: parameter_mapping[name] for name in set(parameter_mapping).intersection(params)}
+    )
 
 
 def create_evaluator(


### PR DESCRIPTION
this is useful for using `partial` to fill in values. below is an example

<img width="460" alt="Screenshot 2024-06-26 at 11 38 47 AM" src="https://github.com/Arize-ai/phoenix/assets/80478925/a7718f2e-1066-43a7-84ac-e082a2a9c7ce">
