### PR TITLE
feat(playground): parse model name and infer provider form span

### DIFF
--- a/app/src/constants/generativeConstants.ts
+++ b/app/src/constants/generativeConstants.ts
@@ -6,3 +6,10 @@ export const ModelProviders: Record<ModelProvider, string> = {
   AZURE_OPENAI: "Azure OpenAI",
   ANTHROPIC: "Anthropic",
 };
+
+/**
+ * The default model provider
+ */
+export const DEFAULT_MODEL_PROVIDER: ModelProvider = "OPENAI";
+
+export const DEFAULT_CHAT_ROLE: ChatMessageRole = "user";

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   startTransition,
   Suspense,
+  useCallback,
   useState,
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
@@ -14,6 +15,7 @@ import {
   Flex,
   Form,
   Text,
+  TextField,
   View,
 } from "@arizeai/components";
 
@@ -95,6 +97,20 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
     `,
     { providerKey: instance.model.provider }
   );
+
+  const onModelNameChange = useCallback(
+    (modelName: string) => {
+      updateModel({
+        instanceId: playgroundInstanceId,
+        model: {
+          provider: instance.model.provider,
+          modelName,
+        },
+      });
+    },
+    [instance.model.provider, playgroundInstanceId, updateModel]
+  );
+
   return (
     <View padding="size-200">
       <Form>
@@ -111,20 +127,19 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
             });
           }}
         />
-        <ModelPicker
-          modelName={instance.model.modelName}
-          provider={instance.model.provider}
-          query={query}
-          onChange={(modelName) => {
-            updateModel({
-              instanceId: playgroundInstanceId,
-              model: {
-                provider: instance.model.provider,
-                modelName,
-              },
-            });
-          }}
-        />
+        {instance.model.provider === "AZURE_OPENAI" ? (
+          <TextField
+            value={instance.model.modelName ?? ""}
+            onChange={onModelNameChange}
+          />
+        ) : (
+          <ModelPicker
+            modelName={instance.model.modelName}
+            provider={instance.model.provider}
+            query={query}
+            onChange={onModelNameChange}
+          />
+        )}
       </Form>
     </View>
   );

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -129,6 +129,7 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
         />
         {instance.model.provider === "AZURE_OPENAI" ? (
           <TextField
+            label="Deployment Name"
             value={instance.model.modelName ?? ""}
             onChange={onModelNameChange}
           />

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MODEL_PROVIDER } from "@phoenix/constants/generativeConstants";
 import {
   _resetInstanceId,
   _resetMessageId,
@@ -325,9 +326,9 @@ describe("getModelProviderFromModelName", () => {
     );
   });
 
-  it("should return AZURE_OPENAI if the model name does not match any known models", () => {
-    expect(getModelProviderFromModelName("test-my-deployment")).toEqual(
-      "AZURE_OPENAI"
+  it(`should return ${DEFAULT_MODEL_PROVIDER} if the model name does not match any known models`, () => {
+    expect(getModelProviderFromModelName("test-my-model")).toEqual(
+      DEFAULT_MODEL_PROVIDER
     );
   });
 });

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -233,7 +233,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
         model_name: "claude-3-5-sonnet-20240620",
       },
     });
-    const azureAttributes = JSON.stringify({
+    const unknownAttributes = JSON.stringify({
       ...spanAttributesWithInputMessages,
       llm: {
         ...spanAttributesWithInputMessages.llm,
@@ -282,13 +282,13 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
     expect(
       transformSpanAttributesToPlaygroundInstance({
         ...basePlaygroundSpan,
-        attributes: azureAttributes,
+        attributes: unknownAttributes,
       })
     ).toEqual({
       playgroundInstance: {
         ...expectedPlaygroundInstanceWithIO,
         model: {
-          provider: "AZURE_OPENAI",
+          provider: DEFAULT_MODEL_PROVIDER,
           modelName: "test-my-deployment",
         },
       },

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -1,7 +1,5 @@
 export const NUM_MAX_PLAYGROUND_INSTANCES = 4;
 
-export const DEFAULT_CHAT_ROLE = "user";
-
 /**
  * Map of {@link ChatMessageRole} to potential role values.
  * Used to map roles to a canonical role.
@@ -26,3 +24,9 @@ export const SPAN_ATTRIBUTES_PARSING_ERROR =
   "Unable to parse span attributes, attributes must be valid JSON.";
 export const MODEL_NAME_PARSING_ERROR =
   "Unable to parse model name, expected llm.model_name to be present.";
+
+export const modelProviderToModelPrefixMap: Record<ModelProvider, string[]> = {
+  AZURE_OPENAI: [],
+  ANTHROPIC: ["claude"],
+  OPENAI: ["gpt", "o1"],
+};

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -12,3 +12,17 @@ export const ChatRoleMap: Record<ChatMessageRole, string[]> = {
   system: ["system"],
   tool: ["tool"],
 };
+
+/**
+ * Parsing errors for parsing a span to a playground instance
+ */
+export const INPUT_MESSAGES_PARSING_ERROR =
+  "Unable to parse span input messages, expected messages which include a role and content.";
+export const OUTPUT_MESSAGES_PARSING_ERROR =
+  "Unable to parse span output messages, expected messages which include a role and content.";
+export const OUTPUT_VALUE_PARSING_ERROR =
+  "Unable to parse span output expected output.value to be present.";
+export const SPAN_ATTRIBUTES_PARSING_ERROR =
+  "Unable to parse span attributes, attributes must be valid JSON.";
+export const MODEL_NAME_PARSING_ERROR =
+  "Unable to parse model name, expected llm.model_name to be present.";

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -65,7 +65,6 @@ export const llmOutputMessageSchema = z.object({
 /**
  * The zod schema for output attributes
  * @see {@link https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md|Semantic Conventions}
-
  */
 export const outputSchema = z.object({
   [SemanticAttributePrefixes.output]: z.object({
@@ -92,3 +91,13 @@ const chatMessageSchema = schemaForType<ChatMessage>()(
  * The zod schema for ChatMessages
  */
 export const chatMessagesSchema = z.array(chatMessageSchema);
+
+/**
+ * The zod schema for llm model name
+ * @see {@link https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md|Semantic Conventions}
+ */
+export const modelNameSchema = z.object({
+  [SemanticAttributePrefixes.llm]: z.object({
+    [LLMAttributePostfixes.model_name]: z.string(),
+  }),
+});

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -4,6 +4,10 @@ import { devtools } from "zustand/middleware";
 import { TemplateLanguages } from "@phoenix/components/templateEditor/constants";
 import { getTemplateLanguageUtils } from "@phoenix/components/templateEditor/templateEditorUtils";
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
+import {
+  DEFAULT_CHAT_ROLE,
+  DEFAULT_MODEL_PROVIDER,
+} from "@phoenix/constants/generativeConstants";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
@@ -90,7 +94,7 @@ export function createPlaygroundInstance(): PlaygroundInstance {
   return {
     id: generateInstanceId(),
     template: generateChatCompletionTemplate(),
-    model: { provider: "OPENAI", modelName: "gpt-4o" },
+    model: { provider: DEFAULT_MODEL_PROVIDER, modelName: "gpt-4o" },
     tools: [],
     toolChoice: "auto",
     input: { variables: {} },
@@ -226,7 +230,7 @@ export const createPlaygroundStore = (
               ...instance,
               messages: [
                 ...instance.template.messages,
-                { role: "user", content: "{question}" },
+                { role: DEFAULT_CHAT_ROLE, content: "{question}" },
               ],
             };
           }

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -54,7 +54,7 @@ type ManualInput = {
 
 type PlaygroundInput = DatasetInput | ManualInput;
 
-type ModelConfig = {
+export type ModelConfig = {
   provider: ModelProvider;
   modelName: string | null;
 };


### PR DESCRIPTION
resolves #4998 


https://github.com/user-attachments/assets/3adad49d-73a0-4b15-a4eb-f278288447cd


### Small fix on azure
Azure OpenAI api requires you to pass in a string model name which matches the deployment name which is user defined (backed by a real open ai model)
Note: Still missing - azure endpoint / api version: https://github.com/Arize-ai/phoenix/issues/5023



https://github.com/user-attachments/assets/bfc50f4f-50b2-4958-84af-281cae1d0195



