### PR TITLE
ci: tox posargs for pytest only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
   ruff: ruff check --fix {posargs:.}
   mypy: mypy {posargs:.}
   test: pytest -n auto --nf {posargs:.}
-  ci: ruff format --diff {posargs:.}
-  ci: ruff check --no-fix {posargs:.}
-  ci: mypy {posargs:.}
+  ci: ruff format --diff .
+  ci: ruff check --no-fix .
+  ci: mypy .
   ci: pytest -n auto -x {posargs:.}


### PR DESCRIPTION
putting `posargs` on everything doesn't make sense in the first place because it would not be compatible