### PR TITLE
feat: Improve urlencoding logic + bug fixes

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -227,7 +227,7 @@ class GRPCSpanExporter(_GRPCSpanExporter):
         if bound_args.arguments.get("endpoint") is None:
             _, endpoint = _normalized_endpoint(None)
             bound_args.arguments["endpoint"] = endpoint
-        super().__init__(*args, **kwargs)
+        super().__init__(**bound_args.arguments)
 
 
 def _maybe_http_endpoint(parsed_endpoint: ParseResult) -> bool:

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -59,20 +59,19 @@ def parse_env_headers(s: str) -> Dict[str, str]:
         match = _HEADER_PATTERN.fullmatch(header.strip())
         if not match:
             parts = header.split("=", 1)
-            if len(parts) == 2:
-                name, value = parts
-                encoded_header = f"{urllib.parse.quote(name)}={urllib.parse.quote(value)}"
+            name, value = parts
+            encoded_header = f"{urllib.parse.quote(name)}={urllib.parse.quote(value)}"
             match = _HEADER_PATTERN.fullmatch(encoded_header.strip())
             if not match:
                 _logger.warning(
                     "Header format invalid! Header values in environment variables must be "
                     "URL encoded: %s",
-                    header,
+                    f"{name}: ****",
                 )
                 continue
             _logger.warning(
-                f"Header values in environment variables should be URL encoded, ``{header}`` "
-                f"was urlencoded to: ``{encoded_header}``"
+                "Header values in environment variables should be URL encoded, attempting to "
+                "URL encode header: {name}: ****"
             )
 
         name, value = header.split("=", 1)


### PR DESCRIPTION
- If a HEADER that's passed using `PHOENIX_CLIENT_HEADERS` environment variable is not URL encoded, we will attempt to URL encode the header along while also printing a warning message. This PR mangles the header values, in case sensitive information such as authorization tokens are included in them.
- Furthermore, this PR fixes a bug where headers were not always properly being piped through when using the GRPC SpanExporter