### PR TITLE
refactor: use production db setup for all tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,18 +218,8 @@ def px_client(
 
 
 @pytest.fixture
-def acall(
-    loop: AbstractEventLoop,
-) -> Callable[..., Awaitable[Any]]:
-    async def _(f: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        return (
-            await asyncio.gather(
-                loop.run_in_executor(None, partial(f, *args, **kwargs)),
-                asyncio.sleep(0.1),
-            )
-        )[0]
-
-    return _
+def acall(loop: AbstractEventLoop) -> Callable[..., Awaitable[Any]]:
+    return lambda f, *_, **__: loop.run_in_executor(None, partial(f, *_, **__))
 
 
 @contextlib.asynccontextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from starlette.types import ASGIApp
 
 
-def pytest_addoption(parser: Parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--run-postgres",
         action="store_true",
@@ -47,7 +47,7 @@ def pytest_addoption(parser: Parser):
     )
 
 
-def pytest_collection_modifyitems(config: Config, items: List[Any]):
+def pytest_collection_modifyitems(config: Config, items: List[Any]) -> None:
     skip_postgres = pytest.mark.skip(reason="Skipping Postgres tests")
     if not config.getoption("--run-postgres"):
         for item in items:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser: Parser):
     parser.addoption(
         "--run-postgres",
         action="store_true",
-        default=True,
+        default=False,
         help="Run tests that require Postgres",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,51 +7,48 @@ from time import sleep
 from typing import (
     Any,
     AsyncContextManager,
-    AsyncGenerator,
     AsyncIterator,
     Awaitable,
     Callable,
     Iterator,
+    List,
     Literal,
     Tuple,
 )
 
 import httpx
 import pytest
+from _pytest.config import Config, Parser
+from _pytest.fixtures import SubRequest
 from asgi_lifespan import LifespanManager
 from httpx import URL, Request, Response
 from phoenix.config import EXPORT_DIR
 from phoenix.core.model_schema_adapter import create_model_from_inferences
 from phoenix.db import models
 from phoenix.db.bulk_inserter import BulkInserter
-from phoenix.db.engines import aio_sqlite_engine
+from phoenix.db.engines import aio_postgresql_engine, aio_sqlite_engine
 from phoenix.inferences.inferences import EMPTY_INFERENCES
 from phoenix.pointcloud.umap_parameters import get_umap_parameters
-from phoenix.server.app import SessionFactory, create_app
+from phoenix.server.app import SessionFactory, _db, create_app
 from phoenix.server.grpc_server import GrpcServer
 from phoenix.session.client import Client
 from psycopg import Connection
 from pytest_postgresql import factories
 from sqlalchemy import make_url
-from sqlalchemy.ext.asyncio import (
-    AsyncEngine,
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from starlette.types import ASGIApp
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser):
     parser.addoption(
         "--run-postgres",
         action="store_true",
-        default=False,
+        default=True,
         help="Run tests that require Postgres",
     )
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: Config, items: List[Any]):
     skip_postgres = pytest.mark.skip(reason="Skipping Postgres tests")
     if not config.getoption("--run-postgres"):
         for item in items:
@@ -78,23 +75,23 @@ def openai_api_key(monkeypatch: pytest.MonkeyPatch) -> str:
     return api_key
 
 
-phoenix_postgresql = factories.postgresql("postgresql_proc")
+postgresql_connection = factories.postgresql("postgresql_proc")
 
 
-def create_async_postgres_engine(psycopg_connection: Connection) -> AsyncEngine:
-    connection = psycopg_connection.cursor().connection
+@pytest.fixture()
+async def postgresql_url(postgresql_connection: Connection) -> AsyncIterator[URL]:
+    connection = postgresql_connection
     user = connection.info.user
     password = connection.info.password
     database = connection.info.dbname
     host = connection.info.host
     port = connection.info.port
-    async_database_url = f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{database}"
-    return create_async_engine(async_database_url)
+    yield make_url(f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{database}")
 
 
 @pytest.fixture
-async def postgres_engine(phoenix_postgresql: Connection) -> AsyncGenerator[AsyncEngine, None]:
-    engine = create_async_postgres_engine(phoenix_postgresql)
+async def postgresql_engine(postgresql_url: URL) -> AsyncIterator[AsyncEngine]:
+    engine = aio_postgresql_engine(postgresql_url, migrate=False)
     async with engine.begin() as conn:
         await conn.run_sync(models.Base.metadata.create_all)
     yield engine
@@ -102,212 +99,59 @@ async def postgres_engine(phoenix_postgresql: Connection) -> AsyncGenerator[Asyn
 
 
 @pytest.fixture(params=["sqlite", "postgresql"])
-def dialect(request):
+def dialect(request: SubRequest) -> str:
     return request.param
 
 
 @pytest.fixture
-async def sqlite_engine() -> AsyncEngine:
+async def sqlite_engine() -> AsyncIterator[AsyncEngine]:
     engine = aio_sqlite_engine(make_url("sqlite+aiosqlite://"), migrate=False, shared_cache=False)
     async with engine.begin() as conn:
         await conn.run_sync(models.Base.metadata.create_all)
-    return engine
+    yield engine
+    await engine.dispose()
 
 
 @pytest.fixture
-def session(request, dialect) -> AsyncSession:
+def db(request: SubRequest, dialect: str) -> Callable[[], AsyncContextManager[AsyncSession]]:
     if dialect == "sqlite":
-        return request.getfixturevalue("sqlite_session")
+        return _db_with_lock(request.getfixturevalue("sqlite_engine"))
     elif dialect == "postgresql":
-        return request.getfixturevalue("postgres_session")
-    raise ValueError(f"Unknown session fixture: {dialect}")
-
-
-@pytest.fixture
-def db(request, dialect) -> async_sessionmaker:
-    if dialect == "sqlite":
-        return request.getfixturevalue("sqlite_db")
-    elif dialect == "postgresql":
-        return request.getfixturevalue("postgres_db")
+        return _db_with_lock(request.getfixturevalue("postgresql_engine"))
     raise ValueError(f"Unknown db fixture: {dialect}")
 
 
-@pytest.fixture
-async def sqlite_db(
-    sqlite_engine: AsyncEngine,
-) -> AsyncGenerator[Callable[[], AsyncContextManager[AsyncSession]], None]:
-    Session = async_sessionmaker(sqlite_engine, expire_on_commit=False)
+def _db_with_lock(engine: AsyncEngine) -> Callable[[], AsyncContextManager[AsyncSession]]:
+    lock, db = asyncio.Lock(), _db(engine)
 
-    async with Session.begin() as session:
-
-        @contextlib.asynccontextmanager
-        async def factory() -> AsyncIterator[AsyncSession]:
+    @contextlib.asynccontextmanager
+    async def _() -> AsyncIterator[AsyncSession]:
+        async with lock, db() as session:
             yield session
 
-        yield factory
+    return _
 
 
 @pytest.fixture
-async def postgres_db(
-    postgres_engine: AsyncEngine,
-) -> AsyncGenerator[Callable[[], AsyncContextManager[AsyncSession]], None]:
-    Session = async_sessionmaker(postgres_engine, expire_on_commit=False)
-    async with Session.begin() as session:
-
-        @contextlib.asynccontextmanager
-        async def factory() -> AsyncIterator[AsyncSession]:
-            yield session
-
-        yield factory
-
-
-@pytest.fixture
-async def sqlite_session(
-    sqlite_db: Callable[[], AsyncContextManager[AsyncSession]],
-) -> AsyncGenerator[AsyncSession, None]:
-    async with sqlite_db() as session:
-        yield session
-
-
-@pytest.fixture
-async def postgres_session(
-    postgres_db: Callable[[], AsyncContextManager[AsyncSession]],
-) -> AsyncGenerator[AsyncSession, None]:
-    async with postgres_db() as session:
-        yield session
-
-
-@pytest.fixture
-async def project(session: AsyncSession) -> None:
+async def project(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     project = models.Project(name="test_project")
-    session.add(project)
+    async with db() as session:
+        session.add(project)
 
 
 @pytest.fixture
-async def test_client(test_app: ASGIApp):
+async def httpx_client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=test_app), base_url="http://test"
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
         yield client
 
 
 @pytest.fixture
-def test_phoenix_clients(test_app: ASGIApp) -> Tuple[httpx.Client, httpx.AsyncClient]:
-    class SyncTransport(httpx.BaseTransport):
-        def __init__(self, asgi_transport: httpx.ASGITransport):
-            self.asgi_transport = asgi_transport
-
-        def handle_request(self, request: Request) -> Response:
-            response = asyncio.run(self.asgi_transport.handle_async_request(request))
-
-            async def read_stream():
-                content = b""
-                async for chunk in response.stream:
-                    content += chunk
-                return content
-
-            content = asyncio.run(read_stream())
-            return Response(
-                status_code=response.status_code,
-                headers=response.headers,
-                content=content,
-                request=request,
-            )
-
-    class AsyncTransport(httpx.AsyncBaseTransport):
-        def __init__(self, asgi_transport: httpx.ASGITransport):
-            self.asgi_transport = asgi_transport
-
-        async def handle_async_request(self, request: Request) -> Response:
-            response = await self.asgi_transport.handle_async_request(request)
-
-            async def read_stream():
-                content = b""
-                async for chunk in response.stream:
-                    content += chunk
-                return content
-
-            content = await read_stream()
-            return Response(
-                status_code=response.status_code,
-                headers=response.headers,
-                content=content,
-                request=request,
-            )
-
-    asgi_transport = httpx.ASGITransport(app=test_app)
-    sync_transport = SyncTransport(asgi_transport=asgi_transport)
-    sync_client = httpx.Client(transport=sync_transport, base_url="http://test")
-    async_transport = AsyncTransport(asgi_transport=asgi_transport)
-    async_client = httpx.AsyncClient(transport=async_transport, base_url="http://test")
-    return sync_client, async_client
-
-
-@pytest.fixture
-def prod_db(request, dialect) -> async_sessionmaker:
-    """
-    Instantiates DB in a manner similar to production.
-    """
-    if dialect == "sqlite":
-        return request.getfixturevalue("prod_sqlite_db")
-    elif dialect == "postgresql":
-        return request.getfixturevalue("prod_postgres_db")
-    raise ValueError(f"Unknown db fixture: {dialect}")
-
-
-@pytest.fixture
-def prod_sqlite_db(
-    sqlite_engine: AsyncEngine,
-) -> Callable[[], AsyncContextManager[AsyncSession]]:
-    """
-    Instantiates SQLite in a manner similar to production.
-    """
-    Session = async_sessionmaker(sqlite_engine, expire_on_commit=False)
-
-    @contextlib.asynccontextmanager
-    async def factory() -> AsyncIterator[AsyncSession]:
-        async with Session.begin() as session:
-            yield session
-
-    return factory
-
-
-@pytest.fixture
-def prod_postgres_db(
-    postgres_engine: AsyncEngine,
-) -> Callable[[], AsyncContextManager[AsyncSession]]:
-    """
-    Instantiates Postgres in a manner similar to production.
-    """
-    Session = async_sessionmaker(postgres_engine, expire_on_commit=False)
-
-    @contextlib.asynccontextmanager
-    async def factory() -> AsyncIterator[AsyncSession]:
-        async with Session.begin() as session:
-            yield session
-
-    return factory
-
-
-@pytest.fixture
-async def prod_app(dialect, prod_db) -> AsyncIterator[ASGIApp]:
-    factory = SessionFactory(session_factory=prod_db, dialect=dialect)
-    async with contextlib.AsyncExitStack() as stack:
-        await stack.enter_async_context(patch_bulk_inserter())
-        await stack.enter_async_context(patch_grpc_server())
-        app = create_app(
-            db=factory,
-            model=create_model_from_inferences(EMPTY_INFERENCES, None),
-            export_path=EXPORT_DIR,
-            umap_params=get_umap_parameters(None),
-            serve_ui=False,
-        )
-        manager = await stack.enter_async_context(LifespanManager(app))
-        yield manager.app
-
-
-@pytest.fixture
-async def test_app(dialect, db) -> AsyncIterator[ASGIApp]:
+async def app(
+    dialect: str,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> AsyncIterator[ASGIApp]:
     factory = SessionFactory(session_factory=db, dialect=dialect)
     async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(patch_bulk_inserter())
@@ -329,8 +173,8 @@ async def loop() -> AbstractEventLoop:
 
 
 @pytest.fixture
-def prod_httpx_clients(
-    prod_app: ASGIApp,
+def httpx_clients(
+    app: ASGIApp,
     loop: AbstractEventLoop,
 ) -> Tuple[httpx.Client, httpx.AsyncClient]:
     class Transport(httpx.BaseTransport, httpx.AsyncBaseTransport):
@@ -352,7 +196,7 @@ def prod_httpx_clients(
                 request=request,
             )
 
-    transport = Transport(httpx.ASGITransport(prod_app))
+    transport = Transport(httpx.ASGITransport(app))
     base_url = "http://test"
     return (
         httpx.Client(transport=transport, base_url=base_url),
@@ -362,9 +206,9 @@ def prod_httpx_clients(
 
 @pytest.fixture
 def px_client(
-    prod_httpx_clients: Tuple[httpx.Client, httpx.AsyncClient],
+    httpx_clients,
 ) -> Iterator[Client]:
-    sync_client, _ = prod_httpx_clients
+    sync_client, _ = httpx_clients
     client = Client()
     client._client = sync_client
     client._base_url = str(sync_client.base_url)
@@ -374,7 +218,15 @@ def px_client(
 
 @pytest.fixture
 def acall(loop: AbstractEventLoop) -> Callable[..., Awaitable[Any]]:
-    return lambda f, *_, **__: loop.run_in_executor(None, partial(f, *_, **__))
+    async def _(f: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return (
+            await asyncio.gather(
+                loop.run_in_executor(None, partial(f, *args, **kwargs)),
+                asyncio.sleep(0.1),
+            )
+        )[0]
+
+    return _
 
 
 @contextlib.asynccontextmanager

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -7,7 +7,7 @@ from phoenix.inferences.inferences import EmbeddingColumnNames, Inferences, Sche
 
 
 @pytest.fixture
-def inferences_with_large_embedding_vector():
+def inferences_with_large_embedding_vector() -> None:
     num_records = 3
     embedding_dimensions = 7
 
@@ -48,7 +48,7 @@ def inferences_with_large_embedding_vector():
 
 
 @pytest.fixture
-def inferences_with_embedding_vector():
+def inferences_with_embedding_vector() -> None:
     num_records = 3
     embedding_dimensions = 5
 
@@ -87,14 +87,14 @@ def inferences_with_embedding_vector():
 
 def test_invalid_model_embeddings_primary_and_ref_embedding_size_mismatch(
     inferences_with_embedding_vector, inferences_with_large_embedding_vector
-):
+) -> None:
     with pytest.raises(ValueError):
         _ = _get_embedding_dimensions(
             inferences_with_embedding_vector, inferences_with_large_embedding_vector
         )
 
 
-def test_valid_model_embeddings(inferences_with_embedding_vector):
+def test_valid_model_embeddings(inferences_with_embedding_vector) -> None:
     embedding_dimensions = _get_embedding_dimensions(
         inferences_with_embedding_vector, inferences_with_embedding_vector
     )
@@ -107,7 +107,7 @@ def test_valid_model_embeddings(inferences_with_embedding_vector):
 
 def test_valid_model_embeddings_one_inferences_missing_embeddings_feature(
     inferences_with_embedding_vector,
-):
+) -> None:
     num_records = 3
     input_dataframe = DataFrame(
         {
@@ -135,7 +135,7 @@ def test_valid_model_embeddings_one_inferences_missing_embeddings_feature(
     ]
 
 
-def test_valid_model_with_nan_embeddings(inferences_with_embedding_vector):
+def test_valid_model_with_nan_embeddings(inferences_with_embedding_vector) -> None:
     inferences_with_embedding_vector.dataframe["embedding_vector0"] = np.nan
     embedding_dimensions = _get_embedding_dimensions(
         inferences_with_embedding_vector,

--- a/tests/core/test_model_schema.py
+++ b/tests/core/test_model_schema.py
@@ -52,7 +52,7 @@ def test_role_precedence() -> None:
     assert len(list(model[TAG])) == 0
 
 
-def test_column_names_coerced_to_str():
+def test_column_names_coerced_to_str() -> None:
     df = pd.DataFrame(columns=["0", 1, "2"])
     model = Schema()(df)
     assert set(model[PRIMARY].columns) == set(map(str, model[PRIMARY].columns))
@@ -60,7 +60,7 @@ def test_column_names_coerced_to_str():
     assert 1 in set(df.columns) - set(model[PRIMARY].columns)
 
 
-def test_df_padding():
+def test_df_padding() -> None:
     model = Schema()(pd.DataFrame({"A": [1]}))
     inf_roles = iter(InferencesRole)
     assert not model[next(inf_roles)].empty
@@ -70,7 +70,7 @@ def test_df_padding():
         assert df.empty
 
 
-def test_df_column_insertion():
+def test_df_column_insertion() -> None:
     model = Schema()(pd.DataFrame())
     for ds_role in InferencesRole:
         df = model[ds_role]
@@ -115,7 +115,7 @@ FULL_SCHEMA = Schema(
 )
 
 
-def test_iterable_column_names():
+def test_iterable_column_names() -> None:
     assert set(iter(Schema())) == set()
     desired_names = (
         set("ABCDEFGHIJKLMNRSTU")
@@ -330,7 +330,7 @@ def test_embedding_dimensions_extraction() -> None:
     ) == {"E": FEATURE, "F": TAG, "G": PROMPT}
 
 
-def test_raise_if_dim_role_is_unassigned():
+def test_raise_if_dim_role_is_unassigned() -> None:
     with pytest.raises(ValueError):
         _ = Dimension()
     for role in InvalidRole:
@@ -365,5 +365,5 @@ def test_raise_if_dim_role_is_unassigned():
         FULL_SCHEMA,
     ],
 )
-def test_schema_to_json(schema: Schema):
+def test_schema_to_json(schema: Schema) -> None:
     assert schema == Schema.from_json(schema.to_json())

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 @pytest.fixture
 async def simple_dataset(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     """
     A dataset with one example added in one version
     """

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,46 +1,51 @@
+from typing import AsyncContextManager, Callable
+
 import pytest
 from phoenix.db import models
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.fixture
-async def simple_dataset(session):
+async def simple_dataset(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     """
     A dataset with one example added in one version
     """
+    async with db() as session:
+        dataset = models.Dataset(
+            id=0,
+            name="simple dataset",
+            description=None,
+            metadata_={"info": "a test dataset"},
+        )
+        session.add(dataset)
+        await session.flush()
 
-    dataset = models.Dataset(
-        id=0,
-        name="simple dataset",
-        description=None,
-        metadata_={"info": "a test dataset"},
-    )
-    session.add(dataset)
-    await session.flush()
+        dataset_version_0 = models.DatasetVersion(
+            id=0,
+            dataset_id=0,
+            description="the first version",
+            metadata_={"info": "gotta get some test data somewhere"},
+        )
+        session.add(dataset_version_0)
+        await session.flush()
 
-    dataset_version_0 = models.DatasetVersion(
-        id=0,
-        dataset_id=0,
-        description="the first version",
-        metadata_={"info": "gotta get some test data somewhere"},
-    )
-    session.add(dataset_version_0)
-    await session.flush()
+        example_0 = models.DatasetExample(
+            id=0,
+            dataset_id=0,
+        )
+        session.add(example_0)
+        await session.flush()
 
-    example_0 = models.DatasetExample(
-        id=0,
-        dataset_id=0,
-    )
-    session.add(example_0)
-    await session.flush()
-
-    example_0_revision_0 = models.DatasetExampleRevision(
-        id=0,
-        dataset_example_id=0,
-        dataset_version_id=0,
-        input={"in": "foo"},
-        output={"out": "bar"},
-        metadata_={"info": "the first reivision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_0_revision_0)
-    await session.flush()
+        example_0_revision_0 = models.DatasetExampleRevision(
+            id=0,
+            dataset_example_id=0,
+            dataset_version_id=0,
+            input={"in": "foo"},
+            output={"out": "bar"},
+            metadata_={"info": "the first reivision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_0_revision_0)
+        await session.flush()

--- a/tests/datasets/test_experiments.py
+++ b/tests/datasets/test_experiments.py
@@ -1,8 +1,9 @@
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, AsyncContextManager, Awaitable, Callable, Dict
 from unittest.mock import patch
 
+import httpx
 from phoenix.db import models
 from phoenix.experiments import run_experiment
 from phoenix.experiments.evaluators import (
@@ -20,11 +21,18 @@ from phoenix.experiments.types import (
 )
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 @patch("opentelemetry.sdk.trace.export.SimpleSpanProcessor.on_end")
-async def test_run_experiment(_, db, httpx_clients, simple_dataset, acall):
+async def test_run_experiment(
+    _,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    httpx_clients: httpx.AsyncClient,
+    simple_dataset: Any,
+    acall: Callable[..., Awaitable[Any]],
+):
     async with db() as session:
         nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"
@@ -129,7 +137,13 @@ async def test_run_experiment(_, db, httpx_clients, simple_dataset, acall):
 
 
 @patch("opentelemetry.sdk.trace.export.SimpleSpanProcessor.on_end")
-async def test_run_experiment_with_llm_eval(_, db, httpx_clients, simple_dataset, acall):
+async def test_run_experiment_with_llm_eval(
+    _,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    httpx_clients: httpx.AsyncClient,
+    simple_dataset: Any,
+    acall: Callable[..., Awaitable[Any]],
+):
     async with db() as session:
         nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"

--- a/tests/datasets/test_experiments.py
+++ b/tests/datasets/test_experiments.py
@@ -3,8 +3,6 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 from unittest.mock import patch
 
-import nest_asyncio
-import pytest
 from phoenix.db import models
 from phoenix.experiments import run_experiment
 from phoenix.experiments.evaluators import (
@@ -26,15 +24,9 @@ from strawberry.relay import GlobalID
 
 
 @patch("opentelemetry.sdk.trace.export.SimpleSpanProcessor.on_end")
-async def test_run_experiment(_, session, test_phoenix_clients, simple_dataset):
-    if "asyncpg" in str(session.get_bind().url):
-        pytest.xfail(
-            "FIX THIS: sqlalchemy.exc.InvalidRequestError: Can't operate on "
-            "closed transaction inside context manager."
-        )
-    nest_asyncio.apply()
-
-    nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
+async def test_run_experiment(_, db, httpx_clients, simple_dataset, acall):
+    async with db() as session:
+        nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"
 
     example_input = {"input": "fancy input 1"}
@@ -54,7 +46,7 @@ async def test_run_experiment(_, session, test_phoenix_clients, simple_dataset):
         },
     )
 
-    with patch("phoenix.experiments.functions._phoenix_clients", return_value=test_phoenix_clients):
+    with patch("phoenix.experiments.functions._phoenix_clients", return_value=httpx_clients):
         task_output = {"doesn't matter": "this is the output"}
 
         def experiment_task(_) -> Dict[str, str]:
@@ -78,7 +70,8 @@ async def test_run_experiment(_, session, test_phoenix_clients, simple_dataset):
             lambda reference, expected: expected == reference,
             lambda reference, expected: expected is reference,
         ]
-        experiment = run_experiment(
+        experiment = await acall(
+            run_experiment,
             dataset=test_dataset,
             task=experiment_task,
             experiment_name="test",
@@ -100,30 +93,34 @@ async def test_run_experiment(_, session, test_phoenix_clients, simple_dataset):
         assert experiment_model.description == "test description"
         assert experiment_model.repetitions == 1  # TODO: Enable repetitions #3584
 
-        experiment_runs = (
-            (
-                await session.execute(
-                    select(models.ExperimentRun).where(models.ExperimentRun.dataset_example_id == 0)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert len(experiment_runs) == 1, "The experiment was configured to have 1 repetition"
-        for run in experiment_runs:
-            assert run.output == {"task_output": {"doesn't matter": "this is the output"}}
-
-            evaluations = (
+        async with db() as session:
+            experiment_runs = (
                 (
                     await session.execute(
-                        select(models.ExperimentRunAnnotation)
-                        .where(models.ExperimentRunAnnotation.experiment_run_id == run.id)
-                        .order_by(models.ExperimentRunAnnotation.name)
+                        select(models.ExperimentRun).where(
+                            models.ExperimentRun.dataset_example_id == 0
+                        )
                     )
                 )
                 .scalars()
                 .all()
             )
+        assert len(experiment_runs) == 1, "The experiment was configured to have 1 repetition"
+        for run in experiment_runs:
+            assert run.output == {"task_output": {"doesn't matter": "this is the output"}}
+
+            async with db() as session:
+                evaluations = (
+                    (
+                        await session.execute(
+                            select(models.ExperimentRunAnnotation)
+                            .where(models.ExperimentRunAnnotation.experiment_run_id == run.id)
+                            .order_by(models.ExperimentRunAnnotation.name)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
             assert len(evaluations) == len(evaluators)
             assert evaluations[0].score == 0.0
             assert evaluations[1].score == 1.0
@@ -132,15 +129,9 @@ async def test_run_experiment(_, session, test_phoenix_clients, simple_dataset):
 
 
 @patch("opentelemetry.sdk.trace.export.SimpleSpanProcessor.on_end")
-async def test_run_experiment_with_llm_eval(_, session, test_phoenix_clients, simple_dataset):
-    if "asyncpg" in str(session.get_bind().url):
-        pytest.xfail(
-            "FIX THIS: sqlalchemy.exc.InvalidRequestError: Can't operate on "
-            "closed transaction inside context manager."
-        )
-    nest_asyncio.apply()
-
-    nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
+async def test_run_experiment_with_llm_eval(_, db, httpx_clients, simple_dataset, acall):
+    async with db() as session:
+        nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"
 
     test_dataset = Dataset(
@@ -175,7 +166,7 @@ async def test_run_experiment_with_llm_eval(_, session, test_phoenix_clients, si
         async def _async_generate(self, prompt: str, **kwargs: Any) -> str:
             return " doesn't matter I can't think!\nLABEL: false"
 
-    with patch("phoenix.experiments.functions._phoenix_clients", return_value=test_phoenix_clients):
+    with patch("phoenix.experiments.functions._phoenix_clients", return_value=httpx_clients):
 
         def experiment_task(input, example, metadata):
             assert input == {"input": "fancy input 1"}
@@ -183,7 +174,8 @@ async def test_run_experiment_with_llm_eval(_, session, test_phoenix_clients, si
             assert isinstance(example, Example)
             return "doesn't matter, this is the output"
 
-        experiment = run_experiment(
+        experiment = await acall(
+            run_experiment,
             dataset=test_dataset,
             task=experiment_task,
             experiment_name="test",
@@ -206,31 +198,35 @@ async def test_run_experiment_with_llm_eval(_, session, test_phoenix_clients, si
         assert experiment_model.name == "test"
         assert experiment_model.description == "test description"
 
-        experiment_runs = (
-            (
-                await session.execute(
-                    select(models.ExperimentRun).where(models.ExperimentRun.dataset_example_id == 0)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert len(experiment_runs) == 1, "The experiment was configured to have 1 repetition"
-        for run in experiment_runs:
-            assert run.output == {"task_output": "doesn't matter, this is the output"}
-
-        for run in experiment_runs:
-            evaluations = (
+        async with db() as session:
+            experiment_runs = (
                 (
                     await session.execute(
-                        select(models.ExperimentRunAnnotation)
-                        .where(models.ExperimentRunAnnotation.experiment_run_id == run.id)
-                        .order_by(models.ExperimentRunAnnotation.name)
+                        select(models.ExperimentRun).where(
+                            models.ExperimentRun.dataset_example_id == 0
+                        )
                     )
                 )
                 .scalars()
                 .all()
             )
+        assert len(experiment_runs) == 1, "The experiment was configured to have 1 repetition"
+        for run in experiment_runs:
+            assert run.output == {"task_output": "doesn't matter, this is the output"}
+
+        for run in experiment_runs:
+            async with db() as session:
+                evaluations = (
+                    (
+                        await session.execute(
+                            select(models.ExperimentRunAnnotation)
+                            .where(models.ExperimentRunAnnotation.experiment_run_id == run.id)
+                            .order_by(models.ExperimentRunAnnotation.name)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
             assert len(evaluations) == 2
             assert evaluations[0].score == 0.0
             assert evaluations[1].score == 1.0

--- a/tests/datasets/test_experiments.py
+++ b/tests/datasets/test_experiments.py
@@ -32,7 +32,7 @@ async def test_run_experiment(
     httpx_clients: httpx.AsyncClient,
     simple_dataset: Any,
     acall: Callable[..., Awaitable[Any]],
-):
+) -> None:
     async with db() as session:
         nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"
@@ -143,7 +143,7 @@ async def test_run_experiment_with_llm_eval(
     httpx_clients: httpx.AsyncClient,
     simple_dataset: Any,
     acall: Callable[..., Awaitable[Any]],
-):
+) -> None:
     async with db() as session:
         nonexistent_experiment = (await session.execute(select(models.Experiment))).scalar()
     assert not nonexistent_experiment, "There should be no experiments in the database"
@@ -182,7 +182,7 @@ async def test_run_experiment_with_llm_eval(
 
     with patch("phoenix.experiments.functions._phoenix_clients", return_value=httpx_clients):
 
-        def experiment_task(input, example, metadata):
+        def experiment_task(input, example, metadata) -> None:
             assert input == {"input": "fancy input 1"}
             assert metadata == {}
             assert isinstance(example, Example)
@@ -246,7 +246,7 @@ async def test_run_experiment_with_llm_eval(
             assert evaluations[1].score == 1.0
 
 
-def test_evaluator_decorator():
+def test_evaluator_decorator() -> None:
     @create_evaluator()
     def can_i_count_this_high(x: int) -> bool:
         return x < 3
@@ -258,7 +258,7 @@ def test_evaluator_decorator():
     assert can_i_count_this_high.kind == AnnotatorKind.CODE.value
 
 
-async def test_async_evaluator_decorator():
+async def test_async_evaluator_decorator() -> None:
     @create_evaluator(name="override", kind="LLM")
     async def can_i_count_this_high(x: int) -> bool:
         return x < 3
@@ -270,7 +270,7 @@ async def test_async_evaluator_decorator():
     assert can_i_count_this_high.kind == AnnotatorKind.LLM.value
 
 
-def test_binding_arguments_to_decorated_evaluators():
+def test_binding_arguments_to_decorated_evaluators() -> None:
     example = Example(
         id="1",
         input={"input": "the biggest number I know"},

--- a/tests/db/insertion/test_helpers.py
+++ b/tests/db/insertion/test_helpers.py
@@ -28,7 +28,7 @@ class Test_insert_on_conflict:
         self,
         on_conflict: OnConflict,
         db: Callable[[], AsyncContextManager[AsyncSession]],
-    ):
+    ) -> None:
         async with db() as session:
             dialect = SupportedSQLDialect(session.bind.dialect.name)
             values = dict(
@@ -66,7 +66,7 @@ class Test_insert_on_conflict:
         self,
         on_conflict: OnConflict,
         db: Callable[[], AsyncContextManager[AsyncSession]],
-    ):
+    ) -> None:
         async with db() as session:
             project_rowid = await session.scalar(
                 insert(models.Project).values(dict(name="abc")).returning(models.Project.id)

--- a/tests/db/test_engines.py
+++ b/tests/db/test_engines.py
@@ -1,14 +1,14 @@
 from phoenix.db.engines import get_async_db_url
 
 
-def test_get_async_sqlite_db_url():
+def test_get_async_sqlite_db_url() -> None:
     connection_str = "sqlite:///phoenix.db"
     url = get_async_db_url(connection_str)
     assert url.drivername == "sqlite+aiosqlite"
     assert url.database == "phoenix.db"
 
 
-def test_get_async_postgresql_db_url():
+def test_get_async_postgresql_db_url() -> None:
     # Test credentials as url params
     connection_str = "postgresql://@localhost:5432/phoenix?user=user&password=password"
     url = get_async_db_url(connection_str)

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -1,24 +1,37 @@
+from typing import Any, AsyncContextManager, Callable
+
 from phoenix.db import models
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def test_projects_with_session_injection(session, project):
+async def test_projects_with_session_injection(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    project: Any,
+):
     # this test demonstrates parametrizing the session fixture
     statement = select(models.Project).where(models.Project.name == "test_project")
-    result = (await session.execute(statement)).scalars().first()
+    async with db() as session:
+        result = (await session.execute(statement)).scalars().first()
     assert result is not None
 
 
-async def test_projects_with_db_injection(db, project):
+async def test_projects_with_db_injection(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    project: Any,
+):
     # this test demonstrates mixing the db and model fixtures
+    statement = select(models.Project).where(models.Project.name == "test_project")
     async with db() as session:
-        statement = select(models.Project).where(models.Project.name == "test_project")
         result = (await session.execute(statement)).scalars().first()
-        assert result is not None
+    assert result is not None
 
 
-async def test_empty_projects(session):
+async def test_empty_projects(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     # shows that databases are reset between tests
     statement = select(models.Project).where(models.Project.name == "test_project")
-    result = (await session.execute(statement)).scalars().first()
+    async with db() as session:
+        result = (await session.execute(statement)).scalars().first()
     assert not result

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 async def test_projects_with_session_injection(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     project: Any,
-):
+) -> None:
     # this test demonstrates parametrizing the session fixture
     statement = select(models.Project).where(models.Project.name == "test_project")
     async with db() as session:
@@ -19,7 +19,7 @@ async def test_projects_with_session_injection(
 async def test_projects_with_db_injection(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     project: Any,
-):
+) -> None:
     # this test demonstrates mixing the db and model fixtures
     statement = select(models.Project).where(models.Project.name == "test_project")
     async with db() as session:
@@ -29,7 +29,7 @@ async def test_projects_with_db_injection(
 
 async def test_empty_projects(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     # shows that databases are reset between tests
     statement = select(models.Project).where(models.Project.name == "test_project")
     async with db() as session:

--- a/tests/inferences/test_inferences.py
+++ b/tests/inferences/test_inferences.py
@@ -8,7 +8,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Type
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,10 @@ class TestParseDataFrameAndSchema:
     _NUM_RECORDS = 5
     _EMBEDDING_DIMENSION = 7
 
-    def test_schema_contains_all_dataframe_columns_results_in_unchanged_output(self, caplog):
+    def test_schema_contains_all_dataframe_columns_results_in_unchanged_output(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -68,7 +71,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_column_present_in_dataframe_but_missing_from_schema_is_dropped(self, caplog):
+    def test_column_present_in_dataframe_but_missing_from_schema_is_dropped(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -97,7 +103,8 @@ class TestParseDataFrameAndSchema:
         )
 
     def test_some_features_excluded_removes_excluded_features_columns_and_keeps_the_rest(
-        self, caplog
+        self,
+        caplog: LogCaptureFixture,
     ):
         input_dataframe = DataFrame(
             {
@@ -135,8 +142,9 @@ class TestParseDataFrameAndSchema:
         )
 
     def test_all_features_and_tags_excluded_sets_schema_features_and_tags_fields_to_none(
-        self, caplog
-    ):
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -173,7 +181,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_excluded_single_column_schema_fields_set_to_none(self, caplog):
+    def test_excluded_single_column_schema_fields_set_to_none(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -205,7 +216,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_no_input_schema_features_and_no_excluded_column_names_discovers_features(self, caplog):
+    def test_no_input_schema_features_and_no_excluded_column_names_discovers_features(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -233,8 +247,9 @@ class TestParseDataFrameAndSchema:
         )
 
     def test_no_input_schema_features_and_nonempty_excluded_column_names_discovers_features(
-        self, caplog
-    ):
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -272,7 +287,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_excluded_column_not_contained_in_dataframe_logs_warning(self, caplog):
+    def test_excluded_column_not_contained_in_dataframe_logs_warning(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -307,7 +325,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_schema_includes_embedding_feature_has_all_embedding_columns_included(self, caplog):
+    def test_schema_includes_embedding_feature_has_all_embedding_columns_included(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -339,7 +360,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_schema_includes_relationships(self, caplog):
+    def test_schema_includes_relationships(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -365,7 +389,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_embedding_columns_of_excluded_embedding_feature_are_removed(self, caplog):
+    def test_embedding_columns_of_excluded_embedding_feature_are_removed(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -424,7 +451,10 @@ class TestParseDataFrameAndSchema:
             caplog=caplog,
         )
 
-    def test_excluding_all_embedding_features_sets_schema_embedding_field_to_none(self, caplog):
+    def test_excluding_all_embedding_features_sets_schema_embedding_field_to_none(
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -462,8 +492,9 @@ class TestParseDataFrameAndSchema:
         )
 
     def test_excluding_an_embedding_column_rather_than_the_embedding_feature_name_logs_warning(
-        self, caplog
-    ):
+        self,
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -501,8 +532,8 @@ class TestParseDataFrameAndSchema:
 
     def test_excluding_embedding_feature_with_same_name_as_embedding_column_does_not_warn_user(
         self,
-        caplog,
-    ):
+        caplog: LogCaptureFixture,
+    ) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_id": [str(x) for x in range(self.num_records)],
@@ -539,8 +570,8 @@ class TestParseDataFrameAndSchema:
 
     def test_inferences_coerce_vectors_from_lists_to_arrays(
         self,
-        caplog,
-    ):
+        caplog: LogCaptureFixture,
+    ) -> None:
         vec = np.random.random(10)
         input_dataframe = DataFrame(
             {
@@ -605,7 +636,7 @@ class TestParseDataFrameAndSchema:
                 return True
         return False
 
-    def test_inferences_normalization_columns_already_normalized(self):
+    def test_inferences_normalization_columns_already_normalized(self) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_label": [f"label{index}" for index in range(self.num_records)],
@@ -630,7 +661,7 @@ class TestParseDataFrameAndSchema:
 
         assert output_dataframe.equals(input_dataframe)
 
-    def test_inferences_normalization_prediction_id_integer_to_string(self):
+    def test_inferences_normalization_prediction_id_integer_to_string(self) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_label": [f"label{index}" for index in range(self.num_records)],
@@ -656,7 +687,7 @@ class TestParseDataFrameAndSchema:
         expected_dataframe["prediction_id"] = expected_dataframe["prediction_id"].astype(str)
         assert output_dataframe.equals(expected_dataframe)
 
-    def test_inferences_normalization_columns_add_missing_prediction_id(self):
+    def test_inferences_normalization_columns_add_missing_prediction_id(self) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_label": [f"label{index}" for index in range(self.num_records)],
@@ -685,18 +716,18 @@ class TestParseDataFrameAndSchema:
         assert output_dataframe.dtypes["prediction_id"], "string"
 
     @property
-    def num_records(self):
+    def num_records(self) -> None:
         return self._NUM_RECORDS
 
     @property
-    def embedding_dimension(self):
+    def embedding_dimension(self) -> None:
         return self._EMBEDDING_DIMENSION
 
 
 class TestDataset:
     _NUM_RECORDS = 9
 
-    def test_inferences_normalization_columns_already_normalized(self):
+    def test_inferences_normalization_columns_already_normalized(self) -> None:
         input_dataframe = DataFrame(
             {
                 "prediction_label": [f"label{index}" for index in range(self.num_records)],
@@ -818,12 +849,15 @@ class TestDataset:
             Inferences(dataframe=input_df, schema=input_schema)
 
     @property
-    def num_records(self):
+    def num_records(self) -> None:
         return self._NUM_RECORDS
 
 
 @contextmanager
-def raises_inferences_error(validation_error_type, message):
+def raises_inferences_error(
+    validation_error_type: Type[BaseException],
+    message: str,
+) -> None:
     with raises(DatasetError) as exc_info:
         yield
     assert [type(error) for error in exc_info.value.errors] == [validation_error_type]
@@ -831,7 +865,7 @@ def raises_inferences_error(validation_error_type, message):
     assert str(error) == str(exc_info.value) == message
 
 
-def random_uuids(num_records: int):
+def random_uuids(num_records: int) -> None:
     return [str(uuid.uuid4()) for _ in range(num_records)]
 
 

--- a/tests/inferences/test_schema.py
+++ b/tests/inferences/test_schema.py
@@ -5,7 +5,7 @@ from phoenix.inferences.schema import (
 )
 
 
-def test_json_serialization():
+def test_json_serialization() -> None:
     s = Schema(
         feature_column_names=["feature_1"],
         embedding_feature_column_names={
@@ -25,7 +25,7 @@ def test_json_serialization():
     )
 
 
-def test_json_serialization_with_LLM():
+def test_json_serialization_with_LLM() -> None:
     s = Schema(
         feature_column_names=["feature_1"],
         prompt_column_names=EmbeddingColumnNames(
@@ -48,7 +48,7 @@ def test_json_serialization_with_LLM():
     assert schema_from_json.response_column_names.vector_column_name == "response_vector"
 
 
-def test_json_serialization_with_relationships():
+def test_json_serialization_with_relationships() -> None:
     s = Schema(
         prompt_column_names=RetrievalEmbeddingColumnNames(
             vector_column_name="vec_1",
@@ -64,7 +64,7 @@ def test_json_serialization_with_relationships():
     assert schema_from_json.prompt_column_names.context_retrieval_ids_column_name == "ids_1"
 
 
-def test_corpus_schema_normalization():
+def test_corpus_schema_normalization() -> None:
     s = Schema(
         id_column_name="id_1",
         document_column_names=EmbeddingColumnNames(

--- a/tests/inferences/test_validation.py
+++ b/tests/inferences/test_validation.py
@@ -8,7 +8,7 @@ _NUM_RECORDS = 5
 _EMBEDDING_DIMENSION = 7
 
 
-def test_embeddings_vector_length_mismatch():
+def test_embeddings_vector_length_mismatch() -> None:
     input_dataframe = DataFrame(
         {
             "prediction_id": [str(x) for x in range(_NUM_RECORDS)],
@@ -39,7 +39,7 @@ def test_embeddings_vector_length_mismatch():
     assert isinstance(errors[0], err.EmbeddingVectorSizeMismatch)
 
 
-def test_invalid_embeddings_vector_length():
+def test_invalid_embeddings_vector_length() -> None:
     input_dataframe = DataFrame(
         {
             "prediction_id": [str(x) for x in range(_NUM_RECORDS)],
@@ -69,7 +69,7 @@ def test_invalid_embeddings_vector_length():
     assert isinstance(errors[0], err.InvalidEmbeddingVectorSize)
 
 
-def test_embeddings_vector_invalid_type():
+def test_embeddings_vector_invalid_type() -> None:
     input_dataframe = DataFrame(
         {
             "prediction_id": [str(x) for x in range(_NUM_RECORDS)],
@@ -111,7 +111,7 @@ def test_embeddings_vector_invalid_type():
     assert isinstance(errors[1], err.InvalidEmbeddingVectorValuesDataType)
 
 
-def test_embedding_reserved_columns():
+def test_embedding_reserved_columns() -> None:
     input_dataframe = DataFrame(
         {
             "prediction_id": [str(x) for x in range(_NUM_RECORDS)],

--- a/tests/metrics/test_retrieval_metrics.py
+++ b/tests/metrics/test_retrieval_metrics.py
@@ -6,7 +6,7 @@ from sklearn.metrics import ndcg_score
 
 @pytest.mark.parametrize("k", [None, -1, 0, 1, 2, 1000])
 @pytest.mark.parametrize("scores", [[], [0], [1], [0, 0, 1], [np.nan, 1], [np.nan], [0, 2, np.nan]])
-def test_ranking_metrics_ndcg(k, scores):
+def test_ranking_metrics_ndcg(k, scores) -> None:
     actual = RetrievalMetrics(scores).ndcg(k)
     if not np.all(np.isfinite(np.array(scores))):
         desired = np.nan
@@ -25,7 +25,7 @@ def test_ranking_metrics_ndcg(k, scores):
 
 @pytest.mark.parametrize("k", [None, -1, 0, 1, 2, 1000])
 @pytest.mark.parametrize("scores", [[], [0], [1], [0, 0, 1], [np.nan, 1], [np.nan], [0, 2, np.nan]])
-def test_ranking_metrics_precision(k, scores):
+def test_ranking_metrics_precision(k, scores) -> None:
     actual = RetrievalMetrics(scores).precision(k)
     if not np.all(np.isfinite(np.array(scores))):
         desired = np.nan
@@ -47,7 +47,7 @@ def test_ranking_metrics_precision(k, scores):
         ([0, 2, np.nan], 1 / 2),
     ],
 )
-def test_ranking_metrics_reciprocal_rank(scores, desired):
+def test_ranking_metrics_reciprocal_rank(scores, desired) -> None:
     actual = RetrievalMetrics(scores).reciprocal_rank()
     assert np.isclose(actual, desired, equal_nan=True)
 
@@ -64,6 +64,6 @@ def test_ranking_metrics_reciprocal_rank(scores, desired):
         ([0, 2, np.nan], 1),
     ],
 )
-def test_ranking_metrics_hit(scores, desired):
+def test_ranking_metrics_hit(scores, desired) -> None:
     actual = RetrievalMetrics(scores).hit()
     assert np.isclose(actual, desired, equal_nan=True)

--- a/tests/metrics/test_scalar_drift.py
+++ b/tests/metrics/test_scalar_drift.py
@@ -15,7 +15,7 @@ reference_data = pd.DataFrame(
 )
 
 
-def test_psi_categorical_binning():
+def test_psi_categorical_binning() -> None:
     metric = metrics.PSI(
         operand=Column(column_name),
         reference_data=reference_data,
@@ -33,7 +33,7 @@ def test_psi_categorical_binning():
         )
 
 
-def test_psi_interval_binning():
+def test_psi_interval_binning() -> None:
     metric = metrics.PSI(
         operand=Column(column_name),
         reference_data=reference_data,
@@ -59,7 +59,7 @@ def test_psi_interval_binning():
         )
 
 
-def test_psi_quantile_binning():
+def test_psi_quantile_binning() -> None:
     metric = metrics.PSI(
         operand=Column(column_name),
         reference_data=reference_data,

--- a/tests/server/api/conftest.py
+++ b/tests/server/api/conftest.py
@@ -1,14 +1,15 @@
 from datetime import datetime
-from typing import Tuple
+from typing import AsyncContextManager, Callable, Tuple
 
 import pytest
 from phoenix.db import models
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.fixture
-async def span_data_with_documents(prod_db) -> None:
-    async with prod_db() as session:
+async def span_data_with_documents(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+    async with db() as session:
         project = models.Project(name="default")
         session.add(project)
         await session.flush()
@@ -40,7 +41,7 @@ async def span_data_with_documents(prod_db) -> None:
             events=[
                 {
                     "name": "exception",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(),
                     "exception.message": "uh-oh",
                 }
             ],
@@ -55,588 +56,594 @@ async def span_data_with_documents(prod_db) -> None:
 
 
 @pytest.fixture
-async def simple_dataset(session):
+async def simple_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with one example added in one version
     """
+    async with db() as session:
+        dataset = models.Dataset(
+            id=0,
+            name="simple dataset",
+            description=None,
+            metadata_={"info": "a test dataset"},
+        )
+        session.add(dataset)
+        await session.flush()
 
-    dataset = models.Dataset(
-        id=0,
-        name="simple dataset",
-        description=None,
-        metadata_={"info": "a test dataset"},
-    )
-    session.add(dataset)
-    await session.flush()
+        dataset_version_0 = models.DatasetVersion(
+            id=0,
+            dataset_id=0,
+            description="the first version",
+            metadata_={"info": "gotta get some test data somewhere"},
+        )
+        session.add(dataset_version_0)
+        await session.flush()
 
-    dataset_version_0 = models.DatasetVersion(
-        id=0,
-        dataset_id=0,
-        description="the first version",
-        metadata_={"info": "gotta get some test data somewhere"},
-    )
-    session.add(dataset_version_0)
-    await session.flush()
+        example_0 = models.DatasetExample(
+            id=0,
+            dataset_id=0,
+        )
+        session.add(example_0)
+        await session.flush()
 
-    example_0 = models.DatasetExample(
-        id=0,
-        dataset_id=0,
-    )
-    session.add(example_0)
-    await session.flush()
-
-    example_0_revision_0 = models.DatasetExampleRevision(
-        id=0,
-        dataset_example_id=0,
-        dataset_version_id=0,
-        input={"in": "foo"},
-        output={"out": "bar"},
-        metadata_={"info": "the first reivision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_0_revision_0)
-    await session.flush()
+        example_0_revision_0 = models.DatasetExampleRevision(
+            id=0,
+            dataset_example_id=0,
+            dataset_version_id=0,
+            input={"in": "foo"},
+            output={"out": "bar"},
+            metadata_={"info": "the first reivision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_0_revision_0)
+        await session.flush()
 
 
 @pytest.fixture
-async def empty_dataset(session):
+async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with three versions, where two examples are added, patched, then deleted
     """
+    async with db() as session:
+        dataset = models.Dataset(
+            id=1,
+            name="empty dataset",
+            description="emptied after two revisions",
+            metadata_={},
+        )
+        session.add(dataset)
+        await session.flush()
 
-    dataset = models.Dataset(
-        id=1,
-        name="empty dataset",
-        description="emptied after two revisions",
-        metadata_={},
-    )
-    session.add(dataset)
-    await session.flush()
+        dataset_version_1 = models.DatasetVersion(
+            id=1,
+            dataset_id=1,
+            description="data gets added",
+            metadata_={"info": "gotta get some test data somewhere"},
+        )
+        session.add(dataset_version_1)
+        await session.flush()
 
-    dataset_version_1 = models.DatasetVersion(
-        id=1,
-        dataset_id=1,
-        description="data gets added",
-        metadata_={"info": "gotta get some test data somewhere"},
-    )
-    session.add(dataset_version_1)
-    await session.flush()
+        example_1 = models.DatasetExample(
+            id=1,
+            dataset_id=1,
+        )
+        session.add(example_1)
+        await session.flush()
 
-    example_1 = models.DatasetExample(
-        id=1,
-        dataset_id=1,
-    )
-    session.add(example_1)
-    await session.flush()
+        example_2 = models.DatasetExample(
+            id=2,
+            dataset_id=1,
+        )
+        session.add(example_2)
+        await session.flush()
 
-    example_2 = models.DatasetExample(
-        id=2,
-        dataset_id=1,
-    )
-    session.add(example_2)
-    await session.flush()
+        example_1_revision_1 = models.DatasetExampleRevision(
+            id=1,
+            dataset_example_id=1,
+            dataset_version_id=1,
+            input={"in": "foo"},
+            output={"out": "bar"},
+            metadata_={"info": "first revision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_1_revision_1)
+        await session.flush()
 
-    example_1_revision_1 = models.DatasetExampleRevision(
-        id=1,
-        dataset_example_id=1,
-        dataset_version_id=1,
-        input={"in": "foo"},
-        output={"out": "bar"},
-        metadata_={"info": "first revision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_1_revision_1)
-    await session.flush()
+        example_2_revision_1 = models.DatasetExampleRevision(
+            id=2,
+            dataset_example_id=2,
+            dataset_version_id=1,
+            input={"in": "foofoo"},
+            output={"out": "barbar"},
+            metadata_={"info": "first revision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_2_revision_1)
+        await session.flush()
 
-    example_2_revision_1 = models.DatasetExampleRevision(
-        id=2,
-        dataset_example_id=2,
-        dataset_version_id=1,
-        input={"in": "foofoo"},
-        output={"out": "barbar"},
-        metadata_={"info": "first revision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_2_revision_1)
-    await session.flush()
+        dataset_version_2 = models.DatasetVersion(
+            id=2,
+            dataset_id=1,
+            description="data gets patched",
+            metadata_={"info": "all caps patch"},
+        )
+        session.add(dataset_version_2)
+        await session.flush()
 
-    dataset_version_2 = models.DatasetVersion(
-        id=2,
-        dataset_id=1,
-        description="data gets patched",
-        metadata_={"info": "all caps patch"},
-    )
-    session.add(dataset_version_2)
-    await session.flush()
+        example_1_revision_2 = models.DatasetExampleRevision(
+            id=3,
+            dataset_example_id=1,
+            dataset_version_id=2,
+            input={"in": "FOO"},
+            output={"out": "BAR"},
+            metadata_={"info": "all caps revision"},
+            revision_kind="PATCH",
+        )
+        session.add(example_1_revision_2)
+        await session.flush()
 
-    example_1_revision_2 = models.DatasetExampleRevision(
-        id=3,
-        dataset_example_id=1,
-        dataset_version_id=2,
-        input={"in": "FOO"},
-        output={"out": "BAR"},
-        metadata_={"info": "all caps revision"},
-        revision_kind="PATCH",
-    )
-    session.add(example_1_revision_2)
-    await session.flush()
+        example_2_revision_2 = models.DatasetExampleRevision(
+            id=4,
+            dataset_example_id=2,
+            dataset_version_id=2,
+            input={"in": "FOOFOO"},
+            output={"out": "BARBAR"},
+            metadata_={"info": "all caps revision"},
+            revision_kind="PATCH",
+        )
+        session.add(example_2_revision_2)
+        await session.flush()
 
-    example_2_revision_2 = models.DatasetExampleRevision(
-        id=4,
-        dataset_example_id=2,
-        dataset_version_id=2,
-        input={"in": "FOOFOO"},
-        output={"out": "BARBAR"},
-        metadata_={"info": "all caps revision"},
-        revision_kind="PATCH",
-    )
-    session.add(example_2_revision_2)
-    await session.flush()
+        dataset_version_3 = models.DatasetVersion(
+            id=3,
+            dataset_id=1,
+            description="data gets deleted",
+            metadata_={"info": "all gone"},
+        )
+        session.add(dataset_version_3)
+        await session.flush()
 
-    dataset_version_3 = models.DatasetVersion(
-        id=3,
-        dataset_id=1,
-        description="data gets deleted",
-        metadata_={"info": "all gone"},
-    )
-    session.add(dataset_version_3)
-    await session.flush()
+        example_1_revision_3 = models.DatasetExampleRevision(
+            id=5,
+            dataset_example_id=1,
+            dataset_version_id=3,
+            input={},
+            output={},
+            metadata_={"info": "all caps revision"},
+            revision_kind="DELETE",
+        )
+        session.add(example_1_revision_3)
+        await session.flush()
 
-    example_1_revision_3 = models.DatasetExampleRevision(
-        id=5,
-        dataset_example_id=1,
-        dataset_version_id=3,
-        input={},
-        output={},
-        metadata_={"info": "all caps revision"},
-        revision_kind="DELETE",
-    )
-    session.add(example_1_revision_3)
-    await session.flush()
-
-    example_2_revision_3 = models.DatasetExampleRevision(
-        id=6,
-        dataset_example_id=2,
-        dataset_version_id=3,
-        input={},
-        output={},
-        metadata_={"info": "all caps revision"},
-        revision_kind="DELETE",
-    )
-    session.add(example_2_revision_3)
-    await session.flush()
+        example_2_revision_3 = models.DatasetExampleRevision(
+            id=6,
+            dataset_example_id=2,
+            dataset_version_id=3,
+            input={},
+            output={},
+            metadata_={"info": "all caps revision"},
+            revision_kind="DELETE",
+        )
+        session.add(example_2_revision_3)
+        await session.flush()
 
 
 @pytest.fixture
-async def dataset_with_revisions(session):
+async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with six versions, first two examples are added, then one example is patched and a
     third example is added.
 
     The last four revisions alternate between adding then removing an example.
     """
-
-    dataset = models.Dataset(
-        id=2,
-        name="revised dataset",
-        description="this dataset grows over time",
-        metadata_={},
-    )
-    session.add(dataset)
-    await session.flush()
-
-    dataset_version_4 = models.DatasetVersion(
-        id=4,
-        dataset_id=2,
-        description="data gets added",
-        metadata_={"info": "gotta get some test data somewhere"},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:04+00:00"),
-    )
-    session.add(dataset_version_4)
-    await session.flush()
-
-    example_3 = models.DatasetExample(
-        id=3,
-        dataset_id=2,
-    )
-    session.add(example_3)
-    await session.flush()
-
-    example_4 = models.DatasetExample(
-        id=4,
-        dataset_id=2,
-    )
-    session.add(example_4)
-    await session.flush()
-
-    example_3_revision_4 = models.DatasetExampleRevision(
-        id=7,
-        dataset_example_id=3,
-        dataset_version_id=4,
-        input={"in": "foo"},
-        output={"out": "bar"},
-        metadata_={"info": "first revision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_3_revision_4)
-    await session.flush()
-
-    example_4_revision_4 = models.DatasetExampleRevision(
-        id=8,
-        dataset_example_id=4,
-        dataset_version_id=4,
-        input={"in": "foofoo"},
-        output={"out": "barbar"},
-        metadata_={"info": "first revision"},
-        revision_kind="CREATE",
-    )
-    session.add(example_4_revision_4)
-    await session.flush()
-
-    dataset_version_5 = models.DatasetVersion(
-        id=5,
-        dataset_id=2,
-        description="data gets patched and added",
-        metadata_={},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:05+00:00"),
-    )
-    session.add(dataset_version_5)
-    await session.flush()
-
-    dataset_version_6 = models.DatasetVersion(
-        id=6,
-        dataset_id=2,
-        description="datum gets created",
-        metadata_={},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:06+00:00"),
-    )
-    session.add(dataset_version_6)
-    await session.flush()
-
-    dataset_version_7 = models.DatasetVersion(
-        id=7,
-        dataset_id=2,
-        description="datum gets deleted",
-        metadata_={},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:07+00:00"),
-    )
-    session.add(dataset_version_7)
-    await session.flush()
-
-    dataset_version_8 = models.DatasetVersion(
-        id=8,
-        dataset_id=2,
-        description="datum gets created",
-        metadata_={},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:08+00:00"),
-    )
-    session.add(dataset_version_8)
-    await session.flush()
-
-    dataset_version_9 = models.DatasetVersion(
-        id=9,
-        dataset_id=2,
-        description="datum gets deleted",
-        metadata_={},
-        created_at=datetime.fromisoformat("2024-05-28T00:00:09+00:00"),
-    )
-    session.add(dataset_version_9)
-    await session.flush()
-
-    example_5 = models.DatasetExample(
-        id=5,
-        dataset_id=2,
-    )
-    session.add(example_5)
-    await session.flush()
-
-    example_6 = models.DatasetExample(
-        id=6,
-        dataset_id=2,
-    )
-    session.add(example_6)
-    await session.flush()
-
-    example_7 = models.DatasetExample(
-        id=7,
-        dataset_id=2,
-    )
-    session.add(example_7)
-    await session.flush()
-
-    example_4_revision_5 = models.DatasetExampleRevision(
-        id=9,
-        dataset_example_id=4,
-        dataset_version_id=5,
-        input={"in": "updated foofoo"},
-        output={"out": "updated barbar"},
-        metadata_={"info": "updating revision"},
-        revision_kind="PATCH",
-    )
-    session.add(example_4_revision_5)
-    await session.flush()
-
-    example_5_revision_5 = models.DatasetExampleRevision(
-        id=10,
-        dataset_example_id=5,
-        dataset_version_id=5,
-        input={"in": "look at me"},
-        output={"out": "i have all the answers"},
-        metadata_={"info": "a new example"},
-        revision_kind="CREATE",
-    )
-    session.add(example_5_revision_5)
-    await session.flush()
-
-    example_6_revision_6 = models.DatasetExampleRevision(
-        id=11,
-        dataset_example_id=example_6.id,
-        dataset_version_id=dataset_version_6.id,
-        input={"in": "look at us"},
-        output={"out": "we have all the answers"},
-        metadata_={"info": "a new example"},
-        revision_kind="CREATE",
-    )
-    session.add(example_6_revision_6)
-    await session.flush()
-
-    example_6_revision_7 = models.DatasetExampleRevision(
-        id=12,
-        dataset_example_id=example_6.id,
-        dataset_version_id=dataset_version_7.id,
-        input={"in": "look at us"},
-        output={"out": "we have all the answers"},
-        metadata_={"info": "a new example"},
-        revision_kind="DELETE",
-    )
-    session.add(example_6_revision_7)
-    await session.flush()
-
-    example_7_revision_8 = models.DatasetExampleRevision(
-        id=13,
-        dataset_example_id=example_7.id,
-        dataset_version_id=dataset_version_8.id,
-        input={"in": "look at me"},
-        output={"out": "i have all the answers"},
-        metadata_={"info": "a newer example"},
-        revision_kind="CREATE",
-    )
-    session.add(example_7_revision_8)
-    await session.flush()
-
-    example_7_revision_9 = models.DatasetExampleRevision(
-        id=14,
-        dataset_example_id=example_7.id,
-        dataset_version_id=dataset_version_9.id,
-        input={"in": "look at me"},
-        output={"out": "i have all the answers"},
-        metadata_={"info": "a newer example"},
-        revision_kind="DELETE",
-    )
-    session.add(example_7_revision_9)
-    await session.flush()
-
-
-@pytest.fixture
-async def dataset_with_experiments_without_runs(session, empty_dataset):
-    experiment_0 = models.Experiment(
-        id=0,
-        dataset_id=1,
-        dataset_version_id=1,
-        name="test",
-        repetitions=1,
-        metadata_={"info": "a test experiment"},
-    )
-    session.add(experiment_0)
-    await session.flush()
-
-    experiment_1 = models.Experiment(
-        id=1,
-        dataset_id=1,
-        dataset_version_id=2,
-        name="second test",
-        repetitions=1,
-        metadata_={"info": "a second test experiment"},
-    )
-    session.add(experiment_1)
-    await session.flush()
-
-
-@pytest.fixture
-async def dataset_with_experiments_and_runs(session, dataset_with_experiments_without_runs):
-    experiment_run_0 = models.ExperimentRun(
-        id=0,
-        experiment_id=0,
-        dataset_example_id=1,
-        output={"out": "barr"},
-        repetition_number=1,
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-        error=None,
-    )
-    session.add(experiment_run_0)
-    await session.flush()
-
-    experiment_run_1 = models.ExperimentRun(
-        id=1,
-        experiment_id=0,
-        dataset_example_id=2,
-        output={"out": "barbarr"},
-        repetition_number=1,
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-        error=None,
-    )
-    session.add(experiment_run_1)
-    await session.flush()
-
-    experiment_run_2 = models.ExperimentRun(
-        id=2,
-        experiment_id=1,
-        dataset_example_id=1,
-        output={"out": "bar"},
-        repetition_number=1,
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-        error=None,
-    )
-    session.add(experiment_run_2)
-    await session.flush()
-
-    experiment_run_3 = models.ExperimentRun(
-        id=3,
-        experiment_id=1,
-        dataset_example_id=2,
-        output=None,
-        repetition_number=1,
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-        error="something funny happened",
-    )
-    session.add(experiment_run_3)
-    await session.flush()
-
-
-@pytest.fixture
-async def dataset_with_experiments_runs_and_evals(session, dataset_with_experiments_and_runs):
-    experiment_evaluation_0 = models.ExperimentRunAnnotation(
-        id=0,
-        experiment_run_id=0,
-        name="test",
-        annotator_kind="LLM",
-        label="test",
-        score=0.8,
-        explanation="test",
-        error=None,
-        metadata_={"info": "a test evaluation"},
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-    )
-    session.add(experiment_evaluation_0)
-    await session.flush()
-
-    experiment_evaluation_1 = models.ExperimentRunAnnotation(
-        id=1,
-        experiment_run_id=1,
-        name="test",
-        annotator_kind="LLM",
-        label="test",
-        score=0.9,
-        explanation="test",
-        error=None,
-        metadata_={"info": "a test evaluation"},
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-    )
-    session.add(experiment_evaluation_1)
-    await session.flush()
-
-    experiment_evaluation_2 = models.ExperimentRunAnnotation(
-        id=2,
-        experiment_run_id=2,
-        name="second experiment",
-        annotator_kind="LLM",
-        label="test2",
-        score=1,
-        explanation="test",
-        error=None,
-        metadata_={"info": "a test evaluation"},
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-    )
-    session.add(experiment_evaluation_2)
-    await session.flush()
-
-    experiment_evaluation_3 = models.ExperimentRunAnnotation(
-        id=3,
-        experiment_run_id=3,
-        name="experiment",
-        annotator_kind="LLM",
-        label="test2",
-        score=None,
-        explanation="test",
-        error="something funnier happened",
-        metadata_={"info": "a test evaluation"},
-        start_time=datetime.now(),
-        end_time=datetime.now(),
-    )
-    session.add(experiment_evaluation_3)
-    await session.flush()
-
-
-@pytest.fixture
-async def dataset_with_messages(session) -> Tuple[int, int]:
-    dataset_id = await session.scalar(
-        insert(models.Dataset).returning(models.Dataset.id),
-        [{"name": "xyz", "metadata_": {}}],
-    )
-    dataset_version_id = await session.scalar(
-        insert(models.DatasetVersion).returning(models.DatasetVersion.id),
-        [{"dataset_id": dataset_id, "metadata_": {}}],
-    )
-    dataset_example_ids = list(
-        await session.scalars(
-            insert(models.DatasetExample).returning(models.DatasetExample.id),
-            [{"dataset_id": dataset_id}, {"dataset_id": dataset_id}],
+    async with db() as session:
+        dataset = models.Dataset(
+            id=2,
+            name="revised dataset",
+            description="this dataset grows over time",
+            metadata_={},
         )
-    )
-    await session.scalar(
-        insert(models.DatasetExampleRevision).returning(models.DatasetExampleRevision.id),
-        [
-            {
-                "revision_kind": "CREATE",
-                "dataset_example_id": dataset_example_ids[0],
-                "dataset_version_id": dataset_version_id,
-                "input": {
-                    "messages": [
-                        {"role": "system", "content": "x"},
-                        {"role": "user", "content": "y"},
-                    ]
+        session.add(dataset)
+        await session.flush()
+
+        dataset_version_4 = models.DatasetVersion(
+            id=4,
+            dataset_id=2,
+            description="data gets added",
+            metadata_={"info": "gotta get some test data somewhere"},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:04+00:00"),
+        )
+        session.add(dataset_version_4)
+        await session.flush()
+
+        example_3 = models.DatasetExample(
+            id=3,
+            dataset_id=2,
+        )
+        session.add(example_3)
+        await session.flush()
+
+        example_4 = models.DatasetExample(
+            id=4,
+            dataset_id=2,
+        )
+        session.add(example_4)
+        await session.flush()
+
+        example_3_revision_4 = models.DatasetExampleRevision(
+            id=7,
+            dataset_example_id=3,
+            dataset_version_id=4,
+            input={"in": "foo"},
+            output={"out": "bar"},
+            metadata_={"info": "first revision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_3_revision_4)
+        await session.flush()
+
+        example_4_revision_4 = models.DatasetExampleRevision(
+            id=8,
+            dataset_example_id=4,
+            dataset_version_id=4,
+            input={"in": "foofoo"},
+            output={"out": "barbar"},
+            metadata_={"info": "first revision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_4_revision_4)
+        await session.flush()
+
+        dataset_version_5 = models.DatasetVersion(
+            id=5,
+            dataset_id=2,
+            description="data gets patched and added",
+            metadata_={},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:05+00:00"),
+        )
+        session.add(dataset_version_5)
+        await session.flush()
+
+        dataset_version_6 = models.DatasetVersion(
+            id=6,
+            dataset_id=2,
+            description="datum gets created",
+            metadata_={},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:06+00:00"),
+        )
+        session.add(dataset_version_6)
+        await session.flush()
+
+        dataset_version_7 = models.DatasetVersion(
+            id=7,
+            dataset_id=2,
+            description="datum gets deleted",
+            metadata_={},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:07+00:00"),
+        )
+        session.add(dataset_version_7)
+        await session.flush()
+
+        dataset_version_8 = models.DatasetVersion(
+            id=8,
+            dataset_id=2,
+            description="datum gets created",
+            metadata_={},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:08+00:00"),
+        )
+        session.add(dataset_version_8)
+        await session.flush()
+
+        dataset_version_9 = models.DatasetVersion(
+            id=9,
+            dataset_id=2,
+            description="datum gets deleted",
+            metadata_={},
+            created_at=datetime.fromisoformat("2024-05-28T00:00:09+00:00"),
+        )
+        session.add(dataset_version_9)
+        await session.flush()
+
+        example_5 = models.DatasetExample(
+            id=5,
+            dataset_id=2,
+        )
+        session.add(example_5)
+        await session.flush()
+
+        example_6 = models.DatasetExample(
+            id=6,
+            dataset_id=2,
+        )
+        session.add(example_6)
+        await session.flush()
+
+        example_7 = models.DatasetExample(
+            id=7,
+            dataset_id=2,
+        )
+        session.add(example_7)
+        await session.flush()
+
+        example_4_revision_5 = models.DatasetExampleRevision(
+            id=9,
+            dataset_example_id=4,
+            dataset_version_id=5,
+            input={"in": "updated foofoo"},
+            output={"out": "updated barbar"},
+            metadata_={"info": "updating revision"},
+            revision_kind="PATCH",
+        )
+        session.add(example_4_revision_5)
+        await session.flush()
+
+        example_5_revision_5 = models.DatasetExampleRevision(
+            id=10,
+            dataset_example_id=5,
+            dataset_version_id=5,
+            input={"in": "look at me"},
+            output={"out": "i have all the answers"},
+            metadata_={"info": "a new example"},
+            revision_kind="CREATE",
+        )
+        session.add(example_5_revision_5)
+        await session.flush()
+
+        example_6_revision_6 = models.DatasetExampleRevision(
+            id=11,
+            dataset_example_id=example_6.id,
+            dataset_version_id=dataset_version_6.id,
+            input={"in": "look at us"},
+            output={"out": "we have all the answers"},
+            metadata_={"info": "a new example"},
+            revision_kind="CREATE",
+        )
+        session.add(example_6_revision_6)
+        await session.flush()
+
+        example_6_revision_7 = models.DatasetExampleRevision(
+            id=12,
+            dataset_example_id=example_6.id,
+            dataset_version_id=dataset_version_7.id,
+            input={"in": "look at us"},
+            output={"out": "we have all the answers"},
+            metadata_={"info": "a new example"},
+            revision_kind="DELETE",
+        )
+        session.add(example_6_revision_7)
+        await session.flush()
+
+        example_7_revision_8 = models.DatasetExampleRevision(
+            id=13,
+            dataset_example_id=example_7.id,
+            dataset_version_id=dataset_version_8.id,
+            input={"in": "look at me"},
+            output={"out": "i have all the answers"},
+            metadata_={"info": "a newer example"},
+            revision_kind="CREATE",
+        )
+        session.add(example_7_revision_8)
+        await session.flush()
+
+        example_7_revision_9 = models.DatasetExampleRevision(
+            id=14,
+            dataset_example_id=example_7.id,
+            dataset_version_id=dataset_version_9.id,
+            input={"in": "look at me"},
+            output={"out": "i have all the answers"},
+            metadata_={"info": "a newer example"},
+            revision_kind="DELETE",
+        )
+        session.add(example_7_revision_9)
+        await session.flush()
+
+
+@pytest.fixture
+async def dataset_with_experiments_without_runs(db, empty_dataset):
+    async with db() as session:
+        experiment_0 = models.Experiment(
+            id=0,
+            dataset_id=1,
+            dataset_version_id=1,
+            name="test",
+            repetitions=1,
+            metadata_={"info": "a test experiment"},
+        )
+        session.add(experiment_0)
+        await session.flush()
+
+        experiment_1 = models.Experiment(
+            id=1,
+            dataset_id=1,
+            dataset_version_id=2,
+            name="second test",
+            repetitions=1,
+            metadata_={"info": "a second test experiment"},
+        )
+        session.add(experiment_1)
+        await session.flush()
+
+
+@pytest.fixture
+async def dataset_with_experiments_and_runs(db, dataset_with_experiments_without_runs):
+    async with db() as session:
+        experiment_run_0 = models.ExperimentRun(
+            id=0,
+            experiment_id=0,
+            dataset_example_id=1,
+            output={"out": "barr"},
+            repetition_number=1,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            error=None,
+        )
+        session.add(experiment_run_0)
+        await session.flush()
+
+        experiment_run_1 = models.ExperimentRun(
+            id=1,
+            experiment_id=0,
+            dataset_example_id=2,
+            output={"out": "barbarr"},
+            repetition_number=1,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            error=None,
+        )
+        session.add(experiment_run_1)
+        await session.flush()
+
+        experiment_run_2 = models.ExperimentRun(
+            id=2,
+            experiment_id=1,
+            dataset_example_id=1,
+            output={"out": "bar"},
+            repetition_number=1,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            error=None,
+        )
+        session.add(experiment_run_2)
+        await session.flush()
+
+        experiment_run_3 = models.ExperimentRun(
+            id=3,
+            experiment_id=1,
+            dataset_example_id=2,
+            output=None,
+            repetition_number=1,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            error="something funny happened",
+        )
+        session.add(experiment_run_3)
+        await session.flush()
+
+
+@pytest.fixture
+async def dataset_with_experiments_runs_and_evals(db, dataset_with_experiments_and_runs):
+    async with db() as session:
+        experiment_evaluation_0 = models.ExperimentRunAnnotation(
+            id=0,
+            experiment_run_id=0,
+            name="test",
+            annotator_kind="LLM",
+            label="test",
+            score=0.8,
+            explanation="test",
+            error=None,
+            metadata_={"info": "a test evaluation"},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+        session.add(experiment_evaluation_0)
+        await session.flush()
+
+        experiment_evaluation_1 = models.ExperimentRunAnnotation(
+            id=1,
+            experiment_run_id=1,
+            name="test",
+            annotator_kind="LLM",
+            label="test",
+            score=0.9,
+            explanation="test",
+            error=None,
+            metadata_={"info": "a test evaluation"},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+        session.add(experiment_evaluation_1)
+        await session.flush()
+
+        experiment_evaluation_2 = models.ExperimentRunAnnotation(
+            id=2,
+            experiment_run_id=2,
+            name="second experiment",
+            annotator_kind="LLM",
+            label="test2",
+            score=1,
+            explanation="test",
+            error=None,
+            metadata_={"info": "a test evaluation"},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+        session.add(experiment_evaluation_2)
+        await session.flush()
+
+        experiment_evaluation_3 = models.ExperimentRunAnnotation(
+            id=3,
+            experiment_run_id=3,
+            name="experiment",
+            annotator_kind="LLM",
+            label="test2",
+            score=None,
+            explanation="test",
+            error="something funnier happened",
+            metadata_={"info": "a test evaluation"},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+        session.add(experiment_evaluation_3)
+        await session.flush()
+
+
+@pytest.fixture
+async def dataset_with_messages(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> Tuple[int, int]:
+    async with db() as session:
+        dataset_id = await session.scalar(
+            insert(models.Dataset).returning(models.Dataset.id),
+            [{"name": "xyz", "metadata_": {}}],
+        )
+        dataset_version_id = await session.scalar(
+            insert(models.DatasetVersion).returning(models.DatasetVersion.id),
+            [{"dataset_id": dataset_id, "metadata_": {}}],
+        )
+        dataset_example_ids = list(
+            await session.scalars(
+                insert(models.DatasetExample).returning(models.DatasetExample.id),
+                [{"dataset_id": dataset_id}, {"dataset_id": dataset_id}],
+            )
+        )
+        await session.scalar(
+            insert(models.DatasetExampleRevision).returning(models.DatasetExampleRevision.id),
+            [
+                {
+                    "revision_kind": "CREATE",
+                    "dataset_example_id": dataset_example_ids[0],
+                    "dataset_version_id": dataset_version_id,
+                    "input": {
+                        "messages": [
+                            {"role": "system", "content": "x"},
+                            {"role": "user", "content": "y"},
+                        ]
+                    },
+                    "output": {
+                        "messages": [
+                            {"role": "assistant", "content": "z"},
+                        ]
+                    },
+                    "metadata_": {},
                 },
-                "output": {
-                    "messages": [
-                        {"role": "assistant", "content": "z"},
-                    ]
+                {
+                    "revision_kind": "CREATE",
+                    "dataset_example_id": dataset_example_ids[1],
+                    "dataset_version_id": dataset_version_id,
+                    "input": {
+                        "messages": [
+                            {"role": "system", "content": "xx"},
+                            {"role": "user", "content": "yy"},
+                        ]
+                    },
+                    "output": {
+                        "messages": [
+                            {"role": "assistant", "content": "zz"},
+                        ]
+                    },
+                    "metadata_": {},
                 },
-                "metadata_": {},
-            },
-            {
-                "revision_kind": "CREATE",
-                "dataset_example_id": dataset_example_ids[1],
-                "dataset_version_id": dataset_version_id,
-                "input": {
-                    "messages": [
-                        {"role": "system", "content": "xx"},
-                        {"role": "user", "content": "yy"},
-                    ]
-                },
-                "output": {
-                    "messages": [
-                        {"role": "assistant", "content": "zz"},
-                    ]
-                },
-                "metadata_": {},
-            },
-        ],
-    )
-    return dataset_id, dataset_version_id
+            ],
+        )
+        return dataset_id, dataset_version_id

--- a/tests/server/api/conftest.py
+++ b/tests/server/api/conftest.py
@@ -56,7 +56,7 @@ async def span_data_with_documents(db: Callable[[], AsyncContextManager[AsyncSes
 
 
 @pytest.fixture
-async def simple_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def simple_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with one example added in one version
     """
@@ -100,7 +100,7 @@ async def simple_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
 
 
 @pytest.fixture
-async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with three versions, where two examples are added, patched, then deleted
     """
@@ -229,7 +229,7 @@ async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
 
 
 @pytest.fixture
-async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with six versions, first two examples are added, then one example is patched and a
     third example is added.
@@ -442,7 +442,7 @@ async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSessi
 async def dataset_with_experiments_without_runs(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     empty_dataset: Any,
-):
+) -> None:
     async with db() as session:
         experiment_0 = models.Experiment(
             id=0,
@@ -471,7 +471,7 @@ async def dataset_with_experiments_without_runs(
 async def dataset_with_experiments_and_runs(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     dataset_with_experiments_without_runs: Any,
-):
+) -> None:
     async with db() as session:
         experiment_run_0 = models.ExperimentRun(
             id=0,
@@ -530,7 +530,7 @@ async def dataset_with_experiments_and_runs(
 async def dataset_with_experiments_runs_and_evals(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     dataset_with_experiments_and_runs: Any,
-):
+) -> None:
     async with db() as session:
         experiment_evaluation_0 = models.ExperimentRunAnnotation(
             id=0,

--- a/tests/server/api/conftest.py
+++ b/tests/server/api/conftest.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable, Tuple
+from typing import Any, AsyncContextManager, Callable, Tuple
 
 import pytest
 from phoenix.db import models
@@ -439,7 +439,10 @@ async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSessi
 
 
 @pytest.fixture
-async def dataset_with_experiments_without_runs(db, empty_dataset):
+async def dataset_with_experiments_without_runs(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    empty_dataset: Any,
+):
     async with db() as session:
         experiment_0 = models.Experiment(
             id=0,
@@ -465,7 +468,10 @@ async def dataset_with_experiments_without_runs(db, empty_dataset):
 
 
 @pytest.fixture
-async def dataset_with_experiments_and_runs(db, dataset_with_experiments_without_runs):
+async def dataset_with_experiments_and_runs(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    dataset_with_experiments_without_runs: Any,
+):
     async with db() as session:
         experiment_run_0 = models.ExperimentRun(
             id=0,
@@ -521,7 +527,10 @@ async def dataset_with_experiments_and_runs(db, dataset_with_experiments_without
 
 
 @pytest.fixture
-async def dataset_with_experiments_runs_and_evals(db, dataset_with_experiments_and_runs):
+async def dataset_with_experiments_runs_and_evals(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    dataset_with_experiments_and_runs: Any,
+):
     async with db() as session:
         experiment_evaluation_0 = models.ExperimentRunAnnotation(
             id=0,

--- a/tests/server/api/input_types/test_DimensionFilter.py
+++ b/tests/server/api/input_types/test_DimensionFilter.py
@@ -86,7 +86,7 @@ def test_dimension_filter(
     desired: List[bool],
     types: Optional[List[DimensionType]],
     shapes: Optional[List[DimensionShape]],
-):
+) -> None:
     """
     Dimensions
 

--- a/tests/server/api/input_types/test_TimeRange.py
+++ b/tests/server/api/input_types/test_TimeRange.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from phoenix.server.api.input_types.TimeRange import TimeRange
 
 
-def test_ensure_time_range_utc():
+def test_ensure_time_range_utc() -> None:
     t1 = datetime.now()
     assert t1.tzinfo is None
     assert TimeRange(start=t1, end=t1).start.tzinfo.utcoffset(None) == timedelta()

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -512,9 +512,9 @@ class TestPatchDatasetExamples:
 
 
 async def test_delete_a_dataset(
-    db,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
     httpx_client: httpx.AsyncClient,
-    empty_dataset,
+    empty_dataset: Any,
 ):
     dataset_id = GlobalID(type_name="Dataset", node_id=str(1))
     mutation = textwrap.dedent(

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -15,7 +15,7 @@ from strawberry.relay import GlobalID
 
 async def test_create_dataset(
     httpx_client: httpx.AsyncClient,
-):
+) -> None:
     create_dataset_mutation = """
       mutation ($name: String!, $description: String!, $metadata: JSON!) {
         createDataset(
@@ -515,7 +515,7 @@ async def test_delete_a_dataset(
     db: Callable[[], AsyncContextManager[AsyncSession]],
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
-):
+) -> None:
     dataset_id = GlobalID(type_name="Dataset", node_id=str(1))
     mutation = textwrap.dedent(
         """
@@ -553,7 +553,7 @@ async def test_delete_a_dataset(
 
 async def test_deleting_a_nonexistent_dataset_fails(
     httpx_client: httpx.AsyncClient,
-):
+) -> None:
     dataset_id = GlobalID(type_name="Dataset", node_id=str(1))
     mutation = textwrap.dedent(
         """
@@ -583,7 +583,7 @@ async def test_deleting_a_nonexistent_dataset_fails(
 
 
 @pytest.fixture
-async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     Inserts an empty dataset.
     """
@@ -599,7 +599,7 @@ async def empty_dataset(db: Callable[[], AsyncContextManager[AsyncSession]]):
 
 
 @pytest.fixture
-async def spans(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def spans(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     Inserts three spans from a single trace: a chain root span, a retriever
     child span, and an llm child span.
@@ -705,7 +705,9 @@ async def spans(db: Callable[[], AsyncContextManager[AsyncSession]]):
 
 
 @pytest.fixture
-async def dataset_with_a_single_version(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_a_single_version(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     A dataset with a single example and a single version.
     """
@@ -758,7 +760,7 @@ async def dataset_with_a_single_version(db: Callable[[], AsyncContextManager[Asy
 
 
 @pytest.fixture
-async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_revisions(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with three examples and two versions. The first version creates
     all three examples, and the second version deletes the third example.

--- a/tests/server/api/routers/v1/test_datasets.py
+++ b/tests/server/api/routers/v1/test_datasets.py
@@ -22,7 +22,7 @@ from strawberry.relay import GlobalID
 async def test_get_simple_dataset(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
@@ -43,7 +43,7 @@ async def test_get_simple_dataset(
 async def test_get_empty_dataset(
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(1))
     response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
@@ -64,7 +64,7 @@ async def test_get_empty_dataset(
 async def test_get_dataset_with_revisions(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
@@ -87,7 +87,7 @@ async def test_list_datasets(
     simple_dataset: Any,
     empty_dataset: Any,
     dataset_with_revisions: Any,
-):
+) -> None:
     response = await httpx_client.get("/v1/datasets")
     assert response.status_code == 200
     datasets_json = response.json()
@@ -133,7 +133,7 @@ async def test_list_fewer_datasets(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
     empty_dataset: Any,
-):
+) -> None:
     response = await httpx_client.get("/v1/datasets")
     assert response.status_code == 200
     datasets_json = response.json()
@@ -170,7 +170,7 @@ async def test_list_datasets_with_cursor(
     simple_dataset: Any,
     empty_dataset: Any,
     dataset_with_revisions: Any,
-):
+) -> None:
     response = await httpx_client.get("/v1/datasets", params={"limit": 2})
     assert response.status_code == 200
     datasets_json = response.json()
@@ -225,7 +225,7 @@ async def test_list_datasets_with_cursor(
 async def test_get_dataset_versions(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/versions?limit=2")
     assert response.status_code == 200
@@ -252,7 +252,7 @@ async def test_get_dataset_versions(
 async def test_get_dataset_versions_with_cursor(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/versions?limit=2"
@@ -276,7 +276,7 @@ async def test_get_dataset_versions_with_cursor(
 async def test_get_dataset_versions_with_nonexistent_cursor(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/versions?limit=1"
@@ -290,7 +290,7 @@ async def test_get_dataset_versions_with_nonexistent_cursor(
 async def test_get_dataset_download_empty_dataset(
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(1))
     response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/csv")
     assert response.status_code == 200
@@ -305,7 +305,7 @@ async def test_get_dataset_download_nonexistent_version(
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(1))
     dataset_version_global_id = GlobalID("DatasetVersion", str(4))  # Version for Dataset id=2
     response = await httpx_client.get(
@@ -322,7 +322,7 @@ async def test_get_dataset_download_nonexistent_version(
 async def test_get_dataset_download_latest_version(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/csv")
     assert response.status_code == 200
@@ -346,7 +346,7 @@ async def test_get_dataset_download_latest_version(
 async def test_get_dataset_download_specific_version(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     dataset_global_id = GlobalID("Dataset", str(2))
     dataset_version_global_id = GlobalID("DatasetVersion", str(8))
     response = await httpx_client.get(
@@ -374,7 +374,7 @@ async def test_get_dataset_download_specific_version(
 async def test_get_dataset_jsonl_openai_ft(
     httpx_client: httpx.AsyncClient,
     dataset_with_messages: Tuple[int, int],
-):
+) -> None:
     dataset_id, dataset_version_id = dataset_with_messages
     dataset_global_id = GlobalID(Dataset.__name__, str(dataset_id))
     dataset_version_global_id = GlobalID(DatasetVersion.__name__, str(dataset_version_id))
@@ -405,7 +405,7 @@ async def test_get_dataset_jsonl_openai_ft(
 
 async def test_get_dataset_jsonl_openai_evals(
     httpx_client: httpx.AsyncClient, dataset_with_messages: Tuple[int, int]
-):
+) -> None:
     dataset_id, dataset_version_id = dataset_with_messages
     dataset_global_id = GlobalID(Dataset.__name__, str(dataset_id))
     dataset_version_global_id = GlobalID(DatasetVersion.__name__, str(dataset_version_id))
@@ -431,7 +431,7 @@ async def test_get_dataset_jsonl_openai_evals(
 async def test_post_dataset_upload_json_create_then_append(
     httpx_client: httpx.AsyncClient,
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     name = inspect.stack()[0][3]
     response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
@@ -482,7 +482,7 @@ async def test_post_dataset_upload_json_create_then_append(
 async def test_post_dataset_upload_csv_create_then_append(
     httpx_client: httpx.AsyncClient,
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     name = inspect.stack()[0][3]
     file = gzip.compress(b"a,b,c,d,e,f\n1,2,3,4,5,6\n")
     response = await httpx_client.post(
@@ -537,7 +537,7 @@ async def test_post_dataset_upload_csv_create_then_append(
 async def test_post_dataset_upload_pyarrow_create_then_append(
     httpx_client: httpx.AsyncClient,
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     name = inspect.stack()[0][3]
     df = pd.read_csv(StringIO("a,b,c,d,e,f\n1,2,3,4,5,6\n"))
     table = pa.Table.from_pandas(df)
@@ -613,7 +613,7 @@ async def test_delete_dataset(
 
 async def test_get_dataset_examples_404s_with_nonexistent_dataset_id(
     httpx_client: httpx.AsyncClient,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 404
@@ -623,7 +623,7 @@ async def test_get_dataset_examples_404s_with_nonexistent_dataset_id(
 async def test_get_dataset_examples_404s_with_invalid_global_id(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("InvalidDataset", str(0))
     response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 404
@@ -633,7 +633,7 @@ async def test_get_dataset_examples_404s_with_invalid_global_id(
 async def test_get_dataset_examples_404s_with_nonexistent_version_id(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     version_id = GlobalID("DatasetVersion", str(99))
     response = await httpx_client.get(
@@ -646,7 +646,7 @@ async def test_get_dataset_examples_404s_with_nonexistent_version_id(
 async def test_get_dataset_examples_404s_with_invalid_version_global_id(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     version_id = GlobalID("InvalidDatasetVersion", str(0))
     response = await httpx_client.get(
@@ -659,7 +659,7 @@ async def test_get_dataset_examples_404s_with_invalid_version_global_id(
 async def test_get_simple_dataset_examples(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
@@ -686,7 +686,7 @@ async def test_get_simple_dataset_examples(
 async def test_list_simple_dataset_examples_at_each_version(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(0))
     v0 = GlobalID("DatasetVersion", str(0))
 
@@ -703,7 +703,7 @@ async def test_list_simple_dataset_examples_at_each_version(
 async def test_list_empty_dataset_examples(
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(1))
     response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
@@ -715,7 +715,7 @@ async def test_list_empty_dataset_examples(
 async def test_list_empty_dataset_examples_at_each_version(
     httpx_client: httpx.AsyncClient,
     empty_dataset: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(1))
     v1 = GlobalID("DatasetVersion", str(1))
     v2 = GlobalID("DatasetVersion", str(2))
@@ -752,7 +752,7 @@ async def test_list_empty_dataset_examples_at_each_version(
 async def test_list_dataset_with_revisions_examples(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
@@ -791,7 +791,7 @@ async def test_list_dataset_with_revisions_examples(
 async def test_list_dataset_with_revisions_examples_at_each_version(
     httpx_client: httpx.AsyncClient,
     dataset_with_revisions: Any,
-):
+) -> None:
     global_id = GlobalID("Dataset", str(2))
     v4 = GlobalID("DatasetVersion", str(4))
     v5 = GlobalID("DatasetVersion", str(5))

--- a/tests/server/api/routers/v1/test_datasets.py
+++ b/tests/server/api/routers/v1/test_datasets.py
@@ -3,8 +3,9 @@ import inspect
 import io
 import json
 from io import BytesIO, StringIO
-from typing import Tuple
+from typing import Any, AsyncContextManager, Callable, Tuple
 
+import httpx
 import pandas as pd
 import pyarrow as pa
 import pytest
@@ -14,12 +15,16 @@ from phoenix.db import models
 from phoenix.server.api.types.Dataset import Dataset
 from phoenix.server.api.types.DatasetVersion import DatasetVersion
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
-async def test_get_simple_dataset(test_client, simple_dataset):
+async def test_get_simple_dataset(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(0))
-    response = await test_client.get(f"/v1/datasets/{global_id}")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
     dataset_json = response.json()["data"]
 
@@ -35,9 +40,12 @@ async def test_get_simple_dataset(test_client, simple_dataset):
     assert all(item in dataset_json.items() for item in fixture_values.items())
 
 
-async def test_get_empty_dataset(test_client, empty_dataset):
+async def test_get_empty_dataset(
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(1))
-    response = await test_client.get(f"/v1/datasets/{global_id}")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
     dataset_json = response.json()["data"]
 
@@ -53,9 +61,12 @@ async def test_get_empty_dataset(test_client, empty_dataset):
     assert all(item in dataset_json.items() for item in fixture_values.items())
 
 
-async def test_get_dataset_with_revisions(test_client, dataset_with_revisions):
+async def test_get_dataset_with_revisions(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(f"/v1/datasets/{global_id}")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}")
     assert response.status_code == 200
     dataset_json = response.json()["data"]
 
@@ -71,8 +82,13 @@ async def test_get_dataset_with_revisions(test_client, dataset_with_revisions):
     assert all(item in dataset_json.items() for item in fixture_values.items())
 
 
-async def test_list_datasets(test_client, simple_dataset, empty_dataset, dataset_with_revisions):
-    response = await test_client.get("/v1/datasets")
+async def test_list_datasets(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+    empty_dataset: Any,
+    dataset_with_revisions: Any,
+):
+    response = await httpx_client.get("/v1/datasets")
     assert response.status_code == 200
     datasets_json = response.json()
 
@@ -113,8 +129,12 @@ async def test_list_datasets(test_client, simple_dataset, empty_dataset, dataset
     assert all(item in datasets[2].items() for item in fixture_values.items())
 
 
-async def test_list_fewer_datasets(test_client, simple_dataset, empty_dataset):
-    response = await test_client.get("/v1/datasets")
+async def test_list_fewer_datasets(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+    empty_dataset: Any,
+):
+    response = await httpx_client.get("/v1/datasets")
     assert response.status_code == 200
     datasets_json = response.json()
 
@@ -146,9 +166,12 @@ async def test_list_fewer_datasets(test_client, simple_dataset, empty_dataset):
 
 
 async def test_list_datasets_with_cursor(
-    test_client, simple_dataset, empty_dataset, dataset_with_revisions
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+    empty_dataset: Any,
+    dataset_with_revisions: Any,
 ):
-    response = await test_client.get("/v1/datasets", params={"limit": 2})
+    response = await httpx_client.get("/v1/datasets", params={"limit": 2})
     assert response.status_code == 200
     datasets_json = response.json()
 
@@ -179,7 +202,7 @@ async def test_list_datasets_with_cursor(
     }
     assert all(item in datasets[1].items() for item in fixture_values.items())
 
-    second_page = await test_client.get("/v1/datasets", params={"limit": 2, "cursor": next_cursor})
+    second_page = await httpx_client.get("/v1/datasets", params={"limit": 2, "cursor": next_cursor})
     assert second_page.status_code == 200
 
     second_page_json = second_page.json()
@@ -199,9 +222,12 @@ async def test_list_datasets_with_cursor(
     assert all(item in second_page_datasets[0].items() for item in fixture_values.items())
 
 
-async def test_get_dataset_versions(test_client, dataset_with_revisions):
+async def test_get_dataset_versions(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     dataset_global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(f"/v1/datasets/{dataset_global_id}/versions?limit=2")
+    response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/versions?limit=2")
     assert response.status_code == 200
     assert response.headers.get("content-type") == "application/json"
     assert response.json() == {
@@ -223,9 +249,12 @@ async def test_get_dataset_versions(test_client, dataset_with_revisions):
     }
 
 
-async def test_get_dataset_versions_with_cursor(test_client, dataset_with_revisions):
+async def test_get_dataset_versions_with_cursor(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     dataset_global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/versions?limit=2"
         f'&cursor={GlobalID("DatasetVersion", str(4))}'
     )
@@ -244,9 +273,12 @@ async def test_get_dataset_versions_with_cursor(test_client, dataset_with_revisi
     }
 
 
-async def test_get_dataset_versions_with_nonexistent_cursor(test_client, dataset_with_revisions):
+async def test_get_dataset_versions_with_nonexistent_cursor(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     dataset_global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/versions?limit=1"
         f'&cursor={GlobalID("DatasetVersion", str(1))}'
     )
@@ -255,9 +287,12 @@ async def test_get_dataset_versions_with_nonexistent_cursor(test_client, dataset
     assert response.json() == {"next_cursor": None, "data": []}
 
 
-async def test_get_dataset_download_empty_dataset(test_client, empty_dataset):
+async def test_get_dataset_download_empty_dataset(
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
+):
     dataset_global_id = GlobalID("Dataset", str(1))
-    response = await test_client.get(f"/v1/datasets/{dataset_global_id}/csv")
+    response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/csv")
     assert response.status_code == 200
     assert response.headers.get("content-type") == "text/csv"
     assert response.headers.get("content-encoding") == "gzip"
@@ -267,11 +302,13 @@ async def test_get_dataset_download_empty_dataset(test_client, empty_dataset):
 
 
 async def test_get_dataset_download_nonexistent_version(
-    test_client, empty_dataset, dataset_with_revisions
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
+    dataset_with_revisions: Any,
 ):
     dataset_global_id = GlobalID("Dataset", str(1))
     dataset_version_global_id = GlobalID("DatasetVersion", str(4))  # Version for Dataset id=2
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/csv?version_id={dataset_version_global_id}"
     )
     assert response.status_code == 200
@@ -282,9 +319,11 @@ async def test_get_dataset_download_nonexistent_version(
         pd.read_csv(StringIO(response.content.decode()))
 
 
-async def test_get_dataset_download_latest_version(test_client, dataset_with_revisions):
+async def test_get_dataset_download_latest_version(
+    httpx_client: httpx.AsyncClient, dataset_with_revisions
+):
     dataset_global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(f"/v1/datasets/{dataset_global_id}/csv")
+    response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/csv")
     assert response.status_code == 200
     assert response.headers.get("content-type") == "text/csv"
     assert response.headers.get("content-encoding") == "gzip"
@@ -303,10 +342,13 @@ async def test_get_dataset_download_latest_version(test_client, dataset_with_rev
     assert_frame_equal(actual, expected)
 
 
-async def test_get_dataset_download_specific_version(test_client, dataset_with_revisions):
+async def test_get_dataset_download_specific_version(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     dataset_global_id = GlobalID("Dataset", str(2))
     dataset_version_global_id = GlobalID("DatasetVersion", str(8))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/csv?version_id={dataset_version_global_id}"
     )
     assert response.status_code == 200
@@ -328,11 +370,14 @@ async def test_get_dataset_download_specific_version(test_client, dataset_with_r
     assert_frame_equal(actual, expected)
 
 
-async def test_get_dataset_jsonl_openai_ft(test_client, dataset_with_messages: Tuple[int, int]):
+async def test_get_dataset_jsonl_openai_ft(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_messages: Tuple[int, int],
+):
     dataset_id, dataset_version_id = dataset_with_messages
     dataset_global_id = GlobalID(Dataset.__name__, str(dataset_id))
     dataset_version_global_id = GlobalID(DatasetVersion.__name__, str(dataset_version_id))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/jsonl/openai_ft?version_id={dataset_version_global_id}"
     )
     assert response.status_code == 200
@@ -357,11 +402,13 @@ async def test_get_dataset_jsonl_openai_ft(test_client, dataset_with_messages: T
     }
 
 
-async def test_get_dataset_jsonl_openai_evals(test_client, dataset_with_messages: Tuple[int, int]):
+async def test_get_dataset_jsonl_openai_evals(
+    httpx_client: httpx.AsyncClient, dataset_with_messages: Tuple[int, int]
+):
     dataset_id, dataset_version_id = dataset_with_messages
     dataset_global_id = GlobalID(Dataset.__name__, str(dataset_id))
     dataset_version_global_id = GlobalID(DatasetVersion.__name__, str(dataset_version_id))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{dataset_global_id}/jsonl/openai_evals?version_id={dataset_version_global_id}"
     )
     assert response.status_code == 200
@@ -380,9 +427,12 @@ async def test_get_dataset_jsonl_openai_evals(test_client, dataset_with_messages
     }
 
 
-async def test_post_dataset_upload_json_create_then_append(test_client, session):
+async def test_post_dataset_upload_json_create_then_append(
+    httpx_client: httpx.AsyncClient,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     name = inspect.stack()[0][3]
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         json={
             "action": "create",
@@ -396,7 +446,7 @@ async def test_post_dataset_upload_json_create_then_append(test_client, session)
     assert (data := response.json().get("data"))
     assert (dataset_id := data.get("dataset_id"))
     del response, data
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         json={
             "action": "append",
@@ -409,15 +459,16 @@ async def test_post_dataset_upload_json_create_then_append(test_client, session)
     assert response.status_code == 200
     assert (data := response.json().get("data"))
     assert dataset_id == data.get("dataset_id")
-    revisions = list(
-        await session.scalars(
-            select(models.DatasetExampleRevision)
-            .join(models.DatasetExample)
-            .join_from(models.DatasetExample, models.Dataset)
-            .where(models.Dataset.name == name)
-            .order_by(models.DatasetExample.id)
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+                .order_by(models.DatasetExample.id)
+            )
         )
-    )
     assert len(revisions) == 2
     assert revisions[0].input == {"a": 1, "b": 2, "c": 3}
     assert revisions[0].output == {"b": "2", "c": "3", "d": "4"}
@@ -427,10 +478,13 @@ async def test_post_dataset_upload_json_create_then_append(test_client, session)
     assert revisions[1].metadata_ == {}
 
 
-async def test_post_dataset_upload_csv_create_then_append(test_client, session):
+async def test_post_dataset_upload_csv_create_then_append(
+    httpx_client: httpx.AsyncClient,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     name = inspect.stack()[0][3]
     file = gzip.compress(b"a,b,c,d,e,f\n1,2,3,4,5,6\n")
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
         data={
@@ -446,7 +500,7 @@ async def test_post_dataset_upload_csv_create_then_append(test_client, session):
     assert (dataset_id := data.get("dataset_id"))
     del response, file, data
     file = gzip.compress(b"a,b,c,d,e,f\n11,22,33,44,55,66\n")
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         files={"file": (" ", file, "text/csv", {"Content-Encoding": "gzip"})},
         data={
@@ -460,15 +514,16 @@ async def test_post_dataset_upload_csv_create_then_append(test_client, session):
     assert response.status_code == 200
     assert (data := response.json().get("data"))
     assert dataset_id == data.get("dataset_id")
-    revisions = list(
-        await session.scalars(
-            select(models.DatasetExampleRevision)
-            .join(models.DatasetExample)
-            .join_from(models.DatasetExample, models.Dataset)
-            .where(models.Dataset.name == name)
-            .order_by(models.DatasetExample.id)
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+                .order_by(models.DatasetExample.id)
+            )
         )
-    )
     assert len(revisions) == 2
     assert revisions[0].input == {"a": "1", "b": "2", "c": "3"}
     assert revisions[0].output == {"b": "2", "c": "3", "d": "4"}
@@ -478,7 +533,10 @@ async def test_post_dataset_upload_csv_create_then_append(test_client, session):
     assert revisions[1].metadata_ == {"c": "33", "d": "44", "e": "55"}
 
 
-async def test_post_dataset_upload_pyarrow_create_then_append(test_client, session):
+async def test_post_dataset_upload_pyarrow_create_then_append(
+    httpx_client: httpx.AsyncClient,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     name = inspect.stack()[0][3]
     df = pd.read_csv(StringIO("a,b,c,d,e,f\n1,2,3,4,5,6\n"))
     table = pa.Table.from_pandas(df)
@@ -486,7 +544,7 @@ async def test_post_dataset_upload_pyarrow_create_then_append(test_client, sessi
     with pa.ipc.new_stream(sink, table.schema) as writer:
         writer.write_table(table)
     file = BytesIO(sink.getvalue().to_pybytes())
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         files={"file": (" ", file, "application/x-pandas-pyarrow", {})},
         data={
@@ -507,7 +565,7 @@ async def test_post_dataset_upload_pyarrow_create_then_append(test_client, sessi
     with pa.ipc.new_stream(sink, table.schema) as writer:
         writer.write_table(table)
     file = BytesIO(sink.getvalue().to_pybytes())
-    response = await test_client.post(
+    response = await httpx_client.post(
         url="v1/datasets/upload?sync=true",
         files={"file": (" ", file, "application/x-pandas-pyarrow", {})},
         data={
@@ -521,15 +579,16 @@ async def test_post_dataset_upload_pyarrow_create_then_append(test_client, sessi
     assert response.status_code == 200
     assert (data := response.json().get("data"))
     assert dataset_id == data.get("dataset_id")
-    revisions = list(
-        await session.scalars(
-            select(models.DatasetExampleRevision)
-            .join(models.DatasetExample)
-            .join_from(models.DatasetExample, models.Dataset)
-            .where(models.Dataset.name == name)
-            .order_by(models.DatasetExample.id)
+    async with db() as session:
+        revisions = list(
+            await session.scalars(
+                select(models.DatasetExampleRevision)
+                .join(models.DatasetExample)
+                .join_from(models.DatasetExample, models.Dataset)
+                .where(models.Dataset.name == name)
+                .order_by(models.DatasetExample.id)
+            )
         )
-    )
     assert len(revisions) == 2
     assert revisions[0].input == {"a": 1, "b": 2, "c": 3}
     assert revisions[0].output == {"b": 2, "c": 3, "d": 4}
@@ -539,33 +598,44 @@ async def test_post_dataset_upload_pyarrow_create_then_append(test_client, sessi
     assert revisions[1].metadata_ == {"c": 33, "d": 44, "e": 55}
 
 
-async def test_delete_dataset(test_client, empty_dataset) -> None:
+async def test_delete_dataset(
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
+) -> None:
     url = f"v1/datasets/{GlobalID(Dataset.__name__, str(1))}"
-    assert len((await test_client.get("v1/datasets")).json()["data"]) > 0
-    (await test_client.delete(url)).raise_for_status()
-    assert len((await test_client.get("v1/datasets")).json()["data"]) == 0
+    assert len((await httpx_client.get("v1/datasets")).json()["data"]) > 0
+    (await httpx_client.delete(url)).raise_for_status()
+    assert len((await httpx_client.get("v1/datasets")).json()["data"]) == 0
     with pytest.raises(HTTPStatusError):
-        (await test_client.delete(url)).raise_for_status()
+        (await httpx_client.delete(url)).raise_for_status()
 
 
-async def test_get_dataset_examples_404s_with_nonexistent_dataset_id(test_client):
+async def test_get_dataset_examples_404s_with_nonexistent_dataset_id(
+    httpx_client: httpx.AsyncClient,
+):
     global_id = GlobalID("Dataset", str(0))
-    response = await test_client.get(f"/v1/datasets/{global_id}/examples")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 404
     assert response.content.decode() == f"No dataset with id {global_id} can be found."
 
 
-async def test_get_dataset_examples_404s_with_invalid_global_id(test_client, simple_dataset):
+async def test_get_dataset_examples_404s_with_invalid_global_id(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     global_id = GlobalID("InvalidDataset", str(0))
-    response = await test_client.get(f"/v1/datasets/{global_id}/examples")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 404
     assert "refers to a InvalidDataset" in response.content.decode()
 
 
-async def test_get_dataset_examples_404s_with_nonexistent_version_id(test_client, simple_dataset):
+async def test_get_dataset_examples_404s_with_nonexistent_version_id(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(0))
     version_id = GlobalID("DatasetVersion", str(99))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(version_id)}
     )
     assert response.status_code == 404
@@ -573,20 +643,24 @@ async def test_get_dataset_examples_404s_with_nonexistent_version_id(test_client
 
 
 async def test_get_dataset_examples_404s_with_invalid_version_global_id(
-    test_client, simple_dataset
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
 ):
     global_id = GlobalID("Dataset", str(0))
     version_id = GlobalID("InvalidDatasetVersion", str(0))
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(version_id)}
     )
     assert response.status_code == 404
     assert "refers to a InvalidDatasetVersion" in response.content.decode()
 
 
-async def test_get_simple_dataset_examples(test_client, simple_dataset):
+async def test_get_simple_dataset_examples(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(0))
-    response = await test_client.get(f"/v1/datasets/{global_id}/examples")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
     data = result["data"]
@@ -608,12 +682,15 @@ async def test_get_simple_dataset_examples(test_client, simple_dataset):
         assert example_subset == expected
 
 
-async def test_list_simple_dataset_examples_at_each_version(test_client, simple_dataset):
+async def test_list_simple_dataset_examples_at_each_version(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(0))
     v0 = GlobalID("DatasetVersion", str(0))
 
     # one example is created in version 0
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v0)}
     )
     assert response.status_code == 200
@@ -622,23 +699,28 @@ async def test_list_simple_dataset_examples_at_each_version(test_client, simple_
     assert len(data["examples"]) == 1
 
 
-async def test_list_empty_dataset_examples(test_client, empty_dataset):
+async def test_list_empty_dataset_examples(
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
+):
     global_id = GlobalID("Dataset", str(1))
-    response = await test_client.get(f"/v1/datasets/{global_id}/examples")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
     data = result["data"]
     assert len(data["examples"]) == 0
 
 
-async def test_list_empty_dataset_examples_at_each_version(test_client, empty_dataset):
+async def test_list_empty_dataset_examples_at_each_version(
+    httpx_client: httpx.AsyncClient, empty_dataset
+):
     global_id = GlobalID("Dataset", str(1))
     v1 = GlobalID("DatasetVersion", str(1))
     v2 = GlobalID("DatasetVersion", str(2))
     v3 = GlobalID("DatasetVersion", str(3))
 
     # two examples are created in version 1
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v1)}
     )
     assert response.status_code == 200
@@ -647,7 +729,7 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     assert len(data["examples"]) == 2
 
     # two examples are patched in version 2
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v2)}
     )
     assert response.status_code == 200
@@ -656,7 +738,7 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     assert len(data["examples"]) == 2
 
     # two examples are deleted in version 3
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v3)}
     )
     assert response.status_code == 200
@@ -665,9 +747,12 @@ async def test_list_empty_dataset_examples_at_each_version(test_client, empty_da
     assert len(data["examples"]) == 0
 
 
-async def test_list_dataset_with_revisions_examples(test_client, dataset_with_revisions):
+async def test_list_dataset_with_revisions_examples(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
+):
     global_id = GlobalID("Dataset", str(2))
-    response = await test_client.get(f"/v1/datasets/{global_id}/examples")
+    response = await httpx_client.get(f"/v1/datasets/{global_id}/examples")
     assert response.status_code == 200
     result = response.json()
     data = result["data"]
@@ -702,7 +787,8 @@ async def test_list_dataset_with_revisions_examples(test_client, dataset_with_re
 
 
 async def test_list_dataset_with_revisions_examples_at_each_version(
-    test_client, dataset_with_revisions
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
 ):
     global_id = GlobalID("Dataset", str(2))
     v4 = GlobalID("DatasetVersion", str(4))
@@ -713,7 +799,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     v9 = GlobalID("DatasetVersion", str(9))
 
     # two examples are created in version 4
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v4)}
     )
     assert response.status_code == 200
@@ -722,7 +808,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     assert len(data["examples"]) == 2
 
     # two examples are patched in version 5
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v5)}
     )
     assert response.status_code == 200
@@ -731,7 +817,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     assert len(data["examples"]) == 3
 
     # one example is added in version 6
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v6)}
     )
     assert response.status_code == 200
@@ -740,7 +826,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     assert len(data["examples"]) == 4
 
     # one example is deleted in version 7
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v7)}
     )
     assert response.status_code == 200
@@ -749,7 +835,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     assert len(data["examples"]) == 3
 
     # one example is added in version 8
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v8)}
     )
     assert response.status_code == 200
@@ -758,7 +844,7 @@ async def test_list_dataset_with_revisions_examples_at_each_version(
     assert len(data["examples"]) == 4
 
     # one example is deleted in version 9
-    response = await test_client.get(
+    response = await httpx_client.get(
         f"/v1/datasets/{global_id}/examples", params={"version_id": str(v9)}
     )
     assert response.status_code == 200

--- a/tests/server/api/routers/v1/test_datasets.py
+++ b/tests/server/api/routers/v1/test_datasets.py
@@ -320,7 +320,8 @@ async def test_get_dataset_download_nonexistent_version(
 
 
 async def test_get_dataset_download_latest_version(
-    httpx_client: httpx.AsyncClient, dataset_with_revisions
+    httpx_client: httpx.AsyncClient,
+    dataset_with_revisions: Any,
 ):
     dataset_global_id = GlobalID("Dataset", str(2))
     response = await httpx_client.get(f"/v1/datasets/{dataset_global_id}/csv")
@@ -712,7 +713,8 @@ async def test_list_empty_dataset_examples(
 
 
 async def test_list_empty_dataset_examples_at_each_version(
-    httpx_client: httpx.AsyncClient, empty_dataset
+    httpx_client: httpx.AsyncClient,
+    empty_dataset: Any,
 ):
     global_id = GlobalID("Dataset", str(1))
     v1 = GlobalID("DatasetVersion", str(1))

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -10,7 +10,7 @@ from strawberry.relay import GlobalID
 async def test_experiments_api(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     """
     A simple test of the expected flow for the experiments API flow
     """
@@ -90,7 +90,7 @@ async def test_experiments_api(
 async def test_experiment_404s_with_missing_dataset(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     incorrect_dataset_gid = GlobalID("Dataset", "1")
     response = await httpx_client.post(
         f"/v1/datasets/{incorrect_dataset_gid}/experiments", json={"version_id": None}
@@ -101,7 +101,7 @@ async def test_experiment_404s_with_missing_dataset(
 async def test_experiment_404s_with_missing_version(
     httpx_client: httpx.AsyncClient,
     simple_dataset: Any,
-):
+) -> None:
     correct_dataset_gid = GlobalID("Dataset", "0")
     incorrect_version_gid = GlobalID("DatasetVersion", "9000")
     response = await httpx_client.post(
@@ -114,7 +114,7 @@ async def test_experiment_404s_with_missing_version(
 async def test_reading_experiments(
     httpx_client: httpx.AsyncClient,
     dataset_with_experiments_without_runs: Any,
-):
+) -> None:
     experiment_gid = GlobalID("Experiment", "0")
     dataset_gid = GlobalID("Dataset", "1")
     dataset_version_gid = GlobalID("DatasetVersion", "1")
@@ -134,7 +134,7 @@ async def test_reading_experiments(
 
 async def test_reading_experiment_404s_with_missing_experiment(
     httpx_client: httpx.AsyncClient,
-):
+) -> None:
     incorrect_experiment_gid = GlobalID("Experiment", "9000")
     response = await httpx_client.get(f"/v1/experiments/{incorrect_experiment_gid}")
     assert response.status_code == 404

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -1,11 +1,16 @@
 import datetime
+from typing import Any
 
+import httpx
 import pytest
 from httpx import HTTPStatusError
 from strawberry.relay import GlobalID
 
 
-async def test_experiments_api(test_client, simple_dataset):
+async def test_experiments_api(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     """
     A simple test of the expected flow for the experiments API flow
     """
@@ -14,7 +19,7 @@ async def test_experiments_api(test_client, simple_dataset):
 
     # first, create an experiment associated with a dataset
     created_experiment = (
-        await test_client.post(
+        await httpx_client.post(
             f"/v1/datasets/{dataset_gid}/experiments",
             json={"version_id": None, "repetitions": 1},
         )
@@ -25,14 +30,14 @@ async def test_experiments_api(test_client, simple_dataset):
     assert created_experiment["repetitions"] == 1
 
     dataset_examples = (
-        await test_client.get(
+        await httpx_client.get(
             f"/v1/datasets/{dataset_gid}/examples",
             params={"version_id": str(version_gid)},
         )
     ).json()["data"]["examples"]
 
     # experiments can be read using the GET /experiments route
-    experiment = (await test_client.get(f"/v1/experiments/{experiment_gid}")).json()["data"]
+    experiment = (await httpx_client.get(f"/v1/experiments/{experiment_gid}")).json()["data"]
     assert experiment
     assert created_experiment["repetitions"] == 1
 
@@ -47,14 +52,14 @@ async def test_experiments_api(test_client, simple_dataset):
         "error": "an error message, if applicable",
     }
     run_payload["id"] = (
-        await test_client.post(
+        await httpx_client.post(
             f"/v1/experiments/{experiment_gid}/runs",
             json=run_payload,
         )
     ).json()["data"]["id"]
 
     # experiment runs can be listed for evaluations
-    experiment_runs = (await test_client.get(f"/v1/experiments/{experiment_gid}/runs")).json()[
+    experiment_runs = (await httpx_client.get(f"/v1/experiments/{experiment_gid}/runs")).json()[
         "data"
     ]
     assert experiment_runs
@@ -77,34 +82,43 @@ async def test_experiments_api(test_client, simple_dataset):
         "end_time": datetime.datetime.now().isoformat(),
     }
     experiment_evaluation = (
-        await test_client.post("/v1/experiment_evaluations", json=evaluation_payload)
+        await httpx_client.post("/v1/experiment_evaluations", json=evaluation_payload)
     ).json()
     assert experiment_evaluation
 
 
-async def test_experiment_404s_with_missing_dataset(test_client, simple_dataset):
+async def test_experiment_404s_with_missing_dataset(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     incorrect_dataset_gid = GlobalID("Dataset", "1")
-    response = await test_client.post(
+    response = await httpx_client.post(
         f"/v1/datasets/{incorrect_dataset_gid}/experiments", json={"version_id": None}
     )
     assert response.status_code == 404
 
 
-async def test_experiment_404s_with_missing_version(test_client, simple_dataset):
+async def test_experiment_404s_with_missing_version(
+    httpx_client: httpx.AsyncClient,
+    simple_dataset: Any,
+):
     correct_dataset_gid = GlobalID("Dataset", "0")
     incorrect_version_gid = GlobalID("DatasetVersion", "9000")
-    response = await test_client.post(
+    response = await httpx_client.post(
         f"/v1/datasets/{correct_dataset_gid}/experiments",
         json={"version_id": str(incorrect_version_gid)},
     )
     assert response.status_code == 404
 
 
-async def test_reading_experiments(test_client, dataset_with_experiments_without_runs):
+async def test_reading_experiments(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_experiments_without_runs: Any,
+):
     experiment_gid = GlobalID("Experiment", "0")
     dataset_gid = GlobalID("Dataset", "1")
     dataset_version_gid = GlobalID("DatasetVersion", "1")
-    response = await test_client.get(f"/v1/experiments/{experiment_gid}")
+    response = await httpx_client.get(f"/v1/experiments/{experiment_gid}")
     assert response.status_code == 200
     experiment = response.json()["data"]
     assert "created_at" in experiment
@@ -118,22 +132,24 @@ async def test_reading_experiments(test_client, dataset_with_experiments_without
     assert all(experiment[key] == value for key, value in expected.items())
 
 
-async def test_reading_experiment_404s_with_missing_experiment(test_client):
+async def test_reading_experiment_404s_with_missing_experiment(
+    httpx_client: httpx.AsyncClient,
+):
     incorrect_experiment_gid = GlobalID("Experiment", "9000")
-    response = await test_client.get(f"/v1/experiments/{incorrect_experiment_gid}")
+    response = await httpx_client.get(f"/v1/experiments/{incorrect_experiment_gid}")
     assert response.status_code == 404
 
 
 async def test_deleting_dataset_also_deletes_experiments(
-    test_client,
-    dataset_with_experiments_runs_and_evals,
+    httpx_client: httpx.AsyncClient,
+    dataset_with_experiments_runs_and_evals: Any,
 ) -> None:
     ds_url = f"v1/datasets/{GlobalID('Dataset', str(1))}"
     exp_url = f"v1/experiments/{GlobalID('Experiment', str(1))}"
     runs_url = f"{exp_url}/runs"
-    (await test_client.get(exp_url)).raise_for_status()
-    assert len((await test_client.get(runs_url)).json()["data"]) > 0
-    (await test_client.delete(ds_url)).raise_for_status()
-    assert len((await test_client.get(runs_url)).json()["data"]) == 0
+    (await httpx_client.get(exp_url)).raise_for_status()
+    assert len((await httpx_client.get(runs_url)).json()["data"]) > 0
+    (await httpx_client.delete(ds_url)).raise_for_status()
+    assert len((await httpx_client.get(runs_url)).json()["data"]) == 0
     with pytest.raises(HTTPStatusError):
-        (await test_client.get(exp_url)).raise_for_status()
+        (await httpx_client.get(exp_url)).raise_for_status()

--- a/tests/server/api/routers/v1/test_traces.py
+++ b/tests/server/api/routers/v1/test_traces.py
@@ -1,57 +1,65 @@
 from datetime import datetime
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from sqlalchemy import insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 @pytest.fixture
-async def project_with_a_single_trace_and_span(session) -> None:
+async def project_with_a_single_trace_and_span(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     Contains a project with a single trace and a single span.
     """
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name="project-name").returning(models.Project.id)
-    )
-    trace_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="1",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="project-name").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_id,
-            span_id="1",
-            parent_id=None,
-            name="chain span",
-            span_kind="CHAIN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
-                "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="1",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="1",
+                parent_id=None,
+                name="chain span",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
+                    "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
 
 
 async def test_rest_trace_annotation(
-    session, test_client, project_with_a_single_trace_and_span
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
 ) -> None:
     trace_gid = GlobalID("Trace", "1")
     request_body = {
@@ -70,15 +78,16 @@ async def test_rest_trace_annotation(
         ]
     }
 
-    response = await test_client.post("/v1/trace_annotations", json=request_body)
+    response = await httpx_client.post("/v1/trace_annotations", json=request_body)
     assert response.status_code == 200
 
     data = response.json()["data"]
     annotation_gid = GlobalID.from_id(data[0]["id"])
     annotation_id = from_global_id_with_expected_type(annotation_gid, "TraceAnnotation")
-    orm_annotation = await session.scalar(
-        select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
+        )
 
     assert orm_annotation is not None
     assert orm_annotation.name == "Test Annotation"

--- a/tests/server/api/test_interceptor.py
+++ b/tests/server/api/test_interceptor.py
@@ -10,7 +10,7 @@ class T:
     x: Optional[float] = strawberry.field(default=GqlValueMediator())
 
 
-def test_gql_value_mediator():
+def test_gql_value_mediator() -> None:
     assert T(x=np.nan).x is None
     assert T(x=np.array([np.nan], dtype=np.half)[0]).x is None
     assert isinstance(T(x=1).x, int)

--- a/tests/server/api/test_queries.py
+++ b/tests/server/api/test_queries.py
@@ -13,7 +13,7 @@ from strawberry.relay import GlobalID
 async def test_projects_omits_experiment_projects(
     httpx_client: httpx.AsyncClient,
     projects_with_and_without_experiments: Any,
-):
+) -> None:
     query = """
       query {
         projects {
@@ -50,7 +50,7 @@ async def test_projects_omits_experiment_projects(
 async def test_compare_experiments_returns_expected_comparisons(
     httpx_client: httpx.AsyncClient,
     comparison_experiments: Any,
-):
+) -> None:
     query = """
       query ($experimentIds: [GlobalID!]!) {
         compareExperiments(
@@ -180,7 +180,7 @@ async def test_compare_experiments_returns_expected_comparisons(
 @pytest.fixture
 async def projects_with_and_without_experiments(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     """
     Insert two projects, one that contains traces from an experiment and the other that does not.
     """
@@ -226,7 +226,7 @@ async def projects_with_and_without_experiments(
 
 
 @pytest.fixture
-async def comparison_experiments(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def comparison_experiments(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     Creates a dataset with four examples, three versions, and four experiments.
 

--- a/tests/server/api/test_queries.py
+++ b/tests/server/api/test_queries.py
@@ -48,7 +48,8 @@ async def test_projects_omits_experiment_projects(
 
 
 async def test_compare_experiments_returns_expected_comparisons(
-    httpx_client, comparison_experiments
+    httpx_client: httpx.AsyncClient,
+    comparison_experiments: Any,
 ):
     query = """
       query ($experimentIds: [GlobalID!]!) {

--- a/tests/server/api/types/test_Dataset.py
+++ b/tests/server/api/types/test_Dataset.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from typing import List
+from typing import AsyncContextManager, Callable, List
 
 import pytest
 import pytz
 from phoenix.db import models
 from phoenix.server.api.types.Experiment import Experiment
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
@@ -29,11 +30,11 @@ class TestDatasetExampleNodeInterface:
 
     async def test_unspecified_version_returns_latest_revision(
         self,
-        test_client,
+        httpx_client,
         dataset_with_patch_revision,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -59,11 +60,11 @@ class TestDatasetExampleNodeInterface:
 
     async def test_returns_latest_revision_up_to_specified_version(
         self,
-        test_client,
+        httpx_client,
         dataset_with_patch_revision,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -90,11 +91,11 @@ class TestDatasetExampleNodeInterface:
 
     async def test_returns_latest_revision_up_to_version_even_if_version_does_not_change_example(
         self,
-        test_client,
+        httpx_client,
         dataset_with_three_versions,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -121,11 +122,11 @@ class TestDatasetExampleNodeInterface:
 
     async def test_non_existent_version_id_returns_error(
         self,
-        test_client,
+        httpx_client,
         dataset_with_patch_revision,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -142,11 +143,11 @@ class TestDatasetExampleNodeInterface:
 
     async def test_deleted_dataset_example_returns_error(
         self,
-        test_client,
+        httpx_client,
         dataset_with_deletion,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -173,9 +174,9 @@ class TestDatasetExampleCountResolver:
     """  # noqa: E501
 
     async def test_count_uses_latest_version_when_no_version_is_specified(
-        self, test_client, dataset_with_deletion
+        self, httpx_client, dataset_with_deletion
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -189,8 +190,8 @@ class TestDatasetExampleCountResolver:
         assert response_json.get("errors") is None
         assert response_json["data"] == {"node": {"exampleCount": 0}}
 
-    async def test_count_uses_specified_version(self, test_client, dataset_with_deletion) -> None:
-        response = await test_client.post(
+    async def test_count_uses_specified_version(self, httpx_client, dataset_with_deletion) -> None:
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -231,10 +232,10 @@ class TestDatasetExamplesResolver:
 
     async def test_returns_latest_revisions_when_no_version_is_specified(
         self,
-        test_client,
+        httpx_client,
         dataset_with_patch_revision,
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -272,8 +273,8 @@ class TestDatasetExamplesResolver:
         ]
         assert response_json["data"] == {"node": {"examples": {"edges": edges}}}
 
-    async def test_excludes_deleted_examples(self, test_client, dataset_with_deletion) -> None:
-        response = await test_client.post(
+    async def test_excludes_deleted_examples(self, httpx_client, dataset_with_deletion) -> None:
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -288,9 +289,9 @@ class TestDatasetExamplesResolver:
         assert response_json["data"] == {"node": {"examples": {"edges": []}}}
 
     async def test_returns_latest_revisions_up_to_specified_version(
-        self, test_client, dataset_with_patch_revision
+        self, httpx_client, dataset_with_patch_revision
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -330,9 +331,9 @@ class TestDatasetExamplesResolver:
         assert response_json["data"] == {"node": {"examples": {"edges": edges}}}
 
     async def test_returns_latest_revisions_up_to_version_even_if_version_does_not_change_example(
-        self, test_client, dataset_with_three_versions
+        self, httpx_client, dataset_with_three_versions
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -369,10 +370,10 @@ class TestDatasetExamplesResolver:
 
     async def test_version_id_on_revision_resolver_takes_precedence(
         self,
-        test_client,
+        httpx_client,
         dataset_with_patch_revision,
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -473,7 +474,7 @@ class TestDatasetExamplesResolver:
     ],
 )
 async def test_versions_resolver_returns_versions_in_correct_order(
-    sort_direction, expected_versions, test_client, dataset_with_three_versions
+    sort_direction, expected_versions, httpx_client, dataset_with_three_versions
 ):
     query = """
       query ($datasetId: GlobalID!, $dir: SortDir!, $col: DatasetVersionColumn!) {
@@ -492,7 +493,7 @@ async def test_versions_resolver_returns_versions_in_correct_order(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -521,9 +522,9 @@ class TestDatasetExperimentCountResolver:
     """  # noqa: E501
 
     async def test_experiment_count_uses_all_versions_when_no_version_is_specified(
-        self, test_client, dataset_with_deletion
+        self, httpx_client, dataset_with_deletion
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -538,9 +539,9 @@ class TestDatasetExperimentCountResolver:
         assert response_json["data"] == {"node": {"experimentCount": 2}}
 
     async def test_experiment_count_uses_specified_version(
-        self, test_client, dataset_with_deletion
+        self, httpx_client, dataset_with_deletion
     ) -> None:
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": self.QUERY,
@@ -576,11 +577,11 @@ class TestDatasetExperimentsResolver:
 
     async def test_experiments_have_sequence_number(
         self,
-        test_client,
+        httpx_client,
         interlaced_experiments: List[int],
     ) -> None:
         variables = {"datasetId": str(GlobalID("Dataset", str(2)))}
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={"query": self.QUERY, "variables": variables},
         )
@@ -597,256 +598,257 @@ class TestDatasetExperimentsResolver:
 
 
 @pytest.fixture
-async def dataset_with_patch_revision(session):
+async def dataset_with_patch_revision(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with a single example and two versions. In the first version, the
     dataset example is created. In the second version, the dataset example is
     patched.
     """
-
-    datasets = list(
-        await session.scalars(
-            insert(models.Dataset).returning(models.Dataset),
-            [{"name": "dataset-name", "metadata_": {}}],
+    async with db() as session:
+        datasets = list(
+            await session.scalars(
+                insert(models.Dataset).returning(models.Dataset),
+                [{"name": "dataset-name", "metadata_": {}}],
+            )
         )
-    )
 
-    dataset_versions = list(
-        await session.scalars(
-            insert(models.DatasetVersion).returning(models.DatasetVersion),
-            [
-                {"dataset_id": datasets[0].id, "metadata_": {}},
-                {"dataset_id": datasets[0].id, "metadata_": {}},
-            ],
+        dataset_versions = list(
+            await session.scalars(
+                insert(models.DatasetVersion).returning(models.DatasetVersion),
+                [
+                    {"dataset_id": datasets[0].id, "metadata_": {}},
+                    {"dataset_id": datasets[0].id, "metadata_": {}},
+                ],
+            )
         )
-    )
 
-    dataset_examples = list(
+        dataset_examples = list(
+            await session.scalars(
+                insert(models.DatasetExample).returning(models.DatasetExample),
+                [
+                    {
+                        "dataset_id": datasets[0].id,
+                        "created_at": datetime(
+                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                        ),
+                    },
+                    {
+                        "dataset_id": datasets[0].id,
+                        "created_at": datetime(
+                            year=2020, month=2, day=2, hour=0, minute=0, tzinfo=pytz.utc
+                        ),
+                    },
+                ],
+            )
+        )
+
         await session.scalars(
-            insert(models.DatasetExample).returning(models.DatasetExample),
+            insert(models.DatasetExampleRevision).returning(models.DatasetExampleRevision),
             [
                 {
-                    "dataset_id": datasets[0].id,
-                    "created_at": datetime(
-                        year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                    ),
+                    "dataset_example_id": dataset_examples[0].id,
+                    "dataset_version_id": dataset_versions[0].id,
+                    "input": {"input": "first-input"},
+                    "output": {"output": "first-output"},
+                    "metadata_": {},
+                    "revision_kind": "CREATE",
                 },
                 {
-                    "dataset_id": datasets[0].id,
-                    "created_at": datetime(
-                        year=2020, month=2, day=2, hour=0, minute=0, tzinfo=pytz.utc
-                    ),
+                    "dataset_example_id": dataset_examples[1].id,
+                    "dataset_version_id": dataset_versions[0].id,
+                    "input": {"input": "first-input"},
+                    "output": {"output": "first-output"},
+                    "metadata_": {},
+                    "revision_kind": "CREATE",
+                },
+                {
+                    "dataset_example_id": dataset_examples[0].id,
+                    "dataset_version_id": dataset_versions[1].id,
+                    "input": {"input": "second-input"},
+                    "output": {"output": "second-output"},
+                    "metadata_": {},
+                    "revision_kind": "PATCH",
+                },
+                {
+                    "dataset_example_id": dataset_examples[1].id,
+                    "dataset_version_id": dataset_versions[1].id,
+                    "input": {"input": "second-input"},
+                    "output": {"output": "second-output"},
+                    "metadata_": {},
+                    "revision_kind": "PATCH",
                 },
             ],
         )
-    )
-
-    await session.scalars(
-        insert(models.DatasetExampleRevision).returning(models.DatasetExampleRevision),
-        [
-            {
-                "dataset_example_id": dataset_examples[0].id,
-                "dataset_version_id": dataset_versions[0].id,
-                "input": {"input": "first-input"},
-                "output": {"output": "first-output"},
-                "metadata_": {},
-                "revision_kind": "CREATE",
-            },
-            {
-                "dataset_example_id": dataset_examples[1].id,
-                "dataset_version_id": dataset_versions[0].id,
-                "input": {"input": "first-input"},
-                "output": {"output": "first-output"},
-                "metadata_": {},
-                "revision_kind": "CREATE",
-            },
-            {
-                "dataset_example_id": dataset_examples[0].id,
-                "dataset_version_id": dataset_versions[1].id,
-                "input": {"input": "second-input"},
-                "output": {"output": "second-output"},
-                "metadata_": {},
-                "revision_kind": "PATCH",
-            },
-            {
-                "dataset_example_id": dataset_examples[1].id,
-                "dataset_version_id": dataset_versions[1].id,
-                "input": {"input": "second-input"},
-                "output": {"output": "second-output"},
-                "metadata_": {},
-                "revision_kind": "PATCH",
-            },
-        ],
-    )
 
 
 @pytest.fixture
-async def dataset_with_three_versions(session):
+async def dataset_with_three_versions(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with a single example and three versions. In the first version,
     the dataset example is created. The second version has no associated
     revisions. In the third version, the dataset example is patched.
     """
+    async with db() as session:
+        dataset = models.Dataset(
+            id=1,
+            name="dataset-name",
+            description=None,
+            metadata_={},
+        )
+        session.add(dataset)
+        await session.flush()
 
-    dataset = models.Dataset(
-        id=1,
-        name="dataset-name",
-        description=None,
-        metadata_={},
-    )
-    session.add(dataset)
-    await session.flush()
+        dataset_example = models.DatasetExample(
+            id=1,
+            dataset_id=1,
+            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        )
+        session.add(dataset_example)
+        await session.flush()
 
-    dataset_example = models.DatasetExample(
-        id=1,
-        dataset_id=1,
-        created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-    )
-    session.add(dataset_example)
-    await session.flush()
+        dataset_version_1 = models.DatasetVersion(
+            id=1,
+            dataset_id=1,
+            description="version-1-description",
+            metadata_={"version-1-metadata-key": "version-1-metadata-value"},
+            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        )
+        session.add(dataset_version_1)
+        await session.flush()
 
-    dataset_version_1 = models.DatasetVersion(
-        id=1,
-        dataset_id=1,
-        description="version-1-description",
-        metadata_={"version-1-metadata-key": "version-1-metadata-value"},
-        created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-    )
-    session.add(dataset_version_1)
-    await session.flush()
+        dataset_example_revision_1 = models.DatasetExampleRevision(
+            id=1,
+            dataset_example_id=1,
+            dataset_version_id=1,
+            input={"input": "first-input"},
+            output={"output": "first-output"},
+            metadata_={},
+            revision_kind="CREATE",
+        )
+        session.add(dataset_example_revision_1)
+        await session.flush()
 
-    dataset_example_revision_1 = models.DatasetExampleRevision(
-        id=1,
-        dataset_example_id=1,
-        dataset_version_id=1,
-        input={"input": "first-input"},
-        output={"output": "first-output"},
-        metadata_={},
-        revision_kind="CREATE",
-    )
-    session.add(dataset_example_revision_1)
-    await session.flush()
+        dataset_version_2 = models.DatasetVersion(
+            id=2,
+            dataset_id=1,
+            description="version-2-description",
+            metadata_={"version-2-metadata-key": "version-2-metadata-value"},
+            created_at=datetime(
+                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+            ),  # same created_at as version 1
+        )
+        session.add(dataset_version_2)
+        await session.flush()
 
-    dataset_version_2 = models.DatasetVersion(
-        id=2,
-        dataset_id=1,
-        description="version-2-description",
-        metadata_={"version-2-metadata-key": "version-2-metadata-value"},
-        created_at=datetime(
-            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-        ),  # same created_at as version 1
-    )
-    session.add(dataset_version_2)
-    await session.flush()
+        dataset_version_3 = models.DatasetVersion(
+            id=3,
+            dataset_id=1,
+            description="version-3-description",
+            metadata_={"version-3-metadata-key": "version-3-metadata-value"},
+            created_at=datetime(
+                year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc
+            ),  # created one minute after version 2
+        )
+        session.add(dataset_version_3)
+        await session.flush()
 
-    dataset_version_3 = models.DatasetVersion(
-        id=3,
-        dataset_id=1,
-        description="version-3-description",
-        metadata_={"version-3-metadata-key": "version-3-metadata-value"},
-        created_at=datetime(
-            year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc
-        ),  # created one minute after version 2
-    )
-    session.add(dataset_version_3)
-    await session.flush()
-
-    dataset_example_revision_3 = models.DatasetExampleRevision(
-        id=3,
-        dataset_example_id=1,
-        dataset_version_id=3,
-        input={"input": "third-input"},
-        output={"output": "third-output"},
-        metadata_={},
-        revision_kind="PATCH",
-    )
-    session.add(dataset_example_revision_3)
-    await session.flush()
+        dataset_example_revision_3 = models.DatasetExampleRevision(
+            id=3,
+            dataset_example_id=1,
+            dataset_version_id=3,
+            input={"input": "third-input"},
+            output={"output": "third-output"},
+            metadata_={},
+            revision_kind="PATCH",
+        )
+        session.add(dataset_example_revision_3)
+        await session.flush()
 
 
 @pytest.fixture
-async def dataset_with_deletion(session):
+async def dataset_with_deletion(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with a single example and two versions. In the first version, the
     dataset example is created. In the second version, the dataset example is
     deleted.
     """
 
-    dataset = models.Dataset(
-        id=1,
-        name="dataset-name",
-        description=None,
-        metadata_={},
-    )
-    session.add(dataset)
-    await session.flush()
+    async with db() as session:
+        dataset = models.Dataset(
+            id=1,
+            name="dataset-name",
+            description=None,
+            metadata_={},
+        )
+        session.add(dataset)
+        await session.flush()
 
-    dataset_example = models.DatasetExample(
-        id=1,
-        dataset_id=1,
-        created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-    )
-    session.add(dataset_example)
-    await session.flush()
+        dataset_example = models.DatasetExample(
+            id=1,
+            dataset_id=1,
+            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        )
+        session.add(dataset_example)
+        await session.flush()
 
-    dataset_version_1 = models.DatasetVersion(
-        id=1,
-        dataset_id=1,
-        description=None,
-        metadata_={},
-    )
-    session.add(dataset_version_1)
-    await session.flush()
+        dataset_version_1 = models.DatasetVersion(
+            id=1,
+            dataset_id=1,
+            description=None,
+            metadata_={},
+        )
+        session.add(dataset_version_1)
+        await session.flush()
 
-    dataset_example_revision_1 = models.DatasetExampleRevision(
-        id=1,
-        dataset_example_id=1,
-        dataset_version_id=1,
-        input={"input": "first-input"},
-        output={"output": "first-output"},
-        metadata_={},
-        revision_kind="CREATE",
-    )
-    session.add(dataset_example_revision_1)
-    await session.flush()
+        dataset_example_revision_1 = models.DatasetExampleRevision(
+            id=1,
+            dataset_example_id=1,
+            dataset_version_id=1,
+            input={"input": "first-input"},
+            output={"output": "first-output"},
+            metadata_={},
+            revision_kind="CREATE",
+        )
+        session.add(dataset_example_revision_1)
+        await session.flush()
 
-    dataset_version_2 = models.DatasetVersion(
-        id=2,
-        dataset_id=1,
-        description=None,
-        metadata_={},
-    )
-    session.add(dataset_version_2)
-    await session.flush()
+        dataset_version_2 = models.DatasetVersion(
+            id=2,
+            dataset_id=1,
+            description=None,
+            metadata_={},
+        )
+        session.add(dataset_version_2)
+        await session.flush()
 
-    dataset_example_revision_2 = models.DatasetExampleRevision(
-        id=2,
-        dataset_example_id=1,
-        dataset_version_id=2,
-        input={"input": "first-input"},
-        output={"output": "first-output"},
-        metadata_={},
-        revision_kind="DELETE",
-    )
-    session.add(dataset_example_revision_2)
-    await session.flush()
+        dataset_example_revision_2 = models.DatasetExampleRevision(
+            id=2,
+            dataset_example_id=1,
+            dataset_version_id=2,
+            input={"input": "first-input"},
+            output={"output": "first-output"},
+            metadata_={},
+            revision_kind="DELETE",
+        )
+        session.add(dataset_example_revision_2)
+        await session.flush()
 
-    await session.execute(
-        insert(models.Experiment).returning(models.Experiment.id),
-        [
-            {
-                "dataset_id": 1,
-                "dataset_version_id": 1,
-                "name": "exp-1",
-                "repetitions": 1,
-                "metadata_": {},
-            },
-            {
-                "dataset_id": 1,
-                "dataset_version_id": 2,
-                "name": "exp-2",
-                "repetitions": 1,
-                "metadata_": {},
-            },
-        ],
-    )
+        await session.execute(
+            insert(models.Experiment).returning(models.Experiment.id),
+            [
+                {
+                    "dataset_id": 1,
+                    "dataset_version_id": 1,
+                    "name": "exp-1",
+                    "repetitions": 1,
+                    "metadata_": {},
+                },
+                {
+                    "dataset_id": 1,
+                    "dataset_version_id": 2,
+                    "name": "exp-2",
+                    "repetitions": 1,
+                    "metadata_": {},
+                },
+            ],
+        )

--- a/tests/server/api/types/test_Dataset.py
+++ b/tests/server/api/types/test_Dataset.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable, List
+from typing import Any, AsyncContextManager, Callable, List, Mapping
 
+import httpx
 import pytest
 import pytz
 from phoenix.db import models
@@ -30,8 +31,8 @@ class TestDatasetExampleNodeInterface:
 
     async def test_unspecified_version_returns_latest_revision(
         self,
-        httpx_client,
-        dataset_with_patch_revision,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
         response = await httpx_client.post(
@@ -60,8 +61,8 @@ class TestDatasetExampleNodeInterface:
 
     async def test_returns_latest_revision_up_to_specified_version(
         self,
-        httpx_client,
-        dataset_with_patch_revision,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
         response = await httpx_client.post(
@@ -91,8 +92,8 @@ class TestDatasetExampleNodeInterface:
 
     async def test_returns_latest_revision_up_to_version_even_if_version_does_not_change_example(
         self,
-        httpx_client,
-        dataset_with_three_versions,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_three_versions: Any,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
         response = await httpx_client.post(
@@ -122,8 +123,8 @@ class TestDatasetExampleNodeInterface:
 
     async def test_non_existent_version_id_returns_error(
         self,
-        httpx_client,
-        dataset_with_patch_revision,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
         response = await httpx_client.post(
@@ -143,8 +144,8 @@ class TestDatasetExampleNodeInterface:
 
     async def test_deleted_dataset_example_returns_error(
         self,
-        httpx_client,
-        dataset_with_deletion,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
     ) -> None:
         example_id = str(GlobalID("DatasetExample", str(1)))
         response = await httpx_client.post(
@@ -174,7 +175,9 @@ class TestDatasetExampleCountResolver:
     """  # noqa: E501
 
     async def test_count_uses_latest_version_when_no_version_is_specified(
-        self, httpx_client, dataset_with_deletion
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -190,7 +193,11 @@ class TestDatasetExampleCountResolver:
         assert response_json.get("errors") is None
         assert response_json["data"] == {"node": {"exampleCount": 0}}
 
-    async def test_count_uses_specified_version(self, httpx_client, dataset_with_deletion) -> None:
+    async def test_count_uses_specified_version(
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
+    ) -> None:
         response = await httpx_client.post(
             "/graphql",
             json={
@@ -232,8 +239,8 @@ class TestDatasetExamplesResolver:
 
     async def test_returns_latest_revisions_when_no_version_is_specified(
         self,
-        httpx_client,
-        dataset_with_patch_revision,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -273,7 +280,11 @@ class TestDatasetExamplesResolver:
         ]
         assert response_json["data"] == {"node": {"examples": {"edges": edges}}}
 
-    async def test_excludes_deleted_examples(self, httpx_client, dataset_with_deletion) -> None:
+    async def test_excludes_deleted_examples(
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
+    ) -> None:
         response = await httpx_client.post(
             "/graphql",
             json={
@@ -289,7 +300,9 @@ class TestDatasetExamplesResolver:
         assert response_json["data"] == {"node": {"examples": {"edges": []}}}
 
     async def test_returns_latest_revisions_up_to_specified_version(
-        self, httpx_client, dataset_with_patch_revision
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -331,7 +344,9 @@ class TestDatasetExamplesResolver:
         assert response_json["data"] == {"node": {"examples": {"edges": edges}}}
 
     async def test_returns_latest_revisions_up_to_version_even_if_version_does_not_change_example(
-        self, httpx_client, dataset_with_three_versions
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_three_versions: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -370,8 +385,8 @@ class TestDatasetExamplesResolver:
 
     async def test_version_id_on_revision_resolver_takes_precedence(
         self,
-        httpx_client,
-        dataset_with_patch_revision,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_patch_revision: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -474,7 +489,10 @@ class TestDatasetExamplesResolver:
     ],
 )
 async def test_versions_resolver_returns_versions_in_correct_order(
-    sort_direction, expected_versions, httpx_client, dataset_with_three_versions
+    sort_direction: str,
+    expected_versions: Mapping[str, Any],
+    httpx_client: httpx.AsyncClient,
+    dataset_with_three_versions: Any,
 ):
     query = """
       query ($datasetId: GlobalID!, $dir: SortDir!, $col: DatasetVersionColumn!) {
@@ -522,7 +540,9 @@ class TestDatasetExperimentCountResolver:
     """  # noqa: E501
 
     async def test_experiment_count_uses_all_versions_when_no_version_is_specified(
-        self, httpx_client, dataset_with_deletion
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -539,7 +559,9 @@ class TestDatasetExperimentCountResolver:
         assert response_json["data"] == {"node": {"experimentCount": 2}}
 
     async def test_experiment_count_uses_specified_version(
-        self, httpx_client, dataset_with_deletion
+        self,
+        httpx_client: httpx.AsyncClient,
+        dataset_with_deletion: Any,
     ) -> None:
         response = await httpx_client.post(
             "/graphql",
@@ -577,7 +599,7 @@ class TestDatasetExperimentsResolver:
 
     async def test_experiments_have_sequence_number(
         self,
-        httpx_client,
+        httpx_client: httpx.AsyncClient,
         interlaced_experiments: List[int],
     ) -> None:
         variables = {"datasetId": str(GlobalID("Dataset", str(2)))}

--- a/tests/server/api/types/test_Dataset.py
+++ b/tests/server/api/types/test_Dataset.py
@@ -493,7 +493,7 @@ async def test_versions_resolver_returns_versions_in_correct_order(
     expected_versions: Mapping[str, Any],
     httpx_client: httpx.AsyncClient,
     dataset_with_three_versions: Any,
-):
+) -> None:
     query = """
       query ($datasetId: GlobalID!, $dir: SortDir!, $col: DatasetVersionColumn!) {
         dataset: node(id: $datasetId) {
@@ -620,7 +620,7 @@ class TestDatasetExperimentsResolver:
 
 
 @pytest.fixture
-async def dataset_with_patch_revision(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_patch_revision(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with a single example and two versions. In the first version, the
     dataset example is created. In the second version, the dataset example is
@@ -704,7 +704,7 @@ async def dataset_with_patch_revision(db: Callable[[], AsyncContextManager[Async
 
 
 @pytest.fixture
-async def dataset_with_three_versions(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_three_versions(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with a single example and three versions. In the first version,
     the dataset example is created. The second version has no associated
@@ -788,7 +788,7 @@ async def dataset_with_three_versions(db: Callable[[], AsyncContextManager[Async
 
 
 @pytest.fixture
-async def dataset_with_deletion(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_deletion(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with a single example and two versions. In the first version, the
     dataset example is created. In the second version, the dataset example is

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable
+from typing import Any, AsyncContextManager, Callable, Mapping
 
+import httpx
 import pytest
 import pytz
 from phoenix.config import DEFAULT_PROJECT_NAME
@@ -42,7 +43,10 @@ from strawberry.relay import GlobalID
     ],
 )
 async def test_dataset_example_span_resolver(
-    example_id, expected_span, httpx_client, dataset_with_span_and_nonspan_examples
+    example_id: str,
+    expected_span: Mapping[str, Any],
+    httpx_client: httpx.AsyncClient,
+    dataset_with_span_and_nonspan_examples: Any,
 ):
     query = """
       query ($exampleId: GlobalID!) {
@@ -92,7 +96,8 @@ async def test_dataset_example_span_resolver(
 
 
 async def test_dataset_example_experiment_runs_resolver_returns_relevant_runs(
-    httpx_client, example_with_experiment_runs
+    httpx_client: httpx.AsyncClient,
+    example_with_experiment_runs: Any,
 ) -> None:
     query = """
       query ($exampleId: GlobalID!) {

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pytest
 import pytz
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
@@ -40,7 +42,7 @@ from strawberry.relay import GlobalID
     ],
 )
 async def test_dataset_example_span_resolver(
-    example_id, expected_span, test_client, dataset_with_span_and_nonspan_examples
+    example_id, expected_span, httpx_client, dataset_with_span_and_nonspan_examples
 ):
     query = """
       query ($exampleId: GlobalID!) {
@@ -70,7 +72,7 @@ async def test_dataset_example_span_resolver(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -90,7 +92,7 @@ async def test_dataset_example_span_resolver(
 
 
 async def test_dataset_example_experiment_runs_resolver_returns_relevant_runs(
-    test_client, example_with_experiment_runs
+    httpx_client, example_with_experiment_runs
 ) -> None:
     query = """
       query ($exampleId: GlobalID!) {
@@ -112,7 +114,7 @@ async def test_dataset_example_experiment_runs_resolver_returns_relevant_runs(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -155,200 +157,203 @@ async def test_dataset_example_experiment_runs_resolver_returns_relevant_runs(
 
 
 @pytest.fixture
-async def dataset_with_span_and_nonspan_examples(session):
+async def dataset_with_span_and_nonspan_examples(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
     """
     Dataset with two examples, one that comes from a span and one that does not.
     """
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
-    )
-    trace_rowid = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="0f5bb2e69a0640de87b9d424622b9f13",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
-            end_time=datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    span_rowid = await session.scalar(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_rowid,
-            span_id="c0055a08295841ab946f2a16e5089fad",
-            parent_id=None,
-            name="query",
-            span_kind="CHAIN",
-            start_time=datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
-            end_time=datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
-            attributes={
-                "openinference": {"span": {"kind": "CHAIN"}},
-            },
-            events=[],
-            status_code="OK",
-            status_message="",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=1,
-            cumulative_llm_token_count_completion=1,
+        trace_rowid = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="0f5bb2e69a0640de87b9d424622b9f13",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
+                end_time=datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .values(
-            name="dataset-name",
-            description="dataset-description",
-            metadata_={"metadata": "dataset-metadata"},
+        span_rowid = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_rowid,
+                span_id="c0055a08295841ab946f2a16e5089fad",
+                parent_id=None,
+                name="query",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
+                end_time=datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+                attributes={
+                    "openinference": {"span": {"kind": "CHAIN"}},
+                },
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=1,
+                cumulative_llm_token_count_completion=1,
+            )
+            .returning(models.Span.id)
         )
-        .returning(models.Dataset.id)
-    )
-    example_1_id = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
-            span_rowid=span_rowid,  # this example comes from a span
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .values(
+                name="dataset-name",
+                description="dataset-description",
+                metadata_={"metadata": "dataset-metadata"},
+            )
+            .returning(models.Dataset.id)
         )
-        .returning(models.DatasetExample.id)
-    )
-    example_2_id = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
+        example_1_id = await session.scalar(
+            insert(models.DatasetExample)
+            .values(
+                dataset_id=dataset_id,
+                span_rowid=span_rowid,  # this example comes from a span
+            )
+            .returning(models.DatasetExample.id)
         )
-        .returning(models.DatasetExample.id)
-    )
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .values(
-            dataset_id=dataset_id,
-            description="dataset-version-description",
-            metadata_={"metadata": "dataset-version-metadata"},
+        example_2_id = await session.scalar(
+            insert(models.DatasetExample)
+            .values(
+                dataset_id=dataset_id,
+            )
+            .returning(models.DatasetExample.id)
         )
-        .returning(models.DatasetVersion.id)
-    )
-    await session.execute(
-        insert(models.DatasetExampleRevision).values(
-            dataset_example_id=example_1_id,
-            dataset_version_id=version_id,
-            input={"input": "example-1-version-1-input"},
-            output={"output": "example-1-version-1-output"},
-            metadata_={"metadata": "example-1-version-1-metadata"},
-            revision_kind="CREATE",
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .values(
+                dataset_id=dataset_id,
+                description="dataset-version-description",
+                metadata_={"metadata": "dataset-version-metadata"},
+            )
+            .returning(models.DatasetVersion.id)
         )
-    )
-    await session.execute(
-        insert(models.DatasetExampleRevision).values(
-            dataset_example_id=example_2_id,
-            dataset_version_id=version_id,
-            input={"input": "example-2-version-1-input"},
-            output={"output": "example-2-version-1-output"},
-            metadata_={"metadata": "example-2-version-1-metadata"},
-            revision_kind="CREATE",
+        await session.execute(
+            insert(models.DatasetExampleRevision).values(
+                dataset_example_id=example_1_id,
+                dataset_version_id=version_id,
+                input={"input": "example-1-version-1-input"},
+                output={"output": "example-1-version-1-output"},
+                metadata_={"metadata": "example-1-version-1-metadata"},
+                revision_kind="CREATE",
+            )
         )
-    )
+        await session.execute(
+            insert(models.DatasetExampleRevision).values(
+                dataset_example_id=example_2_id,
+                dataset_version_id=version_id,
+                input={"input": "example-2-version-1-input"},
+                output={"output": "example-2-version-1-output"},
+                metadata_={"metadata": "example-2-version-1-metadata"},
+                revision_kind="CREATE",
+            )
+        )
 
 
 @pytest.fixture
-async def example_with_experiment_runs(session) -> None:
+async def example_with_experiment_runs(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with a single example and two experiments that use the example in
     their runs.
     """
-
-    # insert dataset
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .returning(models.Dataset.id)
-        .values(
-            name="dataset-name",
-            description=None,
-            metadata_={},
+    async with db() as session:
+        # insert dataset
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .returning(models.Dataset.id)
+            .values(
+                name="dataset-name",
+                description=None,
+                metadata_={},
+            )
         )
-    )
 
-    # insert example
-    example_id = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
+        # insert example
+        example_id = await session.scalar(
+            insert(models.DatasetExample)
+            .values(
+                dataset_id=dataset_id,
+            )
+            .returning(models.DatasetExample.id)
         )
-        .returning(models.DatasetExample.id)
-    )
 
-    # insert version
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .returning(models.DatasetVersion.id)
-        .values(
-            dataset_id=dataset_id,
-            description="original-description",
-            metadata_={"metadata": "original-metadata"},
+        # insert version
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .returning(models.DatasetVersion.id)
+            .values(
+                dataset_id=dataset_id,
+                description="original-description",
+                metadata_={"metadata": "original-metadata"},
+            )
         )
-    )
 
-    # insert revision
-    await session.scalar(
-        insert(models.DatasetExampleRevision)
-        .returning(models.DatasetExampleRevision.id)
-        .values(
-            dataset_example_id=example_id,
-            dataset_version_id=version_id,
-            input={"input": "first-input"},
-            output={"output": "first-output"},
-            metadata_={"metadata": "first-metadata"},
-            revision_kind="CREATE",
+        # insert revision
+        await session.scalar(
+            insert(models.DatasetExampleRevision)
+            .returning(models.DatasetExampleRevision.id)
+            .values(
+                dataset_example_id=example_id,
+                dataset_version_id=version_id,
+                input={"input": "first-input"},
+                output={"output": "first-output"},
+                metadata_={"metadata": "first-metadata"},
+                revision_kind="CREATE",
+            )
         )
-    )
 
-    # insert an experiment
-    experiment_1_id = await session.scalar(
-        insert(models.Experiment)
-        .returning(models.Experiment.id)
-        .values(
-            dataset_id=dataset_id,
-            dataset_version_id=version_id,
-            name="experiment-1",
-            description="experiment-1-description",
-            repetitions=1,
-            metadata_={"metadata": "experiment-1-metadata"},
+        # insert an experiment
+        experiment_1_id = await session.scalar(
+            insert(models.Experiment)
+            .returning(models.Experiment.id)
+            .values(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="experiment-1",
+                description="experiment-1-description",
+                repetitions=1,
+                metadata_={"metadata": "experiment-1-metadata"},
+            )
         )
-    )
 
-    # insert an experiment run on the example
-    await session.execute(
-        insert(models.ExperimentRun).values(
-            experiment_id=experiment_1_id,
-            dataset_example_id=example_id,
-            output={"task_output": "experiment-1-run-1-output"},
-            repetition_number=1,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+        # insert an experiment run on the example
+        await session.execute(
+            insert(models.ExperimentRun).values(
+                experiment_id=experiment_1_id,
+                dataset_example_id=example_id,
+                output={"task_output": "experiment-1-run-1-output"},
+                repetition_number=1,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+            )
         )
-    )
 
-    # insert a second experiment
-    experiment_2_id = await session.scalar(
-        insert(models.Experiment)
-        .returning(models.Experiment.id)
-        .values(
-            dataset_id=dataset_id,
-            dataset_version_id=version_id,
-            name="experiment-2",
-            description="experiment-2-description",
-            repetitions=1,
-            metadata_={"metadata": "experiment-2-metadata"},
+        # insert a second experiment
+        experiment_2_id = await session.scalar(
+            insert(models.Experiment)
+            .returning(models.Experiment.id)
+            .values(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="experiment-2",
+                description="experiment-2-description",
+                repetitions=1,
+                metadata_={"metadata": "experiment-2-metadata"},
+            )
         )
-    )
 
-    # insert another run on the example
-    await session.execute(
-        insert(models.ExperimentRun).values(
-            experiment_id=experiment_2_id,
-            dataset_example_id=example_id,
-            output={"task_output": {"output": "experiment-2-run-1-output"}},
-            repetition_number=1,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+        # insert another run on the example
+        await session.execute(
+            insert(models.ExperimentRun).values(
+                experiment_id=experiment_2_id,
+                dataset_example_id=example_id,
+                output={"task_output": {"output": "experiment-2-run-1-output"}},
+                repetition_number=1,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+            )
         )
-    )

--- a/tests/server/api/types/test_DatasetExample.py
+++ b/tests/server/api/types/test_DatasetExample.py
@@ -47,7 +47,7 @@ async def test_dataset_example_span_resolver(
     expected_span: Mapping[str, Any],
     httpx_client: httpx.AsyncClient,
     dataset_with_span_and_nonspan_examples: Any,
-):
+) -> None:
     query = """
       query ($exampleId: GlobalID!) {
         example: node(id: $exampleId) {
@@ -164,7 +164,7 @@ async def test_dataset_example_experiment_runs_resolver_returns_relevant_runs(
 @pytest.fixture
 async def dataset_with_span_and_nonspan_examples(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     """
     Dataset with two examples, one that comes from a span and one that does not.
     """

--- a/tests/server/api/types/test_Experiment.py
+++ b/tests/server/api/types/test_Experiment.py
@@ -13,7 +13,7 @@ from strawberry.relay import GlobalID
 
 
 async def test_experiment_resolver_returns_sequence_number(
-    httpx_client,
+    httpx_client: httpx.AsyncClient,
     interlaced_experiments: List[int],
 ):
     query = """
@@ -41,7 +41,8 @@ async def test_experiment_resolver_returns_sequence_number(
 
 
 async def test_runs_resolver_returns_runs_for_experiment(
-    httpx_client, dataset_with_experiment_runs
+    httpx_client: httpx.AsyncClient,
+    dataset_with_experiment_runs: Any,
 ):
     query = """
       query ($experimentId: GlobalID!) {
@@ -120,7 +121,8 @@ async def test_runs_resolver_returns_runs_for_experiment(
 
 
 async def test_run_count_resolver_returns_correct_counts(
-    httpx_client, experiments_with_runs_and_annotations
+    httpx_client: httpx.AsyncClient,
+    experiments_with_runs_and_annotations: Any,
 ):
     query = """
       query ($datasetId: GlobalID!) {
@@ -179,7 +181,8 @@ async def test_run_count_resolver_returns_correct_counts(
 
 
 async def test_average_run_latency_resolver_returns_correct_values(
-    httpx_client, experiments_with_runs_and_annotations
+    httpx_client: httpx.AsyncClient,
+    experiments_with_runs_and_annotations: Any,
 ):
     query = """
       query ($datasetId: GlobalID!) {
@@ -239,7 +242,9 @@ async def test_average_run_latency_resolver_returns_correct_values(
 
 class TestExperimentAnnotationSummaries:
     async def test_experiment_resolver_returns_expected_values(
-        self, httpx_client, experiments_with_runs_and_annotations
+        self,
+        httpx_client: httpx.AsyncClient,
+        experiments_with_runs_and_annotations: Any,
     ) -> None:
         query = """
           query ($datasetId: GlobalID!) {
@@ -338,7 +343,9 @@ class TestExperimentAnnotationSummaries:
         }
 
     async def test_dataset_resolver_returns_expected_values(
-        self, httpx_client, experiments_with_runs_and_annotations
+        self,
+        httpx_client: httpx.AsyncClient,
+        experiments_with_runs_and_annotations: Any,
     ) -> None:
         query = """
           query ($datasetId: GlobalID!) {

--- a/tests/server/api/types/test_Experiment.py
+++ b/tests/server/api/types/test_Experiment.py
@@ -1,17 +1,19 @@
 from datetime import datetime
 from statistics import mean
-from typing import List
+from typing import Any, AsyncContextManager, Callable, List
 
+import httpx
 import pytest
 import pytz
 from phoenix.db import models
 from phoenix.server.api.types.Experiment import Experiment
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 async def test_experiment_resolver_returns_sequence_number(
-    test_client,
+    httpx_client,
     interlaced_experiments: List[int],
 ):
     query = """
@@ -29,7 +31,7 @@ async def test_experiment_resolver_returns_sequence_number(
             GlobalID(type_name=Experiment.__name__, node_id=str(interlaced_experiments[5]))
         ),
     }
-    response = await test_client.post("/graphql", json={"query": query, "variables": variables})
+    response = await httpx_client.post("/graphql", json={"query": query, "variables": variables})
     assert response.status_code == 200
     response_json = response.json()
     assert response_json.get("errors") is None
@@ -38,7 +40,9 @@ async def test_experiment_resolver_returns_sequence_number(
     }
 
 
-async def test_runs_resolver_returns_runs_for_experiment(test_client, dataset_with_experiment_runs):
+async def test_runs_resolver_returns_runs_for_experiment(
+    httpx_client, dataset_with_experiment_runs
+):
     query = """
       query ($experimentId: GlobalID!) {
         experiment: node(id: $experimentId) {
@@ -60,7 +64,7 @@ async def test_runs_resolver_returns_runs_for_experiment(test_client, dataset_wi
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -116,7 +120,7 @@ async def test_runs_resolver_returns_runs_for_experiment(test_client, dataset_wi
 
 
 async def test_run_count_resolver_returns_correct_counts(
-    test_client, experiments_with_runs_and_annotations
+    httpx_client, experiments_with_runs_and_annotations
 ):
     query = """
       query ($datasetId: GlobalID!) {
@@ -134,7 +138,7 @@ async def test_run_count_resolver_returns_correct_counts(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -175,7 +179,7 @@ async def test_run_count_resolver_returns_correct_counts(
 
 
 async def test_average_run_latency_resolver_returns_correct_values(
-    test_client, experiments_with_runs_and_annotations
+    httpx_client, experiments_with_runs_and_annotations
 ):
     query = """
       query ($datasetId: GlobalID!) {
@@ -193,7 +197,7 @@ async def test_average_run_latency_resolver_returns_correct_values(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -235,7 +239,7 @@ async def test_average_run_latency_resolver_returns_correct_values(
 
 class TestExperimentAnnotationSummaries:
     async def test_experiment_resolver_returns_expected_values(
-        self, test_client, experiments_with_runs_and_annotations
+        self, httpx_client, experiments_with_runs_and_annotations
     ) -> None:
         query = """
           query ($datasetId: GlobalID!) {
@@ -260,7 +264,7 @@ class TestExperimentAnnotationSummaries:
             }
           }
         """
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": query,
@@ -334,7 +338,7 @@ class TestExperimentAnnotationSummaries:
         }
 
     async def test_dataset_resolver_returns_expected_values(
-        self, test_client, experiments_with_runs_and_annotations
+        self, httpx_client, experiments_with_runs_and_annotations
     ) -> None:
         query = """
           query ($datasetId: GlobalID!) {
@@ -352,7 +356,7 @@ class TestExperimentAnnotationSummaries:
             }
           }
         """
-        response = await test_client.post(
+        response = await httpx_client.post(
             "/graphql",
             json={
                 "query": query,
@@ -396,7 +400,10 @@ class TestExperimentAnnotationSummaries:
         }
 
 
-async def test_error_rate_returns_expected_values(test_client, experiments_with_runs) -> None:
+async def test_error_rate_returns_expected_values(
+    httpx_client: httpx.AsyncClient,
+    experiments_with_runs: Any,
+) -> None:
     query = """
       query ($datasetId: GlobalID!) {
         dataset: node(id: $datasetId) {
@@ -413,7 +420,7 @@ async def test_error_rate_returns_expected_values(test_client, experiments_with_
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -447,367 +454,338 @@ async def test_error_rate_returns_expected_values(test_client, experiments_with_
 
 
 @pytest.fixture
-async def dataset_with_experiment_runs(session):
+async def dataset_with_experiment_runs(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     A dataset with an associated experiment with three runs: one that has no
     associated trace, one that has an associated trace, and one that has a
     non-existent trace.
     """
-
-    # insert project
-    project_id = await session.scalar(
-        insert(models.Project).values(name="project-name").returning(models.Project.id)
-    )
-
-    # insert trace
-    await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="trace-id",
-            project_rowid=project_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+    async with db() as session:
+        # insert project
+        project_id = await session.scalar(
+            insert(models.Project).values(name="project-name").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
 
-    # insert dataset
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .returning(models.Dataset.id)
-        .values(
-            name="dataset-name",
-            description="dataset-description",
-            metadata_={"dataset-metadata-key": "dataset-metadata-value"},
+        # insert trace
+        await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="trace-id",
+                project_rowid=project_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-    )
 
-    # insert example
-    example_id = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
-            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        # insert dataset
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .returning(models.Dataset.id)
+            .values(
+                name="dataset-name",
+                description="dataset-description",
+                metadata_={"dataset-metadata-key": "dataset-metadata-value"},
+            )
         )
-        .returning(models.DatasetExample.id)
-    )
 
-    # insert version
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .returning(models.DatasetVersion.id)
-        .values(
-            dataset_id=dataset_id,
-            description="original-description",
-            metadata_={"metadata": "original-metadata"},
-        )
-    )
-
-    # insert revision
-    await session.scalar(
-        insert(models.DatasetExampleRevision)
-        .returning(models.DatasetExampleRevision.id)
-        .values(
-            dataset_example_id=example_id,
-            dataset_version_id=version_id,
-            input={"input": "first-input"},
-            output={"output": "first-output"},
-            metadata_={"metadata": "first-metadata"},
-            revision_kind="CREATE",
-        )
-    )
-
-    # insert experiment
-    experiment_id = await session.scalar(
-        insert(models.Experiment)
-        .returning(models.Experiment.id)
-        .values(
-            dataset_id=dataset_id,
-            dataset_version_id=version_id,
-            name="experiment-name",
-            description="experiment-description",
-            repetitions=3,
-            metadata_={"experiment-metadata-key": "experiment-metadata-value"},
-        )
-    )
-
-    # insert experiment run without associated trace
-    await session.scalar(
-        insert(models.ExperimentRun)
-        .returning(models.ExperimentRun.id)
-        .values(
-            experiment_id=experiment_id,
-            dataset_example_id=example_id,
-            output={"task_output": "run-1-output-value"},
-            repetition_number=1,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-        )
-    )
-
-    # insert experiment run with associated trace
-    await session.scalar(
-        insert(models.ExperimentRun)
-        .returning(models.ExperimentRun.id)
-        .values(
-            experiment_id=experiment_id,
-            dataset_example_id=example_id,
-            output={"task_output": {"run-2-output-key": "run-2-output-value"}},
-            trace_id="trace-id",
-            repetition_number=2,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-        )
-    )
-
-    # insert experiment run with non-existent trace
-    await session.scalar(
-        insert(models.ExperimentRun)
-        .returning(models.ExperimentRun.id)
-        .values(
-            experiment_id=experiment_id,
-            dataset_example_id=example_id,
-            output={"task_output": 12345},
-            trace_id="non-existent-trace-id",
-            repetition_number=3,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-        )
-    )
-
-
-@pytest.fixture
-async def experiments_with_runs_and_annotations(session):
-    """
-    Inserts three experiments, two with runs and annotations and one without.
-    """
-    # insert dataset
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .returning(models.Dataset.id)
-        .values(
-            name="dataset-name",
-            description="dataset-description",
-            metadata_={"dataset-metadata-key": "dataset-metadata-value"},
-        )
-    )
-
-    # insert examples
-    example_ids = (
-        await session.scalars(
+        # insert example
+        example_id = await session.scalar(
             insert(models.DatasetExample)
             .values(
-                [
-                    {
-                        "dataset_id": dataset_id,
-                        "created_at": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                    }
-                    for _ in range(2)
-                ]
+                dataset_id=dataset_id,
+                created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
             )
             .returning(models.DatasetExample.id)
         )
-    ).all()
 
-    # insert version
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .returning(models.DatasetVersion.id)
-        .values(
-            dataset_id=dataset_id,
-            description="version-description",
-            metadata_={},
+        # insert version
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .returning(models.DatasetVersion.id)
+            .values(
+                dataset_id=dataset_id,
+                description="original-description",
+                metadata_={"metadata": "original-metadata"},
+            )
         )
-    )
 
-    # insert revisions
-    await session.scalars(
-        insert(models.DatasetExampleRevision)
-        .returning(models.DatasetExampleRevision.id)
-        .values(
-            [
-                {
-                    "dataset_example_id": example_id,
-                    "dataset_version_id": version_id,
-                    "input": {"input": "input"},
-                    "output": {"output": "output"},
-                    "metadata_": {"metadata": "metadata"},
-                    "revision_kind": "CREATE",
-                }
-                for example_id in example_ids
-            ]
+        # insert revision
+        await session.scalar(
+            insert(models.DatasetExampleRevision)
+            .returning(models.DatasetExampleRevision.id)
+            .values(
+                dataset_example_id=example_id,
+                dataset_version_id=version_id,
+                input={"input": "first-input"},
+                output={"output": "first-output"},
+                metadata_={"metadata": "first-metadata"},
+                revision_kind="CREATE",
+            )
         )
-    )
 
-    # insert experiments
-    experiment_ids = (
-        await session.scalars(
+        # insert experiment
+        experiment_id = await session.scalar(
             insert(models.Experiment)
             .returning(models.Experiment.id)
             .values(
-                [
-                    {
-                        "dataset_id": dataset_id,
-                        "dataset_version_id": version_id,
-                        "name": "experiment-name",
-                        "description": "experiment-description",
-                        "repetitions": 1,
-                        "metadata_": {},
-                    }
-                    for _ in range(3)
-                ]
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="experiment-name",
+                description="experiment-description",
+                repetitions=3,
+                metadata_={"experiment-metadata-key": "experiment-metadata-value"},
             )
         )
-    ).all()
 
-    # insert experiment runs
-    run_ids = (
-        await session.scalars(
+        # insert experiment run without associated trace
+        await session.scalar(
             insert(models.ExperimentRun)
             .returning(models.ExperimentRun.id)
             .values(
+                experiment_id=experiment_id,
+                dataset_example_id=example_id,
+                output={"task_output": "run-1-output-value"},
+                repetition_number=1,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            )
+        )
+
+        # insert experiment run with associated trace
+        await session.scalar(
+            insert(models.ExperimentRun)
+            .returning(models.ExperimentRun.id)
+            .values(
+                experiment_id=experiment_id,
+                dataset_example_id=example_id,
+                output={"task_output": {"run-2-output-key": "run-2-output-value"}},
+                trace_id="trace-id",
+                repetition_number=2,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            )
+        )
+
+        # insert experiment run with non-existent trace
+        await session.scalar(
+            insert(models.ExperimentRun)
+            .returning(models.ExperimentRun.id)
+            .values(
+                experiment_id=experiment_id,
+                dataset_example_id=example_id,
+                output={"task_output": 12345},
+                trace_id="non-existent-trace-id",
+                repetition_number=3,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            )
+        )
+
+
+@pytest.fixture
+async def experiments_with_runs_and_annotations(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+):
+    """
+    Inserts three experiments, two with runs and annotations and one without.
+    """
+    async with db() as session:
+        # insert dataset
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .returning(models.Dataset.id)
+            .values(
+                name="dataset-name",
+                description="dataset-description",
+                metadata_={"dataset-metadata-key": "dataset-metadata-value"},
+            )
+        )
+
+        # insert examples
+        example_ids = (
+            await session.scalars(
+                insert(models.DatasetExample)
+                .values(
+                    [
+                        {
+                            "dataset_id": dataset_id,
+                            "created_at": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                        }
+                        for _ in range(2)
+                    ]
+                )
+                .returning(models.DatasetExample.id)
+            )
+        ).all()
+
+        # insert version
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .returning(models.DatasetVersion.id)
+            .values(
+                dataset_id=dataset_id,
+                description="version-description",
+                metadata_={},
+            )
+        )
+
+        # insert revisions
+        await session.scalars(
+            insert(models.DatasetExampleRevision)
+            .returning(models.DatasetExampleRevision.id)
+            .values(
                 [
-                    # experiment 1 (three repetitions)
-                    *[
-                        {
-                            "experiment_id": experiment_ids[0],
-                            "dataset_example_id": example_id,
-                            "output": {"output-key": "output-value"},
-                            "repetition_number": repetition_number,
-                            "start_time": datetime(
-                                year=2020,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=0,
-                                tzinfo=pytz.utc,
-                            ),
-                            "end_time": datetime(
-                                year=2020,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=repetition_number,
-                                tzinfo=pytz.utc,
-                            ),
-                        }
-                        for repetition_number in range(1, 4)
-                        for example_id in example_ids
-                    ],
-                    # experiment 2 (two repetitions)
-                    *[
-                        {
-                            "experiment_id": experiment_ids[1],
-                            "dataset_example_id": example_id,
-                            "output": {"output-key": "output-value"},
-                            "repetition_number": repetition_number,
-                            "start_time": datetime(
-                                year=2020,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=0,
-                                tzinfo=pytz.utc,
-                            ),
-                            "end_time": datetime(
-                                year=2020,
-                                month=1,
-                                day=1,
-                                hour=0,
-                                minute=0,
-                                second=repetition_number,
-                                tzinfo=pytz.utc,
-                            ),
-                        }
-                        for repetition_number in range(1, 3)
-                        for example_id in example_ids
-                    ],
-                    # experiment 3 (no runs)
+                    {
+                        "dataset_example_id": example_id,
+                        "dataset_version_id": version_id,
+                        "input": {"input": "input"},
+                        "output": {"output": "output"},
+                        "metadata_": {"metadata": "metadata"},
+                        "revision_kind": "CREATE",
+                    }
+                    for example_id in example_ids
                 ]
             )
         )
-    ).all()
 
-    # insert experiment annotations
-    await session.scalar(
-        insert(models.ExperimentRunAnnotation)
-        .returning(models.ExperimentRunAnnotation.id)
-        .values(
-            [
-                # experiment 1, annotation-name-1
-                *[
+        # insert experiments
+        experiment_ids = (
+            await session.scalars(
+                insert(models.Experiment)
+                .returning(models.Experiment.id)
+                .values(
+                    [
+                        {
+                            "dataset_id": dataset_id,
+                            "dataset_version_id": version_id,
+                            "name": "experiment-name",
+                            "description": "experiment-description",
+                            "repetitions": 1,
+                            "metadata_": {},
+                        }
+                        for _ in range(3)
+                    ]
+                )
+            )
+        ).all()
+
+        # insert experiment runs
+        run_ids = (
+            await session.scalars(
+                insert(models.ExperimentRun)
+                .returning(models.ExperimentRun.id)
+                .values(
+                    [
+                        # experiment 1 (three repetitions)
+                        *[
+                            {
+                                "experiment_id": experiment_ids[0],
+                                "dataset_example_id": example_id,
+                                "output": {"output-key": "output-value"},
+                                "repetition_number": repetition_number,
+                                "start_time": datetime(
+                                    year=2020,
+                                    month=1,
+                                    day=1,
+                                    hour=0,
+                                    minute=0,
+                                    second=0,
+                                    tzinfo=pytz.utc,
+                                ),
+                                "end_time": datetime(
+                                    year=2020,
+                                    month=1,
+                                    day=1,
+                                    hour=0,
+                                    minute=0,
+                                    second=repetition_number,
+                                    tzinfo=pytz.utc,
+                                ),
+                            }
+                            for repetition_number in range(1, 4)
+                            for example_id in example_ids
+                        ],
+                        # experiment 2 (two repetitions)
+                        *[
+                            {
+                                "experiment_id": experiment_ids[1],
+                                "dataset_example_id": example_id,
+                                "output": {"output-key": "output-value"},
+                                "repetition_number": repetition_number,
+                                "start_time": datetime(
+                                    year=2020,
+                                    month=1,
+                                    day=1,
+                                    hour=0,
+                                    minute=0,
+                                    second=0,
+                                    tzinfo=pytz.utc,
+                                ),
+                                "end_time": datetime(
+                                    year=2020,
+                                    month=1,
+                                    day=1,
+                                    hour=0,
+                                    minute=0,
+                                    second=repetition_number,
+                                    tzinfo=pytz.utc,
+                                ),
+                            }
+                            for repetition_number in range(1, 3)
+                            for example_id in example_ids
+                        ],
+                        # experiment 3 (no runs)
+                    ]
+                )
+            )
+        ).all()
+
+        # insert experiment annotations
+        await session.scalar(
+            insert(models.ExperimentRunAnnotation)
+            .returning(models.ExperimentRunAnnotation.id)
+            .values(
+                [
+                    # experiment 1, annotation-name-1
+                    *[
+                        {
+                            "experiment_run_id": run_id,
+                            "name": "annotation-name-1",
+                            "annotator_kind": "CODE",
+                            "label": f"label-{score}",
+                            "score": score,
+                            "explanation": "explanation",
+                            "trace_id": None,
+                            "error": None,
+                            "metadata_": {},
+                            "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                            "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                        }
+                        for run_id, score in zip(run_ids[:6], [1, 0, 1, 0, 0, 0])
+                    ],
+                    # experiment 1, annotation-name-2
+                    *[
+                        {
+                            "experiment_run_id": run_id,
+                            "name": "annotation-name-2",
+                            "annotator_kind": "CODE",
+                            "label": f"label-{score}",
+                            "score": score,
+                            "explanation": "explanation",
+                            "trace_id": None,
+                            "error": None,
+                            "metadata_": {},
+                            "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                            "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                        }
+                        for run_id, score in zip(run_ids[:3], [0, 1, 1])
+                    ],
                     {
-                        "experiment_run_id": run_id,
-                        "name": "annotation-name-1",
-                        "annotator_kind": "CODE",
-                        "label": f"label-{score}",
-                        "score": score,
-                        "explanation": "explanation",
-                        "trace_id": None,
-                        "error": None,
-                        "metadata_": {},
-                        "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                        "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    }
-                    for run_id, score in zip(run_ids[:6], [1, 0, 1, 0, 0, 0])
-                ],
-                # experiment 1, annotation-name-2
-                *[
-                    {
-                        "experiment_run_id": run_id,
+                        "experiment_run_id": run_ids[4],
                         "name": "annotation-name-2",
-                        "annotator_kind": "CODE",
-                        "label": f"label-{score}",
-                        "score": score,
-                        "explanation": "explanation",
-                        "trace_id": None,
-                        "error": None,
-                        "metadata_": {},
-                        "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                        "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    }
-                    for run_id, score in zip(run_ids[:3], [0, 1, 1])
-                ],
-                {
-                    "experiment_run_id": run_ids[4],
-                    "name": "annotation-name-2",
-                    "annotator_kind": "CODE",
-                    "label": None,
-                    "score": None,
-                    "explanation": None,
-                    "trace_id": None,
-                    "error": "failed",
-                    "metadata_": {},
-                    "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                },
-                # experiment 2, annotation-name-1
-                *[
-                    {
-                        "experiment_run_id": run_id,
-                        "name": "annotation-name-1",
-                        "annotator_kind": "CODE",
-                        "label": f"label-{score}",
-                        "score": score,
-                        "explanation": "explanation",
-                        "trace_id": None,
-                        "error": None,
-                        "metadata_": {},
-                        "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                        "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    }
-                    for run_id, score in zip(run_ids[6:8], [1, 1])
-                ],
-                # experiment 2, annotation-name-3
-                *[
-                    {
-                        "experiment_run_id": run_id,
-                        "name": "annotation-name-3",
                         "annotator_kind": "CODE",
                         "label": None,
                         "score": None,
@@ -817,135 +795,168 @@ async def experiments_with_runs_and_annotations(session):
                         "metadata_": {},
                         "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
                         "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
-                    }
-                    for run_id in run_ids[6:]
-                ],
-            ]
+                    },
+                    # experiment 2, annotation-name-1
+                    *[
+                        {
+                            "experiment_run_id": run_id,
+                            "name": "annotation-name-1",
+                            "annotator_kind": "CODE",
+                            "label": f"label-{score}",
+                            "score": score,
+                            "explanation": "explanation",
+                            "trace_id": None,
+                            "error": None,
+                            "metadata_": {},
+                            "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                            "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                        }
+                        for run_id, score in zip(run_ids[6:8], [1, 1])
+                    ],
+                    # experiment 2, annotation-name-3
+                    *[
+                        {
+                            "experiment_run_id": run_id,
+                            "name": "annotation-name-3",
+                            "annotator_kind": "CODE",
+                            "label": None,
+                            "score": None,
+                            "explanation": None,
+                            "trace_id": None,
+                            "error": "failed",
+                            "metadata_": {},
+                            "start_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                            "end_time": datetime(2020, 1, 1, 0, 0, tzinfo=pytz.UTC),
+                        }
+                        for run_id in run_ids[6:]
+                    ],
+                ]
+            )
         )
-    )
 
 
 @pytest.fixture
-async def experiments_with_runs(session):
+async def experiments_with_runs(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     Inserts two experiments, the first of which contains one errored run and the
     second of which is empty (i.e., has no runs).
     """
-    # insert dataset
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .returning(models.Dataset.id)
-        .values(
-            name="dataset-name",
-            description="dataset-description",
-            metadata_={"dataset-metadata-key": "dataset-metadata-value"},
-        )
-    )
-
-    # insert examples
-    example_ids = (
-        await session.scalars(
-            insert(models.DatasetExample)
+    async with db() as session:
+        # insert dataset
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .returning(models.Dataset.id)
             .values(
-                [
-                    {
-                        "dataset_id": dataset_id,
-                        "created_at": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                    }
-                    for _ in range(2)
-                ]
+                name="dataset-name",
+                description="dataset-description",
+                metadata_={"dataset-metadata-key": "dataset-metadata-value"},
             )
-            .returning(models.DatasetExample.id)
         )
-    ).all()
 
-    # insert version
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .returning(models.DatasetVersion.id)
-        .values(
-            dataset_id=dataset_id,
-            description="version-description",
-            metadata_={},
+        # insert examples
+        example_ids = (
+            await session.scalars(
+                insert(models.DatasetExample)
+                .values(
+                    [
+                        {
+                            "dataset_id": dataset_id,
+                            "created_at": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                        }
+                        for _ in range(2)
+                    ]
+                )
+                .returning(models.DatasetExample.id)
+            )
+        ).all()
+
+        # insert version
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .returning(models.DatasetVersion.id)
+            .values(
+                dataset_id=dataset_id,
+                description="version-description",
+                metadata_={},
+            )
         )
-    )
 
-    # insert revisions
-    await session.scalars(
-        insert(models.DatasetExampleRevision)
-        .returning(models.DatasetExampleRevision.id)
-        .values(
-            [
-                {
-                    "dataset_example_id": example_id,
-                    "dataset_version_id": version_id,
-                    "input": {"input": "input"},
-                    "output": {"output": "output"},
-                    "metadata_": {"metadata": "metadata"},
-                    "revision_kind": "CREATE",
-                }
-                for example_id in example_ids
-            ]
-        )
-    )
-
-    # insert experiments
-    experiment_ids = (
+        # insert revisions
         await session.scalars(
-            insert(models.Experiment)
-            .returning(models.Experiment.id)
+            insert(models.DatasetExampleRevision)
+            .returning(models.DatasetExampleRevision.id)
             .values(
                 [
                     {
-                        "dataset_id": dataset_id,
+                        "dataset_example_id": example_id,
                         "dataset_version_id": version_id,
-                        "name": "experiment-name",
-                        "description": "experiment-description",
-                        "repetitions": 1,
-                        "metadata_": {},
+                        "input": {"input": "input"},
+                        "output": {"output": "output"},
+                        "metadata_": {"metadata": "metadata"},
+                        "revision_kind": "CREATE",
                     }
-                    for _ in range(2)
+                    for example_id in example_ids
                 ]
             )
         )
-    ).all()
 
-    # insert experiment runs
-    (
-        await session.scalars(
-            insert(models.ExperimentRun)
-            .returning(models.ExperimentRun.id)
-            .values(
-                [
-                    {
-                        "error": "failed",
-                        "experiment_id": experiment_ids[0],
-                        "dataset_example_id": example_ids[0],
-                        "output": {"output-key-test": "output-value"},
-                        "repetition_number": 1,
-                        "start_time": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                        "end_time": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                    },
-                    {
-                        "error": None,
-                        "experiment_id": experiment_ids[0],
-                        "dataset_example_id": example_ids[1],
-                        "output": {"output-key": "output-value"},
-                        "repetition_number": 1,
-                        "start_time": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                        "end_time": datetime(
-                            year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
-                        ),
-                    },
-                ]
+        # insert experiments
+        experiment_ids = (
+            await session.scalars(
+                insert(models.Experiment)
+                .returning(models.Experiment.id)
+                .values(
+                    [
+                        {
+                            "dataset_id": dataset_id,
+                            "dataset_version_id": version_id,
+                            "name": "experiment-name",
+                            "description": "experiment-description",
+                            "repetitions": 1,
+                            "metadata_": {},
+                        }
+                        for _ in range(2)
+                    ]
+                )
             )
-        )
-    ).all()
+        ).all()
+
+        # insert experiment runs
+        (
+            await session.scalars(
+                insert(models.ExperimentRun)
+                .returning(models.ExperimentRun.id)
+                .values(
+                    [
+                        {
+                            "error": "failed",
+                            "experiment_id": experiment_ids[0],
+                            "dataset_example_id": example_ids[0],
+                            "output": {"output-key-test": "output-value"},
+                            "repetition_number": 1,
+                            "start_time": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                            "end_time": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                        },
+                        {
+                            "error": None,
+                            "experiment_id": experiment_ids[0],
+                            "dataset_example_id": example_ids[1],
+                            "output": {"output-key": "output-value"},
+                            "repetition_number": 1,
+                            "start_time": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                            "end_time": datetime(
+                                year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc
+                            ),
+                        },
+                    ]
+                )
+            )
+        ).all()

--- a/tests/server/api/types/test_Experiment.py
+++ b/tests/server/api/types/test_Experiment.py
@@ -15,7 +15,7 @@ from strawberry.relay import GlobalID
 async def test_experiment_resolver_returns_sequence_number(
     httpx_client: httpx.AsyncClient,
     interlaced_experiments: List[int],
-):
+) -> None:
     query = """
       query ($experimentId: GlobalID!) {
         experiment: node(id: $experimentId) {
@@ -43,7 +43,7 @@ async def test_experiment_resolver_returns_sequence_number(
 async def test_runs_resolver_returns_runs_for_experiment(
     httpx_client: httpx.AsyncClient,
     dataset_with_experiment_runs: Any,
-):
+) -> None:
     query = """
       query ($experimentId: GlobalID!) {
         experiment: node(id: $experimentId) {
@@ -123,7 +123,7 @@ async def test_runs_resolver_returns_runs_for_experiment(
 async def test_run_count_resolver_returns_correct_counts(
     httpx_client: httpx.AsyncClient,
     experiments_with_runs_and_annotations: Any,
-):
+) -> None:
     query = """
       query ($datasetId: GlobalID!) {
         dataset: node(id: $datasetId) {
@@ -183,7 +183,7 @@ async def test_run_count_resolver_returns_correct_counts(
 async def test_average_run_latency_resolver_returns_correct_values(
     httpx_client: httpx.AsyncClient,
     experiments_with_runs_and_annotations: Any,
-):
+) -> None:
     query = """
       query ($datasetId: GlobalID!) {
         dataset: node(id: $datasetId) {
@@ -461,7 +461,7 @@ async def test_error_rate_returns_expected_values(
 
 
 @pytest.fixture
-async def dataset_with_experiment_runs(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def dataset_with_experiment_runs(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     A dataset with an associated experiment with three runs: one that has no
     associated trace, one that has an associated trace, and one that has a
@@ -593,7 +593,7 @@ async def dataset_with_experiment_runs(db: Callable[[], AsyncContextManager[Asyn
 @pytest.fixture
 async def experiments_with_runs_and_annotations(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-):
+) -> None:
     """
     Inserts three experiments, two with runs and annotations and one without.
     """
@@ -843,7 +843,7 @@ async def experiments_with_runs_and_annotations(
 
 
 @pytest.fixture
-async def experiments_with_runs(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def experiments_with_runs(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     """
     Inserts two experiments, the first of which contains one errored run and the
     second of which is empty (i.e., has no runs).

--- a/tests/server/api/types/test_ExperimentRun.py
+++ b/tests/server/api/types/test_ExperimentRun.py
@@ -13,7 +13,7 @@ from strawberry.relay import GlobalID
 async def test_annotations_resolver_returns_annotations_for_run(
     httpx_client: httpx.AsyncClient,
     experiment_run_with_annotations: Any,
-):
+) -> None:
     query = """
       query ($runId: GlobalID!) {
         run: node(id: $runId) {
@@ -97,7 +97,9 @@ async def test_annotations_resolver_returns_annotations_for_run(
 
 
 @pytest.fixture
-async def experiment_run_with_annotations(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def experiment_run_with_annotations(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     An experiment run with two annotations.
     """

--- a/tests/server/api/types/test_ExperimentRun.py
+++ b/tests/server/api/types/test_ExperimentRun.py
@@ -1,14 +1,18 @@
 from datetime import datetime
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 import pytz
 from phoenix.db import models
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 async def test_annotations_resolver_returns_annotations_for_run(
-    test_client, experiment_run_with_annotations
+    httpx_client: httpx.AsyncClient,
+    experiment_run_with_annotations: Any,
 ):
     query = """
       query ($runId: GlobalID!) {
@@ -34,7 +38,7 @@ async def test_annotations_resolver_returns_annotations_for_run(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -93,104 +97,105 @@ async def test_annotations_resolver_returns_annotations_for_run(
 
 
 @pytest.fixture
-async def experiment_run_with_annotations(session):
+async def experiment_run_with_annotations(db: Callable[[], AsyncContextManager[AsyncSession]]):
     """
     An experiment run with two annotations.
     """
 
-    # insert dataset
-    dataset_id = await session.scalar(
-        insert(models.Dataset)
-        .returning(models.Dataset.id)
-        .values(
-            name="dataset-name",
-            description="dataset-description",
-            metadata_={"dataset-metadata-key": "dataset-metadata-value"},
+    async with db() as session:
+        # insert dataset
+        dataset_id = await session.scalar(
+            insert(models.Dataset)
+            .returning(models.Dataset.id)
+            .values(
+                name="dataset-name",
+                description="dataset-description",
+                metadata_={"dataset-metadata-key": "dataset-metadata-value"},
+            )
         )
-    )
 
-    # insert example
-    example_id = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
-            created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        # insert example
+        example_id = await session.scalar(
+            insert(models.DatasetExample)
+            .values(
+                dataset_id=dataset_id,
+                created_at=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            )
+            .returning(models.DatasetExample.id)
         )
-        .returning(models.DatasetExample.id)
-    )
 
-    # insert version
-    version_id = await session.scalar(
-        insert(models.DatasetVersion)
-        .returning(models.DatasetVersion.id)
-        .values(
-            dataset_id=dataset_id,
-            description="original-description",
-            metadata_={"metadata": "original-metadata"},
+        # insert version
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .returning(models.DatasetVersion.id)
+            .values(
+                dataset_id=dataset_id,
+                description="original-description",
+                metadata_={"metadata": "original-metadata"},
+            )
         )
-    )
 
-    # insert experiment
-    experiment_id = await session.scalar(
-        insert(models.Experiment)
-        .returning(models.Experiment.id)
-        .values(
-            dataset_id=dataset_id,
-            dataset_version_id=version_id,
-            name="experiment-name",
-            description="experiment-description",
-            repetitions=1,
-            metadata_={"experiment-metadata-key": "experiment-metadata-value"},
+        # insert experiment
+        experiment_id = await session.scalar(
+            insert(models.Experiment)
+            .returning(models.Experiment.id)
+            .values(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="experiment-name",
+                description="experiment-description",
+                repetitions=1,
+                metadata_={"experiment-metadata-key": "experiment-metadata-value"},
+            )
         )
-    )
 
-    # insert experiment run
-    run_id = await session.scalar(
-        insert(models.ExperimentRun)
-        .returning(models.ExperimentRun.id)
-        .values(
-            experiment_id=experiment_id,
-            dataset_example_id=example_id,
-            output={"run-1-output-key": "run-1-output-value"},
-            repetition_number=1,
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+        # insert experiment run
+        run_id = await session.scalar(
+            insert(models.ExperimentRun)
+            .returning(models.ExperimentRun.id)
+            .values(
+                experiment_id=experiment_id,
+                dataset_example_id=example_id,
+                output={"run-1-output-key": "run-1-output-value"},
+                repetition_number=1,
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+            )
         )
-    )
 
-    # insert annotations
-    await session.scalar(
-        insert(models.ExperimentRunAnnotation)
-        .returning(models.ExperimentRunAnnotation.id)
-        .values(
-            experiment_run_id=run_id,
-            name="annotation-1-name",
-            annotator_kind="LLM",
-            label="annotation-1-label",
-            score=0.2,
-            explanation="annotation-1-explanation",
-            trace_id=None,
-            error="annotation-1-error",
-            metadata_={"annotation-1-metadata-key": "annotation-1-metadata-value"},
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+        # insert annotations
+        await session.scalar(
+            insert(models.ExperimentRunAnnotation)
+            .returning(models.ExperimentRunAnnotation.id)
+            .values(
+                experiment_run_id=run_id,
+                name="annotation-1-name",
+                annotator_kind="LLM",
+                label="annotation-1-label",
+                score=0.2,
+                explanation="annotation-1-explanation",
+                trace_id=None,
+                error="annotation-1-error",
+                metadata_={"annotation-1-metadata-key": "annotation-1-metadata-value"},
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+            )
         )
-    )
 
-    await session.scalar(
-        insert(models.ExperimentRunAnnotation)
-        .returning(models.ExperimentRunAnnotation.id)
-        .values(
-            experiment_run_id=run_id,
-            name="annotation-2-name",
-            annotator_kind="LLM",
-            label="annotation-2-label",
-            score=0.2,
-            explanation="annotation-2-explanation",
-            trace_id=None,
-            error="annotation-2-error",
-            metadata_={"annotation-2-metadata-key": "annotation-2-metadata-value"},
-            start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
-            end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+        await session.scalar(
+            insert(models.ExperimentRunAnnotation)
+            .returning(models.ExperimentRunAnnotation.id)
+            .values(
+                experiment_run_id=run_id,
+                name="annotation-2-name",
+                annotator_kind="LLM",
+                label="annotation-2-label",
+                score=0.2,
+                explanation="annotation-2-explanation",
+                trace_id=None,
+                error="annotation-2-error",
+                metadata_={"annotation-2-metadata-key": "annotation-2-metadata-value"},
+                start_time=datetime(year=2020, month=1, day=1, hour=0, minute=0, tzinfo=pytz.utc),
+                end_time=datetime(year=2020, month=1, day=1, hour=0, minute=1, tzinfo=pytz.utc),
+            )
         )
-    )

--- a/tests/server/api/types/test_Project.py
+++ b/tests/server/api/types/test_Project.py
@@ -1,8 +1,9 @@
 # ruff: noqa: E501
 
 from datetime import datetime
-from typing import AsyncContextManager, Callable
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
@@ -481,8 +482,8 @@ async def test_project_spans(
     start_cursor,
     end_cursor,
     has_next_page,
-    httpx_client,
-    llama_index_rag_spans,
+    httpx_client: httpx.AsyncClient,
+    llama_index_rag_spans: Any,
 ) -> None:
     query = """
       query ($projectId: GlobalID!, $after: String = null, $before: String = null, $filterCondition: String = null, $first: Int = null, $last: Int = null, $sort: SpanSort = null) {

--- a/tests/server/api/types/test_Project.py
+++ b/tests/server/api/types/test_Project.py
@@ -1,12 +1,14 @@
 # ruff: noqa: E501
 
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pytest
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
 from phoenix.server.api.types.pagination import Cursor, CursorSortColumn, CursorSortColumnDataType
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 PROJECT_ID = str(GlobalID(type_name="Project", node_id="1"))
@@ -479,7 +481,7 @@ async def test_project_spans(
     start_cursor,
     end_cursor,
     has_next_page,
-    test_client,
+    httpx_client,
     llama_index_rag_spans,
 ) -> None:
     query = """
@@ -508,7 +510,7 @@ async def test_project_spans(
         }
       }
     """
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -529,600 +531,609 @@ async def test_project_spans(
 
 
 @pytest.fixture
-async def llama_index_rag_spans(session):
+async def llama_index_rag_spans(db: Callable[[], AsyncContextManager[AsyncSession]]):
     # Inserts the first three traces from the llama-index-rag trace fixture
     # (minus embeddings) along with associated span evaluations.
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
-    )
-    trace_rowids = (
-        await session.scalars(
-            insert(models.Trace).returning(models.Trace.id),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
+        )
+        trace_rowids = (
+            await session.scalars(
+                insert(models.Trace).returning(models.Trace.id),
+                [
+                    {
+                        "trace_id": "0f5bb2e69a0640de87b9d424622b9f13",
+                        "project_rowid": project_row_id,
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+                    },
+                    {
+                        "trace_id": "a4083327f7d0400a9e99906242e71aa4",
+                        "project_rowid": project_row_id,
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540371+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492242+00:00"),
+                    },
+                    {
+                        "trace_id": "17f383d1c85648899368bde24b566411",
+                        "project_rowid": project_row_id,
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.495969+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336284+00:00"),
+                    },
+                ],
+            )
+        ).all()
+        span_rowids = (
+            await session.scalars(
+                insert(models.Span).returning(models.Span.id),
+                [
+                    {
+                        "trace_rowid": trace_rowids[0],
+                        "span_id": "c0055a08295841ab946f2a16e5089fad",
+                        "parent_id": None,
+                        "name": "query",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {
+                                "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
+                            },
+                            "input": {"value": "How do I use the SDK to upload a ranking model?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 240,
+                        "cumulative_llm_token_count_completion": 56,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[0],
+                        "span_id": "edcd8a83c7b34fd2b83e946f58e9a9c0",
+                        "parent_id": "c0055a08295841ab946f2a16e5089fad",
+                        "name": "retrieve",
+                        "span_kind": "RETRIEVER",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306945+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:23.710062+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "RETRIEVER"}},
+                            "retrieval": {
+                                "documents": [
+                                    {
+                                        "document": {
+                                            "content": "\nRanking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n\n\n",
+                                            "id": "ad17eeea-e339-4195-991b-8eef54b1db65",
+                                            "score": 0.8022561073303223,
+                                        }
+                                    },
+                                    {
+                                        "document": {
+                                            "content": "\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;\n\n",
+                                            "id": "0ce66871-4a50-4d2f-94d2-1531924bf48a",
+                                            "score": 0.7964192032814026,
+                                        }
+                                    },
+                                ]
+                            },
+                            "input": {"value": "How do I use the SDK to upload a ranking model?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[0],
+                        "span_id": "a91ad81bb187489093afeb8f3f5816b5",
+                        "parent_id": "edcd8a83c7b34fd2b83e946f58e9a9c0",
+                        "name": "embedding",
+                        "span_kind": "EMBEDDING",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.307166+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:23.638792+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "EMBEDDING"}},
+                            "embedding": {
+                                "model_name": "text-embedding-ada-002",
+                                "embeddings": [
+                                    {
+                                        "embedding": {
+                                            "vector": [1.0],
+                                            "text": "How do I use the SDK to upload a ranking model?",
+                                        }
+                                    }
+                                ],
+                            },
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[0],
+                        "span_id": "78742859b73e427f90b43ec6cc8c42ba",
+                        "parent_id": "c0055a08295841ab946f2a16e5089fad",
+                        "name": "synthesize",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.710148+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534461+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {
+                                "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
+                            },
+                            "input": {"value": "How do I use the SDK to upload a ranking model?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 240,
+                        "cumulative_llm_token_count_completion": 56,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[0],
+                        "span_id": "258bef0a3e384bcaaa5a388065af0d8f",
+                        "parent_id": "78742859b73e427f90b43ec6cc8c42ba",
+                        "name": "llm",
+                        "span_kind": "LLM",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:23.712144+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.532714+00:00"),
+                        "attributes": {
+                            "llm": {
+                                "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
+                                "input_messages": [
+                                    {
+                                        "message": {
+                                            "role": "system",
+                                        }
+                                    },
+                                    {
+                                        "message": {
+                                            "content": "Context information is below.\n---------------------\nRanking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: How do I use the SDK to upload a ranking model?\nAnswer: ",
+                                            "role": "user",
+                                        }
+                                    },
+                                ],
+                                "model_name": "gpt-3.5-turbo",
+                                "output_messages": [
+                                    {
+                                        "message": {
+                                            "content": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process.",
+                                            "role": "assistant",
+                                        }
+                                    }
+                                ],
+                                "prompt_template": {
+                                    "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
+                                    "variables": {
+                                        "context_str": "Ranking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;",
+                                        "query_str": "How do I use the SDK to upload a ranking model?",
+                                    },
+                                },
+                                "token_count": {
+                                    "prompt": 240.0,
+                                    "total": 296.0,
+                                    "completion": 56.0,
+                                },
+                            },
+                            "output": {
+                                "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
+                            },
+                            "openinference": {"span": {"kind": "LLM"}},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 240,
+                        "cumulative_llm_token_count_completion": 56,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[1],
+                        "span_id": "094ae70b0e9c4dec83601b0f0b89e551",
+                        "parent_id": None,
+                        "name": "query",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540371+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492242+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {
+                                "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
+                            },
+                            "input": {"value": "What drift metrics are supported in Arize?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 315,
+                        "cumulative_llm_token_count_completion": 21,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[1],
+                        "span_id": "fc7f4cb067124f0abed01e5749a6aead",
+                        "parent_id": "094ae70b0e9c4dec83601b0f0b89e551",
+                        "name": "retrieve",
+                        "span_kind": "RETRIEVER",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540449+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.842912+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "RETRIEVER"}},
+                            "retrieval": {
+                                "documents": [
+                                    {
+                                        "document": {
+                                            "content": "\nDrift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\n",
+                                            "id": "60f3c900-dcee-43ef-816e-ae8f5289a544",
+                                            "score": 0.8768844604492188,
+                                        }
+                                    },
+                                    {
+                                        "document": {
+                                            "content": "\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.\n\n",
+                                            "id": "2e468875-ee22-4b5d-a7f4-57074eb5adfa",
+                                            "score": 0.873500406742096,
+                                        }
+                                    },
+                                ]
+                            },
+                            "input": {"value": "What drift metrics are supported in Arize?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[1],
+                        "span_id": "70252f342dcc496dac93404dcfbaa211",
+                        "parent_id": "fc7f4cb067124f0abed01e5749a6aead",
+                        "name": "embedding",
+                        "span_kind": "EMBEDDING",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540677+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:25.768612+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "EMBEDDING"}},
+                            "embedding": {
+                                "model_name": "text-embedding-ada-002",
+                                "embeddings": [
+                                    {
+                                        "embedding": {
+                                            "vector": [1.0],
+                                            "text": "What drift metrics are supported in Arize?",
+                                        }
+                                    }
+                                ],
+                            },
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[1],
+                        "span_id": "c5ff03a4cf534b07a5ad6a00836acb1e",
+                        "parent_id": "094ae70b0e9c4dec83601b0f0b89e551",
+                        "name": "synthesize",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.842986+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492192+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {
+                                "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
+                            },
+                            "input": {"value": "What drift metrics are supported in Arize?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 315,
+                        "cumulative_llm_token_count_completion": 21,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[1],
+                        "span_id": "0890b8716c4943c18b3ad45c6d9aaf5d",
+                        "parent_id": "c5ff03a4cf534b07a5ad6a00836acb1e",
+                        "name": "llm",
+                        "span_kind": "LLM",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:25.844758+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.491989+00:00"),
+                        "attributes": {
+                            "llm": {
+                                "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
+                                "input_messages": [
+                                    {
+                                        "message": {
+                                            "content": "You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.",
+                                            "role": "system",
+                                        }
+                                    },
+                                    {
+                                        "message": {
+                                            "content": "Context information is below.\n---------------------\nDrift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: What drift metrics are supported in Arize?\nAnswer: ",
+                                            "role": "user",
+                                        }
+                                    },
+                                ],
+                                "model_name": "gpt-3.5-turbo",
+                                "output_messages": [
+                                    {
+                                        "message": {
+                                            "content": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance.",
+                                            "role": "assistant",
+                                        }
+                                    }
+                                ],
+                                "prompt_template": {
+                                    "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
+                                    "variables": {
+                                        "context_str": "Drift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.",
+                                        "query_str": "What drift metrics are supported in Arize?",
+                                    },
+                                },
+                                "token_count": {
+                                    "prompt": 315.0,
+                                    "total": 336.0,
+                                    "completion": 21.0,
+                                },
+                            },
+                            "output": {
+                                "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
+                            },
+                            "openinference": {"span": {"kind": "LLM"}},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 315,
+                        "cumulative_llm_token_count_completion": 21,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[2],
+                        "span_id": "63b60ed12a61418ab9bd3757bd7eb09f",
+                        "parent_id": None,
+                        "name": "query",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.495969+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336284+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {"value": "Yes, Arize supports batch models."},
+                            "input": {"value": "Does Arize support batch models?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 374,
+                        "cumulative_llm_token_count_completion": 8,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[2],
+                        "span_id": "2a3744dfdb954d6ea6a1dc0acb1e81d3",
+                        "parent_id": "63b60ed12a61418ab9bd3757bd7eb09f",
+                        "name": "retrieve",
+                        "span_kind": "RETRIEVER",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.496043+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.704469+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "RETRIEVER"}},
+                            "retrieval": {
+                                "documents": [
+                                    {
+                                        "document": {
+                                            "content": "\nArize supports many model types - check out our various Model Types to learn more.&#x20;\n\n",
+                                            "id": "b18c5cbd-ab0b-43d2-b0d3-55e755ee3561",
+                                            "score": 0.8502153754234314,
+                                        }
+                                    },
+                                    {
+                                        "document": {
+                                            "content": 'developers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.\n\n\n\n',
+                                            "id": "a975f095-94b3-4164-9483-dcf94864ee40",
+                                            "score": 0.8405197262763977,
+                                        }
+                                    },
+                                ]
+                            },
+                            "input": {"value": "Does Arize support batch models?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[2],
+                        "span_id": "11d1530f518c4f8cb8154d27a90c7023",
+                        "parent_id": "2a3744dfdb954d6ea6a1dc0acb1e81d3",
+                        "name": "embedding",
+                        "span_kind": "EMBEDDING",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.496177+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:26.644424+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "EMBEDDING"}},
+                            "embedding": {
+                                "model_name": "text-embedding-ada-002",
+                                "embeddings": [
+                                    {
+                                        "embedding": {
+                                            "vector": [1.0],
+                                            "text": "Does Arize support batch models?",
+                                        }
+                                    }
+                                ],
+                            },
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 0,
+                        "cumulative_llm_token_count_completion": 0,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[2],
+                        "span_id": "5f763ad643f2458181062f5a815004e6",
+                        "parent_id": "63b60ed12a61418ab9bd3757bd7eb09f",
+                        "name": "synthesize",
+                        "span_kind": "CHAIN",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.704532+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336235+00:00"),
+                        "attributes": {
+                            "openinference": {"span": {"kind": "CHAIN"}},
+                            "output": {"value": "Yes, Arize supports batch models."},
+                            "input": {"value": "Does Arize support batch models?"},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 374,
+                        "cumulative_llm_token_count_completion": 8,
+                    },
+                    {
+                        "trace_rowid": trace_rowids[2],
+                        "span_id": "d0c8e22b54f1499db8d2b006d4425508",
+                        "parent_id": "5f763ad643f2458181062f5a815004e6",
+                        "name": "llm",
+                        "span_kind": "LLM",
+                        "start_time": datetime.fromisoformat("2023-12-11T17:43:26.706204+00:00"),
+                        "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336029+00:00"),
+                        "attributes": {
+                            "llm": {
+                                "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
+                                "input_messages": [
+                                    {
+                                        "message": {
+                                            "content": "You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.",
+                                            "role": "system",
+                                        }
+                                    },
+                                    {
+                                        "message": {
+                                            "content": 'Context information is below.\n---------------------\nArize supports many model types - check out our various Model Types to learn more.&#x20;\n\ndevelopers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: Does Arize support batch models?\nAnswer: ',
+                                            "role": "user",
+                                        }
+                                    },
+                                ],
+                                "model_name": "gpt-3.5-turbo",
+                                "output_messages": [
+                                    {
+                                        "message": {
+                                            "content": "Yes, Arize supports batch models.",
+                                            "role": "assistant",
+                                        }
+                                    }
+                                ],
+                                "prompt_template": {
+                                    "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
+                                    "variables": {
+                                        "context_str": 'Arize supports many model types - check out our various Model Types to learn more.&#x20;\n\ndevelopers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.',
+                                        "query_str": "Does Arize support batch models?",
+                                    },
+                                },
+                                "token_count": {"prompt": 374.0, "total": 382.0, "completion": 8.0},
+                            },
+                            "output": {"value": "Yes, Arize supports batch models."},
+                            "openinference": {"span": {"kind": "LLM"}},
+                        },
+                        "events": [],
+                        "status_code": "OK",
+                        "status_message": "",
+                        "cumulative_error_count": 0,
+                        "cumulative_llm_token_count_prompt": 374,
+                        "cumulative_llm_token_count_completion": 8,
+                    },
+                ],
+            )
+        ).all()
+        await session.execute(
+            insert(models.SpanAnnotation),
             [
                 {
-                    "trace_id": "0f5bb2e69a0640de87b9d424622b9f13",
-                    "project_rowid": project_row_id,
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
+                    "span_rowid": span_rowids[0],
+                    "name": "Hallucination",
+                    "label": "hallucinated",
+                    "score": 0,
+                    "explanation": "The query asks about how to use the SDK to upload a ranking model. The reference text provides information about ranking models and their challenges, and mentions a specific model 'arize-demo-hotel-ranking'. However, it does not provide any information about how to use an SDK to upload a ranking model. The answer talks about following the documentation provided by the SDK to upload the model, which is not mentioned or suggested in the reference text. Therefore, the answer is not based on the reference text.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
                 },
                 {
-                    "trace_id": "a4083327f7d0400a9e99906242e71aa4",
-                    "project_rowid": project_row_id,
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540371+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492242+00:00"),
+                    "span_rowid": span_rowids[5],
+                    "name": "Hallucination",
+                    "label": "factual",
+                    "score": 1,
+                    "explanation": "The query asks about the drift metrics supported in Arize. The reference text mentions that Arize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. The answer states the same information, that Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Therefore, the answer is based on the information provided in the reference text.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
                 },
                 {
-                    "trace_id": "17f383d1c85648899368bde24b566411",
-                    "project_rowid": project_row_id,
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.495969+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336284+00:00"),
+                    "span_rowid": span_rowids[10],
+                    "name": "Hallucination",
+                    "label": "hallucinated",
+                    "score": 0,
+                    "explanation": "The query asks if Arize supports batch models. The reference text mentions that Arize supports many model types, but it does not specify if batch models are among those supported. Therefore, the answer assumes information that is not available in the reference text.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                },
+                {
+                    "span_rowid": span_rowids[0],
+                    "name": "Q&A Correctness",
+                    "label": "incorrect",
+                    "score": 0,
+                    "explanation": "The reference text does not provide any information on how to use the SDK to upload a ranking model. It only mentions the use of a specific model 'arize-demo-hotel-ranking' and some challenges associated with ranking models. The answer, on the other hand, talks about following the documentation provided by the SDK to upload a ranking model. However, since the reference text does not mention anything about an SDK or its documentation, the answer does not correctly answer the question based on the reference text.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                },
+                {
+                    "span_rowid": span_rowids[5],
+                    "name": "Q&A Correctness",
+                    "label": "correct",
+                    "score": 1,
+                    "explanation": "The reference text clearly states that Arize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. This directly matches the given answer, which states that Arize supports these same drift metrics. Therefore, the answer is correct.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                },
+                {
+                    "span_rowid": span_rowids[10],
+                    "name": "Q&A Correctness",
+                    "label": "incorrect",
+                    "score": 0,
+                    "explanation": "The reference text mentions that Arize supports many model types and provides infrastructure for developers to create, train, and deploy machine-learning models in the cloud. However, it does not specifically mention that Arize supports batch models. Therefore, the answer is not supported by the reference text.",
+                    "metadata_": {},
+                    "annotator_kind": "LLM",
+                    "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
+                    "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
                 },
             ],
         )
-    ).all()
-    span_rowids = (
-        await session.scalars(
-            insert(models.Span).returning(models.Span.id),
-            [
-                {
-                    "trace_rowid": trace_rowids[0],
-                    "span_id": "c0055a08295841ab946f2a16e5089fad",
-                    "parent_id": None,
-                    "name": "query",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306838+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534589+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {
-                            "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
-                        },
-                        "input": {"value": "How do I use the SDK to upload a ranking model?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 240,
-                    "cumulative_llm_token_count_completion": 56,
-                },
-                {
-                    "trace_rowid": trace_rowids[0],
-                    "span_id": "edcd8a83c7b34fd2b83e946f58e9a9c0",
-                    "parent_id": "c0055a08295841ab946f2a16e5089fad",
-                    "name": "retrieve",
-                    "span_kind": "RETRIEVER",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.306945+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:23.710062+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "RETRIEVER"}},
-                        "retrieval": {
-                            "documents": [
-                                {
-                                    "document": {
-                                        "content": "\nRanking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n\n\n",
-                                        "id": "ad17eeea-e339-4195-991b-8eef54b1db65",
-                                        "score": 0.8022561073303223,
-                                    }
-                                },
-                                {
-                                    "document": {
-                                        "content": "\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;\n\n",
-                                        "id": "0ce66871-4a50-4d2f-94d2-1531924bf48a",
-                                        "score": 0.7964192032814026,
-                                    }
-                                },
-                            ]
-                        },
-                        "input": {"value": "How do I use the SDK to upload a ranking model?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[0],
-                    "span_id": "a91ad81bb187489093afeb8f3f5816b5",
-                    "parent_id": "edcd8a83c7b34fd2b83e946f58e9a9c0",
-                    "name": "embedding",
-                    "span_kind": "EMBEDDING",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.307166+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:23.638792+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "EMBEDDING"}},
-                        "embedding": {
-                            "model_name": "text-embedding-ada-002",
-                            "embeddings": [
-                                {
-                                    "embedding": {
-                                        "vector": [1.0],
-                                        "text": "How do I use the SDK to upload a ranking model?",
-                                    }
-                                }
-                            ],
-                        },
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[0],
-                    "span_id": "78742859b73e427f90b43ec6cc8c42ba",
-                    "parent_id": "c0055a08295841ab946f2a16e5089fad",
-                    "name": "synthesize",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.710148+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.534461+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {
-                            "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
-                        },
-                        "input": {"value": "How do I use the SDK to upload a ranking model?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 240,
-                    "cumulative_llm_token_count_completion": 56,
-                },
-                {
-                    "trace_rowid": trace_rowids[0],
-                    "span_id": "258bef0a3e384bcaaa5a388065af0d8f",
-                    "parent_id": "78742859b73e427f90b43ec6cc8c42ba",
-                    "name": "llm",
-                    "span_kind": "LLM",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:23.712144+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.532714+00:00"),
-                    "attributes": {
-                        "llm": {
-                            "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
-                            "input_messages": [
-                                {
-                                    "message": {
-                                        "role": "system",
-                                    }
-                                },
-                                {
-                                    "message": {
-                                        "content": "Context information is below.\n---------------------\nRanking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: How do I use the SDK to upload a ranking model?\nAnswer: ",
-                                        "role": "user",
-                                    }
-                                },
-                            ],
-                            "model_name": "gpt-3.5-turbo",
-                            "output_messages": [
-                                {
-                                    "message": {
-                                        "content": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process.",
-                                        "role": "assistant",
-                                    }
-                                }
-                            ],
-                            "prompt_template": {
-                                "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
-                                "variables": {
-                                    "context_str": "Ranking models are used by search engines to display query results ranked in the order of the highest relevance. These predictions seek to maximize user actions that are then used to evaluate model performance.&#x20;\n\nThe complexity within a ranking model makes failures challenging to pinpoint as a model\u2019s dimensions expand per recommendation. Notable challenges within ranking models include upstream data quality issues, poor-performing segments, the cold start problem, and more. &#x20;\n\n**Use the 'arize-demo-hotel-ranking' model, available in all free accounts, to follow along.**&#x20;",
-                                    "query_str": "How do I use the SDK to upload a ranking model?",
-                                },
-                            },
-                            "token_count": {"prompt": 240.0, "total": 296.0, "completion": 56.0},
-                        },
-                        "output": {
-                            "value": "To use the SDK to upload a ranking model, you can follow the documentation provided by the SDK. The documentation will guide you through the necessary steps to upload the model and integrate it into your system. Make sure to carefully follow the instructions to ensure a successful upload and integration process."
-                        },
-                        "openinference": {"span": {"kind": "LLM"}},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 240,
-                    "cumulative_llm_token_count_completion": 56,
-                },
-                {
-                    "trace_rowid": trace_rowids[1],
-                    "span_id": "094ae70b0e9c4dec83601b0f0b89e551",
-                    "parent_id": None,
-                    "name": "query",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540371+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492242+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {
-                            "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
-                        },
-                        "input": {"value": "What drift metrics are supported in Arize?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 315,
-                    "cumulative_llm_token_count_completion": 21,
-                },
-                {
-                    "trace_rowid": trace_rowids[1],
-                    "span_id": "fc7f4cb067124f0abed01e5749a6aead",
-                    "parent_id": "094ae70b0e9c4dec83601b0f0b89e551",
-                    "name": "retrieve",
-                    "span_kind": "RETRIEVER",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540449+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.842912+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "RETRIEVER"}},
-                        "retrieval": {
-                            "documents": [
-                                {
-                                    "document": {
-                                        "content": "\nDrift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\n",
-                                        "id": "60f3c900-dcee-43ef-816e-ae8f5289a544",
-                                        "score": 0.8768844604492188,
-                                    }
-                                },
-                                {
-                                    "document": {
-                                        "content": "\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.\n\n",
-                                        "id": "2e468875-ee22-4b5d-a7f4-57074eb5adfa",
-                                        "score": 0.873500406742096,
-                                    }
-                                },
-                            ]
-                        },
-                        "input": {"value": "What drift metrics are supported in Arize?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[1],
-                    "span_id": "70252f342dcc496dac93404dcfbaa211",
-                    "parent_id": "fc7f4cb067124f0abed01e5749a6aead",
-                    "name": "embedding",
-                    "span_kind": "EMBEDDING",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.540677+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:25.768612+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "EMBEDDING"}},
-                        "embedding": {
-                            "model_name": "text-embedding-ada-002",
-                            "embeddings": [
-                                {
-                                    "embedding": {
-                                        "vector": [1.0],
-                                        "text": "What drift metrics are supported in Arize?",
-                                    }
-                                }
-                            ],
-                        },
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[1],
-                    "span_id": "c5ff03a4cf534b07a5ad6a00836acb1e",
-                    "parent_id": "094ae70b0e9c4dec83601b0f0b89e551",
-                    "name": "synthesize",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.842986+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.492192+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {
-                            "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
-                        },
-                        "input": {"value": "What drift metrics are supported in Arize?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 315,
-                    "cumulative_llm_token_count_completion": 21,
-                },
-                {
-                    "trace_rowid": trace_rowids[1],
-                    "span_id": "0890b8716c4943c18b3ad45c6d9aaf5d",
-                    "parent_id": "c5ff03a4cf534b07a5ad6a00836acb1e",
-                    "name": "llm",
-                    "span_kind": "LLM",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:25.844758+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.491989+00:00"),
-                    "attributes": {
-                        "llm": {
-                            "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
-                            "input_messages": [
-                                {
-                                    "message": {
-                                        "content": "You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.",
-                                        "role": "system",
-                                    }
-                                },
-                                {
-                                    "message": {
-                                        "content": "Context information is below.\n---------------------\nDrift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: What drift metrics are supported in Arize?\nAnswer: ",
-                                        "role": "user",
-                                    }
-                                },
-                            ],
-                            "model_name": "gpt-3.5-turbo",
-                            "output_messages": [
-                                {
-                                    "message": {
-                                        "content": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance.",
-                                        "role": "assistant",
-                                    }
-                                }
-                            ],
-                            "prompt_template": {
-                                "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
-                                "variables": {
-                                    "context_str": "Drift monitors measure distribution drift, which is the difference between two statistical distributions.&#x20;\n\nArize offers various distributional drift metrics to choose from when setting up a monitor. Each metric is tailored to a specific use case; refer to this guide to help choose the appropriate metric for various ML use cases.\n\nArize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Arize computes drift by measuring distribution changes between the model\u2019s production values and a baseline (reference dataset). Users can configure a baseline to be any time window of a:\n\n1. Pre-production dataset (training, test, validation) or\n2. Fixed or moving time period from production (e.g. last 30 days, last 60 days).&#x20;\n\nBaselines are saved in Arize so that users can compare several versions and/or environments against each other across moving or fixed time windows. For more details on baselines, visit here.",
-                                    "query_str": "What drift metrics are supported in Arize?",
-                                },
-                            },
-                            "token_count": {"prompt": 315.0, "total": 336.0, "completion": 21.0},
-                        },
-                        "output": {
-                            "value": "Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance."
-                        },
-                        "openinference": {"span": {"kind": "LLM"}},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 315,
-                    "cumulative_llm_token_count_completion": 21,
-                },
-                {
-                    "trace_rowid": trace_rowids[2],
-                    "span_id": "63b60ed12a61418ab9bd3757bd7eb09f",
-                    "parent_id": None,
-                    "name": "query",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.495969+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336284+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {"value": "Yes, Arize supports batch models."},
-                        "input": {"value": "Does Arize support batch models?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 374,
-                    "cumulative_llm_token_count_completion": 8,
-                },
-                {
-                    "trace_rowid": trace_rowids[2],
-                    "span_id": "2a3744dfdb954d6ea6a1dc0acb1e81d3",
-                    "parent_id": "63b60ed12a61418ab9bd3757bd7eb09f",
-                    "name": "retrieve",
-                    "span_kind": "RETRIEVER",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.496043+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.704469+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "RETRIEVER"}},
-                        "retrieval": {
-                            "documents": [
-                                {
-                                    "document": {
-                                        "content": "\nArize supports many model types - check out our various Model Types to learn more.&#x20;\n\n",
-                                        "id": "b18c5cbd-ab0b-43d2-b0d3-55e755ee3561",
-                                        "score": 0.8502153754234314,
-                                    }
-                                },
-                                {
-                                    "document": {
-                                        "content": 'developers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.\n\n\n\n',
-                                        "id": "a975f095-94b3-4164-9483-dcf94864ee40",
-                                        "score": 0.8405197262763977,
-                                    }
-                                },
-                            ]
-                        },
-                        "input": {"value": "Does Arize support batch models?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[2],
-                    "span_id": "11d1530f518c4f8cb8154d27a90c7023",
-                    "parent_id": "2a3744dfdb954d6ea6a1dc0acb1e81d3",
-                    "name": "embedding",
-                    "span_kind": "EMBEDDING",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.496177+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:26.644424+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "EMBEDDING"}},
-                        "embedding": {
-                            "model_name": "text-embedding-ada-002",
-                            "embeddings": [
-                                {
-                                    "embedding": {
-                                        "vector": [1.0],
-                                        "text": "Does Arize support batch models?",
-                                    }
-                                }
-                            ],
-                        },
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 0,
-                    "cumulative_llm_token_count_completion": 0,
-                },
-                {
-                    "trace_rowid": trace_rowids[2],
-                    "span_id": "5f763ad643f2458181062f5a815004e6",
-                    "parent_id": "63b60ed12a61418ab9bd3757bd7eb09f",
-                    "name": "synthesize",
-                    "span_kind": "CHAIN",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.704532+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336235+00:00"),
-                    "attributes": {
-                        "openinference": {"span": {"kind": "CHAIN"}},
-                        "output": {"value": "Yes, Arize supports batch models."},
-                        "input": {"value": "Does Arize support batch models?"},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 374,
-                    "cumulative_llm_token_count_completion": 8,
-                },
-                {
-                    "trace_rowid": trace_rowids[2],
-                    "span_id": "d0c8e22b54f1499db8d2b006d4425508",
-                    "parent_id": "5f763ad643f2458181062f5a815004e6",
-                    "name": "llm",
-                    "span_kind": "LLM",
-                    "start_time": datetime.fromisoformat("2023-12-11T17:43:26.706204+00:00"),
-                    "end_time": datetime.fromisoformat("2023-12-11T17:43:27.336029+00:00"),
-                    "attributes": {
-                        "llm": {
-                            "invocation_parameters": '{"model": "gpt-3.5-turbo", "temperature": 0.0, "max_tokens": None}',
-                            "input_messages": [
-                                {
-                                    "message": {
-                                        "content": "You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.",
-                                        "role": "system",
-                                    }
-                                },
-                                {
-                                    "message": {
-                                        "content": 'Context information is below.\n---------------------\nArize supports many model types - check out our various Model Types to learn more.&#x20;\n\ndevelopers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: Does Arize support batch models?\nAnswer: ',
-                                        "role": "user",
-                                    }
-                                },
-                            ],
-                            "model_name": "gpt-3.5-turbo",
-                            "output_messages": [
-                                {
-                                    "message": {
-                                        "content": "Yes, Arize supports batch models.",
-                                        "role": "assistant",
-                                    }
-                                }
-                            ],
-                            "prompt_template": {
-                                "template": "system: You are an expert Q&A system that is trusted around the world.\nAlways answer the query using the provided context information, and not prior knowledge.\nSome rules to follow:\n1. Never directly reference the given context in your answer.\n2. Avoid statements like 'Based on the context, ...' or 'The context information ...' or anything along those lines.\nuser: Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the query.\nQuery: {query_str}\nAnswer: \nassistant: ",
-                                "variables": {
-                                    "context_str": 'Arize supports many model types - check out our various Model Types to learn more.&#x20;\n\ndevelopers to create, train, and deploy machine-learning models in the cloud. Monitor and observe models deployed on SageMaker with Arize for data quality issues, performance checks, and drift.&#x20;\n\n{% content-ref url="spell.md" %}\nspell.md\n{% endcontent-ref %}\n\n> Spell is an end-to-end ML platform that provides infrastructure for company to deploy and train models. Visualize your model\'s performance, understand drift & data quality issues, and share insights learned from your models deployed on Spell.\n\n{% content-ref url="ubiops.md" %}\nubiops.md\n{% endcontent-ref %}\n\n> UbiOps is an MLOps platform with APIs to deploy and serve models. The Arize platform can easily integrate with UbiOps to enable model observability, explainability, and monitoring.\n\n{% content-ref url="weights-and-biases.md" %}\nweights-and-biases.md\n{% endcontent-ref %}\n\n> Weights and Biases helps you build better model by logging metrics and visualize your experiments before production. Arize helps you visualize your model performance, understand drift & data quality issues, and share insights learned from your models.',
-                                    "query_str": "Does Arize support batch models?",
-                                },
-                            },
-                            "token_count": {"prompt": 374.0, "total": 382.0, "completion": 8.0},
-                        },
-                        "output": {"value": "Yes, Arize supports batch models."},
-                        "openinference": {"span": {"kind": "LLM"}},
-                    },
-                    "events": [],
-                    "status_code": "OK",
-                    "status_message": "",
-                    "cumulative_error_count": 0,
-                    "cumulative_llm_token_count_prompt": 374,
-                    "cumulative_llm_token_count_completion": 8,
-                },
-            ],
-        )
-    ).all()
-    await session.execute(
-        insert(models.SpanAnnotation),
-        [
-            {
-                "span_rowid": span_rowids[0],
-                "name": "Hallucination",
-                "label": "hallucinated",
-                "score": 0,
-                "explanation": "The query asks about how to use the SDK to upload a ranking model. The reference text provides information about ranking models and their challenges, and mentions a specific model 'arize-demo-hotel-ranking'. However, it does not provide any information about how to use an SDK to upload a ranking model. The answer talks about following the documentation provided by the SDK to upload the model, which is not mentioned or suggested in the reference text. Therefore, the answer is not based on the reference text.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-            {
-                "span_rowid": span_rowids[5],
-                "name": "Hallucination",
-                "label": "factual",
-                "score": 1,
-                "explanation": "The query asks about the drift metrics supported in Arize. The reference text mentions that Arize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. The answer states the same information, that Arize supports drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. Therefore, the answer is based on the information provided in the reference text.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-            {
-                "span_rowid": span_rowids[10],
-                "name": "Hallucination",
-                "label": "hallucinated",
-                "score": 0,
-                "explanation": "The query asks if Arize supports batch models. The reference text mentions that Arize supports many model types, but it does not specify if batch models are among those supported. Therefore, the answer assumes information that is not available in the reference text.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-            {
-                "span_rowid": span_rowids[0],
-                "name": "Q&A Correctness",
-                "label": "incorrect",
-                "score": 0,
-                "explanation": "The reference text does not provide any information on how to use the SDK to upload a ranking model. It only mentions the use of a specific model 'arize-demo-hotel-ranking' and some challenges associated with ranking models. The answer, on the other hand, talks about following the documentation provided by the SDK to upload a ranking model. However, since the reference text does not mention anything about an SDK or its documentation, the answer does not correctly answer the question based on the reference text.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-            {
-                "span_rowid": span_rowids[5],
-                "name": "Q&A Correctness",
-                "label": "correct",
-                "score": 1,
-                "explanation": "The reference text clearly states that Arize calculates drift metrics such as Population Stability Index, KL Divergence, and Wasserstein Distance. This directly matches the given answer, which states that Arize supports these same drift metrics. Therefore, the answer is correct.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-            {
-                "span_rowid": span_rowids[10],
-                "name": "Q&A Correctness",
-                "label": "incorrect",
-                "score": 0,
-                "explanation": "The reference text mentions that Arize supports many model types and provides infrastructure for developers to create, train, and deploy machine-learning models in the cloud. However, it does not specifically mention that Arize supports batch models. Therefore, the answer is not supported by the reference text.",
-                "metadata_": {},
-                "annotator_kind": "LLM",
-                "created_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-                "updated_at": datetime.fromisoformat("2024-05-20T01:42:11+00:00"),
-            },
-        ],
-    )

--- a/tests/server/api/types/test_Project.py
+++ b/tests/server/api/types/test_Project.py
@@ -532,7 +532,7 @@ async def test_project_spans(
 
 
 @pytest.fixture
-async def llama_index_rag_spans(db: Callable[[], AsyncContextManager[AsyncSession]]):
+async def llama_index_rag_spans(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
     # Inserts the first three traces from the llama-index-rag trace fixture
     # (minus embeddings) along with associated span evaluations.
     async with db() as session:

--- a/tests/server/api/types/test_Span.py
+++ b/tests/server/api/types/test_Span.py
@@ -1,15 +1,17 @@
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.Span import Span
 from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 async def test_project_resolver_returns_correct_project(
-    test_client, project_with_a_single_trace_and_span
+    httpx_client, project_with_a_single_trace_and_span
 ) -> None:
     query = """
       query ($spanId: GlobalID!) {
@@ -24,7 +26,7 @@ async def test_project_resolver_returns_correct_project(
       }
     """
     span_id = str(GlobalID(Span.__name__, str(1)))
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": query,
@@ -44,43 +46,46 @@ async def test_project_resolver_returns_correct_project(
 
 
 @pytest.fixture
-async def project_with_a_single_trace_and_span(session) -> None:
+async def project_with_a_single_trace_and_span(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     Contains a project with a single trace and a single span.
     """
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name="project-name").returning(models.Project.id)
-    )
-    trace_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="1",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="project-name").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_id,
-            span_id="1",
-            parent_id=None,
-            name="chain span",
-            span_kind="CHAIN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
-                "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="1",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="1",
+                parent_id=None,
+                name="chain span",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
+                    "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )

--- a/tests/server/api/types/test_Span.py
+++ b/tests/server/api/types/test_Span.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.Project import Project
@@ -11,7 +12,8 @@ from strawberry.relay import GlobalID
 
 
 async def test_project_resolver_returns_correct_project(
-    httpx_client, project_with_a_single_trace_and_span
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
 ) -> None:
     query = """
       query ($spanId: GlobalID!) {

--- a/tests/server/api/types/test_SpanAnnotation.py
+++ b/tests/server/api/types/test_SpanAnnotation.py
@@ -1,60 +1,67 @@
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from sqlalchemy import insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 @pytest.fixture
-async def project_with_a_single_trace_and_span(session) -> None:
+async def project_with_a_single_trace_and_span(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     Contains a project with a single trace and a single span.
     """
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name="project-name").returning(models.Project.id)
-    )
-    trace_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="1",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="project-name").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_id,
-            span_id="1",
-            parent_id=None,
-            name="chain span",
-            span_kind="CHAIN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
-                "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="1",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="1",
+                parent_id=None,
+                name="chain span",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
+                    "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
 
 
 async def test_annotating_a_span(
-    session, test_client, project_with_a_single_trace_and_span
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    httpx_client,
+    project_with_a_single_trace_and_span,
 ) -> None:
     span_gid = GlobalID("Span", "1")
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """
@@ -92,9 +99,10 @@ async def test_annotating_a_span(
     data = response.json()["data"]
     annotation_gid = GlobalID.from_id(data["createSpanAnnotations"]["spanAnnotations"][0]["id"])
     annotation_id = from_global_id_with_expected_type(annotation_gid, "SpanAnnotation")
-    orm_annotation = await session.scalar(
-        select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
+        )
     assert orm_annotation.name == "Test Annotation"
     assert orm_annotation.annotator_kind == "HUMAN"
     assert orm_annotation.label == "True"
@@ -102,7 +110,7 @@ async def test_annotating_a_span(
     assert orm_annotation.explanation == "This is a test annotation."
     assert orm_annotation.metadata_ == dict()
 
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """
@@ -144,7 +152,7 @@ async def test_annotating_a_span(
     assert orm_annotation.explanation == "Updated explanation"
     assert orm_annotation.metadata_ == {"updated": True}
 
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """

--- a/tests/server/api/types/test_SpanAnnotation.py
+++ b/tests/server/api/types/test_SpanAnnotation.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -57,8 +58,8 @@ async def project_with_a_single_trace_and_span(
 
 async def test_annotating_a_span(
     db: Callable[[], AsyncContextManager[AsyncSession]],
-    httpx_client,
-    project_with_a_single_trace_and_span,
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
 ) -> None:
     span_gid = GlobalID("Span", "1")
     response = await httpx_client.post(
@@ -143,10 +144,10 @@ async def test_annotating_a_span(
             },
         },
     )
-
-    orm_annotation = await session.scalar(
-        select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
+        )
     assert orm_annotation.name == "Updated Annotation"
     assert orm_annotation.label == "Positive"
     assert orm_annotation.explanation == "Updated explanation"
@@ -177,8 +178,8 @@ async def test_annotating_a_span(
             },
         },
     )
-
-    orm_annotation = await session.scalar(
-        select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.SpanAnnotation).where(models.SpanAnnotation.id == annotation_id)
+        )
     assert not orm_annotation

--- a/tests/server/api/types/test_TraceAnnotation.py
+++ b/tests/server/api/types/test_TraceAnnotation.py
@@ -1,60 +1,68 @@
 from datetime import datetime
+from typing import Any, AsyncContextManager, Callable
 
+import httpx
 import pytest
 from phoenix.db import models
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from sqlalchemy import insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.relay import GlobalID
 
 
 @pytest.fixture
-async def project_with_a_single_trace_and_span(session) -> None:
+async def project_with_a_single_trace_and_span(
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+) -> None:
     """
     Contains a project with a single trace and a single span.
     """
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name="project-name").returning(models.Project.id)
-    )
-    trace_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="1",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="project-name").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_id,
-            span_id="1",
-            parent_id=None,
-            name="chain span",
-            span_kind="CHAIN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
-                "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="1",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="1",
+                parent_id=None,
+                name="chain span",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "chain-span-input-value", "mime_type": "text/plain"},
+                    "output": {"value": "chain-span-output-value", "mime_type": "text/plain"},
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
 
 
 async def test_annotating_a_trace(
-    session, test_client, project_with_a_single_trace_and_span
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
 ) -> None:
     trace_gid = GlobalID("Trace", "1")
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """
@@ -92,9 +100,10 @@ async def test_annotating_a_trace(
     data = response.json()["data"]
     annotation_gid = GlobalID.from_id(data["createTraceAnnotations"]["traceAnnotations"][0]["id"])
     annotation_id = from_global_id_with_expected_type(annotation_gid, "TraceAnnotation")
-    orm_annotation = await session.scalar(
-        select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
+        )
     assert orm_annotation.name == "Test Annotation"
     assert orm_annotation.annotator_kind == "HUMAN"
     assert orm_annotation.label == "True"
@@ -102,7 +111,7 @@ async def test_annotating_a_trace(
     assert orm_annotation.explanation == "This is a test annotation."
     assert orm_annotation.metadata_ == dict()
 
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """
@@ -144,7 +153,7 @@ async def test_annotating_a_trace(
     assert orm_annotation.explanation == "Updated explanation"
     assert orm_annotation.metadata_ == {"updated": True}
 
-    response = await test_client.post(
+    response = await httpx_client.post(
         "/graphql",
         json={
             "query": """

--- a/tests/server/api/types/test_TraceAnnotation.py
+++ b/tests/server/api/types/test_TraceAnnotation.py
@@ -96,7 +96,7 @@ async def test_annotating_a_trace(
             },
         },
     )
-
+    assert response.status_code == 200
     data = response.json()["data"]
     annotation_gid = GlobalID.from_id(data["createTraceAnnotations"]["traceAnnotations"][0]["id"])
     annotation_id = from_global_id_with_expected_type(annotation_gid, "TraceAnnotation")
@@ -144,6 +144,7 @@ async def test_annotating_a_trace(
             },
         },
     )
+    assert response.status_code == 200
     async with db() as session:
         orm_annotation = await session.scalar(
             select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
@@ -178,6 +179,7 @@ async def test_annotating_a_trace(
             },
         },
     )
+    assert response.status_code == 200
     async with db() as session:
         orm_annotation = await session.scalar(
             select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)

--- a/tests/server/api/types/test_TraceAnnotation.py
+++ b/tests/server/api/types/test_TraceAnnotation.py
@@ -144,10 +144,10 @@ async def test_annotating_a_trace(
             },
         },
     )
-
-    orm_annotation = await session.scalar(
-        select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
+        )
     assert orm_annotation.name == "Updated Annotation"
     assert orm_annotation.label == "Positive"
     assert orm_annotation.explanation == "Updated explanation"
@@ -178,8 +178,8 @@ async def test_annotating_a_trace(
             },
         },
     )
-
-    orm_annotation = await session.scalar(
-        select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
-    )
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.TraceAnnotation).where(models.TraceAnnotation.id == annotation_id)
+        )
     assert not orm_annotation

--- a/tests/server/api/types/test_node.py
+++ b/tests/server/api/types/test_node.py
@@ -3,20 +3,20 @@ from phoenix.server.api.types.node import from_global_id, from_global_id_with_ex
 from strawberry.relay import GlobalID
 
 
-def test_from_global_id_returns_type_name_and_node_id():
+def test_from_global_id_returns_type_name_and_node_id() -> None:
     global_id = GlobalID(type_name="Dimension", node_id=str(1))
     type_name, node_id = from_global_id(global_id)
     assert type_name == "Dimension"
     assert node_id == 1
 
 
-def test_from_global_id_with_expected_type_returns_node_id():
+def test_from_global_id_with_expected_type_returns_node_id() -> None:
     global_id = GlobalID(type_name="Dimension", node_id=str(1))
     node_id = from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")
     assert node_id == 1
 
 
-def test_from_global_id_with_expected_type_raises_value_error_for_unexpected_type():
+def test_from_global_id_with_expected_type_raises_value_error_for_unexpected_type() -> None:
     global_id = GlobalID(type_name="EmbeddingDimension", node_id=str(1))
     with pytest.raises(ValueError):
         from_global_id_with_expected_type(global_id=global_id, expected_type_name="Dimension")

--- a/tests/server/api/types/test_pagination.py
+++ b/tests/server/api/types/test_pagination.py
@@ -12,7 +12,7 @@ from phoenix.server.api.types.pagination import (
 )
 
 
-def test_connection_from_list():
+def test_connection_from_list() -> None:
     dimensions = [
         Dimension(
             id_attr=0,
@@ -53,7 +53,7 @@ def test_connection_from_list():
     assert next_connection.page_info.has_next_page is False
 
 
-def test_connection_from_list_reverse():
+def test_connection_from_list_reverse() -> None:
     dimensions = [
         Dimension(
             id_attr=0,
@@ -95,7 +95,7 @@ def test_connection_from_list_reverse():
     assert next_connection.page_info.has_previous_page is False
 
 
-def test_connection_from_empty_list():
+def test_connection_from_empty_list() -> None:
     connection = connection_from_list([], ConnectionArgs(first=2))
 
     assert len(connection.edges) == 0

--- a/tests/server/test_telemetry.py
+++ b/tests/server/test_telemetry.py
@@ -1,7 +1,7 @@
 from phoenix.server.telemetry import normalize_http_collector_endpoint
 
 
-def test_normalize_http_collector_endpoint():
+def test_normalize_http_collector_endpoint() -> None:
     assert normalize_http_collector_endpoint("http://localhost:4317") == "http://localhost:4317"
     assert normalize_http_collector_endpoint("https://localhost:4317") == "https://localhost:4317"
     assert normalize_http_collector_endpoint("localhost:4317") == "http://localhost:4317"

--- a/tests/session/test_client.py
+++ b/tests/session/test_client.py
@@ -22,7 +22,7 @@ from respx import MockRouter
 from strawberry.relay import GlobalID
 
 
-def test_base_path(monkeypatch: pytest.MonkeyPatch):
+def test_base_path(monkeypatch: pytest.MonkeyPatch) -> None:
     # Reset environment variables
     monkeypatch.delenv("PHOENIX_HOST", False)
     monkeypatch.delenv("PHOENIX_PORT", False)
@@ -47,7 +47,7 @@ def test_base_path(monkeypatch: pytest.MonkeyPatch):
 
 def test_get_spans_dataframe(
     client: Client, endpoint: str, dataframe: pd.DataFrame, respx_mock: MockRouter
-):
+) -> None:
     url = urljoin(endpoint, "v1/spans")
 
     respx_mock.post(url).mock(Response(200, content=_df_to_bytes(dataframe)))
@@ -63,7 +63,7 @@ def test_query_spans(
     endpoint: str,
     dataframe: pd.DataFrame,
     respx_mock: MockRouter,
-):
+) -> None:
     df0, df1 = dataframe.iloc[:1, :], dataframe.iloc[1:, :]
     url = urljoin(endpoint, "v1/spans")
 
@@ -91,7 +91,7 @@ def test_get_evaluations(
     endpoint: str,
     evaluations: SpanEvaluations,
     respx_mock: MockRouter,
-):
+) -> None:
     url = urljoin(endpoint, "v1/evaluations")
 
     table = evaluations.to_pyarrow_table()
@@ -111,10 +111,10 @@ def test_log_traces_sends_oltp_spans(
     endpoint: str,
     trace_ds: TraceDataset,
     respx_mock: MockRouter,
-):
+) -> None:
     span_counter = 0
 
-    def request_callback(request):
+    def request_callback(request) -> None:
         assert request.headers["content-type"] == "application/x-protobuf"
         assert request.headers["content-encoding"] == "gzip"
         content = gzip.decompress(request.content)
@@ -135,7 +135,7 @@ def test_log_traces_to_project(
     endpoint: str,
     trace_ds: TraceDataset,
     respx_mock: MockRouter,
-):
+) -> None:
     span_counter = 0
 
     def request_callback(request: httpx.Request) -> httpx.Response:
@@ -271,7 +271,7 @@ def test_get_dataset_returns_expected_dataset(
     assert example.updated_at == datetime.fromisoformat("2024-06-12T22:46:31+00:00")
 
 
-def test_client_headers(endpoint: str, respx_mock: MockRouter):
+def test_client_headers(endpoint: str, respx_mock: MockRouter) -> None:
     client = Client(endpoint=endpoint, headers={"x-api-key": "my-api-key"})
     dataset_id = str(GlobalID("Dataset", str(1)))
     respx_mock.get(urljoin(endpoint, f"v1/datasets/{dataset_id}/examples")).mock(

--- a/tests/trace/dsl/conftest.py
+++ b/tests/trace/dsl/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pytest
 from phoenix.config import DEFAULT_PROJECT_NAME
@@ -8,207 +9,209 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.fixture
-async def default_project(session: AsyncSession) -> None:
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
-    )
-    trace_row_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="0123",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+async def default_project(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="2345",
-            parent_id=None,
-            name="root span",
-            span_kind="UNKNOWN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "210"},
-                "output": {"value": "321"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+        trace_row_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="0123",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="4567",
-            parent_id="2345",
-            name="retriever span",
-            span_kind="RETRIEVER",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
-            attributes={
-                "input": {
-                    "value": "xyz",
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="2345",
+                parent_id=None,
+                name="root span",
+                span_kind="UNKNOWN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "210"},
+                    "output": {"value": "321"},
                 },
-                "retrieval": {
-                    "documents": [
-                        {"document": {"content": "A", "score": 1}},
-                        {"document": {"content": "B", "score": 2}},
-                        {"document": {"content": "C", "score": 3}},
-                    ],
-                },
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="4567",
+                parent_id="2345",
+                name="retriever span",
+                span_kind="RETRIEVER",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
+                attributes={
+                    "input": {
+                        "value": "xyz",
+                    },
+                    "retrieval": {
+                        "documents": [
+                            {"document": {"content": "A", "score": 1}},
+                            {"document": {"content": "B", "score": 2}},
+                            {"document": {"content": "C", "score": 3}},
+                        ],
+                    },
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
 
 
 @pytest.fixture
-async def abc_project(session: AsyncSession) -> None:
-    project_row_id = await session.scalar(
-        insert(models.Project).values(name="abc").returning(models.Project.id)
-    )
-    trace_row_id = await session.scalar(
-        insert(models.Trace)
-        .values(
-            trace_id="012",
-            project_rowid=project_row_id,
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+async def abc_project(db: Callable[[], AsyncContextManager[AsyncSession]]) -> None:
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="abc").returning(models.Project.id)
         )
-        .returning(models.Trace.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="234",
-            parent_id="123",
-            name="root span",
-            span_kind="UNKNOWN",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "input": {"value": "xy%z*"},
-                "output": {"value": "321"},
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=1,
-            cumulative_llm_token_count_prompt=100,
-            cumulative_llm_token_count_completion=200,
+        trace_row_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="012",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
         )
-        .returning(models.Span.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="345",
-            parent_id="234",
-            name="embedding span",
-            span_kind="EMBEDDING",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
-            attributes={
-                "input": {
-                    "value": "XY%*Z",
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="234",
+                parent_id="123",
+                name="root span",
+                span_kind="UNKNOWN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "input": {"value": "xy%z*"},
+                    "output": {"value": "321"},
                 },
-                "metadata": {
-                    "a.b.c": 123,
-                    "1.2.3": "abc",
-                    "x.y": {"z.a": {"b.c": 321}},
-                },
-                "embedding": {
-                    "model_name": "xyz",
-                    "embeddings": [
-                        {"embedding": {"vector": [1, 2, 3], "text": "123"}},
-                        {"embedding": {"vector": [2, 3, 4], "text": "234"}},
-                    ],
-                },
-            },
-            events=[],
-            status_code="OK",
-            status_message="no problemo",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=1,
+                cumulative_llm_token_count_prompt=100,
+                cumulative_llm_token_count_completion=200,
+            )
+            .returning(models.Span.id)
         )
-        .returning(models.Span.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="456",
-            parent_id="234",
-            name="retriever span",
-            span_kind="RETRIEVER",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
-            attributes={
-                "attributes": "attributes",
-                "input": {
-                    "value": "xy%*z",
-                },
-                "retrieval": {
-                    "documents": [
-                        {"document": {"content": "A", "score": 1}},
-                        {"document": {"content": "B", "score": 2}},
-                        {"document": {"content": "C", "score": 3}},
-                    ],
-                },
-            },
-            events=[],
-            status_code="OK",
-            status_message="okay",
-            cumulative_error_count=0,
-            cumulative_llm_token_count_prompt=0,
-            cumulative_llm_token_count_completion=0,
-        )
-        .returning(models.Span.id)
-    )
-    await session.execute(
-        insert(models.Span)
-        .values(
-            trace_rowid=trace_row_id,
-            span_id="567",
-            parent_id="234",
-            name="llm span",
-            span_kind="LLM",
-            start_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
-            end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
-            attributes={
-                "attributes": {"attributes": "attributes"},
-                "llm": {
-                    "token_count": {
-                        "prompt": 100,
-                        "completion": 200,
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="345",
+                parent_id="234",
+                name="embedding span",
+                span_kind="EMBEDDING",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
+                attributes={
+                    "input": {
+                        "value": "XY%*Z",
+                    },
+                    "metadata": {
+                        "a.b.c": 123,
+                        "1.2.3": "abc",
+                        "x.y": {"z.a": {"b.c": 321}},
+                    },
+                    "embedding": {
+                        "model_name": "xyz",
+                        "embeddings": [
+                            {"embedding": {"vector": [1, 2, 3], "text": "123"}},
+                            {"embedding": {"vector": [2, 3, 4], "text": "234"}},
+                        ],
                     },
                 },
-            },
-            events=[],
-            status_code="ERROR",
-            status_message="uh-oh",
-            cumulative_error_count=1,
-            cumulative_llm_token_count_prompt=100,
-            cumulative_llm_token_count_completion=200,
+                events=[],
+                status_code="OK",
+                status_message="no problemo",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
         )
-        .returning(models.Span.id)
-    )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="456",
+                parent_id="234",
+                name="retriever span",
+                span_kind="RETRIEVER",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
+                attributes={
+                    "attributes": "attributes",
+                    "input": {
+                        "value": "xy%*z",
+                    },
+                    "retrieval": {
+                        "documents": [
+                            {"document": {"content": "A", "score": 1}},
+                            {"document": {"content": "B", "score": 2}},
+                            {"document": {"content": "C", "score": 3}},
+                        ],
+                    },
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_row_id,
+                span_id="567",
+                parent_id="234",
+                name="llm span",
+                span_kind="LLM",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={
+                    "attributes": {"attributes": "attributes"},
+                    "llm": {
+                        "token_count": {
+                            "prompt": 100,
+                            "completion": 200,
+                        },
+                    },
+                },
+                events=[],
+                status_code="ERROR",
+                status_message="uh-oh",
+                cumulative_error_count=1,
+                cumulative_llm_token_count_prompt=100,
+                cumulative_llm_token_count_completion=200,
+            )
+            .returning(models.Span.id)
+        )

--- a/tests/trace/dsl/test_filter.py
+++ b/tests/trace/dsl/test_filter.py
@@ -1,6 +1,6 @@
 import ast
 import sys
-from typing import List, Optional
+from typing import Any, AsyncContextManager, Callable, List, Optional
 from unittest.mock import patch
 from uuid import UUID
 
@@ -149,7 +149,11 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[List[str]])
     ],
 )
 async def test_filter_translated(
-    session: AsyncSession, expression: str, expected: str, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    expression: str,
+    expected: str,
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     with patch.object(
         phoenix.trace.dsl.filter,
@@ -159,7 +163,8 @@ async def test_filter_translated(
         f = SpanFilter(expression)
     assert unparse(f.translated).strip() == expected
     # next line is only to test that the syntax is accepted
-    await session.execute(f(select(models.Span.id)))
+    async with db() as session:
+        await session.execute(f(select(models.Span.id)))
 
 
 @pytest.mark.parametrize(

--- a/tests/trace/dsl/test_query.py
+++ b/tests/trace/dsl/test_query.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import AsyncContextManager, Callable
 
 import pandas as pd
 import pytest
@@ -7,7 +8,9 @@ from phoenix.trace.dsl import SpanQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def test_select_all(session: AsyncSession, abc_project: None) -> None:
+async def test_select_all(
+    db: Callable[[], AsyncContextManager[AsyncSession]], abc_project: None
+) -> None:
     # i.e. `get_spans_dataframe`
     sq = SpanQuery()
     expected = pd.DataFrame(
@@ -65,7 +68,8 @@ async def test_select_all(session: AsyncSession, abc_project: None) -> None:
             "events": [[], [], [], []],
         }
     ).set_index("context.span_id", drop=False)
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -73,7 +77,7 @@ async def test_select_all(session: AsyncSession, abc_project: None) -> None:
 
 
 async def test_select_all_with_no_data(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery()
     expected = pd.DataFrame(
@@ -90,14 +94,17 @@ async def test_select_all_with_no_data(
             "events",
         ]
     ).set_index("context.span_id", drop=False)
-    actual = await session.run_sync(sq, project_name="opq")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="opq")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
     )
 
 
-async def test_select(session: AsyncSession, default_project: None, abc_project: None) -> None:
+async def test_select(
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+) -> None:
     sq = SpanQuery().select("name", tcp="llm.token_count.prompt")
     expected = pd.DataFrame(
         {
@@ -106,7 +113,8 @@ async def test_select(session: AsyncSession, default_project: None, abc_project:
             "tcp": [None, None, None, 100.0],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -114,7 +122,7 @@ async def test_select(session: AsyncSession, default_project: None, abc_project:
 
 
 async def test_select_parent_id_as_span_id(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select("name", span_id="parent_id")
     expected = pd.DataFrame(
@@ -123,7 +131,8 @@ async def test_select_parent_id_as_span_id(
             "name": ["root span", "embedding span", "retriever span", "llm span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -131,7 +140,7 @@ async def test_select_parent_id_as_span_id(
 
 
 async def test_select_trace_id_as_index(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select("span_id").with_index("trace_id")
     expected = pd.DataFrame(
@@ -140,7 +149,8 @@ async def test_select_trace_id_as_index(
             "context.span_id": ["234", "345", "456", "567"],
         }
     ).set_index("context.trace_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1).sort_values("context.span_id"),
         expected.sort_index().sort_index(axis=1).sort_values("context.span_id"),
@@ -148,7 +158,7 @@ async def test_select_trace_id_as_index(
 
 
 async def test_select_nonexistent(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select("name", "opq", "opq.rst")
     expected = pd.DataFrame(
@@ -159,7 +169,8 @@ async def test_select_nonexistent(
             "opq.rst": [None, None, None, None],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -167,7 +178,7 @@ async def test_select_nonexistent(
 
 
 async def test_default_project(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select(
         "name",
@@ -180,7 +191,8 @@ async def test_default_project(
             "Latency (milliseconds)": [30000.0],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, root_spans_only=True)
+    async with db() as session:
+        actual = await session.run_sync(sq, root_spans_only=True)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -188,7 +200,7 @@ async def test_default_project(
 
 
 async def test_root_spans_only(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select(
         "name",
@@ -201,14 +213,17 @@ async def test_root_spans_only(
             "Latency (milliseconds)": [30000.0],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc", root_spans_only=True)
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc", root_spans_only=True)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
     )
 
 
-async def test_start_time(session: AsyncSession, default_project: None, abc_project: None) -> None:
+async def test_start_time(
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+) -> None:
     sq = SpanQuery().select("name")
     expected = pd.DataFrame(
         {
@@ -216,20 +231,23 @@ async def test_start_time(session: AsyncSession, default_project: None, abc_proj
             "name": ["llm span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(
-        sq,
-        project_name="abc",
-        start_time=datetime.fromisoformat(
-            "2021-01-01T00:00:20.000+00:00",
-        ),
-    )
+    async with db() as session:
+        actual = await session.run_sync(
+            sq,
+            project_name="abc",
+            start_time=datetime.fromisoformat(
+                "2021-01-01T00:00:20.000+00:00",
+            ),
+        )
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
     )
 
 
-async def test_end_time(session: AsyncSession, default_project: None, abc_project: None) -> None:
+async def test_end_time(
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+) -> None:
     sq = SpanQuery().select("name")
     expected = pd.DataFrame(
         {
@@ -237,27 +255,31 @@ async def test_end_time(session: AsyncSession, default_project: None, abc_projec
             "name": ["root span", "embedding span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(
-        sq,
-        project_name="abc",
-        end_time=datetime.fromisoformat(
-            "2021-01-01T00:00:01.000+00:00",
-        ),
-    )
+    async with db() as session:
+        actual = await session.run_sync(
+            sq,
+            project_name="abc",
+            end_time=datetime.fromisoformat(
+                "2021-01-01T00:00:01.000+00:00",
+            ),
+        )
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
     )
 
 
-async def test_limit(session: AsyncSession, default_project: None, abc_project: None) -> None:
+async def test_limit(
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+) -> None:
     sq = SpanQuery()
-    actual = await session.run_sync(sq, project_name="abc", limit=2)
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc", limit=2)
     assert actual.index.tolist() == ["234", "345"]
 
 
 async def test_limit_with_select_statement(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().select("context.span_id")
     expected = pd.DataFrame(
@@ -265,7 +287,8 @@ async def test_limit_with_select_statement(
             "context.span_id": ["234", "345"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc", limit=2)
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc", limit=2)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -273,7 +296,7 @@ async def test_limit_with_select_statement(
 
 
 async def test_filter_for_none(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -288,7 +311,8 @@ async def test_filter_for_none(
             "name": [],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -300,7 +324,7 @@ async def test_filter_for_none(
 
 
 async def test_filter_for_not_none(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -315,7 +339,8 @@ async def test_filter_for_not_none(
             "name": ["root span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -323,7 +348,7 @@ async def test_filter_for_not_none(
 
 
 async def test_filter_for_substring_case_sensitive_not_glob_not_like(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -338,7 +363,8 @@ async def test_filter_for_substring_case_sensitive_not_glob_not_like(
             "input.value": ["xy%*z"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -346,7 +372,7 @@ async def test_filter_for_substring_case_sensitive_not_glob_not_like(
 
 
 async def test_filter_for_not_substring_case_sensitive_not_glob_not_like(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -361,7 +387,8 @@ async def test_filter_for_not_substring_case_sensitive_not_glob_not_like(
             "input.value": ["xy%z*", "XY%*Z"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -369,7 +396,7 @@ async def test_filter_for_not_substring_case_sensitive_not_glob_not_like(
 
 
 async def test_filter_on_nonexistent_is_not_none(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -381,7 +408,8 @@ async def test_filter_on_nonexistent_is_not_none(
     expected = pd.DataFrame(
         columns=["context.span_id", "name"],
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -389,7 +417,7 @@ async def test_filter_on_nonexistent_is_not_none(
 
 
 async def test_filter_on_nonexistent_is_none(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -404,7 +432,8 @@ async def test_filter_on_nonexistent_is_none(
             "name": ["root span", "embedding span", "retriever span", "llm span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -412,7 +441,7 @@ async def test_filter_on_nonexistent_is_none(
 
 
 async def test_filter_on_latency(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -429,7 +458,8 @@ async def test_filter_on_latency(
             "Latency (milliseconds)": [10000.0],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -437,7 +467,7 @@ async def test_filter_on_latency(
 
 
 async def test_filter_on_cumulative_token_count(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -450,7 +480,8 @@ async def test_filter_on_cumulative_token_count(
             "name": ["root span"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -458,7 +489,7 @@ async def test_filter_on_cumulative_token_count(
 
 
 async def test_filter_on_metadata_with_arithmetic(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -473,7 +504,8 @@ async def test_filter_on_metadata_with_arithmetic(
             "metadata['a.b.c']": [123],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -481,7 +513,7 @@ async def test_filter_on_metadata_with_arithmetic(
 
 
 async def test_filter_on_metadata_cast_as_int(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -496,7 +528,8 @@ async def test_filter_on_metadata_cast_as_int(
             "metadata['a.b.c']": [123],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -504,7 +537,7 @@ async def test_filter_on_metadata_cast_as_int(
 
 
 async def test_filter_on_metadata_substring_search(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -519,7 +552,8 @@ async def test_filter_on_metadata_substring_search(
             "metadata['1.2.3']": ["abc"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -527,7 +561,7 @@ async def test_filter_on_metadata_substring_search(
 
 
 async def test_filter_on_metadata_cast_as_str(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -542,7 +576,8 @@ async def test_filter_on_metadata_cast_as_str(
             "metadata['1.2.3']": ["abc"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -550,7 +585,7 @@ async def test_filter_on_metadata_cast_as_str(
 
 
 async def test_filter_on_metadata_using_subscript_key(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -565,7 +600,8 @@ async def test_filter_on_metadata_using_subscript_key(
             "metadata['1.2.3']": ["abc"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -573,7 +609,7 @@ async def test_filter_on_metadata_using_subscript_key(
 
 
 async def test_filter_on_metadata_using_subscript_keys_list_with_single_key(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -588,7 +624,8 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_single_key(
             "metadata[['1.2.3']]": ["abc"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -596,7 +633,7 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_single_key(
 
 
 async def test_filter_on_metadata_using_subscript_keys_list_with_multiple_keys(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -611,7 +648,8 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_multiple_keys(
             "metadata[['x.y', 'z.a']]": [{"b.c": 321}],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -619,7 +657,7 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_multiple_keys(
 
 
 async def test_filter_on_attribute_using_subscript_key(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -634,7 +672,8 @@ async def test_filter_on_attribute_using_subscript_key(
             "attributes['attributes']": ["attributes"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -642,7 +681,7 @@ async def test_filter_on_attribute_using_subscript_key(
 
 
 async def test_filter_on_attribute_using_subscript_keys_list_with_single_key(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -657,7 +696,8 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_single_key(
             "attributes[['attributes']]": ["attributes"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -665,7 +705,7 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_single_key(
 
 
 async def test_filter_on_attribute_using_subscript_keys_list_with_multiple_keys(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -680,7 +720,8 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_multiple_keys(
             "attributes[['attributes', 'attributes']]": ["attributes"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -688,7 +729,7 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_multiple_keys(
 
 
 async def test_filter_on_span_id_single(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -703,7 +744,8 @@ async def test_filter_on_span_id_single(
             "embedding.model_name": ["xyz"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -711,7 +753,7 @@ async def test_filter_on_span_id_single(
 
 
 async def test_filter_on_span_id_multiple(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -726,7 +768,8 @@ async def test_filter_on_span_id_multiple(
             "embedding.model_name": ["xyz", None],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -734,7 +777,7 @@ async def test_filter_on_span_id_multiple(
 
 
 async def test_filter_on_trace_id_single(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -749,7 +792,8 @@ async def test_filter_on_trace_id_single(
             "context.trace_id": ["012", "012", "012", "012"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -757,7 +801,7 @@ async def test_filter_on_trace_id_single(
 
 
 async def test_filter_on_trace_id_multiple(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -772,7 +816,8 @@ async def test_filter_on_trace_id_multiple(
             "context.trace_id": ["012", "012", "012", "012"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -780,7 +825,7 @@ async def test_filter_on_trace_id_multiple(
 
 
 async def test_explode_embeddings_no_select(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().explode("embedding.embeddings")
     expected = pd.DataFrame(
@@ -791,7 +836,8 @@ async def test_explode_embeddings_no_select(
             "embedding.vector": [[1, 2, 3], [2, 3, 4]],
         }
     ).set_index(["context.span_id", "position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -799,7 +845,7 @@ async def test_explode_embeddings_no_select(
 
 
 async def test_explode_embeddings_with_select_and_no_kwargs(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -817,7 +863,8 @@ async def test_explode_embeddings_with_select_and_no_kwargs(
             "embedding.vector": [[1, 2, 3], [2, 3, 4]],
         }
     ).set_index(["context.span_id", "position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -825,7 +872,7 @@ async def test_explode_embeddings_with_select_and_no_kwargs(
 
 
 async def test_explode_documents_no_select(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().explode(
         "retrieval.documents",
@@ -840,7 +887,8 @@ async def test_explode_documents_no_select(
             "score": [1, 2, 3],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -848,7 +896,7 @@ async def test_explode_documents_no_select(
 
 
 async def test_explode_documents_with_select_and_non_ascii_kwargs(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -870,7 +918,8 @@ async def test_explode_documents_with_select_and_non_ascii_kwargs(
             "スコア": [1, 2, 3],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -878,7 +927,7 @@ async def test_explode_documents_with_select_and_non_ascii_kwargs(
 
 
 async def test_concat_documents_no_select(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().concat(
         "retrieval.documents",
@@ -890,7 +939,8 @@ async def test_concat_documents_no_select(
             "content": ["A\n\nB\n\nC"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -898,7 +948,7 @@ async def test_concat_documents_no_select(
 
 
 async def test_concat_documents_no_select_but_no_data(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = SpanQuery().concat(
         "retrieval.documents",
@@ -907,7 +957,8 @@ async def test_concat_documents_no_select_but_no_data(
     expected = pd.DataFrame(
         columns=["context.span_id", "content"],
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="opq")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="opq")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -915,7 +966,7 @@ async def test_concat_documents_no_select_but_no_data(
 
 
 async def test_concat_documents_with_select(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -932,7 +983,8 @@ async def test_concat_documents_with_select(
             "content": ["A\n\nB\n\nC"],
         }
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -940,7 +992,7 @@ async def test_concat_documents_with_select(
 
 
 async def test_concat_documents_with_select_but_no_data(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -953,7 +1005,8 @@ async def test_concat_documents_with_select_but_no_data(
     expected = pd.DataFrame(
         columns=["context.span_id", "content", "context.trace_id"],
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="opq")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="opq")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -961,7 +1014,7 @@ async def test_concat_documents_with_select_but_no_data(
 
 
 async def test_concat_documents_with_select_but_with_typo_in_array_name(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -974,7 +1027,8 @@ async def test_concat_documents_with_select_but_with_typo_in_array_name(
     expected = pd.DataFrame(
         columns=["context.span_id", "content", "context.trace_id"],
     ).set_index("context.span_id")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -982,7 +1036,7 @@ async def test_concat_documents_with_select_but_with_typo_in_array_name(
 
 
 async def test_concat_documents_with_select_and_non_default_separator(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -999,7 +1053,8 @@ async def test_concat_documents_with_select_and_non_default_separator(
             "text": ["123,234"],
         }
     ).set_index("name")
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1007,7 +1062,7 @@ async def test_concat_documents_with_select_and_non_default_separator(
 
 
 async def test_explode_and_concat_on_same_array(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -1028,7 +1083,8 @@ async def test_explode_and_concat_on_same_array(
             "score": [1, 2, 3],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1036,7 +1092,7 @@ async def test_explode_and_concat_on_same_array(
 
 
 async def test_explode_and_concat_on_same_array_but_no_data(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -1057,7 +1113,8 @@ async def test_explode_and_concat_on_same_array_but_no_data(
             "score",
         ]
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="opq")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="opq")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1065,10 +1122,11 @@ async def test_explode_and_concat_on_same_array_but_no_data(
 
 
 async def test_explode_and_concat_on_same_array_with_same_label(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
-    if "asyncpg" in str(session.get_bind().url):
-        pytest.xfail("FIX THIS: this test does not currently pass for postgres")
+    async with db() as session:
+        if "asyncpg" in str(session.get_bind().url):
+            pytest.xfail("FIX THIS: this test does not currently pass for postgres")
     sq = (
         SpanQuery()
         .concat(
@@ -1087,7 +1145,8 @@ async def test_explode_and_concat_on_same_array_with_same_label(
             "content": ["A\n\nB\n\nC", "A\n\nB\n\nC", "A\n\nB\n\nC"],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1095,7 +1154,7 @@ async def test_explode_and_concat_on_same_array_with_same_label(
 
 
 async def test_explode_and_concat_on_same_array_but_with_typo_in_concat_array_name(
-    session: AsyncSession,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
     default_project: None,
     abc_project: None,
 ) -> None:
@@ -1118,7 +1177,8 @@ async def test_explode_and_concat_on_same_array_but_with_typo_in_concat_array_na
             "score": [1, 2, 3],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1126,12 +1186,13 @@ async def test_explode_and_concat_on_same_array_but_with_typo_in_concat_array_na
 
 
 async def test_explode_and_concat_on_same_array_but_with_typo_in_explode_array_name(
-    session: AsyncSession,
+    db: Callable[[], AsyncContextManager[AsyncSession]],
     default_project: None,
     abc_project: None,
 ) -> None:
-    if "asyncpg" in str(session.get_bind().url):
-        pytest.xfail("FIX THIS: this test does not currently pass for postgres")
+    async with db() as session:
+        if "asyncpg" in str(session.get_bind().url):
+            pytest.xfail("FIX THIS: this test does not currently pass for postgres")
     sq = (
         SpanQuery()
         .concat(
@@ -1149,7 +1210,8 @@ async def test_explode_and_concat_on_same_array_but_with_typo_in_explode_array_n
             "content": ["A\n\nB\n\nC"],
         }
     ).set_index(["context.span_id"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),
@@ -1157,7 +1219,7 @@ async def test_explode_and_concat_on_same_array_but_with_typo_in_explode_array_n
 
 
 async def test_explode_and_concat_on_same_array_with_non_ascii_kwargs(
-    session: AsyncSession, default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
 ) -> None:
     sq = (
         SpanQuery()
@@ -1180,7 +1242,8 @@ async def test_explode_and_concat_on_same_array_with_non_ascii_kwargs(
             "スコア": [1, 2, 3],
         }
     ).set_index(["context.span_id", "document_position"])
-    actual = await session.run_sync(sq, project_name="abc")
+    async with db() as session:
+        actual = await session.run_sync(sq, project_name="abc")
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),

--- a/tests/trace/dsl/test_query.py
+++ b/tests/trace/dsl/test_query.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AsyncContextManager, Callable
+from typing import Any, AsyncContextManager, Callable
 
 import pandas as pd
 import pytest
@@ -77,7 +77,9 @@ async def test_select_all(
 
 
 async def test_select_all_with_no_data(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery()
     expected = pd.DataFrame(
@@ -103,7 +105,9 @@ async def test_select_all_with_no_data(
 
 
 async def test_select(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("name", tcp="llm.token_count.prompt")
     expected = pd.DataFrame(
@@ -122,7 +126,9 @@ async def test_select(
 
 
 async def test_select_parent_id_as_span_id(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("name", span_id="parent_id")
     expected = pd.DataFrame(
@@ -140,7 +146,9 @@ async def test_select_parent_id_as_span_id(
 
 
 async def test_select_trace_id_as_index(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("span_id").with_index("trace_id")
     expected = pd.DataFrame(
@@ -158,7 +166,9 @@ async def test_select_trace_id_as_index(
 
 
 async def test_select_nonexistent(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("name", "opq", "opq.rst")
     expected = pd.DataFrame(
@@ -178,7 +188,9 @@ async def test_select_nonexistent(
 
 
 async def test_default_project(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select(
         "name",
@@ -200,7 +212,9 @@ async def test_default_project(
 
 
 async def test_root_spans_only(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select(
         "name",
@@ -222,7 +236,9 @@ async def test_root_spans_only(
 
 
 async def test_start_time(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("name")
     expected = pd.DataFrame(
@@ -246,7 +262,9 @@ async def test_start_time(
 
 
 async def test_end_time(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("name")
     expected = pd.DataFrame(
@@ -270,7 +288,9 @@ async def test_end_time(
 
 
 async def test_limit(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery()
     async with db() as session:
@@ -279,7 +299,9 @@ async def test_limit(
 
 
 async def test_limit_with_select_statement(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().select("context.span_id")
     expected = pd.DataFrame(
@@ -296,7 +318,9 @@ async def test_limit_with_select_statement(
 
 
 async def test_filter_for_none(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -324,7 +348,9 @@ async def test_filter_for_none(
 
 
 async def test_filter_for_not_none(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -348,7 +374,9 @@ async def test_filter_for_not_none(
 
 
 async def test_filter_for_substring_case_sensitive_not_glob_not_like(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -372,7 +400,9 @@ async def test_filter_for_substring_case_sensitive_not_glob_not_like(
 
 
 async def test_filter_for_not_substring_case_sensitive_not_glob_not_like(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -396,7 +426,9 @@ async def test_filter_for_not_substring_case_sensitive_not_glob_not_like(
 
 
 async def test_filter_on_nonexistent_is_not_none(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -417,7 +449,9 @@ async def test_filter_on_nonexistent_is_not_none(
 
 
 async def test_filter_on_nonexistent_is_none(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -441,7 +475,9 @@ async def test_filter_on_nonexistent_is_none(
 
 
 async def test_filter_on_latency(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -467,7 +503,9 @@ async def test_filter_on_latency(
 
 
 async def test_filter_on_cumulative_token_count(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -489,7 +527,9 @@ async def test_filter_on_cumulative_token_count(
 
 
 async def test_filter_on_metadata_with_arithmetic(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -513,7 +553,9 @@ async def test_filter_on_metadata_with_arithmetic(
 
 
 async def test_filter_on_metadata_cast_as_int(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -537,7 +579,9 @@ async def test_filter_on_metadata_cast_as_int(
 
 
 async def test_filter_on_metadata_substring_search(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -561,7 +605,9 @@ async def test_filter_on_metadata_substring_search(
 
 
 async def test_filter_on_metadata_cast_as_str(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -585,7 +631,9 @@ async def test_filter_on_metadata_cast_as_str(
 
 
 async def test_filter_on_metadata_using_subscript_key(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -609,7 +657,9 @@ async def test_filter_on_metadata_using_subscript_key(
 
 
 async def test_filter_on_metadata_using_subscript_keys_list_with_single_key(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -633,7 +683,9 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_single_key(
 
 
 async def test_filter_on_metadata_using_subscript_keys_list_with_multiple_keys(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -657,7 +709,9 @@ async def test_filter_on_metadata_using_subscript_keys_list_with_multiple_keys(
 
 
 async def test_filter_on_attribute_using_subscript_key(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -681,7 +735,9 @@ async def test_filter_on_attribute_using_subscript_key(
 
 
 async def test_filter_on_attribute_using_subscript_keys_list_with_single_key(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -705,7 +761,9 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_single_key(
 
 
 async def test_filter_on_attribute_using_subscript_keys_list_with_multiple_keys(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -729,7 +787,9 @@ async def test_filter_on_attribute_using_subscript_keys_list_with_multiple_keys(
 
 
 async def test_filter_on_span_id_single(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -753,7 +813,9 @@ async def test_filter_on_span_id_single(
 
 
 async def test_filter_on_span_id_multiple(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -777,7 +839,9 @@ async def test_filter_on_span_id_multiple(
 
 
 async def test_filter_on_trace_id_single(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -801,7 +865,9 @@ async def test_filter_on_trace_id_single(
 
 
 async def test_filter_on_trace_id_multiple(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -825,7 +891,9 @@ async def test_filter_on_trace_id_multiple(
 
 
 async def test_explode_embeddings_no_select(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().explode("embedding.embeddings")
     expected = pd.DataFrame(
@@ -845,7 +913,9 @@ async def test_explode_embeddings_no_select(
 
 
 async def test_explode_embeddings_with_select_and_no_kwargs(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -872,7 +942,9 @@ async def test_explode_embeddings_with_select_and_no_kwargs(
 
 
 async def test_explode_documents_no_select(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().explode(
         "retrieval.documents",
@@ -896,7 +968,9 @@ async def test_explode_documents_no_select(
 
 
 async def test_explode_documents_with_select_and_non_ascii_kwargs(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -927,7 +1001,9 @@ async def test_explode_documents_with_select_and_non_ascii_kwargs(
 
 
 async def test_concat_documents_no_select(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().concat(
         "retrieval.documents",
@@ -948,7 +1024,9 @@ async def test_concat_documents_no_select(
 
 
 async def test_concat_documents_no_select_but_no_data(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = SpanQuery().concat(
         "retrieval.documents",
@@ -966,7 +1044,9 @@ async def test_concat_documents_no_select_but_no_data(
 
 
 async def test_concat_documents_with_select(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -992,7 +1072,9 @@ async def test_concat_documents_with_select(
 
 
 async def test_concat_documents_with_select_but_no_data(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -1014,7 +1096,9 @@ async def test_concat_documents_with_select_but_no_data(
 
 
 async def test_concat_documents_with_select_but_with_typo_in_array_name(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -1036,7 +1120,9 @@ async def test_concat_documents_with_select_but_with_typo_in_array_name(
 
 
 async def test_concat_documents_with_select_and_non_default_separator(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -1062,7 +1148,9 @@ async def test_concat_documents_with_select_and_non_default_separator(
 
 
 async def test_explode_and_concat_on_same_array(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -1092,7 +1180,9 @@ async def test_explode_and_concat_on_same_array(
 
 
 async def test_explode_and_concat_on_same_array_but_no_data(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()
@@ -1122,7 +1212,9 @@ async def test_explode_and_concat_on_same_array_but_no_data(
 
 
 async def test_explode_and_concat_on_same_array_with_same_label(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     async with db() as session:
         if "asyncpg" in str(session.get_bind().url):
@@ -1219,7 +1311,9 @@ async def test_explode_and_concat_on_same_array_but_with_typo_in_explode_array_n
 
 
 async def test_explode_and_concat_on_same_array_with_non_ascii_kwargs(
-    db: Callable[[], AsyncContextManager[AsyncSession]], default_project: None, abc_project: None
+    db: Callable[[], AsyncContextManager[AsyncSession]],
+    default_project: Any,
+    abc_project: Any,
 ) -> None:
     sq = (
         SpanQuery()

--- a/tests/trace/test_attributes.py
+++ b/tests/trace/test_attributes.py
@@ -134,7 +134,7 @@ def test_get_attribute_value(
         ),
     ],
 )
-def test_unflatten(key_value_pairs, desired):
+def test_unflatten(key_value_pairs, desired) -> None:
     actual = dict(unflatten(key_value_pairs))
     assert actual == desired
     actual = dict(unflatten(reversed(key_value_pairs)))
@@ -157,7 +157,7 @@ def test_unflatten(key_value_pairs, desired):
         ),
     ],
 )
-def test_unflatten_separator(separator, key_value_pairs, desired):
+def test_unflatten_separator(separator, key_value_pairs, desired) -> None:
     actual = dict(unflatten(key_value_pairs, separator=separator))
     assert actual == desired
     actual = dict(unflatten(reversed(key_value_pairs), separator=separator))

--- a/tests/trace/test_exporter.py
+++ b/tests/trace/test_exporter.py
@@ -3,7 +3,7 @@ from phoenix.config import PORT
 from phoenix.trace.exporter import HttpExporter
 
 
-def test_exporter(monkeypatch: pytest.MonkeyPatch):
+def test_exporter(monkeypatch: pytest.MonkeyPatch) -> None:
     # Test that it defaults to local
     monkeypatch.delenv("PHOENIX_COLLECTOR_ENDPOINT", False)
     exporter = HttpExporter()

--- a/tests/trace/test_otel.py
+++ b/tests/trace/test_otel.py
@@ -34,7 +34,7 @@ from pytest import approx
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 
 
-def test_decode_encode(span):
+def test_decode_encode(span) -> None:
     otlp_span = encode_span_to_otlp(span)
     assert otlp_span.name == "test_span"
     assert otlp_span.trace_id == _encode_identifier(span.context.trace_id)
@@ -77,7 +77,7 @@ def test_decode_encode(span):
         (SpanStatusCode.UNSET, otlp.Status.StatusCode.STATUS_CODE_UNSET),
     ],
 )
-def test_decode_encode_status_code(span, span_status_code, otlp_status_code):
+def test_decode_encode_status_code(span, span_status_code, otlp_status_code) -> None:
     span = replace(span, status_code=span_status_code)
     otlp_span = encode_span_to_otlp(span)
     assert otlp_span.status.code == otlp_status_code
@@ -86,7 +86,7 @@ def test_decode_encode_status_code(span, span_status_code, otlp_status_code):
 
 
 @pytest.mark.parametrize("span_kind", list(SpanKind))
-def test_decode_encode_span_kind(span, span_kind):
+def test_decode_encode_span_kind(span, span_kind) -> None:
     span = replace(span, span_kind=span_kind)
     span = replace(
         span,
@@ -141,7 +141,7 @@ def test_decode_encode_span_kind(span, span_kind):
         ),
     ],
 )
-def test_decode_encode_attributes(span, attributes, otlp_key_value):
+def test_decode_encode_attributes(span, attributes, otlp_key_value) -> None:
     span = replace(span, attributes={**span.attributes, **attributes})
     otlp_span = encode_span_to_otlp(span)
     assert MessageToJson(otlp_key_value) in set(map(MessageToJson, otlp_span.attributes))
@@ -149,7 +149,7 @@ def test_decode_encode_attributes(span, attributes, otlp_key_value):
     assert decoded_span.attributes == span.attributes
 
 
-def test_decode_encode_events(span):
+def test_decode_encode_events(span) -> None:
     event_name = str(random())
     exception_message = str(random())
     exception_type = str(random())
@@ -226,7 +226,7 @@ def test_decode_encode_events(span):
     assert decoded_span.events == span.events
 
 
-def test_decode_encode_documents(span):
+def test_decode_encode_documents(span) -> None:
     content = str(random())
     score = random()
     document_metadata = {
@@ -294,7 +294,7 @@ def test_decode_encode_documents(span):
     )
 
 
-def test_decode_encode_embeddings(span):
+def test_decode_encode_embeddings(span) -> None:
     text = str(random())
     vector = list(np.random.rand(3))
     attributes = {
@@ -343,7 +343,7 @@ def test_decode_encode_embeddings(span):
     )
 
 
-def test_decode_encode_message_tool_calls(span):
+def test_decode_encode_message_tool_calls(span) -> None:
     attributes = {
         "llm": {
             "output_messages": [
@@ -398,7 +398,7 @@ def test_decode_encode_message_tool_calls(span):
     )
 
 
-def test_decode_encode_llm_prompt_template_variables(span):
+def test_decode_encode_llm_prompt_template_variables(span) -> None:
     attributes = {
         "llm": {"prompt_template": {"variables": {"context_str": "123", "query_str": "321"}}}
     }
@@ -424,7 +424,7 @@ def test_decode_encode_llm_prompt_template_variables(span):
     )
 
 
-def test_decode_encode_tool_parameters(span):
+def test_decode_encode_tool_parameters(span) -> None:
     attributes = {
         "tool": {
             "parameters": {

--- a/tests/trace/test_projects.py
+++ b/tests/trace/test_projects.py
@@ -3,7 +3,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from phoenix.trace import using_project
 
 
-def test_enable_tracing_can_dynamically_modify_resource_project():
+def test_enable_tracing_can_dynamically_modify_resource_project() -> None:
     # all spans created while managed by `using_project` will have their project name
     # dynamically overridden
     pre_override = ReadableSpan(name="pre-override")
@@ -15,7 +15,7 @@ def test_enable_tracing_can_dynamically_modify_resource_project():
     assert ResourceAttributes.PROJECT_NAME not in post_override.resource.attributes
 
 
-def test_nested_project_overrides():
+def test_nested_project_overrides() -> None:
     with using_project(project_name="project1"):
         with_override = ReadableSpan(name="override")
         with using_project(project_name="project2"):

--- a/tests/trace/test_schemas.py
+++ b/tests/trace/test_schemas.py
@@ -8,7 +8,7 @@ from phoenix.trace.schemas import (
 )
 
 
-def test_span_construction():
+def test_span_construction() -> None:
     span = Span(
         name="test",
         parent_id=None,
@@ -25,7 +25,7 @@ def test_span_construction():
     assert span.name == "test"
 
 
-def test_span_with_exception():
+def test_span_with_exception() -> None:
     span = Span(
         name="exception-span",
         parent_id=None,

--- a/tests/trace/test_span_evaluations.py
+++ b/tests/trace/test_span_evaluations.py
@@ -16,7 +16,7 @@ from phoenix.trace.span_evaluations import (
 from pyarrow import parquet
 
 
-def test_span_evaluations_construction():
+def test_span_evaluations_construction() -> None:
     num_records = 5
     span_ids = [f"span_{index}" for index in range(num_records)]
 
@@ -38,7 +38,7 @@ def test_span_evaluations_construction():
     assert "score" in eval_ds.dataframe.columns
 
 
-def power_set(s):
+def power_set(s) -> None:
     for result in chain.from_iterable(combinations(s, r) for r in range(len(s) + 1)):
         yield dict(result)
 
@@ -50,7 +50,7 @@ BAD_RESULTS = list(power_set(list({"score": "0", "label": 1, "explanation": 2}.i
 @pytest.mark.parametrize("span_id", [None, "span_id", "context.span_id"])
 @pytest.mark.parametrize("position", [None, "position", "document_position"])
 @pytest.mark.parametrize("result", RESULTS)
-def test_document_evaluations_construction(span_id, position, result):
+def test_document_evaluations_construction(span_id, position, result) -> None:
     eval_name = "my_eval"
     rand1, rand2 = random(), random()
     df = pd.DataFrame([{**result, **{span_id: "x", position: 0, rand1: rand1, rand2: rand2}}])
@@ -84,14 +84,14 @@ def test_document_evaluations_construction(span_id, position, result):
 
 
 @pytest.mark.parametrize("result", BAD_RESULTS)
-def test_document_evaluations_bad_results(result):
+def test_document_evaluations_bad_results(result) -> None:
     eval_name = "my_eval"
     df = pd.DataFrame([{**result, **{"span_id": "x", "position": 0}}])
     with pytest.raises(ValueError):
         DocumentEvaluations(eval_name=eval_name, dataframe=df)
 
 
-def test_document_evaluations_edge_cases():
+def test_document_evaluations_edge_cases() -> None:
     eval_name = "my_eval"
     # empty should be fine
     df = pd.DataFrame()
@@ -102,7 +102,7 @@ def test_document_evaluations_edge_cases():
     assert actual.shape == (0, 0)
 
 
-def test_span_evaluations_save_and_load_preserves_data(tmp_path):
+def test_span_evaluations_save_and_load_preserves_data(tmp_path) -> None:
     num_records = 5
     span_ids = [f"span_{index}" for index in range(num_records)]
     dataframe = pd.DataFrame(
@@ -133,7 +133,7 @@ def test_span_evaluations_save_and_load_preserves_data(tmp_path):
     assert read_evals.id == evals.id
 
 
-def test_document_evaluations_save_and_load_preserves_data(tmp_path):
+def test_document_evaluations_save_and_load_preserves_data(tmp_path) -> None:
     dataframe = pd.DataFrame(
         {
             "context.span_id": ["span_1", "span_1", "span_2"],
@@ -163,7 +163,7 @@ def test_document_evaluations_save_and_load_preserves_data(tmp_path):
     assert read_evals.id == evals.id
 
 
-def test_evaluations_load_raises_error_when_input_id_does_not_match_metadata(tmp_path):
+def test_evaluations_load_raises_error_when_input_id_does_not_match_metadata(tmp_path) -> None:
     num_records = 5
     span_ids = [f"span_{index}" for index in range(num_records)]
     dataframe = pd.DataFrame(
@@ -187,7 +187,7 @@ def test_evaluations_load_raises_error_when_input_id_does_not_match_metadata(tmp
         Evaluations.load(updated_id, tmp_path)
 
 
-def test_parse_schema_metadata_raise_error_on_invalid_metadata():
+def test_parse_schema_metadata_raise_error_on_invalid_metadata() -> None:
     schema = pyarrow.schema(
         [
             pyarrow.field("label", pyarrow.string()),

--- a/tests/trace/test_span_json_decoder.py
+++ b/tests/trace/test_span_json_decoder.py
@@ -1,7 +1,7 @@
 from phoenix.trace.span_json_decoder import json_to_span
 
 
-def test_span_json_decoder_document_retrieval():
+def test_span_json_decoder_document_retrieval() -> None:
     span = json_to_span(
         {
             "name": "retrieve",

--- a/tests/trace/test_trace_dataset.py
+++ b/tests/trace/test_trace_dataset.py
@@ -22,7 +22,7 @@ from phoenix.trace.trace_dataset import TraceDataset, _parse_schema_metadata
 from pyarrow import parquet
 
 
-def test_trace_dataset_construction():
+def test_trace_dataset_construction() -> None:
     num_records = 5
     traces_df = pd.DataFrame(
         {
@@ -42,7 +42,7 @@ def test_trace_dataset_construction():
     assert isinstance(ds.dataframe, pd.DataFrame)
 
 
-def test_trace_dataset_validation():
+def test_trace_dataset_validation() -> None:
     num_records = 5
     # DataFrame with no span_kind
     traces_df = pd.DataFrame(
@@ -62,7 +62,7 @@ def test_trace_dataset_validation():
         _ = TraceDataset(traces_df)
 
 
-def test_trace_dataset_construction_from_spans():
+def test_trace_dataset_construction_from_spans() -> None:
     spans = [
         Span(
             name="name-0",
@@ -150,7 +150,7 @@ def test_trace_dataset_construction_from_spans():
     assert_frame_equal(expected_dataframe, dataset.dataframe[expected_dataframe.columns])
 
 
-def test_trace_dataset_construction_with_evaluations():
+def test_trace_dataset_construction_with_evaluations() -> None:
     num_records = 5
     span_ids = [f"span_{index}" for index in range(num_records)]
     traces_df = pd.DataFrame(
@@ -261,7 +261,7 @@ def test_trace_dataset_save_and_load_preserve_values(tmp_path) -> None:
     assert_frame_equal(read_ds.evaluations[0].dataframe, eval_ds.dataframe)
 
 
-def test_trace_dataset_load_logs_warning_when_an_evaluation_cannot_be_loaded(tmp_path):
+def test_trace_dataset_load_logs_warning_when_an_evaluation_cannot_be_loaded(tmp_path) -> None:
     num_records = 5
     traces_df = pd.DataFrame(
         {
@@ -312,7 +312,7 @@ def test_trace_dataset_load_logs_warning_when_an_evaluation_cannot_be_loaded(tmp
     assert read_ds.evaluations == []
 
 
-def test_trace_dataset_load_raises_error_when_input_id_does_not_match_metadata(tmp_path):
+def test_trace_dataset_load_raises_error_when_input_id_does_not_match_metadata(tmp_path) -> None:
     num_records = 5
     traces_df = pd.DataFrame(
         {

--- a/tests/utilities/test_error_handling.py
+++ b/tests/utilities/test_error_handling.py
@@ -2,7 +2,7 @@ import pytest
 from phoenix.utilities.error_handling import graceful_fallback
 
 
-def test_graceful_fallback_forwards_call_to_fallback_function():
+def test_graceful_fallback_forwards_call_to_fallback_function() -> None:
     def fallback(v) -> int:
         return v - 1
 
@@ -15,9 +15,9 @@ def test_graceful_fallback_forwards_call_to_fallback_function():
     assert check_the_answer(42) == 41
 
 
-def test_graceful_fallback_logs_errors(caplog):
+def test_graceful_fallback_logs_errors(caplog) -> None:
     @graceful_fallback(fallback_method=lambda *args, **kwargs: None)
-    def failing_function(*args, **kwargs):
+    def failing_function(*args, **kwargs) -> None:
         raise ValueError("This is a test error.")
 
     failing_function("foo", bar="baz")  # graceful_fallback suppresses the error
@@ -32,9 +32,9 @@ def test_graceful_fallback_logs_errors(caplog):
     ), "Traceback should be logged"
 
 
-def test_graceful_fallback_only_suppresses_specified_errors():
+def test_graceful_fallback_only_suppresses_specified_errors() -> None:
     @graceful_fallback(fallback_method=lambda *args, **kwargs: None, exceptions=(ValueError,))
-    def bad_division():
+    def bad_division() -> float:
         return 1 / 0
 
     with pytest.raises(ZeroDivisionError):

--- a/tests/utilities/test_re.py
+++ b/tests/utilities/test_re.py
@@ -54,7 +54,7 @@ from phoenix.utilities.re import parse_env_headers
         ),
     ],
 )
-def test_get_env_client_headers(headers, expected, warn, caplog):
+def test_get_env_client_headers(headers, expected, warn, caplog) -> None:
     if warn:
         with caplog.at_level(level="WARNING"):
             assert parse_env_headers(headers) == dict(expected)


### PR DESCRIPTION
## Notes
1. Putting a lock on postgres allows it to be used for insertion tests (previously we had to skip it for these tests). 
    - Unfortunately, this means the `session` fixture is no longer viable, because it would cause a deadlock.