### PR TITLE
fix: Correct import path in UI

### DIFF
--- a/app/src/pages/dataset/RunExperimentButton.tsx
+++ b/app/src/pages/dataset/RunExperimentButton.tsx
@@ -20,7 +20,7 @@ const SET_BASE_URL_PYTHON =
   `# Set the phoenix collector endpoint. Commonly http://localhost:6060 \n` +
   `os.environ["PHOENIX_COLLECTOR_ENDPOINT"] = "<your-phoenix-url>"`;
 const TASK_PYTHON =
-  `from phoenix.experiments import Example\n` +
+  `from phoenix.experiments.types import Example\n` +
   `# Define your task\n` +
   `# Typically should be an LLM call or a call to your application\n` +
   `def my_task(example: Example) -> str:\n` +


### PR DESCRIPTION
The `RunExperimentButton` uses shows incorrect import path. This fixes the docstring.