### PR TITLE
fix: handle badly ingested llm spans gracefully

### DIFF
--- a/app/src/openInference/tracing/__tests__/types.test.ts
+++ b/app/src/openInference/tracing/__tests__/types.test.ts
@@ -1,0 +1,13 @@
+import { isAttributeMessage } from "../types";
+
+describe("isAttributeMessage", () => {
+  it("should return true if the message conforms to an object with a role", () => {
+    expect(isAttributeMessage({ role: "system " })).toBe(true);
+  });
+
+  it("should return false if the message does not conform to a reasonable shape", () => {
+    expect(isAttributeMessage({})).toBe(false);
+    expect(isAttributeMessage("")).toBe(false);
+    expect(isAttributeMessage(null)).toBe(false);
+  });
+});

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -1,4 +1,5 @@
 import {
+  DocumentAttributePostfixes,
   EmbeddingAttributePostfixes,
   ImageAttributesPostfixes,
   LLMAttributePostfixes,
@@ -7,12 +8,9 @@ import {
   MessageContentsAttributePostfixes,
   RerankerAttributePostfixes,
   RetrievalAttributePostfixes,
+  SemanticAttributePrefixes,
   ToolAttributePostfixes,
 } from "@arizeai/openinference-semantic-conventions";
-import {
-  DocumentAttributePostfixes,
-  SemanticAttributePrefixes,
-} from "@arizeai/openinference-semantic-conventions/src/trace/SemanticConventions";
 
 export type AttributeTool = {
   [ToolAttributePostfixes.name]?: string;
@@ -121,7 +119,13 @@ export function isAttributeMessages(
 ): messages is AttributeMessages {
   return (
     Array.isArray(messages) &&
-    messages.every((message) => isAttributeMessage(message))
+    messages.every((message) => {
+      return (
+        typeof message === "object" &&
+        SemanticAttributePrefixes.message in message &&
+        isAttributeMessage(message[SemanticAttributePrefixes.message])
+      );
+    })
   );
 }
 
@@ -135,7 +139,6 @@ export function isAttributeMessage(
   return (
     typeof message === "object" &&
     message !== null &&
-    MessageAttributePostfixes.role in message &&
-    MessageAttributePostfixes.content in message
+    MessageAttributePostfixes.role in message
   );
 }

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -100,8 +100,8 @@ export type AttributeReranker = {
 export type AttributeLlm = {
   [LLMAttributePostfixes.model_name]?: string;
   [LLMAttributePostfixes.token_count]?: number;
-  [LLMAttributePostfixes.input_messages]?: AttributeMessages;
-  [LLMAttributePostfixes.output_messages]?: AttributeMessages;
+  [LLMAttributePostfixes.input_messages]?: AttributeMessages | unknown;
+  [LLMAttributePostfixes.output_messages]?: AttributeMessages | unknown;
   [LLMAttributePostfixes.invocation_parameters]?: string;
   [LLMAttributePostfixes.prompts]?: string[];
   [LLMAttributePostfixes.prompt_template]?: AttributePromptTemplate;
@@ -112,3 +112,30 @@ export type AttributePromptTemplate = {
   [LLMPromptTemplateAttributePostfixes.template]: string;
   [LLMPromptTemplateAttributePostfixes.variables]: Record<string, string>;
 };
+
+/**
+ * Type guard for LLM messages
+ */
+export function isAttributeMessages(
+  messages: unknown
+): messages is AttributeMessages {
+  return (
+    Array.isArray(messages) &&
+    messages.every((message) => isAttributeMessage(message))
+  );
+}
+
+/**
+ * Type guard for LLM message. This is not fully safe and uses rough duck typing.
+ * TODO: make this more water tight via zod or other
+ */
+export function isAttributeMessage(
+  message: unknown
+): message is AttributeMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    MessageAttributePostfixes.role in message &&
+    MessageAttributePostfixes.content in message
+  );
+}

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -540,7 +540,7 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
       return [];
     }
     return (outputMessagesValue
-      ?.map((obj) => obj[SemanticAttributePrefixes.message])
+      .map((obj) => obj[SemanticAttributePrefixes.message])
       .filter(Boolean) || []) as AttributeMessage[];
   }, [llmAttributes]);
 

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -76,6 +76,7 @@ import {
   AttributeReranker,
   AttributeRetrieval,
   AttributeTool,
+  isAttributeMessages,
 } from "@phoenix/openInference/tracing/types";
 import { assertUnreachable, isStringArray } from "@phoenix/typeUtils";
 import { formatFloat, numberFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -491,7 +492,15 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
     if (llmAttributes == null) {
       return [];
     }
-    return (llmAttributes[LLMAttributePostfixes.input_messages]
+    const inputMessagesValue =
+      llmAttributes[LLMAttributePostfixes.input_messages];
+
+    // At this point, we cannot trust the type of outputMessagesValue
+    if (!isAttributeMessages(inputMessagesValue)) {
+      return [];
+    }
+
+    return (inputMessagesValue
       ?.map((obj) => obj[SemanticAttributePrefixes.message])
       .filter(Boolean) || []) as AttributeMessage[];
   }, [llmAttributes]);
@@ -523,7 +532,14 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
     if (llmAttributes == null) {
       return [];
     }
-    return (llmAttributes[LLMAttributePostfixes.output_messages]
+    const outputMessagesValue =
+      llmAttributes[LLMAttributePostfixes.output_messages];
+
+    // At this point, we cannot trust the type of outputMessagesValue
+    if (!isAttributeMessages(outputMessagesValue)) {
+      return [];
+    }
+    return (outputMessagesValue
       ?.map((obj) => obj[SemanticAttributePrefixes.message])
       .filter(Boolean) || []) as AttributeMessage[];
   }, [llmAttributes]);


### PR DESCRIPTION
resolves #4912 

Makes sure that llm message blocks contain lists of objects before rendering content. If malformed it just falls back to IO

<img width="1897" alt="Screenshot 2024-10-08 at 11 06 08 AM" src="https://github.com/user-attachments/assets/7723eedd-b837-4fd2-8144-3f4a6da55c8b">
<img width="1900" alt="Screenshot 2024-10-08 at 11 06 20 AM" src="https://github.com/user-attachments/assets/79e578c5-8a65-4d40-9063-9d33ce220968">
