### PR TITLE
feat(annotations): annotations UI

### DIFF
--- a/app/src/components/dataset/CreateDatasetForm.tsx
+++ b/app/src/components/dataset/CreateDatasetForm.tsx
@@ -68,7 +68,6 @@ export function CreateDatasetForm(props: CreateDatasetFormProps) {
         },
         onError: (error) => {
           // TODO(datasets): cleanup error handling to show human friendly error
-
           onDatasetCreateError(error);
         },
       });

--- a/app/src/contexts/FeatureFlagsContext.tsx
+++ b/app/src/contexts/FeatureFlagsContext.tsx
@@ -3,7 +3,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { Dialog, DialogContainer, Switch, View } from "@arizeai/components";
 
-type FeatureFlag = "__CLEAR__"; // No feature flags right now
+type FeatureFlag = "annotations";
 export type FeatureFlagsContextType = {
   featureFlags: Record<FeatureFlag, boolean>;
   setFeatureFlags: (featureFlags: Record<FeatureFlag, boolean>) => void;
@@ -12,7 +12,7 @@ export type FeatureFlagsContextType = {
 export const LOCAL_STORAGE_FEATURE_FLAGS_KEY = "arize-phoenix-feature-flags";
 
 const DEFAULT_FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
-  __CLEAR__: false,
+  annotations: false,
 };
 
 function getFeatureFlags(): Record<FeatureFlag, boolean> {

--- a/app/src/pages/trace/AnnotationActionMenu.tsx
+++ b/app/src/pages/trace/AnnotationActionMenu.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+import { ActionMenu, Flex, Icon, Icons, Item, Text } from "@arizeai/components";
+
+type AnnotationActionMenuProps = {
+  onDelete: () => void;
+  isDisabled?: boolean;
+};
+
+enum AnnotationAction {
+  DELETE = "deleteAnnotation",
+}
+
+/**
+ * A generic action menu for annotations that can be extended
+ */
+export function AnnotationActionMenu(props: AnnotationActionMenuProps) {
+  const { onDelete, isDisabled = false } = props;
+  return (
+    <div
+      // TODO: add this logic to the ActionMenu component
+      onClick={(e) => {
+        // prevent parent anchor link from being followed
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <ActionMenu
+        align="end"
+        buttonSize="compact"
+        isDisabled={isDisabled}
+        onAction={(action) => {
+          switch (action) {
+            case AnnotationAction.DELETE:
+              onDelete();
+              break;
+          }
+        }}
+      >
+        <Item key={AnnotationAction.DELETE}>
+          <Flex
+            direction="row"
+            gap="size-75"
+            justifyContent="start"
+            alignItems="center"
+          >
+            <Icon svg={<Icons.TrashOutline />} />
+            <Text>Delete</Text>
+          </Flex>
+        </Item>
+      </ActionMenu>
+    </div>
+  );
+}

--- a/app/src/pages/trace/EditSpanAnnotationsButton.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsButton.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode, useState } from "react";
+
+import { Button, DialogContainer, Icon, Icons } from "@arizeai/components";
+
+import { EditSpanAnnotationsDialog } from "./EditSpanAnnotationsDialog";
+
+export function EditSpanAnnotationsButton(props: {
+  spanNodeId: string;
+  projectId: string;
+}) {
+  const { spanNodeId, projectId } = props;
+  const [dialog, setDialog] = useState<ReactNode>(null);
+  return (
+    <>
+      <Button
+        variant="default"
+        icon={<Icon svg={<Icons.EditOutline />} />}
+        onClick={() =>
+          setDialog(
+            <EditSpanAnnotationsDialog
+              spanNodeId={spanNodeId}
+              projectId={projectId}
+            />
+          )
+        }
+      >
+        Annotate
+      </Button>
+      <DialogContainer
+        type="slideOver"
+        isDismissable
+        onDismiss={() => setDialog(null)}
+      >
+        {dialog}
+      </DialogContainer>
+    </>
+  );
+}

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -1,0 +1,394 @@
+import React, { Suspense, useMemo, useState } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { css } from "@emotion/react";
+
+import {
+  Alert,
+  Button,
+  Card,
+  Dialog,
+  Flex,
+  Icon,
+  Icons,
+  Item,
+  Label,
+  ListBox,
+  PopoverTrigger,
+  TextField,
+  View,
+} from "@arizeai/components";
+
+import { Empty } from "@phoenix/components/Empty";
+import { useNotifySuccess } from "@phoenix/contexts";
+import { formatFloat } from "@phoenix/utils/numberFormatUtils";
+
+import { EditSpanAnnotationsDialogNewAnnotationQuery } from "./__generated__/EditSpanAnnotationsDialogNewAnnotationQuery.graphql";
+import {
+  AnnotatorKind,
+  EditSpanAnnotationsDialogQuery,
+  EditSpanAnnotationsDialogQuery$data,
+} from "./__generated__/EditSpanAnnotationsDialogQuery.graphql";
+import { SpanAnnotationActionMenu } from "./SpanAnnotationActionMenu";
+import { SpanAnnotationForm } from "./SpanAnnotationForm";
+
+type EditSpanAnnotationsDialogProps = {
+  spanNodeId: string;
+  projectId: string;
+};
+export function EditSpanAnnotationsDialog(
+  props: EditSpanAnnotationsDialogProps
+) {
+  const { projectId, spanNodeId } = props;
+  const [newAnnotationName, setNewAnnotationName] = useState<string | null>(
+    null
+  );
+  return (
+    <Dialog
+      title="Annotate"
+      size="M"
+      extra={
+        <NewAnnotationButton
+          projectId={projectId}
+          spanNodeId={spanNodeId}
+          onAnnotationNameSelect={setNewAnnotationName}
+        />
+      }
+    >
+      <div
+        css={css`
+          height: 100%;
+          overflow-y: auto;
+          padding: var(--ac-global-dimension-size-200);
+        `}
+      >
+        {newAnnotationName && (
+          <View paddingBottom="size-200">
+            <NewSpanAnnotationCard
+              name={newAnnotationName}
+              onDelete={() => {
+                setNewAnnotationName(null);
+              }}
+            />
+          </View>
+        )}
+        <Suspense>
+          <EditSpanAnnotations {...props} />
+        </Suspense>
+      </div>
+    </Dialog>
+  );
+}
+
+type NewAnnotationButtonProps = {
+  projectId: string;
+  spanNodeId: string;
+  onAnnotationNameSelect: (name: string) => void;
+};
+
+function NewAnnotationButton(props: NewAnnotationButtonProps) {
+  const { projectId, spanNodeId, onAnnotationNameSelect } = props;
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  return (
+    <PopoverTrigger
+      placement="bottom end"
+      crossOffset={300}
+      isOpen={isPopoverOpen}
+      onOpenChange={(isOpen) => {
+        setIsPopoverOpen(isOpen);
+      }}
+    >
+      <Button
+        variant="default"
+        size="compact"
+        icon={<Icon svg={<Icons.PlusCircleOutline />} />}
+        onClick={() => {
+          setIsPopoverOpen(true);
+        }}
+      >
+        New
+      </Button>
+      <NewAnnotationPopover
+        projectId={projectId}
+        spanNodeId={spanNodeId}
+        onAnnotationNameSelect={(name) => {
+          onAnnotationNameSelect(name);
+          setIsPopoverOpen(false);
+        }}
+      />
+    </PopoverTrigger>
+  );
+}
+
+type NewAnnotationPopoverProps = {
+  projectId: string;
+  spanNodeId: string;
+  onAnnotationNameSelect: (name: string) => void;
+};
+
+function NewAnnotationPopover(props: NewAnnotationPopoverProps) {
+  const { projectId, spanNodeId, onAnnotationNameSelect } = props;
+  return (
+    <Card
+      title="New Annotation"
+      backgroundColor="light"
+      borderColor="light"
+      variant="compact"
+      bodyStyle={{ padding: 0 }}
+    >
+      <Suspense>
+        <NewAnnotationPopoverContent
+          projectId={projectId}
+          spanId={spanNodeId}
+          onAnnotationNameSelect={onAnnotationNameSelect}
+        />
+      </Suspense>
+    </Card>
+  );
+}
+type EditSpanAnnotationsProps = EditSpanAnnotationsDialogProps;
+function EditSpanAnnotations(props: EditSpanAnnotationsProps) {
+  const data = useLazyLoadQuery<EditSpanAnnotationsDialogQuery>(
+    graphql`
+      query EditSpanAnnotationsDialogQuery($spanId: GlobalID!) {
+        span: node(id: $spanId) {
+          id
+          ... on Span {
+            spanAnnotations {
+              id
+              name
+              annotatorKind
+              score
+              label
+              explanation
+            }
+          }
+        }
+      }
+    `,
+    { spanId: props.spanNodeId }
+  );
+  const annotations = data.span.spanAnnotations || [];
+  const hasAnnotations = annotations.length > 0;
+  return (
+    <div>
+      {!hasAnnotations && (
+        <Empty graphicKey="documents" message="No annotations for this span" />
+      )}
+      <ul
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: var(--ac-global-dimension-size-200);
+        `}
+      >
+        {annotations.map((annotation, idx) => (
+          <li key={idx}>
+            <SpanAnnotationCard annotation={annotation} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function NewSpanAnnotationCard(props: { name: string; onDelete: () => void }) {
+  const { name, onDelete } = props;
+
+  return (
+    <Card
+      variant="compact"
+      title={name}
+      extra={
+        <Flex direction="row" alignItems="center" gap="size-100">
+          <AnnotatorKindLabel kind="HUMAN" />
+          <Button
+            variant="default"
+            size="compact"
+            isDisabled
+            aria-label="delete annotation"
+            icon={<Icon svg={<Icons.CloseOutline />} />}
+            onClick={onDelete}
+          />
+        </Flex>
+      }
+      bodyStyle={{ padding: 0 }}
+    >
+      <SpanAnnotationForm
+        initialData={{ name }}
+        onSubmit={(data) => {
+          alert(JSON.stringify(data));
+        }}
+      />
+    </Card>
+  );
+}
+
+type Annotation = NonNullable<
+  EditSpanAnnotationsDialogQuery$data["span"]["spanAnnotations"]
+>[number];
+
+function SpanAnnotationCard(props: { annotation: Annotation }) {
+  const { annotation } = props;
+  const [error, setError] = useState<Error | null>(null);
+  const notifySuccess = useNotifySuccess();
+  const isLLMAnnotation = annotation.annotatorKind === "LLM";
+  /* By default we collapse LLM annotations since for now they are non-editable */
+  const isDefaultCollapsed = isLLMAnnotation;
+  const isReadOnly = isLLMAnnotation;
+  return (
+    <Card
+      variant="compact"
+      title={annotation.name}
+      titleExtra={
+        annotation.label ||
+        (typeof annotation.score == "number" &&
+          formatFloat(annotation.score)) ||
+        null
+      }
+      collapsible
+      defaultOpen={!isDefaultCollapsed}
+      bodyStyle={{ padding: 0 }}
+      extra={
+        <Flex gap="size-100" alignItems="center">
+          <AnnotatorKindLabel kind={annotation.annotatorKind} />
+          <SpanAnnotationActionMenu
+            annotationId={annotation.id}
+            annotationName={annotation.name}
+            onSpanAnnotationDelete={() => {
+              notifySuccess({
+                title: `Annotation Deleted`,
+                message: `Annotation ${annotation.name} has been deleted.`,
+              });
+            }}
+            onSpanAnnotationDeleteError={(error: Error) => {
+              setError(error);
+            }}
+          />
+        </Flex>
+      }
+    >
+      {error && (
+        <Alert variant="danger" banner>
+          {error.message}
+        </Alert>
+      )}
+      <SpanAnnotationForm initialData={annotation} isReadOnly={isReadOnly} />
+    </Card>
+  );
+}
+
+function AnnotatorKindLabel(props: { kind: AnnotatorKind }) {
+  const { kind } = props;
+  return (
+    <Label color={kind === "HUMAN" ? "blue-900" : "orange-900"}>{kind}</Label>
+  );
+}
+
+function NewAnnotationPopoverContent(props: {
+  projectId: string;
+  spanId: string;
+  /**
+   * Callback when an annotation name is selected
+   * @param name The name of the annotation
+   */
+  onAnnotationNameSelect: (name: string) => void;
+}) {
+  const { projectId, spanId, onAnnotationNameSelect } = props;
+  const data = useLazyLoadQuery<EditSpanAnnotationsDialogNewAnnotationQuery>(
+    graphql`
+      query EditSpanAnnotationsDialogNewAnnotationQuery(
+        $projectId: GlobalID!
+        $spanId: GlobalID!
+      ) {
+        project: node(id: $projectId) {
+          id
+          ... on Project {
+            spanAnnotationNames
+          }
+        }
+        span: node(id: $spanId) {
+          id
+          ... on Span {
+            spanAnnotations {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      projectId,
+      spanId,
+    }
+  );
+
+  // Use deferred?
+  const [newName, setNewName] = useState<string>("");
+  const existingAnnotationNames = useMemo(() => {
+    return (
+      data?.span?.spanAnnotations?.map((annotation) => annotation.name) || []
+    );
+  }, [data.span.spanAnnotations]);
+
+  const availableNames = useMemo(() => {
+    const names = data.project.spanAnnotationNames || [];
+    return names.filter((name) => !existingAnnotationNames.includes(name));
+  }, [data.project.spanAnnotationNames, existingAnnotationNames]);
+  const hasAvailableNames = availableNames.length > 0;
+  return (
+    <>
+      <View padding="size-200">
+        <Flex direction="row" gap="size-100" alignItems="end">
+          <TextField
+            label="Annotation Name"
+            value={newName}
+            placeholder="e.x. correctness"
+            onChange={(newName) => {
+              setNewName(newName);
+            }}
+          />
+          <Button
+            variant="primary"
+            onClick={() => {
+              onAnnotationNameSelect(newName);
+            }}
+          >
+            Create
+          </Button>
+        </Flex>
+      </View>
+      {hasAvailableNames && (
+        <>
+          <View
+            borderTopWidth="thin"
+            borderBottomWidth="thin"
+            borderColor="light"
+            paddingStart="size-200"
+            paddingTop="size-100"
+            paddingBottom="size-100"
+            backgroundColor="grey-300"
+          >
+            <label>or select from existing</label>
+          </View>
+          <ListBox
+            selectionMode="single"
+            onSelectionChange={(keys) => {
+              // Single select so we can just use the first key
+              if (keys === "all" || keys.size === 0) {
+                return;
+              }
+              const name = keys.entries().next().value[0];
+              onAnnotationNameSelect(name);
+            }}
+            disabledKeys={existingAnnotationNames}
+          >
+            {availableNames.map((name) => (
+              <Item key={name}>{name}</Item>
+            ))}
+          </ListBox>
+        </>
+      )}
+    </>
+  );
+}

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -234,6 +234,7 @@ function NewSpanAnnotationCard(props: {
     <Card
       variant="compact"
       title={name}
+      borderColor="orange-900"
       extra={
         <Flex direction="row" alignItems="center" gap="size-100">
           <AnnotatorKindLabel kind="HUMAN" />

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -28,6 +28,7 @@ import {
   EditSpanAnnotationsDialogQuery,
   EditSpanAnnotationsDialogQuery$data,
 } from "./__generated__/EditSpanAnnotationsDialogQuery.graphql";
+import { NewSpanAnnotationForm } from "./NewSpanAnnotationForm";
 import { SpanAnnotationActionMenu } from "./SpanAnnotationActionMenu";
 import { SpanAnnotationForm } from "./SpanAnnotationForm";
 
@@ -64,8 +65,12 @@ export function EditSpanAnnotationsDialog(
         {newAnnotationName && (
           <View paddingBottom="size-200">
             <NewSpanAnnotationCard
+              spanNodeId={spanNodeId}
               name={newAnnotationName}
               onDelete={() => {
+                setNewAnnotationName(null);
+              }}
+              onCreated={() => {
                 setNewAnnotationName(null);
               }}
             />
@@ -191,8 +196,16 @@ function EditSpanAnnotations(props: EditSpanAnnotationsProps) {
   );
 }
 
-function NewSpanAnnotationCard(props: { name: string; onDelete: () => void }) {
-  const { name, onDelete } = props;
+function NewSpanAnnotationCard(props: {
+  spanNodeId: string;
+  name: string;
+  onDelete: () => void;
+  /**
+   * Callback when the annotation is created
+   */
+  onCreated: () => void;
+}) {
+  const { spanNodeId, name, onDelete, onCreated } = props;
 
   return (
     <Card
@@ -213,11 +226,10 @@ function NewSpanAnnotationCard(props: { name: string; onDelete: () => void }) {
       }
       bodyStyle={{ padding: 0 }}
     >
-      <SpanAnnotationForm
-        initialData={{ name }}
-        onSubmit={(data) => {
-          alert(JSON.stringify(data));
-        }}
+      <NewSpanAnnotationForm
+        annotationName={name}
+        spanNodeId={spanNodeId}
+        onCreated={onCreated}
       />
     </Card>
   );

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -44,6 +44,7 @@ export function EditSpanAnnotationsDialog(
     null
   );
   const [fetchKey, setFetchKey] = useState(0);
+  const notifySuccess = useNotifySuccess();
   return (
     <Dialog
       title="Annotate"
@@ -53,7 +54,7 @@ export function EditSpanAnnotationsDialog(
         <NewAnnotationButton
           projectId={projectId}
           spanNodeId={spanNodeId}
-          isDisabled={newAnnotationName !== null}
+          disabled={newAnnotationName !== null}
           onAnnotationNameSelect={setNewAnnotationName}
         />
       }
@@ -76,6 +77,10 @@ export function EditSpanAnnotationsDialog(
               onCreated={() => {
                 setNewAnnotationName(null);
                 setFetchKey((key) => key + 1);
+                notifySuccess({
+                  title: `New Span Annotation`,
+                  message: `Annotation ${newAnnotationName} has been created.`,
+                });
               }}
             />
           </View>
@@ -91,12 +96,17 @@ export function EditSpanAnnotationsDialog(
 type NewAnnotationButtonProps = {
   projectId: string;
   spanNodeId: string;
-  isDisabled?: boolean;
+  disabled?: boolean;
   onAnnotationNameSelect: (name: string) => void;
 };
 
 function NewAnnotationButton(props: NewAnnotationButtonProps) {
-  const { projectId, isDisabled, spanNodeId, onAnnotationNameSelect } = props;
+  const {
+    projectId,
+    disabled = false,
+    spanNodeId,
+    onAnnotationNameSelect,
+  } = props;
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   return (
     <PopoverTrigger
@@ -109,7 +119,7 @@ function NewAnnotationButton(props: NewAnnotationButtonProps) {
     >
       <Button
         variant="default"
-        isDisabled={isDisabled}
+        disabled={disabled}
         size="compact"
         icon={<Icon svg={<Icons.PlusCircleOutline />} />}
         onClick={() => {
@@ -259,10 +269,6 @@ function SpanAnnotationCard(props: { annotation: Annotation }) {
   const { annotation } = props;
   const [error, setError] = useState<Error | null>(null);
   const notifySuccess = useNotifySuccess();
-  const isLLMAnnotation = annotation.annotatorKind === "LLM";
-  /* By default we collapse LLM annotations since for now they are non-editable */
-  const isDefaultCollapsed = isLLMAnnotation;
-  const isReadOnly = isLLMAnnotation;
   return (
     <Card
       variant="compact"
@@ -274,7 +280,6 @@ function SpanAnnotationCard(props: { annotation: Annotation }) {
         null
       }
       collapsible
-      defaultOpen={!isDefaultCollapsed}
       bodyStyle={{ padding: 0 }}
       extra={
         <Flex gap="size-100" alignItems="center">
@@ -300,7 +305,8 @@ function SpanAnnotationCard(props: { annotation: Annotation }) {
           {error.message}
         </Alert>
       )}
-      <SpanAnnotationForm initialData={annotation} isReadOnly={isReadOnly} />
+      {/* TODO make it editable */}
+      <SpanAnnotationForm initialData={annotation} isReadOnly={true} />
     </Card>
   );
 }

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -358,7 +358,6 @@ function NewAnnotationPopoverContent(props: {
     }
   );
 
-  // Use deferred?
   const [newName, setNewName] = useState<string>("");
   const existingAnnotationNames = useMemo(() => {
     return (

--- a/app/src/pages/trace/NewSpanAnnotationForm.tsx
+++ b/app/src/pages/trace/NewSpanAnnotationForm.tsx
@@ -1,23 +1,53 @@
 import React from "react";
 import { graphql, useMutation } from "react-relay";
 
-import { SpanAnnotationForm } from "./SpanAnnotationForm";
+import { NewSpanAnnotationFormMutation } from "./__generated__/NewSpanAnnotationFormMutation.graphql";
+import {
+  CreateAnnotationInput,
+  SpanAnnotationForm,
+} from "./SpanAnnotationForm";
 
 export type NewSpanAnnotationFormProps = {
   annotationName: string;
+  spanNodeId: string;
+  onCreated: () => void;
 };
 
 export function NewSpanAnnotationForm(props: NewSpanAnnotationFormProps) {
-  const { annotationName: name } = props;
-  const [commit, isCommitting] = useMutation<NewSpanAnnotationMutation>(graphql`
-    mutation NewSpanAnnotationMutation($input: CreateSpanAnnotationInput!) {
-      createSpanAnnotation(input: $input) {
-        spanAnnotation {
-          id
-          name
+  const { annotationName: name, spanNodeId, onCreated } = props;
+  const [commit, isCommitting] = useMutation<NewSpanAnnotationFormMutation>(
+    graphql`
+      mutation NewSpanAnnotationFormMutation(
+        $input: CreateSpanAnnotationInput!
+      ) {
+        createSpanAnnotations(input: [$input]) {
+          spanAnnotations {
+            id
+            name
+          }
         }
       }
-    }
-  `);
-  return <SpanAnnotationForm initialData={{ name }} />;
+    `
+  );
+  const onSubmit = (data: CreateAnnotationInput) => {
+    commit({
+      variables: {
+        input: {
+          spanId: spanNodeId,
+          annotatorKind: "HUMAN",
+          ...data,
+        },
+      },
+      onCompleted: () => {
+        onCreated();
+      },
+    });
+  };
+  return (
+    <SpanAnnotationForm
+      initialData={{ name }}
+      isSubmitting={isCommitting}
+      onSubmit={onSubmit}
+    />
+  );
 }

--- a/app/src/pages/trace/NewSpanAnnotationForm.tsx
+++ b/app/src/pages/trace/NewSpanAnnotationForm.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { graphql, useMutation } from "react-relay";
+
+import { SpanAnnotationForm } from "./SpanAnnotationForm";
+
+export type NewSpanAnnotationFormProps = {
+  annotationName: string;
+};
+
+export function NewSpanAnnotationForm(props: NewSpanAnnotationFormProps) {
+  const { annotationName: name } = props;
+  const [commit, isCommitting] = useMutation<NewSpanAnnotationMutation>(graphql`
+    mutation NewSpanAnnotationMutation($input: CreateSpanAnnotationInput!) {
+      createSpanAnnotation(input: $input) {
+        spanAnnotation {
+          id
+          name
+        }
+      }
+    }
+  `);
+  return <SpanAnnotationForm initialData={{ name }} />;
+}

--- a/app/src/pages/trace/SpanAnnotationActionMenu.tsx
+++ b/app/src/pages/trace/SpanAnnotationActionMenu.tsx
@@ -1,0 +1,112 @@
+import React, {
+  ReactNode,
+  startTransition,
+  useCallback,
+  useState,
+} from "react";
+import { graphql, useMutation } from "react-relay";
+
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  Flex,
+  Text,
+  View,
+} from "@arizeai/components";
+
+import { SpanAnnotationActionMenuDeleteMutation } from "./__generated__/SpanAnnotationActionMenuDeleteMutation.graphql";
+import { AnnotationActionMenu } from "./AnnotationActionMenu";
+
+type SpanAnnotationActionMenuProps = {
+  annotationId: string;
+  annotationName: string;
+  onSpanAnnotationDelete: () => void;
+  onSpanAnnotationDeleteError: (error: Error) => void;
+};
+
+export function SpanAnnotationActionMenu(props: SpanAnnotationActionMenuProps) {
+  const {
+    annotationId,
+    annotationName,
+    onSpanAnnotationDelete,
+    onSpanAnnotationDeleteError,
+  } = props;
+  const [confirmDialog, setConfirmDialog] = useState<ReactNode>(null);
+  const [commitDelete, isCommittingDelete] =
+    useMutation<SpanAnnotationActionMenuDeleteMutation>(graphql`
+      mutation SpanAnnotationActionMenuDeleteMutation(
+        $annotationId: GlobalID!
+      ) {
+        deleteSpanAnnotations(input: { annotationIds: [$annotationId] }) {
+          __typename
+        }
+      }
+    `);
+
+  const handleDelete = useCallback(() => {
+    startTransition(() => {
+      commitDelete({
+        variables: {
+          annotationId,
+        },
+        onCompleted: () => {
+          onSpanAnnotationDelete();
+        },
+        onError: (error) => {
+          onSpanAnnotationDeleteError(error);
+        },
+      });
+    });
+  }, [
+    commitDelete,
+    annotationId,
+    onSpanAnnotationDelete,
+    onSpanAnnotationDeleteError,
+  ]);
+  const onDelete = useCallback(() => {
+    setConfirmDialog(
+      <Dialog size="S" title="Delete Annotation">
+        <View padding="size-200">
+          <Text color="danger">
+            {`Are you sure you want to delete annotation ${annotationName}? This cannot be undone.`}
+          </Text>
+        </View>
+        <View
+          paddingEnd="size-200"
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          borderTopColor="light"
+          borderTopWidth="thin"
+        >
+          <Flex direction="row" justifyContent="end">
+            <Button
+              variant="danger"
+              onClick={() => {
+                handleDelete();
+                setConfirmDialog(null);
+              }}
+            >
+              Delete Annotation
+            </Button>
+          </Flex>
+        </View>
+      </Dialog>
+    );
+  }, [handleDelete, annotationName]);
+  return (
+    <div>
+      <AnnotationActionMenu
+        onDelete={onDelete}
+        isDisabled={isCommittingDelete}
+      />
+      <DialogContainer
+        type="modal"
+        isDismissable
+        onDismiss={() => setConfirmDialog(null)}
+      >
+        {confirmDialog}
+      </DialogContainer>
+    </div>
+  );
+}

--- a/app/src/pages/trace/SpanAnnotationForm.tsx
+++ b/app/src/pages/trace/SpanAnnotationForm.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useRef } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { css } from "@emotion/react";
+
+import { Button, Flex, TextArea, TextField, View } from "@arizeai/components";
+interface AnnotationInterface {
+  name: string;
+  score?: number | string | null;
+  label?: string | null;
+  explanation?: string | null;
+}
+
+type SpanAnnotationFormProps = {
+  /**
+   * The initial data to populate the form with
+   */
+  initialData: AnnotationInterface;
+  /**
+   * Whether the form is read only
+   */
+  isReadOnly?: boolean;
+  /**
+   * Callback to call when the form is submitted
+   */
+  onSubmit?: (data: AnnotationInterface) => void;
+};
+/**
+ * A form to create or edit a span annotation
+ */
+export function SpanAnnotationForm(props: SpanAnnotationFormProps) {
+  const { initialData, isReadOnly, onSubmit } = props;
+  const formRef = useRef<HTMLFormElement>(null);
+  const {
+    control,
+    handleSubmit,
+    formState: { isDirty, isValid },
+    setError,
+  } = useForm({
+    defaultValues: initialData,
+    disabled: isReadOnly,
+  });
+
+  // Internal onSubmit that performs validation
+  const _onSubmit = useCallback(
+    (data: AnnotationInterface) => {
+      if (!data.label && data.score === "") {
+        setError("label", {
+          type: "manual",
+          message: "Label or score is required",
+        });
+        setError("score", {
+          type: "manual",
+          message: "Label or score is required",
+        });
+        return;
+      }
+      onSubmit && onSubmit(data);
+    },
+    [onSubmit, setError]
+  );
+
+  return (
+    <form onSubmit={handleSubmit(_onSubmit)} ref={formRef}>
+      <View padding="size-200">
+        <Flex direction="column" gap="size-100">
+          <div
+            css={css`
+              display: flex;
+              flex-direction: row;
+              gap: var(--ac-global-dimension-size-100);
+              & > * {
+                flex: 1 1 auto;
+              }
+            `}
+          >
+            <Controller
+              name="label"
+              control={control}
+              render={({
+                field: { onChange, onBlur, value },
+                fieldState: { invalid, error },
+              }) => (
+                <TextField
+                  label="Label"
+                  placeholder="e.x. good, bad"
+                  description="A categorical label like 'good' or 'bad'"
+                  isReadOnly={isReadOnly}
+                  errorMessage={error?.message}
+                  validationState={invalid ? "invalid" : "valid"}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  value={value?.toString() || ""}
+                />
+              )}
+            />
+            <Controller
+              name="score"
+              control={control}
+              render={({
+                field: { onChange, onBlur, value },
+                fieldState: { invalid, error },
+              }) => (
+                <TextField
+                  label="Score"
+                  placeholder="e.x. 0.8"
+                  description="A numeric grade"
+                  errorMessage={error?.message}
+                  isReadOnly={isReadOnly}
+                  validationState={invalid ? "invalid" : "valid"}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  value={value?.toString() || ""}
+                />
+              )}
+            />
+          </div>
+          <Controller
+            name="explanation"
+            control={control}
+            render={({
+              field: { onChange, onBlur, value },
+              fieldState: { invalid, error },
+            }) => (
+              <TextArea
+                label="Explanation"
+                height={100}
+                isReadOnly={isReadOnly}
+                description="Why this score or label was given"
+                errorMessage={error?.message}
+                validationState={invalid ? "invalid" : "valid"}
+                onChange={onChange}
+                onBlur={onBlur}
+                value={value?.toString() || ""}
+              />
+            )}
+          />
+        </Flex>
+      </View>
+      <>
+        {!isReadOnly ? (
+          <View padding="size-200" borderTopWidth="thin" borderColor="dark">
+            <Flex direction="row" justifyContent="end">
+              <Button
+                variant="primary"
+                type="submit"
+                isDisabled={!isValid || !isDirty}
+                onClick={() => {
+                  // TODO: This is a bit of a hack as the form is not working in a dialog for some reason
+                  // It probably has to do with the nested DOM structure under which it is being mounted
+                  formRef.current?.requestSubmit();
+                }}
+              >
+                Save
+              </Button>
+            </Flex>
+          </View>
+        ) : null}
+      </>
+    </form>
+  );
+}

--- a/app/src/pages/trace/SpanAnnotationForm.tsx
+++ b/app/src/pages/trace/SpanAnnotationForm.tsx
@@ -77,9 +77,14 @@ export function SpanAnnotationForm(props: SpanAnnotationFormProps) {
             css={css`
               display: flex;
               flex-direction: row;
+              width: 100%;
+              overflow: hidden;
               gap: var(--ac-global-dimension-size-100);
               & > * {
                 flex: 1 1 auto;
+              }
+              .ac-textfield {
+                min-width: 0;
               }
             `}
           >
@@ -134,7 +139,7 @@ export function SpanAnnotationForm(props: SpanAnnotationFormProps) {
             }) => (
               <TextArea
                 label="Explanation"
-                height={100}
+                height={70}
                 isReadOnly={isReadOnly}
                 description="Why this score or label was given"
                 errorMessage={error?.message}
@@ -149,11 +154,19 @@ export function SpanAnnotationForm(props: SpanAnnotationFormProps) {
       </View>
       <>
         {!isReadOnly ? (
-          <View padding="size-200" borderTopWidth="thin" borderColor="dark">
+          <View
+            paddingTop="size-100"
+            paddingBottom="size-100"
+            paddingEnd="size-200"
+            paddingStart="size-200"
+            borderTopWidth="thin"
+            borderColor="dark"
+          >
             <Flex direction="row" justifyContent="end">
               <Button
-                variant="primary"
+                variant={isDirty ? "primary" : "default"}
                 type="submit"
+                size="compact"
                 isDisabled={!isValid || !isDirty || isSubmitting}
                 onClick={() => {
                   // TODO: This is a bit of a hack as the form is not working in a dialog for some reason

--- a/app/src/pages/trace/SpanAnnotationForm.tsx
+++ b/app/src/pages/trace/SpanAnnotationForm.tsx
@@ -112,6 +112,7 @@ export function SpanAnnotationForm(props: SpanAnnotationFormProps) {
               }) => (
                 <TextField
                   label="Score"
+                  type="number"
                   placeholder="e.x. 0.8"
                   description="A numeric grade"
                   errorMessage={error?.message}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -70,6 +70,7 @@ import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon
 import { TraceTree } from "@phoenix/components/trace/TraceTree";
 import { useSpanStatusCodeColor } from "@phoenix/components/trace/useSpanStatusCodeColor";
 import { useNotifySuccess, useTheme } from "@phoenix/contexts";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import {
   AttributeDocument,
   AttributeEmbedding,
@@ -93,6 +94,7 @@ import {
   TraceDetailsQuery,
   TraceDetailsQuery$data,
 } from "./__generated__/TraceDetailsQuery.graphql";
+import { EditSpanAnnotationsButton } from "./EditSpanAnnotationsButton";
 import { SpanCodeDropdown } from "./SpanCodeDropdown";
 import { SpanEvaluationsTable } from "./SpanEvaluationsTable";
 import { SpanToDatasetExampleDialog } from "./SpanToDatasetExampleDialog";
@@ -303,7 +305,10 @@ export function TraceDetails(props: TraceDetailsProps) {
         <Panel>
           <ScrollingTabsWrapper>
             {selectedSpan ? (
-              <SelectedSpanDetails selectedSpan={selectedSpan} />
+              <SelectedSpanDetails
+                selectedSpan={selectedSpan}
+                projectId={projectId}
+              />
             ) : null}
           </ScrollingTabsWrapper>
         </Panel>
@@ -431,10 +436,17 @@ const attributesContextualHelp = (
   </Flex>
 );
 
-function SelectedSpanDetails({ selectedSpan }: { selectedSpan: Span }) {
+function SelectedSpanDetails({
+  selectedSpan,
+  projectId,
+}: {
+  selectedSpan: Span;
+  projectId: string;
+}) {
   const hasExceptions = useMemo<boolean>(() => {
     return spanHasException(selectedSpan);
   }, [selectedSpan]);
+  const showAnnotations = useFeatureFlag("annotations");
   return (
     <Flex direction="column" flex="1 1 auto" height="100%">
       <View
@@ -457,6 +469,12 @@ function SelectedSpanDetails({ selectedSpan }: { selectedSpan: Span }) {
               spanId={selectedSpan.context.spanId}
             />
             <AddSpanToDatasetButton span={selectedSpan} />
+            {showAnnotations ? (
+              <EditSpanAnnotationsButton
+                spanNodeId={selectedSpan.id}
+                projectId={projectId}
+              />
+            ) : null}
           </Flex>
         </Flex>
       </View>

--- a/app/src/pages/trace/__generated__/EditSpanAnnotationsDialogNewAnnotationQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/EditSpanAnnotationsDialogNewAnnotationQuery.graphql.ts
@@ -1,0 +1,201 @@
+/**
+ * @generated SignedSource<<8d4bbc077e978ba841e4de75aff8ad6c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type EditSpanAnnotationsDialogNewAnnotationQuery$variables = {
+  projectId: string;
+  spanId: string;
+};
+export type EditSpanAnnotationsDialogNewAnnotationQuery$data = {
+  readonly project: {
+    readonly id: string;
+    readonly spanAnnotationNames?: ReadonlyArray<string>;
+  };
+  readonly span: {
+    readonly id: string;
+    readonly spanAnnotations?: ReadonlyArray<{
+      readonly id: string;
+      readonly name: string;
+    }>;
+  };
+};
+export type EditSpanAnnotationsDialogNewAnnotationQuery = {
+  response: EditSpanAnnotationsDialogNewAnnotationQuery$data;
+  variables: EditSpanAnnotationsDialogNewAnnotationQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "projectId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "spanId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "projectId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "spanAnnotationNames",
+      "storageKey": null
+    }
+  ],
+  "type": "Project",
+  "abstractKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "spanId"
+  }
+],
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanAnnotation",
+      "kind": "LinkedField",
+      "name": "spanAnnotations",
+      "plural": true,
+      "selections": [
+        (v2/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Span",
+  "abstractKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditSpanAnnotationsDialogNewAnnotationQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "span",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditSpanAnnotationsDialogNewAnnotationQuery",
+    "selections": [
+      {
+        "alias": "project",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "span",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v2/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c27b51c4efeddd745d11b03ac3704a87",
+    "id": null,
+    "metadata": {},
+    "name": "EditSpanAnnotationsDialogNewAnnotationQuery",
+    "operationKind": "query",
+    "text": "query EditSpanAnnotationsDialogNewAnnotationQuery(\n  $projectId: GlobalID!\n  $spanId: GlobalID!\n) {\n  project: node(id: $projectId) {\n    __typename\n    id\n    ... on Project {\n      spanAnnotationNames\n    }\n  }\n  span: node(id: $spanId) {\n    __typename\n    id\n    ... on Span {\n      spanAnnotations {\n        id\n        name\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7498876efb347b23dc5d3a1fa0c3f2ef";
+
+export default node;

--- a/app/src/pages/trace/__generated__/EditSpanAnnotationsDialogQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/EditSpanAnnotationsDialogQuery.graphql.ts
@@ -1,0 +1,175 @@
+/**
+ * @generated SignedSource<<7184374db9223191cda8fda4684866cd>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type AnnotatorKind = "HUMAN" | "LLM";
+export type EditSpanAnnotationsDialogQuery$variables = {
+  spanId: string;
+};
+export type EditSpanAnnotationsDialogQuery$data = {
+  readonly span: {
+    readonly id: string;
+    readonly spanAnnotations?: ReadonlyArray<{
+      readonly annotatorKind: AnnotatorKind;
+      readonly explanation: string | null;
+      readonly id: string;
+      readonly label: string | null;
+      readonly name: string;
+      readonly score: number | null;
+    }>;
+  };
+};
+export type EditSpanAnnotationsDialogQuery = {
+  response: EditSpanAnnotationsDialogQuery$data;
+  variables: EditSpanAnnotationsDialogQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "spanId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "spanId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanAnnotation",
+      "kind": "LinkedField",
+      "name": "spanAnnotations",
+      "plural": true,
+      "selections": [
+        (v2/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "annotatorKind",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "score",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "label",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "explanation",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Span",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditSpanAnnotationsDialogQuery",
+    "selections": [
+      {
+        "alias": "span",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditSpanAnnotationsDialogQuery",
+    "selections": [
+      {
+        "alias": "span",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4703de6d0a741188580b0c6bc115471e",
+    "id": null,
+    "metadata": {},
+    "name": "EditSpanAnnotationsDialogQuery",
+    "operationKind": "query",
+    "text": "query EditSpanAnnotationsDialogQuery(\n  $spanId: GlobalID!\n) {\n  span: node(id: $spanId) {\n    __typename\n    id\n    ... on Span {\n      spanAnnotations {\n        id\n        name\n        annotatorKind\n        score\n        label\n        explanation\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0e5850a0584aaf8e194cad2066d9b2fe";
+
+export default node;

--- a/app/src/pages/trace/__generated__/NewSpanAnnotationFormMutation.graphql.ts
+++ b/app/src/pages/trace/__generated__/NewSpanAnnotationFormMutation.graphql.ts
@@ -1,0 +1,126 @@
+/**
+ * @generated SignedSource<<79ed54366bce1fa7c735125598139cc8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AnnotatorKind = "HUMAN" | "LLM";
+export type CreateSpanAnnotationInput = {
+  annotatorKind: AnnotatorKind;
+  explanation?: string | null;
+  label?: string | null;
+  metadata?: any;
+  name: string;
+  score?: number | null;
+  spanId: string;
+};
+export type NewSpanAnnotationFormMutation$variables = {
+  input: CreateSpanAnnotationInput;
+};
+export type NewSpanAnnotationFormMutation$data = {
+  readonly createSpanAnnotations: {
+    readonly spanAnnotations: ReadonlyArray<{
+      readonly id: string;
+      readonly name: string;
+    }>;
+  };
+};
+export type NewSpanAnnotationFormMutation = {
+  response: NewSpanAnnotationFormMutation$data;
+  variables: NewSpanAnnotationFormMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "items": [
+          {
+            "kind": "Variable",
+            "name": "input.0",
+            "variableName": "input"
+          }
+        ],
+        "kind": "ListValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "SpanAnnotationMutationPayload",
+    "kind": "LinkedField",
+    "name": "createSpanAnnotations",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "SpanAnnotation",
+        "kind": "LinkedField",
+        "name": "spanAnnotations",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewSpanAnnotationFormMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NewSpanAnnotationFormMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "0a925286639f9e4c3e0d8dd9a7fbb359",
+    "id": null,
+    "metadata": {},
+    "name": "NewSpanAnnotationFormMutation",
+    "operationKind": "mutation",
+    "text": "mutation NewSpanAnnotationFormMutation(\n  $input: CreateSpanAnnotationInput!\n) {\n  createSpanAnnotations(input: [$input]) {\n    spanAnnotations {\n      id\n      name\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f15659fb1f6af1293742a5fa1edf52e5";
+
+export default node;

--- a/app/src/pages/trace/__generated__/SpanAnnotationActionMenuDeleteMutation.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanAnnotationActionMenuDeleteMutation.graphql.ts
@@ -1,0 +1,101 @@
+/**
+ * @generated SignedSource<<603156bd64d9bf9bdc5d25052634c9ae>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type SpanAnnotationActionMenuDeleteMutation$variables = {
+  annotationId: string;
+};
+export type SpanAnnotationActionMenuDeleteMutation$data = {
+  readonly deleteSpanAnnotations: {
+    readonly __typename: "SpanAnnotationMutationPayload";
+  };
+};
+export type SpanAnnotationActionMenuDeleteMutation = {
+  response: SpanAnnotationActionMenuDeleteMutation$data;
+  variables: SpanAnnotationActionMenuDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "annotationId"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "items": [
+              {
+                "kind": "Variable",
+                "name": "annotationIds.0",
+                "variableName": "annotationId"
+              }
+            ],
+            "kind": "ListValue",
+            "name": "annotationIds"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "SpanAnnotationMutationPayload",
+    "kind": "LinkedField",
+    "name": "deleteSpanAnnotations",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SpanAnnotationActionMenuDeleteMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SpanAnnotationActionMenuDeleteMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "6745f5629565f1a550bcc4cf6514b795",
+    "id": null,
+    "metadata": {},
+    "name": "SpanAnnotationActionMenuDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation SpanAnnotationActionMenuDeleteMutation(\n  $annotationId: GlobalID!\n) {\n  deleteSpanAnnotations(input: {annotationIds: [$annotationId]}) {\n    __typename\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "911d3053fb16cfc65512f83b0d428772";
+
+export default node;

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -14,7 +14,7 @@ export interface PreferencesProps {
 export interface PreferencesState extends PreferencesProps {
   /**
    * Sets the display mode of markdown text
-   * @param generativeTextDisplayMode
+   * @param markdownDisplayMode
    */
   setMarkdownDisplayMode: (markdownDisplayMode: MarkdownDisplayMode) => void;
 }


### PR DESCRIPTION
resolves #3825 

This is a minimum working pre-release UI for adding annotations to spans. It does not include edits, only additions and deletions. There are known UX issues that will be addressed as follow-ups.

<img width="2056" alt="Screenshot 2024-07-22 at 10 24 08 PM" src="https://github.com/user-attachments/assets/fe434b27-2884-4254-801d-3cde6b7b8548">
