### PR TITLE
feat(auth): create system key

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -96,6 +96,11 @@ input ClusterInput {
   id: ID
 }
 
+input CreateApiKeyInput {
+  name: String!
+  description: String
+}
+
 input CreateDatasetInput {
   name: String!
   description: String
@@ -110,6 +115,12 @@ input CreateSpanAnnotationInput {
   score: Float = null
   explanation: String = null
   metadata: JSON! = {}
+}
+
+type CreateSystemApiKeyMutationPayload {
+  jwt: String!
+  apiKey: SystemApiKey!
+  query: Query!
 }
 
 input CreateTraceAnnotationInput {
@@ -886,6 +897,7 @@ type Mutation {
   createTraceAnnotations(input: [CreateTraceAnnotationInput!]!): TraceAnnotationMutationPayload!
   patchTraceAnnotations(input: [PatchAnnotationInput!]!): TraceAnnotationMutationPayload!
   deleteTraceAnnotations(input: DeleteAnnotationsInput!): TraceAnnotationMutationPayload!
+  createSystemApiKey(input: CreateApiKeyInput!): CreateSystemApiKeyMutationPayload!
 }
 
 """An object with a Globally Unique ID"""

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -99,6 +99,7 @@ input ClusterInput {
 input CreateApiKeyInput {
   name: String!
   description: String
+  expiresAt: DateTime
 }
 
 input CreateDatasetInput {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "arize-phoenix-evals>=0.13.1",
   "fastapi",
   "pydantic>=1.0,!=2.0.*,<3,", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
+  "pyjwt",
 ]
 dynamic = ["version"]
 

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -74,3 +74,17 @@ class Context(BaseContext):
     event_queue: CanPutItem[DmlEvent] = _NoOp()
     corpus: Optional[Model] = None
     read_only: bool = False
+    secret: Optional[str] = None
+
+    def get_secret(self) -> str:
+        """A type safe way to get the application secret. Throws an error if the secret is not set.
+
+        Returns:
+            str: the phoenix secret
+        """
+        if self.secret is None:
+            raise ValueError(
+                "Application secret not set."
+                " Please set the PHOENIX_SECRET environment variable and re-deploy the application."
+            )
+        return self.secret

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -1,5 +1,6 @@
 import strawberry
 
+from phoenix.server.api.mutations.api_key_mutations import ApiKeyMutationMixin
 from phoenix.server.api.mutations.dataset_mutations import DatasetMutationMixin
 from phoenix.server.api.mutations.experiment_mutations import ExperimentMutationMixin
 from phoenix.server.api.mutations.export_events_mutations import ExportEventsMutationMixin
@@ -16,5 +17,6 @@ class Mutation(
     ExportEventsMutationMixin,
     SpanAnnotationMutationMixin,
     TraceAnnotationMutationMixin,
+    ApiKeyMutationMixin,
 ):
     pass

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -54,8 +54,8 @@ class ApiKeyMutationMixin:
                 insert(models.APIKey)
                 .values(
                     user_id=system_user.id,
-                    name=input.name or "System API Key",
-                    description=input.description or "System API Key",
+                    name=input.name,
+                    description=input.description or None,
                 )
                 .returning(models.APIKey)
             )

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -39,6 +39,7 @@ class ApiKeyMutationMixin:
         self, info: Info[Context, None], input: CreateApiKeyInput
     ) -> CreateSystemApiKeyMutationPayload:
         # TODO(auth): safe guard against auth being disabled and secret not being set
+        secret: str = info.get_secret()
         if secret is None:
             raise ValueError("Cannot create keys without a secret")
         async with info.context.db() as session:

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -65,7 +65,7 @@ class ApiKeyMutationMixin:
         encoded_jwt = create_jwt(
             secret=info.context.get_secret(),
             name=api_key.name,
-            user_id=api_key.user_id,
+            id=api_key.id,
             description=api_key.description,
             iat=api_key.created_at,
             exp=api_key.expires_at,
@@ -91,7 +91,7 @@ def create_jwt(
     description: Optional[str],
     iat: datetime,
     exp: Optional[datetime],
-    user_id: int,
+    id: int,
 ) -> str:
     """Create a signed JSON Web Token for authentication
 
@@ -101,7 +101,7 @@ def create_jwt(
         description (Optional[str]): description of the token
         iat (datetime): the issued at time
         exp (Optional[datetime]): the expiry, if set
-        user_id (int): the system / end-user id
+        id (int): the id of the key
         algorithm (str, optional): the algorithm to use. Defaults to "HS256".
 
     Returns:
@@ -111,7 +111,7 @@ def create_jwt(
         "name": name,
         "description": description,
         "iat": iat.utcnow(),
-        "user_id": user_id,
+        "id": id,
     }
     if exp is not None:
         payload["exp"] = exp.utcnow()

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import jwt
+import strawberry
+from sqlalchemy import insert, select
+from strawberry import UNSET
+from strawberry.types import Info
+
+from phoenix.config import get_auth_settings
+from phoenix.db import models
+from phoenix.server.api.context import Context
+from phoenix.server.api.mutations.auth import IsAuthenticated
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.SystemApiKey import SystemApiKey
+
+
+@strawberry.type
+class CreateSystemApiKeyMutationPayload:
+    jwt: str
+    api_key: SystemApiKey
+    query: Query
+
+
+@strawberry.input
+class CreateApiKeyInput:
+    name: str
+    description: Optional[str] = UNSET
+
+
+# TODO(auth): mount this centrally
+_, secret = get_auth_settings()
+
+
+@strawberry.type
+class ApiKeyMutationMixin:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])  # type: ignore
+    async def create_system_api_key(
+        self, info: Info[Context, None], input: CreateApiKeyInput
+    ) -> CreateSystemApiKeyMutationPayload:
+        # TODO(auth): safe guard against auth being disabled and secret not being set
+        if secret is None:
+            raise ValueError("Cannot create keys without a secret")
+        async with info.context.db() as session:
+            # Get the system user - note this could be pushed into a dataloader
+            system_user = await session.scalar(
+                select(models.User)
+                .join(models.User.role)  # Join User with UserRole
+                .where(models.UserRole.role == "SYSTEM")  # Filter where role is SYSTEM
+                .limit(1)
+            )
+            if system_user is None:
+                raise ValueError("System user not found")
+
+            api_key = await session.scalar(
+                insert(models.APIKey)
+                .values(
+                    user_id=system_user.id,
+                    name=input.name or "System API Key",
+                    description=input.description,
+                )
+                .returning(models.APIKey)
+            )
+            assert api_key is not None
+
+        encoded_jwt = create_jwt(
+            secret=secret,
+            name=api_key.name,
+            user_id=api_key.user_id,
+            description=api_key.description,
+            iat=api_key.created_at,
+            exp=api_key.expires_at,
+        )
+        return CreateSystemApiKeyMutationPayload(
+            jwt=encoded_jwt,
+            api_key=SystemApiKey(
+                id_attr=api_key.id,
+                name=api_key.name,
+                description=api_key.description,
+                created_at=api_key.created_at,
+                expires_at=api_key.expires_at,
+            ),
+            query=Query(),
+        )
+
+
+def create_jwt(
+    *,
+    secret: str,
+    algorithm: str = "HS256",
+    name: str,
+    description: Optional[str],
+    iat: datetime,
+    exp: Optional[datetime],
+    user_id: int,
+) -> str:
+    """Create a signed JSON Web Token for authentication
+
+    Args:
+        secret (str): the secret to sign with
+        name (str): name of the key / token
+        description (Optional[str]): description of the token
+        iat (datetime): the issued at time
+        exp (Optional[datetime]): the expiry, if set
+        user_id (int): the system / end-user id
+        algorithm (str, optional): the algorithm to use. Defaults to "HS256".
+
+    Returns:
+        str: _description_
+    """
+    payload: Dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "iat": iat.utcnow(),
+        "user_id": user_id,
+    }
+    if exp is not None:
+        payload["exp"] = exp.utcnow()
+
+    # Encode the payload to create the JWT
+    token = jwt.encode(payload, secret, algorithm=algorithm)
+
+    return token

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -7,10 +7,9 @@ from sqlalchemy import insert, select
 from strawberry import UNSET
 from strawberry.types import Info
 
-from phoenix.config import get_auth_settings
 from phoenix.db import models
 from phoenix.server.api.context import Context
-from phoenix.server.api.mutations.auth import IsAuthenticated, HasSecret
+from phoenix.server.api.mutations.auth import HasSecret, IsAuthenticated
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.SystemApiKey import SystemApiKey
 
@@ -26,10 +25,6 @@ class CreateSystemApiKeyMutationPayload:
 class CreateApiKeyInput:
     name: str
     description: Optional[str] = UNSET
-
-
-# TODO(auth): mount this centrally
-_, secret = get_auth_settings()
 
 
 @strawberry.type

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -100,7 +100,7 @@ def create_jwt(
         algorithm (str, optional): the algorithm to use. Defaults to "HS256".
 
     Returns:
-        str: _description_
+        str: The encoded JWT
     """
     payload: Dict[str, Any] = {
         "name": name,

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -25,6 +25,7 @@ class CreateSystemApiKeyMutationPayload:
 class CreateApiKeyInput:
     name: str
     description: Optional[str] = UNSET
+    expires_at: Optional[datetime] = UNSET
 
 
 @strawberry.type
@@ -51,6 +52,7 @@ class ApiKeyMutationMixin:
                     user_id=system_user.id,
                     name=input.name,
                     description=input.description or None,
+                    expires_at=input.expires_at or None,
                 )
                 .returning(models.APIKey)
             )

--- a/src/phoenix/server/api/mutations/auth.py
+++ b/src/phoenix/server/api/mutations/auth.py
@@ -9,3 +9,10 @@ class IsAuthenticated(BasePermission):
 
     async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
         return not info.context.read_only
+
+
+class HasSecret(BasePermission):
+    message = "Application secret is not set"
+
+    async def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
+        return info.context.secret is not None

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -276,7 +276,26 @@ def create_graphql_router(
     cache_for_dataloaders: Optional[CacheForDataLoaders] = None,
     event_queue: CanPutItem[DmlEvent],
     read_only: bool = False,
+    secret: Optional[str] = None,
 ) -> GraphQLRouter:  # type: ignore[type-arg]
+    """Creates the GraphQL router.
+
+    Args:
+        schema (BaseSchema): The GraphQL schema.
+        db (DbSessionFactory): The database session factory pointing to a SQL database.
+        model (Model): The Model representing inferences (legacy)
+        export_path (Path): the file path to export data to for download (legacy)
+        last_updated_at (CanGetLastUpdatedAt): How to get the last updated timestamp for updates.
+        event_queue (CanPutItem[DmlEvent]): The event queue for DML events.
+        corpus (Optional[Model], optional): the corpus for UMAP projection. Defaults to None.
+        cache_for_dataloaders (Optional[CacheForDataLoaders], optional): GraphQL data loaders.
+        read_only (bool, optional): Marks the app as read-only. Defaults to False.
+        secret (Optional[str], optional): The application secret for auth. Defaults to None.
+
+    Returns:
+        GraphQLRouter: _description_
+    """
+
     def get_context() -> Context:
         return Context(
             db=db,
@@ -336,6 +355,7 @@ def create_graphql_router(
             ),
             cache_for_dataloaders=cache_for_dataloaders,
             read_only=read_only,
+            secret=secret,
         )
 
     return GraphQLRouter(
@@ -409,6 +429,7 @@ def create_app(
     initial_evaluations: Optional[Iterable[pb.Evaluation]] = None,
     serve_ui: bool = True,
     clean_up_callbacks: List[Callable[[], None]] = [],
+    secret: Optional[str] = None,
 ) -> FastAPI:
     clean_ups: List[Callable[[], None]] = clean_up_callbacks  # To be called at app shutdown.
     initial_batch_of_spans: Iterable[Tuple[Span, str]] = (
@@ -472,6 +493,7 @@ def create_app(
         event_queue=dml_event_handler,
         cache_for_dataloaders=cache_for_dataloaders,
         read_only=read_only,
+        secret=secret,
     )
     if enable_prometheus:
         from phoenix.server.prometheus import PrometheusMiddleware

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -293,7 +293,7 @@ def create_graphql_router(
         secret (Optional[str], optional): The application secret for auth. Defaults to None.
 
     Returns:
-        GraphQLRouter: _description_
+        GraphQLRouter: The router mounted at /graphql
     """
 
     def get_context() -> Context:

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
         reference_inferences,
     )
 
-    authentication_enabled, auth_secret = get_auth_settings()
+    authentication_enabled, secret = get_auth_settings()
 
     fixture_spans: List[Span] = []
     fixture_evals: List[pb.Evaluation] = []
@@ -271,6 +271,7 @@ if __name__ == "__main__":
         initial_spans=fixture_spans,
         initial_evaluations=fixture_evals,
         clean_up_callbacks=instrumentation_cleanups,
+        secret=secret,
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()


### PR DESCRIPTION
resolves #4234

This introduces create system API creation mutation. It is not wored up, is intended for scaffolding a working UI.

```graphql
mutation {
  createSystemApiKey(input: { name: "system-api-key"}) {
    jwt
    apiKey {
      name
      description
      createdAt
      expiresAt
    }
  }
}
```

Payload

```json
{
  "data": {
    "createSystemApiKey": {
      "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoic3lzdGVtLWFwaS1rZXkiLCJkZXNjcmlwdGlvbiI6bnVsbCwiaWF0IjoxNzIzNjg3NTI4LCJpZCI6OH0.29TOm3JM2aY5vdALWnNlLA7cJXM1r3UZu3ApiqfEhpg",
      "apiKey": {
        "name": "system-api-key",
        "description": null,
        "createdAt": "2024-08-15T02:05:28+00:00",
        "expiresAt": null
      }
    }
  }
}
```