### PR TITLE
fix(playwright): make rate-limiting test run last

### DIFF
--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  // workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -35,16 +35,19 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
       testIgnore: "**/*.rate-limit.spec.ts",
     },
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
+      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
       testIgnore: "**/*.rate-limit.spec.ts",
     },
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
       testIgnore: "**/*.rate-limit.spec.ts",
     },
     {

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -37,14 +37,17 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      testIgnore: "**/*.rate-limit.spec.ts",
     },
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
+      testIgnore: "**/*.rate-limit.spec.ts",
     },
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      testIgnore: "**/*.rate-limit.spec.ts",
     },
     {
       name: "rate limit",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -19,8 +19,6 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  // workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
makes playwright rate limiting spec run last and bumps workers in ci