### PR TITLE
fix: Update phoenix otel dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "cachetools",
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=0.13.1",
-  "arize-phoenix-otel>=0.4.1",
+  "arize-phoenix-otel>=0.5.1",
   "fastapi",
   "fastapi-mail",
   "pydantic>=1.0,!=2.0.*,<3", # exclude 2.0.* since it does not support the `json_encoders` configuration setting


### PR DESCRIPTION
- Update dependency on `arize-phoenix-otel` to ensure that `register` picks up auth environment variables