### PR TITLE
chore(ui): add an error boundary arround span info to catch malformed attributes

### DIFF
--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -1,17 +1,22 @@
 import React, { ReactNode } from "react";
+import { css } from "@emotion/react";
+
+import { EmptyGraphic, Flex, View } from "@arizeai/components";
+
+import { ExternalLink } from "./ExternalLink";
 type ErrorBoundaryProps = { children: ReactNode };
 export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
-  { hasError: boolean }
+  { hasError: boolean; error: unknown }
 > {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: null };
   }
 
-  static getDerivedStateFromError(_error: unknown) {
+  static getDerivedStateFromError(error: unknown) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    return { hasError: true, error };
   }
 
   componentDidCatch(_error: unknown, _errorInfo: unknown) {
@@ -22,7 +27,44 @@ export class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       // You can render any custom fallback UI
-      return <h1>Something went wrong.</h1>;
+      return (
+        <View padding="size-200">
+          <Flex direction="column">
+            <Flex direction="column" width="100%" alignItems="center">
+              <EmptyGraphic graphicKey="error" />
+              <h1>Something went wrong</h1>
+            </Flex>
+            <p>
+              We strive to do our very best but 🐛 bugs happen. It would mean a
+              lot to us if you could file a an issue. If you feel comfortable,
+              please include the error details below in your issue. We will get
+              back to you as soon as we can.
+            </p>
+
+            <Flex direction="row" width="100%" justifyContent="end">
+              <ExternalLink href="https://github.com/Arize-ai/phoenix/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D">
+                file an issue with us
+              </ExternalLink>
+            </Flex>
+            <details open>
+              <summary>error details</summary>
+              <pre
+                css={css`
+                  white-space: pre-wrap;
+                  overflow-wrap: break-word;
+                  overflow: hidden;
+                  overflow-y: auto;
+                  max-height: 500px;
+                `}
+              >
+                {this.state.error instanceof Error
+                  ? this.state.error.message
+                  : null}
+              </pre>
+            </details>
+          </Flex>
+        </View>
+      );
     }
 
     return this.props.children;

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -119,7 +119,10 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
             <ul css={annotationListCSS}>
               {annotations.map((annotation) => (
                 <li key={annotation.id}>
-                  <AnnotationLabel annotation={annotation} />
+                  <AnnotationLabel
+                    annotation={annotation}
+                    annotationDisplayPreference="label"
+                  />
                 </li>
               ))}
             </ul>

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -275,7 +275,9 @@ export function SpanDetails({
         <TabPane name={"Info"}>
           <Flex direction="row" height="100%">
             <SpanInfoWrap>
-              <SpanInfo span={span} />
+              <ErrorBoundary>
+                <SpanInfo span={span} />
+              </ErrorBoundary>
             </SpanInfoWrap>
             {showSpanAside ? <SpanAside span={span} /> : null}
           </Flex>


### PR DESCRIPTION
If semantic attributes are not properly setup, we can end up with parsing or JS errors. This adds an error boundary lower down so we can catch it within the tab
<img width="1019" alt="Screenshot 2024-08-07 at 4 17 58 PM" src="https://github.com/user-attachments/assets/0eaf74a6-c5ab-4bcb-9307-1908f1edf4e9">
