### PR TITLE
ci: exclude buggy scipy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy!=1.14.1; platform_system == 'Darwin'",  # installation issues on MacOS
+  "scipy!=1.14.1; platform_system == 'Darwin'",  # MacOS installation issue: https://github.com/scipy/scipy/issues/21424
   "scipy; platform_system != 'Darwin'",
   "wrapt",
   "protobuf>=3.20, <6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy!=1.14.2",
+  "scipy!=1.14.1",
   "wrapt",
   "protobuf>=3.20, <6.0",
   "grpcio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy",
+  "scipy<1.14.0",
   "wrapt",
   "protobuf>=3.20, <6.0",
   "grpcio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy<1.14.0",
+  "scipy!=1.14.2",
   "wrapt",
   "protobuf>=3.20, <6.0",
   "grpcio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy!=1.14.1",
+  "scipy!=1.14.1; platform_system == 'Darwin'",  # installation issues on MacOS
+  "scipy; platform_system != 'Darwin'",
   "wrapt",
   "protobuf>=3.20, <6.0",
   "grpcio",


### PR DESCRIPTION
`scipy==1.14.1` appears to be causing installations issues on MacOS.