### PR TITLE
fix: remove incorrect URL in python guide

### DIFF
--- a/app/src/components/project/PythonProjectGuide.tsx
+++ b/app/src/components/project/PythonProjectGuide.tsx
@@ -40,7 +40,7 @@ function getEnvironmentVariablesPython({
   if (isHosted) {
     return `PHOENIX_CLIENT_HEADERS='api_key=<your-api-key>'\nPHOENIX_COLLECTOR_ENDPOINT='${HOSTED_PHOENIX_URL}'`;
   } else if (isAuthEnabled) {
-    return `PHOENIX_API_KEY='<your-api-key>'\nPHOENIX_COLLECTOR_ENDPOINT='${HOSTED_PHOENIX_URL}'`;
+    return `PHOENIX_API_KEY='<your-api-key>'`;
   }
   return `PHOENIX_COLLECTOR_ENDPOINT='${BASE_URL}'`;
 }


### PR DESCRIPTION
resolves #4844 

This corrects the hard-coded hosted phoenix URL that was in the authenticated guide

**before**
<img width="903" alt="Screenshot 2024-10-02 at 5 47 04 PM" src="https://github.com/user-attachments/assets/7c69d9d9-0a94-4313-b5c9-6d0ac09d0c50">
