### PR TITLE
chore: Use `phoenix.otel` in notebooks

### DIFF
--- a/scripts/fixtures/vision.ipynb
+++ b/scripts/fixtures/vision.ipynb
@@ -28,11 +28,6 @@
     "from faker import Faker\n",
     "from openinference.instrumentation import TraceConfig\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
-    "from openinference.semconv.resource import ResourceAttributes\n",
-    "from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.resources import Resource\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px"
    ]
@@ -44,11 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:4317\"\n",
-    "tracer_provider = TracerProvider(\n",
-    "    resource=Resource({ResourceAttributes.PROJECT_NAME: \"vision-fixture\"})\n",
-    ")\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
+    "from phoenix.otel import register\n",
+    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:4317\", project_name=\"vision-fixture\")\n",
     "config = TraceConfig(base64_image_max_length=1_000_000_000)\n",
     "OpenAIInstrumentor().instrument(tracer_provider=tracer_provider, config=config)"
    ]

--- a/tutorials/demos/demo_llama_index_rag.ipynb
+++ b/tutorials/demos/demo_llama_index_rag.ipynb
@@ -100,14 +100,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/demos/demo_llama_index_rag.ipynb
+++ b/tutorials/demos/demo_llama_index_rag.ipynb
@@ -100,6 +100,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/evals/evals_sql_correctness_eval_with_custom_agent.ipynb
+++ b/tutorials/evals/evals_sql_correctness_eval_with_custom_agent.ipynb
@@ -151,14 +151,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/evals/evals_sql_correctness_eval_with_custom_agent.ipynb
+++ b/tutorials/evals/evals_sql_correctness_eval_with_custom_agent.ipynb
@@ -151,6 +151,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/evals/evaluate_rag.ipynb
+++ b/tutorials/evals/evaluate_rag.ipynb
@@ -171,14 +171,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/evals/evaluate_rag.ipynb
+++ b/tutorials/evals/evaluate_rag.ipynb
@@ -171,6 +171,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/experiments/langchain_email_extraction.ipynb
+++ b/tutorials/experiments/langchain_email_extraction.ipynb
@@ -92,10 +92,10 @@
     "from langchain_openai.chat_models import ChatOpenAI\n",
     "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
-    "from phoenix.otel import register\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.experiments import evaluate_experiment, run_experiment\n",
+    "from phoenix.otel import register\n",
     "\n",
     "nest_asyncio.apply()"
    ]

--- a/tutorials/experiments/langchain_email_extraction.ipynb
+++ b/tutorials/experiments/langchain_email_extraction.ipynb
@@ -92,9 +92,7 @@
     "from langchain_openai.chat_models import ChatOpenAI\n",
     "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.experiments import evaluate_experiment, run_experiment\n",
@@ -144,11 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:4317\"\n",
-    "(tracer_provider := TracerProvider()).add_span_processor(\n",
-    "    SimpleSpanProcessor(OTLPSpanExporter(endpoint))\n",
-    ")\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:4317\")\n",
     "LangChainInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)\n",
     "OpenAIInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]

--- a/tutorials/experiments/llama-index/answer_and_context_relevancy.ipynb
+++ b/tutorials/experiments/llama-index/answer_and_context_relevancy.ipynb
@@ -81,13 +81,11 @@
     "from llama_index.core.llama_dataset import download_llama_dataset\n",
     "from llama_index.llms.openai import OpenAI\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.experiments import evaluate_experiment, run_experiment\n",
     "from phoenix.experiments.types import Explanation, Score\n",
+    "from phoenix.otel import register\n",
     "\n",
     "nest_asyncio.apply()"
    ]
@@ -121,10 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:4317\"\n",
-    "(tracer_provider := TracerProvider()).add_span_processor(\n",
-    "    SimpleSpanProcessor(OTLPSpanExporter(endpoint))\n",
-    ")\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:4317\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/experiments/llama-index/guideline_eval.ipynb
+++ b/tutorials/experiments/llama-index/guideline_eval.ipynb
@@ -80,13 +80,11 @@
     "from llama_index.core.evaluation import GuidelineEvaluator\n",
     "from llama_index.llms.openai import OpenAI\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.experiments import evaluate_experiment, run_experiment\n",
     "from phoenix.experiments.types import Explanation, Score\n",
+    "from phoenix.otel import register\n",
     "\n",
     "nest_asyncio.apply()"
    ]
@@ -120,10 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:4317\"\n",
-    "(tracer_provider := TracerProvider()).add_span_processor(\n",
-    "    SimpleSpanProcessor(OTLPSpanExporter(endpoint))\n",
-    ")\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:4317\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/experiments/llama-index/pairwise_eval.ipynb
+++ b/tutorials/experiments/llama-index/pairwise_eval.ipynb
@@ -81,13 +81,11 @@
     ")\n",
     "from llama_index.llms.openai import OpenAI\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.experiments import evaluate_experiment, run_experiment\n",
     "from phoenix.experiments.types import Explanation, Score\n",
+    "from phoenix.otel import register\n",
     "\n",
     "nest_asyncio.apply()"
    ]
@@ -121,10 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:4317\"\n",
-    "(tracer_provider := TracerProvider()).add_span_processor(\n",
-    "    SimpleSpanProcessor(OTLPSpanExporter(endpoint))\n",
-    ")\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:4317\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/experiments/run_experiments_with_llama_index.ipynb
+++ b/tutorials/experiments/run_experiments_with_llama_index.ipynb
@@ -53,15 +53,13 @@
     "from llama_index.llms.openai import OpenAI\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px\n",
     "from phoenix.evals import OpenAIModel\n",
     "from phoenix.experiments import run_experiment\n",
     "from phoenix.experiments.evaluators import ConcisenessEvaluator\n",
     "from phoenix.experiments.types import EvaluationResult, Example, ExperimentRun\n",
+    "from phoenix.otel import register\n",
     "\n",
     "nest_asyncio.apply()"
    ]
@@ -81,10 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = trace_sdk.TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)\n",
     "OpenAIInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]

--- a/tutorials/experiments/summarization.ipynb
+++ b/tutorials/experiments/summarization.ipynb
@@ -99,14 +99,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = trace_sdk.TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "OpenAIInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/experiments/summarization.ipynb
+++ b/tutorials/experiments/summarization.ipynb
@@ -99,6 +99,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
+++ b/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
@@ -40,15 +40,7 @@
    "source": [
     "import json\n",
     "import os\n",
-    "import warnings"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import warnings\n",
     "from getpass import getpass\n",
     "from typing import Any, Dict\n",
     "from uuid import uuid4\n",
@@ -62,11 +54,9 @@
     "    SpanAttributes,\n",
     ")\n",
     "from opentelemetry import trace as trace_api\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
     "\n",
     "import phoenix as px\n",
+    "from phoenix.otel import register\n",
     "\n",
     "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
     "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")"
@@ -85,14 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ENDPOINT = \"http://localhost:6006/v1\"\n",
-    "FEEDBACK_ENDPOINT = f\"{ENDPOINT}/span_annotations\"\n",
-    "OPENAI_API_URL = \"https://api.openai.com/v1/chat/completions\"\n",
-    "\n",
-    "tracer_provider = trace_sdk.TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(f\"{ENDPOINT}/traces\")))\n",
-    "trace_api.set_tracer_provider(tracer_provider)\n",
-    "TRACER = trace_api.get_tracer(__name__)"
+    "px.launch_app()"
    ]
   },
   {
@@ -101,7 +84,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "px.launch_app()"
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENDPOINT = \"http://localhost:6006/v1\"\n",
+    "FEEDBACK_ENDPOINT = f\"{ENDPOINT}/span_annotations\"\n",
+    "OPENAI_API_URL = \"https://api.openai.com/v1/chat/completions\"\n",
+    "TRACER = trace_api.get_tracer(__name__)"
    ]
   },
   {
@@ -241,8 +236,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "phoenix",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tutorials/integrations/arize_anyscale_traces_and_embeddings.ipynb
+++ b/tutorials/integrations/arize_anyscale_traces_and_embeddings.ipynb
@@ -203,6 +203,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/integrations/arize_anyscale_traces_and_embeddings.ipynb
+++ b/tutorials/integrations/arize_anyscale_traces_and_embeddings.ipynb
@@ -203,14 +203,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/integrations/bedrock_tracing_tutorial.ipynb
+++ b/tutorials/integrations/bedrock_tracing_tutorial.ipynb
@@ -64,13 +64,10 @@
     "\n",
     "import boto3\n",
     "from openinference.instrumentation.bedrock import BedrockInstrumentor\n",
-    "from opentelemetry import trace as trace_api\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.resources import Resource\n",
-    "from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor\n",
+    "from opentelemetry.sdk.trace.export import ConsoleSpanExporter\n",
     "\n",
-    "import phoenix as px"
+    "import phoenix as px\n",
+    "from phoenix.otel import register, SimpleSpanProcessor"
    ]
   },
   {
@@ -103,14 +100,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resource = Resource(attributes={})\n",
-    "tracer_provider = trace_sdk.TracerProvider(resource=resource)\n",
-    "span_console_exporter = ConsoleSpanExporter()\n",
     "phoenix_otlp_endpoint = urljoin(session_url, \"v1/traces\")\n",
-    "phoenix_exporter = OTLPSpanExporter(endpoint=phoenix_otlp_endpoint)\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_console_exporter))\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=phoenix_exporter))\n",
-    "trace_api.set_tracer_provider(tracer_provider=tracer_provider)"
+    "tracer_provider = register()\n",
+    "tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=ConsoleSpanExporter()))\n",
+    "tracer_provider.add_span_processor(SimpleSpanProcessor(endpoint=phoenix_otlp_endpoint))"
    ]
   },
   {
@@ -212,8 +205,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "phoenix",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tutorials/integrations/bedrock_tracing_tutorial.ipynb
+++ b/tutorials/integrations/bedrock_tracing_tutorial.ipynb
@@ -67,7 +67,7 @@
     "from opentelemetry.sdk.trace.export import ConsoleSpanExporter\n",
     "\n",
     "import phoenix as px\n",
-    "from phoenix.otel import register, SimpleSpanProcessor"
+    "from phoenix.otel import SimpleSpanProcessor, register"
    ]
   },
   {

--- a/tutorials/llm_application_tracing_evaluating_and_analysis.ipynb
+++ b/tutorials/llm_application_tracing_evaluating_and_analysis.ipynb
@@ -111,14 +111,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/llm_application_tracing_evaluating_and_analysis.ipynb
+++ b/tutorials/llm_application_tracing_evaluating_and_analysis.ipynb
@@ -111,6 +111,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/llm_ops_overview.ipynb
+++ b/tutorials/llm_ops_overview.ipynb
@@ -113,14 +113,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/llm_ops_overview.ipynb
+++ b/tutorials/llm_ops_overview.ipynb
@@ -113,6 +113,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/mistral/evaluate_rag--mistral.ipynb
+++ b/tutorials/mistral/evaluate_rag--mistral.ipynb
@@ -156,6 +156,7 @@
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
     "from openinference.instrumentation.mistralai import MistralAIInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/mistral/evaluate_rag--mistral.ipynb
+++ b/tutorials/mistral/evaluate_rag--mistral.ipynb
@@ -156,14 +156,9 @@
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
     "from openinference.instrumentation.mistralai import MistralAIInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "MistralAIInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]

--- a/tutorials/ragas_retrieval_evals_tutorial.ipynb
+++ b/tutorials/ragas_retrieval_evals_tutorial.ipynb
@@ -142,6 +142,7 @@
    "source": [
     "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/ragas_retrieval_evals_tutorial.ipynb
+++ b/tutorials/ragas_retrieval_evals_tutorial.ipynb
@@ -142,14 +142,9 @@
    "source": [
     "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import SpanLimits, TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider(span_limits=SpanLimits(max_attributes=100_000))\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)\n",
     "LangChainInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]

--- a/tutorials/tracing/crewai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/crewai_tracing_tutorial.ipynb
@@ -63,16 +63,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from opentelemetry import trace as trace_api\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "tracer_provider = trace_sdk.TracerProvider()\n",
-    "span_exporter = OTLPSpanExporter(\"http://localhost:6006/v1/traces\")\n",
-    "span_processor = SimpleSpanProcessor(span_exporter)\n",
-    "tracer_provider.add_span_processor(span_processor)\n",
-    "trace_api.set_tracer_provider(tracer_provider)"
+    "tracer_provider = register(endpoint=\"http://localhost:6006/v1/traces\")"
    ]
   },
   {
@@ -92,7 +85,7 @@
    "source": [
     "from openinference.instrumentation.crewai import CrewAIInstrumentor\n",
     "\n",
-    "CrewAIInstrumentor().instrument(skip_dep_check=True)"
+    "CrewAIInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },
   {

--- a/tutorials/tracing/dspy_tracing_tutorial.ipynb
+++ b/tutorials/tracing/dspy_tracing_tutorial.ipynb
@@ -320,19 +320,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.dspy import DSPyInstrumentor\n",
-    "from opentelemetry import trace as trace_api\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk import trace as trace_sdk\n",
-    "from opentelemetry.sdk.resources import Resource\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "resource = Resource(attributes={})\n",
-    "tracer_provider = trace_sdk.TracerProvider(resource=resource)\n",
-    "span_otlp_exporter = OTLPSpanExporter(endpoint=endpoint)\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter=span_otlp_exporter))\n",
-    "\n",
-    "trace_api.set_tracer_provider(tracer_provider=tracer_provider)\n",
+    "register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "DSPyInstrumentor().instrument(skip_dep_check=True)"
    ]
   },

--- a/tutorials/tracing/dspy_tracing_tutorial.ipynb
+++ b/tutorials/tracing/dspy_tracing_tutorial.ipynb
@@ -320,6 +320,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.dspy import DSPyInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
@@ -115,14 +115,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_openai_agent_tracing_tutorial.ipynb
@@ -115,6 +115,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -108,6 +108,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_sql_retriever_tutorial.ipynb
@@ -108,14 +108,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/tracing/llama_index_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_tracing_tutorial.ipynb
@@ -177,6 +177,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",

--- a/tutorials/tracing/llama_index_tracing_tutorial.ipynb
+++ b/tutorials/tracing/llama_index_tracing_tutorial.ipynb
@@ -177,14 +177,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/tracing/tracing_with_projects_tutorial.ipynb
+++ b/tutorials/tracing/tracing_with_projects_tutorial.ipynb
@@ -199,14 +199,9 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter\n",
-    "from opentelemetry.sdk.trace import TracerProvider\n",
-    "from opentelemetry.sdk.trace.export import SimpleSpanProcessor\n",
+    "from phoenix.otel import register\n",
     "\n",
-    "endpoint = \"http://127.0.0.1:6006/v1/traces\"\n",
-    "tracer_provider = TracerProvider()\n",
-    "tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))\n",
-    "\n",
+    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
     "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
    ]
   },

--- a/tutorials/tracing/tracing_with_projects_tutorial.ipynb
+++ b/tutorials/tracing/tracing_with_projects_tutorial.ipynb
@@ -199,6 +199,7 @@
    "outputs": [],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
+    "\n",
     "from phoenix.otel import register\n",
     "\n",
     "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",


### PR DESCRIPTION
Update all notebooks to use `phoenix.otel` (except for the manual instrumentation notebook, which is raw opentelemetry)