### PR TITLE
fix: Re-enable run button on subscription error

### DIFF
--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -5,6 +5,7 @@ import { css } from "@emotion/react";
 
 import { Card, Flex, Icon, Icons } from "@arizeai/components";
 
+import { useNotifyError } from "@phoenix/contexts";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
@@ -223,6 +224,7 @@ function PlaygroundOutputText(props: PlaygroundInstanceProps) {
   const instance = instances.find(
     (instance) => instance.id === props.playgroundInstanceId
   );
+  const updateInstance = usePlaygroundContext((state) => state.updateInstance);
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
@@ -230,6 +232,7 @@ function PlaygroundOutputText(props: PlaygroundInstanceProps) {
   const markPlaygroundInstanceComplete = usePlaygroundContext(
     (state) => state.markPlaygroundInstanceComplete
   );
+  const notifyError = useNotifyError();
   if (!instance) {
     throw new Error("No instance found");
   }
@@ -311,9 +314,17 @@ function PlaygroundOutputText(props: PlaygroundInstanceProps) {
       markPlaygroundInstanceComplete(props.playgroundInstanceId);
     },
     onFailed: () => {
-      // TODO(apowell): display error message?
-      // TODO(apowell): clear run id?
       markPlaygroundInstanceComplete(props.playgroundInstanceId);
+      updateInstance({
+        instanceId: props.playgroundInstanceId,
+        patch: {
+          activeRunId: null,
+        },
+      });
+      notifyError({
+        title: "Failed to get output",
+        message: "Please try again.",
+      });
     },
   });
 

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -123,11 +123,13 @@ function useChatCompletionSubscription({
   runId,
   onNext,
   onCompleted,
+  onFailed,
 }: {
   params: PlaygroundOutputSubscription$variables;
   runId: number;
   onNext: (response: PlaygroundOutputSubscription$data) => void;
   onCompleted: () => void;
+  onFailed: (error: Error) => void;
 }) {
   const config = useMemo<
     GraphQLSubscriptionConfig<PlaygroundOutputSubscription>
@@ -174,6 +176,9 @@ function useChatCompletionSubscription({
       },
       onCompleted: () => {
         onCompleted();
+      },
+      onError: (error) => {
+        onFailed(error);
       },
     }),
     // eslint-disable-next-line react-compiler/react-compiler
@@ -303,6 +308,11 @@ function PlaygroundOutputText(props: PlaygroundInstanceProps) {
       }
     },
     onCompleted: () => {
+      markPlaygroundInstanceComplete(props.playgroundInstanceId);
+    },
+    onFailed: () => {
+      // TODO(apowell): display error message?
+      // TODO(apowell): clear run id?
       markPlaygroundInstanceComplete(props.playgroundInstanceId);
     },
   });


### PR DESCRIPTION
When an error occurs during output generation we mark the instance as no longer running.

Output continues to say "running" however.

We should display an error message and revert the state of the output box back to its initial state most likely