### PR TITLE
fix: ensure span annotations appear in sorted order by name

### DIFF
--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -194,8 +194,8 @@ class Span(Node):
     ) -> List[SpanAnnotation]:
         span_id = self.id_attr
         annotations = await info.context.data_loaders.span_annotations.load(span_id)
-        sort_key = SpanAnnotationColumn.createdAt.value
-        sort_descending = True
+        sort_key = SpanAnnotationColumn.name.value
+        sort_descending = False
         if sort:
             sort_key = sort.col.value
             sort_descending = sort.dir is SortDir.desc


### PR DESCRIPTION
resolves #4143

![Screenshot 2024-08-06 at 9 09 12 AM](https://github.com/user-attachments/assets/cbf90317-5c01-411b-a749-3b879a9e9017)
