### PR TITLE
feat: add db table for trace sessions

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -450,4 +450,4 @@ jobs:
       - name: Set up `tox` with `tox-uv`
         run: uv tool install tox --with tox-uv
       - name: Run integration tests
-        run: tox run -e integration_tests -- -ra -x -n auto
+        run: tox run -e integration_tests -- -ra -x -n 10 --reruns 5

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1120,6 +1120,7 @@ type Project implements Node {
   spanLatencyMsQuantile(probability: Float!, timeRange: TimeRange, filterCondition: String): Float
   trace(traceId: ID!): Trace
   spans(timeRange: TimeRange, first: Int = 50, last: Int, after: String, before: String, sort: SpanSort, rootSpansOnly: Boolean, filterCondition: String): SpanConnection!
+  sessions(timeRange: TimeRange, first: Int = 50, after: String): ProjectSessionConnection!
 
   """
   Names of all available annotations for traces. (The list contains no duplicates.)
@@ -1156,6 +1157,31 @@ type ProjectEdge {
 
   """The item at the end of the edge"""
   node: Project!
+}
+
+type ProjectSession implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  sessionId: String!
+  traces(first: Int = 50, last: Int, after: String, before: String): TraceConnection!
+}
+
+"""A connection to a list of items."""
+type ProjectSessionConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ProjectSessionEdge!]!
+}
+
+"""An edge in a connection."""
+type ProjectSessionEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ProjectSession!
 }
 
 type PromptResponse {
@@ -1535,6 +1561,24 @@ type TraceAnnotationMutationPayload {
 input TraceAnnotationSort {
   col: TraceAnnotationColumn!
   dir: SortDir!
+}
+
+"""A connection to a list of items."""
+type TraceConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [TraceEdge!]!
+}
+
+"""An edge in a connection."""
+type TraceEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: Trace!
 }
 
 type UMAPPoint {

--- a/requirements/integration-tests.txt
+++ b/requirements/integration-tests.txt
@@ -8,6 +8,7 @@ portpicker
 psutil
 pyjwt
 pytest-randomly
+pytest-rerunfailures
 pytest-smtpd
 types-beautifulsoup4
 types-psutil

--- a/src/phoenix/db/migrations/versions/4ded9e43755f_create_trace_session_table.py
+++ b/src/phoenix/db/migrations/versions/4ded9e43755f_create_trace_session_table.py
@@ -1,0 +1,55 @@
+"""create project_session table
+
+Revision ID: 4ded9e43755f
+Revises: cd164e83824f
+Create Date: 2024-10-08 22:53:24.539786
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4ded9e43755f"
+down_revision: Union[str, None] = "cd164e83824f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_sessions",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("session_id", sa.String, unique=True, nullable=False),
+        sa.Column(
+            "project_id",
+            sa.Integer,
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("start_time", sa.TIMESTAMP(timezone=True), index=True, nullable=False),
+        sa.Column("end_time", sa.TIMESTAMP(timezone=True), index=True, nullable=False),
+    )
+    with op.batch_alter_table("traces") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "project_session_id",
+                sa.Integer,
+                sa.ForeignKey("project_sessions.id", ondelete="CASCADE"),
+                nullable=True,
+            ),
+        )
+    op.create_index(
+        "ix_traces_project_session_id",
+        "traces",
+        ["project_session_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_traces_project_session_id")
+    with op.batch_alter_table("traces") as batch_op:
+        batch_op.drop_column("project_session_id")
+    op.drop_table("project_sessions")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -156,6 +156,24 @@ class Project(Base):
     )
 
 
+class ProjectSession(Base):
+    __tablename__ = "project_sessions"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    session_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
+    end_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
+    traces: Mapped[List["Trace"]] = relationship(
+        "Trace",
+        back_populates="project_session",
+        uselist=True,
+    )
+
+
 class Trace(Base):
     __tablename__ = "traces"
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -164,6 +182,11 @@ class Trace(Base):
         index=True,
     )
     trace_id: Mapped[str]
+    project_session_id: Mapped[int] = mapped_column(
+        ForeignKey("project_sessions.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
     end_time: Mapped[datetime] = mapped_column(UtcTimeStamp)
 
@@ -187,6 +210,10 @@ class Trace(Base):
         back_populates="trace",
         cascade="all, delete-orphan",
         uselist=True,
+    )
+    project_session: Mapped[ProjectSession] = relationship(
+        "ProjectSession",
+        back_populates="traces",
     )
     experiment_runs: Mapped[List["ExperimentRun"]] = relationship(
         primaryjoin="foreign(ExperimentRun.trace_id) == Trace.trace_id",

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -72,6 +72,7 @@ from phoenix.server.api.types.pagination import (
     connection_from_list,
 )
 from phoenix.server.api.types.Project import Project
+from phoenix.server.api.types.ProjectSession import ProjectSession, to_gql_project_session
 from phoenix.server.api.types.SortDir import SortDir
 from phoenix.server.api.types.Span import Span, to_gql_span
 from phoenix.server.api.types.SystemApiKey import SystemApiKey
@@ -476,6 +477,14 @@ class Query:
             if span is None:
                 raise NotFound(f"Unknown span: {id}")
             return to_gql_span(span)
+        elif type_name == ProjectSession.__name__:
+            async with info.context.db() as session:
+                project_session = await session.scalar(
+                    select(models.ProjectSession).filter_by(id=node_id)
+                )
+            if project_session is None:
+                raise NotFound(f"Unknown project_session: {id}")
+            return to_gql_project_session(project_session)
         elif type_name == Dataset.__name__:
             dataset_stmt = select(models.Dataset).where(models.Dataset.id == node_id)
             async with info.context.db() as session:

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+import strawberry
+from sqlalchemy import desc, select
+from strawberry import UNSET, Info
+from strawberry.relay import Connection, Node, NodeID
+
+from phoenix.db import models
+from phoenix.server.api.context import Context
+from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, connection_from_list
+from phoenix.server.api.types.Trace import Trace, to_gql_trace
+
+
+@strawberry.type
+class ProjectSession(Node):
+    id_attr: NodeID[int]
+    session_id: str
+
+    @strawberry.field
+    async def traces(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+    ) -> Connection[Trace]:
+        args = ConnectionArgs(
+            first=first,
+            after=after if isinstance(after, CursorString) else None,
+            last=last,
+            before=before if isinstance(before, CursorString) else None,
+        )
+        stmt = (
+            select(models.Trace)
+            .filter_by(project_session_id=self.id_attr)
+            .order_by(desc(models.Trace.id))
+            .limit(first)
+        )
+        async with info.context.db() as session:
+            traces = await session.stream_scalars(stmt)
+            data = [to_gql_trace(trace) async for trace in traces]
+        return connection_from_list(data=data, args=args)
+
+
+def to_gql_project_session(
+    project_session: models.ProjectSession,
+) -> ProjectSession:
+    return ProjectSession(
+        id_attr=project_session.id,
+        session_id=project_session.session_id,
+    )

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -82,3 +82,11 @@ class Trace(Node):
                 stmt = stmt.order_by(models.TraceAnnotation.created_at.desc())
             annotations = await session.scalars(stmt)
         return [to_gql_trace_annotation(annotation) for annotation in annotations]
+
+
+def to_gql_trace(trace: models.Trace) -> Trace:
+    return Trace(
+        id_attr=trace.id,
+        project_rowid=trace.project_rowid,
+        trace_id=trace.trace_id,
+    )

--- a/tests/integration/db_migrations/conftest.py
+++ b/tests/integration/db_migrations/conftest.py
@@ -1,16 +1,20 @@
 import os
+from contextlib import ExitStack
 from pathlib import Path
 from secrets import token_hex
 from typing import Any, Iterator
+from unittest import mock
 
 import phoenix
 import pytest
 import sqlean  # type: ignore[import-untyped]
 from alembic.config import Config
-from phoenix.config import ENV_PHOENIX_SQL_DATABASE_SCHEMA, ENV_PHOENIX_SQL_DATABASE_URL
+from phoenix.config import ENV_PHOENIX_SQL_DATABASE_SCHEMA
 from phoenix.db.engines import set_postgresql_search_path
 from pytest import TempPathFactory
-from sqlalchemy import Engine, NullPool, create_engine, event, make_url
+from sqlalchemy import URL, Engine, NullPool, create_engine, event
+
+from integration._helpers import _random_schema
 
 
 @pytest.fixture
@@ -21,33 +25,46 @@ def _alembic_config() -> Config:
     return cfg
 
 
+@pytest.fixture(autouse=True, scope="function")
+def _env_postgresql_schema(
+    _sql_database_url: URL,
+) -> Iterator[None]:
+    if not _sql_database_url.get_backend_name().startswith("postgresql"):
+        yield
+        return
+    with ExitStack() as stack:
+        schema = stack.enter_context(_random_schema(_sql_database_url))
+        values = [(ENV_PHOENIX_SQL_DATABASE_SCHEMA, schema)]
+        stack.enter_context(mock.patch.dict(os.environ, values))
+        yield
+
+
 @pytest.fixture
 def _engine(
-    _env_phoenix_sql_database_url: Any,
+    _sql_database_url: URL,
+    _env_postgresql_schema: Any,
     tmp_path_factory: TempPathFactory,
 ) -> Iterator[Engine]:
-    url = make_url(os.environ[ENV_PHOENIX_SQL_DATABASE_URL])
-    backend = url.get_backend_name()
-    if backend.startswith("sqlite"):
+    backend = _sql_database_url.get_backend_name()
+    if backend == "sqlite":
         tmp = tmp_path_factory.getbasetemp() / Path(__file__).parent.name
         tmp.mkdir(parents=True, exist_ok=True)
         file = tmp / f".{token_hex(16)}.db"
-        database = f"file:///{file}"
         engine = create_engine(
-            url=url.set(drivername="sqlite", database=database),
-            creator=lambda: sqlean.connect(database, uri=True),
+            url=_sql_database_url.set(database=str(file)),
+            creator=lambda: sqlean.connect(f"file:///{file}", uri=True),
             poolclass=NullPool,
             echo=True,
         )
-    elif backend.startswith("postgresql"):
-        assert (schema := os.environ.get(ENV_PHOENIX_SQL_DATABASE_SCHEMA))
+    elif backend == "postgresql":
+        schema = os.environ[ENV_PHOENIX_SQL_DATABASE_SCHEMA]
         engine = create_engine(
-            url=url.set(drivername="postgresql+psycopg"),
+            url=_sql_database_url.set(drivername="postgresql+psycopg"),
             poolclass=NullPool,
             echo=True,
         )
         event.listen(engine, "connect", set_postgresql_search_path(schema))
     else:
-        pytest.fail(f"Unknown database backend: {backend}")
+        pytest.fail(f"Unknown backend: {backend}")
     yield engine
     engine.dispose()

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -1,38 +1,317 @@
 import os
+from typing import Optional, Tuple
 
 import pytest
 from alembic import command
 from alembic.config import Config
 from phoenix.config import ENV_PHOENIX_SQL_DATABASE_SCHEMA
-from sqlalchemy import Engine, text
+from sqlalchemy import (
+    INTEGER,
+    TIMESTAMP,
+    VARCHAR,
+    Engine,
+    ForeignKeyConstraint,
+    MetaData,
+    PrimaryKeyConstraint,
+    Row,
+    UniqueConstraint,
+    text,
+)
 
 
 def test_up_and_down_migrations(
-    _alembic_config: Config,
     _engine: Engine,
+    _alembic_config: Config,
 ) -> None:
-    table = "alembic_version"
+    with pytest.raises(BaseException, match="alembic_version"):
+        _version_num(_engine)
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "cf03bd6bae1d")
+        _down(_engine, _alembic_config, "base")
+    _up(_engine, _alembic_config, "cf03bd6bae1d")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "10460e46d750")
+        _down(_engine, _alembic_config, "cf03bd6bae1d")
+    _up(_engine, _alembic_config, "10460e46d750")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "3be8647b87d8")
+        _down(_engine, _alembic_config, "10460e46d750")
+    _up(_engine, _alembic_config, "3be8647b87d8")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "cd164e83824f")
+        _down(_engine, _alembic_config, "3be8647b87d8")
+    _up(_engine, _alembic_config, "cd164e83824f")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "4ded9e43755f")
+
+        metadata = MetaData()
+        metadata.reflect(bind=_engine)
+
+        assert (project_sessions := metadata.tables.get("project_sessions")) is not None
+
+        columns = {str(col.name): col for col in project_sessions.columns}
+
+        column = columns.pop("id", None)
+        assert column is not None
+        assert column.primary_key
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("session_id", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, VARCHAR)
+        del column
+
+        column = columns.pop("project_id", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("start_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        column = columns.pop("end_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        assert not columns
+        del columns
+
+        indexes = {str(idx.name): idx for idx in project_sessions.indexes}
+
+        index = indexes.pop("ix_project_sessions_start_time", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        index = indexes.pop("ix_project_sessions_end_time", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        assert not indexes
+        del indexes
+
+        constraints = {str(con.name): con for con in project_sessions.constraints}
+
+        constraint = constraints.pop("pk_project_sessions", None)
+        assert constraint is not None
+        assert isinstance(constraint, PrimaryKeyConstraint)
+        del constraint
+
+        constraint = constraints.pop("uq_project_sessions_session_id", None)
+        assert constraint is not None
+        assert isinstance(constraint, UniqueConstraint)
+        del constraint
+
+        constraint = constraints.pop("fk_project_sessions_project_id_projects", None)
+        assert constraint is not None
+        assert isinstance(constraint, ForeignKeyConstraint)
+        assert constraint.ondelete == "CASCADE"
+        del constraint
+
+        assert not constraints
+        del constraints
+
+        assert (traces := metadata.tables.get("traces")) is not None
+
+        columns = {str(col.name): col for col in traces.columns}
+
+        column = columns.pop("id", None)
+        assert column is not None
+        assert column.primary_key
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("trace_id", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, VARCHAR)
+        del column
+
+        column = columns.pop("project_rowid", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("start_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        column = columns.pop("end_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        column = columns.pop("project_session_id", None)
+        assert column is not None
+        assert column.nullable
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        assert not columns
+        del columns
+
+        indexes = {str(idx.name): idx for idx in traces.indexes}
+
+        index = indexes.pop("ix_traces_project_rowid", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        index = indexes.pop("ix_traces_start_time", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        index = indexes.pop("ix_traces_project_session_id", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        assert not indexes
+        del indexes
+
+        constraints = {str(con.name): con for con in traces.constraints}
+
+        constraint = constraints.pop("pk_traces", None)
+        assert isinstance(constraint, PrimaryKeyConstraint)
+        del constraint
+
+        constraint = constraints.pop("uq_traces_trace_id", None)
+        assert isinstance(constraint, UniqueConstraint)
+        del constraint
+
+        constraint = constraints.pop("fk_traces_project_rowid_projects", None)
+        assert isinstance(constraint, ForeignKeyConstraint)
+        assert constraint.ondelete == "CASCADE"
+        del constraint
+
+        constraint = constraints.pop("fk_traces_project_session_id_project_sessions", None)
+        assert isinstance(constraint, ForeignKeyConstraint)
+        assert constraint.ondelete == "CASCADE"
+        del constraint
+
+        assert not constraints
+        del constraints
+
+        _down(_engine, _alembic_config, "cd164e83824f")
+
+        metadata = MetaData()
+        metadata.reflect(bind=_engine)
+
+        assert metadata.tables.get("project_sessions") is None
+
+        assert (traces := metadata.tables.get("traces")) is not None
+
+        columns = {str(col.name): col for col in traces.columns}
+
+        column = columns.pop("id", None)
+        assert column is not None
+        assert column.primary_key
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("trace_id", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, VARCHAR)
+        del column
+
+        column = columns.pop("project_rowid", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, INTEGER)
+        del column
+
+        column = columns.pop("start_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        column = columns.pop("end_time", None)
+        assert column is not None
+        assert not column.nullable
+        assert isinstance(column.type, TIMESTAMP)
+        del column
+
+        assert not columns
+        del columns
+
+        indexes = {str(idx.name): idx for idx in traces.indexes}
+
+        index = indexes.pop("ix_traces_project_rowid", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        index = indexes.pop("ix_traces_start_time", None)
+        assert index is not None
+        assert not index.unique
+        del index
+
+        assert not indexes
+        del indexes
+
+        constraints = {str(con.name): con for con in traces.constraints}
+
+        constraint = constraints.pop("pk_traces", None)
+        assert isinstance(constraint, PrimaryKeyConstraint)
+        del constraint
+
+        constraint = constraints.pop("uq_traces_trace_id", None)
+        assert isinstance(constraint, UniqueConstraint)
+        del constraint
+
+        constraint = constraints.pop("fk_traces_project_rowid_projects", None)
+        assert isinstance(constraint, ForeignKeyConstraint)
+        assert constraint.ondelete == "CASCADE"
+        del constraint
+
+        assert not constraints
+        del constraints
+    _up(_engine, _alembic_config, "4ded9e43755f")
+
+
+def _up(_engine: Engine, _alembic_config: Config, revision: str) -> None:
+    with _engine.connect() as conn:
+        _alembic_config.attributes["connection"] = conn
+        command.upgrade(_alembic_config, revision)
+    _engine.dispose()
+    assert _version_num(_engine) == (revision,)
+
+
+def _down(_engine: Engine, _alembic_config: Config, revision: str) -> None:
+    with _engine.connect() as conn:
+        _alembic_config.attributes["connection"] = conn
+        command.downgrade(_alembic_config, revision)
+    _engine.dispose()
+    assert _version_num(_engine) == (None if revision == "base" else (revision,))
+
+
+def _version_num(_engine: Engine) -> Optional[Row[Tuple[str]]]:
+    schema_prefix = ""
     if _engine.url.get_backend_name().startswith("postgresql"):
-        schema = os.environ[ENV_PHOENIX_SQL_DATABASE_SCHEMA]
-        assert schema
-        table = f"{schema}.{table}"
-    stmt = text(f"SELECT version_num FROM {table}")
+        assert (schema := os.environ[ENV_PHOENIX_SQL_DATABASE_SCHEMA])
+        schema_prefix = f"{schema}."
+    table, column = "alembic_version", "version_num"
+    stmt = text(f"SELECT {column} FROM {schema_prefix}{table}")
     with _engine.connect() as conn:
-        with pytest.raises(BaseException, match=table):
-            conn.execute(stmt)
-    _engine.dispose()
-    with _engine.connect() as conn:
-        _alembic_config.attributes["connection"] = conn
-        command.upgrade(_alembic_config, "head")
-    _engine.dispose()
-    with _engine.connect() as conn:
-        version_num = conn.execute(stmt).first()
-        assert version_num == ("cd164e83824f",)
-    _engine.dispose()
-    with _engine.connect() as conn:
-        _alembic_config.attributes["connection"] = conn
-        command.downgrade(_alembic_config, "base")
-    _engine.dispose()
-    with _engine.connect() as conn:
-        assert conn.execute(stmt).first() is None
-    _engine.dispose()
+        return conn.execute(stmt).first()

--- a/tests/integration/project_sessions/conftest.py
+++ b/tests/integration/project_sessions/conftest.py
@@ -1,0 +1,13 @@
+from typing import Any, Iterator
+
+import pytest
+
+from .._helpers import _server
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _app(
+    _env_phoenix_sql_database_url: Any,
+) -> Iterator[None]:
+    with _server():
+        yield

--- a/tests/integration/project_sessions/test_project_sessions.py
+++ b/tests/integration/project_sessions/test_project_sessions.py
@@ -1,0 +1,93 @@
+from contextlib import ExitStack
+from secrets import token_hex
+from time import sleep
+from typing import List
+
+import pytest
+from openinference.semconv.trace import SpanAttributes
+from opentelemetry.trace import Span, use_span
+from opentelemetry.util.types import AttributeValue
+from pytest import param
+
+from .._helpers import _gql, _grpc_span_exporter, _start_span
+
+
+class TestProjectSessions:
+    @pytest.mark.parametrize(
+        "session_id",
+        [
+            param(0, id="integer"),
+            param(3.14, id="float"),
+            param(True, id="bool"),
+            param("abc", id="string"),
+            param(" a b c ", id="string with extra spaces"),
+            param(" ", id="empty string"),
+            param([1, 2], id="list of integers"),
+            param([1.1, 2.2], id="list of floats"),
+            param([True, False], id="list of bools"),
+            param(["a", "b"], id="list of strings"),
+            param([], id="empty list"),
+        ],
+    )
+    def test_span_ingestion_with_session_id(
+        self,
+        session_id: AttributeValue,
+    ) -> None:
+        # remove extra whitespaces
+        str_session_id = str(session_id).strip()
+        num_traces, num_spans_per_trace = 2, 3
+        assert num_traces > 1 and num_spans_per_trace > 2
+        project_names = [token_hex(8)]
+        spans: List[Span] = []
+        for _ in range(num_traces):
+            project_names.append(token_hex(8))
+            with ExitStack() as stack:
+                for i in range(num_spans_per_trace):
+                    if i == 0:
+                        # Not all spans are required to have `session_id`.
+                        attributes = None
+                    elif i == 1:
+                        # In case of conflict, the `Span` with later `end_time` wins.
+                        attributes = {SpanAttributes.SESSION_ID: session_id}
+                    elif str_session_id:
+                        attributes = {SpanAttributes.SESSION_ID: token_hex(8)}
+                    span = _start_span(
+                        project_name=project_names[-1],
+                        exporter=_grpc_span_exporter(),
+                        attributes=attributes,
+                    )
+                    spans.append(span)
+                    stack.enter_context(use_span(span, end_on_exit=True))
+                    sleep(0.001)
+        assert len(spans) == num_traces * num_spans_per_trace
+        sleep(5)
+        res, *_ = _gql(
+            query="query{"
+            "projects(first: 1000){edges{node{name "
+            "sessions(first: 1000){edges{node{sessionId "
+            "traces(first: 1000){edges{node{"
+            "spans(first: 1000){edges{node{context{spanId}}}}}}}}}}}}}}"
+        )
+        project_name = project_names[-1]
+        sessions_by_project = {
+            edge["node"]["name"]: {
+                session["node"]["sessionId"]: session
+                for session in edge["node"]["sessions"]["edges"]
+            }
+            for edge in res["data"]["projects"]["edges"]
+            if edge["node"]["name"] == project_name
+        }
+        sessions_by_id = sessions_by_project.get(project_name)
+        if not str_session_id:
+            assert not sessions_by_id
+            return
+        assert sessions_by_id
+        assert (session := sessions_by_id.get(str_session_id))
+        assert (traces := [edge["node"] for edge in session["node"]["traces"]["edges"]])
+        assert len(traces) == num_traces
+        gql_spans = [edge["node"] for trace in traces for edge in trace["spans"]["edges"]]
+        assert len(gql_spans) == len(spans)
+        expected_span_ids = {
+            span.get_span_context().span_id.to_bytes(8, "big").hex() for span in spans
+        }
+        assert {span["context"]["spanId"] for span in gql_spans} == expected_span_ids

--- a/tests/integration/server/test_launch_app.py
+++ b/tests/integration/server/test_launch_app.py
@@ -28,7 +28,7 @@ class TestLaunchApp:
                     _start_span(
                         project_name=project_name,
                         span_name=span_name,
-                        exporter=exporter(headers=None),
+                        exporter=exporter(),
                     ).end()
                 sleep(2)
                 project = _get_gql_spans(None, "name")[project_name]


### PR DESCRIPTION
resolves #4854 
resolves #5010

# Notes
- Added `project_sessions` with foreign key on `traces`
- Since each span can have a different the project name, to eliminate ambiguity, the project for the session is defined by the span with the max `end_time`.

<img width="400" alt="Screenshot 2024-10-15 at 3 59 01 PM" src="https://github.com/user-attachments/assets/1b11ebb5-41c2-4b6b-9d77-620e08a6340f">
