### PR TITLE
fix(auth): make access token required in `/auth/refresh`

### DIFF
--- a/src/phoenix/auth.py
+++ b/src/phoenix/auth.py
@@ -69,7 +69,7 @@ def set_access_token_cookie(response: Response, access_token: str) -> Response:
     return _set_token_cookie(
         response=response,
         cookie_name=PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
-        cookie_max_age=PHOENIX_ACCESS_TOKEN_MAX_AGE,
+        cookie_max_age=PHOENIX_TOKEN_MAX_AGE,
         token=access_token,
     )
 
@@ -78,7 +78,7 @@ def set_refresh_token_cookie(response: Response, refresh_token: str) -> Response
     return _set_token_cookie(
         response=response,
         cookie_name=PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
-        cookie_max_age=PHOENIX_REFRESH_TOKEN_MAX_AGE,
+        cookie_max_age=PHOENIX_TOKEN_MAX_AGE,
         token=refresh_token,
     )
 
@@ -197,12 +197,10 @@ JWT_ALGORITHM = "HS256"
 """The algorithm to use for the JSON Web Token."""
 PHOENIX_ACCESS_TOKEN_COOKIE_NAME = "phoenix-access-token"
 """The name of the cookie that stores the Phoenix access token."""
-PHOENIX_ACCESS_TOKEN_MAX_AGE = timedelta(minutes=10)
-"""The maximum age of the Phoenix access token."""
 PHOENIX_REFRESH_TOKEN_COOKIE_NAME = "phoenix-refresh-token"
 """The name of the cookie that stores the Phoenix refresh token."""
-PHOENIX_REFRESH_TOKEN_MAX_AGE = timedelta(days=31)
-"""The maximum age of the Phoenix refresh token."""
+PHOENIX_TOKEN_MAX_AGE = timedelta(days=31)
+"""The maximum age of the Phoenix access and refresh tokens."""
 
 
 class Token(str): ...


### PR DESCRIPTION
Make `/auth/refresh` require an access token. Makes the `Max-Age` property the same for both access and refresh tokens so they are both still present in the cookies even after the access token have expired.

resolves #4543
resolves #4531
