### PR TITLE
ci: skip webkit for playwright tests

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       # We're skipping WebKit because of recurring issues with caching,
       # despite always installing it on cache-hit.
-      CI_PLAYWRIGHT_SKIP_WEBKIT: true
+      CI_PLAYWRIGHT_SKIP_WEBKIT: false
     steps:
       - uses: actions/checkout@v4
       - name: Install PNPM

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -13,7 +13,8 @@ jobs:
       run:
         working-directory: ./app
     env:
-      # Skip WebKit for the caching issue noted below.
+      # We're skipping WebKit because of recurring issues with caching,
+      # despite always installing it on cache-hit.
       CI_PLAYWRIGHT_SKIP_WEBKIT: true
     steps:
       - uses: actions/checkout@v4
@@ -41,12 +42,10 @@ jobs:
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
-# We're skipping WebKit because we have encountered recurring issues with caching,
-# despite always installing it on cache-hit.
-#      - name: Install system dependencies for WebKit
-#        # WebKit dependencies can't be cached and must always be installed.
-#        if: steps.playwright-cache.outputs.cache-hit == 'true'
-#        run: pnpm exec playwright install-deps webkit
+      - name: Install system dependencies for WebKit
+        if: ${{ env.CI_PLAYWRIGHT_SKIP_WEBKIT != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
+        # WebKit dependencies can't be cached and must always be installed.
+        run: pnpm exec playwright install-deps webkit
       - name: Build the app
         run: pnpm run build
       - uses: actions/setup-python@v5

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -12,6 +12,9 @@ jobs:
     defaults:
       run:
         working-directory: ./app
+    env:
+      # Skip WebKit for the caching issue noted below.
+      CI_PLAYWRIGHT_SKIP_WEBKIT: true
     steps:
       - uses: actions/checkout@v4
       - name: Install PNPM
@@ -58,8 +61,7 @@ jobs:
       - run: uv pip install --system ../. uvloop
       - run: uv pip list
       - name: Run Playwright tests
-        # Skip WebKit for the issue noted above.
-        run: pnpm exec playwright test --project "chromium" --project "firefox"
+        run: pnpm exec playwright test
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -59,7 +59,7 @@ jobs:
       - run: uv pip list
       - name: Run Playwright tests
         # Disable WebKit for the issue noted above.
-        run: pnpm exec playwright test --grep-invert "webkit"
+        run: pnpm exec playwright test --project "chromium" --project "firefox"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       # We're skipping WebKit because of recurring issues with caching,
       # despite always installing it on cache-hit.
-      CI_PLAYWRIGHT_SKIP_WEBKIT: false
+      CI_PLAYWRIGHT_SKIP_WEBKIT: true
     steps:
       - uses: actions/checkout@v4
       - name: Install PNPM

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -43,8 +43,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
       - name: Install system dependencies for WebKit
-        if: ${{ env.CI_PLAYWRIGHT_SKIP_WEBKIT != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
         # WebKit dependencies can't be cached and must always be installed.
+        if: ${{ env.CI_PLAYWRIGHT_SKIP_WEBKIT != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
         run: pnpm exec playwright install-deps webkit
       - name: Build the app
         run: pnpm run build

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -38,10 +38,12 @@ jobs:
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
-      - name: Install system dependencies for WebKit
-        # WebKit dependencies can't be cached and must always be installed
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps webkit
+# We're disabling WebKit because we have encountered recurring issues with caching,
+# despite always installing it on cache-hit.
+#      - name: Install system dependencies for WebKit
+#        # WebKit dependencies can't be cached and must always be installed.
+#        if: steps.playwright-cache.outputs.cache-hit == 'true'
+#        run: pnpm exec playwright install-deps webkit
       - name: Build the app
         run: pnpm run build
       - uses: actions/setup-python@v5
@@ -56,7 +58,8 @@ jobs:
       - run: uv pip install --system ../. uvloop
       - run: uv pip list
       - name: Run Playwright tests
-        run: pnpm exec playwright test
+        # Disable WebKit for the issue noted above.
+        run: pnpm exec playwright test --grep-invert "webkit"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
-# We're disabling WebKit because we have encountered recurring issues with caching,
+# We're skipping WebKit because we have encountered recurring issues with caching,
 # despite always installing it on cache-hit.
 #      - name: Install system dependencies for WebKit
 #        # WebKit dependencies can't be cached and must always be installed.
@@ -58,7 +58,7 @@ jobs:
       - run: uv pip install --system ../. uvloop
       - run: uv pip list
       - name: Run Playwright tests
-        # Disable WebKit for the issue noted above.
+        # Skip WebKit for the issue noted above.
         run: pnpm exec playwright test --project "chromium" --project "firefox"
       - uses: actions/upload-artifact@v4
         if: always()

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices, Project } from "@playwright/test";
 
 /**
  * Read environment variables from file.
@@ -6,6 +6,42 @@ import { defineConfig, devices } from "@playwright/test";
  */
 // import dotenv from 'dotenv';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+// Skip WebKit for CI because of recurring issues with caching binaries.
+const skipWebKit = process.env.CI_PLAYWRIGHT_SKIP_WEBKIT === "true";
+
+const projects: Project[] = [
+  {
+    name: "chromium",
+    use: { ...devices["Desktop Chrome"] },
+    // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
+    testIgnore: "**/*.rate-limit.spec.ts",
+  },
+  {
+    name: "firefox",
+    use: { ...devices["Desktop Firefox"] },
+    // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
+    testIgnore: "**/*.rate-limit.spec.ts",
+  },
+];
+
+if (!skipWebKit) {
+  projects.push({
+    name: "webkit",
+    use: { ...devices["Desktop Safari"] },
+    // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
+    testIgnore: "**/*.rate-limit.spec.ts",
+  });
+}
+
+projects.push({
+  name: "rate limit",
+  use: { ...devices["Desktop Chrome"] },
+  dependencies: skipWebKit
+    ? ["chromium", "firefox"]
+    : ["chromium", "firefox", "webkit"],
+  testMatch: "**/*.rate-limit.spec.ts",
+});
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -31,51 +67,7 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-      testIgnore: "**/*.rate-limit.spec.ts",
-    },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-      testIgnore: "**/*.rate-limit.spec.ts",
-    },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-      // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
-      testIgnore: "**/*.rate-limit.spec.ts",
-    },
-    {
-      name: "rate limit",
-      use: { ...devices["Desktop Chrome"] },
-      dependencies: ["chromium", "firefox", "webkit"],
-      testMatch: "**/*.rate-limit.spec.ts",
-    },
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+  projects: projects,
 
   /* Run your local dev server before starting the tests */
   webServer: {


### PR DESCRIPTION
We're skipping WebKit for CI because of recurring issues with caching, despite always installing it on cache-hit.