### PR TITLE
feat: auth for swagger UI

### DIFF
--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
 from phoenix.auth import ClaimSetStatus
@@ -40,6 +41,9 @@ async def authentication(request: Request) -> None:
 
 dependencies = [Depends(prevent_access_in_read_only_mode)]
 if ENABLE_AUTH:
+    dependencies.append(
+        Depends(APIKeyHeader(name="Authorization", scheme_name="Bearer", auto_error=False))
+    )
     dependencies.append(Depends(authentication))
 
 router = APIRouter(

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -42,7 +42,14 @@ async def authentication(request: Request) -> None:
 dependencies = [Depends(prevent_access_in_read_only_mode)]
 if ENABLE_AUTH:
     dependencies.append(
-        Depends(APIKeyHeader(name="Authorization", scheme_name="Bearer", auto_error=False))
+        Depends(
+            APIKeyHeader(
+                name="Authorization",
+                scheme_name="Bearer",
+                auto_error=False,
+                description="Enter `Bearer` followed by a space and then the token.",
+            )
+        )
     )
     dependencies.append(Depends(authentication))
 


### PR DESCRIPTION
resolves #4275 

Caveat: `Bearer ` prefix must be [manually added](https://stackoverflow.com/a/32995636) when entering the token.