### PR TITLE
docs: clarify evaluators quickstart

### DIFF
--- a/docs/quickstart/evals.md
+++ b/docs/quickstart/evals.md
@@ -58,10 +58,9 @@ You should now see a view like this.
 
 ## 3. Evaluate and Log Results
 
-Set up evaluators (in this casefor hallucinations and Q\&A correctness), run the evaluations, and log the results to visualize them in Phoenix.
+Set up evaluators (in this case for hallucinations and Q\&A correctness), run the evaluations, and log the results to visualize them in Phoenix.
 
-{% tabs %}
-{% tab title="Hallucinations and Q&A Evaluations" %}
+
 ```python
 !pip install openai
 
@@ -78,9 +77,13 @@ eval_model = OpenAIModel(model="gpt-4-turbo-preview", api_key=api_key)
 hallucination_evaluator = HallucinationEvaluator(eval_model)
 qa_evaluator = QAEvaluator(eval_model)
 
-# Run the evaluations
-# Assume 'queries_df' is your input dataframe for Q&A correctness
-# and Hallucination.
+# Assume 'queries_df' is your input dataframe 
+# for `hallucination_evaluator` your input df needs to have columns 'output', 'input', 'context'
+# for `qa_evaluator` your input df needs to have columns 'output', 'input', 'reference'
+assert all(column in queries_df.columns for column in ['output', 'input', 'context', 'reference'])
+
+# Run the evaluators, each evaluator will return a dataframe with evaluation results
+# We upload the evaluation results to Phoenix in the next step
 hallucination_eval_df, qa_eval_df = run_evals(
     dataframe=queries_df,
     evaluators=[hallucination_evaluator, qa_evaluator],
@@ -95,8 +98,6 @@ px.Client().log_evaluations(
     SpanEvaluations(eval_name="QA Correctness", dataframe=qa_eval_df)
 )
 ```
-{% endtab %}
-{% endtabs %}
 
 {% hint style="info" %}
 This quickstart uses OpenAI and requires an OpenAI API key, but we support a wide variety of APIs and [models](../api/evaluation-models.md).


### PR DESCRIPTION
Changes made

1. Clarify what the schema of the dataframe is for the Q&A and Hallucination evaluators are
2. Remove unnecessary tab