### PR TITLE
docs: remove outdated warning re selection of rails

### DIFF
--- a/docs/evaluation/how-to-evals/bring-your-own-evaluator.md
+++ b/docs/evaluation/how-to-evals/bring-your-own-evaluator.md
@@ -72,10 +72,6 @@ relevance_classifications = llm_classify(
 
 The classify uses a `snap_to_rails` function that searches the output string of the LLM for the classes in the classification list. It handles cases where no class is available, both classes are available or the string is a substring of the other class such as irrelevant and relevant.&#x20;
 
-{% hint style="warning" %}
-When selecting classification labels to use, avoid using any labels that contain the whole text of another label - for example "_relevant_" and "ir_relevant_". This will create some results to be incorrectly marked as "UNPARSEABLE". Instead, use entirely different values - for example "relevant" and "unrelated".
-{% endhint %}
-
 ```
 #Rails examples
 #Removes extra information and maps to class


### PR DESCRIPTION
I believe this warning is not necessary: 
- the `snap_to_rail` [code](https://github.com/Arize-ai/phoenix/blob/c9a9dc8d7d2953b88fe20daa26f11aa5d51de1ff/packages/phoenix-evals/src/phoenix/evals/utils.py#L60-L89) checks rails from longest to shortest, removing any matches as they are found. So in the example given, any instances of "irrelevant" will be removed from the string before matches for "relevant" are checked, eliminating the possibility of the error described.
- the rest of the document that this warning is in does not follow this advice and gives examples of using "relevant" and "irrelevant" as rails directly above the warning
- the default templates ignore this warning in multiple places, e.g. [here](https://github.com/Arize-ai/phoenix/blob/c9a9dc8d7d2953b88fe20daa26f11aa5d51de1ff/packages/phoenix-evals/src/phoenix/evals/default_templates.py#L483)