### PR TITLE
feat: finer grain last N time range

### DIFF
--- a/app/src/components/datetime/LastNTimeRangeContext.tsx
+++ b/app/src/components/datetime/LastNTimeRangeContext.tsx
@@ -1,9 +1,6 @@
-import React, {
-  createContext,
-  startTransition,
-  useCallback,
-  useState,
-} from "react";
+import React, { createContext } from "react";
+
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 import { LastNTimeRangeKey } from "./types";
 import { getTimeRangeFromLastNTimeRangeKey } from "./utils";
@@ -36,23 +33,21 @@ export function useLastNTimeRange(): LastNTimeRangeContextType {
 }
 
 export function LastNTimeRangeProvider({
-  initialTimeRangeKey = "7d",
   children,
 }: {
-  initialTimeRangeKey?: LastNTimeRangeKey;
   children: React.ReactNode;
 }) {
-  const [timeRangeKey, _setTimeRangeKey] =
-    useState<LastNTimeRangeKey>(initialTimeRangeKey);
-  const [timeRange, _setTimeRange] = useState<TimeRange>(() => {
-    return getTimeRangeFromLastNTimeRangeKey(initialTimeRangeKey);
-  });
-  const setTimeRangeKey = useCallback((key: LastNTimeRangeKey) => {
-    startTransition(() => {
-      _setTimeRangeKey(key);
-      _setTimeRange(getTimeRangeFromLastNTimeRangeKey(key));
-    });
-  }, []);
+  const timeRangeKey = usePreferencesContext(
+    (state) => state.lastNTimeRangeKey
+  );
+  const setTimeRangeKey = usePreferencesContext(
+    (state) => state.setLastNTimeRangeKey
+  );
+
+  // TODO: this caching doesn't move the time forward and is flawed
+  // Needs refactoring
+  const timeRange = getTimeRangeFromLastNTimeRangeKey(timeRangeKey);
+
   return (
     <LastNTimeRangeContext.Provider
       value={{

--- a/app/src/components/datetime/LastNTimeRangePicker.tsx
+++ b/app/src/components/datetime/LastNTimeRangePicker.tsx
@@ -17,7 +17,7 @@ export function LastNTimeRangePicker(props: LastNTimeRangePickerProps) {
       aria-label={"Time Range"}
       addonBefore={<Icon svg={<Icons.CalendarOutline />} />}
       isDisabled={isDisabled}
-      defaultSelectedKey={selectedKey}
+      selectedKey={selectedKey}
       onSelectionChange={(key: Key) => {
         onSelectionChange && onSelectionChange(key as LastNTimeRangeKey);
       }}

--- a/app/src/components/datetime/constants.ts
+++ b/app/src/components/datetime/constants.ts
@@ -1,6 +1,9 @@
 import { LastNTimeRange, LastNTimeRangeKey } from "./types";
 
 export const LAST_N_TIME_RANGES: LastNTimeRange[] = [
+  { key: "15m", label: "Last 15 Min" },
+  { key: "1h", label: "Last Hour" },
+  { key: "12h", label: "Last 12 Hours" },
   { key: "1d", label: "Last Day" },
   { key: "7d", label: "Last 7 Days" },
   { key: "30d", label: "Last Month" },

--- a/app/src/components/datetime/types.ts
+++ b/app/src/components/datetime/types.ts
@@ -1,2 +1,9 @@
-export type LastNTimeRangeKey = "1d" | "7d" | "30d" | "all";
+export type LastNTimeRangeKey =
+  | "15m"
+  | "1h"
+  | "12h"
+  | "1d"
+  | "7d"
+  | "30d"
+  | "all";
 export type LastNTimeRange = { key: LastNTimeRangeKey; label: string };

--- a/app/src/components/datetime/utils.ts
+++ b/app/src/components/datetime/utils.ts
@@ -1,4 +1,11 @@
-import { addDays, startOfHour, subDays } from "date-fns";
+import {
+  addDays,
+  startOfHour,
+  startOfMinute,
+  subDays,
+  subHours,
+  subMinutes,
+} from "date-fns";
 
 import { assertUnreachable } from "@phoenix/typeUtils";
 
@@ -12,6 +19,21 @@ export function getTimeRangeFromLastNTimeRangeKey(
   // We round down to facilitate caching.
   const end = startOfHour(addDays(now, 365));
   switch (key) {
+    case "15m":
+      return {
+        start: startOfMinute(subMinutes(now, 15)),
+        end,
+      };
+    case "1h":
+      return {
+        start: startOfMinute(subHours(now, 1)),
+        end,
+      };
+    case "12h":
+      return {
+        start: startOfHour(subHours(now, 12)),
+        end,
+      };
     case "1d":
       return {
         start: startOfHour(subDays(now, 1)),

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -1,6 +1,8 @@
 import { create, StateCreator } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
+import { LastNTimeRangeKey } from "@phoenix/components/datetime/types";
+
 export type MarkdownDisplayMode = "text" | "markdown";
 
 export interface PreferencesProps {
@@ -14,6 +16,10 @@ export interface PreferencesProps {
    * @default true
    */
   traceStreamingEnabled: boolean;
+  /**
+   * The last N time range to load data for
+   */
+  lastNTimeRangeKey: LastNTimeRangeKey;
   /**
    * Whether or not to automatically refresh projects
    * @default true
@@ -42,6 +48,10 @@ export interface PreferencesState extends PreferencesProps {
    */
   setTraceStreamingEnabled: (traceStreamingEnabled: boolean) => void;
   /**
+   * Setter for the last N time range to load data for
+   */
+  setLastNTimeRangeKey: (lastNTimeRangeKey: LastNTimeRangeKey) => void;
+  /**
    * Setter for enabling/disabling project auto refresh
    * @param projectsAutoRefreshEnabled
    */
@@ -69,6 +79,10 @@ export const createPreferencesStore = (
     traceStreamingEnabled: true,
     setTraceStreamingEnabled: (traceStreamingEnabled) => {
       set({ traceStreamingEnabled });
+    },
+    lastNTimeRangeKey: "7d",
+    setLastNTimeRangeKey: (lastNTimeRangeKey) => {
+      set({ lastNTimeRangeKey });
     },
     projectsAutoRefreshEnabled: true,
     setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled) => {


### PR DESCRIPTION
Some users may need much finer grain last N if they are ingesting large amounts of data per minute. This restricts the time range in the UI.


<img width="374" alt="Screenshot 2024-09-16 at 6 07 43 PM" src="https://github.com/user-attachments/assets/890e5d0c-9869-411c-905e-6a50fa466d0b">
