### PR TITLE
fix: handle `ndarray` for `json.dumps` in `encode_span_to_otlp`

### DIFF
--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -48,6 +48,7 @@ from phoenix.trace.schemas import (
     SpanStatusCode,
     TraceID,
 )
+from phoenix.utilities.json import jsonify
 
 DOCUMENT_METADATA = DocumentAttributes.DOCUMENT_METADATA
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
@@ -194,7 +195,7 @@ def encode_span_to_otlp(span: Span) -> otlp.Span:
         elif isinstance(value, Mapping):
             attributes.pop(key, None)
             if key.endswith(JSON_STRING_ATTRIBUTES):
-                attributes[key] = json.dumps(value)
+                attributes[key] = json.dumps(jsonify(value))
             else:
                 attributes.update(
                     flatten(


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/4810

```
File /opt/anaconda3/envs/phoenix/lib/python3.11/site-packages/phoenix/trace/otel.py:197, in encode_span_to_otlp(span)
    195 attributes.pop(key, None)
    196 if key.endswith(JSON_STRING_ATTRIBUTES):
--> 197     attributes[key] = json.dumps(value)
```