### PR TITLE
fix: support `pydantic` in the range `2.4.1<=pydantic<=2.7.1`

### DIFF
--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Generic, List, Optional, TypedDict, Union
+from typing import Any, Dict, Generic, List, Optional, TypedDict, TypeVar, Union
 
-from typing_extensions import TypeAlias, TypeVar, assert_never
+from typing_extensions import TypeAlias, assert_never
 
 from .pydantic_compat import V1RoutesBaseModel
 


### PR DESCRIPTION
Looks like I unnecessarily imported `TypeVar` from `typing_extensions` rather than `typing`, which is not supported by `pydantic` versions in the range `2.4.1<=pydantic<=2.7.1`.

For details, see https://github.com/pydantic/pydantic/issues/9499

resolves #4310
