### PR TITLE
ci: set fail-fast to false for integration tests

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -295,6 +295,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         py: [ 3.9, 3.12 ]
         db: [ sqlite, postgresql ]


### PR DESCRIPTION
As a temporary measure, removing fail-fast allows the PR author to assess whether the PR should be merged, even if some runners encounter flaky integration tests.​