### PR TITLE
fix(auth): infer origin url

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -8,7 +8,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, overload
 from urllib.parse import urlparse
-from warnings import warn
 
 from phoenix.utilities.logging import log_a_list
 
@@ -107,14 +106,6 @@ The duration, in minutes, before refresh tokens expire.
 ENV_PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES = "PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES"
 """
 The duration, in minutes, before password reset tokens expire.
-"""
-ENV_PHOENIX_BASE_URL = "PHOENIX_BASE_URL"
-"""
-The URL used to access Phoenix from a browser. This is needed to ensure that the
-`redirect_uri` parameter is correct during OAuth2 authorization code flows if an
-OAuth2 IDP is configured. If you have a reverse proxy in front of Phoenix that
-exposes Phoenix through a subpath, ensure that the subpath appears at the end of
-this URL. Strongly consider using HTTPS since HTTP is insecure.
 """
 
 # SMTP settings
@@ -426,24 +417,6 @@ def get_env_oauth2_settings() -> List[OAuth2ClientConfig]:
         if (match := pattern.match(env_var)) is not None and (idp_name := match.group(1).lower()):
             idp_names.add(idp_name)
     return [OAuth2ClientConfig.from_env(idp_name) for idp_name in sorted(idp_names)]
-
-
-def get_env_base_url() -> Optional[str]:
-    """
-    Gets base URL from environment variable.
-    """
-    if (base_url := os.getenv(ENV_PHOENIX_BASE_URL)) is None:
-        return None
-    if base_url.startswith("http://"):
-        warn(
-            "The Phoenix base URL is configured using HTTP, which is insecure. "
-            "Consider using HTTPS."
-        )
-    elif not base_url.startswith("https://"):
-        raise ValueError(
-            f"{ENV_PHOENIX_BASE_URL} must be a valid URL using the HTTP or HTTPS protocols."
-        )
-    return base_url
 
 
 PHOENIX_DIR = Path(__file__).resolve().parent

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -629,7 +629,6 @@ def create_app(
     email_sender: Optional[EmailSender] = None,
     oauth2_client_configs: Optional[List[OAuth2ClientConfig]] = None,
     bulk_inserter_factory: Optional[Callable[..., BulkInserter]] = None,
-    base_url: Optional[str] = None,
 ) -> FastAPI:
     logger.info(f"Server umap params: {umap_params}")
     bulk_inserter_factory = bulk_inserter_factory or BulkInserter
@@ -776,7 +775,6 @@ def create_app(
     app.state.access_token_expiry = access_token_expiry
     app.state.refresh_token_expiry = refresh_token_expiry
     app.state.oauth2_clients = OAuth2Clients.from_configs(oauth2_client_configs or [])
-    app.state.base_url = base_url
     app.state.db = db
     app.state.email_sender = email_sender
     app = _add_get_secret_method(app=app, secret=secret)

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -19,7 +19,6 @@ from phoenix.config import (
     EXPORT_DIR,
     get_env_access_token_expiry,
     get_env_auth_settings,
-    get_env_base_url,
     get_env_database_connection_str,
     get_env_database_schema,
     get_env_db_logging_level,
@@ -407,7 +406,6 @@ def main() -> None:
         scaffolder_config=scaffolder_config,
         email_sender=email_sender,
         oauth2_client_configs=get_env_oauth2_settings(),
-        base_url=get_env_base_url(),
     )
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()


### PR DESCRIPTION
Remove the `PHOENIX_BASE_URL` environment variable, since we can infer the origin URL via the referer header.

resolves #4736
