### PR TITLE
fix(auth): ensure oauth login respects return url

### DIFF
--- a/app/src/pages/auth/LoginPage.tsx
+++ b/app/src/pages/auth/LoginPage.tsx
@@ -28,6 +28,7 @@ export function LoginPage() {
   const oAuth2Idps = window.Config.oAuth2Idps;
   const hasOAuth2Idps = oAuth2Idps.length > 0;
   const [searchParams, setSearchParams] = useSearchParams();
+  const returnUrl = searchParams.get("returnUrl");
   return (
     <AuthLayout>
       <Flex direction="column" gap="size-200" alignItems="center">
@@ -49,6 +50,7 @@ export function LoginPage() {
                   key={idp.name}
                   idpName={idp.name}
                   idpDisplayName={idp.displayName}
+                  returnUrl={returnUrl}
                 />
               </li>
             ))}

--- a/app/src/pages/auth/OAuth2Login.tsx
+++ b/app/src/pages/auth/OAuth2Login.tsx
@@ -6,6 +6,7 @@ import { Button } from "@arizeai/components";
 type OAuth2LoginProps = {
   idpName: string;
   idpDisplayName: string;
+  returnUrl?: string | null;
 };
 
 const loginCSS = css`
@@ -30,10 +31,14 @@ const loginCSS = css`
   }
 `;
 
-export function OAuth2Login({ idpName, idpDisplayName }: OAuth2LoginProps) {
+export function OAuth2Login({
+  idpName,
+  idpDisplayName,
+  returnUrl,
+}: OAuth2LoginProps) {
   return (
     <form
-      action={`/oauth2/${idpName}/login`}
+      action={`/oauth2/${idpName}/login${returnUrl ? `?returnUrl=${returnUrl}` : ""}`}
       method="post"
       css={loginCSS}
       data-provider={idpName}

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -308,7 +308,7 @@ def _get_return_url(*, secret: str, state: str) -> Optional[str]:
     Parses the return URL from the OAuth2 state.
     """
     try:
-        payload = jwt.decode(state, secret)
+        payload = jwt.decode(s=state, key=secret)
         return_url = payload.get(_RETURN_URL)
         assert isinstance(return_url, str) or return_url is None
         return return_url

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -1,7 +1,9 @@
+import json
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Dict, Optional
 
+from authlib.common.security import generate_token
 from authlib.integrations.starlette_client import OAuthError
 from authlib.integrations.starlette_client import StarletteOAuth2App as OAuth2Client
 from fastapi import APIRouter, Path, Request
@@ -37,7 +39,12 @@ async def login(
     ):
         return _redirect_to_login(error=f"Unknown IDP: {idp_name}.")
     redirect_uri = request.url_for("create_tokens", idp_name=idp_name)
-    response: RedirectResponse = await oauth2_client.authorize_redirect(request, redirect_uri)
+    state = _generate_state_for_oauth2_authorization_code_flow(
+        return_url=request.query_params.get("returnUrl")
+    )
+    response: RedirectResponse = await oauth2_client.authorize_redirect(
+        request, redirect_uri, state=state
+    )
     return response
 
 
@@ -45,6 +52,7 @@ async def login(
 async def create_tokens(
     request: Request,
     idp_name: Annotated[str, Path(min_length=1, pattern=_LOWERCASE_ALPHANUMS_AND_UNDERSCORES)],
+    state: str,
 ) -> RedirectResponse:
     assert isinstance(access_token_expiry := request.app.state.access_token_expiry, timedelta)
     assert isinstance(refresh_token_expiry := request.app.state.refresh_token_expiry, timedelta)
@@ -76,7 +84,7 @@ async def create_tokens(
         access_token_expiry=access_token_expiry,
         refresh_token_expiry=refresh_token_expiry,
     )
-    response = RedirectResponse(url="/")  # todo: sanitize a return url
+    response = RedirectResponse(url=_get_return_url(state) or "/")
     response = set_access_token_cookie(
         response=response, access_token=access_token, max_age=access_token_expiry
     )
@@ -274,8 +282,33 @@ class UsernameAlreadyInUse(Exception):
     pass
 
 
+def _generate_state_for_oauth2_authorization_code_flow(return_url: Optional[str]) -> str:
+    """
+    Generates a JSON string containing the OAuth2 state and return URL. This
+    allows us to pass the return URL to the OAuth2 authorization server via the
+    `state` query and have it returned to us in the callback without needing to
+    maintain state.
+    """
+    return json.dumps({"state": generate_token(), _RETURN_URL: return_url})
+
+
+def _get_return_url(state: str) -> Optional[str]:
+    """
+    Parses the return URL from the OAuth2 state.
+    """
+    try:
+        return_url = json.loads(state).get(_RETURN_URL)
+        assert isinstance(return_url, str) or return_url is None
+        return return_url
+    except json.JSONDecodeError:
+        return None
+
+
 def _redirect_to_login(*, error: str) -> RedirectResponse:
     """
     Creates a RedirectResponse to the login page to display an error message.
     """
     return RedirectResponse(url=URL("/login").include_query_params(error=error))
+
+
+_RETURN_URL = "return_url"


### PR DESCRIPTION
Ensures that OAuth2 login respects the `returnUrl` query parameter so that users are returned to the specific URL they were trying to access upon login. This is accomplished by using JWTs to encode the return URL inside the state parameter used by the OAuth2 authorization code flow.

resolves #4653
