### PR TITLE
docs(quickstart): update inferences documentation to correct example syntax

### DIFF
--- a/docs/quickstart/phoenix-inferences/README.md
+++ b/docs/quickstart/phoenix-inferences/README.md
@@ -79,12 +79,12 @@ _**Important**_**:** The fields used in a Schema will _vary_ depending on the mo
 
 For examples on how Schema are defined for other model types (NLP, tabular, LLM-based applications), see example notebooks under [Embedding Analysis](../../notebooks.md#embedding-analysis) and [Structured Data Analysis](../../notebooks.md#structured-data-analysis).
 
-### Step 4: Wrap into Inference object
+### Step 4: Wrap into Inferences object
 
-Wrap your `train_df` and schema `train_schema`  into a Phoenix `inference` object:
+Wrap your `train_df` and schema `train_schema`  into a Phoenix `Inferences` object:
 
 ```python
-train_ds = Inference(dataframe=train_df, schema=train_schema, name="training")
+train_ds = px.Inferences(dataframe=train_df, schema=train_schema, name="training")
 ```
 
 ### Step 5: Launch Phoenix!


### PR DESCRIPTION
PR is not related to an existing open issue. 

Corrects [published documentation](https://docs.arize.com/phoenix/inferences/phoenix-inferences) (believed to be located at `docs/quickstart/phoenix-inferences/README.md`) to address a problem with the provided example. 

Step 4 previously threw an error because "Inference" was not defined. There are two issues here: the class name should be "Inferences" (plural) and referenced via the `px` object. Additionally, instructions referring to the singular "inference" were updated for consistency.

This contribution was identified during a public workshop hosted by the Brain Wave Collective (@brainwavecollective). We learned about Phoenix from our friend Mikyo King (@mikeldking) who spoke at an RMAIIG meeting in Colorado. Credit for this contribution goes entirely to Thienthanh Trinh (@ttrinh2306) for finding this issue and identifying the solution that is being submitted here. 