### PR TITLE
fix(playground): improve playground error handling

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -96,7 +96,11 @@ enum ChatCompletionMessageRole {
   AI
 }
 
-union ChatCompletionSubscriptionPayload = TextChunk | ToolCallChunk | FinishedChatCompletion
+type ChatCompletionSubscriptionError {
+  message: String!
+}
+
+union ChatCompletionSubscriptionPayload = TextChunk | ToolCallChunk | FinishedChatCompletion | ChatCompletionSubscriptionError
 
 input ClearProjectInput {
   id: GlobalID!

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<310f2749422dcd246ac79c7ddf439c23>>
+ * @generated SignedSource<<ba65ab9fe3de490faf7a710506a23cc8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,6 +47,9 @@ export type PlaygroundOutputSubscription$variables = {
 };
 export type PlaygroundOutputSubscription$data = {
   readonly chatCompletion: {
+    readonly __typename: "ChatCompletionSubscriptionError";
+    readonly message: string;
+  } | {
     readonly __typename: "FinishedChatCompletion";
     readonly span: {
       readonly id: string;
@@ -228,6 +231,20 @@ v7 = [
         ],
         "type": "FinishedChatCompletion",
         "abstractKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "message",
+            "storageKey": null
+          }
+        ],
+        "type": "ChatCompletionSubscriptionError",
+        "abstractKey": null
       }
     ],
     "storageKey": null
@@ -265,16 +282,16 @@ return {
     "selections": (v7/*: any*/)
   },
   "params": {
-    "cacheID": "54f42285c230d77abe27c047dc37e700",
+    "cacheID": "96dec42dd14805e9b1adc1c112321064",
     "id": null,
     "metadata": {},
     "name": "PlaygroundOutputSubscription",
     "operationKind": "subscription",
-    "text": "subscription PlaygroundOutputSubscription(\n  $messages: [ChatCompletionMessageInput!]!\n  $model: GenerativeModelInput!\n  $invocationParameters: InvocationParameters!\n  $tools: [JSON!]\n  $templateOptions: TemplateOptions\n  $apiKey: String\n) {\n  chatCompletion(input: {messages: $messages, model: $model, invocationParameters: $invocationParameters, tools: $tools, template: $templateOptions, apiKey: $apiKey}) {\n    __typename\n    ... on TextChunk {\n      content\n    }\n    ... on ToolCallChunk {\n      id\n      function {\n        name\n        arguments\n      }\n    }\n    ... on FinishedChatCompletion {\n      span {\n        id\n      }\n    }\n  }\n}\n"
+    "text": "subscription PlaygroundOutputSubscription(\n  $messages: [ChatCompletionMessageInput!]!\n  $model: GenerativeModelInput!\n  $invocationParameters: InvocationParameters!\n  $tools: [JSON!]\n  $templateOptions: TemplateOptions\n  $apiKey: String\n) {\n  chatCompletion(input: {messages: $messages, model: $model, invocationParameters: $invocationParameters, tools: $tools, template: $templateOptions, apiKey: $apiKey}) {\n    __typename\n    ... on TextChunk {\n      content\n    }\n    ... on ToolCallChunk {\n      id\n      function {\n        name\n        arguments\n      }\n    }\n    ... on FinishedChatCompletion {\n      span {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      message\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2ee0074ffec630990e0c4bc90b17a86a";
+(node as any).hash = "c29d5c7acf3f5090b92480ce34101fa6";
 
 export default node;

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -692,6 +692,9 @@ def _template_formatter(template_language: TemplateLanguage) -> TemplateFormatte
 
 
 def _serialize_event(event: SpanEvent) -> Dict[str, Any]:
+    """
+    Serializes a SpanEvent to a dictionary.
+    """
     return {k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in asdict(event).items()}
 
 

--- a/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionSubscription.test_openai_emits_expected_payloads_and_records_expected_span_on_error[sqlite].yaml
+++ b/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionSubscription.test_openai_emits_expected_payloads_and_records_expected_span_on_error[sqlite].yaml
@@ -1,0 +1,19 @@
+interactions:
+- request:
+    body: '{"messages": [{"content": "Who won the World Cup in 2018? Answer in one
+      word", "role": "user"}], "model": "gpt-4", "stream": true, "stream_options":
+      {"include_usage": true}, "temperature": 0.1}'
+    headers: {}
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n    \"error\": {\n        \"message\": \"Incorrect API key provided:
+        sk-01234*6789. You can find your API key at https://platform.openai.com/account/api-keys.\",\n
+        \       \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\":
+        \"invalid_api_key\"\n    }\n}\n"
+    headers: {}
+    status:
+      code: 401
+      message: Unauthorized
+version: 1


### PR DESCRIPTION
https://github.com/user-attachments/assets/859af056-666f-4cb6-a92e-2eb055cb65b7

Improves error handling to yield an error type in the subscription so we can still return the final span at the end, even if an error occurs midway.

resolves #5187
