### PR TITLE
chore: ignore additional packages for type check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,8 @@ module = [
   "orjson",  # suppress fastapi internal type errors
   "pypistats",
   "authlib.*",
+  "google.*",
+  "mistralai.*",
 ]
 ignore_missing_imports = true
 

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -638,7 +638,7 @@ def close_app(delete_data: bool = False) -> None:
 def _get_url(host: str, port: int, notebook_env: NotebookEnvironment) -> str:
     """Determines the IFrame URL based on whether this is in a Colab or in a local notebook"""
     if notebook_env == NotebookEnvironment.COLAB:
-        from google.colab.output import eval_js  # type: ignore
+        from google.colab.output import eval_js
 
         return str(eval_js(f"google.colab.kernel.proxyPort({port}, {{'cache': true}})"))
     if notebook_env == NotebookEnvironment.SAGEMAKER:
@@ -656,7 +656,7 @@ def _get_url(host: str, port: int, notebook_env: NotebookEnvironment) -> str:
 def _is_colab() -> bool:
     """Determines whether this is in a Colab"""
     try:
-        import google.colab  # type: ignore # noqa: F401
+        import google.colab  # noqa: F401
     except ImportError:
         return False
     try:


### PR DESCRIPTION
ignore type errors when the symlink to `src/phoenix/evals` exists