### PR TITLE
chore(auth): add auth-related tables and migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,10 @@ clean = [
   "jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace **/*.ipynb **/internal/*.ipynb **/tracing/*.ipynb **/dolly-pythia-fine-tuned/*.ipynb",
 ]
 
+[tool.hatch.envs.symlink.scripts]
+create = "ln -s src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'auth migration symlink created'"
+remove = "rm src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'auth migration symlink removed'"
+
 [tool.hatch.envs.publish]
 dependencies = [
   "check-wheel-contents",
@@ -300,7 +304,7 @@ testpypi = [
   "twine upload  --verbose --repository testpypi dist/*",
 ]
 pypi = [
-  "[ -f 'src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py' ] || { echo 'Remove symlink for auth migration before publishing.'; exit 1; }",
+  "if [ -L src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py ]; then echo 'remove auth migration symlink before publishing with `hatch run symlink:remove`'; exit 1; fi",
   "check-wheel-contents dist/",
   "twine upload --verbose dist/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,7 @@ clean = [
 link = "cd src/phoenix/db/migrations/versions && ln -s ../future_versions/cd164e83824f_users_and_tokens.py cd164e83824f_users_and_tokens.py && echo 'created auth migration symlink'"
 unlink = "rm src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'removed auth migration symlink'"
 upgrade = "cd src/phoenix/db && alembic upgrade cd164e83824f && echo 'ran auth up-migration'"
-downgrade = "cd src/phoenix/db && alembic downgrade 3be8647b87d8 && echo 'ran auth down-migration'"
+down = "cd src/phoenix/db && alembic downgrade 3be8647b87d8 && echo 'ran auth down-migration'"
 
 [tool.hatch.envs.publish]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ testpypi = [
   "twine upload  --verbose --repository testpypi dist/*",
 ]
 pypi = [
+  "[ -f 'src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py' ] || { echo 'Remove symlink for auth migration before publishing.'; exit 1; }",
   "check-wheel-contents dist/",
   "twine upload --verbose dist/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,7 +291,7 @@ clean = [
 [tool.hatch.envs.auth.scripts]
 link = "cd src/phoenix/db/migrations/versions && ln -s ../future_versions/cd164e83824f_users_and_tokens.py cd164e83824f_users_and_tokens.py && echo 'created auth migration symlink'"
 unlink = "rm src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'removed auth migration symlink'"
-upgrade = "cd src/phoenix/db && alembic upgrade cd164e83824f && echo 'ran auth up-migration'"
+up = "cd src/phoenix/db && alembic upgrade cd164e83824f && echo 'ran auth up-migration'"
 down = "cd src/phoenix/db && alembic downgrade 3be8647b87d8 && echo 'ran auth down-migration'"
 
 [tool.hatch.envs.publish]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,9 +288,11 @@ clean = [
   "jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace **/*.ipynb **/internal/*.ipynb **/tracing/*.ipynb **/dolly-pythia-fine-tuned/*.ipynb",
 ]
 
-[tool.hatch.envs.symlink.scripts]
-create = "ln -s src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'auth migration symlink created'"
-remove = "rm src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'auth migration symlink removed'"
+[tool.hatch.envs.auth.scripts]
+link = "cd src/phoenix/db/migrations/versions && ln -s ../future_versions/cd164e83824f_users_and_tokens.py cd164e83824f_users_and_tokens.py && echo 'created auth migration symlink'"
+unlink = "rm src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py && echo 'removed auth migration symlink'"
+upgrade = "cd src/phoenix/db && alembic upgrade cd164e83824f && echo 'ran auth up-migration'"
+downgrade = "cd src/phoenix/db && alembic downgrade 3be8647b87d8 && echo 'ran auth down-migration'"
 
 [tool.hatch.envs.publish]
 dependencies = [
@@ -304,7 +306,7 @@ testpypi = [
   "twine upload  --verbose --repository testpypi dist/*",
 ]
 pypi = [
-  "if [ -L src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py ]; then echo 'remove auth migration symlink before publishing with `hatch run symlink:remove`'; exit 1; fi",
+  "if [ -L src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py ]; then echo 'remove auth migration symlink before publishing with `hatch run auth:unlink`'; exit 1; fi",
   "check-wheel-contents dist/",
   "twine upload --verbose dist/*",
 ]

--- a/src/phoenix/db/migrations/future_versions/README.md
+++ b/src/phoenix/db/migrations/future_versions/README.md
@@ -1,0 +1,4 @@
+# Future Migrations
+
+This folder contains future migrations for unreleased features that are under active development. Do not run these migrations unless you are a Phoenix developer.
+

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -6,10 +6,140 @@ Create Date: 2024-08-01 18:36:52.157604
 
 """
 
-from typing import Sequence, Union
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, TypedDict, Union
 
 import sqlalchemy as sa
 from alembic import op
+from phoenix.datetime_utils import normalize_datetime
+from sqlalchemy import (
+    JSON,
+    TIMESTAMP,
+    CheckConstraint,
+    Dialect,
+    ForeignKey,
+    MetaData,
+    TypeDecorator,
+    func,
+    insert,
+)
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio.engine import AsyncConnection
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+)
+from sqlalchemy.sql import true
+
+
+class JSONB(JSON):
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    __visit_name__ = "JSONB"
+
+
+@compiles(JSONB, "sqlite")  # type: ignore
+def _(*args: Any, **kwargs: Any) -> str:
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    return "JSONB"
+
+
+JSON_ = (
+    JSON()
+    .with_variant(
+        postgresql.JSONB(),  # type: ignore
+        "postgresql",
+    )
+    .with_variant(
+        JSONB(),
+        "sqlite",
+    )
+)
+
+
+class JsonDict(TypeDecorator[Dict[str, Any]]):
+    # See # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    cache_ok = True
+    impl = JSON_
+
+    def process_bind_param(self, value: Optional[Dict[str, Any]], _: Dialect) -> Dict[str, Any]:
+        return value if isinstance(value, dict) else {}
+
+
+class JsonList(TypeDecorator[List[Any]]):
+    # See # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    cache_ok = True
+    impl = JSON_
+
+    def process_bind_param(self, value: Optional[List[Any]], _: Dialect) -> List[Any]:
+        return value if isinstance(value, list) else []
+
+
+class UtcTimeStamp(TypeDecorator[datetime]):
+    # See # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    cache_ok = True
+    impl = TIMESTAMP(timezone=True)
+
+    def process_bind_param(self, value: Optional[datetime], _: Dialect) -> Optional[datetime]:
+        return normalize_datetime(value)
+
+    def process_result_value(self, value: Optional[Any], _: Dialect) -> Optional[datetime]:
+        return normalize_datetime(value, timezone.utc)
+
+
+class ExperimentRunOutput(TypedDict, total=False):
+    task_output: Any
+
+
+class Base(DeclarativeBase):
+    # Enforce best practices for naming constraints
+    # https://alembic.sqlalchemy.org/en/latest/naming.html#integration-of-naming-conventions-into-operations-autogenerate
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(table_name)s_%(column_0_N_name)s",
+            "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+            "ck": "ck_%(table_name)s_`%(constraint_name)s`",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
+    type_annotation_map = {
+        Dict[str, Any]: JsonDict,
+        List[Dict[str, Any]]: JsonList,
+        ExperimentRunOutput: JsonDict,
+    }
+
+
+class UserRole(Base):
+    __tablename__ = "user_roles"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    role: Mapped[str] = mapped_column(
+        CheckConstraint("action IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        unique=True,
+    )
+
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_role_id: Mapped[int] = mapped_column(
+        ForeignKey("user_roles.id"),
+        index=True,
+    )
+    username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+    email_address: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+    auth_method: Mapped[str] = mapped_column(
+        CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
+    )
+    password_hash: Mapped[Optional[str]]
+    reset_password: Mapped[bool] = mapped_column(server_default=true())
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
 
 # revision identifiers, used by Alembic.
 revision: str = "cd164e83824f"
@@ -18,11 +148,54 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+async def insert_roles_and_users(connection: AsyncConnection) -> None:
+    """
+    Populates the `user_roles` table and adds a system user and initial admin
+    user to the `users` table.
+    """
+    await connection.execute(
+        insert(UserRole).values([{"role": "SYSTEM"}, {"role": "ADMIN"}, {"role": "GENERAL"}])
+    )
+    system_user_role_id = sa.select(UserRole.id).where(UserRole.role == "SYSTEM").scalar_subquery()
+    admin_user_role_id = sa.select(UserRole.id).where(UserRole.role == "ADMIN").scalar_subquery()
+    await connection.execute(
+        insert(User).values(
+            [
+                {
+                    "user_role_id": system_user_role_id,
+                    "username": None,
+                    "email_address": None,
+                    "auth_method": "LOCAL",
+                    "password_hash": None,
+                    "reset_password": False,
+                },
+                {
+                    "user_role_id": admin_user_role_id,
+                    "username": "admin",
+                    "email_address": None,
+                    "auth_method": "LOCAL",
+                    "password_hash": None,  # todo: replace this with the hashed PHOENIX_SECRET
+                    "reset_password": True,
+                },
+            ]
+        )
+    )
+
+
 def upgrade() -> None:
     op.create_table(
         "user_roles",
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("role", sa.String, nullable=False, unique=True),
+        sa.Column(
+            "role",
+            sa.String,
+            sa.CheckConstraint(
+                "role IN ('SYSTEM', 'ADMIN', 'GENERAL')",
+                name="valid_role",
+            ),
+            nullable=False,
+            unique=True,
+        ),
     )
     op.create_table(
         "users",
@@ -34,7 +207,8 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column("email_address", sa.String, nullable=False, unique=True, index=True),
+        sa.Column("username", sa.String, nullable=True, unique=True, index=True),
+        sa.Column("email_address", sa.String, nullable=True, unique=True, index=True),
         sa.Column(
             "auth_method",
             sa.String,
@@ -116,6 +290,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
         ),
     )
+    op.run_async(insert_roles_and_users)
 
 
 def downgrade() -> None:

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -114,7 +114,7 @@ class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
     role: Mapped[str] = mapped_column(
-        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'MEMBER')", name="valid_role"),
         unique=True,
     )
 
@@ -189,7 +189,7 @@ def upgrade() -> None:
             "role",
             sa.String,
             sa.CheckConstraint(
-                "role IN ('SYSTEM', 'ADMIN', 'GENERAL')",
+                "role IN ('SYSTEM', 'ADMIN', 'MEMBER')",
                 name="valid_role",
             ),
             nullable=False,

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -31,7 +31,6 @@ from sqlalchemy.orm import (
     Mapped,
     mapped_column,
 )
-from sqlalchemy.sql import true
 
 
 class JSONB(JSON):
@@ -133,7 +132,7 @@ class User(Base):
         CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
     )
     password_hash: Mapped[Optional[str]]
-    reset_password: Mapped[bool] = mapped_column(server_default=true())
+    reset_password: Mapped[bool]
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
@@ -216,7 +215,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("password_hash", sa.String, nullable=True),
-        sa.Column("reset_password", sa.Boolean, nullable=False, server_default=sa.sql.true()),
+        sa.Column("reset_password", sa.Boolean, nullable=False),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -113,10 +113,7 @@ class Base(DeclarativeBase):
 class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
-    role: Mapped[str] = mapped_column(
-        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'MEMBER')", name="valid_role"),
-        unique=True,
-    )
+    role: Mapped[str] = mapped_column(unique=True)
 
 
 class User(Base):
@@ -188,10 +185,6 @@ def upgrade() -> None:
         sa.Column(
             "role",
             sa.String,
-            sa.CheckConstraint(
-                "role IN ('SYSTEM', 'ADMIN', 'MEMBER')",
-                name="valid_role",
-            ),
             nullable=False,
             unique=True,
         ),

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -253,7 +253,7 @@ def upgrade() -> None:
         ),
     )
     op.create_table(
-        "api_keys_actions",
+        "audit_api_keys",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
             "api_key_id",
@@ -286,7 +286,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("api_keys_actions")
+    op.drop_table("audit_api_keys")
     op.drop_table("api_keys")
     op.drop_table("users")
     op.drop_table("user_roles")

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -127,7 +127,7 @@ class User(Base):
         index=True,
     )
     username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
-    email_address: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+    email: Mapped[str] = mapped_column(nullable=False, unique=True, index=True)
     auth_method: Mapped[str] = mapped_column(
         CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
     )
@@ -163,7 +163,7 @@ async def insert_roles_and_users(connection: AsyncConnection) -> None:
                 {
                     "user_role_id": system_user_role_id,
                     "username": None,
-                    "email_address": None,
+                    "email": "system@localhost",
                     "auth_method": "LOCAL",
                     "password_hash": None,
                     "reset_password": False,
@@ -171,7 +171,7 @@ async def insert_roles_and_users(connection: AsyncConnection) -> None:
                 {
                     "user_role_id": admin_user_role_id,
                     "username": "admin",
-                    "email_address": None,
+                    "email": "admin@localhost",
                     "auth_method": "LOCAL",
                     "password_hash": None,  # todo: replace this with the hashed PHOENIX_SECRET
                     "reset_password": True,
@@ -207,7 +207,7 @@ def upgrade() -> None:
             index=True,
         ),
         sa.Column("username", sa.String, nullable=True, unique=True, index=True),
-        sa.Column("email_address", sa.String, nullable=True, unique=True, index=True),
+        sa.Column("email", sa.String, nullable=False, unique=True, index=True),
         sa.Column(
             "auth_method",
             sa.String,

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -1,0 +1,26 @@
+"""users and tokens
+
+Revision ID: cd164e83824f
+Revises: 10460e46d750
+Create Date: 2024-08-01 18:36:52.157604
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa  # noqa: F401
+from alembic import op  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision: str = "cd164e83824f"
+down_revision: Union[str, None] = "10460e46d750"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -8,8 +8,8 @@ Create Date: 2024-08-01 18:36:52.157604
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa  # noqa: F401
-from alembic import op  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "cd164e83824f"
@@ -19,8 +19,111 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    pass
+    op.create_table(
+        "user_roles",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, unique=True),
+    )
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_role_id",
+            sa.Integer,
+            sa.ForeignKey("user_roles.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("email_address", sa.String, nullable=False, unique=True, index=True),
+        sa.Column("auth_method", sa.String, nullable=False),
+        sa.Column("password_hash", sa.String, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "created_by",
+            sa.Integer,
+            sa.ForeignKey("users.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("description", sa.String, nullable=True),
+        sa.Column("trailing_characters", sa.String, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "expires_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_table(
+        "access_tokens",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
 
 
 def downgrade() -> None:
-    pass
+    op.drop_table("password_reset_tokens")
+    op.drop_table("refresh_tokens")
+    op.drop_table("access_tokens")
+    op.drop_table("api_keys")
+    op.drop_table("users")
+    op.drop_table("user_roles")

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -260,7 +260,7 @@ def upgrade() -> None:
         ),
     )
     op.create_table(
-        "api_keys_logs",
+        "api_keys_actions",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
             "api_key_id",
@@ -293,7 +293,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("api_keys_logs")
+    op.drop_table("api_keys_actions")
     op.drop_table("api_keys")
     op.drop_table("users")
     op.drop_table("user_roles")

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -35,7 +35,12 @@ def upgrade() -> None:
             index=True,
         ),
         sa.Column("email_address", sa.String, nullable=False, unique=True, index=True),
-        sa.Column("auth_method", sa.String, nullable=False),
+        sa.Column(
+            "auth_method",
+            sa.String,
+            sa.CheckConstraint("auth_method IN ('LOCAL')", "valid_auth_method"),
+            nullable=False,
+        ),
         sa.Column("password_hash", sa.String, nullable=True),
         sa.Column("reset_password", sa.Boolean, nullable=False, server_default=sa.sql.true()),
         sa.Column(

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     op.create_table(
         "user_roles",
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("name", sa.String, nullable=False, unique=True),
+        sa.Column("role", sa.String, nullable=False, unique=True),
     )
     op.create_table(
         "users",

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -37,6 +37,7 @@ def upgrade() -> None:
         sa.Column("email_address", sa.String, nullable=False, unique=True, index=True),
         sa.Column("auth_method", sa.String, nullable=False),
         sa.Column("password_hash", sa.String, nullable=True),
+        sa.Column("reset_password", sa.Boolean, nullable=False, server_default=sa.sql.true()),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
@@ -66,16 +67,8 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column(
-            "created_by",
-            sa.Integer,
-            sa.ForeignKey("users.id"),
-            nullable=False,
-            index=True,
-        ),
         sa.Column("name", sa.String, nullable=False),
         sa.Column("description", sa.String, nullable=True),
-        sa.Column("trailing_characters", sa.String, nullable=False),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
@@ -89,28 +82,28 @@ def upgrade() -> None:
         ),
     )
     op.create_table(
-        "access_tokens",
+        "api_keys_logs",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
-            "created_at",
-            sa.TIMESTAMP(timezone=True),
+            "api_key_id",
+            sa.Integer,
+            sa.ForeignKey("api_keys.id"),
             nullable=False,
-            server_default=sa.func.now(),
+            index=True,
         ),
-    )
-    op.create_table(
-        "refresh_tokens",
-        sa.Column("id", sa.Integer, primary_key=True),
         sa.Column(
-            "created_at",
-            sa.TIMESTAMP(timezone=True),
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id"),
             nullable=False,
-            server_default=sa.func.now(),
+            index=True,
         ),
-    )
-    op.create_table(
-        "password_reset_tokens",
-        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "action",
+            sa.String,
+            sa.CheckConstraint("action IN ('CREATE', 'DELETE')", "valid_action"),
+            nullable=False,
+        ),
         sa.Column(
             "created_at",
             sa.TIMESTAMP(timezone=True),
@@ -121,9 +114,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("password_reset_tokens")
-    op.drop_table("refresh_tokens")
-    op.drop_table("access_tokens")
+    op.drop_table("api_keys_logs")
     op.drop_table("api_keys")
     op.drop_table("users")
     op.drop_table("user_roles")

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -114,7 +114,7 @@ class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
     role: Mapped[str] = mapped_column(
-        CheckConstraint("action IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
         unique=True,
     )
 

--- a/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/future_versions/cd164e83824f_users_and_tokens.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "cd164e83824f"
-down_revision: Union[str, None] = "10460e46d750"
+down_revision: Union[str, None] = "3be8647b87d8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/.gitignore
+++ b/src/phoenix/db/migrations/versions/.gitignore
@@ -1,0 +1,1 @@
+cd164e83824f_users_and_tokens.py

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -635,7 +635,7 @@ class User(Base):
         index=True,
     )
     username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
-    email_address: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+    email: Mapped[str] = mapped_column(nullable=False, unique=True, index=True)
     auth_method: Mapped[str] = mapped_column(
         CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -658,8 +658,8 @@ class APIKey(Base):
     expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
 
-class APIKeysAction(Base):
-    __tablename__ = "api_keys_actions"
+class AuditAPIKey(Base):
+    __tablename__ = "audit_api_keys"
     id: Mapped[int] = mapped_column(primary_key=True)
     api_key_id: Mapped[int] = mapped_column(
         ForeignKey("api_keys.id"),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -661,8 +661,8 @@ class APIKey(Base):
     expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
 
-class APIKeysLog(Base):
-    __tablename__ = "api_keys_logs"
+class APIKeysAction(Base):
+    __tablename__ = "api_keys_actions"
     id: Mapped[int] = mapped_column(primary_key=True)
     api_key_id: Mapped[int] = mapped_column(
         ForeignKey("api_keys.id"),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -659,6 +659,7 @@ if ENABLE_AUTH:
         created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
         expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
+    # todo: standardize audit table format (https://github.com/Arize-ai/phoenix/issues/4185)
     class AuditAPIKey(Base):
         __tablename__ = "audit_api_keys"
         id: Mapped[int] = mapped_column(primary_key=True)

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -616,3 +616,62 @@ class ExperimentRunAnnotation(Base):
             "name",
         ),
     )
+
+
+class UserRoles(Base):
+    __tablename__ = "user_roles"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(unique=True)
+
+
+class Users(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_role_id: Mapped[int] = mapped_column(
+        ForeignKey("user_roles.id"),
+        index=True,
+    )
+    email_address: Mapped[str] = mapped_column(unique=True, index=True)
+    auth_method: Mapped[str]
+    password_hash: Mapped[Optional[str]]
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
+
+class APIKeys(Base):
+    __tablename__ = "api_keys"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"),
+        index=True,
+    )
+    created_by: Mapped[int] = mapped_column(
+        ForeignKey("users.id"),
+        index=True,
+    )
+    name: Mapped[str]
+    description: Mapped[Optional[str]]
+    trailing_characters: Mapped[str]
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+
+
+class AccessTokens(Base):
+    __tablename__ = "access_tokens"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+
+
+class RefreshTokens(Base):
+    __tablename__ = "refresh_tokens"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+
+
+class PasswordResetTokens(Base):
+    __tablename__ = "password_reset_tokens"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -621,7 +621,7 @@ class ExperimentRunAnnotation(Base):
 class UserRoles(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
-    name: Mapped[str] = mapped_column(unique=True)
+    role: Mapped[str] = mapped_column(unique=True)
 
 
 class Users(Base):

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -621,10 +621,7 @@ class ExperimentRunAnnotation(Base):
 class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
-    role: Mapped[str] = mapped_column(
-        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'MEMBER')", name="valid_role"),
-        unique=True,
-    )
+    role: Mapped[str] = mapped_column(unique=True)
 
 
 class User(Base):

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -622,7 +622,7 @@ class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
     role: Mapped[str] = mapped_column(
-        CheckConstraint("action IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
         unique=True,
     )
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -622,7 +622,7 @@ class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
     role: Mapped[str] = mapped_column(
-        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        CheckConstraint("role IN ('SYSTEM', 'ADMIN', 'MEMBER')", name="valid_role"),
         unique=True,
     )
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -618,13 +618,13 @@ class ExperimentRunAnnotation(Base):
     )
 
 
-class UserRoles(Base):
+class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
     role: Mapped[str] = mapped_column(unique=True)
 
 
-class Users(Base):
+class User(Base):
     __tablename__ = "users"
     id: Mapped[int] = mapped_column(primary_key=True)
     user_role_id: Mapped[int] = mapped_column(
@@ -641,7 +641,7 @@ class Users(Base):
     deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
 
-class APIKeys(Base):
+class APIKey(Base):
     __tablename__ = "api_keys"
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[int] = mapped_column(
@@ -659,19 +659,19 @@ class APIKeys(Base):
     expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
 
-class AccessTokens(Base):
+class AccessToken(Base):
     __tablename__ = "access_tokens"
     id: Mapped[int] = mapped_column(primary_key=True)
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
 
 
-class RefreshTokens(Base):
+class RefreshToken(Base):
     __tablename__ = "refresh_tokens"
     id: Mapped[int] = mapped_column(primary_key=True)
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
 
 
-class PasswordResetTokens(Base):
+class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"
     id: Mapped[int] = mapped_column(primary_key=True)
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -621,7 +621,10 @@ class ExperimentRunAnnotation(Base):
 class UserRole(Base):
     __tablename__ = "user_roles"
     id: Mapped[int] = mapped_column(primary_key=True)
-    role: Mapped[str] = mapped_column(unique=True)
+    role: Mapped[str] = mapped_column(
+        CheckConstraint("action IN ('SYSTEM', 'ADMIN', 'GENERAL')", name="valid_role"),
+        unique=True,
+    )
 
 
 class User(Base):
@@ -631,7 +634,8 @@ class User(Base):
         ForeignKey("user_roles.id"),
         index=True,
     )
-    email_address: Mapped[str] = mapped_column(unique=True, index=True)
+    username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+    email_address: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
     auth_method: Mapped[str] = mapped_column(
         CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -632,7 +632,9 @@ class User(Base):
         index=True,
     )
     email_address: Mapped[str] = mapped_column(unique=True, index=True)
-    auth_method: Mapped[str]
+    auth_method: Mapped[str] = mapped_column(
+        CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
+    )
     password_hash: Mapped[Optional[str]]
     reset_password: Mapped[bool] = mapped_column(server_default=true())
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import (
     mapped_column,
     relationship,
 )
-from sqlalchemy.sql import expression, true
+from sqlalchemy.sql import expression
 
 from phoenix.datetime_utils import normalize_datetime
 
@@ -640,7 +640,7 @@ class User(Base):
         CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
     )
     password_hash: Mapped[Optional[str]]
-    reset_password: Mapped[bool] = mapped_column(server_default=true())
+    reset_password: Mapped[bool]
     created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.sql import expression
 
+from phoenix.config import ENABLE_AUTH
 from phoenix.datetime_utils import normalize_datetime
 
 
@@ -618,60 +619,60 @@ class ExperimentRunAnnotation(Base):
     )
 
 
-class UserRole(Base):
-    __tablename__ = "user_roles"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    role: Mapped[str] = mapped_column(unique=True)
+# todo: unnest the following models when auth is released (https://github.com/Arize-ai/phoenix/issues/4183)
+if ENABLE_AUTH:
 
+    class UserRole(Base):
+        __tablename__ = "user_roles"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        role: Mapped[str] = mapped_column(unique=True)
 
-class User(Base):
-    __tablename__ = "users"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    user_role_id: Mapped[int] = mapped_column(
-        ForeignKey("user_roles.id"),
-        index=True,
-    )
-    username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
-    email: Mapped[str] = mapped_column(nullable=False, unique=True, index=True)
-    auth_method: Mapped[str] = mapped_column(
-        CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
-    )
-    password_hash: Mapped[Optional[str]]
-    reset_password: Mapped[bool]
-    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        UtcTimeStamp, server_default=func.now(), onupdate=func.now()
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
+    class User(Base):
+        __tablename__ = "users"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        user_role_id: Mapped[int] = mapped_column(
+            ForeignKey("user_roles.id"),
+            index=True,
+        )
+        username: Mapped[Optional[str]] = mapped_column(nullable=True, unique=True, index=True)
+        email: Mapped[str] = mapped_column(nullable=False, unique=True, index=True)
+        auth_method: Mapped[str] = mapped_column(
+            CheckConstraint("auth_method IN ('LOCAL')", name="valid_auth_method")
+        )
+        password_hash: Mapped[Optional[str]]
+        reset_password: Mapped[bool]
+        created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+        updated_at: Mapped[datetime] = mapped_column(
+            UtcTimeStamp, server_default=func.now(), onupdate=func.now()
+        )
+        deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
+    class APIKey(Base):
+        __tablename__ = "api_keys"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        user_id: Mapped[int] = mapped_column(
+            ForeignKey("users.id"),
+            index=True,
+        )
+        name: Mapped[str]
+        description: Mapped[Optional[str]]
+        created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+        expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
 
-class APIKey(Base):
-    __tablename__ = "api_keys"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey("users.id"),
-        index=True,
-    )
-    name: Mapped[str]
-    description: Mapped[Optional[str]]
-    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
-    expires_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
-
-
-class AuditAPIKey(Base):
-    __tablename__ = "audit_api_keys"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    api_key_id: Mapped[int] = mapped_column(
-        ForeignKey("api_keys.id"),
-        nullable=False,
-        index=True,
-    )
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey("users.id"),
-        nullable=False,
-        index=True,
-    )
-    action: Mapped[str] = mapped_column(
-        CheckConstraint("action IN ('CREATE', 'DELETE')", name="valid_action")
-    )
-    created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
+    class AuditAPIKey(Base):
+        __tablename__ = "audit_api_keys"
+        id: Mapped[int] = mapped_column(primary_key=True)
+        api_key_id: Mapped[int] = mapped_column(
+            ForeignKey("api_keys.id"),
+            nullable=False,
+            index=True,
+        )
+        user_id: Mapped[int] = mapped_column(
+            ForeignKey("users.id"),
+            nullable=False,
+            index=True,
+        )
+        action: Mapped[str] = mapped_column(
+            CheckConstraint("action IN ('CREATE', 'DELETE')", name="valid_action")
+        )
+        created_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())


### PR DESCRIPTION
Adds the following database tables:

- `user_roles`
- `users`
- `api_keys`
- `audit_api_keys`

Adds migrations to create these tables, to populate the `user_roles` with system, admin, and member roles, and to populate the `users` table with a system user and an initial admin user.

Adds temporary `hatch` commands for development purposes:

- `hatch run auth:link` to add a symlink to the auth migration.
- `hatch run auth:unlink` to remove that symlink.
- `hatch run auth:up` to run the auth up-migration.
- `hatch run auth:down` to run the auth down-migration.

resolves #4043
