### PR TITLE
fix(playground): add openai as a container dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ pg = [
 ]
 container = [
   "prometheus-client",
+  "openai>=1.0.0",
   "opentelemetry-sdk",
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-exporter-otlp",


### PR DESCRIPTION
Adds OpenAI as a dependency for playground.

resolves #5075