### PR TITLE
fix(playground): make messages collapsible so they can be dragged

### DIFF
--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -219,6 +219,7 @@ function SortableMessageItem({
   return (
     <li ref={setNodeRef} style={dragAndDropLiStyles}>
       <Card
+        collapsible
         variant="compact"
         bodyStyle={{ padding: 0 }}
         {...messageCardStyles}

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -33,7 +33,7 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
   },
   input: { variableKeys: [], variablesValueCache: {} },
   tools: [],
-  toolChoice: undefined,
+  toolChoice: "auto",
   template: {
     __type: "chat",
     // These id's are not 0, 1, 2, because we create a playground instance (including messages) at the top of the transformSpanAttributesToPlaygroundInstance function

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -97,7 +97,8 @@ export function createPlaygroundInstance(): PlaygroundInstance {
     template: generateChatCompletionTemplate(),
     model: { provider: DEFAULT_MODEL_PROVIDER, modelName: "gpt-4o" },
     tools: [],
-    toolChoice: undefined,
+    // Default to auto tool choice as you are probably testing the LLM for it's ability to pick
+    toolChoice: "auto",
     // TODO(apowell) - use datasetId if in dataset mode
     input: { variablesValueCache: {}, variableKeys: [] },
     output: undefined,

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -119,7 +119,11 @@ export interface PlaygroundInstance {
   id: number;
   template: PlaygroundTemplate;
   tools: Tool[];
-  toolChoice: ToolChoice | undefined;
+  /**
+   * How the LLM should choose the tool to use
+   * @default "auto"
+   */
+  toolChoice: ToolChoice;
   input: PlaygroundInput;
   model: ModelConfig;
   output: ChatMessage[] | undefined | string;


### PR DESCRIPTION
Very large messages are hard to drag since the center never crosses the threshold of the message above. This makes it at least possible to drag it over.

https://github.com/user-attachments/assets/8eadd6ee-d289-4273-8650-bb873665a58d

