### PR TITLE
chore: expand exclude-paths for release please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,21 @@
         ".": {
             "package-name": "arize-phoenix",
             "release-type": "python",
-            "exclude-paths": ["packages"]
+            "exclude-paths": [
+              ".github",
+              ".tours",
+              "api_reference",
+              "docs",
+              "examples",
+              "internal_docs",
+              "js",
+              "kustomize",
+              "packages",
+              "requirements",
+              "scripts",
+              "tests",
+              "tutorials"
+            ]
         },
         "packages/phoenix-evals": {
             "package-name": "arize-phoenix-evals",


### PR DESCRIPTION
[exclude-paths](https://github.com/googleapis/release-please/blob/3202daa81d0a5ef8f8959ec48aa5f79159fde997/schemas/config.json#L214-L215): Path of commits to be excluded from parsing. If all files from commit belong to one of the paths it will be skipped