### PR TITLE
fix: allow invocations of OpenAIModel without api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sdist
 
 # Testing
 coverage.xml
+.tox
 
 # devtools
 pyrightconfig.json

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -19,7 +19,6 @@ from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
 
-OPENAI_API_KEY_ENVVAR_NAME = "OPENAI_API_KEY"
 MINIMUM_OPENAI_VERSION = "1.0.0"
 MODEL_TOKEN_LIMIT_MAPPING = {
     "gpt-3.5-turbo-instruct": 4096,
@@ -152,20 +151,6 @@ class OpenAIModel(BaseModel):
         self._is_azure = bool(self.azure_endpoint)
 
         self._model_uses_legacy_completion_api = self.model.startswith(LEGACY_COMPLETION_API_MODELS)
-        if self.api_key is None:
-            api_key = os.getenv(OPENAI_API_KEY_ENVVAR_NAME)
-            if api_key is None:
-                # TODO: Create custom AuthenticationError
-                if self._is_azure:
-                    raise RuntimeError(
-                        "Azure API key not provided. Pass it as an argument to 'api_key' "
-                        "or set it in your environment: 'export OPENAI_API_KEY=****'"
-                    )
-                raise RuntimeError(
-                    "OpenAI's API key not provided. Pass it as an argument to 'api_key' "
-                    "or set it in your environment: 'export OPENAI_API_KEY=sk-****'"
-                )
-            self.api_key = api_key
 
         # Set the version, organization, and base_url - default to openAI
         self.api_version = self.api_version or self._openai.api_version

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from dataclasses import dataclass, field, fields
 from typing import (

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_generate.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_generate.py
@@ -10,8 +10,9 @@ import pytest
 import respx
 from phoenix.evals import OpenAIModel, llm_generate
 from phoenix.evals.models.litellm import LiteLLMModel
-from phoenix.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME
 from respx.patterns import M
+
+OPENAI_API_KEY_ENVVAR_NAME = "OPENAI_API_KEY"
 
 
 @pytest.mark.respx(base_url="https://api.openai.com/v1/chat/completions")

--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_openai.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_openai.py
@@ -2,7 +2,10 @@ from unittest import mock
 
 import pytest
 from openai import AzureOpenAI, OpenAI
-from phoenix.evals.models.openai import OPENAI_API_KEY_ENVVAR_NAME, OpenAIModel
+from phoenix.evals.models.openai import OpenAIModel
+
+OPENAI_API_KEY_ENVVAR_NAME = "OPENAI_API_KEY"
+AZURE_OPENAI_API_KEY_ENVVAR_NAME = "AZURE_OPENAI_API_KEY"
 
 
 def test_openai_model(monkeypatch):
@@ -19,7 +22,7 @@ def test_openai_model(monkeypatch):
 
 
 def test_azure_openai_model(monkeypatch):
-    monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
+    monkeypatch.setenv(AZURE_OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     model = OpenAIModel(
         model="gpt-4-turbo-preview",
         api_version="2023-07-01-preview",
@@ -29,7 +32,7 @@ def test_azure_openai_model(monkeypatch):
 
 
 def test_azure_openai_model_added_custom_header(monkeypatch):
-    monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
+    monkeypatch.setenv(AZURE_OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     header_key = "header"
     header_value = "my-example-header-value"
     default_headers = {header_key: header_value}
@@ -65,7 +68,7 @@ def test_azure_fails_when_missing_options(monkeypatch):
 
 
 def test_azure_supports_function_calling(monkeypatch):
-    monkeypatch.setenv(OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
+    monkeypatch.setenv(AZURE_OPENAI_API_KEY_ENVVAR_NAME, "sk-0123456789")
     model = OpenAIModel(
         model="gpt-4-turbo-preview",
         api_version="2023-07-01-preview",


### PR DESCRIPTION
`AzureOpenAI` and `AsyncAzureOpenAI` don't need an API key if using Active Directory. The combinations of valid parameters and environment variables is complex (`azure_ad_token`, `azure_ad_token_provider`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_AD_TOKEN`). This PR allows the OpenAI SDK to parse environment variables and validate rather than us trying to parse and validate.

resolves #3813

