### PR TITLE
feat(trace): add a span aside with timing info and feedback

### DIFF
--- a/app/src/components/trace/SpanItem.tsx
+++ b/app/src/components/trace/SpanItem.tsx
@@ -3,8 +3,8 @@ import { css } from "@emotion/react";
 
 import { Flex, Text, View } from "@arizeai/components";
 
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { SpanStatusCode } from "@phoenix/pages/project/__generated__/SpansTable_spans.graphql";
-import { TokenCount } from "@phoenix/pages/project/TokenCount";
 
 import { LatencyText } from "./LatencyText";
 import { SpanKindLabel } from "./SpanKindLabel";

--- a/app/src/components/trace/TokenCount.tsx
+++ b/app/src/components/trace/TokenCount.tsx
@@ -6,6 +6,7 @@ import {
   Icon,
   Icons,
   Text,
+  TextProps,
   Tooltip,
   TooltipTrigger,
   TriggerWrap,
@@ -24,6 +25,10 @@ type TokenCountProps = {
    * The number of tokens in the completion
    */
   tokenCountCompletion: number;
+  /**
+   * The size of the icon and text
+   */
+  textSize?: TextProps["textSize"];
 };
 
 /**
@@ -33,7 +38,7 @@ export function TokenCount(props: TokenCountProps) {
   return (
     <TooltipTrigger>
       <TriggerWrap>
-        <TokenItem>{props.tokenCountTotal}</TokenItem>
+        <TokenItem textSize={props.textSize}>{props.tokenCountTotal}</TokenItem>
       </TriggerWrap>
       <Tooltip>
         <Flex direction="column" gap="size-50">
@@ -51,16 +56,22 @@ export function TokenCount(props: TokenCountProps) {
   );
 }
 
-function TokenItem({ children }: { children: number }) {
+function TokenItem({
+  children,
+  ...textProps
+}: {
+  children: number;
+  textSize?: TextProps["textSize"];
+}) {
   return (
-    <Flex direction="row" gap="size-25" alignItems="center">
+    <Flex direction="row" gap="size-50" alignItems="center">
       <Icon
         svg={<Icons.TokensOutline />}
         css={css`
           color: var(--ac-global-text-color-900);
         `}
       />
-      <Text>{children}</Text>
+      <Text {...textProps}>{children}</Text>
     </Flex>
   );
 }

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 
 import { Flex, Text, View } from "@arizeai/components";
 
-import { TokenCount } from "@phoenix/pages/project/TokenCount";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
 
 import { LatencyText } from "./LatencyText";
 import { SpanKindIcon } from "./SpanKindIcon";

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -32,6 +32,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 
@@ -52,7 +53,6 @@ import {
   EVALS_KEY_SEPARATOR,
   getGqlSort,
 } from "./tableUtils";
-import { TokenCount } from "./TokenCount";
 type SpansTableProps = {
   project: SpansTable_spans$key;
 };

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -37,6 +37,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanKindLabel } from "@phoenix/components/trace/SpanKindLabel";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { ISpanItem } from "@phoenix/components/trace/types";
 import { createSpanTree, SpanTreeNode } from "@phoenix/components/trace/utils";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
@@ -59,7 +60,6 @@ import {
   EVALS_KEY_SEPARATOR,
   getGqlSort,
 } from "./tableUtils";
-import { TokenCount } from "./TokenCount";
 type TracesTableProps = {
   project: TracesTable_spans$key;
 };

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -1,8 +1,10 @@
 import React, { PropsWithChildren, useMemo } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
+import { css } from "@emotion/react";
 
 import { Flex, Text, View } from "@arizeai/components";
 
+import { AnnotationLabel } from "@phoenix/components/annotation";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
@@ -12,8 +14,15 @@ import { fullTimeFormatter } from "@phoenix/utils/timeFormatUtils";
 import { SpanAside_span$key } from "./__generated__/SpanAside_span.graphql";
 import { SpanAsideSpanQuery } from "./__generated__/SpanAsideSpanQuery.graphql";
 
+const annotationListCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-global-dimension-size-100);
+  align-items: flex-start;
+`;
+
 /**
- *
+ * A component that shows the details of a span that is supplementary to the main span details
  * @returns
  */
 export function SpanAside(props: { span: SpanAside_span$key }) {
@@ -28,6 +37,13 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
         tokenCountTotal
         tokenCountPrompt
         tokenCountCompletion
+        spanAnnotations {
+          id
+          name
+          label
+          annotatorKind
+          score
+        }
       }
     `,
     props.span
@@ -50,6 +66,8 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
     return endDate.getTime() - startDate.getTime();
   }, [endDate, startDate]);
   const statusColor = useSpanStatusCodeColor(code);
+  const annotations = data.spanAnnotations;
+  const hasAnnotations = annotations.length > 0;
   return (
     <View
       padding="size-200"
@@ -96,6 +114,19 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
             />
           </LabeledValue>
         ) : null}
+        {hasAnnotations && (
+          <LabeledValue label="Feedback">
+            <Flex direction="row" gap="size-50">
+              <ul css={annotationListCSS}>
+                {annotations.map((annotation) => (
+                  <li key={annotation.id}>
+                    <AnnotationLabel annotation={annotation} />
+                  </li>
+                ))}
+              </ul>
+            </Flex>
+          </LabeledValue>
+        )}
       </Flex>
     </View>
   );

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -24,7 +24,6 @@ const annotationListCSS = css`
 
 /**
  * A component that shows the details of a span that is supplementary to the main span details
- * @returns
  */
 export function SpanAside(props: { span: SpanAside_span$key }) {
   const [data] = useRefetchableFragment<SpanAsideSpanQuery, SpanAside_span$key>(
@@ -117,15 +116,13 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
         ) : null}
         {hasAnnotations && (
           <LabeledValue label="Feedback">
-            <Flex direction="row" gap="size-50">
-              <ul css={annotationListCSS}>
-                {annotations.map((annotation) => (
-                  <li key={annotation.id}>
-                    <AnnotationLabel annotation={annotation} />
-                  </li>
-                ))}
-              </ul>
-            </Flex>
+            <ul css={annotationListCSS}>
+              {annotations.map((annotation) => (
+                <li key={annotation.id}>
+                  <AnnotationLabel annotation={annotation} />
+                </li>
+              ))}
+            </ul>
           </LabeledValue>
         )}
       </Flex>

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -16,6 +16,7 @@ import { SpanAsideSpanQuery } from "./__generated__/SpanAsideSpanQuery.graphql";
 
 const annotationListCSS = css`
   display: flex;
+  padding-top: var(--ac-global-dimension-size-50);
   flex-direction: column;
   gap: var(--ac-global-dimension-size-100);
   align-items: flex-start;

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -1,0 +1,116 @@
+import React, { PropsWithChildren, useMemo } from "react";
+import { graphql, useRefetchableFragment } from "react-relay";
+
+import { Flex, Text, View } from "@arizeai/components";
+
+import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { useSpanStatusCodeColor } from "@phoenix/components/trace/useSpanStatusCodeColor";
+import { fullTimeFormatter } from "@phoenix/utils/timeFormatUtils";
+
+import { SpanAside_span$key } from "./__generated__/SpanAside_span.graphql";
+import { SpanAsideSpanQuery } from "./__generated__/SpanAsideSpanQuery.graphql";
+
+/**
+ *
+ * @returns
+ */
+export function SpanAside(props: { span: SpanAside_span$key }) {
+  const [data] = useRefetchableFragment<SpanAsideSpanQuery, SpanAside_span$key>(
+    graphql`
+      fragment SpanAside_span on Span
+      @refetchable(queryName: "SpanAsideSpanQuery") {
+        id
+        code: statusCode
+        startTime
+        endTime
+        tokenCountTotal
+        tokenCountPrompt
+        tokenCountCompletion
+      }
+    `,
+    props.span
+  );
+  const {
+    startTime,
+    endTime,
+    code,
+    tokenCountCompletion,
+    tokenCountPrompt,
+    tokenCountTotal,
+  } = data;
+  const startDate = useMemo(() => new Date(startTime), [startTime]);
+  const endDate = useMemo(
+    () => (endTime ? new Date(endTime) : null),
+    [endTime]
+  );
+  const latencyMs = useMemo(() => {
+    if (!endDate) return null;
+    return endDate.getTime() - startDate.getTime();
+  }, [endDate, startDate]);
+  const statusColor = useSpanStatusCodeColor(code);
+  return (
+    <View
+      padding="size-200"
+      borderColor="dark"
+      backgroundColor="light"
+      borderLeftWidth="thin"
+      width="210px"
+      flex="none"
+      minHeight="100%"
+    >
+      <Flex direction="column" gap="size-200">
+        <LabeledValue label="Status">
+          <Flex direction="row" gap="size-50" alignItems="center">
+            <SpanStatusCodeIcon statusCode={code} />
+            <Text textSize="xlarge" color={statusColor}>
+              {code}
+            </Text>
+          </Flex>
+        </LabeledValue>
+        <LabeledValue label="Start Time">
+          <Text textSize="xlarge">{fullTimeFormatter(startDate)}</Text>
+        </LabeledValue>
+        {endDate && (
+          <LabeledValue label="End Time">
+            <Text textSize="xlarge">{fullTimeFormatter(endDate)}</Text>
+          </LabeledValue>
+        )}
+        <LabeledValue label="Latency">
+          <Text textSize="xlarge">
+            {typeof latencyMs === "number" ? (
+              <LatencyText latencyMs={latencyMs} textSize="xlarge" />
+            ) : (
+              "--"
+            )}
+          </Text>
+        </LabeledValue>
+        {tokenCountTotal ? (
+          <LabeledValue label="Total Tokens" key="tokens">
+            <TokenCount
+              tokenCountTotal={tokenCountTotal}
+              tokenCountPrompt={tokenCountPrompt ?? 0}
+              tokenCountCompletion={tokenCountCompletion ?? 0}
+              textSize="xlarge"
+            />
+          </LabeledValue>
+        ) : null}
+      </Flex>
+    </View>
+  );
+}
+
+function LabeledValue({
+  label,
+  children,
+}: PropsWithChildren<{ label: string }>) {
+  return (
+    <Flex direction="column">
+      <Text elementType="h3" textSize="medium" color="text-700">
+        {label}
+      </Text>
+      {children}
+    </Flex>
+  );
+}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -250,9 +250,18 @@ function ScrollingTabsWrapper({ children }: PropsWithChildren) {
         .ac-tabs {
           height: 100%;
           overflow: hidden;
+          .ac-tabs__extra {
+            width: 100%;
+            padding-right: var(--ac-global-dimension-size-200);
+            padding-bottom: var(--ac-global-dimension-size-50);
+          }
           .ac-tabs__pane-container {
+            min-height: 100%;
             height: 100%;
             overflow-y: auto;
+            div[role="tabpanel"] {
+              height: 100%;
+            }
           }
         }
       `}

--- a/app/src/pages/trace/__generated__/SpanAsideSpanQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanAsideSpanQuery.graphql.ts
@@ -1,0 +1,167 @@
+/**
+ * @generated SignedSource<<941764d5b2b1ee45d859e0edc02b2d53>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SpanAsideSpanQuery$variables = {
+  id: string;
+};
+export type SpanAsideSpanQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"SpanAside_span">;
+  };
+};
+export type SpanAsideSpanQuery = {
+  response: SpanAsideSpanQuery$data;
+  variables: SpanAsideSpanQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SpanAsideSpanQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SpanAside_span"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SpanAsideSpanQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "TypeDiscriminator",
+            "abstractKey": "__isNode"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": "code",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "statusCode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endTime",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "tokenCountTotal",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "tokenCountPrompt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "tokenCountCompletion",
+                "storageKey": null
+              }
+            ],
+            "type": "Span",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c66beac101f3f1ebbc4f905322dbfda0",
+    "id": null,
+    "metadata": {},
+    "name": "SpanAsideSpanQuery",
+    "operationKind": "query",
+    "text": "query SpanAsideSpanQuery(\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpanAside_span\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "37b6d5584933520677f8fcb68c0e5810";
+
+export default node;

--- a/app/src/pages/trace/__generated__/SpanAsideSpanQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanAsideSpanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<941764d5b2b1ee45d859e0edc02b2d53>>
+ * @generated SignedSource<<6dabf94682f3c879102ec3789967d9d1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,14 @@ v1 = [
     "name": "id",
     "variableName": "id"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -90,13 +97,7 @@ return {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -141,6 +142,46 @@ return {
                 "kind": "ScalarField",
                 "name": "tokenCountCompletion",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SpanAnnotation",
+                "kind": "LinkedField",
+                "name": "spanAnnotations",
+                "plural": true,
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "label",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "annotatorKind",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "score",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
               }
             ],
             "type": "Span",
@@ -152,16 +193,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c66beac101f3f1ebbc4f905322dbfda0",
+    "cacheID": "878027b90513af8f947e6aa408450057",
     "id": null,
     "metadata": {},
     "name": "SpanAsideSpanQuery",
     "operationKind": "query",
-    "text": "query SpanAsideSpanQuery(\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpanAside_span\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n}\n"
+    "text": "query SpanAsideSpanQuery(\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpanAside_span\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n  spanAnnotations {\n    id\n    name\n    label\n    annotatorKind\n    score\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "37b6d5584933520677f8fcb68c0e5810";
+(node as any).hash = "cb5cab60889623d77ad0c96c98b3f8ac";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SpanAside_span.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanAside_span.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14c81412604c26fb24d0f446ee24402d>>
+ * @generated SignedSource<<ebb8ab32330c4b99061aafd8b83bbde0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,12 +9,20 @@
 // @ts-nocheck
 
 import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+export type AnnotatorKind = "HUMAN" | "LLM";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 import { FragmentRefs } from "relay-runtime";
 export type SpanAside_span$data = {
   readonly code: SpanStatusCode;
   readonly endTime: string | null;
   readonly id: string;
+  readonly spanAnnotations: ReadonlyArray<{
+    readonly annotatorKind: AnnotatorKind;
+    readonly id: string;
+    readonly label: string | null;
+    readonly name: string;
+    readonly score: number | null;
+  }>;
   readonly startTime: string;
   readonly tokenCountCompletion: number | null;
   readonly tokenCountPrompt: number | null;
@@ -28,7 +36,15 @@ export type SpanAside_span$key = {
 
 import SpanAsideSpanQuery_graphql from './SpanAsideSpanQuery.graphql';
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": {
@@ -46,13 +62,7 @@ const node: ReaderFragment = {
   },
   "name": "SpanAside_span",
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "id",
-      "storageKey": null
-    },
+    (v0/*: any*/),
     {
       "alias": "code",
       "args": null,
@@ -94,12 +104,53 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "tokenCountCompletion",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanAnnotation",
+      "kind": "LinkedField",
+      "name": "spanAnnotations",
+      "plural": true,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "label",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "annotatorKind",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "score",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Span",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "37b6d5584933520677f8fcb68c0e5810";
+(node as any).hash = "cb5cab60889623d77ad0c96c98b3f8ac";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SpanAside_span.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanAside_span.graphql.ts
@@ -1,0 +1,105 @@
+/**
+ * @generated SignedSource<<14c81412604c26fb24d0f446ee24402d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
+import { FragmentRefs } from "relay-runtime";
+export type SpanAside_span$data = {
+  readonly code: SpanStatusCode;
+  readonly endTime: string | null;
+  readonly id: string;
+  readonly startTime: string;
+  readonly tokenCountCompletion: number | null;
+  readonly tokenCountPrompt: number | null;
+  readonly tokenCountTotal: number | null;
+  readonly " $fragmentType": "SpanAside_span";
+};
+export type SpanAside_span$key = {
+  readonly " $data"?: SpanAside_span$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SpanAside_span">;
+};
+
+import SpanAsideSpanQuery_graphql from './SpanAsideSpanQuery.graphql';
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": SpanAsideSpanQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "SpanAside_span",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": "code",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "statusCode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startTime",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endTime",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tokenCountTotal",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tokenCountPrompt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "tokenCountCompletion",
+      "storageKey": null
+    }
+  ],
+  "type": "Span",
+  "abstractKey": null
+};
+
+(node as any).hash = "37b6d5584933520677f8fcb68c0e5810";
+
+export default node;

--- a/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c9d1c7fbc58f677a6bde1871de931d83>>
+ * @generated SignedSource<<7eb51329b17691743da5b3613ed3c293>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -64,7 +64,7 @@ export type SpanDetailsQuery$data = {
     readonly tokenCountCompletion: number | null;
     readonly tokenCountPrompt: number | null;
     readonly tokenCountTotal: number | null;
-    readonly " $fragmentSpreads": FragmentRefs<"SpanFeedback_annotations">;
+    readonly " $fragmentSpreads": FragmentRefs<"SpanAside_span" | "SpanFeedback_annotations">;
   } | {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
@@ -409,6 +409,11 @@ return {
                 "args": null,
                 "kind": "FragmentSpread",
                 "name": "SpanFeedback_annotations"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "SpanAside_span"
               }
             ],
             "type": "Span",
@@ -482,6 +487,20 @@ return {
                   }
                 ],
                 "storageKey": null
+              },
+              {
+                "alias": "code",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "statusCode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endTime",
+                "storageKey": null
               }
             ],
             "type": "Span",
@@ -493,16 +512,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1a2fd0a554755d7a72f92f71ca891a76",
+    "cacheID": "fa2339b82801c134af4c9a75a9543866",
     "id": null,
     "metadata": {},
     "name": "SpanDetailsQuery",
     "operationKind": "query",
-    "text": "query SpanDetailsQuery(\n  $spanId: GlobalID!\n) {\n  span: node(id: $spanId) {\n    __typename\n    ... on Span {\n      id\n      context {\n        spanId\n        traceId\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      tokenCountPrompt\n      tokenCountCompletion\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        documentPosition\n        name\n        label\n        score\n        explanation\n      }\n      spanAnnotations {\n        name\n      }\n      ...SpanFeedback_annotations\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanFeedback_annotations on Span {\n  spanAnnotations {\n    name\n    label\n    score\n    explanation\n    annotatorKind\n  }\n}\n"
+    "text": "query SpanDetailsQuery(\n  $spanId: GlobalID!\n) {\n  span: node(id: $spanId) {\n    __typename\n    ... on Span {\n      id\n      context {\n        spanId\n        traceId\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      tokenCountPrompt\n      tokenCountCompletion\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        documentPosition\n        name\n        label\n        score\n        explanation\n      }\n      spanAnnotations {\n        name\n      }\n      ...SpanFeedback_annotations\n      ...SpanAside_span\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n}\n\nfragment SpanFeedback_annotations on Span {\n  spanAnnotations {\n    name\n    label\n    score\n    explanation\n    annotatorKind\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b2cb5f7c63f463b9b0e3b6f86724132f";
+(node as any).hash = "eaf52d9b37b1f5a29cae360a05b7c975";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7eb51329b17691743da5b3613ed3c293>>
+ * @generated SignedSource<<15286f0446f997087c2392d071de7a69>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -484,7 +484,8 @@ return {
                     "kind": "ScalarField",
                     "name": "annotatorKind",
                     "storageKey": null
-                  }
+                  },
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -512,12 +513,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fa2339b82801c134af4c9a75a9543866",
+    "cacheID": "b1a80a0108c40baebf6e64b811ca0202",
     "id": null,
     "metadata": {},
     "name": "SpanDetailsQuery",
     "operationKind": "query",
-    "text": "query SpanDetailsQuery(\n  $spanId: GlobalID!\n) {\n  span: node(id: $spanId) {\n    __typename\n    ... on Span {\n      id\n      context {\n        spanId\n        traceId\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      tokenCountPrompt\n      tokenCountCompletion\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        documentPosition\n        name\n        label\n        score\n        explanation\n      }\n      spanAnnotations {\n        name\n      }\n      ...SpanFeedback_annotations\n      ...SpanAside_span\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n}\n\nfragment SpanFeedback_annotations on Span {\n  spanAnnotations {\n    name\n    label\n    score\n    explanation\n    annotatorKind\n  }\n}\n"
+    "text": "query SpanDetailsQuery(\n  $spanId: GlobalID!\n) {\n  span: node(id: $spanId) {\n    __typename\n    ... on Span {\n      id\n      context {\n        spanId\n        traceId\n      }\n      name\n      spanKind\n      statusCode: propagatedStatusCode\n      statusMessage\n      startTime\n      parentId\n      latencyMs\n      tokenCountTotal\n      tokenCountPrompt\n      tokenCountCompletion\n      input {\n        value\n        mimeType\n      }\n      output {\n        value\n        mimeType\n      }\n      attributes\n      events {\n        name\n        message\n        timestamp\n      }\n      documentRetrievalMetrics {\n        evaluationName\n        ndcg\n        precision\n        hit\n      }\n      documentEvaluations {\n        documentPosition\n        name\n        label\n        score\n        explanation\n      }\n      spanAnnotations {\n        name\n      }\n      ...SpanFeedback_annotations\n      ...SpanAside_span\n    }\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanAside_span on Span {\n  id\n  code: statusCode\n  startTime\n  endTime\n  tokenCountTotal\n  tokenCountPrompt\n  tokenCountCompletion\n  spanAnnotations {\n    id\n    name\n    label\n    annotatorKind\n    score\n  }\n}\n\nfragment SpanFeedback_annotations on Span {\n  spanAnnotations {\n    name\n    label\n    score\n    explanation\n    annotatorKind\n  }\n}\n"
   }
 };
 })();

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -36,7 +36,6 @@ export interface PreferencesState extends PreferencesProps {
   /**
    * Setter for enabling/disabling the span aside
    * @param showSpanAside
-   * @returns
    */
   setShowSpanAside: (showSpanAside: boolean) => void;
 }

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -28,6 +28,17 @@ export interface PreferencesState extends PreferencesProps {
    * @returns
    */
   setTraceStreamingEnabled: (traceStreamingEnabled: boolean) => void;
+  /**
+   * Whether or not to show the span aside that contains details about timing, status, etc.
+   * @default true
+   */
+  showSpanAside: boolean;
+  /**
+   * Setter for enabling/disabling the span aside
+   * @param showSpanAside
+   * @returns
+   */
+  setShowSpanAside: (showSpanAside: boolean) => void;
 }
 
 export const createPreferencesStore = (
@@ -42,6 +53,10 @@ export const createPreferencesStore = (
     traceStreamingEnabled: true,
     setTraceStreamingEnabled: (traceStreamingEnabled) => {
       set({ traceStreamingEnabled });
+    },
+    showSpanAside: true,
+    setShowSpanAside: (showSpanAside) => {
+      set({ showSpanAside });
     },
   });
   return create<PreferencesState>()(


### PR DESCRIPTION
resolves #4029 

Adds a span aside section that can be collapsed that contains timing info. Will add annotations next.
<img width="2011" alt="Screenshot 2024-07-30 at 8 47 10 AM" src="https://github.com/user-attachments/assets/08f10fbd-d7da-44af-88cf-658a5abbd864">
