### PR TITLE
feat(annotations): add cta for span annotations

### DIFF
--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -29,7 +29,6 @@ import {
   View,
 } from "@arizeai/components";
 
-import { Empty } from "@phoenix/components/Empty";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { formatFloat } from "@phoenix/utils/numberFormatUtils";
 
@@ -45,6 +44,7 @@ import { EditSpanAnnotationsDialogSpanAnnotationsQuery } from "./__generated__/E
 import { NewSpanAnnotationForm } from "./NewSpanAnnotationForm";
 import { SpanAnnotationActionMenu } from "./SpanAnnotationActionMenu";
 import { AnnotationFormData, SpanAnnotationForm } from "./SpanAnnotationForm";
+import { SpanAnnotationsEmpty } from "./SpanAnnotationsEmpty";
 
 type EditSpanAnnotationsDialogProps = {
   spanNodeId: string;
@@ -227,9 +227,7 @@ function SpanAnnotationsList(props: {
   const hasAnnotations = annotations.length > 0;
   return (
     <div>
-      {!hasAnnotations && (
-        <Empty graphicKey="documents" message="No annotations for this span" />
-      )}
+      {!hasAnnotations && <SpanAnnotationsEmpty />}
       <ul
         css={css`
           display: flex;

--- a/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsDialog.tsx
@@ -29,6 +29,7 @@ import {
   View,
 } from "@arizeai/components";
 
+import { Empty } from "@phoenix/components/Empty";
 import { useNotifySuccess } from "@phoenix/contexts";
 import { formatFloat } from "@phoenix/utils/numberFormatUtils";
 
@@ -44,7 +45,6 @@ import { EditSpanAnnotationsDialogSpanAnnotationsQuery } from "./__generated__/E
 import { NewSpanAnnotationForm } from "./NewSpanAnnotationForm";
 import { SpanAnnotationActionMenu } from "./SpanAnnotationActionMenu";
 import { AnnotationFormData, SpanAnnotationForm } from "./SpanAnnotationForm";
-import { SpanAnnotationsEmpty } from "./SpanAnnotationsEmpty";
 
 type EditSpanAnnotationsDialogProps = {
   spanNodeId: string;
@@ -227,7 +227,9 @@ function SpanAnnotationsList(props: {
   const hasAnnotations = annotations.length > 0;
   return (
     <div>
-      {!hasAnnotations && <SpanAnnotationsEmpty />}
+      {!hasAnnotations && (
+        <Empty graphicKey="documents" message="No annotations for this span" />
+      )}
       <ul
         css={css`
           display: flex;

--- a/app/src/pages/trace/SpanAnnotationsEmpty.tsx
+++ b/app/src/pages/trace/SpanAnnotationsEmpty.tsx
@@ -7,6 +7,8 @@ import {
   DialogContainer,
   EmptyGraphic,
   Flex,
+  Icon,
+  Icons,
   Text,
   View,
 } from "@arizeai/components";
@@ -40,8 +42,13 @@ export function SpanAnnotationsEmpty() {
       <Flex direction="column" gap="size-100" alignItems="center">
         <EmptyGraphic graphicKey="documents" />
         <Text>No annotations for this span</Text>
-        <Button variant="default" onClick={onGettingStartedClick}>
-          Add Annotations
+        <Button
+          variant="default"
+          size={"compact"}
+          onClick={onGettingStartedClick}
+          icon={<Icon svg={<Icons.Edit2Outline />} />}
+        >
+          How to Annotate
         </Button>
       </Flex>
       <DialogContainer onDismiss={() => setDialog(null)} isDismissable>

--- a/app/src/pages/trace/SpanAnnotationsEmpty.tsx
+++ b/app/src/pages/trace/SpanAnnotationsEmpty.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, useState } from "react";
+import { css } from "@emotion/react";
+
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  EmptyGraphic,
+  Flex,
+  Text,
+  View,
+} from "@arizeai/components";
+
+import { ExternalLink } from "@phoenix/components";
+
+export function SpanAnnotationsEmpty() {
+  const [dialog, setDialog] = useState<ReactNode>(null);
+  const onGettingStartedClick = () => {
+    setDialog(
+      <Dialog title="Span Annotations" isDismissable>
+        <View padding="size-200">
+          <p
+            css={css`
+              margin: 0 0 var(--ac-global-dimension-size-100) 0;
+            `}
+          >
+            Annotations are pivotal for tracking and improving the performance
+            of your application. Phoenix allows for both LLM and HUMAN
+            annotations.
+          </p>
+          <ExternalLink href="https://docs.arize.com/phoenix/tracing/concepts-tracing/how-to-evaluate-traces">
+            View annotation documentation
+          </ExternalLink>
+        </View>
+      </Dialog>
+    );
+  };
+  return (
+    <View padding={"size-200"}>
+      <Flex direction="column" gap="size-100" alignItems="center">
+        <EmptyGraphic graphicKey="documents" />
+        <Text>No annotations for this span</Text>
+        <Button variant="default" onClick={onGettingStartedClick}>
+          Add Annotations
+        </Button>
+      </Flex>
+      <DialogContainer onDismiss={() => setDialog(null)} isDismissable>
+        {dialog}
+      </DialogContainer>
+    </View>
+  );
+}

--- a/app/src/pages/trace/SpanFeedback.tsx
+++ b/app/src/pages/trace/SpanFeedback.tsx
@@ -16,6 +16,7 @@ import {
   SpanFeedback_annotations$data,
   SpanFeedback_annotations$key,
 } from "./__generated__/SpanFeedback_annotations.graphql";
+import { SpanAnnotationsEmpty } from "./SpanAnnotationsEmpty";
 
 const columns = [
   {
@@ -125,7 +126,8 @@ export function SpanFeedback({ span }: { span: SpanFeedback_annotations$key }) {
       (annotation) => annotation.annotatorKind === "LLM"
     );
   }, [data.spanAnnotations]);
-  return (
+  const hasAnnotations = data.spanAnnotations.length > 0;
+  return hasAnnotations ? (
     <Accordion>
       <AccordionItem id={"evaluations"} title={"Evaluations"}>
         <SpanAnnotationsTable annotations={llmAnnotations} />
@@ -134,5 +136,7 @@ export function SpanFeedback({ span }: { span: SpanFeedback_annotations$key }) {
         <SpanAnnotationsTable annotations={humanAnnotations} />
       </AccordionItem>
     </Accordion>
+  ) : (
+    <SpanAnnotationsEmpty />
   );
 }


### PR DESCRIPTION
resolves #4142 

- adds cta to both annotate dialog and feedback tab on span details - only displays when there are no annotations of either type (human / llm)

![image](https://github.com/user-attachments/assets/d1eb0336-1573-4462-b96b-18fb11755afe)


![Screenshot 2024-08-07 at 11 52 11 AM](https://github.com/user-attachments/assets/3dadae15-62e6-43e8-b9f8-5c51ea4b0a9a)
