### PR TITLE
fix: Do not pin span in url for playground trace details slideover

### DIFF
--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useSearchParams } from "react-router-dom";
 import { css } from "@emotion/react";
 
 import {
@@ -40,6 +41,20 @@ const playgroundWrapCSS = css`
 
 export function Playground(props: InitialPlaygroundState) {
   const showStreamToggle = useFeatureFlag("playgroundNonStreaming");
+  const [, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    setSearchParams(
+      (searchParams) => {
+        // remove lingering selectedSpanNodeId param so as to not poison the trace details slideover
+        // with stale data from previous pages
+        searchParams.delete("selectedSpanNodeId");
+        return searchParams;
+      },
+      { replace: true }
+    );
+  }, [setSearchParams]);
+
   return (
     <PlaygroundProvider {...props}>
       <div css={playgroundWrapCSS}>

--- a/app/src/pages/playground/SpanPlaygroundPage.tsx
+++ b/app/src/pages/playground/SpanPlaygroundPage.tsx
@@ -28,7 +28,11 @@ export function SpanPlaygroundPage() {
   return (
     <Flex direction="column" height={"100%"}>
       <SpanPlaygroundBanners span={span} parsingErrors={parsingErrors} />
-      <Playground instances={[playgroundInstance]} />
+      <Playground
+        // remount the playground when the span changes, resetting all local state, closing dialogs, etc.
+        key={span.id}
+        instances={[playgroundInstance]}
+      />
     </Flex>
   );
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/422e3171-1849-4d45-ae83-c3ebe3a7282c

In addition to removing `selectedSpanNodeId` from the url on playground page, fixing the original issue; I also added a key to the playground page component in order to reset the page's state when the spanId segment of the url changes. This is somewhat of a sledgehammer approach compared to selectively resetting state based on the span url, but it catches many more edge cases.


Resolves #5193 