### PR TITLE
fix: evaluate existing experiment runs

### DIFF
--- a/src/phoenix/experiments/functions.py
+++ b/src/phoenix/experiments/functions.py
@@ -447,14 +447,14 @@ def evaluate_experiment(
         )
         if not dataset.examples:
             raise ValueError(f"Dataset has no examples: {dataset_id=}, {dataset_version_id=}")
-        experiment_runs = tuple(
-            ExperimentRun.from_dict(exp_run)
+        experiment_runs = {
+            exp_run["id"]: ExperimentRun.from_dict(exp_run)
             for exp_run in sync_client.get(f"/v1/experiments/{experiment.id}/runs").json()["data"]
-        )
+        }
         if not experiment_runs:
             raise ValueError("Experiment has not been run")
         params = ExperimentParameters(n_examples=len(dataset.examples))
-        task_summary = TaskSummary.from_task_runs(params, experiment_runs)
+        task_summary = TaskSummary.from_task_runs(params, experiment_runs.values())
         ran_experiment = object.__new__(RanExperiment)
         ran_experiment.__init__(  # type: ignore[misc]
             dataset=dataset,

--- a/src/phoenix/experiments/types.py
+++ b/src/phoenix/experiments/types.py
@@ -126,7 +126,6 @@ class Dataset:
     examples: Mapping[ExampleId, Example] = field(repr=False, default_factory=dict)
 
     def __post_init__(self) -> None:
-        assert isinstance(self.id, DatasetId)
         object.__setattr__(self, "examples", _ReadOnly(self.examples))
 
     def __len__(self) -> int:
@@ -167,8 +166,10 @@ class Dataset:
     @classmethod
     def from_dict(cls, obj: Mapping[str, Any]) -> Dataset:
         examples = tuple(map(Example.from_dict, obj.get("examples") or ()))
+        id_ = obj.get("dataset_id") or obj.get("id")
+        assert isinstance(id_, DatasetId)
         return cls(
-            id=(obj.get("dataset_id") or obj.get("id")),
+            id=id_,
             version_id=obj["version_id"],
             examples={ex.id: ex for ex in examples},
         )

--- a/src/phoenix/experiments/types.py
+++ b/src/phoenix/experiments/types.py
@@ -166,10 +166,8 @@ class Dataset:
     @classmethod
     def from_dict(cls, obj: Mapping[str, Any]) -> Dataset:
         examples = tuple(map(Example.from_dict, obj.get("examples") or ()))
-        id_ = obj.get("dataset_id") or obj.get("id")
-        assert isinstance(id_, DatasetId)
         return cls(
-            id=id_,
+            id=obj["dataset_id"],
             version_id=obj["version_id"],
             examples={ex.id: ex for ex in examples},
         )

--- a/src/phoenix/experiments/types.py
+++ b/src/phoenix/experiments/types.py
@@ -126,6 +126,7 @@ class Dataset:
     examples: Mapping[ExampleId, Example] = field(repr=False, default_factory=dict)
 
     def __post_init__(self) -> None:
+        assert isinstance(self.id, DatasetId)
         object.__setattr__(self, "examples", _ReadOnly(self.examples))
 
     def __len__(self) -> int:
@@ -167,7 +168,7 @@ class Dataset:
     def from_dict(cls, obj: Mapping[str, Any]) -> Dataset:
         examples = tuple(map(Example.from_dict, obj.get("examples") or ()))
         return cls(
-            id=obj["id"],
+            id=(obj.get("dataset_id") or obj.get("id")),
             version_id=obj["version_id"],
             examples={ex.id: ex for ex in examples},
         )
@@ -225,7 +226,7 @@ class ExperimentRun:
         )
 
     def __post_init__(self) -> None:
-        if bool(self.output) == bool(self.error):
+        if self.output is None and self.error is None:
             raise ValueError("Must specify exactly one of experiment_run_output or error")
 
 
@@ -284,7 +285,7 @@ class ExperimentEvaluationRun:
         )
 
     def __post_init__(self) -> None:
-        if bool(self.result) == bool(self.error):
+        if self.result is None and self.error is None:
             raise ValueError("Must specify either result or error")
 
 

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -20,6 +20,8 @@ router = APIRouter(tags=["experiments"], include_in_schema=False)
 
 
 class ExperimentRun(V1RoutesBaseModel):
+    id: str = Field(description="The ID of the experiment run")
+    experiment_id: str = Field(description="The ID of the experiment")
     dataset_example_id: str = Field(
         description="The ID of the dataset example used in the experiment run"
     )

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -20,8 +20,6 @@ router = APIRouter(tags=["experiments"], include_in_schema=False)
 
 
 class ExperimentRun(V1RoutesBaseModel):
-    id: str = Field(description="The ID of the experiment run")
-    experiment_id: str = Field(description="The ID of the experiment")
     dataset_example_id: str = Field(
         description="The ID of the dataset example used in the experiment run"
     )
@@ -110,7 +108,12 @@ async def create_experiment_run(
     return CreateExperimentResponseBody(data=CreateExperimentRunResponseBodyData(id=str(run_gid)))
 
 
-class ListExperimentRunsResponseBody(ResponseBody[List[ExperimentRun]]):
+class ExperimentRunResponse(ExperimentRun):
+    id: str = Field(description="The ID of the experiment run")
+    experiment_id: str = Field(description="The ID of the experiment")
+
+
+class ListExperimentRunsResponseBody(ResponseBody[List[ExperimentRunResponse]]):
     pass
 
 
@@ -149,7 +152,7 @@ async def list_experiment_runs(
             experiment_gid = GlobalID("Experiment", str(exp_run.experiment_id))
             example_gid = GlobalID("DatasetExample", str(exp_run.dataset_example_id))
             runs.append(
-                ExperimentRun(
+                ExperimentRunResponse(
                     start_time=exp_run.start_time,
                     end_time=exp_run.end_time,
                     experiment_id=str(experiment_gid),

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from phoenix.db import models
@@ -53,50 +54,14 @@ async def simple_dataset(
 
 
 @pytest.fixture
-async def simple_dataset_with_experiment_run(
+async def simple_dataset_with_one_experiment_run(
     db: DbSessionFactory,
+    simple_dataset: Any,
 ) -> None:
     """
-    A dataset with one example added in one version
+    A dataset with one example added in one version plus one experiment run
     """
     async with db() as session:
-        dataset = models.Dataset(
-            id=0,
-            name="simple dataset",
-            description=None,
-            metadata_={"info": "a test dataset"},
-        )
-        session.add(dataset)
-        await session.flush()
-
-        dataset_version_0 = models.DatasetVersion(
-            id=0,
-            dataset_id=0,
-            description="the first version",
-            metadata_={"info": "gotta get some test data somewhere"},
-        )
-        session.add(dataset_version_0)
-        await session.flush()
-
-        example_0 = models.DatasetExample(
-            id=0,
-            dataset_id=0,
-        )
-        session.add(example_0)
-        await session.flush()
-
-        example_0_revision_0 = models.DatasetExampleRevision(
-            id=0,
-            dataset_example_id=0,
-            dataset_version_id=0,
-            input={"in": "foo"},
-            output={"out": "bar"},
-            metadata_={"info": "the first reivision"},
-            revision_kind="CREATE",
-        )
-        session.add(example_0_revision_0)
-        await session.flush()
-
         experiment_0 = models.Experiment(
             id=0,
             dataset_id=0,

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -51,6 +51,52 @@ async def simple_dataset(
         session.add(example_0_revision_0)
         await session.flush()
 
+
+@pytest.fixture
+async def simple_dataset_with_experiment_run(
+    db: DbSessionFactory,
+) -> None:
+    """
+    A dataset with one example added in one version
+    """
+    async with db() as session:
+        dataset = models.Dataset(
+            id=0,
+            name="simple dataset",
+            description=None,
+            metadata_={"info": "a test dataset"},
+        )
+        session.add(dataset)
+        await session.flush()
+
+        dataset_version_0 = models.DatasetVersion(
+            id=0,
+            dataset_id=0,
+            description="the first version",
+            metadata_={"info": "gotta get some test data somewhere"},
+        )
+        session.add(dataset_version_0)
+        await session.flush()
+
+        example_0 = models.DatasetExample(
+            id=0,
+            dataset_id=0,
+        )
+        session.add(example_0)
+        await session.flush()
+
+        example_0_revision_0 = models.DatasetExampleRevision(
+            id=0,
+            dataset_example_id=0,
+            dataset_version_id=0,
+            input={"in": "foo"},
+            output={"out": "bar"},
+            metadata_={"info": "the first reivision"},
+            revision_kind="CREATE",
+        )
+        session.add(example_0_revision_0)
+        await session.flush()
+
         experiment_0 = models.Experiment(
             id=0,
             dataset_id=0,

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timezone
+
 import pytest
 from phoenix.db import models
+from phoenix.db.models import ExperimentRunOutput
 from phoenix.server.types import DbSessionFactory
 
 
@@ -46,4 +49,28 @@ async def simple_dataset(
             revision_kind="CREATE",
         )
         session.add(example_0_revision_0)
+        await session.flush()
+
+        experiment_0 = models.Experiment(
+            id=0,
+            dataset_id=0,
+            dataset_version_id=0,
+            name="simple experiment",
+            description=None,
+            repetitions=1,
+            metadata_={"info": "a test experiment"},
+        )
+        session.add(experiment_0)
+        await session.flush()
+
+        experiment_run_0 = models.ExperimentRun(
+            id=0,
+            experiment_id=0,
+            dataset_example_id=0,
+            repetition_number=1,
+            output=ExperimentRunOutput(task_output=1),
+            start_time=datetime.now(timezone.utc),
+            end_time=datetime.now(timezone.utc),
+        )
+        session.add(experiment_run_0)
         await session.flush()

--- a/tests/datasets/test_experiments.py
+++ b/tests/datasets/test_experiments.py
@@ -253,7 +253,7 @@ async def test_run_evaluation(
     _,
     db: DbSessionFactory,
     httpx_clients: httpx.AsyncClient,
-    simple_dataset_with_experiment_run: Any,
+    simple_dataset_with_one_experiment_run: Any,
     acall: Callable[..., Awaitable[Any]],
 ) -> None:
     experiment = Experiment(

--- a/tests/datasets/test_experiments.py
+++ b/tests/datasets/test_experiments.py
@@ -1,4 +1,5 @@
 import json
+from asyncio import sleep
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict
 from unittest.mock import patch
@@ -252,7 +253,7 @@ async def test_run_evaluation(
     _,
     db: DbSessionFactory,
     httpx_clients: httpx.AsyncClient,
-    simple_dataset: Any,
+    simple_dataset_with_experiment_run: Any,
     acall: Callable[..., Awaitable[Any]],
 ) -> None:
     experiment = Experiment(
@@ -264,6 +265,7 @@ async def test_run_evaluation(
     )
     with patch("phoenix.experiments.functions._phoenix_clients", return_value=httpx_clients):
         await acall(evaluate_experiment, experiment, evaluators=[lambda _: _])
+        await sleep(0.1)
         async with db() as session:
             evaluations = list(await session.scalars(select(models.ExperimentRunAnnotation)))
         assert len(evaluations) == 1


### PR DESCRIPTION
resolves #4209 

This PR fixes the following error, when `evaluate_experiment` is executed on an existing experiment run, i.e. when the experiment run entries are pulled from the phoenix server.

```
    166 @classmethod
    167 def from_dict(cls, obj: Mapping[str, Any]) -> Dataset:
    168     examples = tuple(map(Example.from_dict, obj.get(“examples”) or ()))
    169     return cls(
--> 170         id=obj["id"],
    171         version_id=obj[“version_id”],
    172         examples={ex.id: ex for ex in examples},
```