### PR TITLE
fix: run_experiment works even if nest_asyncio is not applied

### DIFF
--- a/src/phoenix/datasets/experiments.py
+++ b/src/phoenix/datasets/experiments.py
@@ -309,6 +309,11 @@ def run_experiment(
     print("✅ Task runs completed.")
 
     if evaluators_by_name:
+        # The same httpx client cannot be used in more than one event loop
+        # without nest_asyncio, so we must ensure that we have separate clients
+        # for running tasks and evaluators. For details, see:
+        # https://github.com/encode/httpx/discussions/2959#discussioncomment-7665278
+        sync_client, async_client = _phoenix_clients()
         _evaluate_experiment(
             experiment,
             evaluators=evaluators_by_name,


### PR DESCRIPTION
Script to reproduce issue (use the dataset from the quickstart notebook).

```python
from typing import Any, Dict

import phoenix as px
from openai import OpenAI
from phoenix.datasets.experiments import run_experiment
from phoenix.datasets.types import Example

phoenix_client = px.Client()
dataset = phoenix_client.get_dataset(id="RGF0YXNldDo4")


openai_client = OpenAI()

task_prompt_template = "Answer in a few words: {question}"


def task(example: Example) -> str:
    question = example.input["question"]
    message_content = task_prompt_template.format(question=question)
    response = openai_client.chat.completions.create(
        model="gpt-4o", messages=[{"role": "user", "content": message_content}]
    )
    return response.choices[0].message.content


def jaccard_similarity(output: str, expected: Dict[str, Any]) -> float:
    actual_words = set(output.lower().split(" "))
    expected_words = set(expected["answer"].lower().split(" "))
    words_in_common = actual_words.intersection(expected_words)
    all_words = actual_words.union(expected_words)
    return len(words_in_common) / len(all_words)


experiment = run_experiment(
    dataset,
    task,
    experiment_name="initial-experiment",
    evaluators=[
        jaccard_similarity,
    ],
)

```

resolves #3708
