### PR TITLE
fix(experiments): order annotations by name to make output deterministic

### DIFF
--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -433,7 +433,7 @@ function AnnotationAggregationCell({
       return 100;
     }
     // Avoid division by zero
-    const range = correctedMin - correctedMax || 1;
+    const range = correctedMax - correctedMin || 1;
     return ((value - correctedMin) / range) * 100;
   }, [value, min, max]);
   return (

--- a/src/phoenix/server/api/types/ExperimentRun.py
+++ b/src/phoenix/server/api/types/ExperimentRun.py
@@ -53,7 +53,7 @@ class ExperimentRun(Node):
                 await session.scalars(
                     select(models.ExperimentRunAnnotation)
                     .where(models.ExperimentRunAnnotation.experiment_run_id == run_id)
-                    .order_by(models.ExperimentRunAnnotation.id.desc())
+                    .order_by(models.ExperimentRunAnnotation.name.desc())
                 )
             ).all()
         return connection_from_list(


### PR DESCRIPTION
Before and after
<img width="703" alt="Screenshot 2024-07-02 at 1 50 43 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/cc456979-8475-4c27-aab4-9bc0134e02a0">
<img width="705" alt="Screenshot 2024-07-02 at 1 50 22 PM" src="https://github.com/Arize-ai/phoenix/assets/5640648/749bc792-f729-4ffc-9972-3b301eef6897">
