### PR TITLE
feat: Add arize-phoenix-otel as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "cachetools",
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=0.13.1",
+  "arize-phoenix-otel>=0.4.1",
   "fastapi",
   "pydantic>=1.0,!=2.0.*,<3", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "pyjwt",

--- a/src/phoenix/otel
+++ b/src/phoenix/otel
@@ -1,0 +1,1 @@
+../../packages/phoenix-otel/src/phoenix/otel/


### PR DESCRIPTION
Add the `arize-phoenix-otel` package a dependency for a Phoenix.

This is an independently-installable wrapper for OpenTelemetry primitives that helps simplify the OTel configuration process.