### PR TITLE
docs: fix incorrect env var in docstring

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -51,7 +51,7 @@ def register(
 
     Args:
         endpoint (str, optional): The collector endpoint to which spans will be exported. If not
-            provided, the `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be used. The
+            provided, the `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be used. The
             export protocol will be inferred from the endpoint.
         project_name (str, optional): The name of the project to which spans will be associated. If
             not provided, the `PHOENIX_PROJECT_NAME` environment variable will be used.
@@ -102,7 +102,7 @@ class TracerProvider(_TracerProvider):
     Args:
         endpoint (str, optional): The collector endpoint to which spans will be exported. If
             specified, a default SpanProcessor will be created and added to this TracerProvider.
-            If not provided, the `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be
+            If not provided, the `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be
             used to infer which collector endpoint to use, defaults to the gRPC endpoint. When
             specifying the endpoint, the transport method (HTTP or gRPC) will be inferred from the
             URL.
@@ -203,7 +203,7 @@ class SimpleSpanProcessor(_SimpleSpanProcessor):
         span_exporter (SpanExporter, optional): The `SpanExporter` to which ended spans will be
             passed.
         endpoint (str, optional): The collector endpoint to which spans will be exported. If not
-            provided, the `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be used to
+            provided, the `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be used to
             infer which collector endpoint to use, defaults to the gRPC endpoint. When specifying
             the endpoint, the transport method (HTTP or gRPC) will be inferred from the URL.
         headers (dict, optional): Optional headers to include in the request to the collector.
@@ -248,7 +248,7 @@ class BatchSpanProcessor(_BatchSpanProcessor):
         span_exporter (SpanExporter, optional): The `SpanExporter` to which ended spans will be
             passed.
         endpoint (str, optional): The collector endpoint to which spans will be exported. If not
-            provided, the `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be used to
+            provided, the `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be used to
             infer which collector endpoint to use, defaults to the gRPC endpoint. When specifying
             the endpoint, the transport method (HTTP or gRPC) will be inferred from the URL.
         headers (dict, optional): Optional headers to include in the request to the collector.
@@ -288,7 +288,7 @@ class HTTPSpanExporter(_HTTPSpanExporter):
 
     Args:
         endpoint (str, optional): OpenTelemetry Collector receiver endpoint. If not provided, the
-            `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be used to infer which
+            `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be used to infer which
             collector endpoint to use, defaults to the HTTP endpoint.
         headers: Headers to send when exporting. If not provided, the `PHOENIX_CLIENT_HEADERS`
             or `OTEL_EXPORTER_OTLP_HEADERS` environment variables will be used.
@@ -337,7 +337,7 @@ class GRPCSpanExporter(_GRPCSpanExporter):
 
     Args:
         endpoint (str, optional): OpenTelemetry Collector receiver endpoint. If not provided, the
-            `PHOENIX_OTEL_COLLECTOR_ENDPOINT` environment variable will be used to infer which
+            `PHOENIX_COLLECTOR_ENDPOINT` environment variable will be used to infer which
             collector endpoint to use, defaults to the gRPC endpoint.
         insecure: Connection type
         credentials: Credentials object for server authentication


### PR DESCRIPTION
Fixes incorrect docstring.

resolves #4787
