### PR TITLE
feat(playground): Implement editable input variable textareas (#4987)

### DIFF
--- a/app/src/components/code/CodeWrap.tsx
+++ b/app/src/components/code/CodeWrap.tsx
@@ -1,10 +1,18 @@
 import React, { ReactNode } from "react";
 
-import { View } from "@arizeai/components";
+import { View, ViewStyleProps } from "@arizeai/components";
 
-export function CodeWrap({ children }: { children: ReactNode }) {
+export function CodeWrap({
+  children,
+  ...props
+}: { children: ReactNode } & ViewStyleProps) {
   return (
-    <View borderColor="light" borderWidth="thin" borderRadius="small">
+    <View
+      borderColor="light"
+      borderWidth="thin"
+      borderRadius="small"
+      {...props}
+    >
       {children}
     </View>
   );

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -22,6 +22,7 @@ import { InitialPlaygroundState } from "@phoenix/store";
 
 import { NUM_MAX_PLAYGROUND_INSTANCES } from "./constants";
 import { PlaygroundCredentialsDropdown } from "./PlaygroundCredentialsDropdown";
+import { PlaygroundInput } from "./PlaygroundInput";
 import { PlaygroundInputTypeTypeRadioGroup } from "./PlaygroundInputModeRadioGroup";
 import { PlaygroundOutput } from "./PlaygroundOutput";
 import { PlaygroundRunButton } from "./PlaygroundRunButton";
@@ -121,7 +122,6 @@ const playgroundInputOutputPanelContentCSS = css`
 
 function PlaygroundContent() {
   const instances = usePlaygroundContext((state) => state.instances);
-  const inputs = usePlaygroundContext((state) => state.input);
   const numInstances = instances.length;
   const isSingleInstance = numInstances === 1;
 
@@ -170,13 +170,9 @@ function PlaygroundContent() {
               id="input"
               extra={<PlaygroundInputTypeTypeRadioGroup />}
             >
-              <pre>
-                {JSON.stringify(
-                  "variables" in inputs ? inputs.variables : "inputs go here",
-                  null,
-                  2
-                )}
-              </pre>
+              <View padding="size-200">
+                <PlaygroundInput />
+              </View>
             </AccordionItem>
             <AccordionItem title="Output" id="output">
               <View padding="size-200" height="100%">

--- a/app/src/pages/playground/PlaygroundInput.tsx
+++ b/app/src/pages/playground/PlaygroundInput.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
-import { Flex } from "@arizeai/components";
+import { Flex, Text, View } from "@arizeai/components";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import {
   selectDerivedInputVariables,
   selectInputVariableKeys,
 } from "@phoenix/store";
+import { assertUnreachable } from "@phoenix/typeUtils";
 
 import { VariableEditor } from "./VariableEditor";
 
@@ -16,15 +17,50 @@ export function PlaygroundInput() {
   const setVariableValue = usePlaygroundContext(
     (state) => state.setVariableValue
   );
+  const templateLanguage = usePlaygroundContext(
+    (state) => state.templateLanguage
+  );
+
+  if (variableKeys.length === 0) {
+    let templateSyntax = "";
+    switch (templateLanguage) {
+      case "f-string": {
+        templateSyntax = "{input name}";
+        break;
+      }
+      case "mustache": {
+        templateSyntax = "{{input name}}";
+        break;
+      }
+      default:
+        assertUnreachable(templateLanguage);
+    }
+    return (
+      <View padding="size-100">
+        <Flex direction="column" justifyContent="center" alignItems="center">
+          <Text color="text-700">
+            Add variable inputs to your prompt using{" "}
+            <Text color="text-900">{templateSyntax}</Text> within your prompt
+            template.
+          </Text>
+        </Flex>
+      </View>
+    );
+  }
+
   return (
     <Flex direction="column" gap="size-200" width="100%">
-      {variableKeys.map((key) => {
+      {variableKeys.map((variableKey, i) => {
         return (
           <VariableEditor
-            key={key}
-            label={key}
-            value={variables[key]}
-            onChange={(value) => setVariableValue(key, value)}
+            // using the index as the key actually prevents the UI from
+            // flickering; if we use the variable key directly, it will
+            // re-mount the entire editor and cause a flicker because key may
+            // change rapidly for a given variable
+            key={i}
+            label={variableKey}
+            value={variables[variableKey]}
+            onChange={(value) => setVariableValue(variableKey, value)}
           />
         );
       })}

--- a/app/src/pages/playground/PlaygroundInput.tsx
+++ b/app/src/pages/playground/PlaygroundInput.tsx
@@ -1,11 +1,36 @@
 import React from "react";
 
-import { Card } from "@arizeai/components";
+import { Card, Flex, TextArea } from "@arizeai/components";
+
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import {
+  selectDerivedInputVariables,
+  selectInputVariableKeys,
+} from "@phoenix/store";
 
 export function PlaygroundInput() {
+  const variables = usePlaygroundContext(selectDerivedInputVariables);
+  const variableKeys = usePlaygroundContext(selectInputVariableKeys);
+  const setVariableValue = usePlaygroundContext(
+    (state) => state.setVariableValue
+  );
   return (
     <Card title="Input" collapsible variant="compact">
-      Input goes here
+      <Flex direction="column" gap="size-200" width="100%">
+        {variableKeys.map((key) => {
+          return (
+            <TextArea
+              key={key}
+              label={key}
+              value={variables[key]}
+              height={65}
+              onChange={(value) => {
+                setVariableValue(key, value);
+              }}
+            />
+          );
+        })}
+      </Flex>
     </Card>
   );
 }

--- a/app/src/pages/playground/PlaygroundInput.tsx
+++ b/app/src/pages/playground/PlaygroundInput.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 
-import { Card, Flex, TextArea } from "@arizeai/components";
+import { Flex } from "@arizeai/components";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import {
   selectDerivedInputVariables,
   selectInputVariableKeys,
 } from "@phoenix/store";
+
+import { VariableEditor } from "./VariableEditor";
 
 export function PlaygroundInput() {
   const variables = usePlaygroundContext(selectDerivedInputVariables);
@@ -15,22 +17,17 @@ export function PlaygroundInput() {
     (state) => state.setVariableValue
   );
   return (
-    <Card title="Input" collapsible variant="compact">
-      <Flex direction="column" gap="size-200" width="100%">
-        {variableKeys.map((key) => {
-          return (
-            <TextArea
-              key={key}
-              label={key}
-              value={variables[key]}
-              height={65}
-              onChange={(value) => {
-                setVariableValue(key, value);
-              }}
-            />
-          );
-        })}
-      </Flex>
-    </Card>
+    <Flex direction="column" gap="size-200" width="100%">
+      {variableKeys.map((key) => {
+        return (
+          <VariableEditor
+            key={key}
+            label={key}
+            value={variables[key]}
+            onChange={(value) => setVariableValue(key, value)}
+          />
+        );
+      })}
+    </Flex>
   );
 }

--- a/app/src/pages/playground/VariableEditor.tsx
+++ b/app/src/pages/playground/VariableEditor.tsx
@@ -5,10 +5,10 @@ import ReactCodeMirror, {
   BasicSetupOptions,
   EditorView,
 } from "@uiw/react-codemirror";
-import { css } from "@emotion/react";
 
 import { Field } from "@arizeai/components";
 
+import { CodeWrap } from "@phoenix/components/code";
 import { useTheme } from "@phoenix/contexts";
 
 type VariableEditorProps = {
@@ -37,11 +37,7 @@ export const VariableEditor = ({
   const codeMirrorTheme = theme === "light" ? githubLight : nord;
   return (
     <Field label={label}>
-      <div
-        css={css`
-          width: 100%;
-        `}
-      >
+      <CodeWrap width="100%">
         <ReactCodeMirror
           theme={codeMirrorTheme}
           basicSetup={basicSetupOptions}
@@ -49,7 +45,7 @@ export const VariableEditor = ({
           extensions={extensions}
           onChange={onChange}
         />
-      </div>
+      </CodeWrap>
     </Field>
   );
 };

--- a/app/src/pages/playground/VariableEditor.tsx
+++ b/app/src/pages/playground/VariableEditor.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { githubLight } from "@uiw/codemirror-theme-github";
+import { nord } from "@uiw/codemirror-theme-nord";
+import ReactCodeMirror, {
+  BasicSetupOptions,
+  EditorView,
+} from "@uiw/react-codemirror";
+import { css } from "@emotion/react";
+
+import { Field } from "@arizeai/components";
+
+import { useTheme } from "@phoenix/contexts";
+
+type VariableEditorProps = {
+  label?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+};
+
+const basicSetupOptions: BasicSetupOptions = {
+  lineNumbers: false,
+  highlightActiveLine: false,
+  foldGutter: false,
+  highlightActiveLineGutter: false,
+  bracketMatching: false,
+  syntaxHighlighting: false,
+};
+
+const extensions = [EditorView.lineWrapping];
+
+export const VariableEditor = ({
+  label,
+  value,
+  onChange,
+}: VariableEditorProps) => {
+  const { theme } = useTheme();
+  const codeMirrorTheme = theme === "light" ? githubLight : nord;
+  return (
+    <Field label={label}>
+      <div
+        css={css`
+          width: 100%;
+        `}
+      >
+        <ReactCodeMirror
+          theme={codeMirrorTheme}
+          basicSetup={basicSetupOptions}
+          value={value}
+          extensions={extensions}
+          onChange={onChange}
+        />
+      </div>
+    </Field>
+  );
+};

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -26,7 +26,7 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
     provider: "OPENAI",
     modelName: "gpt-4o",
   },
-  input: { variables: {} },
+  input: { variableKeys: [], variablesValueCache: {} },
   tools: [],
   toolChoice: "auto",
   template: {

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -129,6 +129,9 @@ export const createPlaygroundStore = (
     operationType: "chat",
     inputMode: "manual",
     input: {
+      // select variablesValueCache and variableKeys from the input in order
+      // to capture the current value of all valid variables across all instances' prompts
+      // if you just select variablesValueCache, then you may display stale values
       variablesValueCache: {
         question: "",
       },

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -93,7 +93,8 @@ export function createPlaygroundInstance(): PlaygroundInstance {
     model: { provider: "OPENAI", modelName: "gpt-4o" },
     tools: [],
     toolChoice: "auto",
-    input: { variables: {} },
+    // TODO(apowell) - use datasetId if in dataset mode
+    input: { variablesValueCache: {}, variableKeys: [] },
     output: undefined,
     activeRunId: null,
     isRunning: false,
@@ -128,15 +129,10 @@ export const createPlaygroundStore = (
     operationType: "chat",
     inputMode: "manual",
     input: {
-      // TODO(apowell): When implementing variable forms, we should maintain a separate
-      // map of variableName to variableValue. This will allow us to "cache" variable values
-      // as the user types and will prevent data loss if users accidentally change the variable name
-      variables: {
-        // TODO(apowell): This is hardcoded based on the default chat template
-        // Instead we should calculate this based on the template on store creation
-        // Not a huge deal since this will be overridden on the first keystroke
+      variablesValueCache: {
         question: "",
       },
+      variableKeys: ["question"],
     },
     templateLanguage: TemplateLanguages.Mustache,
     setInputMode: (inputMode: PlaygroundInputMode) => set({ inputMode }),
@@ -295,7 +291,7 @@ export const createPlaygroundStore = (
     },
     calculateVariables: () => {
       const instances = get().instances;
-      const variables: Record<string, string> = {};
+      const variables = new Set<string>();
       const utils = getTemplateLanguageUtils(get().templateLanguage);
       instances.forEach((instance) => {
         const instanceType = instance.template.__type;
@@ -310,7 +306,7 @@ export const createPlaygroundStore = (
                 message.content
               );
               extractedVariables.forEach((variable) => {
-                variables[variable] = "";
+                variables.add(variable);
               });
             });
             break;
@@ -320,7 +316,7 @@ export const createPlaygroundStore = (
               instance.template.prompt
             );
             extractedVariables.forEach((variable) => {
-              variables[variable] = "";
+              variables.add(variable);
             });
             break;
           }
@@ -329,7 +325,20 @@ export const createPlaygroundStore = (
           }
         }
       });
-      set({ input: { variables: { ...variables } } });
+      set({
+        input: { ...get().input, variableKeys: [...Array.from(variables)] },
+      });
+    },
+    setVariableValue: (key: string, value: string) => {
+      const input = get().input;
+      if ("variablesValueCache" in input) {
+        set({
+          input: {
+            ...input,
+            variablesValueCache: { ...input.variablesValueCache, [key]: value },
+          },
+        });
+      }
     },
     ...initialProps,
   });
@@ -337,3 +346,34 @@ export const createPlaygroundStore = (
 };
 
 export type PlaygroundStore = ReturnType<typeof createPlaygroundStore>;
+
+/**
+ * Selects the variable keys from the playground state
+ * @param state the playground state
+ * @returns the variable keys
+ */
+export const selectInputVariableKeys = (state: PlaygroundState) => {
+  if ("variableKeys" in state.input) {
+    return state.input.variableKeys;
+  }
+  return [];
+};
+
+/**
+ * Selects the derived input variables from the playground state
+ * @param state the playground state
+ * @returns the derived input variables
+ */
+export const selectDerivedInputVariables = (state: PlaygroundState) => {
+  if ("variableKeys" in state.input) {
+    const input = state.input;
+    const variableKeys = input.variableKeys;
+    const variablesValueCache = input.variablesValueCache;
+    const valueMap: Record<string, string> = {};
+    variableKeys.forEach((key) => {
+      valueMap[key] = variablesValueCache?.[key] || "";
+    });
+    return valueMap;
+  }
+  return {};
+};

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -130,9 +130,9 @@ export const createPlaygroundStore = (
     operationType: "chat",
     inputMode: "manual",
     input: {
-      // select variablesValueCache and variableKeys from the input in order
-      // to capture the current value of all valid variables across all instances' prompts
-      // if you just select variablesValueCache, then you may display stale values
+      // to get a record of visible variables and their values,
+      // use usePlaygroundContext(selectDerivedInputVariables). do not render variablesValueCache
+      // directly or users will see stale values.
       variablesValueCache: {
         question: "",
       },

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -9,6 +9,7 @@ import { assertUnreachable } from "@phoenix/typeUtils";
 import {
   GenAIOperationType,
   InitialPlaygroundState,
+  isManualInput,
   PlaygroundChatTemplate,
   PlaygroundInputMode,
   PlaygroundInstance,
@@ -334,7 +335,7 @@ export const createPlaygroundStore = (
     },
     setVariableValue: (key: string, value: string) => {
       const input = get().input;
-      if ("variablesValueCache" in input) {
+      if (isManualInput(input)) {
         set({
           input: {
             ...input,
@@ -356,7 +357,7 @@ export type PlaygroundStore = ReturnType<typeof createPlaygroundStore>;
  * @returns the variable keys
  */
 export const selectInputVariableKeys = (state: PlaygroundState) => {
-  if ("variableKeys" in state.input) {
+  if (isManualInput(state.input)) {
     return state.input.variableKeys;
   }
   return [];
@@ -368,7 +369,7 @@ export const selectInputVariableKeys = (state: PlaygroundState) => {
  * @returns the derived input variables
  */
 export const selectDerivedInputVariables = (state: PlaygroundState) => {
-  if ("variableKeys" in state.input) {
+  if (isManualInput(state.input)) {
     const input = state.input;
     const variableKeys = input.variableKeys;
     const variablesValueCache = input.variablesValueCache;

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -49,7 +49,8 @@ type DatasetInput = {
 };
 
 type ManualInput = {
-  variables: Record<string, string>;
+  variablesValueCache: Record<string, string>;
+  variableKeys: string[];
 };
 
 type PlaygroundInput = DatasetInput | ManualInput;
@@ -190,4 +191,6 @@ export interface PlaygroundState extends PlaygroundProps {
    * Calculate the variables used across all instances
    */
   calculateVariables: () => void;
+
+  setVariableValue: (key: string, value: string) => void;
 }

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -49,7 +49,7 @@ type DatasetInput = {
 };
 
 type ManualInput = {
-  variablesValueCache: Record<string, string>;
+  variablesValueCache: Record<string, string | undefined>;
   variableKeys: string[];
 };
 
@@ -194,3 +194,19 @@ export interface PlaygroundState extends PlaygroundProps {
 
   setVariableValue: (key: string, value: string) => void;
 }
+
+/**
+ * Check if the input is manual
+ */
+export const isManualInput = (input: PlaygroundInput): input is ManualInput => {
+  return "variablesValueCache" in input && "variableKeys" in input;
+};
+
+/**
+ * Check if the input is a dataset
+ */
+export const isDatasetInput = (
+  input: PlaygroundInput
+): input is DatasetInput => {
+  return "datasetId" in input;
+};


### PR DESCRIPTION

https://github.com/user-attachments/assets/aabfe5ad-8d0a-4058-be8d-e1dc581e9e51

Uses codemirror without lang and with line wrapping.
Additionally, implements a variable value cache so that variable values stick around when changing syntax type or variable name.