### PR TITLE
fix: conditionally display re-ranker queries in span details

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -816,12 +816,11 @@ function RerankerSpanInfo(props: {
     () => spanAttributes[SemanticAttributePrefixes.reranker] || null,
     [spanAttributes]
   );
-  const query = useMemo<string>(() => {
+  const query = useMemo<string | null>(() => {
     if (rerankerAttributes == null) {
-      return "";
+      return null;
     }
-    return (rerankerAttributes[RerankerAttributePostfixes.query] ||
-      "") as string;
+    return rerankerAttributes[RerankerAttributePostfixes.query] || null;
   }, [rerankerAttributes]);
   const input_documents = useMemo<AttributeDocument[]>(() => {
     if (rerankerAttributes == null) {
@@ -845,9 +844,11 @@ function RerankerSpanInfo(props: {
   return (
     <Flex direction="column" gap="size-200">
       <MarkdownDisplayProvider>
-        <Card title="Query" {...defaultCardProps}>
-          <ConnectedMarkdownBlock>{query}</ConnectedMarkdownBlock>
-        </Card>
+        {query && (
+          <Card title="Query" {...defaultCardProps}>
+            <ConnectedMarkdownBlock>{query}</ConnectedMarkdownBlock>
+          </Card>
+        )}
       </MarkdownDisplayProvider>
       <Card
         title={"Input Documents"}

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -855,6 +855,7 @@ function RerankerSpanInfo(props: {
         titleExtra={<Counter variant="light">{numInputDocuments}</Counter>}
         {...defaultCardProps}
         defaultOpen={false}
+        bodyStyle={{ padding: 0 }}
       >
         {
           <ul
@@ -884,6 +885,7 @@ function RerankerSpanInfo(props: {
         title={"Output Documents"}
         titleExtra={<Counter variant="light">{numOutputDocuments}</Counter>}
         {...defaultCardProps}
+        bodyStyle={{ padding: 0 }}
       >
         {
           <ul


### PR DESCRIPTION
Some re-rankers such as this [Lost-in-the-middle re-ranker](https://docs.haystack.deepset.ai/docs/lostinthemiddleranker#in-a-pipeline) do not require queries. So we display the query card in the span details only conditionally.

![Screenshot 2024-08-16 at 12 40 13 PM](https://github.com/user-attachments/assets/4233239a-30b8-47ba-9b83-8f89d97fc61a)

![Screenshot 2024-08-16 at 12 40 38 PM](https://github.com/user-attachments/assets/c160648a-2f63-4725-bc94-3ff51dfac257)

resolves [#916](https://github.com/Arize-ai/openinference/issues/916)
