### PR TITLE
feat(ui): add trace tree controls

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.7.0",
+    "@arizeai/components": "^1.8.0",
     "@arizeai/openinference-semantic-conventions": "^0.8.0",
     "@arizeai/point-cloud": "^3.0.6",
     "@codemirror/autocomplete": "6.12.0",
@@ -86,7 +86,7 @@
     "build:static": "cpy ./static ../src/phoenix/server",
     "build:relay": "relay-compiler",
     "test": "jest --config ./jest.config.js",
-    "dev": "pnpm run dev:server & pnpm run build:static && pnpm run build:relay && vite",
+    "dev": "pnpm run dev:server:demo & pnpm run build:static && pnpm run build:relay && vite",
     "dev:ui": "pnpm run build:static && pnpm run build:relay && vite",
     "dev:server:mnist": "python3 -m phoenix.server.main --dev --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main --dev fixture fashion_mnist --primary-only true",

--- a/app/package.json
+++ b/app/package.json
@@ -86,7 +86,7 @@
     "build:static": "cpy ./static ../src/phoenix/server",
     "build:relay": "relay-compiler",
     "test": "jest --config ./jest.config.js",
-    "dev": "pnpm run dev:server:demo & pnpm run build:static && pnpm run build:relay && vite",
+    "dev": "pnpm run dev:server & pnpm run build:static && pnpm run build:relay && vite",
     "dev:ui": "pnpm run build:static && pnpm run build:relay && vite",
     "dev:server:mnist": "python3 -m phoenix.server.main --dev --umap_params 0,30,550 fixture fashion_mnist",
     "dev:server:mnist:single": "python3 -m phoenix.server.main --dev fixture fashion_mnist --primary-only true",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -9,8 +9,8 @@ overrides:
 
 dependencies:
   '@arizeai/components':
-    specifier: ^1.7.0
-    version: 1.7.0(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^1.8.0
+    version: 1.8.0(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)
   '@arizeai/openinference-semantic-conventions':
     specifier: ^0.8.0
     version: 0.8.0
@@ -234,8 +234,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@arizeai/components@1.7.0(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-825UkeDQB8NhuZNJ+jNTJJOzQJOuPFEPvrhBT11ooBwRVJ4UhzzN0QOxtkuM1AjtnHGlW7sAY5cIlpqTHZOX4g==}
+  /@arizeai/components@1.8.0(@types/react@18.2.48)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-taBLtaUo+0Dc1Q7FnS6hdLAqbzlJumFqIYGAHtONHGb4BWyNUa4vC0CUNvUlrIRIpumQQeBbmMqqloCxJLqutQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=18'

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -12,6 +12,8 @@ import {
   Flex,
   Icon,
   Icons,
+  Tooltip,
+  TooltipTrigger,
   View,
 } from "@arizeai/components";
 
@@ -86,48 +88,62 @@ function TraceTreeToolbar() {
   return (
     <View borderBottomWidth="thin" borderColor="dark" padding="size-100">
       <Flex direction="row" justifyContent="end" flex="none" gap="size-100">
-        <Button
-          variant="default"
-          size="compact"
-          aria-label={isCollapsed ? "Expand all" : "Collapse all"}
-          onClick={() => {
-            setIsCollapsed(!isCollapsed);
-          }}
-          icon={
-            <Icon
-              svg={
-                isCollapsed ? (
-                  <Icons.RowCollapseOutline />
-                ) : (
-                  <Icons.RowExpandOutline />
-                )
-              }
-            />
-          }
-        />
-        <Button
-          variant="default"
-          size="compact"
-          aria-label={
-            showMetricsInTraceTree
+        <TooltipTrigger offset={5}>
+          <Button
+            variant="default"
+            size="compact"
+            aria-label={isCollapsed ? "Expand all" : "Collapse all"}
+            onClick={() => {
+              setIsCollapsed(!isCollapsed);
+            }}
+            icon={
+              <Icon
+                svg={
+                  isCollapsed ? (
+                    <Icons.RowCollapseOutline />
+                  ) : (
+                    <Icons.RowExpandOutline />
+                  )
+                }
+              />
+            }
+          />
+          <Tooltip>
+            {isCollapsed
+              ? "Expand all nested spans"
+              : "Collapse all nested spans"}
+          </Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger offset={5}>
+          <Button
+            variant="default"
+            size="compact"
+            aria-label={
+              showMetricsInTraceTree
+                ? "Hide metrics in trace tree"
+                : "Show metrics in trace tree"
+            }
+            onClick={() => {
+              setShowMetricsInTraceTree(!showMetricsInTraceTree);
+            }}
+            icon={
+              <Icon
+                svg={
+                  showMetricsInTraceTree ? (
+                    <Icons.TimerOutline />
+                  ) : (
+                    <Icons.TimerOffOutline />
+                  )
+                }
+              />
+            }
+          />
+          <Tooltip>
+            {showMetricsInTraceTree
               ? "Hide metrics in trace tree"
-              : "Show metrics in trace tree"
-          }
-          onClick={() => {
-            setShowMetricsInTraceTree(!showMetricsInTraceTree);
-          }}
-          icon={
-            <Icon
-              svg={
-                showMetricsInTraceTree ? (
-                  <Icons.TimerOutline />
-                ) : (
-                  <Icons.TimerOffOutline />
-                )
-              }
-            />
-          }
-        />
+              : "Show metrics in trace tree"}
+          </Tooltip>
+        </TooltipTrigger>
       </Flex>
     </View>
   );

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -1,13 +1,27 @@
-import React, { PropsWithChildren, startTransition, useState } from "react";
+import React, {
+  PropsWithChildren,
+  startTransition,
+  useEffect,
+  useState,
+} from "react";
 import { css } from "@emotion/react";
 
-import { classNames, Flex, Icon, Icons } from "@arizeai/components";
+import {
+  Button,
+  classNames,
+  Flex,
+  Icon,
+  Icons,
+  View,
+} from "@arizeai/components";
 
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 import { LatencyText } from "./LatencyText";
 import { SpanKindIcon } from "./SpanKindIcon";
 import { SpanStatusCodeIcon } from "./SpanStatusCodeIcon";
+import { TraceTreeProvider, useTraceTree } from "./TraceTreeContext";
 import { ISpanItem, SpanStatusCodeType } from "./types";
 import { createSpanTree, SpanTreeNode } from "./utils";
 
@@ -26,23 +40,96 @@ export function TraceTree(props: TraceTreeProps) {
   const { spans, onSpanClick, selectedSpanNodeId } = props;
   const spanTree = createSpanTree(spans);
   return (
-    <ul
-      css={css`
-        display: flex;
-        flex-direction: column;
-        width: 100%;
-        min-width: 300px;
-      `}
-    >
-      {spanTree.map((spanNode) => (
-        <SpanTreeItem
-          key={spanNode.span.id}
-          node={spanNode}
-          onSpanClick={onSpanClick}
-          selectedSpanNodeId={selectedSpanNodeId}
+    <TraceTreeProvider>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+          height: 100%;
+          align-items: stretch;
+        `}
+      >
+        <TraceTreeToolbar />
+        <ul
+          css={css`
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            overflow: auto;
+          `}
+          data-testid="trace-tree"
+        >
+          {spanTree.map((spanNode) => (
+            <SpanTreeItem
+              key={spanNode.span.id}
+              node={spanNode}
+              onSpanClick={onSpanClick}
+              selectedSpanNodeId={selectedSpanNodeId}
+            />
+          ))}
+        </ul>
+      </div>
+    </TraceTreeProvider>
+  );
+}
+
+function TraceTreeToolbar() {
+  const showMetricsInTraceTree = usePreferencesContext(
+    (state) => state.showMetricsInTraceTree
+  );
+  const setShowMetricsInTraceTree = usePreferencesContext(
+    (state) => state.setShowMetricsInTraceTree
+  );
+  const { isCollapsed, setIsCollapsed } = useTraceTree();
+  return (
+    <View borderBottomWidth="thin" borderColor="dark" padding="size-100">
+      <Flex direction="row" justifyContent="end" flex="none" gap="size-100">
+        <Button
+          variant="default"
+          size="compact"
+          aria-label={isCollapsed ? "Expand all" : "Collapse all"}
+          onClick={() => {
+            setIsCollapsed(!isCollapsed);
+          }}
+          icon={
+            <Icon
+              svg={
+                isCollapsed ? (
+                  <Icons.RowCollapseOutline />
+                ) : (
+                  <Icons.RowExpandOutline />
+                )
+              }
+            />
+          }
         />
-      ))}
-    </ul>
+        <Button
+          variant="default"
+          size="compact"
+          aria-label={
+            showMetricsInTraceTree
+              ? "Hide metrics in trace tree"
+              : "Show metrics in trace tree"
+          }
+          onClick={() => {
+            setShowMetricsInTraceTree(!showMetricsInTraceTree);
+          }}
+          icon={
+            <Icon
+              svg={
+                showMetricsInTraceTree ? (
+                  <Icons.TimerOutline />
+                ) : (
+                  <Icons.TimerOffOutline />
+                )
+              }
+            />
+          }
+        />
+      </Flex>
+    </View>
   );
 }
 
@@ -68,7 +155,17 @@ function SpanTreeItem<TSpan extends ISpanItem>(props: {
   const { node, selectedSpanNodeId, onSpanClick, nestingLevel = 0 } = props;
   const childNodes = node.children;
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { isCollapsed: treeIsCollapsed } = useTraceTree();
   const hasChildren = childNodes.length > 0;
+  const showMetricsInTraceTree = usePreferencesContext(
+    (state) => state.showMetricsInTraceTree
+  );
+
+  // React to global changes to the trace tree state and change local state
+  useEffect(() => {
+    setIsCollapsed(treeIsCollapsed);
+  }, [treeIsCollapsed]);
+
   const {
     name,
     latencyMs,
@@ -83,6 +180,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(props: {
         className="button--reset"
         css={css`
           width: 100%;
+          min-width: 200px;
           cursor: pointer;
         `}
         onClick={() => {
@@ -110,16 +208,16 @@ function SpanTreeItem<TSpan extends ISpanItem>(props: {
             {statusCode === "ERROR" ? (
               <SpanStatusCodeIcon statusCode="ERROR" />
             ) : null}
-            {typeof tokenCountTotal === "number" ? (
+            {typeof tokenCountTotal === "number" && showMetricsInTraceTree ? (
               <TokenCount
                 tokenCountTotal={tokenCountTotal}
                 tokenCountPrompt={tokenCountPrompt ?? 0}
                 tokenCountCompletion={tokenCountCompletion ?? 0}
               />
             ) : null}
-            {latencyMs === null ? null : (
+            {latencyMs != null && showMetricsInTraceTree ? (
               <LatencyText latencyMs={latencyMs} showIcon={false} />
-            )}
+            ) : null}
           </Flex>
           <div css={spanControlsCSS} data-testid="span-controls">
             {hasChildren ? (

--- a/app/src/components/trace/TraceTreeContext.tsx
+++ b/app/src/components/trace/TraceTreeContext.tsx
@@ -1,0 +1,40 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  startTransition,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+export type TraceTreeContextType = {
+  isCollapsed: boolean;
+  setIsCollapsed: (theme: boolean) => void;
+};
+
+export const TraceTreeConnext = createContext<TraceTreeContextType | null>(
+  null
+);
+
+export function useTraceTree() {
+  const context = useContext(TraceTreeConnext);
+  if (context === null) {
+    throw new Error("useTheme must be used within a TraceTreeProvider");
+  }
+  return context;
+}
+
+export function TraceTreeProvider(props: PropsWithChildren) {
+  const [isCollapsed, _setIsCollapsed] = useState<boolean>(false);
+  const setIsCollapsed = useCallback((collapsed: boolean) => {
+    startTransition(() => {
+      _setIsCollapsed(collapsed);
+    });
+  }, []);
+
+  return (
+    <TraceTreeConnext.Provider value={{ isCollapsed, setIsCollapsed }}>
+      {props.children}
+    </TraceTreeConnext.Provider>
+  );
+}

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -9,6 +9,20 @@ export interface PreferencesProps {
    * @default "text"
    */
   markdownDisplayMode: MarkdownDisplayMode;
+  /**
+   * Whether or not streaming is enabled for a projects traces
+   * @default true
+   */
+  traceStreamingEnabled: boolean;
+  /**
+   * Whether or not to show the span aside that contains details about timing, status, etc.
+   * @default true
+   */
+  showSpanAside: boolean;
+  /**
+   * Whether or not the trace tree shows metrics
+   */
+  showMetricsInTraceTree: boolean;
 }
 
 export interface PreferencesState extends PreferencesProps {
@@ -18,33 +32,27 @@ export interface PreferencesState extends PreferencesProps {
    */
   setMarkdownDisplayMode: (markdownDisplayMode: MarkdownDisplayMode) => void;
   /**
-   * Whether or not streaming is enabled for a projects traces
-   * @default true
-   */
-  traceStreamingEnabled: boolean;
-  /**
    * Setter for enabling/disabling trace streaming
    * @param traceStreamingEnabled
    * @returns
    */
   setTraceStreamingEnabled: (traceStreamingEnabled: boolean) => void;
   /**
-   * Whether or not to show the span aside that contains details about timing, status, etc.
-   * @default true
-   */
-  showSpanAside: boolean;
-  /**
    * Setter for enabling/disabling the span aside
    * @param showSpanAside
    */
   setShowSpanAside: (showSpanAside: boolean) => void;
+  /**
+   * Setter for enabling/disabling metrics in the trace tree
+   * @param showMetricsInTraceTree
+   */
+  setShowMetricsInTraceTree: (showMetricsInTraceTree: boolean) => void;
 }
 
 export const createPreferencesStore = (
   initialProps?: Partial<PreferencesProps>
 ) => {
   const preferencesStore: StateCreator<PreferencesState> = (set) => ({
-    ...initialProps,
     markdownDisplayMode: "text",
     setMarkdownDisplayMode: (markdownDisplayMode) => {
       set({ markdownDisplayMode });
@@ -57,6 +65,11 @@ export const createPreferencesStore = (
     setShowSpanAside: (showSpanAside) => {
       set({ showSpanAside });
     },
+    showMetricsInTraceTree: true,
+    setShowMetricsInTraceTree: (showMetricsInTraceTree) => {
+      set({ showMetricsInTraceTree });
+    },
+    ...initialProps,
   });
   return create<PreferencesState>()(
     persist(devtools(preferencesStore), {


### PR DESCRIPTION
Adds the ability to hide metrics (token counts, timing) as well as the ability to collapse the tree so you can expand as you go.

resolves #4145


<img width="445" alt="Screenshot 2024-08-06 at 2 10 08 PM" src="https://github.com/user-attachments/assets/2eb7924e-6830-4f39-a28d-8d61b139ea9e">


