### PR TITLE
fix(playground): Remove unused statements in language grammars

### DIFF
--- a/app/src/components/templateEditor/language/fString/fStringTemplating.syntax.grammar
+++ b/app/src/components/templateEditor/language/fString/fStringTemplating.syntax.grammar
@@ -31,5 +31,4 @@
 @local tokens {
   RBrace { "}" }
   Variable { ("\\" "}") | (![}])+ }
-  @else else
 }

--- a/app/src/components/templateEditor/language/mustacheLike/mustacheLikeTemplating.syntax.grammar
+++ b/app/src/components/templateEditor/language/mustacheLike/mustacheLikeTemplating.syntax.grammar
@@ -31,5 +31,4 @@
 @local tokens {
   RBrace { "}}" }
   Variable { (![}])+ | "{" (![}])+ ("}" | "\\") }
-  @else else
 }


### PR DESCRIPTION
Removes this warning from `pnpm dev`

<img width="981" alt="image" src="https://github.com/user-attachments/assets/0fb94e58-12f7-4335-a272-38a2c0bae6c8">
