### PR TITLE
docs: Change column name 'value' to 'score' in example SpanEvaluations dataframe

### DIFF
--- a/docs/tracing/how-to-tracing/llm-evaluations.md
+++ b/docs/tracing/how-to-tracing/llm-evaluations.md
@@ -12,7 +12,7 @@ An evaluation must have a `name` (e.g. "Q\&A Correctness") and its DataFrame mus
 
 A dataframe of span evaluations would look similar like the table below. It must contain `span_id` as an index or as a column. Once ingested, Phoenix uses the `span_id` to associate the evaluation with its target span.
 
-<table><thead><tr><th>span_id</th><th>label</th><th data-type="number">value</th><th>explanation</th></tr></thead><tbody><tr><td>5B8EF798A381</td><td>correct</td><td>1</td><td>"this is correct ..."</td></tr><tr><td>E19B7EC3GG02</td><td>incorrect</td><td>0</td><td>"this is incorrect ..."</td></tr></tbody></table>
+<table><thead><tr><th>span_id</th><th>label</th><th data-type="number">score</th><th>explanation</th></tr></thead><tbody><tr><td>5B8EF798A381</td><td>correct</td><td>1</td><td>"this is correct ..."</td></tr><tr><td>E19B7EC3GG02</td><td>incorrect</td><td>0</td><td>"this is incorrect ..."</td></tr></tbody></table>
 
 The evaluations dataframe can be sent to Phoenix as follows. Note that the name of the evaluation must be supplied through the `eval_name=` parameter. In this case we name it "Q\&A Correctness".
 


### PR DESCRIPTION
Simple fix for dataframe input example in Log Evaluations Results doc page. Column name 'value' in the example table is not correct, it should be 'score'.