### PR TITLE
fix: Propagate span annotation metadata to examples on all mutations

### DIFF
--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -266,7 +266,7 @@ class Span(Node):
                 "score": annotation.score,
                 "explanation": annotation.explanation,
                 "metadata": annotation.metadata,
-                "annotator_kind": annotation.annotator_kind,
+                "annotator_kind": annotation.annotator_kind.value,
             }
         # Merge annotations into the metadata
         metadata = {

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -240,7 +240,7 @@ class Span(Node):
     @strawberry.field(
         description="The span's attributes translated into an example revision for a dataset",
     )  # type: ignore
-    def as_example_revision(self, info: Info[Context, None]) -> SpanAsExampleRevision:
+    async def as_example_revision(self, info: Info[Context, None]) -> SpanAsExampleRevision:
         db_span = self.db_span
         attributes = db_span.attributes
         span_io = _SpanIO(
@@ -258,7 +258,7 @@ class Span(Node):
         )
 
         # Fetch annotations associated with this span
-        span_annotations = self.span_annotations(info)
+        span_annotations = await self.span_annotations(info)
         annotations = dict()
         for annotation in span_annotations:
             annotations[annotation.name] = {


### PR DESCRIPTION
Resolves #4167 

Span annotations should be propagated to dataset example metadata when added. However this functionality wasn't available on all mutations that created dataset examples.

This PR ensures that even if creating a dataset example via the `add_examples_to_dataset` mutation, associated span annotations are added to the metadata.