### PR TITLE
fix: Default to adding span annotations to queue

### DIFF
--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -196,7 +196,7 @@ class AnnotateSpansResponseBody(ResponseBody[List[InsertedSpanAnnotation]]):
 async def annotate_spans(
     request: Request,
     request_body: AnnotateSpansRequestBody,
-    sync: bool = Query(default=True, description="If true, fulfill request synchronously."),
+    sync: bool = Query(default=False, description="If true, fulfill request synchronously."),
 ) -> AnnotateSpansResponseBody:
     if not request_body.data:
         return AnnotateSpansResponseBody(data=[])


### PR DESCRIPTION
Defaults to `sync=False` on the `/span_annotations` route. This allows us to send annotations even if the span has not yet been exported by default.