### PR TITLE
fix(auth): show reset password button only for locally authenticated users

### DIFF
--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -42,6 +42,7 @@ export function ViewerProvider({
           role {
             name
           }
+          authMethod
           ...APIKeysTableFragment
         }
       }

--- a/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b6aa985d62c7f2768388ff32ef27e10f>>
+ * @generated SignedSource<<9165c4bbcd695cd2e9608aa9143549ab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,6 +101,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "authMethod",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "UserApiKey",
             "kind": "LinkedField",
             "name": "apiKeys",
@@ -138,16 +145,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4c8790abe3ec8e077913422cb62c6b3f",
+    "cacheID": "12e359dfec5f96fcfcbeff2e8110b80f",
     "id": null,
     "metadata": {},
     "name": "ViewerContextRefetchQuery",
     "operationKind": "query",
-    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n    }\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0fda3314d35e251b11f0ed180df72f44";
+(node as any).hash = "bec0ae2a629134a5b9afe1846eaec2c9";
 
 export default node;

--- a/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b404e55614d071f40b1328bc81b05cc5>>
+ * @generated SignedSource<<4943c441f0a18f63c691a565344bcaf7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,9 +9,11 @@
 // @ts-nocheck
 
 import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+export type AuthMethod = "LOCAL" | "OAUTH2";
 import { FragmentRefs } from "relay-runtime";
 export type ViewerContext_viewer$data = {
   readonly viewer: {
+    readonly authMethod: AuthMethod;
     readonly email: string;
     readonly id: string;
     readonly profilePictureUrl: string | null;
@@ -97,6 +99,13 @@ const node: ReaderFragment = {
           "storageKey": null
         },
         {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "authMethod",
+          "storageKey": null
+        },
+        {
           "args": null,
           "kind": "FragmentSpread",
           "name": "APIKeysTableFragment"
@@ -109,6 +118,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "0fda3314d35e251b11f0ed180df72f44";
+(node as any).hash = "bec0ae2a629134a5b9afe1846eaec2c9";
 
 export default node;

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b60e823c28195489be2e021960df6d6>>
+ * @generated SignedSource<<53a3f976f98fd4315fee6e61174280eb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -123,6 +123,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "authMethod",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "UserApiKey",
             "kind": "LinkedField",
             "name": "apiKeys",
@@ -161,12 +168,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "60c31f9b6cb4ed2cbdfcfe1c11255556",
+    "cacheID": "d63c6184305079deb38a6f6235ba88e6",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n    }\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/profile/ViewerProfileCard.tsx
+++ b/app/src/pages/profile/ViewerProfileCard.tsx
@@ -81,15 +81,17 @@ export function ViewerProfileCard() {
       variant="compact"
       bodyStyle={{ padding: 0 }}
       extra={
-        <Button
-          variant="default"
-          size="compact"
-          onClick={() => {
-            navigate("/reset-password");
-          }}
-        >
-          Reset Password
-        </Button>
+        viewer.authMethod === "LOCAL" && (
+          <Button
+            variant="default"
+            size="compact"
+            onClick={() => {
+              navigate("/reset-password");
+            }}
+          >
+            Reset Password
+          </Button>
+        )
       }
     >
       <View paddingTop="size-200" paddingStart="size-200" paddingEnd="size-200">


### PR DESCRIPTION
Show option to reset password only for locally authenticated users. We're currently showing it to users authenticated via a third-party OAuth2 IDP, which doesn't make sense.

## Locally Authenticated User

<img width="761" alt="Screenshot 2024-10-02 at 3 23 55 PM" src="https://github.com/user-attachments/assets/812665c3-5114-4483-a2a0-c64d92ac7b35">

## OAuth2 Authenticated User

<img width="755" alt="Screenshot 2024-10-02 at 3 24 13 PM" src="https://github.com/user-attachments/assets/45f1d69c-e94a-41bc-9980-d4be386d63d8">

resolves #4727
