### PR TITLE
feat: Implement serverside rate limiter

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -93,7 +93,6 @@ from phoenix.server.api.schema import schema
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.grpc_server import GrpcServer
-from phoenix.server.rate_limiters import StrawberryRateLimiterExtension
 from phoenix.server.telemetry import initialize_opentelemetry_tracer_provider
 from phoenix.server.types import (
     CanGetLastUpdatedAt,
@@ -631,7 +630,6 @@ def create_app(
     )
     tracer_provider = None
     strawberry_extensions = schema.get_extensions()
-    strawberry_extensions.append(StrawberryRateLimiterExtension())
     if server_instrumentation_is_enabled():
         tracer_provider = initialize_opentelemetry_tracer_provider()
         from opentelemetry.trace import TracerProvider

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -93,6 +93,7 @@ from phoenix.server.api.schema import schema
 from phoenix.server.dml_event import DmlEvent
 from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.grpc_server import GrpcServer
+from phoenix.server.rate_limiters import StrawberryRateLimiterExtension
 from phoenix.server.telemetry import initialize_opentelemetry_tracer_provider
 from phoenix.server.types import (
     CanGetLastUpdatedAt,
@@ -630,6 +631,7 @@ def create_app(
     )
     tracer_provider = None
     strawberry_extensions = schema.get_extensions()
+    strawberry_extensions.append(StrawberryRateLimiterExtension())
     if server_instrumentation_is_enabled():
         tracer_provider = initialize_opentelemetry_tracer_provider()
         from opentelemetry.trace import TracerProvider

--- a/src/phoenix/server/rate_limiters.py
+++ b/src/phoenix/server/rate_limiters.py
@@ -124,8 +124,7 @@ class ServerRateLimiter:
         for ii in active_indices:
             partition = self.cache_partitions[ii]
             if key in partition:
-                bucket = partition[key]
-                del partition[key]
+                bucket = partition.pop(key)
                 break
 
         current_partition = self.cache_partitions[current_partition_index]

--- a/src/phoenix/server/rate_limiters.py
+++ b/src/phoenix/server/rate_limiters.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from functools import partial
 from time import time
+from typing import List, Optional
 
 from phoenix.exceptions import PhoenixException
 
@@ -14,8 +15,8 @@ class TokenBucket:
     An implementation of the token-bucket algorithm for use as a rate limiter.
 
     Args:
-    per_second_request_rate (float): The allowed request rate.
-    enforcement_window_minutes (float): The time window over which the rate limit is enforced.
+        per_second_request_rate (float): The allowed request rate.
+        enforcement_window_minutes (float): The time window over which the rate limit is enforced.
     """
 
     def __init__(
@@ -47,55 +48,82 @@ class TokenBucket:
 
 
 class ServerRateLimiter:
+    """
+    This rate limiter holds a cache of token buckets that enforce rate limits.
+
+    The cache is stored in partitions that rotate every `partition_seconds`.
+    Every time the cache is accessed, inactive partitions are purged. If enough
+    time has passed, the entire cache is purged.
+    """
+
     def __init__(
         self,
         per_second_rate_limit: float = 0.5,
         enforcement_window_seconds: float = 5,
-        expiration_seconds: float = 60,
-        num_partitions: int = 2,
+        partition_seconds: float = 60,
+        active_partitions: int = 3,
     ):
-        bucket_factory = partial(
+        self.bucket_factory = partial(
             TokenBucket,
             per_second_request_rate=per_second_rate_limit,
             enforcement_window_seconds=enforcement_window_seconds,
         )
-        self.rate_limiters = defaultdict(bucket_factory)
-        self.expiration_seconds = expiration_seconds
-        self.num_partitions = num_partitions
-        self.cache_partitions = [set() for _ in range(self.num_partitions)]
-        self._last_cleanup_time = time()
+        self.expiration_seconds = partition_seconds
+        self.active_partitions = active_partitions
+        self.num_partitions = active_partitions + 1
+        self._reset_rate_limiters()
 
     def _reset_rate_limiters(self) -> None:
-        self.rate_limiters = defaultdict(TokenBucket)
-        self.cache_partitions = [set() for _ in range(self.num_partitions)]
+        self.cache_partitions = [
+            defaultdict(self.bucket_factory) for _ in range(self.num_partitions)
+        ]
         self._last_cleanup_time = time()
 
-    def _current_bucket_index(self) -> int:
-        return int(time() // self.expiration_seconds) % self.num_partitions  # a cyclic bucket index
+    def _bucket_index(self, timestamp) -> int:
+        return (
+            int(timestamp // self.expiration_seconds) % self.num_partitions
+        )  # a cyclic bucket index
 
-    def _cleanup_expired_limiters(self, current_index: int) -> None:
-        if time() - self._last_cleanup_time >= (self.num_partitions * self.expiration_seconds):
+    def _active_bucket_indices(self, current_index) -> List[int]:
+        return [(current_index - ii) % self.num_partitions for ii in range(self.active_partitions)]
+    
+
+    def _inactive_token_bucket_indices(self, current_index) -> List[int]:
+        active_indices = set(self._active_bucket_indices(current_index))
+        all_indices = set(range(self.num_partitions))
+        return list(all_indices - active_indices)
+
+    def _cleanup_expired_limiters(self, request_time: float) -> None:
+        if time() - self._last_cleanup_time >= (self.active_partitions * self.expiration_seconds):
             self._reset_rate_limiters()
             return
 
-        for ii in range(self.num_partitions):
-            if ii != current_index:
-                for user_id in self.cache_partitions[ii]:
-                    del self.rate_limiters[user_id]
-                self.cache_partitions[ii].clear()
-        self._last_cleanup_time = time()
+        current_bucket_index = self._bucket_index(request_time)
+        inactive_bucket_indices = self._inactive_bucket_indices(current_bucket_index)
+        for ii in inactive_bucket_indices:
+            self.cache_partitions[ii] = defaultdict(self.bucket_factory)
+        self._last_cleanup_time = request_time
 
-    def _update_bucket(self, key: str, current_index: int) -> None:
-        for partition in self.cache_partitions:
+    def _fetch_token_bucket(self, key: str, request_time: float) -> TokenBucket:
+        current_bucket_index = self._bucket_index(request_time)
+        active_bucket_indices = self._active_bucket_indices(current_bucket_index)
+        bucket: Optional[TokenBucket] = None
+        for ii in active_bucket_indices:
+            partition = self.cache_partitions[ii]
             if key in partition:
-                partition.remove(key)
-        self.cache_partitions[current_index].add(key)
+                bucket = partition[key]
+                del partition[key]
+                break
+
+        current_partition = self.cache_partitions[current_bucket_index]
+        if key not in current_partition and bucket is not None:
+            current_partition[key] = bucket
+        return current_partition[key]
 
     def make_request(self, key: str) -> None:
-        current_index = self._current_bucket_index()
-        self._cleanup_expired_limiters(current_index)
-        self._update_bucket(key, current_index)
-        rate_limiter = self.rate_limiters[key]
+        request_time = time()
+        self._cleanup_expired_limiters(request_time)
+        rate_limiter = self._fetch_token_bucket(key, request_time)
         rate_limiter.make_request_if_ready()
 
 

--- a/src/phoenix/server/rate_limiters.py
+++ b/src/phoenix/server/rate_limiters.py
@@ -1,0 +1,118 @@
+from collections import defaultdict
+from functools import partial
+from time import time
+
+from phoenix.exceptions import PhoenixException
+
+
+class UnavailableTokensError(PhoenixException):
+    pass
+
+
+class TokenBucket:
+    """
+    An implementation of the token-bucket algorithm for use as a rate limiter.
+
+    Args:
+    per_second_request_rate (float): The allowed request rate.
+    enforcement_window_minutes (float): The time window over which the rate limit is enforced.
+    """
+
+    def __init__(
+        self,
+        per_second_request_rate: float,
+        enforcement_window_seconds: float = 1,
+    ):
+        self.enforcement_window = enforcement_window_seconds
+        self.rate = per_second_request_rate
+
+        now = time()
+        self.last_checked = now
+        self.tokens = self.max_tokens()
+
+    def max_tokens(self) -> float:
+        return self.rate * self.enforcement_window
+
+    def available_requests(self) -> float:
+        now = time()
+        time_since_last_checked = now - self.last_checked
+        self.tokens = min(self.max_tokens(), self.rate * time_since_last_checked + self.tokens)
+        self.last_checked = now
+        return self.tokens
+
+    def make_request_if_ready(self) -> None:
+        if self.available_requests() < 1:
+            raise UnavailableTokensError
+        self.tokens -= 1
+
+
+class ServerRateLimiter:
+    def __init__(
+        self,
+        per_second_rate_limit: float = 0.5,
+        enforcement_window_seconds: float = 5,
+        expiration_seconds: float = 60,
+        num_partitions: int = 2,
+    ):
+        bucket_factory = partial(
+            TokenBucket,
+            per_second_request_rate=per_second_rate_limit,
+            enforcement_window_seconds=enforcement_window_seconds,
+        )
+        self.rate_limiters = defaultdict(bucket_factory)
+        self.expiration_seconds = expiration_seconds
+        self.num_partitions = num_partitions
+        self.cache_partitions = [set() for _ in range(self.num_partitions)]
+        self._last_cleanup_time = time()
+
+    def _reset_rate_limiters(self) -> None:
+        self.rate_limiters = defaultdict(TokenBucket)
+        self.cache_partitions = [set() for _ in range(self.num_partitions)]
+        self._last_cleanup_time = time()
+
+    def _current_bucket_index(self) -> int:
+        return int(time() // self.expiration_seconds) % self.num_partitions  # a cyclic bucket index
+
+    def _cleanup_expired_limiters(self, current_index: int) -> None:
+        if time() - self._last_cleanup_time >= (self.num_partitions * self.expiration_seconds):
+            self._reset_rate_limiters()
+            return
+
+        for ii in range(self.num_partitions):
+            if ii != current_index:
+                for user_id in self.cache_partitions[ii]:
+                    del self.rate_limiters[user_id]
+                self.cache_partitions[ii].clear()
+        self._last_cleanup_time = time()
+
+    def _update_bucket(self, key: str, current_index: int) -> None:
+        for partition in self.cache_partitions:
+            if key in partition:
+                partition.remove(key)
+        self.cache_partitions[current_index].add(key)
+
+    def make_request(self, key: str) -> None:
+        current_index = self._current_bucket_index()
+        self._cleanup_expired_limiters(current_index)
+        self._update_bucket(key, current_index)
+        rate_limiter = self.rate_limiters[key]
+        rate_limiter.make_request_if_ready()
+
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class RateLimiterMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, rate_limiter: ServerRateLimiter):
+        super().__init__(app)
+        self.rate_limiter = rate_limiter
+
+    async def dispatch(self, request: Request, call_next):
+        client_ip = request.client.host
+        try:
+            self.rate_limiter.make_request(client_ip)
+        except UnavailableTokensError:
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+        response = await call_next(request)
+        return response

--- a/tests/server/test_rate_limiters.py
+++ b/tests/server/test_rate_limiters.py
@@ -106,7 +106,10 @@ def test_rate_limiter_cleans_up_old_partitions():
 
     with warp_time(start):
         limiter = ServerRateLimiter(
-            per_second_rate_limit=1, enforcement_window_seconds=100, partition_seconds=10, active_partitions=2
+            per_second_rate_limit=1,
+            enforcement_window_seconds=100,
+            partition_seconds=10,
+            active_partitions=2,
         )
         limiter.make_request("test_key_1")
         limiter.make_request("test_key_2")
@@ -114,7 +117,7 @@ def test_rate_limiter_cleans_up_old_partitions():
         limiter.make_request("test_key_4")
         partition_sizes = [len(partition) for partition in limiter.cache_partitions]
         assert sum(partition_sizes) == 4
-    
+
     with freeze_time(start + 10):
         # after 10 seconds, the cache rolls over to a second active partition
         limiter.make_request("test_key_4")  # moves test_key_4 to current partition
@@ -124,7 +127,6 @@ def test_rate_limiter_cleans_up_old_partitions():
         assert 2 in partition_sizes  # two rate limiters in current cache partition
         assert 3 in partition_sizes  # three rate limiters remaining in original partition
         assert 0 in partition_sizes  # overflow partition is empty
-
 
     with freeze_time(start + 10 + 21):
         limiter.make_request("fresh_key")  # After 21 seconds, all partitions should be reset

--- a/tests/server/test_rate_limiters.py
+++ b/tests/server/test_rate_limiters.py
@@ -126,8 +126,7 @@ def test_rate_limiter_cleans_up_old_partitions():
         assert sum(partition_sizes) == 5
         assert 2 in partition_sizes  # two rate limiters in current cache partition
         assert 3 in partition_sizes  # three rate limiters remaining in original partition
-        assert 0 in partition_sizes  # overflow partition is empty
 
-    with freeze_time(start + 10 + 21):
-        limiter.make_request("fresh_key")  # After 21 seconds, all partitions should be reset
+    with freeze_time(start + 10 + 40):
+        limiter.make_request("fresh_key")  # when "looping" partitions, they should be reset
         assert sum(len(partition) for partition in limiter.cache_partitions) == 1

--- a/tests/server/test_rate_limiters.py
+++ b/tests/server/test_rate_limiters.py
@@ -1,0 +1,131 @@
+import time
+from contextlib import contextmanager
+from typing import Optional
+from unittest import mock
+
+import pytest
+
+from phoenix.server.rate_limiters import ServerRateLimiter, TokenBucket, UnavailableTokensError
+
+
+@contextmanager
+def freeze_time(frozen_time: Optional[float] = None):
+    frozen_time = time.time() if frozen_time is None else frozen_time
+
+    with mock.patch("time.time") as mock_time:
+        mock_time.return_value = frozen_time
+        yield mock_time
+
+
+@contextmanager
+def warp_time(start: Optional[float]):
+    sleeps = [0]
+    current_time = start
+    start = time.time() if start is None else start
+
+    def instant_sleep(time):
+        nonlocal sleeps
+        sleeps.append(time)
+
+    def time_warp():
+        try:
+            nonlocal current_time
+            nonlocal sleeps
+            current_time += sleeps.pop()
+            return current_time
+        except IndexError:
+            return current_time
+
+    with mock.patch("time.time") as mock_time:
+        with mock.patch("time.sleep") as mock_sleep:
+            mock_sleep.side_effect = instant_sleep
+            mock_time.side_effect = time_warp
+            yield
+
+
+def test_token_bucket_gains_tokens_over_time():
+    start = time.time()
+
+    with freeze_time(start):
+        bucket = TokenBucket(per_second_request_rate=1, enforcement_window_seconds=30)
+        bucket.tokens = 0  # start at 0
+
+    with freeze_time(start + 5):
+        assert bucket.available_requests() == 5
+
+    with freeze_time(start + 10):
+        assert bucket.available_requests() == 10
+
+
+def test_token_bucket_can_max_out_on_requests():
+    start = time.time()
+
+    with freeze_time(start):
+        bucket = TokenBucket(per_second_request_rate=1, enforcement_window_seconds=120)
+        bucket.tokens = 0  # start at 0
+
+    with freeze_time(start + 30):
+        assert bucket.available_requests() == 30
+
+    with freeze_time(start + 120):
+        assert bucket.available_requests() == 120
+
+    with freeze_time(start + 130):
+        assert bucket.available_requests() == 120  # should max out at 120
+
+
+def test_token_bucket_spends_tokens():
+    start = time.time()
+
+    with freeze_time(start):
+        bucket = TokenBucket(per_second_request_rate=1, enforcement_window_seconds=10)
+        bucket.tokens = 0  # start at 0
+
+    with freeze_time(start + 3):
+        assert bucket.available_requests() == 3
+        bucket.make_request_if_ready()
+        assert bucket.available_requests() == 2
+
+
+def test_token_bucket_cannot_spend_unavailable_tokens():
+    start = time.time()
+
+    with freeze_time(start):
+        bucket = TokenBucket(per_second_request_rate=1, enforcement_window_seconds=2)
+        bucket.tokens = 0  # start at 0
+
+    with freeze_time(start + 1):
+        assert bucket.available_requests() == 1
+        bucket.make_request_if_ready()  # should spend one token
+        with pytest.raises(UnavailableTokensError):
+            bucket.make_request_if_ready()  # should raise since no tokens left
+
+
+def test_rate_limiter_cleans_up_old_partitions():
+    start = time.time()
+
+    with warp_time(start):
+        limiter = ServerRateLimiter(
+            per_second_rate_limit=1, enforcement_window_seconds=100, partition_seconds=10, active_partitions=2
+        )
+        limiter.make_request("test_key_1")
+        limiter.make_request("test_key_2")
+        limiter.make_request("test_key_3")
+        limiter.make_request("test_key_4")
+        partition_sizes = [len(partition) for partition in limiter.cache_partitions]
+        assert sum(partition_sizes) == 4
+    
+    with freeze_time(start + 10):
+        # after 10 seconds, the cache rolls over to a second active partition
+        limiter.make_request("test_key_4")  # moves test_key_4 to current partition
+        limiter.make_request("test_key_5")  # creates test_key_5 in current partition
+        partition_sizes = [len(partition) for partition in limiter.cache_partitions]
+        assert sum(partition_sizes) == 5
+        assert 2 in partition_sizes  # two rate limiters in current cache partition
+        assert 3 in partition_sizes  # three rate limiters remaining in original partition
+        assert 0 in partition_sizes  # overflow partition is empty
+
+
+    with freeze_time(start + 10 + 21):
+        limiter.make_request("fresh_key")  # After 21 seconds, all partitions should be reset
+        assert sum(len(partition) for partition in limiter.cache_partitions) == 1


### PR DESCRIPTION
resolves #4344 

- Implements a configurable rate limiter that can be applied to both GQL and REST routes
- Currently rate limits the `login` route by IP
- The IP cache rotates automatically and resets if not accessed for too long