### PR TITLE
feat(experiments): evaluator trace slide-over

### DIFF
--- a/app/src/components/experiment/AnnotationLabel.tsx
+++ b/app/src/components/experiment/AnnotationLabel.tsx
@@ -136,16 +136,14 @@ export function AnnotationLabel({
           </View>
         ) : null}
         {annotation.trace && clickable ? (
-          <View paddingTop="size-50">
+          <View paddingTop="size-100">
             <div
               css={css`
                 display: flex;
                 flex-direction: row;
                 align-items: center;
                 color: var(--ac-global-color-primary);
-                gap: var(--px-spacing-sm);
-
-                margin-top: var(--px-spacing-sm);
+                gap: var(--ac-global-dimension-size-50);
               `}
             >
               <Icon svg={<Icons.InfoOutline />} />

--- a/app/src/components/experiment/AnnotationLabel.tsx
+++ b/app/src/components/experiment/AnnotationLabel.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { css } from "@emotion/react";
 
 import {
-  Button,
   Flex,
   HelpTooltip,
   Icon,
@@ -47,13 +46,14 @@ export function AnnotationLabel({
   annotation: Annotation;
   onClick?: () => void;
 }) {
+  const clickable = typeof onClick == "function";
   const labelValue =
     (typeof annotation.score == "number" && formatFloat(annotation.score)) ||
     annotation.label ||
     "n/a";
 
   return (
-    <TooltipTrigger delay={0} offset={3}>
+    <TooltipTrigger delay={2} offset={3}>
       <TriggerWrap>
         <div
           role="button"
@@ -72,7 +72,11 @@ export function AnnotationLabel({
             }
           `}
           aria-label="Click to view the annotation trace"
-          onClick={onClick}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onClick && onClick();
+          }}
         >
           <Flex direction="row" gap="size-100" alignItems="center">
             <AnnotationColorSwatch annotationName={annotation.name} />
@@ -91,7 +95,7 @@ export function AnnotationLabel({
             >
               <Text textSize="small">{labelValue}</Text>
             </div>
-            {annotation.trace ? (
+            {annotation.trace && clickable ? (
               <Icon svg={<Icons.ArrowIosForwardOutline />} />
             ) : null}
           </Flex>
@@ -131,16 +135,22 @@ export function AnnotationLabel({
             </Flex>
           </View>
         ) : null}
-        {annotation.trace ? (
+        {annotation.trace && clickable ? (
           <View paddingTop="size-50">
-            <Button
-              variant="primary"
-              onClick={onClick}
-              size="compact"
-              icon={<Icon svg={<Icons.Trace />} />}
+            <div
+              css={css`
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                color: var(--ac-global-color-primary);
+                gap: var(--px-spacing-sm);
+
+                margin-top: var(--px-spacing-sm);
+              `}
             >
-              View trace
-            </Button>
+              <Icon svg={<Icons.InfoOutline />} />
+              <span>Click to view evaluator trace</span>
+            </div>
           </View>
         ) : null}
       </HelpTooltip>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -255,6 +255,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                       <TraceDetailsDialog
                         traceId={traceId}
                         projectId={projectId}
+                        title={`Experiment Run Trace`}
                       />
                     );
                   });
@@ -304,7 +305,11 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
 
         return run ? (
           <RunOutputWrap controls={runControls}>
-            <ExperimentRunOutput {...run} displayFullText={displayFullText} />
+            <ExperimentRunOutput
+              {...run}
+              displayFullText={displayFullText}
+              setDialog={setDialog}
+            />
           </RunOutputWrap>
         ) : (
           <NotRunText />
@@ -481,10 +486,20 @@ function ExperimentRowActionMenu(props: {
  * Display the output of an experiment run.
  */
 function ExperimentRunOutput(
-  props: ExperimentRun & { displayFullText: boolean }
+  props: ExperimentRun & {
+    displayFullText: boolean;
+    setDialog: (dialog: ReactNode) => void;
+  }
 ) {
-  const { output, error, startTime, endTime, annotations, displayFullText } =
-    props;
+  const {
+    output,
+    error,
+    startTime,
+    endTime,
+    annotations,
+    displayFullText,
+    setDialog,
+  } = props;
   if (error) {
     return <RunError error={error} />;
   }
@@ -511,7 +526,18 @@ function ExperimentRunOutput(
             <AnnotationLabel
               annotation={annotation}
               onClick={() => {
-                // TODO: Implement annotation click
+                const trace = annotation.trace;
+                if (trace) {
+                  startTransition(() => {
+                    setDialog(
+                      <TraceDetailsDialog
+                        traceId={trace.traceId}
+                        projectId={trace.projectId}
+                        title={`Evaluator Trace: ${annotation.name}`}
+                      />
+                    );
+                  });
+                }
               }}
             />
           </li>
@@ -748,6 +774,8 @@ function SelectedExampleDialog({
                                       );
                                       display: flex;
                                       flex-direction: column;
+                                      justify-content: flex-start;
+                                      align-items: flex-end;
                                       gap: var(
                                         --ac-global-dimension-static-size-100
                                       );
@@ -782,14 +810,16 @@ function SelectedExampleDialog({
 function TraceDetailsDialog({
   traceId,
   projectId,
+  title,
 }: {
   traceId: string;
   projectId: string;
+  title: string;
 }) {
   const navigate = useNavigate();
   return (
     <Dialog
-      title="Run Trace Details"
+      title={title}
       size="fullscreen"
       extra={
         <Button

--- a/tutorials/experiments/experiments_txt2sql.ipynb
+++ b/tutorials/experiments/experiments_txt2sql.ipynb
@@ -29,11 +29,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "import phoenix as px\n",
     "\n",
-    "get_ipython().system = os.system\n",
-    "\n",
-    "!python -m phoenix.server.main serve > arize.log 2>&1 &"
+    "px.launch_app()"
    ]
   },
   {
@@ -297,11 +295,11 @@
    "outputs": [],
    "source": [
     "def no_error(output):\n",
-    "    return 1.0 if output[\"result\"].get(\"error\") is None else 0.0\n",
+    "    return 1.0 if output.get(\"error\") is None else 0.0\n",
     "\n",
     "\n",
     "def has_results(output):\n",
-    "    results = output[\"result\"].get(\"results\")\n",
+    "    results = output.get(\"results\")\n",
     "    print(results)\n",
     "    has_results = results is not None and len(results) > 0\n",
     "    return 1.0 if has_results else 0.0"
@@ -427,9 +425,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Amazing. It looks like we removed one of the errors, and got a result for the incorrect query. Let's add the \"Which team won the most games in 2015?\" row to our dataset, since its answer now looks correct.\n",
-    "\n"
+    "Amazing. It looks like we removed one of the errors, and got a result for the incorrect query. Let's try out using LLM as a judge to see how well it can assess the results.\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phoenix.datasets.evaluators.llm_evaluators import LLMCriteriaEvaluator\n",
+    "from phoenix.datasets.experiments import evaluate_experiment\n",
+    "from phoenix.evals.models import OpenAIModel\n",
+    "\n",
+    "llm_evaluator = LLMCriteriaEvaluator(\n",
+    "    name=\"is_sql\",\n",
+    "    criteria=\"is_sql\",\n",
+    "    description=\"the output is a valid SQL query and that it executes without errors\",\n",
+    "    model=OpenAIModel(),\n",
+    ")\n",
+    "\n",
+    "evaluate_experiment(experiment, evaluators=[llm_evaluator])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/experiments/experiments_txt2sql.ipynb
+++ b/tutorials/experiments/experiments_txt2sql.ipynb
@@ -445,7 +445,7 @@
     "    model=OpenAIModel(),\n",
     ")\n",
     "\n",
-    "evaluate_experiment(experiment, evaluators=[llm_evaluator])\n"
+    "evaluate_experiment(experiment, evaluators=[llm_evaluator])"
    ]
   },
   {


### PR DESCRIPTION
resolves #3613 
resolves #3665 

Displays the evaluator trace when clicked.
<img width="1734" alt="Screenshot 2024-06-26 at 3 36 54 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/2cf85daa-10d3-4f08-af43-193704c15f01">
