### PR TITLE
feat: add trace stream toggle into preferences context

### DIFF
--- a/app/src/components/markdown/MarkdownDisplayContext.tsx
+++ b/app/src/components/markdown/MarkdownDisplayContext.tsx
@@ -31,7 +31,9 @@ export function useMarkdownMode(): MarkdownDisplayContextType {
 }
 
 export function MarkdownDisplayProvider(props: PropsWithChildren) {
-  const mode = usePreferencesContext((state) => state.markdownDisplayMode);
+  const mode = usePreferencesContext((state) => {
+    return state.markdownDisplayMode;
+  });
   const setMarkdownDisplayMode = usePreferencesContext(
     (state) => state.setMarkdownDisplayMode
   );

--- a/app/src/contexts/StreamStateContext.tsx
+++ b/app/src/contexts/StreamStateContext.tsx
@@ -6,6 +6,8 @@ import React, {
   useState,
 } from "react";
 
+import { usePreferencesContext } from "./PreferencesContext";
+
 export type StreamStateContextType = {
   /**
    * Whether or not streaming is enabled.
@@ -44,7 +46,12 @@ export function StreamStateProvider({
   initialFetchKey = "initial",
   children,
 }: PropsWithChildren<{ initialFetchKey?: string }>) {
-  const [isStreaming, setIsStreaming] = useState<boolean>(true);
+  const isStreaming = usePreferencesContext(
+    (state) => state.traceStreamingEnabled
+  );
+  const setIsStreaming = usePreferencesContext(
+    (state) => state.setTraceStreamingEnabled
+  );
   const [fetchKey, _setFetchKey] = useState<string>(initialFetchKey);
 
   const setFetchKey = useCallback(

--- a/app/src/pages/project/StreamToggle.tsx
+++ b/app/src/pages/project/StreamToggle.tsx
@@ -58,7 +58,7 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
   return (
     <Switch
       labelPlacement="start"
-      defaultSelected
+      isSelected={isStreaming}
       onChange={() => {
         setIsStreaming(!isStreaming);
       }}

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -17,6 +17,17 @@ export interface PreferencesState extends PreferencesProps {
    * @param markdownDisplayMode
    */
   setMarkdownDisplayMode: (markdownDisplayMode: MarkdownDisplayMode) => void;
+  /**
+   * Whether or not streaming is enabled for a projects traces
+   * @default true
+   */
+  traceStreamingEnabled: boolean;
+  /**
+   * Setter for enabling/disabling trace streaming
+   * @param traceStreamingEnabled
+   * @returns
+   */
+  setTraceStreamingEnabled: (traceStreamingEnabled: boolean) => void;
 }
 
 export const createPreferencesStore = (
@@ -27,6 +38,10 @@ export const createPreferencesStore = (
     markdownDisplayMode: "text",
     setMarkdownDisplayMode: (markdownDisplayMode) => {
       set({ markdownDisplayMode });
+    },
+    traceStreamingEnabled: true,
+    setTraceStreamingEnabled: (traceStreamingEnabled) => {
+      set({ traceStreamingEnabled });
     },
   });
   return create<PreferencesState>()(


### PR DESCRIPTION
resolves #4023 

Adds `traceStreamingEnabled` into preferences context to preserve project page streaming preferences across sessions


https://github.com/user-attachments/assets/6731821c-6103-4f12-bda3-075b49d2615c

