### PR TITLE
chore: Implement simple email sender to simplify dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
   "arize-phoenix-evals>=0.13.1",
   "arize-phoenix-otel>=0.5.1",
   "fastapi",
-  "fastapi-mail",
   "pydantic>=1.0,!=2.0.*,<3", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",
 ]

--- a/src/phoenix/server/email/sender.py
+++ b/src/phoenix/server/email/sender.py
@@ -1,26 +1,69 @@
+import asyncio
+import smtplib
+import ssl
+from email.message import EmailMessage
 from pathlib import Path
 
-from fastapi_mail import ConnectionConfig, FastMail, MessageSchema
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 EMAIL_TEMPLATE_FOLDER = Path(__file__).parent / "templates"
 
 
-class FastMailSender:
-    def __init__(self, conf: ConnectionConfig) -> None:
-        self._fm = FastMail(conf)
+class SimpleEmailSender:
+    def __init__(
+        self,
+        smtp_server: str,
+        smtp_port: int,
+        username: str,
+        password: str,
+        sender_email: str,
+        use_tls: bool = True,
+        validate_certs: bool = True,
+    ) -> None:
+        self.smtp_server = smtp_server
+        self.smtp_port = smtp_port
+        self.username = username
+        self.password = password
+        self.sender_email = sender_email
+        self.use_tls = use_tls
+        self.validate_certs = validate_certs
+
+        self.env = Environment(
+            loader=FileSystemLoader(EMAIL_TEMPLATE_FOLDER),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
 
     async def send_password_reset_email(
         self,
         email: str,
         reset_url: str,
     ) -> None:
-        message = MessageSchema(
-            subject="[Phoenix] Password Reset Request",
-            recipients=[email],
-            template_body=dict(reset_url=reset_url),
-            subtype="html",
-        )
-        await self._fm.send_message(
-            message,
-            template_name="password_reset.html",
-        )
+        subject = "[Phoenix] Password Reset Request"
+        template_name = "password_reset.html"
+
+        template = self.env.get_template(template_name)
+        html_content = template.render(reset_url=reset_url)
+
+        msg = EmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = self.sender_email
+        msg["To"] = email
+        msg.set_content(html_content, subtype="html")
+
+        def send_email():
+            if self.validate_certs:
+                context: ssl.SSLContext = ssl.create_default_context()
+            else:
+                context: ssl.SSLContext = ssl._create_unverified_context()
+
+            if self.use_tls:
+                server = smtplib.SMTP(self.smtp_server, self.smtp_port)
+                server.starttls(context=context)
+            else:
+                server = smtplib.SMTP_SSL(self.smtp_server, self.smtp_port, context=context)
+
+            server.login(self.username, self.password)
+            server.send_message(msg)
+            server.quit()
+
+        await asyncio.to_thread(send_email)

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -10,7 +10,6 @@ from time import sleep, time
 from typing import List, Optional
 from urllib.parse import urljoin
 
-from fastapi_mail import ConnectionConfig
 from jinja2 import BaseLoader, Environment
 from uvicorn import Config, Server
 
@@ -59,7 +58,7 @@ from phoenix.server.app import (
     create_engine_and_run_migrations,
     instrument_engine_if_enabled,
 )
-from phoenix.server.email.sender import EMAIL_TEMPLATE_FOLDER, FastMailSender
+from phoenix.server.email.sender import SimpleEmailSender
 from phoenix.server.types import DbSessionFactory
 from phoenix.settings import Settings
 from phoenix.trace.fixtures import (
@@ -368,20 +367,15 @@ def main() -> None:
     if mail_sever := get_env_smtp_hostname():
         assert (mail_username := get_env_smtp_username()), "SMTP username is required"
         assert (mail_password := get_env_smtp_password()), "SMTP password is required"
-        assert (mail_from := get_env_smtp_mail_from()), "SMTP mail_from is required"
-        email_sender = FastMailSender(
-            ConnectionConfig(
-                MAIL_USERNAME=mail_username,
-                MAIL_PASSWORD=mail_password,
-                MAIL_FROM=mail_from,
-                MAIL_SERVER=mail_sever,
-                MAIL_PORT=get_env_smtp_port(),
-                VALIDATE_CERTS=get_env_smtp_validate_certs(),
-                USE_CREDENTIALS=True,
-                MAIL_STARTTLS=True,
-                MAIL_SSL_TLS=False,
-                TEMPLATE_FOLDER=EMAIL_TEMPLATE_FOLDER,
-            )
+        assert (sender_email := get_env_smtp_mail_from()), "SMTP mail_from is required"
+        email_sender = SimpleEmailSender(
+            smtp_server=mail_sever,
+            smtp_port=get_env_smtp_port(),
+            username=mail_username,
+            password=mail_password,
+            sender_email=sender_email,
+            use_tls=True,
+            validate_certs=get_env_smtp_validate_certs(),
         )
     app = create_app(
         db=factory,


### PR DESCRIPTION
- `fastapi-mail` adds dependencies that can increase the risk of conflicts, here we implement a simple email sender to avoid this