### PR TITLE
style: fix small typo in app

### DIFF
--- a/app/src/components/project/PythonProjectGuide.tsx
+++ b/app/src/components/project/PythonProjectGuide.tsx
@@ -139,7 +139,7 @@ export function PythonProjectGuide(props: PythonProjectGuideProps) {
       {!isHosted ? (
         <View paddingBottom="size-100">
           <Text>
-            To configure gRPC and baching, see our{" "}
+            To configure gRPC and batching, see our{" "}
             <ExternalLink href={PHOENIX_OTEL_DOC_LINK}>
               setup guide
             </ExternalLink>


### PR DESCRIPTION
There is a small typo in the app where the word `batching` is spelled as `baching`.