### PR TITLE
feat: Add `list_experiments` client method

### DIFF
--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from random import getrandbits
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import Field
 from sqlalchemy import select
 from starlette.requests import Request
@@ -266,9 +266,14 @@ class ListExperimentsResponseBody(ResponseBody[List[Experiment]]):
 )
 async def list_experiments(
     request: Request,
+    project_name: Optional[str] = Query(
+        default=None, description="The project name to get experiments from"
+    ),
 ) -> ListExperimentsResponseBody:
     async with request.app.state.db() as session:
         query = select(models.Experiment).order_by(models.Experiment.id.desc())
+        if project_name:
+            query = query.where(models.Experiment.project_name == project_name)
 
         result = await session.execute(query)
         experiments = result.scalars().all()

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -44,7 +44,7 @@ from phoenix.config import (
 )
 from phoenix.datetime_utils import normalize_datetime
 from phoenix.db.insertion.dataset import DatasetKeys
-from phoenix.experiments.types import Dataset, Example
+from phoenix.experiments.types import Dataset, Example, Experiment
 from phoenix.session.data_extractor import DEFAULT_SPAN_LIMIT, TraceDataExtractor
 from phoenix.trace import Evaluations, TraceDataset
 from phoenix.trace.dsl import SpanQuery
@@ -570,6 +570,14 @@ class Client(TraceDataExtractor):
             metadata=metadata,
             action="append",
         )
+
+    def list_experiments(self, project_name: Optional[str] = None) -> List[Experiment]:
+        response = self._client.get(
+            url=urljoin(self._base_url, "v1/experiments"),
+            params={"project_name": project_name or get_env_project_name()},
+        )
+        experiment_data = response.json()["data"]
+        return [Experiment.from_dict(experiment) for experiment in experiment_data]
 
     def _upload_tabular_dataset(
         self,

--- a/tests/server/api/conftest.py
+++ b/tests/server/api/conftest.py
@@ -450,6 +450,7 @@ async def dataset_with_experiments_without_runs(
             dataset_version_id=1,
             name="test",
             repetitions=1,
+            project_name="default",
             metadata_={"info": "a test experiment"},
         )
         session.add(experiment_0)
@@ -461,6 +462,7 @@ async def dataset_with_experiments_without_runs(
             dataset_version_id=2,
             name="second test",
             repetitions=1,
+            project_name="random",
             metadata_={"info": "a second test experiment"},
         )
         session.add(experiment_1)

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -132,6 +132,22 @@ async def test_reading_experiments(
     assert all(experiment[key] == value for key, value in expected.items())
 
 
+async def test_listing_experiments(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_experiments_without_runs: Any,
+) -> None:
+    experiment_gid_0 = GlobalID("Experiment", "0")
+    experiment_gid_1 = GlobalID("Experiment", "1")
+
+    response = await httpx_client.get("/v1/experiments")
+    assert response.status_code == 200
+    experiments = response.json()["data"]
+    experiment_gids = [experiment["id"] for experiment in experiments]
+    assert len(experiments) == 2
+    assert str(experiment_gid_1) == experiment_gids[0], "experiments are listed newest first"
+    assert str(experiment_gid_0) == experiment_gids[1], "experiments are listed newest first"
+
+
 async def test_reading_experiment_404s_with_missing_experiment(
     httpx_client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/api/routers/v1/test_experiments.py
+++ b/tests/server/api/routers/v1/test_experiments.py
@@ -148,6 +148,20 @@ async def test_listing_experiments(
     assert str(experiment_gid_0) == experiment_gids[1], "experiments are listed newest first"
 
 
+async def test_listing_experiments_by_project_name(
+    httpx_client: httpx.AsyncClient,
+    dataset_with_experiments_without_runs: Any,
+) -> None:
+    experiment_gid_1 = GlobalID("Experiment", "1")
+
+    response = await httpx_client.get("/v1/experiments?project_name=random")
+    assert response.status_code == 200
+    experiments = response.json()["data"]
+    experiment_gids = [experiment["id"] for experiment in experiments]
+    assert len(experiments) == 1
+    assert str(experiment_gid_1) == experiment_gids[0], "Only one experiment should be returned"
+
+
 async def test_reading_experiment_404s_with_missing_experiment(
     httpx_client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
This PR adds REST and Phoenix client support for listing all previously run experiments. When called from the client, the list of `Experiment` objects returned from the client can be passed into the `evaluate_experiment` function in order to run additional evaluations on an experiment after it's been run.

```
import phoenix as px

client = px.Client()
experiments = px.list_experiments()

print(experiments)  # show all experiments

async def good_evaluator(x):
    return True

px.experiments.evaluate_experiment(experiments[0], good_evaluator)
```