### PR TITLE
chore: Enable flaky test allowance in CI only

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -133,15 +133,15 @@ jobs:
       - name: Run tests (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          hatch run test:tests --run-postgres
+          hatch run test:tests --run-postgres --allow-flaky
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
         run: |
-          hatch run test:tests
+          hatch run test:tests --allow-flaky
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: |
-          hatch run test:tests
+          hatch run test:tests --allow-flaky
 
   integration-test:
     runs-on: ${{ matrix.os }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,11 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         help="Run tests that require Postgres",
     )
+    parser.addoption(
+        "--allow-flaky",
+        action="store_true",
+        help="Allows a number of flaky database tests to fail",
+    )
 
 
 def pytest_terminal_summary(
@@ -83,6 +88,8 @@ def pytest_collection_modifyitems(config: Config, items: List[Any]) -> None:
             if "dialect" in item.fixturenames:
                 if "postgresql" in item.callspec.params.values():
                     item.add_marker(skip_postgres)
+
+    if config.getoption("--allow-flaky"):
         for item in items:
             if "dialect" in item.fixturenames:
                 item.add_marker(pytest.mark.xfail(reason="database tests are currently flaky"))


### PR DESCRIPTION
Enables flaky test allowance when run in CI. This is off by default, so we can still run tests normally locally.