### PR TITLE
feat(playground): rudimentary graphql support for messages input

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -66,7 +66,21 @@ enum AuthMethod {
 union Bin = NominalBin | IntervalBin | MissingValueBin
 
 input ChatCompletionInput {
-  message: String!
+  messages: [ChatCompletionMessageInput!]!
+}
+
+input ChatCompletionMessageInput {
+  role: ChatCompletionMessageRole!
+
+  """The content of the message as JSON to support text and tools"""
+  content: JSON!
+}
+
+enum ChatCompletionMessageRole {
+  USER
+  SYSTEM
+  TOOL
+  AI
 }
 
 input ClearProjectInput {

--- a/app/src/pages/playground/MessageRolePicker.tsx
+++ b/app/src/pages/playground/MessageRolePicker.tsx
@@ -42,7 +42,7 @@ export function MessageRolePicker({
     >
       <Item key="system">System</Item>
       <Item key="user">User</Item>
-      <Item key="ai">ai</Item>
+      <Item key="ai">AI</Item>
     </Picker>
   );
 }

--- a/app/src/pages/playground/MessageRolePicker.tsx
+++ b/app/src/pages/playground/MessageRolePicker.tsx
@@ -36,11 +36,13 @@ export function MessageRolePicker({
       data-testid="inferences-time-range"
       aria-label={`Time range for the primary inferences`}
       size="compact"
-      onSelectionChange={() => {}}
+      onSelectionChange={() => {
+        // TODO: fill out
+      }}
     >
       <Item key="system">System</Item>
       <Item key="user">User</Item>
-      <Item key="assistant">Assistant</Item>
+      <Item key="ai">ai</Item>
     </Picker>
   );
 }

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f13c38a36104dff25a3eb75b2df7893c>>
+ * @generated SignedSource<<767976775ee226eb849cf909b42f2897>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,8 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest, GraphQLSubscription } from 'relay-runtime';
+export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
+export type ChatCompletionMessageInput = {
+  content: any;
+  role: ChatCompletionMessageRole;
+};
 export type PlaygroundOutputSubscription$variables = {
-  message: string;
+  messages: ReadonlyArray<ChatCompletionMessageInput>;
 };
 export type PlaygroundOutputSubscription$data = {
   readonly chatCompletion: string;
@@ -25,7 +30,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "message"
+    "name": "messages"
   }
 ],
 v1 = [
@@ -36,8 +41,8 @@ v1 = [
         "fields": [
           {
             "kind": "Variable",
-            "name": "message",
-            "variableName": "message"
+            "name": "messages",
+            "variableName": "messages"
           }
         ],
         "kind": "ObjectValue",
@@ -67,16 +72,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "9f3d7d595d3974bb015d1b73bff91ff5",
+    "cacheID": "0856059e2e3a28a8fda74106924c480d",
     "id": null,
     "metadata": {},
     "name": "PlaygroundOutputSubscription",
     "operationKind": "subscription",
-    "text": "subscription PlaygroundOutputSubscription(\n  $message: String!\n) {\n  chatCompletion(input: {message: $message})\n}\n"
+    "text": "subscription PlaygroundOutputSubscription(\n  $messages: [ChatCompletionMessageInput!]!\n) {\n  chatCompletion(input: {messages: $messages})\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e560f1f0d0df600f9f7eb955c25d4ddc";
+(node as any).hash = "d760af0f8e18301631ba9dcdb148de0b";
 
 export default node;

--- a/app/src/store/playgroundStore.tsx
+++ b/app/src/store/playgroundStore.tsx
@@ -22,7 +22,7 @@ export type PlaygroundTemplate =
 /**
  * The role of a chat message with a LLM
  */
-export type ChatMessageRole = "user" | "assistant" | "system" | "tool";
+export type ChatMessageRole = "user" | "ai" | "system" | "tool";
 
 /**
  * A chat message with a role and content

--- a/src/phoenix/server/api/input_types/ChatCompletionMessageInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionMessageInput.py
@@ -1,0 +1,12 @@
+import strawberry
+from strawberry.scalars import JSON
+
+from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
+
+
+@strawberry.input
+class ChatCompletionMessageInput:
+    role: ChatCompletionMessageRole
+    content: JSON = strawberry.field(
+        description="The content of the message as JSON to support text and tools",
+    )

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -12,10 +12,7 @@ from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMes
 
 if TYPE_CHECKING:
     from openai.types.chat import (
-        ChatCompletionAssistantMessageParam,
         ChatCompletionMessageParam,
-        ChatCompletionSystemMessageParam,
-        ChatCompletionUserMessageParam,
     )
 
 
@@ -27,6 +24,12 @@ class ChatCompletionInput:
 def to_openai_chat_completion_param(
     message: ChatCompletionMessageInput,
 ) -> "ChatCompletionMessageParam":
+    from openai.types.chat import (
+        ChatCompletionAssistantMessageParam,
+        ChatCompletionSystemMessageParam,
+        ChatCompletionUserMessageParam,
+    )
+
     if message.role is ChatCompletionMessageRole.USER:
         return ChatCompletionUserMessageParam(
             {

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator, List
 
 import strawberry
 from sqlalchemy import insert, select
@@ -7,11 +7,48 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.server.api.context import Context
+from phoenix.server.api.input_types.ChatCompletionMessageInput import ChatCompletionMessageInput
+from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
+
+if TYPE_CHECKING:
+    from openai.types.chat import (
+        ChatCompletionAssistantMessageParam,
+        ChatCompletionMessageParam,
+        ChatCompletionSystemMessageParam,
+        ChatCompletionUserMessageParam,
+    )
 
 
 @strawberry.input
 class ChatCompletionInput:
-    message: str
+    messages: List[ChatCompletionMessageInput]
+
+
+def to_openai_chat_completion_param(
+    message: ChatCompletionMessageInput,
+) -> "ChatCompletionMessageParam":
+    if message.role is ChatCompletionMessageRole.USER:
+        return ChatCompletionUserMessageParam(
+            {
+                "content": message.content,
+                "role": "user",
+            }
+        )
+    if message.role is ChatCompletionMessageRole.SYSTEM:
+        return ChatCompletionSystemMessageParam(
+            {
+                "content": message.content,
+                "role": "system",
+            }
+        )
+    if message.role is ChatCompletionMessageRole.AI:
+        return ChatCompletionAssistantMessageParam(
+            {
+                "content": message.content,
+                "role": "assistant",
+            }
+        )
+    raise ValueError(f"Unsupported role: {message.role}")
 
 
 @strawberry.type
@@ -21,13 +58,18 @@ class Subscription:
         self, info: Info[Context, None], input: ChatCompletionInput
     ) -> AsyncIterator[str]:
         from openai import AsyncOpenAI
-        from openai.types.chat import ChatCompletionUserMessageParam
 
         client = AsyncOpenAI()
+
+        # Loop over the input messages and map them to the OpenAI format
+
+        messages: List[ChatCompletionMessageParam] = [
+            to_openai_chat_completion_param(message) for message in input.messages
+        ]
         chunk_contents = []
         start_time = datetime.now()
         async for chunk in await client.chat.completions.create(
-            messages=[ChatCompletionUserMessageParam(role="user", content=input.message)],
+            messages=messages,
             model="gpt-4",
             stream=True,
         ):

--- a/src/phoenix/server/api/types/ChatCompletionMessageRole.py
+++ b/src/phoenix/server/api/types/ChatCompletionMessageRole.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class ChatCompletionMessageRole(Enum):
+    USER = "USER"
+    SYSTEM = "SYSTEM"
+    TOOL = "TOOL"
+    AI = "AI"  # E.g. the assistant. Normalize to AI for consistency.


### PR DESCRIPTION
resolves [4893](https://github.com/Arize-ai/phoenix/issues/4893)

Switches the input of the chat completion message to be a list of messages with roles.

```graphql
subscription {
  chatCompletion(input: {
    messages: [{ role: USER, content: "hello"}]
  })
}
```
https://github.com/user-attachments/assets/dc042fd1-9c3b-4f45-98b7-685b9ac296a3

