### PR TITLE
chore: git ignore symbolic links

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -124,6 +124,8 @@ jobs:
 
   ruff:
     name: Ruff
+    needs: changes
+    if: ${{ needs.changes.outputs.phoenix == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -163,15 +165,6 @@ jobs:
           sparse-checkout: |
             requirements/
             src/phoenix/
-      - name: Remove symbolic links (Non-Windows)
-        run: find . -type l -delete
-        if: runner.os != 'Windows'
-      - name: Remove symbolic links (Windows)
-        run: |
-          Remove-Item src/phoenix/evals
-          Remove-Item src/phoenix/otel
-        shell: powershell
-        if: runner.os == 'Windows'
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@v5
         with:
@@ -209,15 +202,6 @@ jobs:
             src/phoenix/
             tests/unit/
             tests/conftest.py
-      - name: Remove symbolic links (non-Windows)
-        run: find . -type l -delete
-        if: runner.os != 'Windows'
-      - name: Remove symbolic links (Windows)
-        run: |
-          Remove-Item src/phoenix/evals
-          Remove-Item src/phoenix/otel
-        shell: powershell
-        if: runner.os == 'Windows'
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@v5
         with:
@@ -261,15 +245,6 @@ jobs:
             requirements/
             src/phoenix/
             tests/integration/
-      - name: Remove symbolic links (Non-Windows)
-        run: find . -type l -delete
-        if: runner.os != 'Windows'
-      - name: Remove symbolic links (Windows)
-        run: |
-          Remove-Item src/phoenix/evals
-          Remove-Item src/phoenix/otel
-        shell: powershell
-        if: runner.os == 'Windows'
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@v5
         with:
@@ -328,15 +303,6 @@ jobs:
             requirements/
             src/phoenix/
             tests/integration/
-      - name: Remove symbolic links (non-Windows)
-        run: find . -type l -delete
-        if: runner.os != 'Windows'
-      - name: Remove symbolic links (Windows)
-        run: |
-          Remove-Item src/phoenix/evals
-          Remove-Item src/phoenix/otel
-        shell: powershell
-        if: runner.os == 'Windows'
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ examples/agent_framework_comparison/utils/saved_traces/*.parquet
 # python environments
 .conda
 .venv
+
+# Symbolic links
+src/phoenix/evals
+src/phoenix/otel

--- a/src/phoenix/evals
+++ b/src/phoenix/evals
@@ -1,1 +1,0 @@
-../../packages/phoenix-evals/src/phoenix/evals

--- a/src/phoenix/otel
+++ b/src/phoenix/otel
@@ -1,1 +1,0 @@
-../../packages/phoenix-otel/src/phoenix/otel

--- a/src/phoenix/otel
+++ b/src/phoenix/otel
@@ -1,1 +1,1 @@
-../../packages/phoenix-otel/src/phoenix/otel/
+../../packages/phoenix-otel/src/phoenix/otel

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ commands =
   mypy {posargs:.}
 
 [testenv:add_symlinks]
-changedir = {toxinidir}/src/phoenix
+changedir = src/phoenix
 allowlist_externals =
   ln
 commands =
@@ -70,7 +70,7 @@ commands =
   ln -sf ../../packages/phoenix-otel/src/phoenix/otel otel
 
 [testenv:remove_symlinks]
-changedir = {toxinidir}/src/phoenix
+changedir = src/phoenix
 allowlist_externals =
   unlink
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -60,3 +60,19 @@ commands_pre =
   uv pip install --reinstall .
 commands =
   mypy {posargs:.}
+
+[testenv:add_symlinks]
+changedir = {toxinidir}/src/phoenix
+allowlist_externals =
+  ln
+commands =
+  ln -sf ../../packages/phoenix-evals/src/phoenix/evals evals
+  ln -sf ../../packages/phoenix-otel/src/phoenix/otel otel
+
+[testenv:remove_symlinks]
+changedir = {toxinidir}/src/phoenix
+allowlist_externals =
+  unlink
+commands =
+  unlink evals
+  unlink otel


### PR DESCRIPTION
Checking in symlinks to git has been more trouble than it's worth given issues with CI. This PR adds helpers in tox for adding and removing symlinks, but ignores them for git.