### PR TITLE
feat(UI): user preferences context with markdown preferences

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.4.2",
+    "@arizeai/components": "^1.5.1",
     "@arizeai/openinference-semantic-conventions": "^0.8.0",
     "@arizeai/point-cloud": "^3.0.4",
     "@codemirror/autocomplete": "6.12.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@arizeai/components':
-    specifier: ^1.4.2
-    version: 1.4.2(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^1.5.1
+    version: 1.5.1(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)
   '@arizeai/openinference-semantic-conventions':
     specifier: ^0.8.0
     version: 0.8.0
@@ -225,8 +225,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@arizeai/components@1.4.2(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-rRE7ka5+KAbKNrmM5pdVYEWaVB34OaB7HxZdyBHkp5MjC+giTdFnSw+XGEmMEI1HsST5j6E3L7zsTqqP6ravIQ==}
+  /@arizeai/components@1.5.1(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-FaQlP2uYGVTCBkB5CPpe1SbR+gH5TihQ6r0fioka8jtzUbE0ftz8BDQdaVdU16XeEuZIUMVzzryA+US1xj/mug==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=18'

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { Provider, theme } from "@arizeai/components";
 
 import { FeatureFlagsProvider } from "./contexts/FeatureFlagsContext";
+import { PreferencesProvider } from "./contexts/PreferencesContext";
 import { NotificationProvider, ThemeProvider, useTheme } from "./contexts";
 import { GlobalStyles } from "./GlobalStyles";
 import RelayEnvironment from "./RelayEnvironment";
@@ -28,11 +29,13 @@ export function AppContent() {
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <GlobalStyles />
           <FeatureFlagsProvider>
-            <Suspense>
-              <NotificationProvider>
-                <AppRoutes />
-              </NotificationProvider>
-            </Suspense>
+            <PreferencesProvider>
+              <Suspense>
+                <NotificationProvider>
+                  <AppRoutes />
+                </NotificationProvider>
+              </Suspense>
+            </PreferencesProvider>
           </FeatureFlagsProvider>
         </RelayEnvironmentProvider>
       </EmotionThemeProvider>

--- a/app/src/components/markdown/MarkdownDisplayContext.tsx
+++ b/app/src/components/markdown/MarkdownDisplayContext.tsx
@@ -4,8 +4,9 @@ import React, {
   startTransition,
   useCallback,
   useContext,
-  useState,
 } from "react";
+
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 import { MarkdownDisplayMode } from "./types";
 
@@ -29,17 +30,19 @@ export function useMarkdownMode(): MarkdownDisplayContextType {
   return context;
 }
 
-export function MarkdownDisplayProvider(
-  props: PropsWithChildren<{ initialMode?: MarkdownDisplayMode }>
-) {
-  const [mode, _setMode] = useState<MarkdownDisplayMode>(
-    props.initialMode || "text"
+export function MarkdownDisplayProvider(props: PropsWithChildren) {
+  const mode = usePreferencesContext((state) => state.markdownDisplayMode);
+  const setMarkdownDisplayMode = usePreferencesContext(
+    (state) => state.setMarkdownDisplayMode
   );
-  const setMode = useCallback((mode: MarkdownDisplayMode) => {
-    startTransition(() => {
-      _setMode(mode);
-    });
-  }, []);
+  const setMode = useCallback(
+    (mode: MarkdownDisplayMode) => {
+      startTransition(() => {
+        setMarkdownDisplayMode(mode);
+      });
+    },
+    [setMarkdownDisplayMode]
+  );
 
   return (
     <MarkdownDisplayContext.Provider value={{ mode, setMode }}>

--- a/app/src/components/markdown/MarkdownModeRadioGroup.tsx
+++ b/app/src/components/markdown/MarkdownModeRadioGroup.tsx
@@ -25,7 +25,7 @@ export function MarkdownModeRadioGroup({
     <RadioGroup
       size="compact"
       variant="inline-button"
-      defaultValue={mode}
+      value={mode}
       onChange={(value) => {
         onModeChange(value as MarkdownDisplayMode);
       }}

--- a/app/src/contexts/PreferencesContext.tsx
+++ b/app/src/contexts/PreferencesContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, PropsWithChildren, useRef } from "react";
+import { useZustand } from "use-zustand";
+
+import {
+  createPreferencesStore,
+  PreferencesProps,
+  PreferencesState,
+  PreferencesStore,
+} from "@phoenix/store/preferencesStore";
+
+export const PreferencesContext = createContext<PreferencesStore | null>(null);
+
+export function PreferencesProvider({
+  children,
+  ...props
+}: PropsWithChildren<Partial<PreferencesProps>>) {
+  const storeRef = useRef<PreferencesStore>();
+  if (!storeRef.current) {
+    storeRef.current = createPreferencesStore(props);
+  }
+  return (
+    <PreferencesContext.Provider value={storeRef.current}>
+      {children}
+    </PreferencesContext.Provider>
+  );
+}
+
+export function usePreferencesContext<T>(
+  selector: (state: PreferencesState) => T,
+  equalityFn?: (left: T, right: T) => boolean
+): T {
+  const store = React.useContext(PreferencesContext);
+  if (!store)
+    throw new Error("Missing PreferencesContext.Provider in the tree");
+  return useZustand(store, selector, equalityFn);
+}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -900,7 +900,7 @@ function RetrieverSpanInfo(props: {
         </MarkdownDisplayProvider>
       ) : null}
       {hasDocuments ? (
-        <MarkdownDisplayProvider initialMode="markdown">
+        <MarkdownDisplayProvider>
           <Card
             title="Documents"
             {...defaultCardProps}

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -1,0 +1,35 @@
+import { create, StateCreator } from "zustand";
+import { devtools } from "zustand/middleware";
+
+export type MarkdownDisplayMode = "text" | "markdown";
+
+export interface PreferencesProps {
+  /**
+   * The display mode of markdown text
+   * @default "text"
+   */
+  markdownDisplayMode: MarkdownDisplayMode;
+}
+
+export interface PreferencesState extends PreferencesProps {
+  /**
+   * Sets the display mode of markdown text
+   * @param generativeTextDisplayMode
+   */
+  setMarkdownDisplayMode: (markdownDisplayMode: MarkdownDisplayMode) => void;
+}
+
+export const createPreferencesStore = (
+  initialProps?: Partial<PreferencesProps>
+) => {
+  const preferencesStore: StateCreator<PreferencesState> = (set) => ({
+    ...initialProps,
+    markdownDisplayMode: "text",
+    setMarkdownDisplayMode: (markdownDisplayMode) => {
+      set({ markdownDisplayMode });
+    },
+  });
+  return create<PreferencesState>()(devtools(preferencesStore));
+};
+
+export type PreferencesStore = ReturnType<typeof createPreferencesStore>;

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -1,5 +1,5 @@
 import { create, StateCreator } from "zustand";
-import { devtools } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 
 export type MarkdownDisplayMode = "text" | "markdown";
 
@@ -29,7 +29,11 @@ export const createPreferencesStore = (
       set({ markdownDisplayMode });
     },
   });
-  return create<PreferencesState>()(devtools(preferencesStore));
+  return create<PreferencesState>()(
+    persist(devtools(preferencesStore), {
+      name: "arize-phoenix-preferences",
+    })
+  );
 };
 
 export type PreferencesStore = ReturnType<typeof createPreferencesStore>;


### PR DESCRIPTION
resolves #3898

Adds a new preferences context and uses local storage to persist the information automatically. Used to store whether or not the user prefers markdown display or not.

https://github.com/user-attachments/assets/d417d4bb-266a-4eba-9007-1c6b84d040ae

