### PR TITLE
feat: Wire up API keys via env var for Phoenix clients and experiments

### DIFF
--- a/src/phoenix/experiments/functions.py
+++ b/src/phoenix/experiments/functions.py
@@ -77,13 +77,10 @@ from phoenix.utilities.json import jsonify
 
 
 def _phoenix_clients() -> Tuple[httpx.Client, httpx.AsyncClient]:
-    headers = get_env_client_headers()
     return VersionedClient(
         base_url=get_base_url(),
-        headers=headers,
     ), VersionedAsyncClient(
         base_url=get_base_url(),
-        headers=headers,
     )
 
 

--- a/src/phoenix/experiments/functions.py
+++ b/src/phoenix/experiments/functions.py
@@ -41,7 +41,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import Status, StatusCode, Tracer
 from typing_extensions import TypeAlias
 
-from phoenix.config import get_base_url, get_env_client_headers
+from phoenix.config import get_base_url
 from phoenix.evals.executors import get_executor_on_sync_context
 from phoenix.evals.models.rate_limiters import RateLimiter
 from phoenix.evals.utils import get_tqdm_progress_bar_formatter

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -90,7 +90,7 @@ class Client(TraceDataExtractor):
         if api_key:
             headers = {
                 **{k: v for k, v in (headers or {}).items() if k.lower() != "authorization"},
-                "authorization": f"Bearer {api_key}",
+                "Authorization": f"Bearer {api_key}",
             }
         host = get_env_host()
         if host == "0.0.0.0":

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -35,10 +35,8 @@ from pyarrow import ArrowInvalid, Table
 from typing_extensions import TypeAlias, assert_never
 
 from phoenix.config import (
-    get_env_client_headers,
     get_env_collector_endpoint,
     get_env_host,
-    get_env_phoenix_api_key,
     get_env_port,
     get_env_project_name,
 )
@@ -92,7 +90,7 @@ class Client(TraceDataExtractor):
         if api_key:
             headers = {
                 **{k: v for k, v in (headers or {}).items() if k.lower() != "authorization"},
-                "authorization": f"Bearer {api_key}",
+                "Authorization": f"Bearer {api_key}",
             }
         host = get_env_host()
         if host == "0.0.0.0":

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -88,15 +88,12 @@ class Client(TraceDataExtractor):
             )
         if kwargs:
             raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
-        headers = dict((headers or get_env_client_headers() or {}))
+        headers = dict(headers or {})
         if api_key:
             headers = {
                 **{k: v for k, v in (headers or {}).items() if k.lower() != "authorization"},
-                "Authorization": f"Bearer {api_key}",
+                "authorization": f"Bearer {api_key}",
             }
-        elif api_key := get_env_phoenix_api_key():
-            if not headers or ("authorization" not in [k.lower() for k in headers]):
-                headers = {**(headers or {}), "Authorization": f"Bearer {api_key}"}
         host = get_env_host()
         if host == "0.0.0.0":
             host = "127.0.0.1"

--- a/src/phoenix/session/client.py
+++ b/src/phoenix/session/client.py
@@ -90,7 +90,7 @@ class Client(TraceDataExtractor):
         if api_key:
             headers = {
                 **{k: v for k, v in (headers or {}).items() if k.lower() != "authorization"},
-                "Authorization": f"Bearer {api_key}",
+                "authorization": f"Bearer {api_key}",
             }
         host = get_env_host()
         if host == "0.0.0.0":

--- a/src/phoenix/utilities/client.py
+++ b/src/phoenix/utilities/client.py
@@ -22,7 +22,7 @@ class VersionedClient(httpx.Client):
             self.headers.update(env_headers)
         if "authorization" not in [k.lower() for k in self.headers]:
             if api_key := get_env_phoenix_api_key():
-                self.headers["Authorization"] = f"Bearer {api_key}"
+                self.headers["authorization"] = f"Bearer {api_key}"
 
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False
@@ -86,7 +86,7 @@ class VersionedAsyncClient(httpx.AsyncClient):
             self.headers.update(env_headers)
         if "authorization" not in [k.lower() for k in self.headers]:
             if api_key := get_env_phoenix_api_key():
-                self.headers["Authorization"] = f"Bearer {api_key}"
+                self.headers["authorization"] = f"Bearer {api_key}"
 
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False

--- a/src/phoenix/utilities/client.py
+++ b/src/phoenix/utilities/client.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import httpx
 
+from phoenix.config import get_env_client_headers, get_env_phoenix_api_key
+
 PHOENIX_SERVER_VERSION_HEADER = "x-phoenix-server-version"
 
 
@@ -58,6 +60,12 @@ class VersionedClient(httpx.Client):
                 )
 
     def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        headers = dict()
+        if env_headers := get_env_client_headers():
+            headers.update(env_headers)
+        if api_key := get_env_phoenix_api_key():
+            headers["authorization"] = f"Bearer {api_key}"
+        kwargs["headers"] = headers or None
         response = super().request(*args, **kwargs)
         self._check_version(response)
         return response
@@ -111,6 +119,12 @@ class VersionedAsyncClient(httpx.AsyncClient):
                 )
 
     async def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        headers = dict()
+        if env_headers := get_env_client_headers():
+            headers.update(env_headers)
+        if api_key := get_env_phoenix_api_key():
+            headers["authorization"] = f"Bearer {api_key}"
+        kwargs["headers"] = headers or None
         response = await super().request(*args, **kwargs)
         self._check_version(response)
         return response

--- a/src/phoenix/utilities/client.py
+++ b/src/phoenix/utilities/client.py
@@ -17,6 +17,13 @@ class VersionedClient(httpx.Client):
         from phoenix import __version__ as phoenix_version
 
         super().__init__(*args, **kwargs)
+
+        if env_headers := get_env_client_headers():
+            self.headers.update(env_headers)
+        if "authorization" not in [k.lower() for k in self.headers]:
+            if api_key := get_env_phoenix_api_key():
+                self.headers["authorization"] = f"Bearer {api_key}"
+
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False
 
@@ -60,12 +67,6 @@ class VersionedClient(httpx.Client):
                 )
 
     def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
-        headers = dict()
-        if env_headers := get_env_client_headers():
-            headers.update(env_headers)
-        if api_key := get_env_phoenix_api_key():
-            headers["authorization"] = f"Bearer {api_key}"
-        kwargs["headers"] = headers or None
         response = super().request(*args, **kwargs)
         self._check_version(response)
         return response
@@ -80,6 +81,13 @@ class VersionedAsyncClient(httpx.AsyncClient):
         from phoenix import __version__ as phoenix_version
 
         super().__init__(*args, **kwargs)
+
+        if env_headers := get_env_client_headers():
+            self.headers.update(env_headers)
+        if "authorization" not in [k.lower() for k in self.headers]:
+            if api_key := get_env_phoenix_api_key():
+                self.headers["authorization"] = f"Bearer {api_key}"
+
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False
 
@@ -119,12 +127,6 @@ class VersionedAsyncClient(httpx.AsyncClient):
                 )
 
     async def request(self, *args: Any, **kwargs: Any) -> httpx.Response:
-        headers = dict()
-        if env_headers := get_env_client_headers():
-            headers.update(env_headers)
-        if api_key := get_env_phoenix_api_key():
-            headers["authorization"] = f"Bearer {api_key}"
-        kwargs["headers"] = headers or None
         response = await super().request(*args, **kwargs)
         self._check_version(response)
         return response

--- a/src/phoenix/utilities/client.py
+++ b/src/phoenix/utilities/client.py
@@ -22,7 +22,7 @@ class VersionedClient(httpx.Client):
             self.headers.update(env_headers)
         if "authorization" not in [k.lower() for k in self.headers]:
             if api_key := get_env_phoenix_api_key():
-                self.headers["authorization"] = f"Bearer {api_key}"
+                self.headers["Authorization"] = f"Bearer {api_key}"
 
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False
@@ -86,7 +86,7 @@ class VersionedAsyncClient(httpx.AsyncClient):
             self.headers.update(env_headers)
         if "authorization" not in [k.lower() for k in self.headers]:
             if api_key := get_env_phoenix_api_key():
-                self.headers["authorization"] = f"Bearer {api_key}"
+                self.headers["Authorization"] = f"Bearer {api_key}"
 
         self._client_phoenix_version = phoenix_version
         self._warned_on_minor_version_mismatch = False


### PR DESCRIPTION
resolves #4613 

- ensures that PHOENIX_API_KEY is properly propagated to the Client and Experiment modules