### PR TITLE
docs: fix variable name typo in run experiments doc

### DIFF
--- a/docs/datasets-and-experiments/how-to-experiments/run-experiments.md
+++ b/docs/datasets-and-experiments/how-to-experiments/run-experiments.md
@@ -176,7 +176,7 @@ Running an experiment is as easy as calling `run_experiment` with the components
 ```python
 from phoenix.experiments import run_experiment
 
-run_experiment(ds, task=task, evaluators=[no_error, has_results])
+run_experiment(df, task=task, evaluators=[no_error, has_results])
 ```
 
 ### Dry Run

--- a/docs/datasets-and-experiments/how-to-experiments/run-experiments.md
+++ b/docs/datasets-and-experiments/how-to-experiments/run-experiments.md
@@ -176,7 +176,7 @@ Running an experiment is as easy as calling `run_experiment` with the components
 ```python
 from phoenix.experiments import run_experiment
 
-run_experiment(df, task=task, evaluators=[no_error, has_results])
+run_experiment(dataset, task=task, evaluators=[no_error, has_results])
 ```
 
 ### Dry Run


### PR DESCRIPTION
The `ds` variable is never defined. This should have been `df` which is defined on line 32.