### PR TITLE
ci(evals): limit `mistralai` below version 1.0

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
   "litellm>=1.28.9",
   "openai>=1.0.0",
   "vertexai",
-  "mistralai",
+  "mistralai<1",
 ]
 test = [
   "openinference-semantic-conventions",

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -46,7 +46,7 @@ test = [
   "boto3",
   "litellm>=1.28.9",
   "openai>=1.0.0",
-  "mistralai",
+  "mistralai<1",
   "vertexai",
   "respx",
   "nest_asyncio",


### PR DESCRIPTION
CI is failing due to breaking changes