### PR TITLE
fix: Bubble errors up from nested invocation parameter schema transforms

### DIFF
--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -375,7 +375,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       playgroundInstance: {
         ...expectedPlaygroundInstanceWithIO,
       },
-      parsingErrors: [],
+      parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
     });
   });
 
@@ -394,6 +394,23 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
     expect(transformSpanAttributesToPlaygroundInstance(span)).toEqual({
       playgroundInstance: {
         ...expectedPlaygroundInstanceWithIO,
+      },
+      parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
+    });
+  });
+
+  it("should return invocation parameters parsing errors if they are malformed", () => {
+    const parsedAttributes = {
+      llm: {
+        model_name: "gpt-3.5-turbo",
+        invocation_parameters: '"invalid"',
+      },
+    };
+    expect(getModelConfigFromAttributes(parsedAttributes)).toEqual({
+      modelConfig: {
+        modelName: "gpt-3.5-turbo",
+        provider: "OPENAI",
+        invocationParameters: {},
       },
       parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
     });

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -136,8 +136,8 @@ const stringToInvocationParametersSchema = z
   .string()
   .transform((s) => {
     const { json } = safelyParseJSON(s);
-    if (json == null) {
-      return {};
+    if (json == null || typeof json !== "object") {
+      return null;
     }
     // using the invocationParameterSchema as a base,
     // apply all matching keys from the input string,
@@ -156,9 +156,22 @@ const stringToInvocationParametersSchema = z
           ),
         }))
         // reparse the object to ensure the mapped keys are also validated
-        .transform(invocationParameterSchema.parse)
         .parse(json)
     );
+  })
+  .transform((v, ctx) => {
+    const result = invocationParameterSchema.safeParse(v);
+    if (!result.success) {
+      // bubble errors up to the original schema
+      result.error.issues.forEach((issue) => {
+        ctx.addIssue(issue);
+      });
+      // https://zod.dev/?id=validating-during-transform
+      // ensures that this schema still infers the "success" type
+      // errors will throw instead
+      return z.NEVER;
+    }
+    return result.data;
   })
   .default("{}");
 /**

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -7,7 +7,7 @@ import {
 } from "@arizeai/openinference-semantic-conventions";
 
 import { ChatMessage } from "@phoenix/store";
-import { Mutable, schemaForType } from "@phoenix/typeUtils";
+import { isObject, Mutable, schemaForType } from "@phoenix/typeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
 import { InvocationParameters } from "./__generated__/PlaygroundOutputSubscription.graphql";
@@ -136,7 +136,7 @@ const stringToInvocationParametersSchema = z
   .string()
   .transform((s) => {
     const { json } = safelyParseJSON(s);
-    if (json == null || typeof json !== "object") {
+    if (!isObject(json)) {
       return null;
     }
     // using the invocationParameterSchema as a base,


### PR DESCRIPTION
resolves #5198
This allows errors to be displayed in the playground UI when the invocation parameters are totally incorrect on the span

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/7acf4862-1306-4343-9379-42e462e6f687">

This is what happens when I set invocation params to "'hi'" in the database