### PR TITLE
fix: Run Bedrock calls in executor for async

### DIFF
--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_bedrock.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_bedrock.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import boto3
+import pytest
 from phoenix.evals import BedrockModel
 
 
@@ -6,3 +9,12 @@ def test_bedrock_model_can_be_instantiated():
     session = boto3.Session(region_name="us-west-2")
     model = BedrockModel(session=session)
     assert model
+
+
+def test_bedrock_async_propagates_errors():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'invoke_model'"):
+        session = boto3.Session(region_name="us-west-2")
+        client = session.client("bedrock-runtime")
+        model = BedrockModel(session=session, client=client)
+        model.client = None
+        asyncio.run(model._async_generate("prompt"))


### PR DESCRIPTION
Wraps synchronous calls in an executor for async support in Bedrock evals.

The current code makes a synchronous call in an async function. As a result, calling `run_evals`:
1. Doesn't actually parallelize while using bedrock, resulting in very low throughput
2. Doesn't properly display the progress bar since all calls are made before the `gather`. This confuses the user and makes them think something is wrong.

Proper async support in boto3 has been [asked for for years](https://github.com/boto/botocore/issues/458), so I don't think we can count on it any time soon. Wrapping in an executor ties up some threads on I/O, but still results in significantly higher throughput, which I think eval users (including myself) require.