### PR TITLE
fix: add middleware for checking Cross-Site Request Forgery (CSRF) when trusted origins are specified via environment variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ dependencies = [
   "litellm>=1.0.3",
   "openai>=1.0.0",
   "tenacity",
-  "protobuf==3.20",  # version minimum (for tests)
+  "protobuf==3.20.2",  # version minimum (for tests)
   "grpc-interceptor[testing]",
   "responses",
   "tiktoken",

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -335,8 +335,8 @@ def get_env_csrf_trusted_origins() -> List[str]:
             continue
         if not urlparse(origin).hostname:
             raise ValueError(
-                f"Invalid hostname found in in the environment variable "
-                f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
+                f"The environment variable `{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}` contains a url "
+                f"with missing hostname. Please ensure that each url has a valid hostname."
             )
         origins.append(origin)
     return sorted(set(origins))

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -110,7 +110,7 @@ The duration, in minutes, before password reset tokens expire.
 ENV_PHOENIX_CSRF_TRUSTED_ORIGINS = "PHOENIX_CSRF_TRUSTED_ORIGINS"
 """
 A comma-separated list of origins that are allowed to bypass Cross-Site Request Forgery (CSRF)
-protection.
+protection. This is recommended when setting up OAuth2 clients or sending password reset emails.
 """
 
 # SMTP settings

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -327,7 +327,7 @@ def get_env_refresh_token_expiry() -> timedelta:
 
 
 def get_env_csrf_trusted_origins() -> List[str]:
-    origins = []
+    origins: List[str] = []
     if not (csrf_trusted_origins := os.getenv(ENV_PHOENIX_CSRF_TRUSTED_ORIGINS)):
         return origins
     for origin in csrf_trusted_origins.split(","):
@@ -339,7 +339,7 @@ def get_env_csrf_trusted_origins() -> List[str]:
                 f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
             )
         origins.append(origin)
-    return list(set(origins))
+    return sorted(set(origins))
 
 
 def get_env_smtp_username() -> str:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -332,6 +332,11 @@ def get_env_csrf_trusted_origins() -> List[str]:
         for origin in csrf_trusted_origins.split(","):
             if not origin:
                 continue
+            if not urlparse(origin).hostname:
+                raise ValueError(
+                    f"Missing hostname in `{origin}` for environment variable "
+                    f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
+                )
             origins.append(origin)
     return list(set(origins))
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -335,7 +335,7 @@ def get_env_csrf_trusted_origins() -> List[str]:
             continue
         if not urlparse(origin).hostname:
             raise ValueError(
-                f"Missing hostname in `{origin}` for environment variable "
+                f"Invalid hostname found in in the environment variable "
                 f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
             )
         origins.append(origin)

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -109,8 +109,11 @@ The duration, in minutes, before password reset tokens expire.
 """
 ENV_PHOENIX_CSRF_TRUSTED_ORIGINS = "PHOENIX_CSRF_TRUSTED_ORIGINS"
 """
-A comma-separated list of origins that are allowed to bypass Cross-Site Request Forgery (CSRF)
-protection. This is recommended when setting up OAuth2 clients or sending password reset emails.
+A comma-separated list of origins allowed to bypass Cross-Site Request Forgery (CSRF)
+protection. This setting is recommended when configuring OAuth2 clients or sending
+password reset emails. If this variable is left unspecified or contains no origins, CSRF
+protection will not be enabled. In such cases, when a request includes `origin` or `referer`
+headers, those values will not be validated.
 """
 
 # SMTP settings

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -328,16 +328,17 @@ def get_env_refresh_token_expiry() -> timedelta:
 
 def get_env_csrf_trusted_origins() -> List[str]:
     origins = []
-    if csrf_trusted_origins := os.getenv(ENV_PHOENIX_CSRF_TRUSTED_ORIGINS):
-        for origin in csrf_trusted_origins.split(","):
-            if not origin:
-                continue
-            if not urlparse(origin).hostname:
-                raise ValueError(
-                    f"Missing hostname in `{origin}` for environment variable "
-                    f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
-                )
-            origins.append(origin)
+    if not (csrf_trusted_origins := os.getenv(ENV_PHOENIX_CSRF_TRUSTED_ORIGINS)):
+        return origins
+    for origin in csrf_trusted_origins.split(","):
+        if not origin:
+            continue
+        if not urlparse(origin).hostname:
+            raise ValueError(
+                f"Missing hostname in `{origin}` for environment variable "
+                f"`{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}`"
+            )
+        origins.append(origin)
     return list(set(origins))
 
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -107,6 +107,11 @@ ENV_PHOENIX_PASSWORD_RESET_TOKEN_EXPIRY_MINUTES = "PHOENIX_PASSWORD_RESET_TOKEN_
 """
 The duration, in minutes, before password reset tokens expire.
 """
+ENV_PHOENIX_CSRF_TRUSTED_ORIGINS = "PHOENIX_CSRF_TRUSTED_ORIGINS"
+"""
+A comma-separated list of origins that are allowed to bypass Cross-Site Request Forgery (CSRF)
+protection.
+"""
 
 # SMTP settings
 ENV_PHOENIX_SMTP_HOSTNAME = "PHOENIX_SMTP_HOSTNAME"
@@ -319,6 +324,16 @@ def get_env_refresh_token_expiry() -> timedelta:
     )
     assert minutes > 0
     return timedelta(minutes=minutes)
+
+
+def get_env_csrf_trusted_origins() -> List[str]:
+    origins = []
+    if csrf_trusted_origins := os.getenv(ENV_PHOENIX_CSRF_TRUSTED_ORIGINS):
+        for origin in csrf_trusted_origins.split(","):
+            if not origin:
+                continue
+            origins.append(origin)
+    return list(set(origins))
 
 
 def get_env_smtp_username() -> str:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -688,7 +688,7 @@ def create_app(
         middlewares.append(Middleware(RequestOriginHostnameValidator, trusted_hostnames))
     elif email_sender or oauth2_client_configs:
         logger.warning(
-            "CSRF protection is disabled because trusted origins have not been set via "
+            "CSRF protection can be enabled by listing trusted origins via "
             f"the `{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}` environment variable."
         )
     if authentication_enabled and secret:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -689,7 +689,9 @@ def create_app(
     elif email_sender or oauth2_client_configs:
         logger.warning(
             "CSRF protection can be enabled by listing trusted origins via "
-            f"the `{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}` environment variable."
+            f"the `{ENV_PHOENIX_CSRF_TRUSTED_ORIGINS}` environment variable. "
+            "This is recommended when setting up OAuth2 clients or sending "
+            "password reset emails."
         )
     if authentication_enabled and secret:
         token_store = JwtStore(db, secret)

--- a/tests/integration/auth/conftest.py
+++ b/tests/integration/auth/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from faker import Faker
 from phoenix.auth import DEFAULT_SECRET_LENGTH
 from phoenix.config import (
+    ENV_PHOENIX_CSRF_TRUSTED_ORIGINS,
     ENV_PHOENIX_DISABLE_RATE_LIMIT,
     ENV_PHOENIX_ENABLE_AUTH,
     ENV_PHOENIX_SECRET,
@@ -52,6 +53,7 @@ def _app(
         (ENV_PHOENIX_SMTP_PASSWORD, "test"),
         (ENV_PHOENIX_SMTP_MAIL_FROM, _fake.email()),
         (ENV_PHOENIX_SMTP_VALIDATE_CERTS, "false"),
+        (ENV_PHOENIX_CSRF_TRUSTED_ORIGINS, ",http://localhost,"),
     )
     with ExitStack() as stack:
         stack.enter_context(mock.patch.dict(os.environ, values))

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -84,6 +84,8 @@ class TestOriginAndReferer:
             [dict(referer="http://localhost/xyz"), _OK],
             [dict(origin="http://xyz.com"), _EXPECTATION_401],
             [dict(referer="http://xyz.com/xyz"), _EXPECTATION_401],
+            [dict(origin="http://xyz.com", referer="http://localhost/xyz"), _EXPECTATION_401],
+            [dict(origin="http://localhost", referer="http://xyz.com/xyz"), _EXPECTATION_401],
         ],
     )
     def test_csrf_origin_validation(

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import (
+    Any,
     ContextManager,
     DefaultDict,
     Dict,
@@ -53,6 +54,7 @@ from .._helpers import (
     _grpc_span_exporter,
     _Headers,
     _http_span_exporter,
+    _httpx_client,
     _initiate_password_reset,
     _log_in,
     _log_out,
@@ -71,6 +73,27 @@ from .._helpers import (
 NOW = datetime.now(timezone.utc)
 _decode_jwt = partial(jwt.decode, options=dict(verify_signature=False))
 _TokenT = TypeVar("_TokenT", _AccessToken, _RefreshToken)
+
+
+class TestOriginAndReferer:
+    @pytest.mark.parametrize(
+        "headers,expectation",
+        [
+            [dict(), _OK],
+            [dict(origin="http://localhost"), _OK],
+            [dict(referer="http://localhost/xyz"), _OK],
+            [dict(origin="http://xyz.com"), _EXPECTATION_401],
+            [dict(referer="http://xyz.com/xyz"), _EXPECTATION_401],
+        ],
+    )
+    def test_csrf_origin_validation(
+        self,
+        headers: Dict[str, str],
+        expectation: ContextManager[Any],
+    ) -> None:
+        resp = _httpx_client(headers=headers).get("/healthz")
+        with expectation:
+            resp.raise_for_status()
 
 
 class TestLogIn:


### PR DESCRIPTION
resolves #4883 