### PR TITLE
fix(auth): soft-delete users

### DIFF
--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -98,6 +98,19 @@ class TestLogIn:
         with _EXPECTATION_401:
             _log_in(wrong_password, email=u.email)
 
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    def test_cannot_log_in_with_deleted_user(
+        self,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        _passwords: Iterator[_Password],
+    ) -> None:
+        admin_user = _get_user(UserRoleInput.ADMIN)
+        user = _get_user(role_or_user)
+        admin_user.delete_users(user)
+        with _EXPECTATION_401:
+            user.log_in()
+
 
 class TestLogOut:
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN, _DEFAULT_ADMIN])

--- a/src/phoenix/server/api/dataloaders/users.py
+++ b/src/phoenix/server/api/dataloaders/users.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import DefaultDict, List, Optional
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -25,7 +25,9 @@ class UsersDataLoader(DataLoader[Key, Result]):
         users_by_id: DefaultDict[Key, Result] = defaultdict(None)
         async with self._db() as session:
             data = await session.stream_scalars(
-                select(models.User).where(models.User.id.in_(user_ids))
+                select(models.User).where(
+                    and_(models.User.id.in_(user_ids), models.User.deleted_at.is_(None))
+                )
             )
             async for user in data:
                 users_by_id[user.id] = user

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import strawberry
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from strawberry import UNSET
 from strawberry.relay import GlobalID
 from strawberry.types import Info
@@ -71,7 +71,9 @@ class ApiKeyMutationMixin:
             system_user = await session.scalar(
                 select(models.User)
                 .join(models.UserRole)  # Join User with UserRole
-                .where(models.UserRole.name == user_role.value)  # Filter where role is SYSTEM
+                .where(
+                    and_(models.UserRole.name == user_role.value, models.User.deleted_at.is_(None))
+                )  # Filter where role is SYSTEM
                 .order_by(models.User.id)
                 .limit(1)
             )

--- a/src/phoenix/server/api/mutations/user_mutations.py
+++ b/src/phoenix/server/api/mutations/user_mutations.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import List, Literal, Optional, Tuple
 
 import strawberry
-from sqlalchemy import Boolean, Select, and_, case, cast, delete, distinct, func, select
+from sqlalchemy import Boolean, Select, and_, case, cast, distinct, func, select, update
 from sqlalchemy.orm import joinedload
 from sqlean.dbapi2 import IntegrityError  # type: ignore[import-untyped]
 from strawberry import UNSET
@@ -27,6 +27,7 @@ from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.User import User, to_gql_user
 from phoenix.server.bearer_auth import PhoenixUser
+from phoenix.server.types import AccessTokenId, ApiKeyId, RefreshTokenId
 
 
 @strawberry.input
@@ -195,6 +196,7 @@ class UserMutationMixin:
         info: Info[Context, None],
         input: DeleteUsersInput,
     ) -> None:
+        assert (token_store := info.context.token_store) is not None
         if not input.user_ids:
             return
         user_ids = tuple(
@@ -259,7 +261,30 @@ class UserMutationMixin:
                 raise Conflict("Cannot delete the default admin user")
             if num_resolved_user_ids < len(user_ids):
                 raise NotFound("Some user IDs could not be found")
-            await session.execute(delete(models.User).where(models.User.id.in_(user_ids)))
+            access_token_ids = (
+                AccessTokenId(id)
+                for id in await session.scalars(
+                    select(models.AccessToken.id).where(models.AccessToken.user_id.in_(user_ids))
+                )
+            )
+            refresh_token_ids = (
+                RefreshTokenId(id)
+                for id in await session.scalars(
+                    select(models.AccessToken.id).where(models.AccessToken.user_id.in_(user_ids))
+                )
+            )
+            api_key_ids = (
+                ApiKeyId(id)
+                for id in await session.scalars(
+                    select(models.ApiKey.id).where(models.ApiKey.user_id.in_(user_ids))
+                )
+            )
+            await token_store.revoke(*access_token_ids, *refresh_token_ids, *api_key_ids)
+            await session.execute(
+                update(models.User)
+                .where(models.User.id.in_(user_ids))
+                .values(deleted_at=func.now())
+            )
 
 
 def _select_role_id_by_name(role_name: str) -> Select[Tuple[int]]:

--- a/src/phoenix/server/api/mutations/user_mutations.py
+++ b/src/phoenix/server/api/mutations/user_mutations.py
@@ -252,6 +252,7 @@ class UserMutationMixin:
                     .where(
                         and_(
                             models.User.id.in_(user_ids),
+                            models.User.deleted_at.is_(None),
                             models.User.user_role_id != system_user_role_id,
                         )
                     )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -96,7 +96,12 @@ class Query:
         stmt = (
             select(models.User)
             .join(models.UserRole)
-            .where(models.UserRole.name != enums.UserRole.SYSTEM.value)
+            .where(
+                and_(
+                    models.UserRole.name != enums.UserRole.SYSTEM.value,
+                    models.User.deleted_at.is_(None),
+                )
+            )
             .order_by(models.User.email)
             .options(joinedload(models.User.role))
         )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -477,7 +477,9 @@ class Query:
             async with info.context.db() as session:
                 if not (
                     user := await session.scalar(
-                        select(models.User).where(models.User.id == node_id)
+                        select(models.User).where(
+                            and_(models.User.id == node_id, models.User.deleted_at.is_(None))
+                        )
                     )
                 ):
                     raise NotFound(f"Unknown user: {id}")
@@ -497,7 +499,9 @@ class Query:
             if (
                 user := await session.scalar(
                     select(models.User)
-                    .where(models.User.id == int(user.identity))
+                    .where(
+                        and_(models.User.id == int(user.identity), models.User.deleted_at.is_(None))
+                    )
                     .options(joinedload(models.User.role))
                 )
             ) is None:

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -144,7 +144,9 @@ async def refresh_tokens(request: Request) -> Response:
     async with request.app.state.db() as session:
         if (
             user := await session.scalar(
-                select(OrmUser).where(OrmUser.id == user_id).options(joinedload(OrmUser.role))
+                select(OrmUser)
+                .where(and_(OrmUser.id == user_id, OrmUser.deleted_at.is_(None)))
+                .options(joinedload(OrmUser.role))
             )
         ) is None:
             raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="User not found")

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from functools import partial
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.orm import joinedload
 from starlette.status import HTTP_204_NO_CONTENT, HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND
 
@@ -56,7 +56,9 @@ async def login(request: Request) -> Response:
 
     async with request.app.state.db() as session:
         user = await session.scalar(
-            select(OrmUser).where(OrmUser.email == email).options(joinedload(OrmUser.role))
+            select(OrmUser)
+            .where(and_(OrmUser.email == email, OrmUser.deleted_at.is_(None)))
+            .options(joinedload(OrmUser.role))
         )
         if (
             user is None


### PR DESCRIPTION
Instead of deleting actual tuples in the `users` table, just soft-delete users by adding the `deleted_at` timestamp. Update other routes and resolvers accordingly.

resolves #4561
