### PR TITLE
feat: api keys on viewer node

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1450,10 +1450,8 @@ type User implements Node {
   email: String!
   username: String
   createdAt: DateTime!
-
-  """API keys associated with the user."""
-  apiKeys: [ApiKey!]
   role: UserRole!
+  apiKeys: [ApiKey!]!
 }
 
 type UserApiKey implements ApiKey & Node {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1450,6 +1450,9 @@ type User implements Node {
   email: String!
   username: String
   createdAt: DateTime!
+
+  """API keys associated with the user."""
+  apiKeys: [ApiKey!]
   role: UserRole!
 }
 

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -496,7 +496,10 @@ class Query:
                 )
             ) is None:
                 return None
-        return to_gql_user(user)
+            api_keys = list(
+                await session.scalars(select(models.ApiKey).where(models.ApiKey.user_id == user.id))
+            )
+        return to_gql_user(user, api_keys=api_keys)
 
     @strawberry.field
     def clusters(

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -496,10 +496,7 @@ class Query:
                 )
             ) is None:
                 return None
-            api_keys = list(
-                await session.scalars(select(models.ApiKey).where(models.ApiKey.user_id == user.id))
-            )
-        return to_gql_user(user, api_keys=api_keys)
+        return to_gql_user(user)
 
     @strawberry.field
     def clusters(

--- a/src/phoenix/server/api/types/ApiKey.py
+++ b/src/phoenix/server/api/types/ApiKey.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 import strawberry
 
+from phoenix.db.models import ApiKey as ORMApiKey
+
 
 @strawberry.interface
 class ApiKey:
@@ -13,4 +15,13 @@ class ApiKey:
     )
     expires_at: Optional[datetime] = strawberry.field(
         description="The date and time the API key will expire."
+    )
+
+
+def to_gql_api_key(api_key: ORMApiKey) -> ApiKey:
+    return ApiKey(
+        name=api_key.name,
+        description=api_key.description,
+        created_at=api_key.created_at,
+        expires_at=api_key.expires_at,
     )

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 import strawberry
 from strawberry import Private
@@ -9,6 +9,7 @@ from strawberry.types import Info
 from phoenix.db import models
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
+from phoenix.server.api.types.ApiKey import ApiKey, to_gql_api_key
 
 from .UserRole import UserRole, to_gql_user_role
 
@@ -20,6 +21,9 @@ class User(Node):
     username: Optional[str]
     created_at: datetime
     user_role_id: Private[int]
+    api_keys: Optional[List[ApiKey]] = strawberry.field(
+        default_factory=list, description="API keys associated with the user."
+    )
 
     @strawberry.field
     async def role(self, info: Info[Context, None]) -> UserRole:
@@ -29,14 +33,19 @@ class User(Node):
         return to_gql_user_role(role)
 
 
-def to_gql_user(user: models.User) -> User:
+def to_gql_user(user: models.User, api_keys: Optional[List[models.ApiKey]] = None) -> User:
     """
     Converts an ORM user to a GraphQL user.
     """
+    if api_keys is None:
+        gql_api_keys = []
+    else:
+        gql_api_keys = [to_gql_api_key(api_key) for api_key in api_keys]
     return User(
         id_attr=user.id,
         username=user.username,
         email=user.email,
         created_at=user.created_at,
         user_role_id=user.user_role_id,
+        api_keys=gql_api_keys,
     )

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 
 import strawberry
+from sqlalchemy import select
 from strawberry import Private
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
@@ -21,9 +22,6 @@ class User(Node):
     username: Optional[str]
     created_at: datetime
     user_role_id: Private[int]
-    api_keys: Optional[List[ApiKey]] = strawberry.field(
-        default_factory=list, description="API keys associated with the user."
-    )
 
     @strawberry.field
     async def role(self, info: Info[Context, None]) -> UserRole:
@@ -32,20 +30,23 @@ class User(Node):
             raise NotFound(f"User role with id {self.user_role_id} not found")
         return to_gql_user_role(role)
 
+    @strawberry.field
+    async def api_keys(self, info: Info[Context, None]) -> List[ApiKey]:
+        async with info.context.db() as session:
+            api_keys = await session.scalars(
+                select(models.ApiKey).where(models.ApiKey.user_id == self.id_attr)
+            )
+        return [to_gql_api_key(api_key) for api_key in api_keys]
+
 
 def to_gql_user(user: models.User, api_keys: Optional[List[models.ApiKey]] = None) -> User:
     """
     Converts an ORM user to a GraphQL user.
     """
-    if api_keys is None:
-        gql_api_keys = []
-    else:
-        gql_api_keys = [to_gql_api_key(api_key) for api_key in api_keys]
     return User(
         id_attr=user.id,
         username=user.username,
         email=user.email,
         created_at=user.created_at,
         user_role_id=user.user_role_id,
-        api_keys=gql_api_keys,
     )


### PR DESCRIPTION
resolves #4452 

Adds an optional `api_keys` field to the `User` node. The `viewer` node will populate these API keys on the user if any exist.