### PR TITLE
feat(auth): add environment variables for token expiries

### DIFF
--- a/src/phoenix/auth.py
+++ b/src/phoenix/auth.py
@@ -65,20 +65,24 @@ def validate_password_format(password: str) -> None:
     PASSWORD_REQUIREMENTS.validate(password)
 
 
-def set_access_token_cookie(response: Response, access_token: str) -> Response:
+def set_access_token_cookie(
+    *, response: Response, access_token: str, max_age: timedelta
+) -> Response:
     return _set_token_cookie(
         response=response,
         cookie_name=PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
-        cookie_max_age=PHOENIX_ACCESS_TOKEN_MAX_AGE,
+        cookie_max_age=max_age,
         token=access_token,
     )
 
 
-def set_refresh_token_cookie(response: Response, refresh_token: str) -> Response:
+def set_refresh_token_cookie(
+    *, response: Response, refresh_token: str, max_age: timedelta
+) -> Response:
     return _set_token_cookie(
         response=response,
         cookie_name=PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
-        cookie_max_age=PHOENIX_REFRESH_TOKEN_MAX_AGE,
+        cookie_max_age=max_age,
         token=refresh_token,
     )
 
@@ -197,12 +201,8 @@ JWT_ALGORITHM = "HS256"
 """The algorithm to use for the JSON Web Token."""
 PHOENIX_ACCESS_TOKEN_COOKIE_NAME = "phoenix-access-token"
 """The name of the cookie that stores the Phoenix access token."""
-PHOENIX_ACCESS_TOKEN_MAX_AGE = timedelta(minutes=10)
-"""The maximum age of the Phoenix access token."""
 PHOENIX_REFRESH_TOKEN_COOKIE_NAME = "phoenix-refresh-token"
 """The name of the cookie that stores the Phoenix refresh token."""
-PHOENIX_REFRESH_TOKEN_MAX_AGE = timedelta(days=31)
-"""The maximum age of the Phoenix refresh token."""
 
 
 class Token(str): ...

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -183,8 +183,8 @@ def get_env_access_token_expiry() -> timedelta:
         return _parse_duration(access_token_expiry)
     except ValueError as error:
         raise ValueError(
-            f"Error reading {ENV_PHOENIX_ACCESS_TOKEN_EXPIRY} environment variable"
-        ) from error
+            f"Error reading {ENV_PHOENIX_ACCESS_TOKEN_EXPIRY} environment variable: {str(error)}"
+        )
 
 
 def get_env_refresh_token_expiry() -> timedelta:
@@ -197,8 +197,8 @@ def get_env_refresh_token_expiry() -> timedelta:
         return _parse_duration(refresh_token_expiry)
     except ValueError as error:
         raise ValueError(
-            f"Error reading {ENV_PHOENIX_REFRESH_TOKEN_EXPIRY} environment variable"
-        ) from error
+            f"Error reading {ENV_PHOENIX_REFRESH_TOKEN_EXPIRY} environment variable: {str(error)}"
+        )
 
 
 def _parse_duration(duration_str: str) -> timedelta:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1,9 +1,12 @@
 import os
 import re
 import tempfile
+from datetime import timedelta
 from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
 
 from phoenix.utilities.re import parse_env_headers
 
@@ -71,6 +74,8 @@ ENV_PHOENIX_ENABLE_AUTH = "PHOENIX_ENABLE_AUTH"
 ENV_PHOENIX_SECRET = "PHOENIX_SECRET"
 ENV_PHOENIX_API_KEY = "PHOENIX_API_KEY"
 ENV_PHOENIX_USE_SECURE_COOKIES = "PHOENIX_USE_SECURE_COOKIES"
+ENV_PHOENIX_ACCESS_TOKEN_EXPIRY = "PHOENIX_ACCESS_TOKEN_EXPIRY"
+ENV_PHOENIX_REFRESH_TOKEN_EXPIRY = "PHOENIX_REFRESH_TOKEN_EXPIRY"
 
 
 def server_instrumentation_is_enabled() -> bool:
@@ -166,6 +171,50 @@ def get_auth_settings() -> Tuple[bool, Optional[str]]:
             f"auth is enabled with `{ENV_PHOENIX_ENABLE_AUTH}`"
         )
     return enable_auth, phoenix_secret
+
+
+def get_env_access_token_expiry() -> timedelta:
+    """
+    Gets the access token expiry.
+    """
+    if (access_token_expiry := os.environ.get(ENV_PHOENIX_ACCESS_TOKEN_EXPIRY)) is None:
+        return timedelta(minutes=10)
+    try:
+        return _parse_duration(access_token_expiry)
+    except ValueError as error:
+        raise ValueError(
+            f"Error reading {ENV_PHOENIX_ACCESS_TOKEN_EXPIRY} environment variable"
+        ) from error
+
+
+def get_env_refresh_token_expiry() -> timedelta:
+    """
+    Gets the refresh token expiry.
+    """
+    if (refresh_token_expiry := os.environ.get(ENV_PHOENIX_REFRESH_TOKEN_EXPIRY)) is None:
+        return timedelta(weeks=1)
+    try:
+        return _parse_duration(refresh_token_expiry)
+    except ValueError as error:
+        raise ValueError(
+            f"Error reading {ENV_PHOENIX_REFRESH_TOKEN_EXPIRY} environment variable"
+        ) from error
+
+
+def _parse_duration(duration_str: str) -> timedelta:
+    """
+    Parses a duration string into a timedelta object, assuming the duration is
+    in seconds if no unit is provided.
+    """
+    try:
+        duration = timedelta(seconds=float(duration_str))
+    except ValueError:
+        duration = pd.Timedelta(duration_str)
+    if pd.isnull(duration):
+        raise ValueError("duration cannot be null")
+    if duration <= timedelta(0):
+        raise ValueError("duration must be positive")
+    return duration
 
 
 PHOENIX_DIR = Path(__file__).resolve().parent

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -618,6 +618,8 @@ def create_app(
     startup_callbacks: Iterable[_Callback] = (),
     shutdown_callbacks: Iterable[_Callback] = (),
     secret: Optional[str] = None,
+    access_token_expiry: Optional[timedelta] = None,
+    refresh_token_expiry: Optional[timedelta] = None,
     scaffolder_config: Optional[ScaffolderConfig] = None,
 ) -> FastAPI:
     startup_callbacks_list: List[_Callback] = list(startup_callbacks)
@@ -752,6 +754,8 @@ def create_app(
         )
     app.state.read_only = read_only
     app.state.export_path = export_path
+    app.state.access_token_expiry = access_token_expiry
+    app.state.refresh_token_expiry = refresh_token_expiry
     app.state.db = db
     app = _add_get_secret_method(app=app, secret=secret)
     app = _add_get_token_store_method(app=app, token_store=token_store)

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -18,6 +18,7 @@ import phoenix.trace.v1 as pb
 from phoenix.config import (
     EXPORT_DIR,
     get_auth_settings,
+    get_env_access_token_expiry,
     get_env_database_connection_str,
     get_env_database_schema,
     get_env_enable_prometheus,
@@ -25,6 +26,7 @@ from phoenix.config import (
     get_env_host,
     get_env_host_root_path,
     get_env_port,
+    get_env_refresh_token_expiry,
     get_pids_path,
     get_working_dir,
 )
@@ -387,6 +389,8 @@ if __name__ == "__main__":
         startup_callbacks=[lambda: print(msg)],
         shutdown_callbacks=instrumentation_cleanups,
         secret=secret,
+        access_token_expiry=get_env_access_token_expiry(),
+        refresh_token_expiry=get_env_refresh_token_expiry(),
         scaffolder_config=scaffolder_config,
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+from typing import Callable
+
+import pytest
+
+from phoenix.config import (
+    ENV_PHOENIX_ACCESS_TOKEN_EXPIRY,
+    ENV_PHOENIX_REFRESH_TOKEN_EXPIRY,
+    get_env_access_token_expiry,
+    get_env_refresh_token_expiry,
+)
+
+
+@pytest.mark.parametrize(
+    "env_var_value, error_message",
+    (
+        pytest.param("-3600", "duration must be positive", id="with-negative-integer"),
+        pytest.param("-3600.10", "duration must be positive", id="with-negative-decimal"),
+        pytest.param("-36d", "duration must be positive", id="with-negative-day-unit"),
+        pytest.param("0", "duration must be positive", id="with-zero-duration"),
+        pytest.param("nan", "duration cannot be null", id="with-null"),
+    ),
+)
+@pytest.mark.parametrize(
+    "env_var_name, env_var_getter",
+    (
+        pytest.param(
+            ENV_PHOENIX_ACCESS_TOKEN_EXPIRY, get_env_access_token_expiry, id="access-token-expiry"
+        ),
+        pytest.param(
+            ENV_PHOENIX_REFRESH_TOKEN_EXPIRY,
+            get_env_refresh_token_expiry,
+            id="refresh-token-expiry",
+        ),
+    ),
+)
+def test_get_env_token_expiry_raises_expected_errors_for_invalid_values(
+    env_var_name: str,
+    env_var_getter: Callable[[], timedelta],
+    env_var_value: str,
+    error_message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_var_name, env_var_value)
+    with pytest.raises(
+        ValueError, match=f"Error reading {env_var_name} environment variable"
+    ) as exc_info:
+        env_var_getter()
+    error = exc_info.value
+    assert isinstance(cause := error.__cause__, ValueError)
+    assert str(cause) == error_message

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,9 +81,6 @@ def test_get_env_token_expiry_raises_expected_errors_for_invalid_values(
 ) -> None:
     monkeypatch.setenv(env_var_name, env_var_value)
     with pytest.raises(
-        ValueError, match=f"Error reading {env_var_name} environment variable"
-    ) as exc_info:
+        ValueError, match=f"Error reading {env_var_name} environment variable: {error_message}"
+    ):
         env_var_getter()
-    error = exc_info.value
-    assert isinstance(cause := error.__cause__, ValueError)
-    assert str(cause) == error_message

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,43 @@ from phoenix.config import (
 
 
 @pytest.mark.parametrize(
+    "env_var_value, expected_value",
+    (
+        pytest.param("3600", timedelta(seconds=3600), id="with-positive-unitless-integer"),
+        pytest.param("3600.10", timedelta(seconds=3600.10), id="with-positive-decimal"),
+        pytest.param("36d", timedelta(days=36), id="with-positive-day-unit"),
+        pytest.param(
+            "P4M6DT3H12M45S",
+            timedelta(days=(4 * 30 + 6), hours=3, minutes=12, seconds=45),
+            id="with-iso-8601-duration",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "env_var_name, env_var_getter",
+    (
+        pytest.param(
+            ENV_PHOENIX_ACCESS_TOKEN_EXPIRY, get_env_access_token_expiry, id="access-token-expiry"
+        ),
+        pytest.param(
+            ENV_PHOENIX_REFRESH_TOKEN_EXPIRY,
+            get_env_refresh_token_expiry,
+            id="refresh-token-expiry",
+        ),
+    ),
+)
+def test_get_env_token_expiry_parses_valid_values(
+    env_var_name: str,
+    env_var_getter: Callable[[], timedelta],
+    env_var_value: str,
+    expected_value: timedelta,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_var_name, env_var_value)
+    env_var_getter() == expected_value
+
+
+@pytest.mark.parametrize(
     "env_var_value, error_message",
     (
         pytest.param("-3600", "duration must be positive", id="with-negative-integer"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,8 @@ from phoenix.config import (
     (
         pytest.param("3600", timedelta(seconds=3600), id="with-positive-unitless-integer"),
         pytest.param("3600.10", timedelta(seconds=3600.10), id="with-positive-decimal"),
-        pytest.param("36d", timedelta(days=36), id="with-positive-day-unit"),
+        pytest.param("36 days", timedelta(days=36), id="with-positive-day-unit"),
+        pytest.param("36d", timedelta(days=36), id="with-positive-d-unit"),
         pytest.param(
             "P4M6DT3H12M45S",
             timedelta(days=(4 * 30 + 6), hours=3, minutes=12, seconds=45),
@@ -53,7 +54,7 @@ def test_get_env_token_expiry_parses_valid_values(
     (
         pytest.param("-3600", "duration must be positive", id="with-negative-integer"),
         pytest.param("-3600.10", "duration must be positive", id="with-negative-decimal"),
-        pytest.param("-36d", "duration must be positive", id="with-negative-day-unit"),
+        pytest.param("-36d", "duration must be positive", id="with-negative-d-unit"),
         pytest.param("0", "duration must be positive", id="with-zero-duration"),
         pytest.param("nan", "duration cannot be null", id="with-null"),
     ),


### PR DESCRIPTION
Adds environment variables for token expiries:

- `PHOENIX_ACCESS_TOKEN_EXPIRY` (default 10 min)
- `PHOENIX_REFRESH_TOKEN_EXPIRY` (default 1 week)

If a unitless integer or decimal is passed, assumes it is in seconds. Also accepts duration strings containing units that [can be parsed by `pandas.Timedelta`](https://pandas.pydata.org/docs/user_guide/timedeltas.html#parsing), e.g.,

- `1 days 2 hours`
- `1d 2h`
- `2 w`
- `P0DT0H1M0S` (ISO-8601 duration)

resolves #4584
