### PR TITLE
fix: Align vertical edge padding across playground message editors

### DIFF
--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -221,8 +221,8 @@ function MessageEditor({
     return (
       <View
         paddingTop="size-100"
-        paddingStart="size-200"
-        paddingEnd="size-200"
+        paddingStart="size-250"
+        paddingEnd="size-250"
         paddingBottom="size-200"
       >
         <Field label={"Tool Calls"}>
@@ -281,13 +281,26 @@ function MessageEditor({
     );
   }
   return (
-    <TemplateEditor
-      height="100%"
-      value={message.content}
-      aria-label="Message content"
-      templateLanguage={templateLanguage}
-      onChange={(val) => updateMessage({ content: val })}
-    />
+    <div
+      css={css`
+        & .cm-content {
+          padding-left: var(--ac-global-dimension-size-250);
+          padding-right: var(--ac-global-dimension-size-250);
+        }
+        & .cm-line {
+          padding-left: 0;
+          padding-right: 0;
+        }
+      `}
+    >
+      <TemplateEditor
+        height="100%"
+        value={message.content}
+        aria-label="Message content"
+        templateLanguage={templateLanguage}
+        onChange={(val) => updateMessage({ content: val })}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
<img width="562" alt="image" src="https://github.com/user-attachments/assets/e6f998bb-9349-4f65-9961-ab5e30e82837">

<img width="577" alt="image" src="https://github.com/user-attachments/assets/546a45e7-8b2f-4cd9-a492-766611c2a544">

Text is now aligned with the left edge of collapse carets

See #5117 