### PR TITLE
fix(docker): support arm64 architecture in docker images

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -61,6 +61,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           file: ./Dockerfile
           push: true


### PR DESCRIPTION
Makes the Docker image a multi-architecture build with support for ARM64.

resolves #4383
resolves #3636
