### PR TITLE
fix: pin postgres version at 16 for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - PHOENIX_SQL_DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
   db:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       - POSTGRES_USER=postgres


### PR DESCRIPTION
getting the following error

```
db-1       |
db-1       | PostgreSQL Database directory appears to contain a database; Skipping initialization
db-1       |
db-1       | 2024-10-03 14:57:16.488 UTC [1] FATAL:  database files are incompatible with server
db-1       | 2024-10-03 14:57:16.488 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.0 (Debian 17.0-1.pgdg120+1).
db-1 exited with code 1
```