### PR TITLE
refactor(auth): ensure auth environment variables are read once

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -159,7 +159,7 @@ def get_env_phoenix_api_key() -> Optional[str]:
     return os.environ.get(ENV_PHOENIX_API_KEY)
 
 
-def get_auth_settings() -> Tuple[bool, Optional[str]]:
+def get_env_auth_settings() -> Tuple[bool, Optional[str]]:
     """
     Gets auth settings and performs validation.
     """
@@ -239,8 +239,6 @@ ROOT_DIR = WORKING_DIR
 EXPORT_DIR = ROOT_DIR / "exports"
 INFERENCES_DIR = ROOT_DIR / "inferences"
 TRACE_DATASETS_DIR = ROOT_DIR / "trace_datasets"
-
-ENABLE_AUTH, PHOENIX_SECRET = get_auth_settings()
 
 
 def ensure_working_dir() -> None:

--- a/src/phoenix/server/api/openapi/schema.py
+++ b/src/phoenix/server/api/openapi/schema.py
@@ -2,11 +2,11 @@ from typing import Any, Dict
 
 from fastapi.openapi.utils import get_openapi
 
-from phoenix.server.api.routers.v1 import REST_API_VERSION
-from phoenix.server.api.routers.v1 import router as v1_router
+from phoenix.server.api.routers.v1 import REST_API_VERSION, create_v1_router
 
 
 def get_openapi_schema() -> Dict[str, Any]:
+    v1_router = create_v1_router(authentication_enabled=False)
     return get_openapi(
         title="Arize-Phoenix REST API",
         version=REST_API_VERSION,

--- a/src/phoenix/server/api/routers/__init__.py
+++ b/src/phoenix/server/api/routers/__init__.py
@@ -1,4 +1,4 @@
 from .auth import router as auth_router
-from .v1 import router as v1_router
+from .v1 import create_v1_router
 
-__all__ = ["auth_router", "v1_router"]
+__all__ = ["auth_router", "create_v1_router"]

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -91,7 +91,7 @@ from phoenix.server.api.dataloaders import (
     UserRolesDataLoader,
     UsersDataLoader,
 )
-from phoenix.server.api.routers import auth_router, v1_router
+from phoenix.server.api.routers import auth_router, create_v1_router
 from phoenix.server.api.routers.v1 import REST_API_VERSION
 from phoenix.server.api.schema import schema
 from phoenix.server.bearer_auth import BearerTokenAuthBackend, is_authenticated
@@ -624,7 +624,7 @@ def create_app(
 ) -> FastAPI:
     startup_callbacks_list: List[_Callback] = list(startup_callbacks)
     shutdown_callbacks_list: List[_Callback] = list(shutdown_callbacks)
-    startup_callbacks_list.append(Facilitator(db))
+    startup_callbacks_list.append(Facilitator(db=db, authentication_enabled=authentication_enabled))
     initial_batch_of_spans: Iterable[Tuple[Span, str]] = (
         ()
         if initial_spans is None
@@ -727,7 +727,7 @@ def create_app(
             "defaultModelsExpandDepth": -1,  # hides the schema section in the Swagger UI
         },
     )
-    app.include_router(v1_router)
+    app.include_router(create_v1_router(authentication_enabled))
     app.include_router(router)
     app.include_router(graphql_router)
     if authentication_enabled:

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -17,8 +17,8 @@ from uvicorn import Config, Server
 import phoenix.trace.v1 as pb
 from phoenix.config import (
     EXPORT_DIR,
-    get_auth_settings,
     get_env_access_token_expiry,
+    get_env_auth_settings,
     get_env_database_connection_str,
     get_env_database_schema,
     get_env_enable_prometheus,
@@ -311,7 +311,7 @@ if __name__ == "__main__":
         reference_inferences,
     )
 
-    authentication_enabled, secret = get_auth_settings()
+    authentication_enabled, secret = get_env_auth_settings()
 
     fixture_spans: List[Span] = []
     fixture_evals: List[pb.Evaluation] = []


### PR DESCRIPTION
Avoids the pattern of reading environment variables more than once. With this change, we read auth-related environment variables once and use dependency injection to get the values elsewhere.

resolves #4586
