### PR TITLE
chore: apply naming convention for demo project fixtures

### DIFF
--- a/src/phoenix/trace/fixtures.py
+++ b/src/phoenix/trace/fixtures.py
@@ -147,21 +147,21 @@ demo_llama_index_rag_fixture = TracesFixture(
 
 demo_code_based_agent_fixture = TracesFixture(
     name="demo_code_based_agent",
-    project_name="code_based_agent_demo",
+    project_name="demo_code_based_agent",
     description="Shows traces captured from a code-based agent.",
     file_name="agent-demo-traces.parquet",
 )
 
 demo_langgraph_agent_fixture = TracesFixture(
     name="demo_langgraph_agent",
-    project_name="langgraph_agent_demo",
+    project_name="demo_langgraph_agent",
     description="Shows traces captured from a Langgraph agent.",
     file_name="langgraph-demo-traces.parquet",
 )
 
 demo_llamaindex_workflows_agent_fixture = TracesFixture(
     name="demo_llamaindex_workflows_agent",
-    project_name="llamaindex_workflows_agent_demo",
+    project_name="demo_llamaindex_workflows_agent",
     description="Shows traces captured from a LlamaIndex Workflows agent.",
     file_name="llamaindex-workflow-demo-traces.parquet",
 )


### PR DESCRIPTION
Changes the agent demo project names to start with "demo_"

We haven't yet updated the demo instance of phoenix's yaml to include any of these names, so making this change here before we update that file