### PR TITLE
feat: Pick up authorization headers from environment variable

### DIFF
--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -2,8 +2,11 @@
 
 Provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-aware defaults.
 
-These defaults are aware of the `PHOENIX_COLLECTOR_ENDPOINT`, `PHOENIX_PROJECT_NAME`, and
-`PHOENIX_CLIENT_HEADERS` environment variables.
+These defaults are aware of environment variables you may have set to configure Phoenix:
+- `PHOENIX_COLLECTOR_ENDPOINT`
+- `PHOENIX_PROJECT_NAME`
+- `PHOENIX_CLIENT_HEADERS`
+- `PHOENIX_API_KEY`
 
 # Examples
 
@@ -21,6 +24,11 @@ tracer_provider = register()
 
 This is all you need to get started using OTel with Phoenix! `register` defaults to sending spans
 to an endpoint at `http://localhost` using gRPC.
+
+## Phoenix Authentication
+
+If the `PHOENIX_API_KEY` environment variable is set, `register` will automatically add an
+`authorization` header to each span payload.
 
 ### Configuring the collector endpoint
 

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -308,7 +308,10 @@ class HTTPSpanExporter(_HTTPSpanExporter):
             }
             bound_args.arguments["headers"] = headers if headers else None
         else:
-            headers = bound_args.arguments["headers"]
+            headers = dict()
+            for header_field, value in bound_args.arguments["headers"].items():
+                headers[header_field.lower()] = value
+
             # If the auth header is not in the headers, add it
             if "authorization" not in headers:
                 auth_header = get_env_phoenix_auth_header()
@@ -316,6 +319,8 @@ class HTTPSpanExporter(_HTTPSpanExporter):
                     **headers,
                     **(auth_header or dict()),
                 }
+            else:
+                bound_args.arguments["headers"] = headers
 
         if bound_args.arguments.get("endpoint") is None:
             _, endpoint = _normalized_endpoint(None, use_http=True)
@@ -356,7 +361,10 @@ class GRPCSpanExporter(_GRPCSpanExporter):
             }
             bound_args.arguments["headers"] = headers if headers else None
         else:
-            headers = bound_args.arguments["headers"]
+            headers = dict()
+            for header_field, value in bound_args.arguments["headers"].items():
+                headers[header_field.lower()] = value
+
             # If the auth header is not in the headers, add it
             if "authorization" not in headers:
                 auth_header = get_env_phoenix_auth_header()
@@ -364,6 +372,8 @@ class GRPCSpanExporter(_GRPCSpanExporter):
                     **headers,
                     **(auth_header or dict()),
                 }
+            else:
+                bound_args.arguments["headers"] = headers
 
         if bound_args.arguments.get("endpoint") is None:
             _, endpoint = _normalized_endpoint(None)
@@ -394,8 +404,8 @@ def _exporter_transport(exporter: SpanExporter) -> str:
 
 def _printable_headers(headers: Union[List[Tuple[str, str]], Dict[str, str]]) -> Dict[str, str]:
     if isinstance(headers, dict):
-        return {key.lower(): "****" for key, _ in headers.items()}
-    return {key.lower(): "****" for key, _ in headers}
+        return {key: "****" for key, _ in headers.items()}
+    return {key: "****" for key, _ in headers}
 
 
 def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -317,7 +317,6 @@ class HTTPSpanExporter(_HTTPSpanExporter):
                     **(auth_header or dict()),
                 }
 
-        print(bound_args.arguments)
         if bound_args.arguments.get("endpoint") is None:
             _, endpoint = _normalized_endpoint(None, use_http=True)
             bound_args.arguments["endpoint"] = endpoint
@@ -366,8 +365,6 @@ class GRPCSpanExporter(_GRPCSpanExporter):
                     **(auth_header or dict()),
                 }
 
-        print(sig)
-        print(bound_args.arguments)
         if bound_args.arguments.get("endpoint") is None:
             _, endpoint = _normalized_endpoint(None)
             bound_args.arguments["endpoint"] = endpoint

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 import warnings
-from typing import Any, Callable,Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import ParseResult, urlparse
 
 from openinference.semconv.resource import ResourceAttributes as _ResourceAttributes

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -26,6 +26,7 @@ def get_env_client_headers() -> Optional[Dict[str, str]]:
         return parse_env_headers(headers_str)
     return None
 
+
 def get_env_phoenix_auth_header() -> Optional[str]:
     api_key = os.environ.get(ENV_PHOENIX_API_KEY)
     if api_key:

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -10,6 +10,7 @@ _logger = getLogger(__name__)
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
 ENV_PHOENIX_PROJECT_NAME = "PHOENIX_PROJECT_NAME"
 ENV_PHOENIX_CLIENT_HEADERS = "PHOENIX_CLIENT_HEADERS"
+ENV_PHOENIX_API_KEY = "PHOENIX_API_KEY"
 
 
 def get_env_collector_endpoint() -> Optional[str]:
@@ -24,6 +25,13 @@ def get_env_client_headers() -> Optional[Dict[str, str]]:
     if headers_str := os.getenv(ENV_PHOENIX_CLIENT_HEADERS):
         return parse_env_headers(headers_str)
     return None
+
+def get_env_phoenix_auth_header() -> Optional[str]:
+    api_key = os.environ.get(ENV_PHOENIX_API_KEY)
+    if api_key:
+        return dict(authorization=f"Bearer {api_key}")
+    else:
+        return None
 
 
 # Optional whitespace

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -27,7 +27,7 @@ def get_env_client_headers() -> Optional[Dict[str, str]]:
     return None
 
 
-def get_env_phoenix_auth_header() -> Optional[str]:
+def get_env_phoenix_auth_header() -> Optional[Dict[str, str]]:
     api_key = os.environ.get(ENV_PHOENIX_API_KEY)
     if api_key:
         return dict(authorization=f"Bearer {api_key}")


### PR DESCRIPTION
resolves #4536 

Automatically adds an auth header sensitivity to `phoenix.otel` if PHOENIX_API_KEY is set as an environment variable.

*NOTE* this PR also fixes a bug: in `python=3.8` `inspect.signature` generates the signature off of the `__new__` method of classes instead of `__init__` which can sometimes lead to inconsistencies. In this PR I've normalized how we create generate the instatiation signature so we can properly merge in auth headers if necessary