### PR TITLE
fix(auth): add unique constraint on refresh_token_id in access_tokens table

### DIFF
--- a/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
@@ -100,6 +100,7 @@ def upgrade() -> None:
             sa.Integer,
             sa.ForeignKey("refresh_tokens.id", ondelete="CASCADE"),
             index=True,
+            unique=True,
         ),
         sqlite_autoincrement=True,
     )

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -685,6 +685,7 @@ class AccessToken(Base):
     refresh_token_id: Mapped[int] = mapped_column(
         ForeignKey("refresh_tokens.id", ondelete="CASCADE"),
         index=True,
+        unique=True,
     )
     __table_args__ = (dict(sqlite_autoincrement=True),)
 


### PR DESCRIPTION
Each refresh token should correspond to exactly one access token.

resolves #4607
