### PR TITLE
fix: Use python string formatting for standard template delimiters

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from string import Formatter
 from typing import Callable, List, Mapping, Optional, Tuple, Union
 
 import pandas as pd
@@ -42,17 +43,27 @@ class PromptTemplate:
         options: Optional[PromptOptions] = None,
     ) -> str:
         prompt = self.prompt(options)
-        for variable_name in self.variables:
-            prompt = prompt.replace(
-                self._start_delim + variable_name + self._end_delim,
-                str(variable_values[variable_name]),
-            )
+        if self._start_delim == "{" and self._end_delim == "}":
+            prompt = prompt.format(**variable_values)
+        else:
+            for variable_name in self.variables:
+                prompt = prompt.replace(
+                    self._start_delim + variable_name + self._end_delim,
+                    str(variable_values[variable_name]),
+                )
         return prompt
 
     def _parse_variables(self, text: str) -> List[str]:
-        pattern = re.escape(self._start_delim) + "(.*?)" + re.escape(self._end_delim)
-        variables = re.findall(pattern, text)
-        return variables
+        if self._start_delim == "{" and self._end_delim == "}":
+            formatter = Formatter()
+            variables = [field_name for _, field_name, _, _ in formatter.parse(text) if field_name]
+            return variables
+        else:
+            start = re.escape(self._start_delim)
+            end = re.escape(self._end_delim)
+            pattern = rf"{start}(.*?){end}"
+            variables = re.findall(pattern, text)
+            return variables
 
 
 class ClassificationTemplate(PromptTemplate):

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -3,7 +3,7 @@ import math
 import pytest
 
 from phoenix.evals import RAG_RELEVANCY_PROMPT_TEMPLATE, ClassificationTemplate
-from phoenix.evals.templates import InvalidClassificationTemplateError
+from phoenix.evals.templates import InvalidClassificationTemplateError, PromptTemplate
 
 
 def test_classification_template_raises_error_when_initialized_with_mismatched_labels_and_scores():
@@ -23,3 +23,11 @@ def test_classification_template_score_returns_correct_score_for_present_rail():
 def test_classification_template_score_returns_zero_for_missing_rail():
     score = RAG_RELEVANCY_PROMPT_TEMPLATE.score("missing")
     assert math.isclose(score, 0.0)
+
+
+def test_template_with_default_delimiters_uses_python_string_formatting():
+    template = PromptTemplate(template='Hello, {name}! Look at this JSON {{ "hello": "world" }}')
+    assert (
+        template.format(variable_values={"name": "world"})
+        == 'Hello, world! Look at this JSON { "hello": "world" }'
+    )


### PR DESCRIPTION
resolves #4770 

Uses standard python string formatting with default curly brace variable delimiters ("{", "}")