### PR TITLE
fix: user should be able to initiate password reset again before existing token is used or expires

### DIFF
--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -15,7 +15,6 @@ from typing import (
     TypeVar,
 )
 
-import httpx
 import jwt
 import pytest
 import smtpdfix
@@ -148,16 +147,22 @@ class TestPasswordReset:
         u.log_in()
 
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
-    def test_password_reset_cannot_be_initiated_again_while_in_progress(
+    def test_password_reset_can_be_initiated_multiple_times(
         self,
         role_or_user: _RoleOrUser,
         _get_user: _GetUser,
+        _passwords: Iterator[_Password],
         _smtpd: smtpdfix.AuthController,
     ) -> None:
         u = _get_user(role_or_user)
-        assert u.initiate_password_reset(_smtpd)
-        with pytest.raises(httpx.HTTPStatusError):
-            assert u.initiate_password_reset(_smtpd)
+        new_password = next(_passwords)
+        assert new_password != u.password
+        tokens = [u.initiate_password_reset(_smtpd) for _ in range(2)]
+        for token in tokens[:-1]:
+            with _EXPECTATION_401:
+                token.reset(new_password)
+        # only the most recent one will work
+        tokens[-1].reset(new_password)
 
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_password_reset_can_be_initiated_immediately_after_password_reset(

--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -158,6 +158,7 @@ class TestPasswordReset:
         new_password = next(_passwords)
         assert new_password != u.password
         tokens = [u.initiate_password_reset(_smtpd) for _ in range(2)]
+        assert len(tokens) > 1
         for token in tokens[:-1]:
             with _EXPECTATION_401:
                 token.reset(new_password)

--- a/integration_tests/auth/test_auth.py
+++ b/integration_tests/auth/test_auth.py
@@ -158,12 +158,15 @@ class TestPasswordReset:
         new_password = next(_passwords)
         assert new_password != u.password
         tokens = [u.initiate_password_reset(_smtpd) for _ in range(2)]
-        assert len(tokens) > 1
-        for token in tokens[:-1]:
-            with _EXPECTATION_401:
-                token.reset(new_password)
-        # only the most recent one will work
-        tokens[-1].reset(new_password)
+        assert sum(map(bool, tokens)) > 1
+        for i, token in enumerate(tokens):
+            assert token
+            if i < len(tokens) - 1:
+                with _EXPECTATION_401:
+                    token.reset(new_password)
+                continue
+            # only the last one works
+            token.reset(new_password)
 
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
     def test_password_reset_can_be_initiated_immediately_after_password_reset(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -648,7 +648,7 @@ class User(Base):
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
-    password_reset_token: Mapped["PasswordResetToken"] = relationship(
+    password_reset_token: Mapped[Optional["PasswordResetToken"]] = relationship(
         "PasswordResetToken",
         back_populates="user",
         uselist=False,

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -225,12 +225,12 @@ async def initiate_password_reset(request: Request) -> Response:
                 joinedload(models.User.password_reset_token).load_only(models.PasswordResetToken.id)
             )
         )
-    token_store: TokenStore = request.app.state.get_token_store()
-    if user.password_reset_token:
-        await token_store.revoke(PasswordResetTokenId(user.password_reset_token.id))
     if user is None or user.auth_method != enums.AuthMethod.LOCAL.value:
         # Withold privileged information
         return Response(status_code=HTTP_204_NO_CONTENT)
+    token_store: TokenStore = request.app.state.get_token_store()
+    if user.password_reset_token:
+        await token_store.revoke(PasswordResetTokenId(user.password_reset_token.id))
     password_reset_token_claims = PasswordResetTokenClaims(
         subject=UserId(user.id),
         issued_at=datetime.now(timezone.utc),


### PR DESCRIPTION
resolves #4669 