### PR TITLE
fix(auth): set oauth2 state and nonce cookies with lax samesite policy

### DIFF
--- a/src/phoenix/auth.py
+++ b/src/phoenix/auth.py
@@ -126,6 +126,7 @@ def set_oauth2_nonce_cookie(
 
 
 def _set_cookie(
+    *,
     response: ResponseType,
     cookie_name: str,
     cookie_max_age: timedelta,

--- a/src/phoenix/auth.py
+++ b/src/phoenix/auth.py
@@ -84,6 +84,7 @@ def set_access_token_cookie(
         response=response,
         cookie_name=PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
         cookie_max_age=max_age,
+        samesite="strict",
         value=access_token,
     )
 
@@ -95,6 +96,7 @@ def set_refresh_token_cookie(
         response=response,
         cookie_name=PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
         cookie_max_age=max_age,
+        samesite="strict",
         value=refresh_token,
     )
 
@@ -106,6 +108,7 @@ def set_oauth2_state_cookie(
         response=response,
         cookie_name=PHOENIX_OAUTH2_STATE_COOKIE_NAME,
         cookie_max_age=max_age,
+        samesite="lax",
         value=state,
     )
 
@@ -117,19 +120,24 @@ def set_oauth2_nonce_cookie(
         response=response,
         cookie_name=PHOENIX_OAUTH2_NONCE_COOKIE_NAME,
         cookie_max_age=max_age,
+        samesite="lax",
         value=nonce,
     )
 
 
 def _set_cookie(
-    response: ResponseType, cookie_name: str, cookie_max_age: timedelta, value: str
+    response: ResponseType,
+    cookie_name: str,
+    cookie_max_age: timedelta,
+    samesite: Literal["strict", "lax"],
+    value: str,
 ) -> ResponseType:
     response.set_cookie(
         key=cookie_name,
         value=value,
         secure=get_env_phoenix_use_secure_cookies(),
         httponly=True,
-        samesite="strict",
+        samesite=samesite,
         max_age=int(cookie_max_age.total_seconds()),
     )
     return response


### PR DESCRIPTION
If the user is not yet authenticated with the OAuth2 IDP and has to sign in for the first time, strict cookies won't be sent back to the callback URL.

https://stackoverflow.com/a/42220786

```
I don't think that this can be done for security reasons. SameSite=Strict means that if user has been redirected or just clicked on link to your site (from other host), cookie shouldn't be send. And redirecting is like 'chaining' requests. So if your server redirects to another and this server redirects back immediately with 3xx code, cookie will be sent, because your server is 'on top' of this chain.

However if you redirect to oauth provider and user has to allow there you to access his account it means that this 'chain' is broken, and cookie will no longer be sent even if your site sets it (it is set however not sent). Your redirect is just 'extension' of clicked 'allow' link.
```

resolves #4685
