### PR TITLE
docs: Add OTEL module to API documentation

### DIFF
--- a/api_reference/source/api/otel.rst
+++ b/api_reference/source/api/otel.rst
@@ -1,0 +1,11 @@
+otel package
+============
+
+.. automethod:: otel::register
+
+.. autoclass:: otel::TracerProvider
+
+.. automodule:: otel
+   :members:
+   :exclude-members: register, TracerProvider
+   :no-undoc-members:

--- a/api_reference/source/conf.py
+++ b/api_reference/source/conf.py
@@ -17,6 +17,7 @@ import phoenix
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(BASE_DIR, "src", "phoenix"))
 sys.path.insert(0, os.path.join(BASE_DIR, "packages", "phoenix-evals", "src", "phoenix"))
+sys.path.insert(0, os.path.join(BASE_DIR, "packages", "phoenix-otel", "src", "phoenix"))
 
 
 # -- Generation setup --------------------------------------------------------

--- a/api_reference/source/index.md
+++ b/api_reference/source/index.md
@@ -51,7 +51,8 @@ Want to become a member of Phoenix's community? Check out our [Slack](https://ar
 
 api/session
 api/client
-api/inferences_schema
 api/evals
 api/experiments
+api/otel
+api/inferences_schema
 ```


### PR DESCRIPTION
resolves #4358 

Adds `phoenix.otel` API documentation