### PR TITLE
fix: use dataloader for experiment run annotations

### DIFF
--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -17,6 +17,7 @@ from phoenix.server.api.dataloaders import (
     DocumentRetrievalMetricsDataLoader,
     ExperimentAnnotationSummaryDataLoader,
     ExperimentErrorRatesDataLoader,
+    ExperimentRunAnnotations,
     ExperimentRunCountsDataLoader,
     ExperimentSequenceNumberDataLoader,
     LatencyMsQuantileDataLoader,
@@ -45,6 +46,7 @@ class DataLoaders:
     annotation_summaries: AnnotationSummaryDataLoader
     experiment_annotation_summaries: ExperimentAnnotationSummaryDataLoader
     experiment_error_rates: ExperimentErrorRatesDataLoader
+    experiment_run_annotations: ExperimentRunAnnotations
     experiment_run_counts: ExperimentRunCountsDataLoader
     experiment_sequence_number: ExperimentSequenceNumberDataLoader
     latency_ms_quantile: LatencyMsQuantileDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -12,6 +12,7 @@ from .document_evaluations import DocumentEvaluationsDataLoader
 from .document_retrieval_metrics import DocumentRetrievalMetricsDataLoader
 from .experiment_annotation_summaries import ExperimentAnnotationSummaryDataLoader
 from .experiment_error_rates import ExperimentErrorRatesDataLoader
+from .experiment_run_annotations import ExperimentRunAnnotations
 from .experiment_run_counts import ExperimentRunCountsDataLoader
 from .experiment_sequence_number import ExperimentSequenceNumberDataLoader
 from .latency_ms_quantile import LatencyMsQuantileCache, LatencyMsQuantileDataLoader
@@ -36,6 +37,7 @@ __all__ = [
     "AnnotationSummaryDataLoader",
     "ExperimentAnnotationSummaryDataLoader",
     "ExperimentErrorRatesDataLoader",
+    "ExperimentRunAnnotations",
     "ExperimentRunCountsDataLoader",
     "ExperimentSequenceNumberDataLoader",
     "LatencyMsQuantileDataLoader",

--- a/src/phoenix/server/api/dataloaders/experiment_run_annotations.py
+++ b/src/phoenix/server/api/dataloaders/experiment_run_annotations.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+from typing import (
+    DefaultDict,
+    List,
+)
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db.models import ExperimentRunAnnotation as OrmExperimentRunAnnotation
+from phoenix.server.types import DbSessionFactory
+
+ExperimentRunID: TypeAlias = int
+Key: TypeAlias = ExperimentRunID
+Result: TypeAlias = List[OrmExperimentRunAnnotation]
+
+
+class ExperimentRunAnnotations(DataLoader[Key, Result]):
+    def __init__(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: List[Key]) -> List[Result]:
+        run_ids = tuple(set(keys))
+        annotations: DefaultDict[Key, Result] = defaultdict(list)
+        async with self._db() as session:
+            async for run_id, annotation in await session.stream(
+                select(
+                    OrmExperimentRunAnnotation.experiment_run_id, OrmExperimentRunAnnotation
+                ).where(OrmExperimentRunAnnotation.experiment_run_id.in_(run_ids))
+            ):
+                annotations[run_id].append(annotation)
+        return [
+            sorted(annotations[run_id], key=lambda annotation: annotation.name, reverse=True)
+            for run_id in run_ids
+        ]

--- a/src/phoenix/server/api/types/ExperimentRun.py
+++ b/src/phoenix/server/api/types/ExperimentRun.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Optional
 
 import strawberry
-from sqlalchemy import select
 from strawberry import UNSET
 from strawberry.relay import Connection, GlobalID, Node, NodeID
 from strawberry.scalars import JSON
@@ -48,14 +47,7 @@ class ExperimentRun(Node):
             before=before if isinstance(before, CursorString) else None,
         )
         run_id = self.id_attr
-        async with info.context.db() as session:
-            annotations = (
-                await session.scalars(
-                    select(models.ExperimentRunAnnotation)
-                    .where(models.ExperimentRunAnnotation.experiment_run_id == run_id)
-                    .order_by(models.ExperimentRunAnnotation.name.desc())
-                )
-            ).all()
+        annotations = await info.context.data_loaders.experiment_run_annotations.load(run_id)
         return connection_from_list(
             [to_gql_experiment_run_annotation(annotation) for annotation in annotations], args
         )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -66,6 +66,7 @@ from phoenix.server.api.dataloaders import (
     DocumentRetrievalMetricsDataLoader,
     ExperimentAnnotationSummaryDataLoader,
     ExperimentErrorRatesDataLoader,
+    ExperimentRunAnnotations,
     ExperimentRunCountsDataLoader,
     ExperimentSequenceNumberDataLoader,
     LatencyMsQuantileDataLoader,
@@ -446,6 +447,7 @@ def create_graphql_router(
                 ),
                 experiment_annotation_summaries=ExperimentAnnotationSummaryDataLoader(db),
                 experiment_error_rates=ExperimentErrorRatesDataLoader(db),
+                experiment_run_annotations=ExperimentRunAnnotations(db),
                 experiment_run_counts=ExperimentRunCountsDataLoader(db),
                 experiment_sequence_number=ExperimentSequenceNumberDataLoader(db),
                 latency_ms_quantile=LatencyMsQuantileDataLoader(


### PR DESCRIPTION
I noticed the experiment comparison page was making a ton of queries because I forgot to use a dataloader for experiment run annotations.

resolves #4396
