### PR TITLE
feat: Always prompt as system for OpenAI Models

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -90,8 +90,6 @@ class OpenAIModel(BaseModel):
             Defaults to 0.
         presence_penalty (float, optional): Penalizes repeated tokens. Defaults to 0.
         n (int, optional): How many completions to generate for each prompt. Defaults to 1.
-        prompt_as_system (bool, optional): If True, the prompt will sent using the system role.
-            Defaults to False.
         model_kwargs (Dict[str, Any], optional): Holds any model parameters valid for `create` call
             not explicitly specified. Defaults to an empty dictionary.
         request_timeout (Optional[Union[float, Tuple[float, float]]], optional): Timeout for
@@ -141,7 +139,6 @@ class OpenAIModel(BaseModel):
     frequency_penalty: float = 0
     presence_penalty: float = 0
     n: int = 1
-    prompt_as_system: bool = False
     model_kwargs: Dict[str, Any] = field(default_factory=dict)
     request_timeout: Optional[Union[float, Tuple[float, float]]] = None
 
@@ -283,8 +280,7 @@ class OpenAIModel(BaseModel):
     def _build_messages(
         self, prompt: str, system_instruction: Optional[str] = None
     ) -> List[Dict[str, str]]:
-        prompting_role = "system" if self.prompt_as_system else "user"
-        messages = [{"role": prompting_role, "content": prompt}]
+        messages = [{"role": "system", "content": prompt}]
         if system_instruction:
             messages.insert(0, {"role": "system", "content": str(system_instruction)})
         return messages

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -90,6 +90,8 @@ class OpenAIModel(BaseModel):
             Defaults to 0.
         presence_penalty (float, optional): Penalizes repeated tokens. Defaults to 0.
         n (int, optional): How many completions to generate for each prompt. Defaults to 1.
+        prompt_as_system (bool, optional): If True, the prompt will sent using the system role.
+            Defaults to False.
         model_kwargs (Dict[str, Any], optional): Holds any model parameters valid for `create` call
             not explicitly specified. Defaults to an empty dictionary.
         request_timeout (Optional[Union[float, Tuple[float, float]]], optional): Timeout for
@@ -139,6 +141,7 @@ class OpenAIModel(BaseModel):
     frequency_penalty: float = 0
     presence_penalty: float = 0
     n: int = 1
+    prompt_as_system: bool = False
     model_kwargs: Dict[str, Any] = field(default_factory=dict)
     request_timeout: Optional[Union[float, Tuple[float, float]]] = None
 
@@ -277,11 +280,11 @@ class OpenAIModel(BaseModel):
             enforcement_window_minutes=1,
         )
 
-    @staticmethod
     def _build_messages(
-        prompt: str, system_instruction: Optional[str] = None
+        self, prompt: str, system_instruction: Optional[str] = None
     ) -> List[Dict[str, str]]:
-        messages = [{"role": "user", "content": prompt}]
+        prompting_role = "system" if self.prompt_as_system else "user"
+        messages = [{"role": prompting_role, "content": prompt}]
         if system_instruction:
             messages.insert(0, {"role": "system", "content": str(system_instruction)})
         return messages


### PR DESCRIPTION
resolves #4462

Sends prompts as the system role for `OpenAIModel`: this is because Azure content restrictions (for toxicity, security) will often prevent evals from running. Rudimentary testing shows that both system prompting and user prompting behave similarly.