### PR TITLE
refactor: eliminate consecutive blank lines in log for integration test

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "integration_tests/server/**"
       - "tutorials/**"
       - "pyproject.toml"
       - "packages/**"

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -39,6 +39,7 @@ jobs:
             phoenix:
               - "src/**"
               - "tests/**"
+              - "integration_tests/server/**"
               - "tutorials/**"
               - "pyproject.toml"
             packages:

--- a/integration_tests/server/test_launch_app.py
+++ b/integration_tests/server/test_launch_app.py
@@ -84,7 +84,7 @@ def launch() -> Iterator[None]:
         while not log.empty():
             # For unknown reasons, this hangs if we try to print immediately
             # after `get()`, so we collect the lines and print them later.
-            if (line := log.get()) or (logs and logs[-1] != line):
+            if (line := log.get()) or (logs and logs[-1].rstrip() != line.rstrip()):
                 logs.append(line)
         for line in logs:
             print(line, end="")

--- a/integration_tests/server/test_launch_app.py
+++ b/integration_tests/server/test_launch_app.py
@@ -80,7 +80,7 @@ def launch() -> Iterator[None]:
         process.terminate()
         process.wait(10)
     finally:
-        logs = []
+        logs: List[str] = []
         while not log.empty():
             # For unknown reasons, this hangs if we try to print immediately
             # after `get()`, so we collect the lines and print them later.

--- a/integration_tests/server/test_launch_app.py
+++ b/integration_tests/server/test_launch_app.py
@@ -84,7 +84,8 @@ def launch() -> Iterator[None]:
         while not log.empty():
             # For unknown reasons, this hangs if we try to print immediately
             # after `get()`, so we collect the lines and print them later.
-            logs.append(log.get())
+            if (line := log.get()) or (logs and logs[-1] != line):
+                logs.append(line)
         for line in logs:
             print(line, end="")
 

--- a/integration_tests/server/test_launch_app.py
+++ b/integration_tests/server/test_launch_app.py
@@ -80,13 +80,13 @@ def launch() -> Iterator[None]:
         process.terminate()
         process.wait(10)
     finally:
-        logs: List[str] = []
+        lines: List[str] = []
         while not log.empty():
             # For unknown reasons, this hangs if we try to print immediately
             # after `get()`, so we collect the lines and print them later.
-            if (line := log.get()) or (logs and logs[-1].rstrip() != line.rstrip()):
-                logs.append(line)
-        for line in logs:
+            if (line := log.get()) or (lines and lines[-1].rstrip() != line.rstrip()):
+                lines.append(line)
+        for line in lines:
             print(line, end="")
 
 


### PR DESCRIPTION
Sometimes when things fail, there can be an enormous amount of blank lines for some reason.