### PR TITLE
docs: create MongoDB example notebook

### DIFF
--- a/tutorials/integrations/tracing_and_evals_with_mongodb_and_llama_index.ipynb
+++ b/tutorials/integrations/tracing_and_evals_with_mongodb_and_llama_index.ipynb
@@ -1,623 +1,614 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "NqjcGG9QJhUJ",
-      "metadata": {
-        "id": "NqjcGG9QJhUJ"
-      },
-      "source": [
-        "<center>\n",
-        "    <p style=\"text-align:center\">\n",
-        "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
-        "        <br>\n",
-        "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
-        "        |\n",
-        "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
-        "        |\n",
-        "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
-        "    </p>\n",
-        "</center>\n",
-        "<h1 align=\"center\">Tracing and Evaluating a LlamaIndex Application using MongoDB Atlas as Vector Store</h1>\n",
-        "\n",
-        "<h2 align=\"center\"> LaMA Stack (LlamaIndex,  MongoDB and Arize) </h2>\n",
-        "\n",
-        "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
-        "\n",
-        "In this tutorial, you will:\n",
-        "- Generate data into a MongoDB Collection to be later used as a Vector Store.\n",
-        "- Build a simple query engine using LlamaIndex that uses retrieval-augmented generation to answer questions over the Arize documentation,\n",
-        "- Record trace data in [OpenInference tracing](https://github.com/Arize-ai/open-inference-spec/blob/main/trace/spec/traces.md) format using the global `arize_phoenix` handler\n",
-        "- Inspect the traces and spans of your application to identify sources of latency and cost,\n",
-        "- Export your trace data as a pandas dataframe and run an [LLM Evals](https://docs.arize.com/phoenix/concepts/llm-evals) to measure the precision@k of the query engine's retrieval step.\n",
-        "\n",
-        "ℹ️ This notebook requires an OpenAI API key."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "qtPye6KSKNrO",
-      "metadata": {
-        "id": "qtPye6KSKNrO"
-      },
-      "source": [
-        "## 1. Install needed dependencies and import relevant packages"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6",
-      "metadata": {
-        "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install -q uv\n",
-        "!uv pip install -q --system llama-index-embeddings-openai 'arize-phoenix[evals]' llama-index llama-index-callbacks-arize-phoenix llama-index-vector-stores-mongodb llama-index-storage-docstore-mongodb llama-index-storage-index-store-mongodb llama-index-readers-mongodb\n",
-        "!uv pip install -q --system \"openai>=1\" gcsfs nest-asyncio pymongo beautifulsoup4 certifi"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37",
-      "metadata": {
-        "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "import os\n",
-        "import urllib\n",
-        "from getpass import getpass\n",
-        "from urllib.request import urlopen\n",
-        "\n",
-        "import nest_asyncio\n",
-        "import openai\n",
-        "import pandas as pd\n",
-        "import phoenix as px\n",
-        "from llama_index.core import (\n",
-        "    StorageContext, set_global_handler\n",
-        ")\n",
-        "from llama_index.embeddings.openai import OpenAIEmbedding\n",
-        "from llama_index.core.indices.vector_store.base import VectorStoreIndex\n",
-        "from llama_index.core.retrievers import VectorIndexRetriever\n",
-        "from llama_index.core.query_engine import RetrieverQueryEngine\n",
-        "from llama_index.llms.openai import OpenAI\n",
-        "from llama_index.readers.mongodb import SimpleMongoReader\n",
-        "from llama_index.vector_stores.mongodb import MongoDBAtlasVectorSearch\n",
-        "from llama_index.core.settings import Settings\n",
-        "from phoenix.evals import (\n",
-        "    HallucinationEvaluator, OpenAIModel, QAEvaluator,\n",
-        "    RelevanceEvaluator, run_evals\n",
-        ")\n",
-        "from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents\n",
-        "from phoenix.trace import DocumentEvaluations, SpanEvaluations\n",
-        "from pymongo.operations import SearchIndexModel\n",
-        "from tqdm import tqdm\n",
-        "\n",
-        "\n",
-        "nest_asyncio.apply()  # needed for concurrent evals in notebook environments\n",
-        "pd.set_option(\"display.max_colwidth\", 1000)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "xVBBk-SRKauo",
-      "metadata": {
-        "id": "xVBBk-SRKauo"
-      },
-      "source": [
-        "## 2. Set up MongoDB Atlas\n",
-        "\n",
-        "To effectively use this notebook for MongoDB operations, it's essential to have a MongoDB account set up with a database and collection already created. Additionally, you need to have a vector index created as described in the MongoDB Atlas Search documentation.\n",
-        "\n",
-        "This can be done by following this steps:\n",
-        "\n",
-        "1. Create a MongoDB Atlas account.\n",
-        "2. Create a database.\n",
-        "3. Add a new collection to that database.\n",
-        "4. Create a search index with the following structure in the recently created collection:\n",
-        "\n",
-        "{\n",
-        "  \"fields\": [\n",
-        "    {\n",
-        "      \"numDimensions\": 1536,\n",
-        "      \"path\": \"embedding\",\n",
-        "      \"similarity\": \"euclidean\",\n",
-        "      \"type\": \"vector\"\n",
-        "    }\n",
-        "  ]\n",
-        "}\n",
-        "\n",
-        "\n",
-        "Whenever the set up is complete, you can check the connection to your notebook as shown below.\n",
-        "\n",
-        "**Note: You must add your ip address to the ip white list of your Mongo database in order to succesfuly connect.**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680",
-      "metadata": {
-        "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680"
-      },
-      "outputs": [],
-      "source": [
-        "mongo_username = \"\" #Replace with your mongo username\n",
-        "mongo_password = \"\" #Replace with your mongo password\n",
-        "\n",
-        "from pymongo.mongo_client import MongoClient\n",
-        "from pymongo.server_api import ServerApi\n",
-        "\n",
-        "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
-        "\n",
-        "# Create a new client and connect to the server\n",
-        "client = MongoClient(uri, server_api=ServerApi('1'))\n",
-        "\n",
-        "# Send a ping to confirm a successful connection\n",
-        "try:\n",
-        "    client.admin.command('ping')\n",
-        "    print(\"Pinged your deployment. You successfully connected to MongoDB!\")\n",
-        "except Exception as e:\n",
-        "    print(e)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Zq6kWB0JOnQ4",
-      "metadata": {
-        "id": "Zq6kWB0JOnQ4"
-      },
-      "source": [
-        "Now that the initial setup is complete, our next step involves generating and storing data in the newly created collection. The essential data elements required for each entry in the collection are 'text' and 'embedding'. The 'text' field should contain the textual information, while the 'embedding' field must store the corresponding vector representation. This structured approach ensures that each record in our collection is equipped with the necessary attributes for effective text search and vector-based operations."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "534df8f5-225d-4022-801a-4e935f1999dd",
-      "metadata": {
-        "id": "534df8f5-225d-4022-801a-4e935f1999dd"
-      },
-      "outputs": [],
-      "source": [
-        "url = \"https://storage.googleapis.com/arize-assets/xander/mongodb/mongodb_dataset.json\"\n",
-        "\n",
-        "with urllib.request.urlopen(url) as response:\n",
-        "    buffer = response.read()\n",
-        "    data = json.loads(buffer.decode(\"utf-8\"))\n",
-        "    rows = data[\"rows\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "GCdd5QkFnTSe",
-      "metadata": {
-        "id": "GCdd5QkFnTSe"
-      },
-      "source": [
-        "We then proceed to store data into our previously created collection."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 579
-        },
-        "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
-        "outputId": "4bc65215-e718-4e2b-cc4f-0fffbbfdd176"
-      },
-      "outputs": [],
-      "source": [
-        "db_name = 'phoenix'\n",
-        "collection_name = 'phoenix-docs'\n",
-        "\n",
-        "db = client[db_name]  # Replace with your database name\n",
-        "collection = db[collection_name]  # Replace with your collection name\n",
-        "\n",
-        "# Assuming 'overwrite=True' means you want to clear the collection first and insert nodes\n",
-        "overwrite=True\n",
-        "if overwrite:\n",
-        "    collection.delete_many({})\n",
-        "    nodes = []\n",
-        "    for row in rows:\n",
-        "        node = {\n",
-        "            \"embedding\": row[\"embedding\"],\n",
-        "            \"text\": row[\"text\"],\n",
-        "            \"id\": row[\"id\"],\n",
-        "            \"source_doc_id\": row[\"doc_id\"]  # Assuming this is a relationship reference\n",
-        "        }\n",
-        "        nodes.append(node)\n",
-        "\n",
-        "    # Insert the documents into MongoDB Atlas\n",
-        "    collection.insert_many(nodes)\n",
-        "    print(\"Succesfully added nodes into mongodb!\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "sCt7AW7yniQi",
-      "metadata": {
-        "id": "sCt7AW7yniQi"
-      },
-      "source": [
-        "## 3. Configure Your OpenAI API Key\n",
-        "\n",
-        "Set your OpenAI API key if it is not already set as an environment variable."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc",
-      "metadata": {
-        "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc"
-      },
-      "outputs": [],
-      "source": [
-        "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
-        "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
-        "openai.api_key = openai_api_key\n",
-        "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "F46Fd3fboaIk",
-      "metadata": {
-        "id": "F46Fd3fboaIk"
-      },
-      "source": [
-        "## 4. Launch your phoenix application\n",
-        "\n",
-        "Enable Phoenix tracing within LlamaIndex by setting `arize_phoenix` as the global handler. This will mount Phoenix's [OpenInferenceTraceCallback](https://docs.arize.com/phoenix/integrations/llamaindex) as the global handler. Phoenix uses OpenInference traces - an open-source standard for capturing and storing LLM application traces that enables LLM applications to seamlessly integrate with LLM observability solutions such as Phoenix."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "inBg-ABOOiyf",
-      "metadata": {
-        "id": "inBg-ABOOiyf"
-      },
-      "outputs": [],
-      "source": [
-        "session = px.launch_app()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "FOzn_95tPijl",
-      "metadata": {
-        "id": "FOzn_95tPijl"
-      },
-      "outputs": [],
-      "source": [
-        "set_global_handler(\"arize_phoenix\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "43rV8DPhos_K",
-      "metadata": {
-        "id": "43rV8DPhos_K"
-      },
-      "source": [
-        "This example uses a `MongoDBAtlasVectorSearch` and uses the previously generated collection to work fully connected with MongoDB but you can use whatever LlamaIndex application you like."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "IHqbRGn3u8r3",
-      "metadata": {
-        "id": "IHqbRGn3u8r3"
-      },
-      "outputs": [],
-      "source": [
-        "db_name = 'phoenix' # Replace with your database name\n",
-        "collection_name = 'phoenix-docs' # Replace with your collection name\n",
-        "vector_index_name = 'vector_index' # Replace with your vector index name\n",
-        "Settings.llm = OpenAI(model=\"gpt-4o\", temperature=0.0)\n",
-        "Settings.embed_model = OpenAIEmbedding(model=\"text-embedding-ada-002\")\n",
-        "\n",
-        "db = client[db_name]\n",
-        "collection = db[collection_name]\n",
-        "\n",
-        "# You can obtain your uri @... format directly in mongo atlas\n",
-        "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
-        "\n",
-        "query_dict = {}\n",
-        "reader = SimpleMongoReader(uri=uri)\n",
-        "documents = reader.load_data(\n",
-        "    db_name,\n",
-        "    collection_name,\n",
-        "    field_names=[\"text\"],\n",
-        "    query_dict=query_dict,\n",
-        ")\n",
-        "\n",
-        "# Create a new client and connect to the server\n",
-        "client = MongoClient(uri, server_api=ServerApi('1'))\n",
-        "\n",
-        "# create Atlas as a vector store\n",
-        "store = MongoDBAtlasVectorSearch(\n",
-        "    client,\n",
-        "    db_name=db_name,\n",
-        "    collection_name=collection_name,\n",
-        "    vector_index_name=vector_index_name\n",
-        ")\n",
-        "\n",
-        "storage_context = StorageContext.from_defaults(vector_store=store)\n",
-        "\n",
-        "index = VectorStoreIndex.from_documents(\n",
-        "    documents,\n",
-        "    storage_context=storage_context,\n",
-        "    show_progress=True\n",
-        ")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4a89f4f0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Create your index model, then create the search index\n",
-        "search_index_model = SearchIndexModel(\n",
-        "  definition={\n",
-        "    \"fields\": [\n",
-        "      {\n",
-        "        \"type\": \"vector\",\n",
-        "        \"path\": \"embedding\",\n",
-        "        \"numDimensions\": 1536,\n",
-        "        \"similarity\": \"cosine\"\n",
-        "      },\n",
-        "    ]\n",
-        "  },\n",
-        "  name=\"vector_index\",\n",
-        "  type=\"vectorSearch\",\n",
-        ")\n",
-        "\n",
-        "collection.create_search_index(model=search_index_model)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bf5182b4",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Instantiate Atlas Vector Search as a retriever\n",
-        "vector_store_retriever = VectorIndexRetriever(index=index, similarity_top_k=5)\n",
-        "\n",
-        "# Pass the retriever into the query engine\n",
-        "query_engine = RetrieverQueryEngine(retriever=vector_store_retriever)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ieIoKLZoqxgq",
-      "metadata": {
-        "id": "ieIoKLZoqxgq"
-      },
-      "source": [
-        "## 5. Run Your Query Engine and View Your Traces in Phoenix\n",
-        "\n",
-        "We've compiled a list of commonly asked questions about Arize. Let's download the sample queries and take a look."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c",
-      "metadata": {
-        "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c"
-      },
-      "outputs": [],
-      "source": [
-        "queries_url = \"http://storage.googleapis.com/arize-assets/phoenix/datasets/unstructured/llm/context-retrieval/arize_docs_queries.jsonl\"\n",
-        "queries = []\n",
-        "with urlopen(queries_url) as response:\n",
-        "    for line in response:\n",
-        "        line = line.decode(\"utf-8\").strip()\n",
-        "        data = json.loads(line)\n",
-        "        queries.append(data[\"query\"])\n",
-        "queries[:10]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "K-IzxjWf2TGn",
-      "metadata": {
-        "id": "K-IzxjWf2TGn"
-      },
-      "source": [
-        "Let's run the first 10 queries and view the traces in Phoenix.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1e1d0956-1508-4ab9-8af1-311943b636c2",
-      "metadata": {
-        "id": "1e1d0956-1508-4ab9-8af1-311943b636c2"
-      },
-      "outputs": [],
-      "source": [
-        "for query in tqdm(queries[:10]):\n",
-        "    try:\n",
-        "      query_engine.query(query)\n",
-        "    except Exception as e:\n",
-        "      pass\n",
-        "  # Save trace dataset\n",
-        "tds = px.Client().get_trace_dataset()\n",
-        "tds.name = \"phoenix_local\"\n",
-        "tds.to_disc()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Xhaf9CVY2Yy7",
-      "metadata": {
-        "id": "Xhaf9CVY2Yy7"
-      },
-      "source": [
-        "Check the Phoenix UI as your queries run. Your traces should appear in real time.\n",
-        "\n",
-        "Open the Phoenix UI with the link below if you haven't already and click through the queries to better understand how the query engine is performing. For each trace you will see a break\n",
-        "\n",
-        "Phoenix can be used to understand and troubleshoot your by surfacing:\n",
-        " - **Application latency** - highlighting slow invocations of LLMs, Retrievers, etc.\n",
-        " - **Token Usage** - Displays the breakdown of token usage with LLMs to surface up your most expensive LLM calls\n",
-        " - **Runtime Exceptions** - Critical runtime exceptions such as rate-limiting are captured as exception events.\n",
-        " - **Retrieved Documents** - view all the documents retrieved during a retriever call and the score and order in which they were returned\n",
-        " - **Embeddings** - view the embedding text used for retrieval and the underlying embedding model\n",
-        "LLM Parameters - view the parameters used when calling out to an LLM to debug things like temperature and the system prompts\n",
-        " - **Prompt Templates** - Figure out what prompt template is used during the prompting step and what variables were used.\n",
-        " - **Tool Descriptions** - view the description and function signature of the tools your LLM has been given access to\n",
-        " - **LLM Function Calls** - if using OpenAI or other a model with function calls, you can view the function selection and function messages in the input messages to the LLM.\n",
-        "\n",
-        "<img src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/images/RAG_trace_details.png\" alt=\"Trace Details View on Phoenix\" style=\"width:100%; height:auto;\">"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3",
-      "metadata": {
-        "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3"
-      },
-      "outputs": [],
-      "source": [
-        "print(f\"🚀 Open the Phoenix UI if you haven't already: {session.url}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c0zHq7Pp2hnx",
-      "metadata": {
-        "id": "c0zHq7Pp2hnx"
-      },
-      "source": [
-        "## 6. Export and Evaluate Your Trace Data\n",
-        "You can export your trace data as a pandas dataframe for further analysis and evaluation.\n",
-        "\n",
-        "In this case, we will export our retriever spans into two separate dataframes:\n",
-        "\n",
-        "queries_df, in which the retrieved documents for each query are concatenated into a single column,\n",
-        "retrieved_documents_df, in which each retrieved document is \"exploded\" into its own row to enable the evaluation of each query-document pair in isolation.\n",
-        "This will enable us to compute multiple kinds of evaluations, including:\n",
-        "\n",
-        "relevance: Are the retrieved documents grounded in the response?\n",
-        "Q&A correctness: Are your application's responses grounded in the retrieved context?\n",
-        "hallucinations: Is your application making up false information?"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9",
-      "metadata": {
-        "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9"
-      },
-      "outputs": [],
-      "source": [
-        "queries_df = get_qa_with_reference(session)\n",
-        "retrieved_documents_df = get_retrieved_documents(session)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "BGqH0E_J2lx8",
-      "metadata": {
-        "id": "BGqH0E_J2lx8"
-      },
-      "source": [
-        "Next, define your evaluation model and your evaluators.\n",
-        "\n",
-        "Evaluators are built on top of language models and prompt the LLM to assess the quality of responses, the relevance of retrieved documents, etc., and provide a quality signal even in the absence of human-labeled data. Pick an evaluator type and instantiate it with the language model you want to use to perform evaluations using our battle-tested evaluation templates."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "zJzLSmP6mp1o",
-      "metadata": {
-        "id": "zJzLSmP6mp1o"
-      },
-      "outputs": [],
-      "source": [
-        "eval_model = OpenAIModel(\n",
-        "    model=\"gpt-4o\",\n",
-        ")\n",
-        "hallucination_evaluator = HallucinationEvaluator(eval_model)\n",
-        "qa_correctness_evaluator = QAEvaluator(eval_model)\n",
-        "relevance_evaluator = RelevanceEvaluator(eval_model)\n",
-        "\n",
-        "hallucination_eval_df, qa_correctness_eval_df = run_evals(\n",
-        "    dataframe=queries_df,\n",
-        "    evaluators=[hallucination_evaluator, qa_correctness_evaluator],\n",
-        "    provide_explanation=True,\n",
-        ")\n",
-        "relevance_eval_df = run_evals(\n",
-        "    dataframe=retrieved_documents_df,\n",
-        "    evaluators=[relevance_evaluator],\n",
-        "    provide_explanation=True,\n",
-        ")[0]\n",
-        "\n",
-        "\n",
-        "px.Client().log_evaluations(\n",
-        "    SpanEvaluations(eval_name=\"Hallucination\", dataframe=hallucination_eval_df),\n",
-        "    SpanEvaluations(eval_name=\"QA Correctness\", dataframe=qa_correctness_eval_df),\n",
-        ")\n",
-        "px.Client().log_evaluations(DocumentEvaluations(eval_name=\"Relevance\", dataframe=relevance_eval_df))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "s4C3S4Bd2rE_",
-      "metadata": {
-        "id": "s4C3S4Bd2rE_"
-      },
-      "source": [
-        "Your evaluations should now appear as annotations on the appropriate spans in Phoenix.\n",
-        "\n",
-        "![A view of the Phoenix UI with evaluation annotations](https://storage.googleapis.com/arize-assets/phoenix/assets/docs/notebooks/evals/traces_with_evaluation_annotations.png)"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "NqjcGG9QJhUJ",
+   "metadata": {
+    "id": "NqjcGG9QJhUJ"
+   },
+   "source": [
+    "<center>\n",
+    "    <p style=\"text-align:center\">\n",
+    "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+    "        <br>\n",
+    "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
+    "        |\n",
+    "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+    "        |\n",
+    "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
+    "    </p>\n",
+    "</center>\n",
+    "<h1 align=\"center\">Tracing and Evaluating a LlamaIndex Application using MongoDB Atlas as Vector Store</h1>\n",
+    "\n",
+    "<h2 align=\"center\"> LaMA Stack (LlamaIndex,  MongoDB and Arize) </h2>\n",
+    "\n",
+    "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
+    "\n",
+    "In this tutorial, you will:\n",
+    "- Generate data into a MongoDB Collection to be later used as a Vector Store.\n",
+    "- Build a simple query engine using LlamaIndex that uses retrieval-augmented generation to answer questions over the Arize documentation,\n",
+    "- Record trace data in [OpenInference tracing](https://github.com/Arize-ai/open-inference-spec/blob/main/trace/spec/traces.md) format using the global `arize_phoenix` handler\n",
+    "- Inspect the traces and spans of your application to identify sources of latency and cost,\n",
+    "- Export your trace data as a pandas dataframe and run an [LLM Evals](https://docs.arize.com/phoenix/concepts/llm-evals) to measure the precision@k of the query engine's retrieval step.\n",
+    "\n",
+    "ℹ️ This notebook requires an OpenAI API key."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "qtPye6KSKNrO",
+   "metadata": {
+    "id": "qtPye6KSKNrO"
+   },
+   "source": [
+    "## 1. Install needed dependencies and import relevant packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6",
+   "metadata": {
+    "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q uv\n",
+    "!uv pip install -q --system llama-index-embeddings-openai 'arize-phoenix[evals]' llama-index llama-index-callbacks-arize-phoenix llama-index-vector-stores-mongodb llama-index-storage-docstore-mongodb llama-index-storage-index-store-mongodb llama-index-readers-mongodb\n",
+    "!uv pip install -q --system \"openai>=1\" gcsfs nest-asyncio pymongo beautifulsoup4 certifi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37",
+   "metadata": {
+    "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37"
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import urllib\n",
+    "from getpass import getpass\n",
+    "from urllib.request import urlopen\n",
+    "\n",
+    "import nest_asyncio\n",
+    "import openai\n",
+    "import pandas as pd\n",
+    "from llama_index.core import StorageContext, set_global_handler\n",
+    "from llama_index.core.indices.vector_store.base import VectorStoreIndex\n",
+    "from llama_index.core.query_engine import RetrieverQueryEngine\n",
+    "from llama_index.core.retrievers import VectorIndexRetriever\n",
+    "from llama_index.core.settings import Settings\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.readers.mongodb import SimpleMongoReader\n",
+    "from llama_index.vector_stores.mongodb import MongoDBAtlasVectorSearch\n",
+    "from pymongo.operations import SearchIndexModel\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "import phoenix as px\n",
+    "from phoenix.evals import (\n",
+    "    HallucinationEvaluator,\n",
+    "    OpenAIModel,\n",
+    "    QAEvaluator,\n",
+    "    RelevanceEvaluator,\n",
+    "    run_evals,\n",
+    ")\n",
+    "from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents\n",
+    "from phoenix.trace import DocumentEvaluations, SpanEvaluations\n",
+    "\n",
+    "nest_asyncio.apply()  # needed for concurrent evals in notebook environments\n",
+    "pd.set_option(\"display.max_colwidth\", 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "xVBBk-SRKauo",
+   "metadata": {
+    "id": "xVBBk-SRKauo"
+   },
+   "source": [
+    "## 2. Set up MongoDB Atlas\n",
+    "\n",
+    "To effectively use this notebook for MongoDB operations, it's essential to have a MongoDB account set up with a database and collection already created. Additionally, you need to have a vector index created as described in the MongoDB Atlas Search documentation.\n",
+    "\n",
+    "This can be done by following this steps:\n",
+    "\n",
+    "1. Create a MongoDB Atlas account.\n",
+    "2. Create a database.\n",
+    "3. Add a new collection to that database.\n",
+    "4. Create a search index with the following structure in the recently created collection:\n",
+    "\n",
+    "{\n",
+    "  \"fields\": [\n",
+    "    {\n",
+    "      \"numDimensions\": 1536,\n",
+    "      \"path\": \"embedding\",\n",
+    "      \"similarity\": \"euclidean\",\n",
+    "      \"type\": \"vector\"\n",
+    "    }\n",
+    "  ]\n",
+    "}\n",
+    "\n",
+    "\n",
+    "Whenever the set up is complete, you can check the connection to your notebook as shown below.\n",
+    "\n",
+    "**Note: You must add your ip address to the ip white list of your Mongo database in order to succesfuly connect.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680",
+   "metadata": {
+    "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680"
+   },
+   "outputs": [],
+   "source": [
+    "mongo_username = \"\"  # Replace with your mongo username\n",
+    "mongo_password = \"\"  # Replace with your mongo password\n",
+    "\n",
+    "from pymongo.mongo_client import MongoClient\n",
+    "from pymongo.server_api import ServerApi\n",
+    "\n",
+    "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
+    "\n",
+    "# Create a new client and connect to the server\n",
+    "client = MongoClient(uri, server_api=ServerApi(\"1\"))\n",
+    "\n",
+    "# Send a ping to confirm a successful connection\n",
+    "try:\n",
+    "    client.admin.command(\"ping\")\n",
+    "    print(\"Pinged your deployment. You successfully connected to MongoDB!\")\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Zq6kWB0JOnQ4",
+   "metadata": {
+    "id": "Zq6kWB0JOnQ4"
+   },
+   "source": [
+    "Now that the initial setup is complete, our next step involves generating and storing data in the newly created collection. The essential data elements required for each entry in the collection are 'text' and 'embedding'. The 'text' field should contain the textual information, while the 'embedding' field must store the corresponding vector representation. This structured approach ensures that each record in our collection is equipped with the necessary attributes for effective text search and vector-based operations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "534df8f5-225d-4022-801a-4e935f1999dd",
+   "metadata": {
+    "id": "534df8f5-225d-4022-801a-4e935f1999dd"
+   },
+   "outputs": [],
+   "source": [
+    "url = \"https://storage.googleapis.com/arize-assets/xander/mongodb/mongodb_dataset.json\"\n",
+    "\n",
+    "with urllib.request.urlopen(url) as response:\n",
+    "    buffer = response.read()\n",
+    "    data = json.loads(buffer.decode(\"utf-8\"))\n",
+    "    rows = data[\"rows\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "GCdd5QkFnTSe",
+   "metadata": {
+    "id": "GCdd5QkFnTSe"
+   },
+   "source": [
+    "We then proceed to store data into our previously created collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 579
+    },
+    "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
+    "outputId": "4bc65215-e718-4e2b-cc4f-0fffbbfdd176"
+   },
+   "outputs": [],
+   "source": [
+    "db_name = \"phoenix\"\n",
+    "collection_name = \"phoenix-docs\"\n",
+    "\n",
+    "db = client[db_name]  # Replace with your database name\n",
+    "collection = db[collection_name]  # Replace with your collection name\n",
+    "\n",
+    "# Assuming 'overwrite=True' means you want to clear the collection first and insert nodes\n",
+    "overwrite = True\n",
+    "if overwrite:\n",
+    "    collection.delete_many({})\n",
+    "    nodes = []\n",
+    "    for row in rows:\n",
+    "        node = {\n",
+    "            \"embedding\": row[\"embedding\"],\n",
+    "            \"text\": row[\"text\"],\n",
+    "            \"id\": row[\"id\"],\n",
+    "            \"source_doc_id\": row[\"doc_id\"],  # Assuming this is a relationship reference\n",
+    "        }\n",
+    "        nodes.append(node)\n",
+    "\n",
+    "    # Insert the documents into MongoDB Atlas\n",
+    "    collection.insert_many(nodes)\n",
+    "    print(\"Succesfully added nodes into mongodb!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sCt7AW7yniQi",
+   "metadata": {
+    "id": "sCt7AW7yniQi"
+   },
+   "source": [
+    "## 3. Configure Your OpenAI API Key\n",
+    "\n",
+    "Set your OpenAI API key if it is not already set as an environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc",
+   "metadata": {
+    "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc"
+   },
+   "outputs": [],
+   "source": [
+    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "openai.api_key = openai_api_key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "F46Fd3fboaIk",
+   "metadata": {
+    "id": "F46Fd3fboaIk"
+   },
+   "source": [
+    "## 4. Launch your phoenix application\n",
+    "\n",
+    "Enable Phoenix tracing within LlamaIndex by setting `arize_phoenix` as the global handler. This will mount Phoenix's [OpenInferenceTraceCallback](https://docs.arize.com/phoenix/integrations/llamaindex) as the global handler. Phoenix uses OpenInference traces - an open-source standard for capturing and storing LLM application traces that enables LLM applications to seamlessly integrate with LLM observability solutions such as Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inBg-ABOOiyf",
+   "metadata": {
+    "id": "inBg-ABOOiyf"
+   },
+   "outputs": [],
+   "source": [
+    "session = px.launch_app()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "FOzn_95tPijl",
+   "metadata": {
+    "id": "FOzn_95tPijl"
+   },
+   "outputs": [],
+   "source": [
+    "set_global_handler(\"arize_phoenix\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43rV8DPhos_K",
+   "metadata": {
+    "id": "43rV8DPhos_K"
+   },
+   "source": [
+    "This example uses a `MongoDBAtlasVectorSearch` and uses the previously generated collection to work fully connected with MongoDB but you can use whatever LlamaIndex application you like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "IHqbRGn3u8r3",
+   "metadata": {
+    "id": "IHqbRGn3u8r3"
+   },
+   "outputs": [],
+   "source": [
+    "db_name = \"phoenix\"  # Replace with your database name\n",
+    "collection_name = \"phoenix-docs\"  # Replace with your collection name\n",
+    "vector_index_name = \"vector_index\"  # Replace with your vector index name\n",
+    "Settings.llm = OpenAI(model=\"gpt-4o\", temperature=0.0)\n",
+    "Settings.embed_model = OpenAIEmbedding(model=\"text-embedding-ada-002\")\n",
+    "\n",
+    "db = client[db_name]\n",
+    "collection = db[collection_name]\n",
+    "\n",
+    "# You can obtain your uri @... format directly in mongo atlas\n",
+    "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
+    "\n",
+    "query_dict = {}\n",
+    "reader = SimpleMongoReader(uri=uri)\n",
+    "documents = reader.load_data(\n",
+    "    db_name,\n",
+    "    collection_name,\n",
+    "    field_names=[\"text\"],\n",
+    "    query_dict=query_dict,\n",
+    ")\n",
+    "\n",
+    "# Create a new client and connect to the server\n",
+    "client = MongoClient(uri, server_api=ServerApi(\"1\"))\n",
+    "\n",
+    "# create Atlas as a vector store\n",
+    "store = MongoDBAtlasVectorSearch(\n",
+    "    client, db_name=db_name, collection_name=collection_name, vector_index_name=vector_index_name\n",
+    ")\n",
+    "\n",
+    "storage_context = StorageContext.from_defaults(vector_store=store)\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents, storage_context=storage_context, show_progress=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a89f4f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create your index model, then create the search index\n",
+    "search_index_model = SearchIndexModel(\n",
+    "    definition={\n",
+    "        \"fields\": [\n",
+    "            {\"type\": \"vector\", \"path\": \"embedding\", \"numDimensions\": 1536, \"similarity\": \"cosine\"},\n",
+    "        ]\n",
+    "    },\n",
+    "    name=\"vector_index\",\n",
+    "    type=\"vectorSearch\",\n",
+    ")\n",
+    "\n",
+    "collection.create_search_index(model=search_index_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf5182b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate Atlas Vector Search as a retriever\n",
+    "vector_store_retriever = VectorIndexRetriever(index=index, similarity_top_k=5)\n",
+    "\n",
+    "# Pass the retriever into the query engine\n",
+    "query_engine = RetrieverQueryEngine(retriever=vector_store_retriever)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ieIoKLZoqxgq",
+   "metadata": {
+    "id": "ieIoKLZoqxgq"
+   },
+   "source": [
+    "## 5. Run Your Query Engine and View Your Traces in Phoenix\n",
+    "\n",
+    "We've compiled a list of commonly asked questions about Arize. Let's download the sample queries and take a look."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c",
+   "metadata": {
+    "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c"
+   },
+   "outputs": [],
+   "source": [
+    "queries_url = \"http://storage.googleapis.com/arize-assets/phoenix/datasets/unstructured/llm/context-retrieval/arize_docs_queries.jsonl\"\n",
+    "queries = []\n",
+    "with urlopen(queries_url) as response:\n",
+    "    for line in response:\n",
+    "        line = line.decode(\"utf-8\").strip()\n",
+    "        data = json.loads(line)\n",
+    "        queries.append(data[\"query\"])\n",
+    "queries[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "K-IzxjWf2TGn",
+   "metadata": {
+    "id": "K-IzxjWf2TGn"
+   },
+   "source": [
+    "Let's run the first 10 queries and view the traces in Phoenix.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e1d0956-1508-4ab9-8af1-311943b636c2",
+   "metadata": {
+    "id": "1e1d0956-1508-4ab9-8af1-311943b636c2"
+   },
+   "outputs": [],
+   "source": [
+    "for query in tqdm(queries[:10]):\n",
+    "    try:\n",
+    "        query_engine.query(query)\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "# Save trace dataset\n",
+    "tds = px.Client().get_trace_dataset()\n",
+    "tds.name = \"phoenix_local\"\n",
+    "tds.to_disc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Xhaf9CVY2Yy7",
+   "metadata": {
+    "id": "Xhaf9CVY2Yy7"
+   },
+   "source": [
+    "Check the Phoenix UI as your queries run. Your traces should appear in real time.\n",
+    "\n",
+    "Open the Phoenix UI with the link below if you haven't already and click through the queries to better understand how the query engine is performing. For each trace you will see a break\n",
+    "\n",
+    "Phoenix can be used to understand and troubleshoot your by surfacing:\n",
+    " - **Application latency** - highlighting slow invocations of LLMs, Retrievers, etc.\n",
+    " - **Token Usage** - Displays the breakdown of token usage with LLMs to surface up your most expensive LLM calls\n",
+    " - **Runtime Exceptions** - Critical runtime exceptions such as rate-limiting are captured as exception events.\n",
+    " - **Retrieved Documents** - view all the documents retrieved during a retriever call and the score and order in which they were returned\n",
+    " - **Embeddings** - view the embedding text used for retrieval and the underlying embedding model\n",
+    "LLM Parameters - view the parameters used when calling out to an LLM to debug things like temperature and the system prompts\n",
+    " - **Prompt Templates** - Figure out what prompt template is used during the prompting step and what variables were used.\n",
+    " - **Tool Descriptions** - view the description and function signature of the tools your LLM has been given access to\n",
+    " - **LLM Function Calls** - if using OpenAI or other a model with function calls, you can view the function selection and function messages in the input messages to the LLM.\n",
+    "\n",
+    "<img src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/images/RAG_trace_details.png\" alt=\"Trace Details View on Phoenix\" style=\"width:100%; height:auto;\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3",
+   "metadata": {
+    "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"🚀 Open the Phoenix UI if you haven't already: {session.url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0zHq7Pp2hnx",
+   "metadata": {
+    "id": "c0zHq7Pp2hnx"
+   },
+   "source": [
+    "## 6. Export and Evaluate Your Trace Data\n",
+    "You can export your trace data as a pandas dataframe for further analysis and evaluation.\n",
+    "\n",
+    "In this case, we will export our retriever spans into two separate dataframes:\n",
+    "\n",
+    "queries_df, in which the retrieved documents for each query are concatenated into a single column,\n",
+    "retrieved_documents_df, in which each retrieved document is \"exploded\" into its own row to enable the evaluation of each query-document pair in isolation.\n",
+    "This will enable us to compute multiple kinds of evaluations, including:\n",
+    "\n",
+    "relevance: Are the retrieved documents grounded in the response?\n",
+    "Q&A correctness: Are your application's responses grounded in the retrieved context?\n",
+    "hallucinations: Is your application making up false information?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9",
+   "metadata": {
+    "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9"
+   },
+   "outputs": [],
+   "source": [
+    "queries_df = get_qa_with_reference(session)\n",
+    "retrieved_documents_df = get_retrieved_documents(session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BGqH0E_J2lx8",
+   "metadata": {
+    "id": "BGqH0E_J2lx8"
+   },
+   "source": [
+    "Next, define your evaluation model and your evaluators.\n",
+    "\n",
+    "Evaluators are built on top of language models and prompt the LLM to assess the quality of responses, the relevance of retrieved documents, etc., and provide a quality signal even in the absence of human-labeled data. Pick an evaluator type and instantiate it with the language model you want to use to perform evaluations using our battle-tested evaluation templates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "zJzLSmP6mp1o",
+   "metadata": {
+    "id": "zJzLSmP6mp1o"
+   },
+   "outputs": [],
+   "source": [
+    "eval_model = OpenAIModel(\n",
+    "    model=\"gpt-4o\",\n",
+    ")\n",
+    "hallucination_evaluator = HallucinationEvaluator(eval_model)\n",
+    "qa_correctness_evaluator = QAEvaluator(eval_model)\n",
+    "relevance_evaluator = RelevanceEvaluator(eval_model)\n",
+    "\n",
+    "hallucination_eval_df, qa_correctness_eval_df = run_evals(\n",
+    "    dataframe=queries_df,\n",
+    "    evaluators=[hallucination_evaluator, qa_correctness_evaluator],\n",
+    "    provide_explanation=True,\n",
+    ")\n",
+    "relevance_eval_df = run_evals(\n",
+    "    dataframe=retrieved_documents_df,\n",
+    "    evaluators=[relevance_evaluator],\n",
+    "    provide_explanation=True,\n",
+    ")[0]\n",
+    "\n",
+    "\n",
+    "px.Client().log_evaluations(\n",
+    "    SpanEvaluations(eval_name=\"Hallucination\", dataframe=hallucination_eval_df),\n",
+    "    SpanEvaluations(eval_name=\"QA Correctness\", dataframe=qa_correctness_eval_df),\n",
+    ")\n",
+    "px.Client().log_evaluations(DocumentEvaluations(eval_name=\"Relevance\", dataframe=relevance_eval_df))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s4C3S4Bd2rE_",
+   "metadata": {
+    "id": "s4C3S4Bd2rE_"
+   },
+   "source": [
+    "Your evaluations should now appear as annotations on the appropriate spans in Phoenix.\n",
+    "\n",
+    "![A view of the Phoenix UI with evaluation annotations](https://storage.googleapis.com/arize-assets/phoenix/assets/docs/notebooks/evals/traces_with_evaluation_annotations.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/tutorials/integrations/tracing_and_evals_with_mongodb_and_llama_index.ipynb
+++ b/tutorials/integrations/tracing_and_evals_with_mongodb_and_llama_index.ipynb
@@ -1,0 +1,623 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "NqjcGG9QJhUJ",
+      "metadata": {
+        "id": "NqjcGG9QJhUJ"
+      },
+      "source": [
+        "<center>\n",
+        "    <p style=\"text-align:center\">\n",
+        "        <img alt=\"phoenix logo\" src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/phoenix-logo-light.svg\" width=\"200\"/>\n",
+        "        <br>\n",
+        "        <a href=\"https://docs.arize.com/phoenix/\">Docs</a>\n",
+        "        |\n",
+        "        <a href=\"https://github.com/Arize-ai/phoenix\">GitHub</a>\n",
+        "        |\n",
+        "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
+        "    </p>\n",
+        "</center>\n",
+        "<h1 align=\"center\">Tracing and Evaluating a LlamaIndex Application using MongoDB Atlas as Vector Store</h1>\n",
+        "\n",
+        "<h2 align=\"center\"> LaMA Stack (LlamaIndex,  MongoDB and Arize) </h2>\n",
+        "\n",
+        "LlamaIndex provides high-level APIs that enable users to build powerful applications in a few lines of code. However, it can be challenging to understand what is going on under the hood and to pinpoint the cause of issues. Phoenix makes your LLM applications *observable* by visualizing the underlying structure of each call to your query engine and surfacing problematic `spans`` of execution based on latency, token count, or other evaluation metrics.\n",
+        "\n",
+        "In this tutorial, you will:\n",
+        "- Generate data into a MongoDB Collection to be later used as a Vector Store.\n",
+        "- Build a simple query engine using LlamaIndex that uses retrieval-augmented generation to answer questions over the Arize documentation,\n",
+        "- Record trace data in [OpenInference tracing](https://github.com/Arize-ai/open-inference-spec/blob/main/trace/spec/traces.md) format using the global `arize_phoenix` handler\n",
+        "- Inspect the traces and spans of your application to identify sources of latency and cost,\n",
+        "- Export your trace data as a pandas dataframe and run an [LLM Evals](https://docs.arize.com/phoenix/concepts/llm-evals) to measure the precision@k of the query engine's retrieval step.\n",
+        "\n",
+        "ℹ️ This notebook requires an OpenAI API key."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "qtPye6KSKNrO",
+      "metadata": {
+        "id": "qtPye6KSKNrO"
+      },
+      "source": [
+        "## 1. Install needed dependencies and import relevant packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6",
+      "metadata": {
+        "id": "66f1181a-67fb-4aab-b469-40f952ac5ea6"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q uv\n",
+        "!uv pip install -q --system llama-index-embeddings-openai 'arize-phoenix[evals]' llama-index llama-index-callbacks-arize-phoenix llama-index-vector-stores-mongodb llama-index-storage-docstore-mongodb llama-index-storage-index-store-mongodb llama-index-readers-mongodb\n",
+        "!uv pip install -q --system \"openai>=1\" gcsfs nest-asyncio pymongo beautifulsoup4 certifi"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37",
+      "metadata": {
+        "id": "cf89f950-f074-45d7-81d4-b7d4d3158a37"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import os\n",
+        "import urllib\n",
+        "from getpass import getpass\n",
+        "from urllib.request import urlopen\n",
+        "\n",
+        "import nest_asyncio\n",
+        "import openai\n",
+        "import pandas as pd\n",
+        "import phoenix as px\n",
+        "from llama_index.core import (\n",
+        "    StorageContext, set_global_handler\n",
+        ")\n",
+        "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+        "from llama_index.core.indices.vector_store.base import VectorStoreIndex\n",
+        "from llama_index.core.retrievers import VectorIndexRetriever\n",
+        "from llama_index.core.query_engine import RetrieverQueryEngine\n",
+        "from llama_index.llms.openai import OpenAI\n",
+        "from llama_index.readers.mongodb import SimpleMongoReader\n",
+        "from llama_index.vector_stores.mongodb import MongoDBAtlasVectorSearch\n",
+        "from llama_index.core.settings import Settings\n",
+        "from phoenix.evals import (\n",
+        "    HallucinationEvaluator, OpenAIModel, QAEvaluator,\n",
+        "    RelevanceEvaluator, run_evals\n",
+        ")\n",
+        "from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents\n",
+        "from phoenix.trace import DocumentEvaluations, SpanEvaluations\n",
+        "from pymongo.operations import SearchIndexModel\n",
+        "from tqdm import tqdm\n",
+        "\n",
+        "\n",
+        "nest_asyncio.apply()  # needed for concurrent evals in notebook environments\n",
+        "pd.set_option(\"display.max_colwidth\", 1000)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "xVBBk-SRKauo",
+      "metadata": {
+        "id": "xVBBk-SRKauo"
+      },
+      "source": [
+        "## 2. Set up MongoDB Atlas\n",
+        "\n",
+        "To effectively use this notebook for MongoDB operations, it's essential to have a MongoDB account set up with a database and collection already created. Additionally, you need to have a vector index created as described in the MongoDB Atlas Search documentation.\n",
+        "\n",
+        "This can be done by following this steps:\n",
+        "\n",
+        "1. Create a MongoDB Atlas account.\n",
+        "2. Create a database.\n",
+        "3. Add a new collection to that database.\n",
+        "4. Create a search index with the following structure in the recently created collection:\n",
+        "\n",
+        "{\n",
+        "  \"fields\": [\n",
+        "    {\n",
+        "      \"numDimensions\": 1536,\n",
+        "      \"path\": \"embedding\",\n",
+        "      \"similarity\": \"euclidean\",\n",
+        "      \"type\": \"vector\"\n",
+        "    }\n",
+        "  ]\n",
+        "}\n",
+        "\n",
+        "\n",
+        "Whenever the set up is complete, you can check the connection to your notebook as shown below.\n",
+        "\n",
+        "**Note: You must add your ip address to the ip white list of your Mongo database in order to succesfuly connect.**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680",
+      "metadata": {
+        "id": "02258bb7-bf37-4173-8c28-6fb2d25d9680"
+      },
+      "outputs": [],
+      "source": [
+        "mongo_username = \"\" #Replace with your mongo username\n",
+        "mongo_password = \"\" #Replace with your mongo password\n",
+        "\n",
+        "from pymongo.mongo_client import MongoClient\n",
+        "from pymongo.server_api import ServerApi\n",
+        "\n",
+        "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
+        "\n",
+        "# Create a new client and connect to the server\n",
+        "client = MongoClient(uri, server_api=ServerApi('1'))\n",
+        "\n",
+        "# Send a ping to confirm a successful connection\n",
+        "try:\n",
+        "    client.admin.command('ping')\n",
+        "    print(\"Pinged your deployment. You successfully connected to MongoDB!\")\n",
+        "except Exception as e:\n",
+        "    print(e)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "Zq6kWB0JOnQ4",
+      "metadata": {
+        "id": "Zq6kWB0JOnQ4"
+      },
+      "source": [
+        "Now that the initial setup is complete, our next step involves generating and storing data in the newly created collection. The essential data elements required for each entry in the collection are 'text' and 'embedding'. The 'text' field should contain the textual information, while the 'embedding' field must store the corresponding vector representation. This structured approach ensures that each record in our collection is equipped with the necessary attributes for effective text search and vector-based operations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "534df8f5-225d-4022-801a-4e935f1999dd",
+      "metadata": {
+        "id": "534df8f5-225d-4022-801a-4e935f1999dd"
+      },
+      "outputs": [],
+      "source": [
+        "url = \"https://storage.googleapis.com/arize-assets/xander/mongodb/mongodb_dataset.json\"\n",
+        "\n",
+        "with urllib.request.urlopen(url) as response:\n",
+        "    buffer = response.read()\n",
+        "    data = json.loads(buffer.decode(\"utf-8\"))\n",
+        "    rows = data[\"rows\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "GCdd5QkFnTSe",
+      "metadata": {
+        "id": "GCdd5QkFnTSe"
+      },
+      "source": [
+        "We then proceed to store data into our previously created collection."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 579
+        },
+        "id": "39dd567b-f6e7-4706-bce0-e69a7e42546e",
+        "outputId": "4bc65215-e718-4e2b-cc4f-0fffbbfdd176"
+      },
+      "outputs": [],
+      "source": [
+        "db_name = 'phoenix'\n",
+        "collection_name = 'phoenix-docs'\n",
+        "\n",
+        "db = client[db_name]  # Replace with your database name\n",
+        "collection = db[collection_name]  # Replace with your collection name\n",
+        "\n",
+        "# Assuming 'overwrite=True' means you want to clear the collection first and insert nodes\n",
+        "overwrite=True\n",
+        "if overwrite:\n",
+        "    collection.delete_many({})\n",
+        "    nodes = []\n",
+        "    for row in rows:\n",
+        "        node = {\n",
+        "            \"embedding\": row[\"embedding\"],\n",
+        "            \"text\": row[\"text\"],\n",
+        "            \"id\": row[\"id\"],\n",
+        "            \"source_doc_id\": row[\"doc_id\"]  # Assuming this is a relationship reference\n",
+        "        }\n",
+        "        nodes.append(node)\n",
+        "\n",
+        "    # Insert the documents into MongoDB Atlas\n",
+        "    collection.insert_many(nodes)\n",
+        "    print(\"Succesfully added nodes into mongodb!\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "sCt7AW7yniQi",
+      "metadata": {
+        "id": "sCt7AW7yniQi"
+      },
+      "source": [
+        "## 3. Configure Your OpenAI API Key\n",
+        "\n",
+        "Set your OpenAI API key if it is not already set as an environment variable."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc",
+      "metadata": {
+        "id": "52936831-26f8-4ad3-8e3c-0c8b74da72cc"
+      },
+      "outputs": [],
+      "source": [
+        "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+        "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+        "openai.api_key = openai_api_key\n",
+        "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "F46Fd3fboaIk",
+      "metadata": {
+        "id": "F46Fd3fboaIk"
+      },
+      "source": [
+        "## 4. Launch your phoenix application\n",
+        "\n",
+        "Enable Phoenix tracing within LlamaIndex by setting `arize_phoenix` as the global handler. This will mount Phoenix's [OpenInferenceTraceCallback](https://docs.arize.com/phoenix/integrations/llamaindex) as the global handler. Phoenix uses OpenInference traces - an open-source standard for capturing and storing LLM application traces that enables LLM applications to seamlessly integrate with LLM observability solutions such as Phoenix."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "inBg-ABOOiyf",
+      "metadata": {
+        "id": "inBg-ABOOiyf"
+      },
+      "outputs": [],
+      "source": [
+        "session = px.launch_app()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "FOzn_95tPijl",
+      "metadata": {
+        "id": "FOzn_95tPijl"
+      },
+      "outputs": [],
+      "source": [
+        "set_global_handler(\"arize_phoenix\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "43rV8DPhos_K",
+      "metadata": {
+        "id": "43rV8DPhos_K"
+      },
+      "source": [
+        "This example uses a `MongoDBAtlasVectorSearch` and uses the previously generated collection to work fully connected with MongoDB but you can use whatever LlamaIndex application you like."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "IHqbRGn3u8r3",
+      "metadata": {
+        "id": "IHqbRGn3u8r3"
+      },
+      "outputs": [],
+      "source": [
+        "db_name = 'phoenix' # Replace with your database name\n",
+        "collection_name = 'phoenix-docs' # Replace with your collection name\n",
+        "vector_index_name = 'vector_index' # Replace with your vector index name\n",
+        "Settings.llm = OpenAI(model=\"gpt-4o\", temperature=0.0)\n",
+        "Settings.embed_model = OpenAIEmbedding(model=\"text-embedding-ada-002\")\n",
+        "\n",
+        "db = client[db_name]\n",
+        "collection = db[collection_name]\n",
+        "\n",
+        "# You can obtain your uri @... format directly in mongo atlas\n",
+        "uri = f\"mongodb+srv://{mongo_username}:{mongo_password}@cluster0.lq406.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0\"\n",
+        "\n",
+        "query_dict = {}\n",
+        "reader = SimpleMongoReader(uri=uri)\n",
+        "documents = reader.load_data(\n",
+        "    db_name,\n",
+        "    collection_name,\n",
+        "    field_names=[\"text\"],\n",
+        "    query_dict=query_dict,\n",
+        ")\n",
+        "\n",
+        "# Create a new client and connect to the server\n",
+        "client = MongoClient(uri, server_api=ServerApi('1'))\n",
+        "\n",
+        "# create Atlas as a vector store\n",
+        "store = MongoDBAtlasVectorSearch(\n",
+        "    client,\n",
+        "    db_name=db_name,\n",
+        "    collection_name=collection_name,\n",
+        "    vector_index_name=vector_index_name\n",
+        ")\n",
+        "\n",
+        "storage_context = StorageContext.from_defaults(vector_store=store)\n",
+        "\n",
+        "index = VectorStoreIndex.from_documents(\n",
+        "    documents,\n",
+        "    storage_context=storage_context,\n",
+        "    show_progress=True\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4a89f4f0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Create your index model, then create the search index\n",
+        "search_index_model = SearchIndexModel(\n",
+        "  definition={\n",
+        "    \"fields\": [\n",
+        "      {\n",
+        "        \"type\": \"vector\",\n",
+        "        \"path\": \"embedding\",\n",
+        "        \"numDimensions\": 1536,\n",
+        "        \"similarity\": \"cosine\"\n",
+        "      },\n",
+        "    ]\n",
+        "  },\n",
+        "  name=\"vector_index\",\n",
+        "  type=\"vectorSearch\",\n",
+        ")\n",
+        "\n",
+        "collection.create_search_index(model=search_index_model)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bf5182b4",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Instantiate Atlas Vector Search as a retriever\n",
+        "vector_store_retriever = VectorIndexRetriever(index=index, similarity_top_k=5)\n",
+        "\n",
+        "# Pass the retriever into the query engine\n",
+        "query_engine = RetrieverQueryEngine(retriever=vector_store_retriever)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ieIoKLZoqxgq",
+      "metadata": {
+        "id": "ieIoKLZoqxgq"
+      },
+      "source": [
+        "## 5. Run Your Query Engine and View Your Traces in Phoenix\n",
+        "\n",
+        "We've compiled a list of commonly asked questions about Arize. Let's download the sample queries and take a look."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c",
+      "metadata": {
+        "id": "19b9e13d-bf15-4e97-81f5-f80a69784c0c"
+      },
+      "outputs": [],
+      "source": [
+        "queries_url = \"http://storage.googleapis.com/arize-assets/phoenix/datasets/unstructured/llm/context-retrieval/arize_docs_queries.jsonl\"\n",
+        "queries = []\n",
+        "with urlopen(queries_url) as response:\n",
+        "    for line in response:\n",
+        "        line = line.decode(\"utf-8\").strip()\n",
+        "        data = json.loads(line)\n",
+        "        queries.append(data[\"query\"])\n",
+        "queries[:10]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "K-IzxjWf2TGn",
+      "metadata": {
+        "id": "K-IzxjWf2TGn"
+      },
+      "source": [
+        "Let's run the first 10 queries and view the traces in Phoenix.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1e1d0956-1508-4ab9-8af1-311943b636c2",
+      "metadata": {
+        "id": "1e1d0956-1508-4ab9-8af1-311943b636c2"
+      },
+      "outputs": [],
+      "source": [
+        "for query in tqdm(queries[:10]):\n",
+        "    try:\n",
+        "      query_engine.query(query)\n",
+        "    except Exception as e:\n",
+        "      pass\n",
+        "  # Save trace dataset\n",
+        "tds = px.Client().get_trace_dataset()\n",
+        "tds.name = \"phoenix_local\"\n",
+        "tds.to_disc()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "Xhaf9CVY2Yy7",
+      "metadata": {
+        "id": "Xhaf9CVY2Yy7"
+      },
+      "source": [
+        "Check the Phoenix UI as your queries run. Your traces should appear in real time.\n",
+        "\n",
+        "Open the Phoenix UI with the link below if you haven't already and click through the queries to better understand how the query engine is performing. For each trace you will see a break\n",
+        "\n",
+        "Phoenix can be used to understand and troubleshoot your by surfacing:\n",
+        " - **Application latency** - highlighting slow invocations of LLMs, Retrievers, etc.\n",
+        " - **Token Usage** - Displays the breakdown of token usage with LLMs to surface up your most expensive LLM calls\n",
+        " - **Runtime Exceptions** - Critical runtime exceptions such as rate-limiting are captured as exception events.\n",
+        " - **Retrieved Documents** - view all the documents retrieved during a retriever call and the score and order in which they were returned\n",
+        " - **Embeddings** - view the embedding text used for retrieval and the underlying embedding model\n",
+        "LLM Parameters - view the parameters used when calling out to an LLM to debug things like temperature and the system prompts\n",
+        " - **Prompt Templates** - Figure out what prompt template is used during the prompting step and what variables were used.\n",
+        " - **Tool Descriptions** - view the description and function signature of the tools your LLM has been given access to\n",
+        " - **LLM Function Calls** - if using OpenAI or other a model with function calls, you can view the function selection and function messages in the input messages to the LLM.\n",
+        "\n",
+        "<img src=\"https://storage.googleapis.com/arize-assets/phoenix/assets/images/RAG_trace_details.png\" alt=\"Trace Details View on Phoenix\" style=\"width:100%; height:auto;\">"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3",
+      "metadata": {
+        "id": "ffe25cbe-b1a5-4611-b604-82f1f02738c3"
+      },
+      "outputs": [],
+      "source": [
+        "print(f\"🚀 Open the Phoenix UI if you haven't already: {session.url}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c0zHq7Pp2hnx",
+      "metadata": {
+        "id": "c0zHq7Pp2hnx"
+      },
+      "source": [
+        "## 6. Export and Evaluate Your Trace Data\n",
+        "You can export your trace data as a pandas dataframe for further analysis and evaluation.\n",
+        "\n",
+        "In this case, we will export our retriever spans into two separate dataframes:\n",
+        "\n",
+        "queries_df, in which the retrieved documents for each query are concatenated into a single column,\n",
+        "retrieved_documents_df, in which each retrieved document is \"exploded\" into its own row to enable the evaluation of each query-document pair in isolation.\n",
+        "This will enable us to compute multiple kinds of evaluations, including:\n",
+        "\n",
+        "relevance: Are the retrieved documents grounded in the response?\n",
+        "Q&A correctness: Are your application's responses grounded in the retrieved context?\n",
+        "hallucinations: Is your application making up false information?"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9",
+      "metadata": {
+        "id": "b42c0869-f7f7-4fb4-90d3-8e93a18bf1a9"
+      },
+      "outputs": [],
+      "source": [
+        "queries_df = get_qa_with_reference(session)\n",
+        "retrieved_documents_df = get_retrieved_documents(session)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "BGqH0E_J2lx8",
+      "metadata": {
+        "id": "BGqH0E_J2lx8"
+      },
+      "source": [
+        "Next, define your evaluation model and your evaluators.\n",
+        "\n",
+        "Evaluators are built on top of language models and prompt the LLM to assess the quality of responses, the relevance of retrieved documents, etc., and provide a quality signal even in the absence of human-labeled data. Pick an evaluator type and instantiate it with the language model you want to use to perform evaluations using our battle-tested evaluation templates."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "zJzLSmP6mp1o",
+      "metadata": {
+        "id": "zJzLSmP6mp1o"
+      },
+      "outputs": [],
+      "source": [
+        "eval_model = OpenAIModel(\n",
+        "    model=\"gpt-4o\",\n",
+        ")\n",
+        "hallucination_evaluator = HallucinationEvaluator(eval_model)\n",
+        "qa_correctness_evaluator = QAEvaluator(eval_model)\n",
+        "relevance_evaluator = RelevanceEvaluator(eval_model)\n",
+        "\n",
+        "hallucination_eval_df, qa_correctness_eval_df = run_evals(\n",
+        "    dataframe=queries_df,\n",
+        "    evaluators=[hallucination_evaluator, qa_correctness_evaluator],\n",
+        "    provide_explanation=True,\n",
+        ")\n",
+        "relevance_eval_df = run_evals(\n",
+        "    dataframe=retrieved_documents_df,\n",
+        "    evaluators=[relevance_evaluator],\n",
+        "    provide_explanation=True,\n",
+        ")[0]\n",
+        "\n",
+        "\n",
+        "px.Client().log_evaluations(\n",
+        "    SpanEvaluations(eval_name=\"Hallucination\", dataframe=hallucination_eval_df),\n",
+        "    SpanEvaluations(eval_name=\"QA Correctness\", dataframe=qa_correctness_eval_df),\n",
+        ")\n",
+        "px.Client().log_evaluations(DocumentEvaluations(eval_name=\"Relevance\", dataframe=relevance_eval_df))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "s4C3S4Bd2rE_",
+      "metadata": {
+        "id": "s4C3S4Bd2rE_"
+      },
+      "source": [
+        "Your evaluations should now appear as annotations on the appropriate spans in Phoenix.\n",
+        "\n",
+        "![A view of the Phoenix UI with evaluation annotations](https://storage.googleapis.com/arize-assets/phoenix/assets/docs/notebooks/evals/traces_with_evaluation_annotations.png)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a notebook that shows a mongodb+llamaindex RAG pipeline, traced and evaluated. This is an updated version of an existing notebook that we used for a previous webinar, but doesn't look like it ever made it into our repo