### PR TITLE
fix(auth): hard-delete users

### DIFF
--- a/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
+++ b/src/phoenix/db/migrations/versions/cd164e83824f_users_and_tokens.py
@@ -61,11 +61,6 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             onupdate=sa.func.now(),
         ),
-        sa.Column(
-            "deleted_at",
-            sa.TIMESTAMP(timezone=True),
-            nullable=True,
-        ),
         sa.CheckConstraint(
             "(password_hash IS NULL) = (password_salt IS NULL)",
             name="password_hash_and_salt",

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -654,7 +654,6 @@ class User(Base):
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
     )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(UtcTimeStamp)
     password_reset_token: Mapped[Optional["PasswordResetToken"]] = relationship(
         "PasswordResetToken",
         back_populates="user",

--- a/src/phoenix/server/api/dataloaders/users.py
+++ b/src/phoenix/server/api/dataloaders/users.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import DefaultDict, List, Optional
 
-from sqlalchemy import and_, select
+from sqlalchemy import select
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -25,9 +25,7 @@ class UsersDataLoader(DataLoader[Key, Result]):
         users_by_id: DefaultDict[Key, Result] = defaultdict(None)
         async with self._db() as session:
             data = await session.stream_scalars(
-                select(models.User).where(
-                    and_(models.User.id.in_(user_ids), models.User.deleted_at.is_(None))
-                )
+                select(models.User).where(models.User.id.in_(user_ids))
             )
             async for user in data:
                 users_by_id[user.id] = user

--- a/src/phoenix/server/api/mutations/api_key_mutations.py
+++ b/src/phoenix/server/api/mutations/api_key_mutations.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import strawberry
-from sqlalchemy import and_, select
+from sqlalchemy import select
 from strawberry import UNSET
 from strawberry.relay import GlobalID
 from strawberry.types import Info
@@ -71,9 +71,7 @@ class ApiKeyMutationMixin:
             system_user = await session.scalar(
                 select(models.User)
                 .join(models.UserRole)  # Join User with UserRole
-                .where(
-                    and_(models.UserRole.name == user_role.value, models.User.deleted_at.is_(None))
-                )  # Filter where role is SYSTEM
+                .where(models.UserRole.name == user_role.value)  # Filter where role is SYSTEM
                 .order_by(models.User.id)
                 .limit(1)
             )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -96,12 +96,7 @@ class Query:
         stmt = (
             select(models.User)
             .join(models.UserRole)
-            .where(
-                and_(
-                    models.UserRole.name != enums.UserRole.SYSTEM.value,
-                    models.User.deleted_at.is_(None),
-                )
-            )
+            .where(models.UserRole.name != enums.UserRole.SYSTEM.value)
             .order_by(models.User.email)
             .options(joinedload(models.User.role))
         )
@@ -477,9 +472,7 @@ class Query:
             async with info.context.db() as session:
                 if not (
                     user := await session.scalar(
-                        select(models.User).where(
-                            and_(models.User.id == node_id, models.User.deleted_at.is_(None))
-                        )
+                        select(models.User).where(models.User.id == node_id)
                     )
                 ):
                     raise NotFound(f"Unknown user: {id}")
@@ -499,9 +492,7 @@ class Query:
             if (
                 user := await session.scalar(
                     select(models.User)
-                    .where(
-                        and_(models.User.id == int(user.identity), models.User.deleted_at.is_(None))
-                    )
+                    .where(models.User.id == int(user.identity))
                     .options(joinedload(models.User.role))
                 )
             ) is None:


### PR DESCRIPTION
Hard-deletes user tuples rather than keeping a `deleted_at` timestamp column. Enables users to delete their account in order to re-use their email with another account (e.g., with an OAuth2 IDP).

resolves #4676
