### PR TITLE
fix: Derive playground values instead of storing them in state

### DIFF
--- a/app/src/pages/playground/PlaygroundInput.tsx
+++ b/app/src/pages/playground/PlaygroundInput.tsx
@@ -3,24 +3,19 @@ import React from "react";
 import { Flex, Text, View } from "@arizeai/components";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
-import {
-  selectDerivedInputVariables,
-  selectInputVariableKeys,
-} from "@phoenix/store";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
+import { useDerivedPlaygroundVariables } from "./useDerivedPlaygroundVariables";
 import { VariableEditor } from "./VariableEditor";
 
 export function PlaygroundInput() {
-  const variables = usePlaygroundContext(selectDerivedInputVariables);
-  const variableKeys = usePlaygroundContext(selectInputVariableKeys);
+  const { variableKeys, variablesMap } = useDerivedPlaygroundVariables();
   const setVariableValue = usePlaygroundContext(
     (state) => state.setVariableValue
   );
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
-
   if (variableKeys.length === 0) {
     let templateSyntax = "";
     switch (templateLanguage) {
@@ -59,7 +54,7 @@ export function PlaygroundInput() {
             // change rapidly for a given variable
             key={i}
             label={variableKey}
-            value={variables[variableKey]}
+            value={variablesMap[variableKey]}
             onChange={(value) => setVariableValue(variableKey, value)}
           />
         );

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -9,11 +9,7 @@ import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
 import type { ToolCall } from "@phoenix/store";
-import {
-  ChatMessage,
-  generateMessageId,
-  selectDerivedInputVariables,
-} from "@phoenix/store";
+import { ChatMessage, generateMessageId } from "@phoenix/store";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
@@ -26,6 +22,7 @@ import {
 import { isChatMessages } from "./playgroundUtils";
 import { TitleWithAlphabeticIndex } from "./TitleWithAlphabeticIndex";
 import { PlaygroundInstanceProps } from "./types";
+import { useDerivedPlaygroundVariables } from "./useDerivedPlaygroundVariables";
 
 interface PlaygroundOutputProps extends PlaygroundInstanceProps {}
 
@@ -221,7 +218,7 @@ function PlaygroundOutputText(props: PlaygroundInstanceProps) {
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
-  const templateVariables = usePlaygroundContext(selectDerivedInputVariables);
+  const { variablesMap: templateVariables } = useDerivedPlaygroundVariables();
   const markPlaygroundInstanceComplete = usePlaygroundContext(
     (state) => state.markPlaygroundInstanceComplete
   );

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -31,7 +31,7 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
     provider: "OPENAI",
     modelName: "gpt-3.5-turbo",
   },
-  input: { variableKeys: [], variablesValueCache: {} },
+  input: { variablesValueCache: {} },
   tools: [],
   toolChoice: "auto",
   template: {

--- a/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
+++ b/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { isManualInput } from "@phoenix/store";
+
+import { extractVariablesFromInstances } from "./playgroundUtils";
+
+/**
+ * Get the variable keys from all instances in the playground, using the
+ * template language to determine the syntax of the variables
+ */
+export const useDerivedPlaygroundVariableKeys = () => {
+  const { instances, templateLanguage } = usePlaygroundContext((state) => ({
+    instances: state.instances,
+    templateLanguage: state.templateLanguage,
+  }));
+  const variableKeys = useMemo(() => {
+    return extractVariablesFromInstances({
+      instances,
+      templateLanguage,
+    });
+  }, [instances, templateLanguage]);
+
+  return variableKeys;
+};
+
+/**
+ * Get the variable values and keys from all instances in the playground
+ *
+ * Variables are recomputed whenever _anything_ in the playground instances change
+ * or when the template language changes. This can be optimized in the future.
+ */
+export const useDerivedPlaygroundVariables = () => {
+  const variableKeys = useDerivedPlaygroundVariableKeys();
+  const variableValueCache = usePlaygroundContext((state) =>
+    isManualInput(state.input) ? state.input.variablesValueCache : {}
+  );
+  const variablesMap = useMemo(() => {
+    return variableKeys.reduce(
+      (acc, key) => {
+        acc[key] = variableValueCache[key] || "";
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+  }, [variableKeys, variableValueCache]);
+
+  return { variableKeys, variablesMap };
+};

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -87,7 +87,6 @@ type DatasetInput = {
 
 type ManualInput = {
   variablesValueCache: Record<string, string | undefined>;
-  variableKeys: string[];
 };
 
 type PlaygroundInput = DatasetInput | ManualInput;
@@ -231,10 +230,8 @@ export interface PlaygroundState extends PlaygroundProps {
    */
   setTemplateLanguage: (templateLanguage: TemplateLanguage) => void;
   /**
-   * Calculate the variables used across all instances
+   * Set the value of a variable in the input
    */
-  calculateVariables: () => void;
-
   setVariableValue: (key: string, value: string) => void;
 }
 
@@ -242,7 +239,7 @@ export interface PlaygroundState extends PlaygroundProps {
  * Check if the input is manual
  */
 export const isManualInput = (input: PlaygroundInput): input is ManualInput => {
-  return "variablesValueCache" in input && "variableKeys" in input;
+  return "variablesValueCache" in input;
 };
 
 /**


### PR DESCRIPTION
This prevents stale variable inputs from being displayed on the playground.

~~TODO: fix render slowdown. This approach is slower, need to memoize some more things.~~

Performance profiling reveals that dropped frames while typing quickly is due to expensive over-re-rendering. We can fix this later or via react compiler in the future.