### PR TITLE
fix: re-enable server side caching

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -169,7 +169,6 @@ class HeadersMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         response = await call_next(request)
         response.headers["x-colab-notebook-cache-control"] = "no-cache"
-        response.headers["Cache-Control"] = "no-store"
         return response
 
 


### PR DESCRIPTION
Our web build now generates static assets (css / js) in chunks with unique hashes. This allows us to re-enable caching of these files.