### PR TITLE
feat(auth): plumb auth_enabled flag, add a settings page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { Provider, theme } from "@arizeai/components";
 
 import { FeatureFlagsProvider } from "./contexts/FeatureFlagsContext";
+import { FunctionalityProvider } from "./contexts/FunctionalityContext";
 import { PreferencesProvider } from "./contexts/PreferencesContext";
 import { NotificationProvider, ThemeProvider, useTheme } from "./contexts";
 import { GlobalStyles } from "./GlobalStyles";
@@ -15,9 +16,11 @@ import "normalize.css";
 
 export function App() {
   return (
-    <ThemeProvider>
-      <AppContent />
-    </ThemeProvider>
+    <FunctionalityProvider>
+      <ThemeProvider>
+        <AppContent />
+      </ThemeProvider>
+    </FunctionalityProvider>
   );
 }
 

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -30,6 +30,7 @@ import {
   ProjectPage,
   ProjectsPage,
   ProjectsRoot,
+  SettingsPage,
   TracePage,
   TracingRoot,
 } from "./pages";
@@ -131,6 +132,13 @@ const router = createBrowserRouter(
         element={<APIsPage />}
         handle={{
           crumb: () => "APIs",
+        }}
+      />
+      <Route
+        path="/settings"
+        element={<SettingsPage />}
+        handle={{
+          crumb: () => "Settings",
         }}
       />
     </Route>

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -2,3 +2,4 @@ function getSanitizedPath(path: string): string {
   return path.endsWith("/") ? path.slice(0, -1) : path;
 }
 export const BASE_URL = `${window.location.protocol}//${window.location.host}${getSanitizedPath(window.Config.basename)}`;
+export const VERSION = window.Config.platformVersion;

--- a/app/src/contexts/FunctionalityContext.tsx
+++ b/app/src/contexts/FunctionalityContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, PropsWithChildren, useContext } from "react";
+
+/**
+ * Global static context for the functionality of the platform
+ */
+export type FunctionalityContextType = {
+  /**
+   * Will be set to true if the platform is deployed with authentication
+   */
+  authenticationEnabled: boolean;
+};
+
+export const FunctionalityContext =
+  createContext<FunctionalityContextType | null>(null);
+
+export function useFunctionality() {
+  const context = useContext(FunctionalityContext);
+  if (context === null) {
+    throw new Error(
+      "useFunctionality must be used within a FunctionalityProvider"
+    );
+  }
+  return context;
+}
+
+export function FunctionalityProvider(props: PropsWithChildren) {
+  return (
+    <FunctionalityContext.Provider
+      value={{
+        authenticationEnabled: window.Config.authenticationEnabled,
+      }}
+    >
+      {props.children}
+    </FunctionalityContext.Provider>
+  );
+}

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -114,6 +114,13 @@ function SideNav() {
         </ul>
         <ul css={bottomLinksCSS}>
           <li>
+            <NavLink
+              to="/settings"
+              text="Settings"
+              icon={<Icon svg={<Icons.SettingsOutline />} />}
+            />
+          </li>
+          <li>
             <DocsLink />
           </li>
           <li>

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -16,4 +16,5 @@ export * from "./example";
 export * from "./examples";
 export * from "./experiments";
 export * from "./experiment";
+export * from "./settings";
 export * from "./apis";

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -28,7 +28,7 @@ export function SettingsPage() {
   const { authenticationEnabled } = useFunctionality();
   return (
     <main css={settingsPageCSS}>
-      <Flex direction="column" gap="size-100" width="100%">
+      <Flex direction="column" gap="size-200" width="100%">
         <Card title="Platform Settings">
           <form css={formCSS}>
             <Flex direction="row" gap="size-100" alignItems="end">

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -29,7 +29,7 @@ export function SettingsPage() {
   return (
     <main css={settingsPageCSS}>
       <Flex direction="column" gap="size-200" width="100%">
-        <Card title="Platform Settings">
+        <Card title="Platform Settings" variant="compact">
           <form css={formCSS}>
             <Flex direction="row" gap="size-100" alignItems="end">
               <TextField
@@ -61,9 +61,15 @@ export function SettingsPage() {
           </form>
         </Card>
         {authenticationEnabled && (
-          <Card title="API Keys">API settings go here</Card>
+          <Card title="API Keys" variant="compact">
+            API settings go here
+          </Card>
         )}
-        {authenticationEnabled && <Card title="Users">Users go here</Card>}
+        {authenticationEnabled && (
+          <Card title="Users" variant="compact">
+            Users go here
+          </Card>
+        )}
       </Flex>
     </main>
   );

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -1,9 +1,78 @@
 import React from "react";
+import { css } from "@emotion/react";
+
+import { Card, Flex, TextField, View } from "@arizeai/components";
+
+import { CopyToClipboardButton } from "@phoenix/components";
+import { BASE_URL, VERSION } from "@phoenix/config";
+import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
+
+const settingsPageCSS = css`
+  padding: var(--ac-global-dimension-size-400);
+  max-width: 800px;
+  min-width: 500px;
+  box-sizing: border-box;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+const formCSS = css`
+  .ac-field {
+    // Hacky solution to make the text fields fill the remaining space
+    width: calc(100% - var(--ac-global-dimension-size-600));
+  }
+`;
 
 export function SettingsPage() {
+  const { authenticationEnabled } = useFunctionality();
   return (
-    <main>
-      <h1>Settings</h1>
+    <main css={settingsPageCSS}>
+      <Flex direction="column" gap="size-100" width="100%">
+        <Card title="Platform Settings">
+          <form css={formCSS}>
+            <Flex direction="row" gap="size-100" alignItems="end">
+              <TextField
+                label="Hostname"
+                value={BASE_URL}
+                isReadOnly
+                description="Connect to Phoenix over HTTP"
+              />
+              <CopyToClipboardButtonWithPadding text={BASE_URL} />
+            </Flex>
+            <Flex direction="row" gap="size-100" alignItems="end">
+              <TextField
+                label="Platform Version"
+                isReadOnly
+                value={VERSION}
+                description="The version of the Phoenix server"
+              />
+              <CopyToClipboardButtonWithPadding text={VERSION} />
+            </Flex>
+            <Flex direction="row" gap="size-100" alignItems="end">
+              <TextField
+                label="Python Version"
+                isReadOnly
+                value={`pip install 'arize-phoenix==${VERSION}'`}
+                description="The version of the Python client library to use to connect to this Phoenix"
+              />
+              <CopyToClipboardButtonWithPadding text={VERSION} />
+            </Flex>
+          </form>
+        </Card>
+        {authenticationEnabled && (
+          <Card title="API Keys">API settings go here</Card>
+        )}
+        {authenticationEnabled && <Card title="Users">Users go here</Card>}
+      </Flex>
     </main>
+  );
+}
+
+function CopyToClipboardButtonWithPadding(props: { text: string }) {
+  return (
+    <View paddingBottom="19px">
+      <CopyToClipboardButton text={props.text} size="normal" />
+    </View>
   );
 }

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export function SettingsPage() {
+  return (
+    <main>
+      <h1>Settings</h1>
+    </main>
+  );
+}

--- a/app/src/pages/settings/index.tsx
+++ b/app/src/pages/settings/index.tsx
@@ -1,0 +1,1 @@
+export * from "./SettingsPage";

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -14,6 +14,7 @@ declare global {
         nNeighbors: number;
         nSamples: number;
       };
+      authenticationEnabled: boolean;
     };
   }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
         "tracedataset",
         "UMAP",
         "uninstrument",
+        "uvicorn",
         "vertexai",
         "websockets",
         "xlarge",

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -115,6 +115,8 @@ class AppConfig(NamedTuple):
     n_samples: int
     is_development: bool
     web_manifest_path: Path
+    authentication_enabled: bool
+    """ Whether authentication is enabled """
 
 
 class Static(StaticFiles):
@@ -395,6 +397,7 @@ def create_app(
     db: DbSessionFactory,
     export_path: Path,
     model: Model,
+    authentication_enabled: bool,
     umap_params: UMAPParameters,
     corpus: Optional[Model] = None,
     debug: bool = False,
@@ -515,6 +518,7 @@ def create_app(
                     n_neighbors=umap_params.n_neighbors,
                     n_samples=umap_params.n_samples,
                     is_development=dev,
+                    authentication_enabled=authentication_enabled,
                     web_manifest_path=SERVER_DIR / "static" / ".vite" / "manifest.json",
                 ),
             ),

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -507,7 +507,6 @@ def create_app(
     app.include_router(router)
     app.include_router(graphql_router)
     app.add_middleware(GZipMiddleware)
-    print(f"Authentication enabled: {authentication_enabled}")
     if serve_ui:
         app.mount(
             "/",

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -164,6 +164,7 @@ class Static(StaticFiles):
                     "request": request,
                     "is_development": self._app_config.is_development,
                     "manifest": self._web_manifest,
+                    "authentication_enabled": self._app_config.authentication_enabled,
                 },
             )
         except Exception as e:
@@ -506,6 +507,7 @@ def create_app(
     app.include_router(router)
     app.include_router(graphql_router)
     app.add_middleware(GZipMiddleware)
+    print(f"Authentication enabled: {authentication_enabled}")
     if serve_ui:
         app.mount(
             "/",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -83,7 +83,7 @@ _WELCOME_MESSAGE = """
 
 _EXPERIMENTAL_WARNING = """
 🚨 WARNING: Phoenix is running in experimental mode. 🚨
-|  Authentication: {auth_enabled}
+|  Authentication enabled: {auth_enabled}
 """
 
 

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -13,13 +13,13 @@ from uvicorn import Config, Server
 import phoenix.trace.v1 as pb
 from phoenix.config import (
     EXPORT_DIR,
+    get_auth_settings,
     get_env_database_connection_str,
     get_env_enable_prometheus,
     get_env_grpc_port,
     get_env_host,
     get_env_host_root_path,
     get_env_port,
-    get_auth_settings,
     get_pids_path,
     get_working_dir,
 )
@@ -79,6 +79,11 @@ _WELCOME_MESSAGE = """
 |    - gRPC: {grpc_path}
 |    - HTTP: {http_path}
 |  Storage: {storage}
+"""
+
+_EXPERIMENTAL_WARNING = """
+🚨 WARNING: Phoenix is running in experimental mode. 🚨
+|  Authentication: {auth_enabled}
 """
 
 
@@ -281,6 +286,9 @@ if __name__ == "__main__":
             storage=get_printable_db_url(db_connection_str),
         )
     )
+
+    if authentication_enabled:
+        print(_EXPERIMENTAL_WARNING.format(auth_enabled=authentication_enabled))
 
     # Start the server
     server.run()

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -19,6 +19,7 @@ from phoenix.config import (
     get_env_host,
     get_env_host_root_path,
     get_env_port,
+    get_auth_settings,
     get_pids_path,
     get_working_dir,
 )
@@ -212,6 +213,8 @@ if __name__ == "__main__":
         reference_inferences,
     )
 
+    authentication_enabled, auth_secret = get_auth_settings()
+
     fixture_spans: List[Span] = []
     fixture_evals: List[pb.Evaluation] = []
     if trace_dataset_name is not None:
@@ -251,6 +254,7 @@ if __name__ == "__main__":
         db=factory,
         export_path=export_path,
         model=model,
+        authentication_enabled=authentication_enabled,
         umap_params=umap_params,
         corpus=None
         if corpus_inferences is None

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -85,7 +85,8 @@
                 minDist: parseFloat("{{min_dist}}"),
                 nNeighbors: parseInt("{{n_neighbors}}"),
                 nSamples: parseInt("{{n_samples}}"),
-              }
+              },
+              authenticationEnabled: "{{authenticationEnabled}}",
           }),
           writable: false
       });

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -86,7 +86,7 @@
                 nNeighbors: parseInt("{{n_neighbors}}"),
                 nSamples: parseInt("{{n_samples}}"),
               },
-              authenticationEnabled: "{{authenticationEnabled}}",
+              authenticationEnabled: Boolean("{{authentication_enabled}}" == "True"),
           }),
           writable: false
       });

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -383,6 +383,7 @@ class ThreadSession(Session):
             db=factory,
             export_path=self.export_path,
             model=self.model,
+            authentication_enabled=False,
             corpus=self.corpus,
             umap_params=self.umap_parameters,
             initial_spans=trace_dataset.to_spans() if trace_dataset else None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,7 @@ async def app(
         app = create_app(
             db=db,
             model=create_model_from_inferences(EMPTY_INFERENCES, None),
+            authentication_enabled=False,
             export_path=EXPORT_DIR,
             umap_params=get_umap_parameters(None),
             serve_ui=False,


### PR DESCRIPTION
resolves #4192 

Plumbs through the auth enabled flag and displays UI in the new settings page for user and api key management
<img width="1948" alt="Screenshot 2024-08-12 at 12 59 58 PM" src="https://github.com/user-attachments/assets/8e1edf1a-eea8-4357-9396-5e800555808e">
