### PR TITLE
feat: Add span annotations to dataset example metadata

### DIFF
--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -171,7 +171,7 @@ class DatasetMutationMixin:
                 )
             ).all()
 
-            span_annotations_by_span = {span.id: {} for span in spans}
+            span_annotations_by_span: Dict[int, Dict[Any, Any]] = {span.id: {} for span in spans}
             for annotation in span_annotations:
                 span_id = annotation.span_rowid
                 if span_id not in span_annotations_by_span:

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -177,7 +177,6 @@ class DatasetMutationMixin:
                 if span_id not in span_annotations_by_span:
                     span_annotations_by_span[span_id] = dict()
                 span_annotations_by_span[span_id][annotation.name] = {
-                    "name": annotation.name,
                     "label": annotation.label,
                     "score": annotation.score,
                     "explanation": annotation.explanation,

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -181,7 +181,7 @@ class DatasetMutationMixin:
                     "score": annotation.score,
                     "explanation": annotation.explanation,
                     "metadata": annotation.metadata_,
-                    "kind": annotation.annotator_kind,
+                    "annotator_kind": annotation.annotator_kind,
                 }
 
             DatasetExample = models.DatasetExample

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -720,7 +720,7 @@ async def spans(db: DbSessionFactory) -> None:
 async def span_annotation(db):
     async with db() as session:
         span_annotation = models.SpanAnnotation(
-            span_rowid="1",
+            span_rowid=1,
             name="test annotation",
             annotator_kind="HUMAN",
             label="ambiguous",

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -308,7 +308,7 @@ async def test_add_span_to_dataset(
                                                 "score": 0.5,
                                                 "explanation": "meaningful words",
                                                 "metadata": {},
-                                                "kind": "HUMAN",
+                                                "annotator_kind": "HUMAN",
                                             }
                                         },
                                     },

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -207,7 +207,6 @@ async def test_add_span_to_dataset(
     assert response.status_code == 200
     response_json = response.json()
     assert response_json.get("errors") is None
-    breakpoint()
     assert response_json["data"] == {
         "addSpansToDataset": {
             "dataset": {
@@ -305,7 +304,6 @@ async def test_add_span_to_dataset(
                                         },
                                         "annotations": {
                                             "test annotation": {
-                                                "name": "test annotation",
                                                 "label": "ambiguous",
                                                 "score": 0.5,
                                                 "explanation": "meaningful words",

--- a/tests/server/api/mutations/test_dataset_mutations.py
+++ b/tests/server/api/mutations/test_dataset_mutations.py
@@ -168,6 +168,7 @@ async def test_add_span_to_dataset(
     httpx_client: httpx.AsyncClient,
     empty_dataset,
     spans,
+    span_annotation,
 ) -> None:
     dataset_id = GlobalID(type_name="Dataset", node_id=str(1))
     mutation = """
@@ -206,6 +207,7 @@ async def test_add_span_to_dataset(
     assert response.status_code == 200
     response_json = response.json()
     assert response_json.get("errors") is None
+    breakpoint()
     assert response_json["data"] == {
         "addSpansToDataset": {
             "dataset": {
@@ -239,7 +241,8 @@ async def test_add_span_to_dataset(
                                                     }
                                                 }
                                             ],
-                                        }
+                                        },
+                                        "annotations": {},
                                     },
                                     "output": {
                                         "messages": [
@@ -281,6 +284,7 @@ async def test_add_span_to_dataset(
                                                 }
                                             ]
                                         },
+                                        "annotations": {},
                                     },
                                 }
                             }
@@ -298,6 +302,16 @@ async def test_add_span_to_dataset(
                                         "output": {
                                             "value": "chain-span-output-value",
                                             "mime_type": "text/plain",
+                                        },
+                                        "annotations": {
+                                            "test annotation": {
+                                                "name": "test annotation",
+                                                "label": "ambiguous",
+                                                "score": 0.5,
+                                                "explanation": "meaningful words",
+                                                "metadata": {},
+                                                "kind": "HUMAN",
+                                            }
                                         },
                                     },
                                 }
@@ -702,6 +716,21 @@ async def spans(db: DbSessionFactory) -> None:
                 cumulative_llm_token_count_completion=0,
             )
         )
+
+
+@pytest.fixture
+async def span_annotation(db):
+    async with db() as session:
+        span_annotation = models.SpanAnnotation(
+            span_rowid="1",
+            name="test annotation",
+            annotator_kind="HUMAN",
+            label="ambiguous",
+            score=0.5,
+            explanation="meaningful words",
+        )
+        session.add(span_annotation)
+        await session.flush()
 
 
 @pytest.fixture


### PR DESCRIPTION
resolves #3912 

When creating a dataset example from a span, the annotations associated with that span will be "snapshotted" and included in the span metadata under a new key: `annotations`. This key will always be present and empty if the span has no annotations.

If the span does have annotations, the structure of the annotations will be a mapping:

```
metadata:
  annotations:
    annotation_name:
      label: label
      score: score
      explanation: explanation
      metadata: metadata
      annotator_kind: kind
```