### PR TITLE
fix: cache invalidation

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -154,6 +154,7 @@ type Dataset implements Node {
   experimentCount(datasetVersionId: GlobalID): Int!
   experiments(first: Int = 50, last: Int, after: String, before: String): ExperimentConnection!
   experimentAnnotationSummaries: [ExperimentAnnotationSummary!]!
+  lastUpdatedAt: DateTime
 }
 
 enum DatasetColumn {
@@ -626,6 +627,7 @@ type Experiment implements Node {
   errorRate: Float
   averageRunLatencyMs: Float
   project: Project
+  lastUpdatedAt: DateTime
 }
 
 type ExperimentAnnotationSummary {
@@ -1036,7 +1038,9 @@ type PromptResponse {
 
 type Query {
   projects(first: Int = 50, last: Int, after: String, before: String): ProjectConnection!
+  projectsLastUpdatedAt: DateTime
   datasets(first: Int = 50, last: Int, after: String, before: String, sort: DatasetSort): DatasetConnection!
+  datasetsLastUpdatedAt: DateTime
   compareExperiments(experimentIds: [GlobalID!]!): [ExperimentComparison!]!
   functionality: Functionality!
   model: Model!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dev = [
   "prometheus_client",
   "asgi-lifespan",
   "Faker>=26.0.0",
+  "uvloop; platform_system != 'Windows'",
 ]
 evals = []
 experimental = []
@@ -173,6 +174,7 @@ dependencies = [
   "astunparse; python_version<'3.9'",  # `ast.unparse(...)` is only available starting with Python 3.9
   "asgi-lifespan",
   "Faker>=26.0.0",
+  "uvloop; platform_system != 'Windows'",
 ]
 
 [tool.hatch.envs.type]

--- a/src/phoenix/db/insertion/document_annotation.py
+++ b/src/phoenix/db/insertion/document_annotation.py
@@ -7,6 +7,7 @@ from typing_extensions import TypeAlias
 
 from phoenix.db import models
 from phoenix.db.helpers import dedup, num_docs_col
+from phoenix.db.insertion.helpers import as_kv
 from phoenix.db.insertion.types import (
     Insertables,
     Postponed,
@@ -14,6 +15,7 @@ from phoenix.db.insertion.types import (
     QueueInserter,
     Received,
 )
+from phoenix.server.dml_event import DocumentAnnotationDmlEvent
 
 _Name: TypeAlias = str
 _SpanId: TypeAlias = str
@@ -40,10 +42,21 @@ class DocumentAnnotationQueueInserter(
         Precursors.DocumentAnnotation,
         Insertables.DocumentAnnotation,
         models.DocumentAnnotation,
+        DocumentAnnotationDmlEvent,
     ],
     table=models.DocumentAnnotation,
     unique_by=("name", "span_rowid", "document_position"),
 ):
+    async def _events(
+        self,
+        session: AsyncSession,
+        *insertions: Insertables.DocumentAnnotation,
+    ) -> List[DocumentAnnotationDmlEvent]:
+        records = [dict(as_kv(ins.row)) for ins in insertions]
+        stmt = self._insert_on_conflict(*records).returning(self.table.id)
+        ids = tuple([_ async for _ in await session.stream_scalars(stmt)])
+        return [DocumentAnnotationDmlEvent(ids)]
+
     async def _partition(
         self,
         session: AsyncSession,

--- a/src/phoenix/db/insertion/span_annotation.py
+++ b/src/phoenix/db/insertion/span_annotation.py
@@ -7,6 +7,7 @@ from typing_extensions import TypeAlias
 
 from phoenix.db import models
 from phoenix.db.helpers import dedup
+from phoenix.db.insertion.helpers import as_kv
 from phoenix.db.insertion.types import (
     Insertables,
     Postponed,
@@ -14,6 +15,7 @@ from phoenix.db.insertion.types import (
     QueueInserter,
     Received,
 )
+from phoenix.server.dml_event import SpanAnnotationDmlEvent
 
 _Name: TypeAlias = str
 _SpanId: TypeAlias = str
@@ -36,10 +38,21 @@ class SpanAnnotationQueueInserter(
         Precursors.SpanAnnotation,
         Insertables.SpanAnnotation,
         models.SpanAnnotation,
+        SpanAnnotationDmlEvent,
     ],
     table=models.SpanAnnotation,
     unique_by=("name", "span_rowid"),
 ):
+    async def _events(
+        self,
+        session: AsyncSession,
+        *insertions: Insertables.SpanAnnotation,
+    ) -> List[SpanAnnotationDmlEvent]:
+        records = [dict(as_kv(ins.row)) for ins in insertions]
+        stmt = self._insert_on_conflict(*records).returning(self.table.id)
+        ids = tuple([_ async for _ in await session.stream_scalars(stmt)])
+        return [SpanAnnotationDmlEvent(ids)]
+
     async def _partition(
         self,
         session: AsyncSession,

--- a/src/phoenix/db/insertion/types.py
+++ b/src/phoenix/db/insertion/types.py
@@ -21,11 +21,12 @@ from typing import (
 )
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql.dml import ReturningInsert
+from sqlalchemy.sql.dml import Insert
 
 from phoenix.db import models
 from phoenix.db.insertion.constants import DEFAULT_RETRY_ALLOWANCE, DEFAULT_RETRY_DELAY_SEC
-from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.db.insertion.helpers import insert_on_conflict
+from phoenix.server.dml_event import DmlEvent
 from phoenix.server.types import DbSessionFactory
 
 logger = logging.getLogger("__name__")
@@ -40,6 +41,7 @@ _AnyT = TypeVar("_AnyT")
 _PrecursorT = TypeVar("_PrecursorT")
 _InsertableT = TypeVar("_InsertableT", bound=Insertable)
 _RowT = TypeVar("_RowT", bound=models.Base)
+_InsertionEventT = TypeVar("_InsertionEventT", bound=DmlEvent)
 
 
 @dataclass(frozen=True)
@@ -56,7 +58,7 @@ class Postponed(Received[_AnyT]):
     retries_left: int = field(default=DEFAULT_RETRY_ALLOWANCE)
 
 
-class QueueInserter(ABC, Generic[_PrecursorT, _InsertableT, _RowT]):
+class QueueInserter(ABC, Generic[_PrecursorT, _InsertableT, _RowT, _InsertionEventT]):
     table: Type[_RowT]
     unique_by: Sequence[str]
 
@@ -97,59 +99,63 @@ class QueueInserter(ABC, Generic[_PrecursorT, _InsertableT, _RowT]):
         List[Received[_PrecursorT]],
     ]: ...
 
-    async def insert(self) -> Tuple[Type[_RowT], List[int]]:
+    async def insert(self) -> Optional[List[_InsertionEventT]]:
         if not self._queue:
-            return self.table, []
-        parcels = self._queue
-        self._queue = []
-        inserted_ids: List[int] = []
+            return None
+        self._queue, parcels = [], self._queue
+        events: List[_InsertionEventT] = []
         async with self._db() as session:
             to_insert, to_postpone, _ = await self._partition(session, *parcels)
             if to_insert:
-                inserted_ids, to_retry, _ = await self._insert(session, *to_insert)
-                to_postpone.extend(to_retry)
+                events, to_retry, _ = await self._insert(session, *to_insert)
+                if to_retry:
+                    to_postpone.extend(to_retry)
         if to_postpone:
             loop = asyncio.get_running_loop()
             loop.call_later(self._retry_delay_sec, self._queue.extend, to_postpone)
-        return self.table, inserted_ids
+        return events
 
-    def _stmt(self, *records: Mapping[str, Any]) -> ReturningInsert[Tuple[int]]:
-        pk = next(c for c in self.table.__table__.c if c.primary_key)
+    def _insert_on_conflict(self, *records: Mapping[str, Any]) -> Insert:
         return insert_on_conflict(
             *records,
             table=self.table,
             unique_by=self.unique_by,
             dialect=self._db.dialect,
-        ).returning(pk)
+        )
+
+    @abstractmethod
+    async def _events(
+        self,
+        session: AsyncSession,
+        *insertions: _InsertableT,
+    ) -> List[_InsertionEventT]: ...
 
     async def _insert(
         self,
         session: AsyncSession,
-        *insertions: Received[_InsertableT],
-    ) -> Tuple[List[int], List[Postponed[_PrecursorT]], List[Received[_InsertableT]]]:
-        records = [dict(as_kv(ins.item.row)) for ins in insertions]
-        inserted_ids: List[int] = []
+        *parcels: Received[_InsertableT],
+    ) -> Tuple[
+        List[_InsertionEventT],
+        List[Postponed[_PrecursorT]],
+        List[Received[_InsertableT]],
+    ]:
         to_retry: List[Postponed[_PrecursorT]] = []
         failures: List[Received[_InsertableT]] = []
-        stmt = self._stmt(*records)
+        events: List[_InsertionEventT] = []
         try:
             async with session.begin_nested():
-                ids = [id_ async for id_ in await session.stream_scalars(stmt)]
-                inserted_ids.extend(ids)
+                events.extend(await self._events(session, *(p.item for p in parcels)))
         except BaseException:
             logger.exception(
                 f"Failed to bulk insert for {self.table.__name__}. "
-                f"Will try to insert ({len(records)} records) individually instead."
+                f"Will try to insert ({len(parcels)} records) individually instead."
             )
-            for i, record in enumerate(records):
-                stmt = self._stmt(record)
+            for p in parcels:
                 try:
                     async with session.begin_nested():
-                        ids = [id_ async for id_ in await session.stream_scalars(stmt)]
-                        inserted_ids.extend(ids)
+                        events.extend(await self._events(session, p.item))
                 except BaseException:
                     logger.exception(f"Failed to insert for {self.table.__name__}.")
-                    p = insertions[i]
                     if isinstance(p, Postponed) and p.retries_left == 1:
                         failures.append(p)
                     else:
@@ -162,7 +168,7 @@ class QueueInserter(ABC, Generic[_PrecursorT, _InsertableT, _RowT]):
                                 else self._retry_allowance,
                             )
                         )
-        return inserted_ids, to_retry, failures
+        return events, to_retry, failures
 
 
 class Precursors(ABC):

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -1,10 +1,8 @@
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Optional
 
 from strawberry.fastapi import BaseContext
-from typing_extensions import TypeAlias
 
 from phoenix.core.model_schema import Model
 from phoenix.server.api.dataloaders import (
@@ -34,7 +32,8 @@ from phoenix.server.api.dataloaders import (
     TraceEvaluationsDataLoader,
     TraceRowIdsDataLoader,
 )
-from phoenix.server.types import DbSessionFactory
+from phoenix.server.dml_event import DmlEvent
+from phoenix.server.types import CanGetLastUpdatedAt, CanPutItem, DbSessionFactory
 
 
 @dataclass
@@ -65,7 +64,9 @@ class DataLoaders:
     span_annotations: SpanAnnotationsDataLoader
 
 
-ProjectRowId: TypeAlias = int
+class _NoOp:
+    def get(self, *args: Any, **kwargs: Any) -> Any: ...
+    def put(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 @dataclass
@@ -75,6 +76,7 @@ class Context(BaseContext):
     cache_for_dataloaders: Optional[CacheForDataLoaders]
     model: Model
     export_path: Path
+    last_updated_at: CanGetLastUpdatedAt = _NoOp()
+    event_queue: CanPutItem[DmlEvent] = _NoOp()
     corpus: Optional[Model] = None
-    streaming_last_updated_at: Callable[[ProjectRowId], Optional[datetime]] = lambda _: None
     read_only: bool = False

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -1,12 +1,4 @@
 from dataclasses import dataclass, field
-from functools import singledispatchmethod
-
-from phoenix.db.insertion.evaluation import (
-    DocumentEvaluationInsertionEvent,
-    SpanEvaluationInsertionEvent,
-    TraceEvaluationInsertionEvent,
-)
-from phoenix.db.insertion.span import ClearProjectSpansEvent, SpanInsertionEvent
 
 from .annotation_summaries import AnnotationSummaryCache, AnnotationSummaryDataLoader
 from .average_experiment_run_latency import AverageExperimentRunLatencyDataLoader
@@ -88,42 +80,3 @@ class CacheForDataLoaders:
     token_count: TokenCountCache = field(
         default_factory=TokenCountCache,
     )
-
-    def _update_spans(self, project_rowid: int) -> None:
-        self.latency_ms_quantile.invalidate(project_rowid)
-        self.token_count.invalidate(project_rowid)
-        self.record_count.invalidate(project_rowid)
-        self.min_start_or_max_end_time.invalidate(project_rowid)
-
-    def _clear_spans(self, project_rowid: int) -> None:
-        self._update_spans(project_rowid)
-        self.annotation_summary.invalidate_project(project_rowid)
-        self.evaluation_summary.invalidate_project(project_rowid)
-        self.document_evaluation_summary.invalidate_project(project_rowid)
-
-    @singledispatchmethod
-    def invalidate(self, event: SpanInsertionEvent) -> None:
-        project_rowid, *_ = event
-        self._update_spans(project_rowid)
-
-    @invalidate.register
-    def _(self, event: ClearProjectSpansEvent) -> None:
-        project_rowid, *_ = event
-        self._clear_spans(project_rowid)
-
-    @invalidate.register
-    def _(self, event: DocumentEvaluationInsertionEvent) -> None:
-        project_rowid, evaluation_name = event
-        self.document_evaluation_summary.invalidate((project_rowid, evaluation_name))
-
-    @invalidate.register
-    def _(self, event: SpanEvaluationInsertionEvent) -> None:
-        project_rowid, evaluation_name = event
-        self.annotation_summary.invalidate((project_rowid, evaluation_name, "span"))
-        self.evaluation_summary.invalidate((project_rowid, evaluation_name, "span"))
-
-    @invalidate.register
-    def _(self, event: TraceEvaluationInsertionEvent) -> None:
-        project_rowid, evaluation_name = event
-        self.annotation_summary.invalidate((project_rowid, evaluation_name, "trace"))
-        self.evaluation_summary.invalidate((project_rowid, evaluation_name, "trace"))

--- a/src/phoenix/server/api/mutations/experiment_mutations.py
+++ b/src/phoenix/server/api/mutations/experiment_mutations.py
@@ -14,6 +14,7 @@ from phoenix.server.api.mutations.auth import IsAuthenticated
 from phoenix.server.api.types.Experiment import Experiment, to_gql_experiment
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.utils import delete_projects, delete_traces
+from phoenix.server.dml_event import ExperimentDeleteEvent
 
 
 @strawberry.type
@@ -66,6 +67,7 @@ class ExperimentMutationMixin:
             delete_traces(info.context.db, *eval_trace_ids),
             return_exceptions=True,
         )
+        info.context.event_queue.put(ExperimentDeleteEvent(tuple(experiments.keys())))
         return ExperimentMutationPayload(
             experiments=[
                 to_gql_experiment(experiments[experiment_id]) for experiment_id in experiment_ids

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import datetime
 from typing import DefaultDict, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -108,6 +109,10 @@ class Query:
         return connection_from_list(data=data, args=args)
 
     @strawberry.field
+    def projects_last_updated_at(self, info: Info[Context, None]) -> Optional[datetime]:
+        return info.context.last_updated_at.get(models.Project)
+
+    @strawberry.field
     async def datasets(
         self,
         info: Info[Context, None],
@@ -132,6 +137,10 @@ class Query:
         return connection_from_list(
             data=[to_gql_dataset(dataset) for dataset in datasets], args=args
         )
+
+    @strawberry.field
+    def datasets_last_updated_at(self, info: Info[Context, None]) -> Optional[datetime]:
+        return info.context.last_updated_at.get(models.Dataset)
 
     @strawberry.field
     async def compare_experiments(

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -60,6 +60,7 @@ from phoenix.server.api.types.DatasetExample import DatasetExample as DatasetExa
 from phoenix.server.api.types.DatasetVersion import DatasetVersion as DatasetVersionNodeType
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.utils import delete_projects, delete_traces
+from phoenix.server.dml_event import DatasetInsertEvent
 
 from .pydantic_compat import V1RoutesBaseModel
 from .utils import (
@@ -481,6 +482,7 @@ async def upload_dataset(
     if sync:
         async with request.app.state.db() as session:
             dataset_id = (await operation(session)).dataset_id
+        request.state.event_queue.put(DatasetInsertEvent((dataset_id,)))
         return UploadDatasetResponseBody(
             data=UploadDatasetData(dataset_id=str(GlobalID(Dataset.__name__, str(dataset_id))))
         )

--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -11,6 +11,7 @@ from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.dml_event import ExperimentRunAnnotationInsertEvent
 
 from .pydantic_compat import V1RoutesBaseModel
 from .utils import ResponseBody, add_errors_to_responses
@@ -108,6 +109,7 @@ async def upsert_experiment_evaluation(
             ).returning(models.ExperimentRunAnnotation)
         )
     evaluation_gid = GlobalID("ExperimentEvaluation", str(exp_eval_run.id))
+    request.state.event_queue.put(ExperimentRunAnnotationInsertEvent((exp_eval_run.id,)))
     return UpsertExperimentEvaluationResponseBody(
         data=UpsertExperimentEvaluationResponseBodyData(id=str(evaluation_gid))
     )

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -11,6 +11,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.models import ExperimentRunOutput
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.dml_event import ExperimentRunInsertEvent
 
 from .pydantic_compat import V1RoutesBaseModel
 from .utils import ResponseBody, add_errors_to_responses
@@ -102,6 +103,7 @@ async def create_experiment_run(
         )
         session.add(exp_run)
         await session.flush()
+    request.state.event_queue.put(ExperimentRunInsertEvent((exp_run.id,)))
     run_gid = GlobalID("ExperimentRun", str(exp_run.id))
     return CreateExperimentResponseBody(data=CreateExperimentRunResponseBodyData(id=str(run_gid)))
 

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -13,6 +13,7 @@ from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.dml_event import ExperimentInsertEvent
 
 from .pydantic_compat import V1RoutesBaseModel
 from .utils import ResponseBody, add_errors_to_responses
@@ -188,6 +189,7 @@ async def create_experiment(
             dataset_version_globalid = GlobalID(
                 "DatasetVersion", str(experiment.dataset_version_id)
             )
+    request.state.event_queue.put(ExperimentInsertEvent((experiment.id,)))
     return CreateExperimentResponseBody(
         data=Experiment(
             id=str(experiment_globalid),

--- a/src/phoenix/server/api/types/Dataset.py
+++ b/src/phoenix/server/api/types/Dataset.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AsyncIterable, List, Optional, Tuple, cast
+from typing import AsyncIterable, ClassVar, List, Optional, Tuple, Type, cast
 
 import strawberry
 from sqlalchemy import and_, func, select
@@ -27,6 +27,7 @@ from phoenix.server.api.types.SortDir import SortDir
 
 @strawberry.type
 class Dataset(Node):
+    _table: ClassVar[Type[models.Base]] = models.Experiment
     id_attr: NodeID[int]
     name: str
     description: Optional[str]
@@ -283,6 +284,10 @@ class Dataset(Node):
                     error_count,
                 ) in await session.stream(query)
             ]
+
+    @strawberry.field
+    def last_updated_at(self, info: Info[Context, None]) -> Optional[datetime]:
+        return info.context.last_updated_at.get(self._table, self.id_attr)
 
 
 def to_gql_dataset(dataset: models.Dataset) -> Dataset:

--- a/src/phoenix/server/api/types/Experiment.py
+++ b/src/phoenix/server/api/types/Experiment.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import ClassVar, List, Optional, Type
 
 import strawberry
 from sqlalchemy import select
@@ -23,6 +23,7 @@ from phoenix.server.api.types.Project import Project
 
 @strawberry.type
 class Experiment(Node):
+    _table: ClassVar[Type[models.Base]] = models.Experiment
     cached_sequence_number: Private[Optional[int]] = None
     id_attr: NodeID[int]
     name: str
@@ -126,6 +127,10 @@ class Experiment(Node):
             gradient_start_color=db_project.gradient_start_color,
             gradient_end_color=db_project.gradient_end_color,
         )
+
+    @strawberry.field
+    def last_updated_at(self, info: Info[Context, None]) -> Optional[datetime]:
+        return info.context.last_updated_at.get(self._table, self.id_attr)
 
 
 def to_gql_experiment(

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -2,8 +2,10 @@ import operator
 from datetime import datetime
 from typing import (
     Any,
+    ClassVar,
     List,
     Optional,
+    Type,
 )
 
 import strawberry
@@ -38,6 +40,7 @@ from phoenix.trace.dsl import SpanFilter
 
 @strawberry.type
 class Project(Node):
+    _table: ClassVar[Type[models.Base]] = models.Project
     id_attr: NodeID[int]
     name: str
     gradient_start_color: str
@@ -397,7 +400,7 @@ class Project(Node):
         self,
         info: Info[Context, None],
     ) -> Optional[datetime]:
-        return info.context.streaming_last_updated_at(self.id_attr)
+        return info.context.last_updated_at.get(self._table, self.id_attr)
 
     @strawberry.field
     async def validate_span_filter_condition(self, condition: str) -> ValidationResult:

--- a/src/phoenix/server/dml_event.py
+++ b/src/phoenix/server/dml_event.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass, field
+from typing import ClassVar, Tuple, Type
+
+from phoenix.db import models
+
+
+@dataclass(frozen=True)
+class DmlEvent(ABC):
+    """
+    Event corresponding to a Data Manipulation Language (DML)
+    operation, e.g. insertion, update, or deletion.
+    """
+
+    table: ClassVar[Type[models.Base]]
+    ids: Tuple[int, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:
+        return bool(self.ids)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+@dataclass(frozen=True)
+class ProjectDmlEvent(DmlEvent):
+    table = models.Project
+
+
+@dataclass(frozen=True)
+class ProjectDeleteEvent(ProjectDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class SpanDmlEvent(ProjectDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class SpanInsertEvent(SpanDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class SpanDeleteEvent(SpanDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class DatasetDmlEvent(DmlEvent):
+    table = models.Dataset
+
+
+@dataclass(frozen=True)
+class DatasetInsertEvent(DatasetDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class DatasetDeleteEvent(DatasetDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentDmlEvent(DmlEvent):
+    table = models.Experiment
+
+
+@dataclass(frozen=True)
+class ExperimentInsertEvent(ExperimentDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentDeleteEvent(ExperimentDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentRunDmlEvent(DmlEvent):
+    table = models.ExperimentRun
+
+
+@dataclass(frozen=True)
+class ExperimentRunInsertEvent(ExperimentRunDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentRunDeleteEvent(ExperimentRunDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentRunAnnotationDmlEvent(DmlEvent):
+    table = models.ExperimentRunAnnotation
+
+
+@dataclass(frozen=True)
+class ExperimentRunAnnotationInsertEvent(ExperimentRunAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class ExperimentRunAnnotationDeleteEvent(ExperimentRunAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class SpanAnnotationDmlEvent(DmlEvent):
+    table = models.SpanAnnotation
+
+
+@dataclass(frozen=True)
+class SpanAnnotationInsertEvent(SpanAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class SpanAnnotationDeleteEvent(SpanAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class TraceAnnotationDmlEvent(DmlEvent):
+    table = models.TraceAnnotation
+
+
+@dataclass(frozen=True)
+class TraceAnnotationInsertEvent(TraceAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class TraceAnnotationDeleteEvent(TraceAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class DocumentAnnotationDmlEvent(DmlEvent):
+    table = models.DocumentAnnotation
+
+
+@dataclass(frozen=True)
+class DocumentAnnotationInsertEvent(DocumentAnnotationDmlEvent): ...
+
+
+@dataclass(frozen=True)
+class DocumentAnnotationDeleteEvent(DocumentAnnotationDmlEvent): ...

--- a/src/phoenix/server/dml_event_handler.py
+++ b/src/phoenix/server/dml_event_handler.py
@@ -236,7 +236,7 @@ class DmlEventHandler:
         db: DbSessionFactory,
         last_updated_at: CanSetLastUpdatedAt,
         cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
-        sleep_seconds: float = 0.01,
+        sleep_seconds: float = 0.1,
     ) -> None:
         kwargs = _HandlerParams(
             db=db,

--- a/src/phoenix/server/dml_event_handler.py
+++ b/src/phoenix/server/dml_event_handler.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from asyncio import gather
+from inspect import getmro
+from itertools import chain
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypedDict,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from sqlalchemy import Select, select
+from typing_extensions import TypeAlias, Unpack
+
+from phoenix.db.models import (
+    Base,
+    DocumentAnnotation,
+    Project,
+    Span,
+    SpanAnnotation,
+    Trace,
+    TraceAnnotation,
+)
+from phoenix.server.api.dataloaders import CacheForDataLoaders
+from phoenix.server.dml_event import (
+    DmlEvent,
+    DocumentAnnotationDmlEvent,
+    SpanAnnotationDmlEvent,
+    SpanDeleteEvent,
+    SpanDmlEvent,
+    TraceAnnotationDmlEvent,
+)
+from phoenix.server.types import (
+    BatchedCaller,
+    CanSetLastUpdatedAt,
+    DbSessionFactory,
+)
+
+_DmlEventT = TypeVar("_DmlEventT", bound=DmlEvent)
+
+
+class _DmlEventQueue(Generic[_DmlEventT]):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._events: Set[_DmlEventT] = set()
+
+    @property
+    def empty(self) -> bool:
+        return not self._events
+
+    def put(self, event: _DmlEventT) -> None:
+        self._events.add(event)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def __iter__(self) -> Iterator[_DmlEventT]:
+        yield from self._events
+
+
+class _HandlerParams(TypedDict):
+    db: DbSessionFactory
+    last_updated_at: CanSetLastUpdatedAt
+    cache_for_dataloaders: Optional[CacheForDataLoaders]
+    sleep_seconds: float
+
+
+class _HasLastUpdatedAt(ABC):
+    def __init__(
+        self,
+        last_updated_at: CanSetLastUpdatedAt,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._last_updated_at = last_updated_at
+
+
+class _HasCacheForDataLoaders(ABC):
+    def __init__(
+        self,
+        cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._cache_for_dataloaders = cache_for_dataloaders
+
+
+class _DmlEventHandler(
+    _HasLastUpdatedAt,
+    _HasCacheForDataLoaders,
+    BatchedCaller[_DmlEventT],
+    Generic[_DmlEventT],
+    ABC,
+):
+    _batch_factory = cast(Callable[[], _DmlEventQueue[_DmlEventT]], _DmlEventQueue)
+
+    def __init__(self, *, db: DbSessionFactory, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._db = db
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class _GenericDmlEventHandler(_DmlEventHandler[DmlEvent]):
+    async def __call__(self) -> None:
+        for e in self._batch:
+            for id_ in e.ids:
+                self._update(e.table, id_)
+
+    def _update(self, table: Type[Base], id_: int) -> None:
+        self._last_updated_at.set(table, id_)
+
+
+class _SpanDmlEventHandler(_DmlEventHandler[SpanDmlEvent]):
+    async def __call__(self) -> None:
+        if cache := self._cache_for_dataloaders:
+            for id_ in set(chain.from_iterable(e.ids for e in self._batch)):
+                self._clear(cache, id_)
+
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int) -> None:
+        cache.latency_ms_quantile.invalidate(project_id)
+        cache.token_count.invalidate(project_id)
+        cache.record_count.invalidate(project_id)
+        cache.min_start_or_max_end_time.invalidate(project_id)
+
+
+class _SpanDeleteEventHandler(_SpanDmlEventHandler):
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int) -> None:
+        cache.annotation_summary.invalidate_project(project_id)
+        cache.evaluation_summary.invalidate_project(project_id)
+        cache.document_evaluation_summary.invalidate_project(project_id)
+
+
+_AnnotationTable: TypeAlias = Union[
+    Type[SpanAnnotation],
+    Type[TraceAnnotation],
+    Type[DocumentAnnotation],
+]
+
+_AnnotationDmlEventT = TypeVar(
+    "_AnnotationDmlEventT",
+    SpanAnnotationDmlEvent,
+    TraceAnnotationDmlEvent,
+    DocumentAnnotationDmlEvent,
+)
+
+
+class _AnnotationDmlEventHandler(
+    _DmlEventHandler[_AnnotationDmlEventT],
+    Generic[_AnnotationDmlEventT],
+    ABC,
+):
+    _table: _AnnotationTable
+    _base_stmt: Union[Select[Tuple[int, str]], Select[Tuple[int]]] = (
+        select(Project.id).join_from(Project, Trace).distinct()
+    )
+
+    def __init__(self, **kwargs: Unpack[_HandlerParams]) -> None:
+        super().__init__(**kwargs)
+        self._stmt = self._base_stmt
+        if self._cache_for_dataloaders:
+            self._stmt = self._stmt.add_columns(self._table.name)
+
+    def _get_stmt(self) -> Union[Select[Tuple[int, str]], Select[Tuple[int]]]:
+        ids = set(chain.from_iterable(e.ids for e in self._batch))
+        return self._stmt.where(self._table.id.in_(ids))
+
+    @staticmethod
+    @abstractmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None: ...
+
+    async def __call__(self) -> None:
+        async with self._db() as session:
+            async for row in await session.stream(self._get_stmt()):
+                if cache := self._cache_for_dataloaders:
+                    self._clear(cache, row.id, row.name)
+
+
+class _SpanAnnotationDmlEventHandler(_AnnotationDmlEventHandler[SpanAnnotationDmlEvent]):
+    _table = SpanAnnotation
+
+    def __init__(self, **kwargs: Unpack[_HandlerParams]) -> None:
+        super().__init__(**kwargs)
+        self._stmt = self._stmt.join_from(Trace, Span).join_from(Span, self._table)
+
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
+        cache.annotation_summary.invalidate((project_id, name, "span"))
+        cache.evaluation_summary.invalidate((project_id, name, "span"))
+
+
+class _TraceAnnotationDmlEventHandler(_AnnotationDmlEventHandler[TraceAnnotationDmlEvent]):
+    _table = TraceAnnotation
+
+    def __init__(self, **kwargs: Unpack[_HandlerParams]) -> None:
+        super().__init__(**kwargs)
+        self._stmt = self._stmt.join_from(Trace, self._table)
+
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
+        cache.annotation_summary.invalidate((project_id, name, "trace"))
+        cache.evaluation_summary.invalidate((project_id, name, "trace"))
+
+
+class _DocumentAnnotationDmlEventHandler(_AnnotationDmlEventHandler[DocumentAnnotationDmlEvent]):
+    _table = DocumentAnnotation
+
+    def __init__(self, **kwargs: Unpack[_HandlerParams]) -> None:
+        super().__init__(**kwargs)
+        self._stmt = self._stmt.join_from(Trace, Span).join_from(Span, self._table)
+
+    @staticmethod
+    def _clear(cache: CacheForDataLoaders, project_id: int, name: str) -> None:
+        cache.document_evaluation_summary.invalidate((project_id, name))
+
+
+class DmlEventHandler:
+    def __init__(
+        self,
+        *,
+        db: DbSessionFactory,
+        last_updated_at: CanSetLastUpdatedAt,
+        cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
+        sleep_seconds: float = 0.01,
+    ) -> None:
+        kwargs = _HandlerParams(
+            db=db,
+            last_updated_at=last_updated_at,
+            cache_for_dataloaders=cache_for_dataloaders,
+            sleep_seconds=sleep_seconds,
+        )
+        self._handlers: Mapping[Type[DmlEvent], Iterable[_DmlEventHandler[Any]]] = {
+            DmlEvent: [_GenericDmlEventHandler(**kwargs)],
+            SpanDmlEvent: [_SpanDmlEventHandler(**kwargs)],
+            SpanDeleteEvent: [_SpanDeleteEventHandler(**kwargs)],
+            SpanAnnotationDmlEvent: [_SpanAnnotationDmlEventHandler(**kwargs)],
+            TraceAnnotationDmlEvent: [_TraceAnnotationDmlEventHandler(**kwargs)],
+            DocumentAnnotationDmlEvent: [_DocumentAnnotationDmlEventHandler(**kwargs)],
+        }
+        self._all_handlers = frozenset(chain.from_iterable(self._handlers.values()))
+
+    async def __aenter__(self) -> None:
+        await gather(*(h.start() for h in self._all_handlers))
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        await gather(*(h.stop() for h in self._all_handlers))
+
+    def put(self, event: DmlEvent) -> None:
+        if not (isinstance(event, DmlEvent) and event):
+            return
+        for cls in getmro(type(event)):
+            if not (issubclass(cls, DmlEvent) and (handlers := self._handlers.get(cls))):
+                continue
+            for h in handlers:
+                h.put(event)
+            if cls is DmlEvent:
+                break

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -1,8 +1,34 @@
-from typing import AsyncContextManager, Callable
+from abc import ABC, abstractmethod
+from asyncio import Task, create_task, sleep
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import (
+    Any,
+    AsyncContextManager,
+    Callable,
+    DefaultDict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Type,
+    TypeVar,
+)
 
+from cachetools import LRUCache
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
+
+
+class CanSetLastUpdatedAt(Protocol):
+    def set(self, table: Type[models.Base], id_: int) -> None: ...
+
+
+class CanGetLastUpdatedAt(Protocol):
+    def get(self, table: Type[models.Base], id_: Optional[int] = None) -> Optional[datetime]: ...
 
 
 class DbSessionFactory:
@@ -16,3 +42,82 @@ class DbSessionFactory:
 
     def __call__(self) -> AsyncContextManager[AsyncSession]:
         return self._db()
+
+
+_AnyT = TypeVar("_AnyT")
+_ItemT_contra = TypeVar("_ItemT_contra", contravariant=True)
+
+
+class CanPutItem(Protocol[_ItemT_contra]):
+    def put(self, item: _ItemT_contra) -> None: ...
+
+
+class _Batch(CanPutItem[_AnyT], Protocol[_AnyT]):
+    @property
+    def empty(self) -> bool: ...
+    def clear(self) -> None: ...
+    def __iter__(self) -> Iterator[_AnyT]: ...
+
+
+class _HasBatch(Generic[_ItemT_contra], ABC):
+    _batch_factory: Callable[[], _Batch[_ItemT_contra]]
+
+    def __init__(self) -> None:
+        self._batch = self._batch_factory()
+
+    def put(self, item: _ItemT_contra) -> None:
+        self._batch.put(item)
+
+
+class BatchedCaller(_HasBatch[_AnyT], Generic[_AnyT], ABC):
+    def __init__(self, *, sleep_seconds: float = 0.1, **kwargs: Any) -> None:
+        assert sleep_seconds > 0
+        super().__init__(**kwargs)
+        self._running = False
+        self._seconds = sleep_seconds
+        self._tasks: List[Task[None]] = []
+
+    async def start(self) -> None:
+        self._running = True
+        if not self._tasks:
+            self._tasks.append(create_task(self._run()))
+
+    async def stop(self) -> None:
+        self._running = False
+        for task in reversed(self._tasks):
+            if not task.done():
+                task.cancel()
+        self._tasks.clear()
+
+    @abstractmethod
+    async def __call__(self) -> None: ...
+
+    async def _run(self) -> None:
+        while self._running:
+            self._tasks.append(create_task(sleep(self._seconds)))
+            await self._tasks[-1]
+            self._tasks.pop()
+            if self._batch.empty:
+                continue
+            self._tasks.append(create_task(self()))
+            await self._tasks[-1]
+            self._tasks.pop()
+            self._batch.clear()
+
+
+class LastUpdatedAt:
+    def __init__(self) -> None:
+        self._cache: DefaultDict[
+            Type[models.Base],
+            LRUCache[int, datetime],
+        ] = defaultdict(lambda: LRUCache(maxsize=100))
+
+    def get(self, table: Type[models.Base], id_: Optional[int] = None) -> Optional[datetime]:
+        if not (cache := self._cache.get(table)):
+            return None
+        if id_ is None:
+            return max(filter(bool, cache.values()), default=None)
+        return cache.get(id_)
+
+    def set(self, table: Type[models.Base], id_: int) -> None:
+        self._cache[table][id_] = datetime.now(timezone.utc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def httpx_clients(
 
         def handle_request(self, request: Request) -> Response:
             fut = loop.create_task(self.handle_async_request(request))
-            time_cutoff = time.time() + 1
+            time_cutoff = time.time() + 10
             while not fut.done() and time.time() < time_cutoff:
                 time.sleep(0.01)
             if fut.done():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ from phoenix.inferences.inferences import EMPTY_INFERENCES
 from phoenix.pointcloud.umap_parameters import get_umap_parameters
 from phoenix.server.app import _db, create_app
 from phoenix.server.grpc_server import GrpcServer
-from phoenix.server.types import DbSessionFactory
+from phoenix.server.types import BatchedCaller, DbSessionFactory
 from phoenix.session.client import Client
 from psycopg import Connection
 from pytest_postgresql import factories
@@ -96,7 +96,6 @@ async def postgresql_engine(postgresql_url: URL) -> AsyncIterator[AsyncEngine]:
     engine = aio_postgresql_engine(postgresql_url, migrate=False)
     async with engine.begin() as conn:
         await conn.run_sync(models.Base.metadata.create_all)
-    engine.echo = True
     yield engine
     await engine.dispose()
 
@@ -111,7 +110,6 @@ async def sqlite_engine() -> AsyncIterator[AsyncEngine]:
     engine = aio_sqlite_engine(make_url("sqlite+aiosqlite://"), migrate=False, shared_cache=False)
     async with engine.begin() as conn:
         await conn.run_sync(models.Base.metadata.create_all)
-    engine.echo = True
     yield engine
     await engine.dispose()
 
@@ -151,6 +149,7 @@ async def app(
     db: DbSessionFactory,
 ) -> AsyncIterator[ASGIApp]:
     async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(patch_sleepy_service())
         await stack.enter_async_context(patch_bulk_inserter())
         await stack.enter_async_context(patch_grpc_server())
         app = create_app(
@@ -245,6 +244,17 @@ async def patch_bulk_inserter() -> AsyncIterator[None]:
     original = cls.__init__
     name = original.__name__
     changes = {"sleep": 0.001, "retry_delay_sec": 0.001, "retry_allowance": 1000}
+    setattr(cls, name, lambda *_, **__: original(*_, **{**__, **changes}))
+    yield
+    setattr(cls, name, original)
+
+
+@contextlib.asynccontextmanager
+async def patch_sleepy_service() -> AsyncIterator[None]:
+    cls = BatchedCaller
+    original = cls.__init__
+    name = original.__name__
+    changes = {"sleep_seconds": 0.001}
     setattr(cls, name, lambda *_, **__: original(*_, **{**__, **changes}))
     yield
     setattr(cls, name, original)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def httpx_clients(
 
         def handle_request(self, request: Request) -> Response:
             fut = loop.create_task(self.handle_async_request(request))
-            time_cutoff = time.time() + 2
+            time_cutoff = time.time() + 10
             while not fut.done() and time.time() < time_cutoff:
                 time.sleep(0.01)
             if fut.done():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def httpx_clients(
 
         def handle_request(self, request: Request) -> Response:
             fut = loop.create_task(self.handle_async_request(request))
-            time_cutoff = time.time() + 1
+            time_cutoff = time.time() + 2
             while not fut.done() and time.time() < time_cutoff:
                 time.sleep(0.01)
             if fut.done():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ async def app(
     db: DbSessionFactory,
 ) -> AsyncIterator[ASGIApp]:
     async with contextlib.AsyncExitStack() as stack:
-        await stack.enter_async_context(patch_sleepy_service())
+        await stack.enter_async_context(patch_batched_caller())
         await stack.enter_async_context(patch_bulk_inserter())
         await stack.enter_async_context(patch_grpc_server())
         app = create_app(
@@ -250,7 +250,7 @@ async def patch_bulk_inserter() -> AsyncIterator[None]:
 
 
 @contextlib.asynccontextmanager
-async def patch_sleepy_service() -> AsyncIterator[None]:
+async def patch_batched_caller() -> AsyncIterator[None]:
     cls = BatchedCaller
     original = cls.__init__
     name = original.__name__

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def httpx_clients(
 
         def handle_request(self, request: Request) -> Response:
             fut = loop.create_task(self.handle_async_request(request))
-            time_cutoff = time.time() + 10
+            time_cutoff = time.time() + 1
             while not fut.done() and time.time() < time_cutoff:
                 time.sleep(0.01)
             if fut.done():

--- a/tests/server/api/routers/v1/test_annotations.py
+++ b/tests/server/api/routers/v1/test_annotations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from asyncio import gather, sleep
 from datetime import datetime, timezone
 from functools import partial
@@ -28,6 +29,7 @@ from phoenix.trace import DocumentEvaluations, Evaluations, SpanEvaluations, Tra
 from typing_extensions import TypeAlias, assert_never
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="unknown")
 class TestSendingAnnotationsBeforeSpans:
     async def test_sending_annotations_before_spans(
         self,

--- a/tests/server/api/routers/v1/test_annotations.py
+++ b/tests/server/api/routers/v1/test_annotations.py
@@ -1,124 +1,442 @@
+from __future__ import annotations
+
 from asyncio import gather, sleep
-from itertools import chain
-from typing import Any, Awaitable, Callable, Iterator, List, Union, cast, get_args
+from datetime import datetime, timezone
+from functools import partial
+from itertools import product
+from operator import gt, lt
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Set,
+    Union,
+    cast,
+    get_args,
+)
 
 import pandas as pd
+import pytest
 from faker import Faker
+from httpx import AsyncClient
 from phoenix import Client, TraceDataset
-from phoenix.trace import DocumentEvaluations, SpanEvaluations, TraceEvaluations
+from phoenix.trace import DocumentEvaluations, Evaluations, SpanEvaluations, TraceEvaluations
 from typing_extensions import TypeAlias, assert_never
+
+
+class TestSendingAnnotationsBeforeSpans:
+    async def test_sending_annotations_before_spans(
+        self,
+        send_annotations: Callable[[float], Awaitable[None]],
+        send_spans: Callable[[], Awaitable[None]],
+        clear_all_projects: Callable[[], Awaitable[None]],
+        assert_no_evals: Callable[[], Awaitable[None]],
+        assert_no_summaries: Callable[[], Awaitable[None]],
+        assert_eval_scores: Callable[[float], Awaitable[None]],
+        assert_mean_scores: Callable[[float], Awaitable[None]],
+        assert_last_updated_at: Callable[
+            [Callable[[datetime, datetime], bool], datetime],
+            Awaitable[None],
+        ],
+    ) -> None:
+        await send_annotations(0)
+        await assert_no_evals()
+        await assert_no_summaries()
+        t = datetime.now(timezone.utc)
+        await send_spans()
+        await sleep(0.2)
+        await assert_last_updated_at(gt, t)
+        await assert_eval_scores(0)
+        await assert_mean_scores(0)
+        score_offset = 10
+        await send_annotations(score_offset)
+        await sleep(0.2)
+        await assert_eval_scores(score_offset)
+        await assert_mean_scores(score_offset)
+        t = datetime.now(timezone.utc)
+        await assert_last_updated_at(lt, t)
+        await clear_all_projects()
+        await sleep(0.2)
+        await assert_last_updated_at(gt, t)
+        await assert_no_evals()
+        await assert_no_summaries()
+
+    @staticmethod
+    async def _last_updated_at(
+        project_names: List[str],
+        httpx_client: AsyncClient,
+    ) -> Dict[str, datetime]:
+        q = "query{projects{edges{node{name streamingLastUpdatedAt}}}}"
+        resp = await httpx_client.post("/graphql", json=dict(query=q))
+        assert resp.status_code == 200
+        resp_json = resp.json()
+        assert not resp_json.get("errors")
+        return {
+            edge["node"]["name"]: datetime.fromisoformat(edge["node"]["streamingLastUpdatedAt"])
+            for edge in resp_json["data"]["projects"]["edges"]
+            if edge["node"]["name"] in project_names and edge["node"]["streamingLastUpdatedAt"]
+        }
+
+    @staticmethod
+    async def _mean_scores(
+        httpx_client: AsyncClient,
+        summary: _Summary,
+        project_names: List[str],
+        *names: str,
+    ) -> Dict[str, Dict[str, float]]:
+        ans = {}
+        for name in names:
+            q = "query{projects{edges{node{name " + f'{summary}Name:"{name}"' + "){meanScore}}}}}"
+            resp = await httpx_client.post("/graphql", json=dict(query=q))
+            assert resp.status_code == 200
+            resp_json = resp.json()
+            assert not resp_json.get("errors")
+            ans[name] = {
+                edge["node"]["name"]: edge["node"][summary.split("(")[0]]["meanScore"]
+                for edge in resp_json["data"]["projects"]["edges"]
+                if edge["node"]["name"] in project_names
+                and edge["node"][summary.split("(")[0]] is not None
+            }
+        return ans
+
+    @pytest.fixture
+    async def clear_all_projects(
+        self,
+        httpx_client: AsyncClient,
+    ) -> None:
+        async def _() -> None:
+            q = "query{projects{edges{node{id}}}}"
+            resp = await httpx_client.post("/graphql", json=dict(query=q))
+            assert resp.status_code == 200
+            resp_json = resp.json()
+            assert not resp_json.get("errors")
+            for edge in resp_json["data"]["projects"]["edges"]:
+                id_ = edge["node"]["id"]
+                m = "mutation{clearProject(input:{id:" + f'"{id_}"' + "}){__typename}}"
+                resp = await httpx_client.post("/graphql", json=dict(query=m))
+                assert resp.status_code == 200
+                assert not resp.json().get("errors")
+
+        return _
+
+    @pytest.fixture
+    def send_spans(
+        self,
+        traces: Dict[str, TraceDataset],
+        project_names: List[str],
+        px_client: Client,
+        acall: Callable[..., Awaitable[Any]],
+    ) -> Callable[[], Awaitable[None]]:
+        log_traces = (
+            acall(px_client.log_traces, traces[project_name], project_name)
+            for project_name in project_names
+        )
+
+        async def _() -> None:
+            await gather(*log_traces)
+
+        return _
+
+    @pytest.fixture
+    def send_annotations(
+        self,
+        project_names: List[str],
+        eval_names: List[str],
+        anno_names: List[str],
+        rand_span_id: Iterator[str],
+        rand_trace_id: Iterator[str],
+        span_ids: Dict[str, List[str]],
+        trace_ids: Dict[str, List[str]],
+        traces: Dict[str, TraceDataset],
+        px_client: Client,
+        httpx_client: AsyncClient,
+        acall: Callable[..., Awaitable[Any]],
+        fake: Faker,
+        size: int,
+    ) -> Callable[[float], Awaitable[None]]:
+        def span_evaluations(s: float) -> Iterator[Dict[str, Any]]:
+            for project_name in project_names:
+                for j, span_id in enumerate(span_ids[project_name]):
+                    yield dict(score=j + s, span_id=next(rand_span_id))
+                    yield dict(score=j + s, span_id=span_id)
+
+        def trace_evaluations(s: float) -> Iterator[Dict[str, Any]]:
+            for project_name in project_names:
+                for j, trace_id in enumerate(trace_ids[project_name]):
+                    yield dict(score=j + s, trace_id=next(rand_trace_id))
+                    yield dict(score=j + s, trace_id=trace_id)
+
+        def document_evaluations(s: float) -> Iterator[Dict[str, Any]]:
+            for project_name in project_names:
+                for j, span_id in enumerate(span_ids[project_name]):
+                    yield dict(score=j + s, span_id=next(rand_span_id), position=0)
+                    yield dict(score=j + s, span_id=span_id, position=0)
+                    yield dict(score=j + s, span_id=span_id, position=-1)
+                    yield dict(score=j + s, span_id=span_id, position=999_999_999)
+
+        def evaluations(s: float) -> Iterator[Evaluations]:
+            for name, (cls, fn) in product(
+                eval_names,
+                zip(
+                    (SpanEvaluations, TraceEvaluations, DocumentEvaluations),
+                    (span_evaluations, trace_evaluations, document_evaluations),
+                ),
+            ):
+                yield cls(name, pd.DataFrame(fn(s)).sample(frac=1))
+
+        def kwargs(name: str, s: float) -> Dict[str, Any]:
+            return dict(annotator_kind="HUMAN", metadata={}, name=name, result=dict(score=s))
+
+        def span_annotations(s: float) -> Iterator[Dict[str, Any]]:
+            for name, project_name in product(anno_names, project_names):
+                for j, span_id in enumerate(span_ids[project_name]):
+                    yield dict(span_id=next(rand_span_id), **kwargs(name, j + s))
+                    yield dict(span_id=span_id, **kwargs(name, j + s))
+
+        def trace_annotations(s: float) -> Iterator[Dict[str, Any]]:
+            for name, project_name in product(anno_names, project_names):
+                for j, trace_id in enumerate(trace_ids[project_name]):
+                    yield dict(trace_id=next(rand_trace_id), **kwargs(name, j + s))
+                    yield dict(trace_id=trace_id, **kwargs(name, j + s))
+
+        async def _(score_offset: float = 0) -> None:
+            for i in range(size - 1, -1, -1):
+                s = i * fake.pyfloat() + score_offset
+                await gather(
+                    sleep(0.01),
+                    acall(px_client.log_evaluations, *evaluations(s)),
+                    httpx_client.post(
+                        "v1/span_annotations?sync=false",
+                        json=dict(data=list(span_annotations(s))),
+                    ),
+                    httpx_client.post(
+                        "v1/trace_annotations?sync=false",
+                        json=dict(data=list(trace_annotations(s))),
+                    ),
+                )
+
+        return _
+
+    @pytest.fixture
+    def assert_last_updated_at(
+        self,
+        project_names: List[str],
+        httpx_client: AsyncClient,
+    ) -> Callable[[datetime], Awaitable[None]]:
+        async def _(compare: Callable[[datetime, datetime], bool], t: datetime) -> None:
+            projects = await self._last_updated_at(project_names, httpx_client)
+            for project_name in project_names:
+                assert (last_updated_at := projects.get(project_name))
+                assert compare(last_updated_at, t)
+
+        return _
+
+    @pytest.fixture
+    def assert_evals(
+        self,
+        project_names: List[str],
+        eval_names: List[str],
+        anno_names: List[str],
+        span_ids: Dict[str, List[str]],
+        trace_ids: Dict[str, List[str]],
+        traces: Dict[str, TraceDataset],
+        px_client: Client,
+        acall: Callable[..., Awaitable[Any]],
+        size: int,
+    ) -> Callable[[bool, float], Awaitable[None]]:
+        async def _(exist: bool, score_offset: float = 0) -> None:
+            get_evaluations = (
+                cast(List[_Evals], acall(px_client.get_evaluations, project_name))
+                for project_name in project_names
+            )
+            evals = dict(zip(project_names, await gather(*get_evaluations)))
+            for project_name in project_names:
+                if not exist:
+                    assert not evals.get(project_name)
+                    continue
+                assert len(evals[project_name]) == len(eval_names) * len(get_args(_Evals))
+                for e in evals[project_name]:
+                    assert e.eval_name in eval_names
+                    df = e.dataframe.sort_index()
+                    assert len(df) == size
+                    assert (df.score - score_offset).to_list() == list(range(size))
+                    ids = df.index.to_list()
+                    if isinstance(e, SpanEvaluations):
+                        assert ids == span_ids[project_name]
+                    elif isinstance(e, TraceEvaluations):
+                        assert ids == trace_ids[project_name]
+                    elif isinstance(e, DocumentEvaluations):
+                        assert ids == [(span_id, 0) for span_id in span_ids[project_name]]
+                    else:
+                        assert_never(e)
+
+        return _
+
+    @pytest.fixture
+    def assert_no_evals(
+        self,
+        assert_evals: Callable[[bool, float], Awaitable[None]],
+    ) -> Callable[[float], Awaitable[None]]:
+        return partial(assert_evals, False)
+
+    @pytest.fixture
+    def assert_eval_scores(
+        self,
+        assert_evals: Callable[[bool, float], Awaitable[None]],
+    ) -> Callable[[float], Awaitable[None]]:
+        return partial(assert_evals, True)
+
+    @pytest.fixture
+    def assert_summaries(
+        self,
+        project_names: List[str],
+        eval_names: List[str],
+        anno_names: List[str],
+        span_ids: Dict[str, List[str]],
+        trace_ids: Dict[str, List[str]],
+        traces: Dict[str, TraceDataset],
+        px_client: Client,
+        acall: Callable[..., Awaitable[Any]],
+        httpx_client: AsyncClient,
+        mean_score: float,
+    ) -> Callable[[bool, float], Awaitable[None]]:
+        async def _(exist: bool, score_offset: float = 0) -> None:
+            expected = mean_score + score_offset
+            for summaries, names in ((anno_summaries, anno_names), (eval_summaries, eval_names)):
+                for summary in summaries:
+                    mean_scores = await self._mean_scores(
+                        httpx_client, summary, project_names, *names
+                    )
+                    for name in names:
+                        if not exist:
+                            assert not mean_scores.get(name)
+                            continue
+                        assert (projects := mean_scores.get(name))
+                        assert len(projects) == len(project_names)
+                        for project_name in project_names:
+                            actual = projects[project_name]
+                            assert actual == expected
+
+        return _
+
+    @pytest.fixture
+    def assert_mean_scores(
+        self,
+        assert_summaries: Callable[[bool, int], Awaitable[None]],
+    ) -> Callable[[float], Awaitable[None]]:
+        return partial(assert_summaries, True)
+
+    @pytest.fixture
+    def assert_no_summaries(
+        self,
+        assert_summaries: Callable[[bool, int], Awaitable[None]],
+    ) -> Callable[[float], Awaitable[None]]:
+        return partial(assert_summaries, False)
+
+    @pytest.fixture
+    def rand_str(self, fake: Faker) -> Iterator[str]:
+        def _(seen: Set[str]) -> Iterator[str]:
+            while True:
+                if (name := fake.pystr()) not in seen:
+                    seen.add(name)
+                    yield name
+
+        return _(set())
+
+    @pytest.fixture
+    def project_names(self, rand_str: Iterator[str], size: int) -> List[str]:
+        return [f"proj_{next(rand_str)}" for _ in range(size)]
+
+    @pytest.fixture
+    def eval_names(self, rand_str: Iterator[str], size: int) -> List[str]:
+        return [f"eval_{next(rand_str)}" for _ in range(size)]
+
+    @pytest.fixture
+    def anno_names(self, rand_str: Iterator[str], size: int) -> List[str]:
+        return [f"anno_{next(rand_str)}" for _ in range(size)]
+
+    @pytest.fixture
+    async def span(
+        self,
+        px_client: Client,
+        acall: Callable[..., Awaitable[Any]],
+        span_data_with_documents: Any,
+    ) -> pd.DataFrame:
+        return cast(pd.DataFrame, await acall(px_client.get_spans_dataframe)).iloc[:1]
+
+    @pytest.fixture
+    def span_ids(
+        self,
+        rand_span_id: Iterator[str],
+        project_names: List[str],
+        size: int,
+    ) -> Dict[str, List[str]]:
+        return {
+            project_name: sorted(next(rand_span_id) for _ in range(size))
+            for project_name in project_names
+        }
+
+    @pytest.fixture
+    def trace_ids(
+        self,
+        rand_trace_id: Iterator[str],
+        project_names: List[str],
+        size: int,
+    ) -> Dict[str, List[str]]:
+        return {
+            project_name: sorted(next(rand_trace_id) for _ in range(size))
+            for project_name in project_names
+        }
+
+    @pytest.fixture
+    def traces(
+        self,
+        span: pd.DataFrame,
+        span_ids: Dict[str, List[str]],
+        trace_ids: Dict[str, List[str]],
+        project_names: List[str],
+    ) -> Dict[str, TraceDataset]:
+        assert len(span) == 1
+        return {
+            project_name: TraceDataset(
+                pd.concat(
+                    [
+                        span.assign(**{"context.span_id": span_id, "context.trace_id": trace_id})
+                        for span_id, trace_id in zip(
+                            span_ids[project_name], trace_ids[project_name]
+                        )
+                    ]
+                ).set_index("context.span_id", drop=False)
+            )
+            for project_name in project_names
+        }
+
+    @pytest.fixture
+    def mean_score(self, size: int) -> float:
+        return sum(range(size)) / size
+
+    @pytest.fixture
+    def size(self) -> int:
+        return 3
+
 
 _Evals: TypeAlias = Union[SpanEvaluations, TraceEvaluations, DocumentEvaluations]
 
-
-async def test_sending_evaluations_before_span(
-    px_client: Client,
-    span_data_with_documents: Any,
-    acall: Callable[..., Awaitable[Any]],
-    fake: Faker,
-    rand_span_id: Iterator[str],
-    rand_trace_id: Iterator[str],
-) -> None:
-    size = 3
-    eval_names = [fake.pystr() for _ in range(size)]
-    project_names = [fake.pystr() for _ in range(size)]
-    span = cast(pd.DataFrame, await acall(px_client.get_spans_dataframe)).iloc[:1]
-    span_ids, trace_ids, traces = {}, {}, {}
-    for project_name in project_names:
-        span_ids[project_name] = sorted(next(rand_span_id) for _ in range(size))
-        trace_ids[project_name] = sorted(next(rand_trace_id) for _ in range(size))
-        traces[project_name] = pd.concat(
-            [
-                span.assign(**{"context.span_id": span_id, "context.trace_id": trace_id})
-                for span_id, trace_id in zip(span_ids[project_name], trace_ids[project_name])
-            ]
-        ).set_index("context.span_id", drop=False)
-    for i in range(size - 1, -1, -1):
-        s = i * fake.pyfloat()
-        await gather(
-            sleep(0.001),
-            *(
-                acall(
-                    px_client.log_evaluations,
-                    SpanEvaluations(
-                        eval_name,
-                        pd.DataFrame(
-                            chain.from_iterable(
-                                [
-                                    dict(score=j + s, span_id=next(rand_span_id)),
-                                    dict(score=j + s, span_id=span_id),
-                                ]
-                                for j, span_id in enumerate(span_ids[project_name])
-                            )
-                        ).sample(frac=1),
-                    ),
-                    TraceEvaluations(
-                        eval_name,
-                        pd.DataFrame(
-                            chain.from_iterable(
-                                [
-                                    dict(score=j + s, trace_id=next(rand_trace_id)),
-                                    dict(score=j + s, trace_id=trace_id),
-                                ]
-                                for j, trace_id in enumerate(trace_ids[project_name])
-                            )
-                        ).sample(frac=1),
-                    ),
-                    DocumentEvaluations(
-                        eval_name,
-                        pd.DataFrame(
-                            chain.from_iterable(
-                                [
-                                    dict(score=j + s, span_id=next(rand_span_id), position=0),
-                                    dict(score=j + s, span_id=span_id, position=0),
-                                    dict(score=j + s, span_id=span_id, position=-1),
-                                    dict(score=j + s, span_id=span_id, position=999_999_999),
-                                ]
-                                for j, span_id in enumerate(span_ids[project_name])
-                            )
-                        ).sample(frac=1),
-                    ),
-                )
-                for eval_name in eval_names
-                for project_name in project_names
-            ),
-        )
-    await gather(
-        sleep(1),
-        *(
-            acall(
-                px_client.log_traces,
-                TraceDataset(traces[project_name]),
-                project_name=project_name,
-            )
-            for project_name in project_names
-        ),
-    )
-    evals = dict(
-        zip(
-            project_names,
-            cast(
-                List[List[_Evals]],
-                await gather(
-                    *(
-                        acall(px_client.get_evaluations, project_name=project_name)
-                        for project_name in project_names
-                    )
-                ),
-            ),
-        )
-    )
-    for project_name in project_names:
-        assert len(evals[project_name]) == len(eval_names) * len(get_args(_Evals))
-        for e in evals[project_name]:
-            df = e.dataframe.sort_index()
-            assert len(df) == size
-            assert df.score.to_list() == list(range(size))
-            if isinstance(e, SpanEvaluations):
-                assert df.index.to_list() == span_ids[project_name]
-            elif isinstance(e, TraceEvaluations):
-                assert df.index.to_list() == trace_ids[project_name]
-            elif isinstance(e, DocumentEvaluations):
-                assert df.index.to_list() == [(span_id, 0) for span_id in span_ids[project_name]]
-            else:
-                assert_never(e)
+_Summary: TypeAlias = Literal[
+    "spanAnnotationSummary(annotation",
+    "traceAnnotationSummary(annotation",
+    "spanEvaluationSummary(evaluation",
+    "traceEvaluationSummary(evaluation",
+]
+eval_summaries: List[_Summary] = [
+    "spanEvaluationSummary(evaluation",
+    "traceEvaluationSummary(evaluation",
+]
+anno_summaries: List[_Summary] = [
+    "spanAnnotationSummary(annotation",
+    "traceAnnotationSummary(annotation",
+]

--- a/tests/server/api/routers/v1/test_annotations.py
+++ b/tests/server/api/routers/v1/test_annotations.py
@@ -29,7 +29,7 @@ from phoenix.trace import DocumentEvaluations, Evaluations, SpanEvaluations, Tra
 from typing_extensions import TypeAlias, assert_never
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="unknown")
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="CI fails for unknown reason")
 class TestSendingAnnotationsBeforeSpans:
     async def test_sending_annotations_before_spans(
         self,

--- a/tests/server/api/routers/v1/test_annotations.py
+++ b/tests/server/api/routers/v1/test_annotations.py
@@ -209,7 +209,6 @@ class TestSendingAnnotationsBeforeSpans:
             for i in range(size - 1, -1, -1):
                 s = i * fake.pyfloat() + score_offset
                 await gather(
-                    sleep(0.01),
                     acall(px_client.log_evaluations, *evaluations(s)),
                     httpx_client.post(
                         "v1/span_annotations?sync=false",
@@ -220,6 +219,7 @@ class TestSendingAnnotationsBeforeSpans:
                         json=dict(data=list(trace_annotations(s))),
                     ),
                 )
+                await sleep(0.01)
 
         return _
 

--- a/tests/server/api/routers/v1/test_annotations.py
+++ b/tests/server/api/routers/v1/test_annotations.py
@@ -280,8 +280,8 @@ class TestSendingAnnotationsBeforeSpans:
     def assert_no_evals(
         self,
         assert_evals: Callable[[bool, float], Awaitable[None]],
-    ) -> Callable[[float], Awaitable[None]]:
-        return partial(assert_evals, False)
+    ) -> Callable[[], Awaitable[None]]:
+        return partial(assert_evals, False, 0)
 
     @pytest.fixture
     def assert_eval_scores(
@@ -334,8 +334,8 @@ class TestSendingAnnotationsBeforeSpans:
     def assert_no_summaries(
         self,
         assert_summaries: Callable[[bool, int], Awaitable[None]],
-    ) -> Callable[[float], Awaitable[None]]:
-        return partial(assert_summaries, False)
+    ) -> Callable[[], Awaitable[None]]:
+        return partial(assert_summaries, False, 0)
 
     @pytest.fixture
     def rand_str(self, fake: Faker) -> Iterator[str]:


### PR DESCRIPTION
resolves #4121 

This PR implements an internal event handling system for database events. Each handler handles events in batches, sleeping briefly between each batch. Events are generated by graphql mutations, REST API endpoints for insertions and deletions, as well as the bulk inserter for span and annotation ingestion.

One of the event handlers maintains the `last_updated_at` cache. This is used by the UI for automatic page refresh. Right now only the project page (with the traces and spans tables) gets refreshed automatically. After this PR, other pages that can also implement auto-refresh include projects overview, datasets overview, and experiment runs overview.

Other event handlers maintain the `cache_for_dataloaders`, which is currently only used by SQLite.

