### PR TITLE
fix(datasets): show full bar on evals of all 1s

### DIFF
--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -398,13 +398,18 @@ function AnnotationAggregationCell({
   min?: number | null;
   max?: number | null;
 }) {
-  min = typeof min === "number" ? min : 0;
-  max = typeof max === "number" ? max : 1;
   const color = useWordColor(annotationName);
   const percentile = useMemo(() => {
+    // Assume a 0 to 1 range if min and max are not provided
+    const correctedMin = typeof min === "number" ? min : 0;
+    const correctedMax = typeof max === "number" ? max : 1;
+    if (correctedMin === correctedMax && correctedMax === value) {
+      // All the values are the same, so we want to display it as full rather than empty
+      return 100;
+    }
     // Avoid division by zero
-    const range = max - min || 1;
-    return ((value - min) / range) * 100;
+    const range = correctedMin - correctedMax || 1;
+    return ((value - correctedMin) / range) * 100;
   }, [value, min, max]);
   return (
     <TooltipTrigger>
@@ -421,7 +426,7 @@ function AnnotationAggregationCell({
         >
           {floatFormatter(value)}
           <ProgressBar
-            width="30px"
+            width="40px"
             value={percentile}
             aria-label="where the mean score lands between overall min max"
           />


### PR DESCRIPTION
resolve #3711

Show a full bar when you get all 1s.
<img width="658" alt="Screenshot 2024-06-28 at 2 54 46 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/8dc85020-8d5b-47da-bab8-4c0f85f5ce9b">
