### PR TITLE
fix: users should not be asked to reset password again right after they reset their password

### DIFF
--- a/integration_tests/_helpers.py
+++ b/integration_tests/_helpers.py
@@ -856,6 +856,15 @@ def _delete_api_key(
     assert not headers.get("set-cookie")
 
 
+def _will_be_asked_to_reset_password(
+    user: _User,
+) -> bool:
+    query = "query($gid:GlobalID!){node(id:$gid){... on User{passwordNeedsReset}}}"
+    variables = dict(gid=user.gid)
+    resp_dict, _ = user.log_in().gql(query, variables)
+    return cast(bool, resp_dict["data"]["node"]["passwordNeedsReset"])
+
+
 def _log_in(
     password: _Password,
     /,

--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -217,7 +217,7 @@ class TestPasswordReset:
         # new password should work
         new_profile = replace(u.profile, password=new_password)
         new_u = replace(u, profile=new_profile)
-        new_u.log_in().create_api_key()
+        new_u.log_in()
         assert not _will_be_asked_to_reset_password(new_u)
 
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
@@ -476,10 +476,10 @@ class TestPatchViewer:
         new_profile = replace(u.profile, password=new_password)
         new_u = replace(u, profile=new_profile)
         new_tokens = new_u.log_in()
+        assert not _will_be_asked_to_reset_password(new_u)
         with pytest.raises(Exception):
             # old password should no longer work, even with new tokens
             _patch_viewer(new_tokens, old_password, new_password=another_password)
-        assert not _will_be_asked_to_reset_password(new_u)
 
     @pytest.mark.parametrize("role", list(UserRoleInput))
     def test_change_username(
@@ -572,13 +572,13 @@ class TestPatchUser:
             # password should still work
             non_self.log_in()
             return
+        with _EXPECTATION_401:
+            # old password should no longer work
+            non_self.log_in()
         new_profile = replace(non_self.profile, password=new_password)
         new_non_self = replace(non_self, profile=new_profile)
         new_non_self.log_in()
         assert _will_be_asked_to_reset_password(new_non_self)
-        email = new_non_self.email
-        with _EXPECTATION_401:
-            _log_in(old_password, email=email)
 
     @pytest.mark.parametrize(
         "role_or_user,expectation",

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -265,6 +265,7 @@ async def reset_password(request: Request) -> Response:
     user.password_hash = await loop.run_in_executor(
         None, partial(compute_password_hash, password=password, salt=user.password_salt)
     )
+    user.reset_password = False
     async with request.app.state.db() as session:
         session.add(user)
         await session.flush()


### PR DESCRIPTION
resolves #4670 