### PR TITLE
feat(annotations): ability to copy span and trace IDs

### DIFF
--- a/app/src/pages/trace/SpanCodeDropdown.tsx
+++ b/app/src/pages/trace/SpanCodeDropdown.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+import {
+  DropdownButton,
+  DropdownMenu,
+  DropdownTrigger,
+  Flex,
+  Form,
+  Icon,
+  Icons,
+  TextField,
+  View,
+} from "@arizeai/components";
+
+import { CopyToClipboardButton } from "@phoenix/components";
+
+type SpanCodeDropdownProps = {
+  spanId: string;
+  traceId: string;
+};
+/**
+ * A Dropdown that displays how to code against a span or trace
+ */
+export function SpanCodeDropdown(props: SpanCodeDropdownProps) {
+  const { spanId, traceId } = props;
+
+  return (
+    <div
+      css={css`
+        button.ac-dropdown-button {
+          min-width: 50px;
+          .ac-dropdown-button__text {
+            padding-right: 10px;
+          }
+        }
+      `}
+    >
+      <DropdownTrigger placement="bottom right">
+        <DropdownButton addonBefore={<Icon svg={<Icons.Code />} />}>
+          Code
+        </DropdownButton>
+        <DropdownMenu>
+          <View padding="size-200">
+            <Form>
+              <Flex direction="row" gap="size-100" alignItems="end">
+                <TextField label="Span ID" isReadOnly value={spanId} />
+                <CopyToClipboardButton text={spanId} size="normal" />
+              </Flex>
+              <Flex direction="row" gap="size-100" alignItems="end">
+                <TextField label="Trace ID" isReadOnly value={traceId} />
+                <CopyToClipboardButton text={traceId} size="normal" />
+              </Flex>
+            </Form>
+          </View>
+        </DropdownMenu>
+      </DropdownTrigger>
+    </div>
+  );
+}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -93,6 +93,7 @@ import {
   TraceDetailsQuery,
   TraceDetailsQuery$data,
 } from "./__generated__/TraceDetailsQuery.graphql";
+import { SpanCodeDropdown } from "./SpanCodeDropdown";
 import { SpanEvaluationsTable } from "./SpanEvaluationsTable";
 import { SpanToDatasetExampleDialog } from "./SpanToDatasetExampleDialog";
 
@@ -181,6 +182,7 @@ export function TraceDetails(props: TraceDetailsProps) {
                     id
                     context {
                       spanId
+                      traceId
                     }
                     name
                     spanKind
@@ -436,8 +438,8 @@ function SelectedSpanDetails({ selectedSpan }: { selectedSpan: Span }) {
   return (
     <Flex direction="column" flex="1 1 auto" height="100%">
       <View
-        paddingTop="size-75"
-        paddingBottom="size-75"
+        paddingTop="size-100"
+        paddingBottom="size-100"
         paddingStart="size-150"
         paddingEnd="size-200"
         flex="none"
@@ -449,9 +451,13 @@ function SelectedSpanDetails({ selectedSpan }: { selectedSpan: Span }) {
           alignItems="center"
         >
           <SpanItem {...selectedSpan} />
-          <View flex="none">
+          <Flex flex="none" direction="row" alignItems="center" gap="size-100">
+            <SpanCodeDropdown
+              traceId={selectedSpan.context.traceId}
+              spanId={selectedSpan.context.spanId}
+            />
             <AddSpanToDatasetButton span={selectedSpan} />
-          </View>
+          </Flex>
         </Flex>
       </View>
       <Tabs>
@@ -526,7 +532,6 @@ function AddSpanToDatasetButton({ span }: { span: Span }) {
     <>
       <Button
         variant="default"
-        size="compact"
         icon={<Icon svg={<Icons.DatabaseOutline />} />}
         onClick={onAddSpanToDataset}
       >

--- a/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cb61f21b25105ea1d593b0791dd65372>>
+ * @generated SignedSource<<03387a5b510122c5aca7a286f8706af4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,7 @@ export type TraceDetailsQuery$data = {
             readonly attributes: string;
             readonly context: {
               readonly spanId: string;
+              readonly traceId: string;
             };
             readonly documentEvaluations: ReadonlyArray<{
               readonly documentPosition: number;
@@ -133,6 +134,13 @@ v6 = {
       "args": null,
       "kind": "ScalarField",
       "name": "spanId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "traceId",
       "storageKey": null
     }
   ],
@@ -591,16 +599,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "09420fac27c4768b8a68fa7ee918cdfb",
+    "cacheID": "a7eb8bfce36ca7633be29b3bde1952b8",
     "id": null,
     "metadata": {},
     "name": "TraceDetailsQuery",
     "operationKind": "query",
-    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              context {\n                spanId\n              }\n              name\n              spanKind\n              statusCode: propagatedStatusCode\n              statusMessage\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n              input {\n                value\n                mimeType\n              }\n              output {\n                value\n                mimeType\n              }\n              attributes\n              events {\n                name\n                message\n                timestamp\n              }\n              spanEvaluations {\n                name\n                label\n                score\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n              documentEvaluations {\n                documentPosition\n                name\n                label\n                score\n                explanation\n              }\n              ...SpanEvaluationsTable_evals\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanEvaluationsTable_evals on Span {\n  spanEvaluations {\n    name\n    label\n    score\n    explanation\n  }\n}\n"
+    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              context {\n                spanId\n                traceId\n              }\n              name\n              spanKind\n              statusCode: propagatedStatusCode\n              statusMessage\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n              input {\n                value\n                mimeType\n              }\n              output {\n                value\n                mimeType\n              }\n              attributes\n              events {\n                name\n                message\n                timestamp\n              }\n              spanEvaluations {\n                name\n                label\n                score\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n              documentEvaluations {\n                documentPosition\n                name\n                label\n                score\n                explanation\n              }\n              ...SpanEvaluationsTable_evals\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanEvaluationsTable_evals on Span {\n  spanEvaluations {\n    name\n    label\n    score\n    explanation\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d8dff7c0dd0c97ffe1540aff1504de4a";
+(node as any).hash = "77c479ec3740896d2dadf3010f72760a";
 
 export default node;


### PR DESCRIPTION
resolves #3894 

adds the ability to copy paste a span or trace id

<img width="1338" alt="Screenshot 2024-07-15 at 12 19 31 PM" src="https://github.com/user-attachments/assets/4304d716-2d11-4679-9538-3a0c75f8e993">
