### PR TITLE
feat(ui): add the ability to turn off auto-refresh of projects

### DIFF
--- a/app/src/hooks/useInterval.ts
+++ b/app/src/hooks/useInterval.ts
@@ -5,7 +5,7 @@ type Callback = () => void;
 /**
  * Custom hook to use setInterval with React hooks
  * @param callback
- * @param {number | null} delay - if set to undefined or null, no interval will be set
+ * @param {number | null} delay - if set to null, no interval will be set
  */
 export function useInterval(callback: Callback, delay: number | null) {
   const savedCallback = useRef<Callback | null>(null);

--- a/app/src/hooks/useInterval.ts
+++ b/app/src/hooks/useInterval.ts
@@ -1,7 +1,13 @@
 import { useEffect, useRef } from "react";
 
 type Callback = () => void;
-export function useInterval(callback: Callback, delay: number) {
+
+/**
+ * Custom hook to use setInterval with React hooks
+ * @param callback
+ * @param {number | undefined} delay - pass undefined to stop the interval
+ */
+export function useInterval(callback: Callback, delay?: number) {
   const savedCallback = useRef<Callback | null>(null);
 
   // Remember the latest callback.
@@ -14,9 +20,7 @@ export function useInterval(callback: Callback, delay: number) {
     function tick() {
       savedCallback.current && savedCallback.current();
     }
-    if (delay !== null) {
-      const id = setInterval(tick, delay);
-      return () => clearInterval(id);
-    }
+    const id = setInterval(tick, delay);
+    return () => clearInterval(id);
   }, [delay]);
 }

--- a/app/src/hooks/useInterval.ts
+++ b/app/src/hooks/useInterval.ts
@@ -5,9 +5,9 @@ type Callback = () => void;
 /**
  * Custom hook to use setInterval with React hooks
  * @param callback
- * @param {number | undefined} delay - pass undefined to stop the interval
+ * @param {number | null} delay - if set to undefined or null, no interval will be set
  */
-export function useInterval(callback: Callback, delay?: number) {
+export function useInterval(callback: Callback, delay: number | null) {
   const savedCallback = useRef<Callback | null>(null);
 
   // Remember the latest callback.
@@ -20,7 +20,9 @@ export function useInterval(callback: Callback, delay?: number) {
     function tick() {
       savedCallback.current && savedCallback.current();
     }
-    const id = setInterval(tick, delay);
-    return () => clearInterval(id);
+    if (typeof delay === "number") {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
   }, [delay]);
 }

--- a/app/src/pages/projects/ProjectsAutoRefreshToggle.tsx
+++ b/app/src/pages/projects/ProjectsAutoRefreshToggle.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Switch } from "@arizeai/components";
+
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+
+/**
+ * Enable / Disable auto refresh for projects
+ */
+export function ProjectsAutoRefreshToggle() {
+  const autoRefreshEnabled = usePreferencesContext(
+    (state) => state.projectsAutoRefreshEnabled
+  );
+  const setAutoRefreshEnabled = usePreferencesContext(
+    (state) => state.setProjectAutoRefreshEnabled
+  );
+
+  return (
+    <Switch
+      labelPlacement="start"
+      isSelected={autoRefreshEnabled}
+      onChange={() => {
+        setAutoRefreshEnabled(!autoRefreshEnabled);
+      }}
+    >
+      Auto-Refresh
+    </Switch>
+  );
+}

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -23,6 +23,7 @@ import {
   useLastNTimeRange,
 } from "@phoenix/components/datetime";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { useInterval } from "@phoenix/hooks/useInterval";
 import { intFormatter } from "@phoenix/utils/numberFormatUtils";
 
@@ -34,9 +35,10 @@ import { ProjectsPageProjectsQuery } from "./__generated__/ProjectsPageProjectsQ
 import { ProjectsPageQuery } from "./__generated__/ProjectsPageQuery.graphql";
 import { NewProjectButton } from "./NewProjectButton";
 import { ProjectActionMenu } from "./ProjectActionMenu";
+import { ProjectsAutoRefreshToggle } from "./ProjectsAutoRefreshToggle";
 
 const REFRESH_INTERVAL_MS = 10000;
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 50;
 
 export function ProjectsPage() {
   const { timeRange } = useLastNTimeRange();
@@ -49,6 +51,9 @@ export function ProjectsPage() {
 }
 
 export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
+  const autoRefreshEnabled = usePreferencesContext(
+    (state) => state.projectsAutoRefreshEnabled
+  );
   const [notify, holder] = useNotification();
   // Convert the time range to a variable that can be used in the query
   const timeRangeVariable = useMemo(() => {
@@ -83,7 +88,7 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
       @refetchable(queryName: "ProjectsPageProjectsQuery")
       @argumentDefinitions(
         after: { type: "String", defaultValue: null }
-        first: { type: "Int", defaultValue: 100 }
+        first: { type: "Int", defaultValue: 50 }
       ) {
         projects(first: $first, after: $after)
           @connection(key: "ProjectsPage_projects") {
@@ -127,11 +132,16 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
     [hasNext, isLoadingNext, loadNext]
   );
 
-  useInterval(() => {
-    startTransition(() => {
-      refetch({}, { fetchPolicy: "store-and-network" });
-    });
-  }, REFRESH_INTERVAL_MS);
+  useInterval(
+    () => {
+      if (autoRefreshEnabled) {
+        startTransition(() => {
+          refetch({}, { fetchPolicy: "store-and-network" });
+        });
+      }
+    },
+    autoRefreshEnabled ? REFRESH_INTERVAL_MS : undefined
+  );
 
   const onDelete = useCallback(
     (projectName: string) => {
@@ -195,7 +205,13 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
         borderBottomColor="grey-200"
         borderBottomWidth="thin"
       >
-        <Flex direction="row" justifyContent="end" gap="size-100">
+        <Flex
+          direction="row"
+          justifyContent="end"
+          alignItems="center"
+          gap="size-100"
+        >
+          <ProjectsAutoRefreshToggle />
           <NewProjectButton />
           <ConnectedLastNTimeRangePicker />
         </Flex>

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -134,13 +134,11 @@ export function ProjectsPageContent({ timeRange }: { timeRange: TimeRange }) {
 
   useInterval(
     () => {
-      if (autoRefreshEnabled) {
-        startTransition(() => {
-          refetch({}, { fetchPolicy: "store-and-network" });
-        });
-      }
+      startTransition(() => {
+        refetch({}, { fetchPolicy: "store-and-network" });
+      });
     },
-    autoRefreshEnabled ? REFRESH_INTERVAL_MS : undefined
+    autoRefreshEnabled ? REFRESH_INTERVAL_MS : null
   );
 
   const onDelete = useCallback(

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef70df27b154d179725b1e5dc47d9cd4>>
+ * @generated SignedSource<<faacd4f84859f135396e055af17afb13>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -54,7 +54,7 @@ return {
       "name": "after"
     },
     {
-      "defaultValue": 100,
+      "defaultValue": 50,
       "kind": "LocalArgument",
       "name": "first"
     },
@@ -240,6 +240,6 @@ return {
 };
 })();
 
-(node as any).hash = "720b12837ec779f66a493b8c4f993cba";
+(node as any).hash = "56c501357948255461a24411fb6b5847";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageProjectsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d3eeb69b848003c2ca8a1929c7274270>>
+ * @generated SignedSource<<c47d0f2a5fdbadada13bca07e5bacaab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,7 +35,7 @@ var v0 = [
     "name": "after"
   },
   {
-    "defaultValue": 100,
+    "defaultValue": 50,
     "kind": "LocalArgument",
     "name": "first"
   },
@@ -245,16 +245,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dd65be0e4921fda8c7330e4b91d0d016",
+    "cacheID": "ead527a5c3ddda0f6c906c99183edf06",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageProjectsQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageProjectsQuery(\n  $after: String = null\n  $first: Int = 100\n  $timeRange: TimeRange\n) {\n  ...ProjectsPageProjectsFragment_2HEEH6\n}\n\nfragment ProjectsPageProjectsFragment_2HEEH6 on Query {\n  projects(first: $first, after: $after) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ProjectsPageProjectsQuery(\n  $after: String = null\n  $first: Int = 50\n  $timeRange: TimeRange\n) {\n  ...ProjectsPageProjectsFragment_2HEEH6\n}\n\nfragment ProjectsPageProjectsFragment_2HEEH6 on Query {\n  projects(first: $first, after: $after) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "720b12837ec779f66a493b8c4f993cba";
+(node as any).hash = "56c501357948255461a24411fb6b5847";
 
 export default node;

--- a/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
+++ b/app/src/pages/projects/__generated__/ProjectsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<710cc98dcfec479c114a6bdaabef3854>>
+ * @generated SignedSource<<d91769ea4e28132b62dac1ad21ee7811>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,7 @@ v1 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 100
+    "value": 50
   }
 ],
 v2 = {
@@ -214,7 +214,7 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "projects(first:100)"
+        "storageKey": "projects(first:50)"
       },
       {
         "alias": null,
@@ -228,12 +228,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e510243be5e7bcef0561820e0515c779",
+    "cacheID": "35a420462b10b0f0158d042fd39bfabb",
     "id": null,
     "metadata": {},
     "name": "ProjectsPageQuery",
     "operationKind": "query",
-    "text": "query ProjectsPageQuery(\n  $timeRange: TimeRange!\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects(first: 100) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ProjectsPageQuery(\n  $timeRange: TimeRange!\n) {\n  ...ProjectsPageProjectsFragment\n}\n\nfragment ProjectsPageProjectsFragment on Query {\n  projects(first: 50) {\n    edges {\n      project: node {\n        id\n        name\n        gradientStartColor\n        gradientEndColor\n        traceCount(timeRange: $timeRange)\n        endTime\n        latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n        tokenCountTotal(timeRange: $timeRange)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -15,6 +15,11 @@ export interface PreferencesProps {
    */
   traceStreamingEnabled: boolean;
   /**
+   * Whether or not to automatically refresh projects
+   * @default true
+   */
+  projectsAutoRefreshEnabled: boolean;
+  /**
    * Whether or not to show the span aside that contains details about timing, status, etc.
    * @default true
    */
@@ -34,9 +39,13 @@ export interface PreferencesState extends PreferencesProps {
   /**
    * Setter for enabling/disabling trace streaming
    * @param traceStreamingEnabled
-   * @returns
    */
   setTraceStreamingEnabled: (traceStreamingEnabled: boolean) => void;
+  /**
+   * Setter for enabling/disabling project auto refresh
+   * @param projectsAutoRefreshEnabled
+   */
+  setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled: boolean) => void;
   /**
    * Setter for enabling/disabling the span aside
    * @param showSpanAside
@@ -60,6 +69,10 @@ export const createPreferencesStore = (
     traceStreamingEnabled: true,
     setTraceStreamingEnabled: (traceStreamingEnabled) => {
       set({ traceStreamingEnabled });
+    },
+    projectsAutoRefreshEnabled: true,
+    setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled) => {
+      set({ projectsAutoRefreshEnabled });
     },
     showSpanAside: true,
     setShowSpanAside: (showSpanAside) => {


### PR DESCRIPTION
partially addresses #4399

Allows you to turn off auto-refresh of projects so that pagination doesn't get reset as you scroll