### PR TITLE
fix: playwright scaffolding and user action menu rendering

### DIFF
--- a/app/global-setup.ts
+++ b/app/global-setup.ts
@@ -1,10 +1,10 @@
-import { test } from "@playwright/test";
+import { chromium, type FullConfig } from "@playwright/test";
 
-test.describe.configure({ mode: "serial" });
-
-test("first time login expects reset password", async ({ page }) => {
-  await page.goto("http://localhost:6006/login");
-
+async function globalSetup(config: FullConfig) {
+  const { baseURL } = config.projects[0].use;
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.goto(`${baseURL}/login`);
   await page.getByLabel("Email").fill("admin@localhost");
   await page.getByLabel("Password").fill("admin");
   await page.getByRole("button", { name: "Login" }).click();
@@ -15,17 +15,15 @@ test("first time login expects reset password", async ({ page }) => {
   await page.getByLabel("New Password").fill("admin123");
   await page.getByLabel("Confirm Password").fill("admin123");
   await page.getByRole("button", { name: "Reset Password" }).click();
-});
 
-test("create a member", async ({ page }) => {
-  await page.goto("http://localhost:6006/login");
+  await page.goto(`${baseURL}/login`);
 
   await page.getByLabel("Email").fill("admin@localhost");
   await page.getByLabel("Password").fill("admin123");
   await page.getByRole("button", { name: "Login" }).click();
   await page.waitForURL("**/projects/**");
   // Reset the password
-  await page.goto("/settings");
+  await page.goto(`${baseURL}/settings`);
   await page.waitForURL("**/settings");
   await page.getByRole("button", { name: "Add User" }).click();
 
@@ -33,10 +31,13 @@ test("create a member", async ({ page }) => {
   await page.getByLabel("Email").fill("member@localhost.com");
   await page.getByLabel("Password *", { exact: true }).fill("member123");
   await page.getByLabel("Confirm Password").fill("member123");
-  await page.getByLabel("member", { exact: true }).click();
+
+  await page.getByRole("dialog").getByLabel("member", { exact: true }).click();
   await page.getByRole("option", { name: "member" }).click();
   await page
     .getByRole("dialog")
     .getByRole("button", { name: "Add User" })
     .click();
-});
+}
+
+export default globalSetup;

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -8,6 +8,8 @@ module.exports = {
   transform: {
     "^.+\\.[jt]sx?$": ["esbuild-jest"],
   },
+  // .spec.ts files are for playwright e2e tests, jest unit tests are labeled with .test.ts
+  testPathIgnorePatterns: ["\\.spec\\.ts$"],
   transformIgnorePatterns: [".*node_modules/.pnpm/(?!d3)@"],
   moduleNameMapper: {
     "^@phoenix/(.*)$": "<rootDir>/src/$1",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -11,6 +11,7 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  globalSetup: require.resolve("./global-setup"),
   testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -33,10 +34,6 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
-    {
-      name: "setup",
-      testMatch: /global\.setup\.ts/,
-    },
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },

--- a/app/src/pages/settings/UserActionMenu.tsx
+++ b/app/src/pages/settings/UserActionMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useState } from "react";
+import React, { ReactNode, useCallback, useMemo, useState } from "react";
 
 import {
   ActionMenu,
@@ -51,6 +51,43 @@ export function UserActionMenu(props: UserActionMenuProps) {
       <ResetPasswordDialog userId={userId} onClose={() => setDialog(null)} />
     );
   }, [userId]);
+
+  const actionMenuItems = useMemo(() => {
+    const deleteUserItemEl = (
+      <Item key={UserAction.DELETE}>
+        <Flex
+          direction={"row"}
+          gap="size-75"
+          justifyContent={"start"}
+          alignItems={"center"}
+        >
+          <Icon svg={<Icons.TrashOutline />} />
+          <Text>Delete</Text>
+        </Flex>
+      </Item>
+    );
+
+    const resetPasswordItemEl = (
+      <Item key={UserAction.RESET_PASSWORD}>
+        <Flex
+          direction={"row"}
+          gap="size-75"
+          justifyContent={"start"}
+          alignItems={"center"}
+        >
+          <Icon svg={<Icons.TrashOutline />} />
+          <Text>Reset Password</Text>
+        </Flex>
+      </Item>
+    );
+
+    const actionMenuItems = [deleteUserItemEl];
+    if (isLocalAuth(authMethod)) {
+      actionMenuItems.push(resetPasswordItemEl);
+    }
+    return actionMenuItems;
+  }, [authMethod]);
+
   return (
     <div
       // TODO: add this logic to the ActionMenu component
@@ -62,6 +99,7 @@ export function UserActionMenu(props: UserActionMenuProps) {
     >
       <ActionMenu
         align="end"
+        aria-label="User Actions"
         buttonSize="compact"
         onAction={(action) => {
           switch (action) {
@@ -74,32 +112,7 @@ export function UserActionMenu(props: UserActionMenuProps) {
           }
         }}
       >
-        <Item key={UserAction.DELETE}>
-          <Flex
-            direction={"row"}
-            gap="size-75"
-            justifyContent={"start"}
-            alignItems={"center"}
-          >
-            <Icon svg={<Icons.TrashOutline />} />
-            <Text>Delete</Text>
-          </Flex>
-        </Item>
-        {isLocalAuth(authMethod) ? (
-          <Item key={UserAction.RESET_PASSWORD}>
-            <Flex
-              direction={"row"}
-              gap="size-75"
-              justifyContent={"start"}
-              alignItems={"center"}
-            >
-              <Icon svg={<Icons.Edit2Outline />} />
-              <Text>Reset Password</Text>
-            </Flex>
-          </Item>
-        ) : (
-          <></>
-        )}
+        {actionMenuItems}
       </ActionMenu>
       <DialogContainer
         type="modal"

--- a/app/src/pages/settings/UserActionMenu.tsx
+++ b/app/src/pages/settings/UserActionMenu.tsx
@@ -75,7 +75,7 @@ export function UserActionMenu(props: UserActionMenuProps) {
           justifyContent={"start"}
           alignItems={"center"}
         >
-          <Icon svg={<Icons.TrashOutline />} />
+          <Icon svg={<Icons.Refresh />} />
           <Text>Reset Password</Text>
         </Flex>
       </Item>

--- a/app/src/pages/settings/UsersCard.tsx
+++ b/app/src/pages/settings/UsersCard.tsx
@@ -51,12 +51,12 @@ export function UsersCard() {
                   setDialog(null);
                 }}
                 onNewUserCreated={(email) => {
+                  setDialog(null);
                   notifySuccess({
                     title: "User added",
                     message: `User ${email} has been added.`,
                   });
                   setFetchKey((prev) => prev + 1);
-                  setDialog(null);
                 }}
                 onNewUserCreationError={(error) => {
                   notifyError({

--- a/app/tests/getting-started.spec.ts
+++ b/app/tests/getting-started.spec.ts
@@ -1,0 +1,11 @@
+import { test } from "@playwright/test";
+
+test("user can view getting started guide when no traces", async ({ page }) => {
+  await page.goto("http://localhost:6006/");
+  await page.getByPlaceholder("your email address").fill("admin@localhost");
+  await page.getByPlaceholder("your email address").press("Tab");
+  await page.getByPlaceholder("your password").fill("admin123");
+  await page.getByPlaceholder("your password").press("Enter");
+  await page.getByRole("button", { name: "Get Started" }).click();
+  await page.getByLabel("dismiss").click();
+});

--- a/app/tests/user-management.spec.ts
+++ b/app/tests/user-management.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { randomUUID } from "crypto";
+
+test.beforeEach(async ({ page }) => {
+  page.goto("http://localhost:6006/login");
+
+  await page.getByLabel("Email").fill("admin@localhost");
+  await page.getByLabel("Password").fill("admin123");
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.waitForURL("**/projects/**");
+});
+
+test("can create a user", async ({ page }) => {
+  await page.goto("/settings");
+  await page.waitForURL("**/settings");
+  await page.getByRole("button", { name: "Add User" }).click();
+
+  const email = `member-${randomUUID()}@localhost.com`;
+  // Add the user
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password *", { exact: true }).fill("member123");
+  await page.getByLabel("Confirm Password").fill("member123");
+  await page.getByRole("dialog").getByLabel("member", { exact: true }).click();
+  await page
+    .getByRole("dialog")
+    .getByRole("option", { name: "member" })
+    .click();
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Add User" })
+    .click();
+
+  // Check if the user is created
+  await expect(page.getByRole("cell", { name: email })).toBeVisible();
+});


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/4677
Switches playwright to use a global setup hook which guarantees the tests run AFTER setup.

This also contains code from @Parker-Stafford for the action menu options to hide reset password for local