### PR TITLE
refactor: annotator graphql types

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -79,20 +79,20 @@ input CreateDatasetInput {
   metadata: JSON
 }
 
-input CreateSpanAnnotationsInput {
+input CreateSpanAnnotationInput {
   spanId: GlobalID!
   name: String!
-  annotatorKind: String!
+  annotatorKind: AnnotatorKind!
   label: String = null
   score: Float = null
   explanation: String = null
   metadata: JSON! = {}
 }
 
-input CreateTraceAnnotationsInput {
+input CreateTraceAnnotationInput {
   traceId: GlobalID!
   name: String!
-  annotatorKind: String!
+  annotatorKind: AnnotatorKind!
   label: String = null
   score: Float = null
   explanation: String = null
@@ -864,11 +864,11 @@ type Mutation {
   Given a list of clusters, export the corresponding data subset in Parquet format. File name is optional, but if specified, should be without file extension. By default the exported file name is current timestamp.
   """
   exportClusters(clusters: [ClusterInput!]!, fileName: String): ExportedFile!
-  createSpanAnnotations(input: [CreateSpanAnnotationsInput!]!): SpanAnnotationMutationPayload!
-  patchSpanAnnotations(input: [PatchAnnotationsInput!]!): SpanAnnotationMutationPayload!
+  createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
+  patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
-  createTraceAnnotations(input: [CreateTraceAnnotationsInput!]!): TraceAnnotationMutationPayload!
-  patchTraceAnnotations(input: [PatchAnnotationsInput!]!): TraceAnnotationMutationPayload!
+  createTraceAnnotations(input: [CreateTraceAnnotationInput!]!): TraceAnnotationMutationPayload!
+  patchTraceAnnotations(input: [PatchAnnotationInput!]!): TraceAnnotationMutationPayload!
   deleteTraceAnnotations(input: DeleteAnnotationsInput!): TraceAnnotationMutationPayload!
 }
 
@@ -902,10 +902,10 @@ type PageInfo {
   endCursor: String
 }
 
-input PatchAnnotationsInput {
+input PatchAnnotationInput {
   annotationId: GlobalID!
   name: String
-  annotatorKind: String
+  annotatorKind: AnnotatorKind
   label: String
   score: Float
   explanation: String

--- a/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
@@ -4,12 +4,14 @@ import strawberry
 from strawberry.relay import GlobalID
 from strawberry.scalars import JSON
 
+from phoenix.server.api.types.AnnotatorKind import AnnotatorKind
+
 
 @strawberry.input
-class CreateSpanAnnotationsInput:
+class CreateSpanAnnotationInput:
     span_id: GlobalID
     name: str
-    annotator_kind: str
+    annotator_kind: AnnotatorKind
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None

--- a/src/phoenix/server/api/input_types/CreateTraceAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateTraceAnnotationInput.py
@@ -4,12 +4,14 @@ import strawberry
 from strawberry.relay import GlobalID
 from strawberry.scalars import JSON
 
+from phoenix.server.api.types.AnnotatorKind import AnnotatorKind
+
 
 @strawberry.input
-class CreateTraceAnnotationsInput:
+class CreateTraceAnnotationInput:
     trace_id: GlobalID
     name: str
-    annotator_kind: str
+    annotator_kind: AnnotatorKind
     label: Optional[str] = None
     score: Optional[float] = None
     explanation: Optional[str] = None

--- a/src/phoenix/server/api/input_types/PatchAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/PatchAnnotationInput.py
@@ -5,12 +5,14 @@ from strawberry import UNSET
 from strawberry.relay import GlobalID
 from strawberry.scalars import JSON
 
+from phoenix.server.api.types.AnnotatorKind import AnnotatorKind
+
 
 @strawberry.input
-class PatchAnnotationsInput:
+class PatchAnnotationInput:
     annotation_id: GlobalID
     name: Optional[str] = UNSET
-    annotator_kind: Optional[str] = UNSET
+    annotator_kind: Optional[AnnotatorKind] = UNSET
     label: Optional[str] = UNSET
     score: Optional[float] = UNSET
     explanation: Optional[str] = UNSET

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -7,9 +7,9 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.server.api.context import Context
-from phoenix.server.api.input_types.CreateSpanAnnotationsInput import CreateSpanAnnotationsInput
+from phoenix.server.api.input_types.CreateSpanAnnotationInput import CreateSpanAnnotationInput
 from phoenix.server.api.input_types.DeleteAnnotationsInput import DeleteAnnotationsInput
-from phoenix.server.api.input_types.PatchAnnotationsInput import PatchAnnotationsInput
+from phoenix.server.api.input_types.PatchAnnotationInput import PatchAnnotationInput
 from phoenix.server.api.mutations.auth import IsAuthenticated
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.SpanAnnotation import SpanAnnotation, to_gql_span_annotation
@@ -24,7 +24,7 @@ class SpanAnnotationMutationPayload:
 class SpanAnnotationMutationMixin:
     @strawberry.mutation(permission_classes=[IsAuthenticated])  # type: ignore
     async def create_span_annotations(
-        self, info: Info[Context, None], input: List[CreateSpanAnnotationsInput]
+        self, info: Info[Context, None], input: List[CreateSpanAnnotationInput]
     ) -> SpanAnnotationMutationPayload:
         inserted_annotations: Sequence[models.SpanAnnotation] = []
         async with info.context.db() as session:
@@ -54,7 +54,7 @@ class SpanAnnotationMutationMixin:
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])  # type: ignore
     async def patch_span_annotations(
-        self, info: Info[Context, None], input: List[PatchAnnotationsInput]
+        self, info: Info[Context, None], input: List[PatchAnnotationInput]
     ) -> SpanAnnotationMutationPayload:
         patched_annotations = []
         async with info.context.db() as session:

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -35,7 +35,7 @@ class SpanAnnotationMutationMixin:
                     label=annotation.label,
                     score=annotation.score,
                     explanation=annotation.explanation,
-                    annotator_kind=annotation.annotator_kind,
+                    annotator_kind=annotation.annotator_kind.value,
                     metadata_=annotation.metadata,
                 )
                 for annotation in input
@@ -66,7 +66,13 @@ class SpanAnnotationMutationMixin:
                     column.key: patch_value
                     for column, patch_value, column_is_nullable in (
                         (models.SpanAnnotation.name, annotation.name, False),
-                        (models.SpanAnnotation.annotator_kind, annotation.annotator_kind, False),
+                        (
+                            models.SpanAnnotation.annotator_kind,
+                            annotation.annotator_kind.value
+                            if annotation.annotator_kind is not None
+                            else None,
+                            False,
+                        ),
                         (models.SpanAnnotation.label, annotation.label, True),
                         (models.SpanAnnotation.score, annotation.score, True),
                         (models.SpanAnnotation.explanation, annotation.explanation, True),

--- a/src/phoenix/server/api/mutations/trace_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_annotations_mutations.py
@@ -35,7 +35,7 @@ class TraceAnnotationMutationMixin:
                     label=annotation.label,
                     score=annotation.score,
                     explanation=annotation.explanation,
-                    annotator_kind=annotation.annotator_kind,
+                    annotator_kind=annotation.annotator_kind.value,
                     metadata_=annotation.metadata,
                 )
                 for annotation in input
@@ -66,7 +66,13 @@ class TraceAnnotationMutationMixin:
                     column.key: patch_value
                     for column, patch_value, column_is_nullable in (
                         (models.TraceAnnotation.name, annotation.name, False),
-                        (models.TraceAnnotation.annotator_kind, annotation.annotator_kind, False),
+                        (
+                            models.TraceAnnotation.annotator_kind,
+                            annotation.annotator_kind.value
+                            if annotation.annotator_kind is not None
+                            else None,
+                            False,
+                        ),
                         (models.TraceAnnotation.label, annotation.label, True),
                         (models.TraceAnnotation.score, annotation.score, True),
                         (models.TraceAnnotation.explanation, annotation.explanation, True),

--- a/src/phoenix/server/api/mutations/trace_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_annotations_mutations.py
@@ -7,9 +7,9 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.server.api.context import Context
-from phoenix.server.api.input_types.CreateTraceAnnotationsInput import CreateTraceAnnotationsInput
+from phoenix.server.api.input_types.CreateTraceAnnotationInput import CreateTraceAnnotationInput
 from phoenix.server.api.input_types.DeleteAnnotationsInput import DeleteAnnotationsInput
-from phoenix.server.api.input_types.PatchAnnotationsInput import PatchAnnotationsInput
+from phoenix.server.api.input_types.PatchAnnotationInput import PatchAnnotationInput
 from phoenix.server.api.mutations.auth import IsAuthenticated
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.TraceAnnotation import TraceAnnotation, to_gql_trace_annotation
@@ -24,7 +24,7 @@ class TraceAnnotationMutationPayload:
 class TraceAnnotationMutationMixin:
     @strawberry.mutation(permission_classes=[IsAuthenticated])  # type: ignore
     async def create_trace_annotations(
-        self, info: Info[Context, None], input: List[CreateTraceAnnotationsInput]
+        self, info: Info[Context, None], input: List[CreateTraceAnnotationInput]
     ) -> TraceAnnotationMutationPayload:
         inserted_annotations: Sequence[models.TraceAnnotation] = []
         async with info.context.db() as session:
@@ -54,7 +54,7 @@ class TraceAnnotationMutationMixin:
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])  # type: ignore
     async def patch_trace_annotations(
-        self, info: Info[Context, None], input: List[PatchAnnotationsInput]
+        self, info: Info[Context, None], input: List[PatchAnnotationInput]
     ) -> TraceAnnotationMutationPayload:
         patched_annotations = []
         async with info.context.db() as session:

--- a/tests/server/api/types/test_SpanAnnotation.py
+++ b/tests/server/api/types/test_SpanAnnotation.py
@@ -58,7 +58,7 @@ async def test_annotating_a_span(
         "/graphql",
         json={
             "query": """
-                mutation AddSpanAnnotation($input: [CreateSpanAnnotationsInput!]!) {
+                mutation AddSpanAnnotation($input: [CreateSpanAnnotationInput!]!) {
                     createSpanAnnotations(input: $input) {
                         spanAnnotations {
                             id
@@ -106,7 +106,7 @@ async def test_annotating_a_span(
         "/graphql",
         json={
             "query": """
-                mutation PatchSpanAnnotation($input: [PatchAnnotationsInput!]!) {
+                mutation PatchSpanAnnotation($input: [PatchAnnotationInput!]!) {
                     patchSpanAnnotations(input: $input) {
                         spanAnnotations {
                             id

--- a/tests/server/api/types/test_TraceAnnotation.py
+++ b/tests/server/api/types/test_TraceAnnotation.py
@@ -58,7 +58,7 @@ async def test_annotating_a_trace(
         "/graphql",
         json={
             "query": """
-                mutation AddTraceAnnotation($input: [CreateTraceAnnotationsInput!]!) {
+                mutation AddTraceAnnotation($input: [CreateTraceAnnotationInput!]!) {
                     createTraceAnnotations(input: $input) {
                         traceAnnotations {
                             id
@@ -106,7 +106,7 @@ async def test_annotating_a_trace(
         "/graphql",
         json={
             "query": """
-                mutation PatchTraceAnnotation($input: [PatchAnnotationsInput!]!) {
+                mutation PatchTraceAnnotation($input: [PatchAnnotationInput!]!) {
                     patchTraceAnnotations(input: $input) {
                         traceAnnotations {
                             id


### PR DESCRIPTION
Makes the types correctly singular in the graphql types and moves the annotator kind to be an enum