### PR TITLE
fix: get_dataset_versions client method does not break on mixed timestamp formats

### DIFF
--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -410,10 +410,7 @@ class Client(TraceDataExtractor):
         if not (records := response.json()["data"]):
             return pd.DataFrame()
         df = pd.DataFrame.from_records(records, index="version_id")
-        df["created_at"] = pd.to_datetime(
-            df.created_at,
-            format="mixed",  # timestamps may have different formats
-        )
+        df["created_at"] = df["created_at"].apply(datetime.fromisoformat)
         return df
 
     def upload_dataset(

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -410,7 +410,10 @@ class Client(TraceDataExtractor):
         if not (records := response.json()["data"]):
             return pd.DataFrame()
         df = pd.DataFrame.from_records(records, index="version_id")
-        df["created_at"] = pd.to_datetime(df.created_at)
+        df["created_at"] = pd.to_datetime(
+            df.created_at,
+            format="mixed",  # timestamps may have different formats
+        )
         return df
 
     def upload_dataset(


### PR DESCRIPTION
It's currently possible for timestamps to have different resolutions in the DB. Timestamps created by `server_default=func.now()` have second-level resolution, while manually created timestamps have more granular timing information. So you wind up with timestamps that look like this:

```
["2024-07-23T17:32:06.646881+00:00", "2024-07-23T17:32:01+00:00"]
```

resolves #3959
