### PR TITLE
docs: demo dataset ingestion

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -269,7 +269,6 @@ class Scaffolder(DaemonTask):
         )
         self._force_fixture_ingestion = force_fixture_ingestion
         self._scaffold_dataset = scaffold_dataset
-        self.dataset_fixtures = []
 
     async def __aenter__(self) -> None:
         await self.start()

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -258,7 +258,7 @@ class Scaffolder(DaemonTask):
         queue_evaluation: Callable[[pb.Evaluation], Awaitable[None]],
         tracing_fixture_names: Set[str] = set(),
         force_fixture_ingestion: bool = False,
-        scaffold_dataset: bool = False,
+        scaffold_datasets: bool = False,
     ) -> None:
         super().__init__()
         self._db = db
@@ -268,7 +268,7 @@ class Scaffolder(DaemonTask):
             get_trace_fixture_by_name(name) for name in tracing_fixture_names
         )
         self._force_fixture_ingestion = force_fixture_ingestion
-        self._scaffold_dataset = scaffold_dataset
+        self._scaffold_datasets = scaffold_datasets
 
     async def __aenter__(self) -> None:
         await self.start()
@@ -282,9 +282,9 @@ class Scaffolder(DaemonTask):
         Determines whether to load fixtures and handles them.
         """
         if await self._should_load_fixtures():
-            logger.info("Loading demo trace fixtures...")
+            logger.info("Loading trace fixtures...")
             await self._handle_tracing_fixtures()
-            logger.info("Finished demo loading fixtures.")
+            logger.info("Finished loading fixtures.")
         else:
             logger.info("DB is not new, avoid loading demo fixtures.")
 
@@ -328,7 +328,7 @@ class Scaffolder(DaemonTask):
                 )
 
                 # Ingest dataset fixtures
-                if self._scaffold_dataset:
+                if self._scaffold_datasets:
                     await self._handle_dataset_fixtures(fixture)
 
                 project_name = fixture.project_name or fixture.name
@@ -371,7 +371,7 @@ def _lifespan(
     read_only: bool = False,
     tracing_fixture_names: Set[str] = set(),
     force_fixture_ingestion: bool = False,
-    scaffold_dataset: bool = False,
+    scaffold_datasets: bool = False,
 ) -> StatefulLifespan[FastAPI]:
     @contextlib.asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[Dict[str, Any]]:
@@ -393,7 +393,7 @@ def _lifespan(
             queue_evaluation=queue_evaluation,
             tracing_fixture_names=tracing_fixture_names,
             force_fixture_ingestion=force_fixture_ingestion,
-            scaffold_dataset=scaffold_dataset,
+            scaffold_datasets=scaffold_datasets,
         ):
             for callback in startup_callbacks:
                 callback()
@@ -587,7 +587,7 @@ def create_app(
     secret: Optional[str] = None,
     tracing_fixture_names: Set[str] = set(),
     force_fixture_ingestion: bool = False,
-    scaffold_dataset: bool = False,
+    scaffold_datasets: bool = False,
 ) -> FastAPI:
     startup_callbacks_list: List[Callable[[], None]] = list(startup_callbacks)
     shutdown_callbacks_list: List[Callable[[], None]] = list(shutdown_callbacks)
@@ -675,7 +675,7 @@ def create_app(
             startup_callbacks=startup_callbacks_list,
             tracing_fixture_names=tracing_fixture_names,
             force_fixture_ingestion=force_fixture_ingestion,
-            scaffold_dataset=scaffold_dataset,
+            scaffold_datasets=scaffold_datasets,
         ),
         middleware=[
             Middleware(HeadersMiddleware),

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -188,7 +188,11 @@ if __name__ == "__main__":
         "--scaffold-dataset",
         action="store_true",  # default is False
         required=False,
-        help=(""),
+        help=(
+            "Whether or not to add any datasets defined in "
+            "the inputted project or trace fixture. "
+            "Default is False. "
+        ),
     )
 
     datasets_parser = subparsers.add_parser("datasets")

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
         ),
     )
     serve_parser.add_argument(
-        "--scaffold-dataset",
+        "--scaffold-datasets",
         action="store_true",  # default is False
         required=False,
         help=(
@@ -227,7 +227,7 @@ if __name__ == "__main__":
     export_path = Path(args.export_path) if args.export_path else EXPORT_DIR
 
     force_fixture_ingestion = False
-    scaffold_dataset = False
+    scaffold_datasets = False
     if args.command == "datasets":
         primary_inferences_name = args.primary
         reference_inferences_name = args.reference
@@ -282,7 +282,7 @@ if __name__ == "__main__":
                 for fixture in get_trace_fixtures_by_project_name(name)
             )
         force_fixture_ingestion = args.force_fixture_ingestion
-        scaffold_dataset = args.scaffold_dataset
+        scaffold_datasets = args.scaffold_datasets
     host: Optional[str] = args.host or get_env_host()
     display_host = host or "localhost"
     # If the host is "::", the convention is to bind to all interfaces. However, uvicorn
@@ -374,7 +374,7 @@ if __name__ == "__main__":
         secret=secret,
         tracing_fixture_names=tracing_fixture_names,
         force_fixture_ingestion=force_fixture_ingestion,
-        scaffold_dataset=scaffold_dataset,
+        scaffold_datasets=scaffold_datasets,
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -143,7 +143,9 @@ if __name__ == "__main__":
     # Whether the app is running in a development environment
     parser.add_argument("--dev", action="store_true")
     parser.add_argument("--no-ui", action="store_true")
+
     subparsers = parser.add_subparsers(dest="command", required=True)
+
     serve_parser = subparsers.add_parser("serve")
     serve_parser.add_argument(
         "--with-fixture",
@@ -182,14 +184,23 @@ if __name__ == "__main__":
             "database is new."
         ),
     )
+    serve_parser.add_argument(
+        "--scaffold-dataset",
+        action="store_true",  # default is False
+        required=False,
+        help=(""),
+    )
+
     datasets_parser = subparsers.add_parser("datasets")
     datasets_parser.add_argument("--primary", type=str, required=True)
     datasets_parser.add_argument("--reference", type=str, required=False)
     datasets_parser.add_argument("--corpus", type=str, required=False)
     datasets_parser.add_argument("--trace", type=str, required=False)
+
     fixture_parser = subparsers.add_parser("fixture")
     fixture_parser.add_argument("fixture", type=str, choices=[fixture.name for fixture in FIXTURES])
     fixture_parser.add_argument("--primary-only", action="store_true")  # Default is False
+
     trace_fixture_parser = subparsers.add_parser("trace-fixture")
     trace_fixture_parser.add_argument(
         "fixture", type=str, choices=[fixture.name for fixture in TRACES_FIXTURES]
@@ -197,19 +208,22 @@ if __name__ == "__main__":
     trace_fixture_parser.add_argument(
         "--simulate-streaming", action="store_true"
     )  # Default is False
+
     demo_parser = subparsers.add_parser("demo")
     demo_parser.add_argument("fixture", type=str, choices=[fixture.name for fixture in FIXTURES])
     demo_parser.add_argument(
         "trace_fixture", type=str, choices=[fixture.name for fixture in TRACES_FIXTURES]
     )
     demo_parser.add_argument("--simulate-streaming", action="store_true")
-    args = parser.parse_args()
 
+    args = parser.parse_args()
     db_connection_str = (
         args.database_url if args.database_url else get_env_database_connection_str()
     )
     export_path = Path(args.export_path) if args.export_path else EXPORT_DIR
+
     force_fixture_ingestion = False
+    scaffold_dataset = False
     if args.command == "datasets":
         primary_inferences_name = args.primary
         reference_inferences_name = args.reference
@@ -264,6 +278,7 @@ if __name__ == "__main__":
                 for fixture in get_trace_fixtures_by_project_name(name)
             )
         force_fixture_ingestion = args.force_fixture_ingestion
+        scaffold_dataset = args.scaffold_dataset
     host: Optional[str] = args.host or get_env_host()
     display_host = host or "localhost"
     # If the host is "::", the convention is to bind to all interfaces. However, uvicorn
@@ -355,6 +370,7 @@ if __name__ == "__main__":
         secret=secret,
         tracing_fixture_names=tracing_fixture_names,
         force_fixture_ingestion=force_fixture_ingestion,
+        scaffold_dataset=scaffold_dataset,
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()

--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -255,7 +255,6 @@ TRACES_FIXTURES: List[TracesFixture] = [
 NAME_TO_TRACES_FIXTURE: Dict[str, TracesFixture] = {
     fixture.name: fixture for fixture in TRACES_FIXTURES
 }
-# NAME_TO_DATASET_FIXTURE: Dict[str, TracesFixture] = defaultdict(list)
 PROJ_NAME_TO_TRACES_FIXTURE: Dict[str, List[TracesFixture]] = defaultdict(list)
 for fixture in TRACES_FIXTURES:
     if fixture.project_name:

--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -22,9 +22,8 @@ from phoenix.trace.schemas import Span
 from phoenix.trace.trace_dataset import TraceDataset
 from phoenix.trace.utils import (
     download_json_traces_fixture,
-    is_csv_file,
-    is_jsonl_file,
     json_lines_to_df,
+    parse_file_extension,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,9 +64,9 @@ class DatasetFixture:
         if self._df is None:
             url = _url(self.file_name)
 
-            if is_jsonl_file(self.file_name):
+            if parse_file_extension(self.file_name) == ".jsonl":
                 df = json_lines_to_df(download_json_traces_fixture(url))
-            elif is_csv_file(self.file_name):
+            elif parse_file_extension(self.file_name) == ".csv":
                 df = pd.read_csv(_url(self.file_name))
             else:
                 try:
@@ -301,7 +300,7 @@ def load_example_traces(fixture_name: str) -> TraceDataset:
     fixture = get_trace_fixture_by_name(fixture_name)
     url = _url(fixture.file_name)
 
-    if is_jsonl_file(fixture.file_name):
+    if parse_file_extension(fixture.file_name) == ".jsonl":
         return TraceDataset(json_lines_to_df(download_json_traces_fixture(url)))
 
     try:

--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -8,7 +8,18 @@ from io import StringIO
 from random import getrandbits
 from tempfile import NamedTemporaryFile
 from time import sleep, time
-from typing import Dict, Iterable, Iterator, List, NamedTuple, Optional, Sequence, Tuple, cast
+from typing import (
+    DefaultDict,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 from urllib.parse import urljoin
 
 import httpx
@@ -254,7 +265,7 @@ TRACES_FIXTURES: List[TracesFixture] = [
 NAME_TO_TRACES_FIXTURE: Dict[str, TracesFixture] = {
     fixture.name: fixture for fixture in TRACES_FIXTURES
 }
-PROJ_NAME_TO_TRACES_FIXTURE: Dict[str, List[TracesFixture]] = defaultdict(list)
+PROJ_NAME_TO_TRACES_FIXTURE: DefaultDict[str, List[TracesFixture]] = defaultdict(list)
 for fixture in TRACES_FIXTURES:
     if fixture.project_name:
         PROJ_NAME_TO_TRACES_FIXTURE[fixture.project_name].append(fixture)

--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -256,7 +256,7 @@ NAME_TO_TRACES_FIXTURE: Dict[str, TracesFixture] = {
     fixture.name: fixture for fixture in TRACES_FIXTURES
 }
 # NAME_TO_DATASET_FIXTURE: Dict[str, TracesFixture] = defaultdict(list)
-PROJ_NAME_TO_TRACES_FIXTURE: Dict[str, TracesFixture] = defaultdict(list)
+PROJ_NAME_TO_TRACES_FIXTURE: Dict[str, List[TracesFixture]] = defaultdict(list)
 for fixture in TRACES_FIXTURES:
     if fixture.project_name:
         PROJ_NAME_TO_TRACES_FIXTURE[fixture.project_name].append(fixture)
@@ -325,7 +325,7 @@ def send_dataset_fixtures(
     endpoint: str,
     fixtures: Iterable[DatasetFixture],
 ) -> None:
-    expiration = time() + 10
+    expiration = time() + 5
     while time() < expiration:
         try:
             url = urljoin(endpoint, "/healthz")

--- a/src/phoenix/trace/utils.py
+++ b/src/phoenix/trace/utils.py
@@ -18,6 +18,16 @@ def is_jsonl_file(file_path: str) -> bool:
     return False
 
 
+def is_csv_file(file_path: str) -> bool:
+    """
+    Check if the given file is a csv file.
+    """
+    file_extension = os.path.splitext(file_path)[-1]
+    if file_extension == ".csv":
+        return True
+    return False
+
+
 def download_json_traces_fixture(
     url: str,
 ) -> List[str]:

--- a/src/phoenix/trace/utils.py
+++ b/src/phoenix/trace/utils.py
@@ -8,24 +8,8 @@ from urllib import request
 import pandas as pd
 
 
-def is_jsonl_file(file_path: str) -> bool:
-    """
-    Check if the given file is a Parquet file.
-    """
-    file_extension = os.path.splitext(file_path)[-1]
-    if file_extension == ".jsonl":
-        return True
-    return False
-
-
-def is_csv_file(file_path: str) -> bool:
-    """
-    Check if the given file is a csv file.
-    """
-    file_extension = os.path.splitext(file_path)[-1]
-    if file_extension == ".csv":
-        return True
-    return False
+def parse_file_extension(file_path: str) -> str:
+    return os.path.splitext(file_path)[-1]
 
 
 def download_json_traces_fixture(


### PR DESCRIPTION
Using the `--scaffold-dataset` parameter results in the ingestion of dataset defined in the project/trace fixture that was passed in with `with-projects` or `with-trace-fixtures`.

resolves #4248, #4247, #4357 