### PR TITLE
refactor(auth): simplify config

### DIFF
--- a/src/phoenix/server/oauth2.py
+++ b/src/phoenix/server/oauth2.py
@@ -32,7 +32,7 @@ class OAuth2Clients:
         client = OAuth2Client(
             client_id=config.client_id,
             client_secret=config.client_secret,
-            server_metadata_url=config.server_metadata_url,
+            server_metadata_url=config.oidc_config_url,
             client_kwargs={"scope": "openid email profile"},
         )
         assert isinstance(client, OAuth2Client)


### PR DESCRIPTION
Rename "server metadata url" to "oidc config url". Remove IDP-specific logic.

resolves #4712
