### PR TITLE
chore(auth): strengthen check constraints related to auth method

### DIFF
--- a/src/phoenix/auth.py
+++ b/src/phoenix/auth.py
@@ -11,7 +11,6 @@ from starlette.responses import Response
 from typing_extensions import TypeVar
 
 from phoenix.config import get_env_phoenix_use_secure_cookies
-from phoenix.db.models import User as OrmUser
 
 ResponseType = TypeVar("ResponseType", bound=Response)
 
@@ -67,14 +66,6 @@ def validate_password_format(password: str) -> None:
     Checks that the password has a valid format.
     """
     PASSWORD_REQUIREMENTS.validate(password)
-
-
-def is_locally_authenticated(user: OrmUser) -> bool:
-    """
-    Returns true if the user is authenticated locally, i.e., not through an
-    OAuth2 identity provider, and false otherwise.
-    """
-    return user.oauth2_client_id is None and user.oauth2_user_id is None
 
 
 def set_access_token_cookie(

--- a/src/phoenix/db/enums.py
+++ b/src/phoenix/db/enums.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import InstrumentedAttribute
 from phoenix.db import models
 
 
+class AuthMethod(Enum):
+    LOCAL = "LOCAL"
+    OAUTH2 = "OAUTH2"
+
+
 class UserRole(Enum):
     SYSTEM = "SYSTEM"
     ADMIN = "ADMIN"

--- a/src/phoenix/db/enums.py
+++ b/src/phoenix/db/enums.py
@@ -4,11 +4,9 @@ from typing import Mapping, Type
 from sqlalchemy.orm import InstrumentedAttribute
 
 from phoenix.db import models
+from phoenix.db.models import AuthMethod
 
-
-class AuthMethod(Enum):
-    LOCAL = "LOCAL"
-    OAUTH2 = "OAUTH2"
+__all__ = ["AuthMethod", "UserRole", "COLUMN_ENUMS"]
 
 
 class UserRole(Enum):

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -20,7 +20,6 @@ from phoenix.auth import (
 )
 from phoenix.db import models
 from phoenix.db.enums import COLUMN_ENUMS, UserRole
-from phoenix.db.models import SYSTEM_USER_EMAIL
 from phoenix.server.types import DbSessionFactory
 
 
@@ -85,7 +84,7 @@ async def _ensure_user_roles(session: AsyncSession) -> None:
     ) is not None:
         system_user = models.User(
             user_role_id=system_role_id,
-            email=SYSTEM_USER_EMAIL,
+            email="system@localhost",
             reset_password=False,
         )
         session.add(system_user)

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -20,6 +20,7 @@ from phoenix.auth import (
 )
 from phoenix.db import models
 from phoenix.db.enums import COLUMN_ENUMS, UserRole
+from phoenix.db.models import SYSTEM_USER_EMAIL
 from phoenix.server.types import DbSessionFactory
 
 
@@ -84,7 +85,7 @@ async def _ensure_user_roles(session: AsyncSession) -> None:
     ) is not None:
         system_user = models.User(
             user_role_id=system_role_id,
-            email="system@localhost",
+            email=SYSTEM_USER_EMAIL,
             reset_password=False,
         )
         session.add(system_user)

--- a/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
@@ -75,12 +75,8 @@ def upgrade() -> None:
             name="oauth2_client_id_and_user_id",
         ),
         sa.CheckConstraint(
-            """
-                (CASE WHEN password_hash IS NOT NULL THEN 1 ELSE 0 END) +
-                (CASE WHEN oauth2_client_id IS NOT NULL THEN 1 ELSE 0 END) +
-                (CASE WHEN password_hash IS NULL THEN 1 ELSE 0 END) = 1
-            """,
-            name="local_auth_or_oauth2_or_system_user",
+            "password_hash IS NULL or oauth2_client_id IS NULL",
+            name="at_most_one_auth_method",
         ),
         sa.UniqueConstraint(
             "oauth2_client_id",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -699,12 +699,8 @@ class User(Base):
             name="oauth2_client_id_and_user_id",
         ),
         CheckConstraint(
-            """
-                (CASE WHEN password_hash IS NOT NULL THEN 1 ELSE 0 END) +
-                (CASE WHEN oauth2_client_id IS NOT NULL THEN 1 ELSE 0 END) +
-                (CASE WHEN password_hash IS NULL THEN 1 ELSE 0 END) = 1
-            """,
-            name="local_auth_or_oauth2_or_system_user",
+            "password_hash IS NULL or oauth2_client_id IS NULL",
+            name="at_most_one_auth_method",
         ),
         UniqueConstraint(
             "oauth2_client_id",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -690,7 +690,22 @@ class User(Base):
         )
 
     __table_args__ = (
-        CheckConstraint("password_hash is null or password_salt is not null", name="salt"),
+        CheckConstraint(
+            "(password_hash IS NULL) = (password_salt IS NULL)",
+            name="password_hash_and_salt",
+        ),
+        CheckConstraint(
+            "(oauth2_client_id IS NULL) = (oauth2_user_id IS NULL)",
+            name="oauth2_client_id_and_user_id",
+        ),
+        CheckConstraint(
+            """
+                (CASE WHEN password_hash IS NOT NULL THEN 1 ELSE 0 END) +
+                (CASE WHEN oauth2_client_id IS NOT NULL THEN 1 ELSE 0 END) +
+                (CASE WHEN password_hash IS NULL THEN 1 ELSE 0 END) = 1
+            """,
+            name="local_auth_or_oauth2_or_system_user",
+        ),
         UniqueConstraint(
             "oauth2_client_id",
             "oauth2_user_id",

--- a/src/phoenix/server/api/mutations/user_mutations.py
+++ b/src/phoenix/server/api/mutations/user_mutations.py
@@ -18,7 +18,6 @@ from phoenix.auth import (
     PASSWORD_REQUIREMENTS,
     PHOENIX_ACCESS_TOKEN_COOKIE_NAME,
     PHOENIX_REFRESH_TOKEN_COOKIE_NAME,
-    is_locally_authenticated,
     validate_email_format,
     validate_password_format,
 )
@@ -138,7 +137,7 @@ class UserMutationMixin:
                     raise NotFound(f"Role {input.new_role.value} not found")
                 user.user_role_id = user_role_id
             if password := input.new_password:
-                if not is_locally_authenticated(user):
+                if user.auth_method != enums.AuthMethod.LOCAL.value:
                     raise Conflict("Cannot modify password for non-local user")
                 validate_password_format(password)
                 user.password_salt = secrets.token_bytes(DEFAULT_SECRET_LENGTH)
@@ -171,7 +170,7 @@ class UserMutationMixin:
                 raise NotFound("User not found")
             stack.enter_context(session.no_autoflush)
             if password := input.new_password:
-                if not is_locally_authenticated(user):
+                if user.auth_method != enums.AuthMethod.LOCAL.value:
                     raise Conflict("Cannot modify password for non-local user")
                 if not (
                     current_password := input.current_password

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -25,14 +25,13 @@ from phoenix.auth import (
     delete_oauth2_nonce_cookie,
     delete_oauth2_state_cookie,
     delete_refresh_token_cookie,
-    is_locally_authenticated,
     is_valid_password,
     set_access_token_cookie,
     set_refresh_token_cookie,
     validate_password_format,
 )
 from phoenix.config import get_base_url, get_env_disable_rate_limit
-from phoenix.db import models
+from phoenix.db import enums, models
 from phoenix.server.bearer_auth import PhoenixUser, create_access_and_refresh_tokens
 from phoenix.server.email.templates.types import PasswordResetTemplateBody
 from phoenix.server.email.types import EmailSender
@@ -198,7 +197,7 @@ async def initiate_password_reset(request: Request) -> Response:
                 joinedload(models.User.password_reset_token).load_only(models.PasswordResetToken.id)
             )
         )
-    if user is None or not is_locally_authenticated(user):
+    if user is None or user.auth_method != enums.AuthMethod.LOCAL.value:
         # Withold privileged information
         return Response(status_code=HTTP_204_NO_CONTENT)
     token_store: TokenStore = request.app.state.get_token_store()
@@ -230,7 +229,7 @@ async def reset_password(request: Request) -> Response:
     assert (user_id := claims.subject)
     async with request.app.state.db() as session:
         user = await session.scalar(_select_active_user().filter_by(id=int(user_id)))
-    if user is None or not is_locally_authenticated(user):
+    if user is None or user.auth_method != enums.AuthMethod.LOCAL.value:
         # Withold privileged information
         return Response(status_code=HTTP_204_NO_CONTENT)
     validate_password_format(password)

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -7,7 +7,6 @@ from strawberry import Private
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
-from phoenix.auth import is_locally_authenticated
 from phoenix.db import models
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
@@ -54,5 +53,5 @@ def to_gql_user(user: models.User, api_keys: Optional[List[models.ApiKey]] = Non
         email=user.email,
         created_at=user.created_at,
         user_role_id=user.user_role_id,
-        auth_method=AuthMethod.LOCAL if is_locally_authenticated(user) else AuthMethod.OAUTH2,
+        auth_method=AuthMethod(user.auth_method),
     )

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -46,6 +46,7 @@ def to_gql_user(user: models.User, api_keys: Optional[List[models.ApiKey]] = Non
     """
     Converts an ORM user to a GraphQL user.
     """
+    assert user.auth_method is not None
     return User(
         id_attr=user.id,
         password_needs_reset=user.reset_password,


### PR DESCRIPTION
strengthens check constraints related to auth methods

- `password_hash` and `password_salt` must be set or unset together
- `oauth2_client_id` and `oauth2_user_id` must be set or unset together
- a single user can have at most one auth method

resolves #4688
