### PR TITLE
docs (quickstart): fix incorrect object reference in Inferences example

### DIFF
--- a/docs/quickstart/phoenix-inferences/README.md
+++ b/docs/quickstart/phoenix-inferences/README.md
@@ -182,7 +182,7 @@ Read more about comparison dataset Schemas here: [How many schemas do I need?](h
 #### c) Wrap into Inferences object
 
 ```python
-prod_ds = px.Inferences(dataframe=prod_df, schema=schema, name="production")
+prod_ds = px.Inferences(dataframe=prod_df, schema=prod_schema, name="production")
 ```
 
 #### **d) Launch Phoenix with both Inferences!**


### PR DESCRIPTION
This is not related to an existing issue. However, this is another change similar to #4592.

In Quickstart: Inferences Step 6b, the model schema is defined as 'prod_schema'. However, in Step 6c, the px.Inferences sets schema to 'schema'. To enhance the documentation, the px.Inferences sets schema to 'prod_schema'. https://docs.arize.com/phoenix/inferences/phoenix-inferences. 