### PR TITLE
chore: ignore *.grammar for prettier

### DIFF
--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -1,1 +1,3 @@
 __generated__
+
+*.grammar


### PR DESCRIPTION
```
phoenix/app/src/components/templateEditor/language/fString/fStringTemplating.syntax.grammar
phoenix/app/src/components/templateEditor/language/mustacheLike/mustacheLikeTemplating.syntax.grammar
```