### PR TITLE
chore: mask unexpected error messages in graphql api

### DIFF
--- a/src/phoenix/server/api/dataloaders/dataset_example_revisions.py
+++ b/src/phoenix/server/api/dataloaders/dataset_example_revisions.py
@@ -10,6 +10,7 @@ from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
 from phoenix.db import models
+from phoenix.server.api.exceptions import PhoenixGraphQLException
 from phoenix.server.api.types.DatasetExampleRevision import DatasetExampleRevision
 from phoenix.server.types import DbSessionFactory
 
@@ -95,4 +96,11 @@ class DatasetExampleRevisionsDataLoader(DataLoader[Key, Result]):
                 ) in await session.stream(query)
                 if is_valid_version
             }
-        return [results.get(key, ValueError("Could not find revision.")) for key in keys]
+        return [
+            results.get(key, DatasetExampleRevisionException("Could not find revision."))
+            for key in keys
+        ]
+
+
+class DatasetExampleRevisionException(PhoenixGraphQLException):
+    pass

--- a/src/phoenix/server/api/exceptions.py
+++ b/src/phoenix/server/api/exceptions.py
@@ -1,15 +1,29 @@
 from graphql.error import GraphQLError
 from strawberry.extensions import MaskErrors
 
-from phoenix.exceptions import PhoenixException as _PhoenixException
 
-
-class PhoenixGraphQLException(_PhoenixException):
+class CustomGraphQLError(Exception):
     """
     An error that represents an expected error scenario in a GraphQL resolver.
     """
 
-    pass
+
+class BadRequest(CustomGraphQLError):
+    """
+    An error raised due to a malformed or invalid request.
+    """
+
+
+class NotFound(CustomGraphQLError):
+    """
+    An error raised when the requested resource is not found.
+    """
+
+
+class AuthorizationError(CustomGraphQLError):
+    """
+    An error raised when login fails or a user is not authorized to access a resource.
+    """
 
 
 def get_mask_errors_extension() -> MaskErrors:
@@ -21,6 +35,6 @@ def get_mask_errors_extension() -> MaskErrors:
 
 def _should_mask_error(error: GraphQLError) -> bool:
     """
-    Masks expected errors raised from GraphQL resolvers.
+    Masks unexpected errors raised from GraphQL resolvers.
     """
-    return not isinstance(error.original_error, PhoenixGraphQLException)
+    return not isinstance(error.original_error, CustomGraphQLError)

--- a/src/phoenix/server/api/exceptions.py
+++ b/src/phoenix/server/api/exceptions.py
@@ -20,7 +20,7 @@ class NotFound(CustomGraphQLError):
     """
 
 
-class AuthorizationError(CustomGraphQLError):
+class Unauthorized(CustomGraphQLError):
     """
     An error raised when login fails or a user or other entity is not authorized
     to access a resource.

--- a/src/phoenix/server/api/exceptions.py
+++ b/src/phoenix/server/api/exceptions.py
@@ -22,7 +22,8 @@ class NotFound(CustomGraphQLError):
 
 class AuthorizationError(CustomGraphQLError):
     """
-    An error raised when login fails or a user is not authorized to access a resource.
+    An error raised when login fails or a user or other entity is not authorized
+    to access a resource.
     """
 
 

--- a/src/phoenix/server/api/exceptions.py
+++ b/src/phoenix/server/api/exceptions.py
@@ -1,0 +1,26 @@
+from graphql.error import GraphQLError
+from strawberry.extensions import MaskErrors
+
+from phoenix.exceptions import PhoenixException as _PhoenixException
+
+
+class PhoenixGraphQLException(_PhoenixException):
+    """
+    An error that represents an expected error scenario in a GraphQL resolver.
+    """
+
+    pass
+
+
+def get_mask_errors_extension() -> MaskErrors:
+    return MaskErrors(
+        should_mask_error=_should_mask_error,
+        error_message="an unexpected error occurred",
+    )
+
+
+def _should_mask_error(error: GraphQLError) -> bool:
+    """
+    Masks expected errors raised from GraphQL resolvers.
+    """
+    return not isinstance(error.original_error, PhoenixGraphQLException)

--- a/src/phoenix/server/api/mutations/auth_mutations.py
+++ b/src/phoenix/server/api/mutations/auth_mutations.py
@@ -8,7 +8,7 @@ from strawberry.types import Info
 from phoenix.auth import is_valid_password
 from phoenix.db import models
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import AuthorizationError
+from phoenix.server.api.exceptions import Unauthorized
 from phoenix.server.api.mutations.auth import HasSecret
 
 PHOENIX_ACCESS_TOKEN_COOKIE_NAME = "phoenix-access-token"
@@ -36,7 +36,7 @@ class AuthMutationMixin:
                     select(models.User).where(models.User.email == input.email)
                 )
             ) is None or (password_hash := user.password_hash) is None:
-                raise AuthorizationError(FAILED_LOGIN_MESSAGE)
+                raise Unauthorized(FAILED_LOGIN_MESSAGE)
         secret = info.context.get_secret()
         loop = asyncio.get_running_loop()
         if not await loop.run_in_executor(
@@ -45,7 +45,7 @@ class AuthMutationMixin:
                 password=input.password, salt=secret, password_hash=password_hash
             ),
         ):
-            raise AuthorizationError(FAILED_LOGIN_MESSAGE)
+            raise Unauthorized(FAILED_LOGIN_MESSAGE)
         response = info.context.get_response()
         response.set_cookie(
             key=PHOENIX_ACCESS_TOKEN_COOKIE_NAME,

--- a/src/phoenix/server/api/mutations/experiment_mutations.py
+++ b/src/phoenix/server/api/mutations/experiment_mutations.py
@@ -9,7 +9,7 @@ from strawberry.types import Info
 from phoenix.db import models
 from phoenix.db.helpers import get_eval_trace_ids_for_experiments, get_project_names_for_experiments
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import PhoenixGraphQLException
+from phoenix.server.api.exceptions import CustomGraphQLError
 from phoenix.server.api.input_types.DeleteExperimentsInput import DeleteExperimentsInput
 from phoenix.server.api.mutations.auth import IsAuthenticated
 from phoenix.server.api.types.Experiment import Experiment, to_gql_experiment
@@ -53,7 +53,7 @@ class ExperimentMutationMixin:
             }
             if unknown_experiment_ids := set(experiment_ids) - set(experiments.keys()):
                 await savepoint.rollback()
-                raise DeleteExperimentsError(
+                raise CustomGraphQLError(
                     "Failed to delete experiment(s), "
                     "probably due to invalid input experiment ID(s): "
                     + str(
@@ -74,7 +74,3 @@ class ExperimentMutationMixin:
                 to_gql_experiment(experiments[experiment_id]) for experiment_id in experiment_ids
             ]
         )
-
-
-class DeleteExperimentsError(PhoenixGraphQLException):
-    pass

--- a/src/phoenix/server/api/mutations/experiment_mutations.py
+++ b/src/phoenix/server/api/mutations/experiment_mutations.py
@@ -9,6 +9,7 @@ from strawberry.types import Info
 from phoenix.db import models
 from phoenix.db.helpers import get_eval_trace_ids_for_experiments, get_project_names_for_experiments
 from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import PhoenixGraphQLException
 from phoenix.server.api.input_types.DeleteExperimentsInput import DeleteExperimentsInput
 from phoenix.server.api.mutations.auth import IsAuthenticated
 from phoenix.server.api.types.Experiment import Experiment, to_gql_experiment
@@ -52,7 +53,7 @@ class ExperimentMutationMixin:
             }
             if unknown_experiment_ids := set(experiment_ids) - set(experiments.keys()):
                 await savepoint.rollback()
-                raise ValueError(
+                raise DeleteExperimentsError(
                     "Failed to delete experiment(s), "
                     "probably due to invalid input experiment ID(s): "
                     + str(
@@ -73,3 +74,7 @@ class ExperimentMutationMixin:
                 to_gql_experiment(experiments[experiment_id]) for experiment_id in experiment_ids
             ]
         )
+
+
+class DeleteExperimentsError(PhoenixGraphQLException):
+    pass

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -33,6 +33,7 @@ from phoenix.db.models import (
 )
 from phoenix.pointcloud.clustering import Hdbscan
 from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import PhoenixGraphQLException
 from phoenix.server.api.helpers import ensure_list
 from phoenix.server.api.input_types.ClusterInput import ClusterInput
 from phoenix.server.api.input_types.Coordinates import (
@@ -391,7 +392,7 @@ class Query:
             async with info.context.db() as session:
                 project = (await session.execute(project_stmt)).first()
             if project is None:
-                raise ValueError(f"Unknown project: {id}")
+                raise NodeInterfaceException(f"Unknown project: {id}")
             return Project(
                 id_attr=project.id,
                 name=project.name,
@@ -406,7 +407,7 @@ class Query:
             async with info.context.db() as session:
                 trace = (await session.execute(trace_stmt)).first()
             if trace is None:
-                raise ValueError(f"Unknown trace: {id}")
+                raise NodeInterfaceException(f"Unknown trace: {id}")
             return Trace(
                 id_attr=trace.id, trace_id=trace.trace_id, project_rowid=trace.project_rowid
             )
@@ -421,13 +422,13 @@ class Query:
             async with info.context.db() as session:
                 span = await session.scalar(span_stmt)
             if span is None:
-                raise ValueError(f"Unknown span: {id}")
+                raise NodeInterfaceException(f"Unknown span: {id}")
             return to_gql_span(span)
         elif type_name == Dataset.__name__:
             dataset_stmt = select(models.Dataset).where(models.Dataset.id == node_id)
             async with info.context.db() as session:
                 if (dataset := await session.scalar(dataset_stmt)) is None:
-                    raise ValueError(f"Unknown dataset: {id}")
+                    raise NodeInterfaceException(f"Unknown dataset: {id}")
             return to_gql_dataset(dataset)
         elif type_name == DatasetExample.__name__:
             example_id = node_id
@@ -453,7 +454,7 @@ class Query:
                     )
                 )
             if not example:
-                raise ValueError(f"Unknown dataset example: {id}")
+                raise NodeInterfaceException(f"Unknown dataset example: {id}")
             return DatasetExample(
                 id_attr=example.id,
                 created_at=example.created_at,
@@ -464,7 +465,7 @@ class Query:
                     select(models.Experiment).where(models.Experiment.id == node_id)
                 )
             if not experiment:
-                raise ValueError(f"Unknown experiment: {id}")
+                raise NodeInterfaceException(f"Unknown experiment: {id}")
             return Experiment(
                 id_attr=experiment.id,
                 name=experiment.name,
@@ -485,9 +486,9 @@ class Query:
                         )
                     )
                 ):
-                    raise ValueError(f"Unknown experiment run: {id}")
+                    raise NodeInterfaceException(f"Unknown experiment run: {id}")
             return to_gql_experiment_run(run)
-        raise Exception(f"Unknown node type: {type_name}")
+        raise NodeInterfaceException(f"Unknown node type: {type_name}")
 
     @strawberry.field
     def clusters(
@@ -616,3 +617,7 @@ class Query:
         return to_gql_clusters(
             clustered_events=clustered_events,
         )
+
+
+class NodeInterfaceException(PhoenixGraphQLException):
+    pass

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -33,7 +33,7 @@ from phoenix.db.models import (
 )
 from phoenix.pointcloud.clustering import Hdbscan
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import PhoenixGraphQLException
+from phoenix.server.api.exceptions import NotFound
 from phoenix.server.api.helpers import ensure_list
 from phoenix.server.api.input_types.ClusterInput import ClusterInput
 from phoenix.server.api.input_types.Coordinates import (
@@ -392,7 +392,7 @@ class Query:
             async with info.context.db() as session:
                 project = (await session.execute(project_stmt)).first()
             if project is None:
-                raise NodeInterfaceException(f"Unknown project: {id}")
+                raise NotFound(f"Unknown project: {id}")
             return Project(
                 id_attr=project.id,
                 name=project.name,
@@ -407,7 +407,7 @@ class Query:
             async with info.context.db() as session:
                 trace = (await session.execute(trace_stmt)).first()
             if trace is None:
-                raise NodeInterfaceException(f"Unknown trace: {id}")
+                raise NotFound(f"Unknown trace: {id}")
             return Trace(
                 id_attr=trace.id, trace_id=trace.trace_id, project_rowid=trace.project_rowid
             )
@@ -422,13 +422,13 @@ class Query:
             async with info.context.db() as session:
                 span = await session.scalar(span_stmt)
             if span is None:
-                raise NodeInterfaceException(f"Unknown span: {id}")
+                raise NotFound(f"Unknown span: {id}")
             return to_gql_span(span)
         elif type_name == Dataset.__name__:
             dataset_stmt = select(models.Dataset).where(models.Dataset.id == node_id)
             async with info.context.db() as session:
                 if (dataset := await session.scalar(dataset_stmt)) is None:
-                    raise NodeInterfaceException(f"Unknown dataset: {id}")
+                    raise NotFound(f"Unknown dataset: {id}")
             return to_gql_dataset(dataset)
         elif type_name == DatasetExample.__name__:
             example_id = node_id
@@ -454,7 +454,7 @@ class Query:
                     )
                 )
             if not example:
-                raise NodeInterfaceException(f"Unknown dataset example: {id}")
+                raise NotFound(f"Unknown dataset example: {id}")
             return DatasetExample(
                 id_attr=example.id,
                 created_at=example.created_at,
@@ -465,7 +465,7 @@ class Query:
                     select(models.Experiment).where(models.Experiment.id == node_id)
                 )
             if not experiment:
-                raise NodeInterfaceException(f"Unknown experiment: {id}")
+                raise NotFound(f"Unknown experiment: {id}")
             return Experiment(
                 id_attr=experiment.id,
                 name=experiment.name,
@@ -486,9 +486,9 @@ class Query:
                         )
                     )
                 ):
-                    raise NodeInterfaceException(f"Unknown experiment run: {id}")
+                    raise NotFound(f"Unknown experiment run: {id}")
             return to_gql_experiment_run(run)
-        raise NodeInterfaceException(f"Unknown node type: {type_name}")
+        raise NotFound(f"Unknown node type: {type_name}")
 
     @strawberry.field
     def clusters(
@@ -617,7 +617,3 @@ class Query:
         return to_gql_clusters(
             clustered_events=clustered_events,
         )
-
-
-class NodeInterfaceException(PhoenixGraphQLException):
-    pass

--- a/src/phoenix/server/api/schema.py
+++ b/src/phoenix/server/api/schema.py
@@ -1,5 +1,6 @@
 import strawberry
 
+from phoenix.server.api.exceptions import get_mask_errors_extension
 from phoenix.server.api.mutations import Mutation
 from phoenix.server.api.queries import Query
 
@@ -10,4 +11,5 @@ from phoenix.server.api.queries import Query
 schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
+    extensions=[get_mask_errors_extension()],
 )

--- a/tutorials/hosted_phoenix/hosted_phoenix_llamaindex_tutorial.ipynb
+++ b/tutorials/hosted_phoenix/hosted_phoenix_llamaindex_tutorial.ipynb
@@ -47,10 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "id": "rUObjr_Eww9x"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%pip install arize-phoenix arize-phoenix-evals openai openinference-instrumentation-openai opentelemetry-sdk opentelemetry-exporter-otlp\n",
@@ -61,9 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "Cg7wFg21JyyX"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -78,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "QklZGzIFJz4R"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -105,9 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "yp9XJiJtO_Ji"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# setup Arize Phoenix for logging/observability\n",
@@ -133,9 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "wgF_PNZtTm1R"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -145,7 +134,6 @@
     "\n",
     "import nest_asyncio\n",
     "import pandas as pd\n",
-    "import phoenix as px\n",
     "from gcsfs import GCSFileSystem\n",
     "from llama_index.core import (\n",
     "    Settings,\n",
@@ -155,6 +143,8 @@
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.llms.openai import OpenAI\n",
     "from tqdm import tqdm\n",
+    "\n",
+    "import phoenix as px\n",
     "\n",
     "nest_asyncio.apply()  # needed for concurrent evals in notebook environments\n",
     "pd.set_option(\"display.max_colwidth\", 1000)"
@@ -172,9 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "SGL73FxeIOXZ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "file_system = GCSFileSystem(project=\"public-assets-275721\")\n",
@@ -221,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "PD6-S9BY91Dp"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "os.environ[\"PHOENIX_CLIENT_HEADERS\"] = f\"api_key={PHOENIX_API_KEY}\"\n",
@@ -237,14 +223,6 @@
   }
  ],
  "metadata": {
-  "colab": {
-   "name": "llamatrace.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
   }

--- a/tutorials/hosted_phoenix/hosted_phoenix_openai_tutorial.ipynb
+++ b/tutorials/hosted_phoenix/hosted_phoenix_openai_tutorial.ipynb
@@ -35,9 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "aoFI9N0DxQWk"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install arize-otel openinference-instrumentation-openai openai"
@@ -46,22 +44,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Cg7wFg21JyyX",
-    "outputId": "07512b2a-61f4-4b8e-f794-b4f499a211e4"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🔑 Enter your OpenAI API key: ··········\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "from getpass import getpass\n",
@@ -75,22 +59,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "QklZGzIFJz4R",
-    "outputId": "3c681eeb-de7e-498a-906b-a999bddb49a8"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🔑 Enter your Phoenix API key: ··········\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "from getpass import getpass\n",
@@ -114,9 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "yp9XJiJtO_Ji"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from arize_otel import Endpoints, register_otel\n",
@@ -141,24 +109,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "wgF_PNZtTm1R",
-    "outputId": "40b8cc85-edb1-49fe-c876-ce021b8ee18e"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Whispers in the wind\n",
-      "Leaves ruffle with gentle touch\n",
-      "Nature's soft embrace\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import openai\n",
     "\n",
@@ -184,9 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "VxNAjeyTyBc2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install \"arize-phoenix[evals]\""
@@ -204,225 +154,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
-    },
-    "id": "PD6-S9BY91Dp",
-    "outputId": "da25d848-9f3c-433a-c165-ba92f8e2e205"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                            name span_kind parent_id  \\\n",
-      "context.span_id                                        \n",
-      "30f18366408abf1f  ChatCompletion       LLM      None   \n",
-      "\n",
-      "                                       start_time  \\\n",
-      "context.span_id                                     \n",
-      "30f18366408abf1f 2024-07-25 21:23:21.506330+00:00   \n",
-      "\n",
-      "                                         end_time status_code status_message  \\\n",
-      "context.span_id                                                                \n",
-      "30f18366408abf1f 2024-07-25 21:23:22.170959+00:00          OK                  \n",
-      "\n",
-      "                 events   context.span_id                  context.trace_id  \\\n",
-      "context.span_id                                                               \n",
-      "30f18366408abf1f     []  30f18366408abf1f  e1a9815516cb9d2c618b03d975fda1d5   \n",
-      "\n",
-      "                  ... attributes.output.mime_type  attributes.input.mime_type  \\\n",
-      "context.span_id   ...                                                           \n",
-      "30f18366408abf1f  ...            application/json            application/json   \n",
-      "\n",
-      "                 attributes.llm.token_count.completion  \\\n",
-      "context.span_id                                          \n",
-      "30f18366408abf1f                                    18   \n",
-      "\n",
-      "                 attributes.openinference.span.kind  \\\n",
-      "context.span_id                                       \n",
-      "30f18366408abf1f                                LLM   \n",
-      "\n",
-      "                  attributes.llm.model_name  \\\n",
-      "context.span_id                               \n",
-      "30f18366408abf1f         gpt-3.5-turbo-0125   \n",
-      "\n",
-      "                                             attributes.input.value  \\\n",
-      "context.span_id                                                       \n",
-      "30f18366408abf1f  {\"messages\": [{\"role\": \"user\", \"content\": \"Wri...   \n",
-      "\n",
-      "                 attributes.llm.token_count.prompt  \\\n",
-      "context.span_id                                      \n",
-      "30f18366408abf1f                                12   \n",
-      "\n",
-      "                                            attributes.output.value  \\\n",
-      "context.span_id                                                       \n",
-      "30f18366408abf1f  {\"id\":\"chatcmpl-9p0DhUZ5zfsPJP3cf3tXkLqvnEthu\"...   \n",
-      "\n",
-      "                          attributes.llm.invocation_parameters  \\\n",
-      "context.span_id                                                  \n",
-      "30f18366408abf1f  {\"model\": \"gpt-3.5-turbo\", \"max_tokens\": 20}   \n",
-      "\n",
-      "                                     attributes.llm.output_messages  \n",
-      "context.span_id                                                      \n",
-      "30f18366408abf1f  [{'message.content': 'Whispers in the wind\n",
-      "Lea...  \n",
-      "\n",
-      "[1 rows x 22 columns]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "repr_error": "cannot insert context.span_id, already exists",
-       "type": "dataframe"
-      },
-      "text/html": [
-       "\n",
-       "  <div id=\"df-2d732e0d-987c-40b5-af54-dbe0d48413f0\" class=\"colab-df-container\">\n",
-       "    <div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>span_kind</th>\n",
-       "      <th>parent_id</th>\n",
-       "      <th>start_time</th>\n",
-       "      <th>end_time</th>\n",
-       "      <th>status_code</th>\n",
-       "      <th>status_message</th>\n",
-       "      <th>events</th>\n",
-       "      <th>context.span_id</th>\n",
-       "      <th>context.trace_id</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>context.span_id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>\n",
-       "    <div class=\"colab-df-buttons\">\n",
-       "\n",
-       "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-2d732e0d-987c-40b5-af54-dbe0d48413f0')\"\n",
-       "            title=\"Convert this dataframe to an interactive table.\"\n",
-       "            style=\"display:none;\">\n",
-       "\n",
-       "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-       "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-       "  </svg>\n",
-       "    </button>\n",
-       "\n",
-       "  <style>\n",
-       "    .colab-df-container {\n",
-       "      display:flex;\n",
-       "      gap: 12px;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-convert {\n",
-       "      background-color: #E8F0FE;\n",
-       "      border: none;\n",
-       "      border-radius: 50%;\n",
-       "      cursor: pointer;\n",
-       "      display: none;\n",
-       "      fill: #1967D2;\n",
-       "      height: 32px;\n",
-       "      padding: 0 0 0 0;\n",
-       "      width: 32px;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-convert:hover {\n",
-       "      background-color: #E2EBFA;\n",
-       "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-       "      fill: #174EA6;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-buttons div {\n",
-       "      margin-bottom: 4px;\n",
-       "    }\n",
-       "\n",
-       "    [theme=dark] .colab-df-convert {\n",
-       "      background-color: #3B4455;\n",
-       "      fill: #D2E3FC;\n",
-       "    }\n",
-       "\n",
-       "    [theme=dark] .colab-df-convert:hover {\n",
-       "      background-color: #434B5C;\n",
-       "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-       "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-       "      fill: #FFFFFF;\n",
-       "    }\n",
-       "  </style>\n",
-       "\n",
-       "    <script>\n",
-       "      const buttonEl =\n",
-       "        document.querySelector('#df-2d732e0d-987c-40b5-af54-dbe0d48413f0 button.colab-df-convert');\n",
-       "      buttonEl.style.display =\n",
-       "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-       "\n",
-       "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-2d732e0d-987c-40b5-af54-dbe0d48413f0');\n",
-       "        const dataTable =\n",
-       "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-       "                                                    [key], {});\n",
-       "        if (!dataTable) return;\n",
-       "\n",
-       "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-       "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-       "          + ' to learn more about interactive tables.';\n",
-       "        element.innerHTML = '';\n",
-       "        dataTable['output_type'] = 'display_data';\n",
-       "        await google.colab.output.renderOutput(dataTable, element);\n",
-       "        const docLink = document.createElement('div');\n",
-       "        docLink.innerHTML = docLinkHtml;\n",
-       "        element.appendChild(docLink);\n",
-       "      }\n",
-       "    </script>\n",
-       "  </div>\n",
-       "\n",
-       "\n",
-       "    </div>\n",
-       "  </div>\n"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [name, span_kind, parent_id, start_time, end_time, status_code, status_message, events, context.span_id, context.trace_id]\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "os.environ[\"PHOENIX_CLIENT_HEADERS\"] = f\"api_key={PHOENIX_API_KEY}\"\n",
     "os.environ[\"PHOENIX_COLLECTOR_ENDPOINT\"] = \"https://app.phoenix.arize.com/\"\n",
@@ -457,26 +190,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "_BCBdfVqDKUK",
-    "outputId": "79a97b22-2049-4a12-c12d-269cb324d59d"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "📤 Uploading dataset...\n",
-      "💾 Examples uploaded: https://app.phoenix.arize.com/datasets/RGF0YXNldDoy/examples\n",
-      "🗄️ Dataset version ID: RGF0YXNldFZlcnNpb246Mg==\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "\n",
     "import phoenix as px\n",
     "\n",
     "df = pd.DataFrame(\n",
@@ -500,13 +218,6 @@
   }
  ],
  "metadata": {
-  "colab": {
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
   }


### PR DESCRIPTION
With this PR, the default behavior of GraphQL resolvers will be to return an error message of "an unexpected error occurred" for unhandled exceptions. If we wish for the resolver to return a more granular error message, you can return an instance of `CustomGraphQLError` or one of its subclasses. This prevents implementation details and potentially sensitive data from unintentionally leaking through the GraphQL API.