### PR TITLE
fix: openapi yaml parsing for containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "cachetools",
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=0.13.1",
+  "pyyaml", # for OpenAPI
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
pyyaml is available in colab etc. but not in the container. This fixes the rendering via a hosted phoenix.