### PR TITLE
ci: forbid default admin from logging out when running tests concurrently

### DIFF
--- a/integration_tests/_helpers.py
+++ b/integration_tests/_helpers.py
@@ -398,17 +398,23 @@ def _start_span(
     ).start_span(span_name)
 
 
-class _DefaultAdminTokenSequestration:
+class _DefaultAdminTokens(ABC):
     """
     Because the tests can be run concurrently, and we need the default admin to create database
     entities (e.g. to add new users), the default admin should never log out once logged in,
     because logging out invalidates all existing access tokens, resulting in a race among the
     tests. The approach here is to add a middleware to block any inadvertent use of the default
-    admin's access tokens for logging out.
+    admin's access tokens for logging out. This class is intended to be used as a singleton
+    container to ensure that all tokens are always accounted for. Furthermore, the tokens are
+    disambiguated by the port of the server to which they belong.
     """
 
     _set: Set[Tuple[int, str]] = set()
     _lock: Lock = Lock()
+
+    @classmethod
+    def __new__(cls) -> Self:
+        raise NotImplementedError("This class is intended as a singleton to be used directly.")
 
     @classmethod
     def stash(cls, port: int, cookies: str) -> None:
@@ -433,6 +439,45 @@ class _DefaultAdminTokenSequestration:
         return False
 
 
+class _DefaultAdminTokenSequestration(httpx.BaseTransport):
+    """
+    This middleware sequesters the default admin's access and refresh tokens when they pass
+    through the httpx client. If a sequestered token is used to log out, an exception is
+    raised. This is because logging out the default admin during testing would revoke all
+    existing access tokens being held by other concurrent tests attached to the same server.
+    """
+
+    message = "Default admin must not log out during testing."
+    exc_cls = RuntimeError
+
+    def __init__(self, transport: httpx.BaseTransport) -> None:
+        self._transport = transport
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        assert (port := request.url.port)
+        path, headers = request.url.path, request.headers
+        sequester_tokens = False
+        if "auth/login" in path:
+            sequester_tokens = DEFAULT_ADMIN_EMAIL in request.content.decode()
+        elif "auth/refresh" in path:
+            if cookies := headers.get("cookie"):
+                sequester_tokens = _DefaultAdminTokens.intersect(port, cookies)
+        elif (
+            "auth/logout" in path
+            and (cookies := headers.get("cookie"))
+            and _DefaultAdminTokens.intersect(port, cookies)
+        ):
+            raise self.exc_cls(self.message)
+        response = self._transport.handle_request(request)
+        if (
+            sequester_tokens
+            and response.status_code // 100 == 2
+            and (cookies := response.headers.get("set-cookie"))
+        ):
+            _DefaultAdminTokens.stash(port, cookies)
+        return response
+
+
 class _LogResponse(httpx.Response):
     def __init__(self, info: BytesIO, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -454,29 +499,10 @@ class _LogTransport(httpx.BaseTransport):
         self._transport = transport
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        assert (port := request.url.port)
-        sequester_tokens = False
-        if request.url.path.endswith("auth/login"):
-            sequester_tokens = DEFAULT_ADMIN_EMAIL in request.content.decode()
-        elif request.url.path.endswith("auth/refresh"):
-            if cookies := request.headers.get("cookie"):
-                sequester_tokens = _DefaultAdminTokenSequestration.intersect(port, cookies)
-        elif (
-            request.url.path.endswith("auth/logout")
-            and (cookies := request.headers.get("cookie"))
-            and _DefaultAdminTokenSequestration.intersect(port, cookies)
-        ):
-            raise RuntimeError("Default admin must not log out during testing.")
         info = BytesIO()
         info.write(f"{'-'*50}\n".encode())
         info.write(f"{datetime.now(timezone.utc).isoformat()}\n".encode())
         response = self._transport.handle_request(request)
-        if (
-            sequester_tokens
-            and response.status_code // 100 == 2
-            and (cookies := response.headers.get("set-cookie"))
-        ):
-            _DefaultAdminTokenSequestration.stash(port, cookies)
         info.write(f"{response.status_code} {request.method} {request.url}\n".encode())
         info.write(f"{request.headers}\n".encode())
         info.write(f"{response.headers}\n".encode())
@@ -526,7 +552,11 @@ def _httpx_client(
         headers=headers,
         cookies=cookies,
         base_url=get_base_url(),
-        transport=transport or _LogTransport(httpx.HTTPTransport()),
+        transport=_LogTransport(
+            _DefaultAdminTokenSequestration(
+                transport or httpx.HTTPTransport(),
+            )
+        ),
     )
 
 

--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -100,7 +100,7 @@ class TestLogIn:
 
 
 class TestLogOut:
-    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN, _DEFAULT_ADMIN])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_can_log_out(
         self,
         role_or_user: _RoleOrUser,
@@ -125,7 +125,7 @@ class TestLoggedInTokens:
             assert (jti := _decode_jwt(token)["jti"]) not in self._set
             self._set.add(jti)
 
-    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN, _DEFAULT_ADMIN])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_logged_in_tokens_should_change_after_log_out(
         self,
         role_or_user: _RoleOrUser,
@@ -139,7 +139,7 @@ class TestLoggedInTokens:
                 access_tokens.add(logged_in_user.tokens.access_token)
                 refresh_tokens.add(logged_in_user.tokens.refresh_token)
 
-    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN, _DEFAULT_ADMIN])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     @pytest.mark.parametrize("role", list(UserRoleInput))
     def test_logged_in_tokens_should_differ_between_users(
         self,
@@ -160,7 +160,7 @@ class TestLoggedInTokens:
 
 
 class TestRefreshToken:
-    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN, _DEFAULT_ADMIN])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_end_to_end_credentials_flow(
         self,
         role_or_user: _RoleOrUser,

--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -34,6 +34,7 @@ from .._helpers import (
     _AccessToken,
     _ApiKey,
     _create_user,
+    _DefaultAdminTokenSequestration,
     _Expectation,
     _GetUser,
     _GqlId,
@@ -100,6 +101,17 @@ class TestLogIn:
 
 
 class TestLogOut:
+    def test_default_admin_cannot_log_out_during_testing(self) -> None:
+        """
+        This is not a functional test of Phoenix itself. Instead, it is intended to verify
+        that the safeguard preventing the default admin from logging out during concurrent
+        test runs is working as expected.
+        """
+        cls = _DefaultAdminTokenSequestration.exc_cls
+        msg = _DefaultAdminTokenSequestration.message
+        with pytest.raises(cls, match=msg):
+            _DEFAULT_ADMIN.log_in().log_out()
+
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_can_log_out(
         self,


### PR DESCRIPTION
Because the tests can be run concurrently, and we need the default admin to create database entities (e.g. to add new users), the default admin should never log out once logged in, because logging out invalidates all existing access tokens, resulting in a race among the tests. The approach here is to add a middleware to block any inadvertent use of the default admin's access tokens for logging out.