### PR TITLE
fix: update to properly initialize when brought into view

### DIFF
--- a/app/src/components/code/JSONEditor.tsx
+++ b/app/src/components/code/JSONEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo } from "react";
 import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
 import { EditorView, hoverTooltip } from "@codemirror/view";
@@ -13,26 +13,8 @@ import {
   stateExtensions,
 } from "codemirror-json-schema";
 import { JSONSchema7 } from "json-schema";
-import { css } from "@emotion/react";
 
 import { useTheme } from "@phoenix/contexts";
-
-/**
- * The two variables below are used to initialize the JSON editor.
- * This is necessary because code mirror needs to calculate its dimensions to initialize properly.
- * When it is rendered outside of the viewport, the dimensions may not always be calculated correctly.
- * Below we use a combination of an intersection observer and a delay to ensure that the editor is initialized correctly.
- */
-/**
- * The delay in milliseconds before initializing the JSON editor.
- * This is to ensure that the dom is ready before initializing the editor.
- */
-const JSON_EDITOR_INITIALIZATION_DELAY = 1;
-/**
- * The minimum height of the container for the JSON editor prior to initialization.
- * After initialization, the height will be set to auto and grow to fit the editor.
- */
-const JSON_EDITOR_MIN_HEIGHT = "400px";
 
 export type JSONEditorProps = Omit<
   ReactCodeMirrorProps,
@@ -47,9 +29,6 @@ export type JSONEditorProps = Omit<
 export function JSONEditor(props: JSONEditorProps) {
   const { theme } = useTheme();
   const { jsonSchema, ...restProps } = props;
-  const [isVisible, setIsVisible] = useState(false);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
   const codeMirrorTheme = theme === "light" ? githubLight : nord;
   const extensions = useMemo(() => {
     const baseExtensions = [
@@ -70,55 +49,13 @@ export function JSONEditor(props: JSONEditorProps) {
     return baseExtensions;
   }, [jsonSchema]);
 
-  /**
-   * The two useEffect hooks below are used to initialize the JSON editor.
-   * This is necessary because code mirror needs to calculate its dimensions to initialize properly.
-   * When it is rendered outside of the viewport, the dimensions may not always be calculated correctly,
-   * resulting in the editor being invisible or cut off when it is scrolled into view.
-   * Below we use a combination of an intersection observer and a delay to ensure that the editor is initialized correctly.
-   * For a related issue @see https://github.com/codemirror/dev/issues/1076
-   */
-  useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      setIsVisible(entry.isIntersecting);
-    });
-
-    if (containerRef.current) {
-      observer.observe(containerRef.current);
-    }
-    const current = containerRef.current;
-
-    return () => {
-      if (current) {
-        observer.unobserve(current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isVisible && !isInitialized) {
-      // Small delay to ensure DOM is ready
-      const timer = setTimeout(() => {
-        setIsInitialized(true);
-      }, JSON_EDITOR_INITIALIZATION_DELAY);
-      return () => clearTimeout(timer);
-    }
-  }, [isInitialized, isVisible]);
-
   return (
-    <div
-      ref={containerRef}
-      css={css`
-        min-height: ${!isInitialized ? JSON_EDITOR_MIN_HEIGHT : "auto"};
-      `}
-    >
-      <CodeMirror
-        value={props.value}
-        extensions={extensions}
-        editable
-        theme={codeMirrorTheme}
-        {...restProps}
-      />
-    </div>
+    <CodeMirror
+      value={props.value}
+      extensions={extensions}
+      editable
+      theme={codeMirrorTheme}
+      {...restProps}
+    />
   );
 }

--- a/app/src/components/code/JSONEditor.tsx
+++ b/app/src/components/code/JSONEditor.tsx
@@ -76,6 +76,7 @@ export function JSONEditor(props: JSONEditorProps) {
    * When it is rendered outside of the viewport, the dimensions may not always be calculated correctly,
    * resulting in the editor being invisible or cut off when it is scrolled into view.
    * Below we use a combination of an intersection observer and a delay to ensure that the editor is initialized correctly.
+   * For a related issue @see https://github.com/codemirror/dev/issues/1076
    */
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {

--- a/app/src/components/code/LazyEditorWrapper.tsx
+++ b/app/src/components/code/LazyEditorWrapper.tsx
@@ -54,7 +54,6 @@ export function LazyEditorWrapper({
     };
   }, []);
 
-  console.log("test--what2");
   useLayoutEffect(() => {
     if (isVisible && !isInitialized) {
       setIsInitialized(true);

--- a/app/src/components/code/LazyEditorWrapper.tsx
+++ b/app/src/components/code/LazyEditorWrapper.tsx
@@ -1,0 +1,76 @@
+import React, {
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { css } from "@emotion/react";
+
+/**
+ * A wrapper for code mirror editors that lazily initializes the editor when it is scrolled into view.
+ * This is necessary in some cases where a code mirror editor is rendered outside of the viewport.
+ * In those cases, the editor may not be initialized properly and may be invisible or cut off when it is scrolled into view.
+ * @param preInitializationMinHeight The minimum height of the container for the JSON editor prior to initialization.
+ */
+export function LazyEditorWrapper({
+  preInitializationMinHeight,
+  children,
+}: {
+  /**
+   * The minimum height of the container for the JSON editor prior to initialization.
+   * After initialization, the height will be set to auto and grow to fit the editor.
+   * This allows for the editor to properly get its dimensions when it is rendered outside of the viewport.
+   */
+  preInitializationMinHeight: number;
+  children: ReactNode;
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * The two useEffect hooks below are used to initialize the JSON editor.
+   * This is necessary because code mirror needs to calculate its dimensions to initialize properly.
+   * When it is rendered outside of the viewport, the dimensions may not always be calculated correctly,
+   * resulting in the editor being invisible or cut off when it is scrolled into view.
+   * Below we use a combination of an intersection observer and a delay to ensure that the editor is initialized correctly.
+   * For a related issue @see https://github.com/codemirror/dev/issues/1076
+   */
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsVisible(entry.isIntersecting);
+    });
+
+    if (wrapperRef.current) {
+      observer.observe(wrapperRef.current);
+    }
+    const current = wrapperRef.current;
+
+    return () => {
+      if (current) {
+        observer.unobserve(current);
+      }
+    };
+  }, []);
+
+  console.log("test--what2");
+  useLayoutEffect(() => {
+    if (isVisible && !isInitialized) {
+      setIsInitialized(true);
+    }
+  }, [isInitialized, isVisible]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      css={css`
+        min-height: ${!isInitialized
+          ? `${preInitializationMinHeight}px`
+          : "auto"};
+      `}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/generative/ToolChoiceSelector.tsx
+++ b/app/src/components/generative/ToolChoiceSelector.tsx
@@ -77,24 +77,26 @@ export function ToolChoicePicker({
       }}
     >
       {[
-        <Item key="auto">
+        <Item key="auto" textValue="auto">
           <Flex gap={"size-100"}>
             Tools auto-selected by LLM <Label>auto</Label>
           </Flex>
         </Item>,
-        <Item key="required">
+        <Item key="required" textValue="required">
           <Flex gap={"size-100"}>
             Use at least one tool <Label>required</Label>
           </Flex>
         </Item>,
-        <Item key="none">
+        <Item key="none" textValue="none">
           <Flex gap={"size-100"}>
             Don&apos;t use any tools <Label>none</Label>
           </Flex>
         </Item>,
         // Add "TOOL_NAME_PREFIX" prefix to user defined tool names to avoid conflicts with default keys
         ...toolNames.map((toolName) => (
-          <Item key={addToolNamePrefix(toolName)}>{toolName}</Item>
+          <Item key={addToolNamePrefix(toolName)} textValue={toolName}>
+            {toolName}
+          </Item>
         )),
       ]}
     </Picker>

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -65,7 +65,6 @@ export function PlaygroundTool({
       backgroundColor={"yellow-100"}
       borderColor={"yellow-700"}
       variant="compact"
-      key={tool.id}
       title={
         <Flex direction="row" gap="size-100">
           <SpanKindIcon spanKind="tool" />

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Flex, Icon, Icons, Text } from "@arizeai/components";
 
 import { CopyToClipboardButton } from "@phoenix/components";
 import { JSONEditor } from "@phoenix/components/code";
+import { LazyEditorWrapper } from "@phoenix/components/code/LazyEditorWrapper";
 import { SpanKindIcon } from "@phoenix/components/trace";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { openAIToolJSONSchema, openAIToolSchema } from "@phoenix/schemas";
@@ -12,6 +13,12 @@ import { OpenAITool } from "@phoenix/store";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
 import { PlaygroundInstanceProps } from "./types";
+
+/**
+ * The minimum height for the editor before it is initialized.
+ * This is to ensure that the editor is properly initialized when it is rendered outside of the viewport.
+ */
+const TOOL_EDITOR_PRE_INIT_HEIGHT = 400;
 
 export function PlaygroundTool({
   playgroundInstanceId,
@@ -93,11 +100,15 @@ export function PlaygroundTool({
         </Flex>
       }
     >
-      <JSONEditor
-        value={toolDefinition}
-        onChange={onChange}
-        jsonSchema={openAIToolJSONSchema as JSONSchema7}
-      />
+      <LazyEditorWrapper
+        preInitializationMinHeight={TOOL_EDITOR_PRE_INIT_HEIGHT}
+      >
+        <JSONEditor
+          value={toolDefinition}
+          onChange={onChange}
+          jsonSchema={openAIToolJSONSchema as JSONSchema7}
+        />
+      </LazyEditorWrapper>
     </Card>
   );
 }

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -49,7 +49,7 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
         titleExtra={<Counter variant="light">{tools.length}</Counter>}
       >
         <View padding="size-200">
-          <Flex direction="column" gap={"size-100"}>
+          <Flex direction="column">
             <Form>
               <ToolChoicePicker
                 choice={instance.toolChoice}
@@ -64,16 +64,18 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
                 toolNames={toolNames}
               />
             </Form>
-            {tools.map((tool) => {
-              return (
-                <PlaygroundTool
-                  key={tool.id}
-                  playgroundInstanceId={instanceId}
-                  tool={tool}
-                  instanceTools={instance.tools}
-                />
-              );
-            })}
+            <Flex direction="column" gap="size-200">
+              {tools.map((tool) => {
+                return (
+                  <PlaygroundTool
+                    key={tool.id}
+                    playgroundInstanceId={instanceId}
+                    tool={tool}
+                    instanceTools={instance.tools}
+                  />
+                );
+              })}
+            </Flex>
           </Flex>
         </View>
       </AccordionItem>

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -49,7 +49,7 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
         titleExtra={<Counter variant="light">{tools.length}</Counter>}
       >
         <View padding="size-200">
-          <Flex direction="column">
+          <Flex direction="column" gap={"size-100"}>
             <Form>
               <ToolChoicePicker
                 choice={instance.toolChoice}


### PR DESCRIPTION
resolves #5113 

- fixes an issue where our json editors (and probably other code mirror editors) were being cut off or not rendering at all when initially rendered out of the view port
- checked datasets json editors for regressions