### PR TITLE
chore(auth): add auth-related environment variables

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -137,7 +137,7 @@ def get_env_phoenix_secret() -> Optional[str]:
     return phoenix_secret
 
 
-def get_auth_settings() -> Tuple[bool, str]:
+def get_auth_settings() -> Tuple[bool, Optional[str]]:
     """
     Gets auth settings and performs validation.
     """


### PR DESCRIPTION
Adds auth-related environment variables, including:

- `DANGEROUSLY_SET_PHOENIX_ENABLE_AUTH`
- `DANGEROUSLY_SET_PHOENIX_SECRET`

These will eventually become:

- `PHOENIX_ENABLE_AUTH`
- `PHOENIX_SECRET`

when auth is officially released.

resolves #3728
resolves #4041
