### PR TITLE
fix: allow progress bar to be disabled

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -78,6 +78,7 @@ def llm_classify(
     exit_on_error: bool = True,
     run_sync: bool = False,
     concurrency: Optional[int] = None,
+    progress_bar_format: Optional[str] = get_tqdm_progress_bar_formatter("llm_classify"),
 ) -> pd.DataFrame:
     """
     Classifies each input row of the dataframe using an LLM.
@@ -135,6 +136,11 @@ def llm_classify(
             submission is possible. If not provided, a recommended default concurrency is
             set on a per-model basis.
 
+        progress_bar_format(Optional[str]): An optional format for progress bar shown. If not
+            specified, defaults to: llm_classify |{bar}| {n_fmt}/{total_fmt} ({percentage:3.1f}%) "
+            "| ⏳ {elapsed}<{remaining} | {rate_fmt}{postfix}". If 'None' is passed in specifically,
+            the progress_bar log will be disabled.
+
     Returns:
         pandas.DataFrame: A dataframe where the `label` column (at column position 0) contains
             the classification labels. If provide_explanation=True, then an additional column named
@@ -150,7 +156,6 @@ def llm_classify(
     # clients need to be reloaded to ensure that async evals work properly
     model.reload_client()
 
-    tqdm_bar_format = get_tqdm_progress_bar_formatter("llm_classify")
     use_openai_function_call = (
         use_function_calling_if_available
         and isinstance(model, OpenAIModel)
@@ -230,7 +235,7 @@ def llm_classify(
         _run_llm_classification_async,
         run_sync=run_sync,
         concurrency=concurrency,
-        tqdm_bar_format=tqdm_bar_format,
+        tqdm_bar_format=progress_bar_format,
         max_retries=max_retries,
         exit_on_error=exit_on_error,
         fallback_return_value=fallback_return_value,

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -225,7 +225,10 @@ class AsyncExecutor(Executor):
         original_handler = signal.signal(self.termination_signal, termination_handler)
         outputs = [self.fallback_return_value] * len(inputs)
         execution_details = [ExecutionDetails() for _ in range(len(inputs))]
-        progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
+        if self.tqdm_bar_format is None:
+            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format, disable=True)
+        else:
+            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
 
         max_queue_size = 5 * self.concurrency  # limit the queue to bound memory usage
         max_fill = max_queue_size - (2 * self.concurrency)  # ensure there is always room to requeue
@@ -287,7 +290,7 @@ class SyncExecutor(Executor):
             returns an output.
 
         tqdm_bar_format (Optional[str], optional): The format string for the progress bar. Defaults
-            to None.
+            to None. If None, the progress bar is disabled.
 
         max_retries (int, optional): The maximum number of times to retry on exceptions. Defaults to
             10.
@@ -339,7 +342,10 @@ class SyncExecutor(Executor):
             execution_details: List[ExecutionDetails] = [
                 ExecutionDetails() for _ in range(len(inputs))
             ]
-            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
+            if self.tqdm_bar_format is None:
+                progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format, disable=True)
+            else:
+                progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
 
             for index, input in enumerate(inputs):
                 task_start_time = time.time()

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -225,10 +225,11 @@ class AsyncExecutor(Executor):
         original_handler = signal.signal(self.termination_signal, termination_handler)
         outputs = [self.fallback_return_value] * len(inputs)
         execution_details = [ExecutionDetails() for _ in range(len(inputs))]
-        if self.tqdm_bar_format is None:
-            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format, disable=True)
-        else:
-            progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
+        progress_bar = tqdm(
+            total=len(inputs),
+            bar_format=self.tqdm_bar_format,
+            disable=self.tqdm_bar_format is None,
+        )
 
         max_queue_size = 5 * self.concurrency  # limit the queue to bound memory usage
         max_fill = max_queue_size - (2 * self.concurrency)  # ensure there is always room to requeue
@@ -342,10 +343,11 @@ class SyncExecutor(Executor):
             execution_details: List[ExecutionDetails] = [
                 ExecutionDetails() for _ in range(len(inputs))
             ]
-            if self.tqdm_bar_format is None:
-                progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format, disable=True)
-            else:
-                progress_bar = tqdm(total=len(inputs), bar_format=self.tqdm_bar_format)
+            progress_bar = tqdm(
+                total=len(inputs),
+                bar_format=self.tqdm_bar_format,
+                disable=self.tqdm_bar_format is None,
+            )
 
             for index, input in enumerate(inputs):
                 task_start_time = time.time()


### PR DESCRIPTION
Add new parameter to llm_classify to allow progress bar format to be customizable and to be disabled

This was because the logs were noisy and verbose does not disable the progress bar