### PR TITLE
feat(auth): add configurable base url

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, overload
 from urllib.parse import urlparse
+from warnings import warn
 
 from phoenix.utilities.re import parse_env_headers
 
@@ -86,6 +87,14 @@ The duration, in minutes, before refresh tokens expire.
 ENV_PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES = "PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES"
 """
 The duration, in minutes, before password reset tokens expire.
+"""
+ENV_PHOENIX_BASE_URL = "PHOENIX_BASE_URL"
+"""
+The URL used to access Phoenix from a browser. This is needed to ensure that the
+`redirect_uri` parameter is correct during OAuth2 authorization code flows if an
+OAuth2 IDP is configured. If you have a reverse proxy in front of Phoenix that
+exposes Phoenix through a subpath, ensure that the subpath appears at the end of
+this URL. Strongly consider using HTTPS since HTTP is insecure.
 """
 
 # SMTP settings
@@ -399,6 +408,24 @@ def get_env_oauth2_settings() -> List[OAuth2ClientConfig]:
         if (match := pattern.match(env_var)) is not None and (idp_name := match.group(1).lower()):
             idp_names.add(idp_name)
     return [OAuth2ClientConfig.from_env(idp_name) for idp_name in sorted(idp_names)]
+
+
+def get_env_base_url() -> Optional[str]:
+    """
+    Gets base URL from environment variable.
+    """
+    if (base_url := os.getenv(ENV_PHOENIX_BASE_URL)) is None:
+        return None
+    if base_url.startswith("http://"):
+        warn(
+            "The Phoenix base URL is configured using HTTP, which is insecure. "
+            "Consider using HTTPS."
+        )
+    elif not base_url.startswith("https://"):
+        raise ValueError(
+            f"{ENV_PHOENIX_BASE_URL} must be a valid URL using the HTTP or HTTPS protocols."
+        )
+    return base_url
 
 
 PHOENIX_DIR = Path(__file__).resolve().parent

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from starlette.datastructures import URL
 from starlette.responses import RedirectResponse
+from starlette.routing import Router
 from starlette.status import HTTP_302_FOUND
 from typing_extensions import Annotated
 
@@ -383,7 +384,9 @@ def _get_create_tokens_endpoint(*, request: Request, idp_name: str) -> str:
     """
     Gets the endpoint for create tokens route.
     """
-    return str(request.url_for(create_tokens.__name__, idp_name=idp_name))
+    router: Router = request.scope["router"]
+    url_path = router.url_path_for(create_tokens.__name__, idp_name=idp_name)
+    return str(url_path.make_absolute_url(base_url=request.app.state.base_url or request.base_url))
 
 
 def _generate_state_for_oauth2_authorization_code_flow(

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -631,6 +631,7 @@ def create_app(
     email_sender: Optional[EmailSender] = None,
     oauth2_client_configs: Optional[List[OAuth2ClientConfig]] = None,
     bulk_inserter_factory: Optional[Callable[..., BulkInserter]] = None,
+    base_url: Optional[str] = None,
 ) -> FastAPI:
     bulk_inserter_factory = bulk_inserter_factory or BulkInserter
     startup_callbacks_list: List[_Callback] = list(startup_callbacks)
@@ -776,6 +777,7 @@ def create_app(
     app.state.access_token_expiry = access_token_expiry
     app.state.refresh_token_expiry = refresh_token_expiry
     app.state.oauth2_clients = OAuth2Clients.from_configs(oauth2_client_configs or [])
+    app.state.base_url = base_url
     app.state.db = db
     app.state.email_sender = email_sender
     app = _add_get_secret_method(app=app, secret=secret)

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -20,6 +20,7 @@ from phoenix.config import (
     EXPORT_DIR,
     get_env_access_token_expiry,
     get_env_auth_settings,
+    get_env_base_url,
     get_env_database_connection_str,
     get_env_database_schema,
     get_env_enable_prometheus,
@@ -419,6 +420,7 @@ if __name__ == "__main__":
         scaffolder_config=scaffolder_config,
         email_sender=email_sender,
         oauth2_client_configs=get_env_oauth2_settings(),
+        base_url=get_env_base_url(),
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()


### PR DESCRIPTION
Adds `PHOENIX_BASE_URL` parameter. Similar to [`root_url` in Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#root_url).

```
The URL used to access Phoenix from a browser. This is needed to ensure that the
`redirect_uri` parameter is correct during OAuth2 authorization code flows if an
OAuth2 IDP is configured. If you have a reverse proxy in front of Phoenix that
exposes Phoenix through a subpath, ensure that the subpath appears at the end of
this URL. Strongly consider using HTTPS since HTTP is insecure.
```

resolves #4690
