### PR TITLE
chore: loosen scipy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
   "typing-extensions>=4.5; python_version<'3.12'",
   # A minimum version of typing-extensions==4.6.0 is needed to avoid this issue on Python 3.12: https://github.com/Azure/azure-sdk-for-python/issues/33442#issuecomment-1847886784
   "typing-extensions>=4.6; python_version>='3.12'",
-  "scipy!=1.14.1; platform_system == 'Darwin'",  # MacOS installation issue: https://github.com/scipy/scipy/issues/21424
-  "scipy; platform_system != 'Darwin'",
+  "scipy",
   "wrapt",
   "protobuf>=3.20, <6.0",
   "grpcio",


### PR DESCRIPTION
`scipy` was missing a wheel for MacOS on this particular version. They have manually resolved the issue.

For context, see: https://github.com/scipy/scipy/issues/21424
