### PR TITLE
feat(playground): save model config by provider in preferences

### DIFF
--- a/app/src/contexts/PlaygroundContext.tsx
+++ b/app/src/contexts/PlaygroundContext.tsx
@@ -3,7 +3,7 @@ import { useZustand } from "use-zustand";
 
 import {
   createPlaygroundStore,
-  PlaygroundProps,
+  InitialPlaygroundState,
   PlaygroundState,
   PlaygroundStore,
 } from "@phoenix/store";
@@ -13,7 +13,7 @@ export const PlaygroundContext = createContext<PlaygroundStore | null>(null);
 export function PlaygroundProvider({
   children,
   ...props
-}: PropsWithChildren<Partial<PlaygroundProps>>) {
+}: PropsWithChildren<InitialPlaygroundState>) {
   const [store] = useState<PlaygroundStore>(() => createPlaygroundStore(props));
   return (
     <PlaygroundContext.Provider value={store}>

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -18,6 +18,8 @@ import {
   Picker,
   Text,
   TextField,
+  Tooltip,
+  TooltipTrigger,
   View,
 } from "@arizeai/components";
 
@@ -25,7 +27,9 @@ import {
   AZURE_OPENAI_API_VERSIONS,
   ModelProviders,
 } from "@phoenix/constants/generativeConstants";
+import { useNotifySuccess } from "@phoenix/contexts";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { PlaygroundInstance } from "@phoenix/store";
 
 import { ModelConfigButtonDialogQuery } from "./__generated__/ModelConfigButtonDialogQuery.graphql";
@@ -43,6 +47,9 @@ function AzureOpenAiModelConfigFormField({
   instance: PlaygroundInstance;
 }) {
   const updateModel = usePlaygroundContext((state) => state.updateModel);
+  const modelConfigByProvider = usePreferencesContext(
+    (state) => state.modelConfigByProvider
+  );
 
   const updateModelConfig = useCallback(
     ({
@@ -58,9 +65,10 @@ function AzureOpenAiModelConfigFormField({
           ...instance.model,
           [configKey]: value,
         },
+        modelConfigByProvider,
       });
     },
-    [instance.id, instance.model, updateModel]
+    [instance.id, instance.model, modelConfigByProvider, updateModel]
   );
 
   return (
@@ -128,13 +136,7 @@ export function ModelConfigButton(props: ModelConfigButtonProps) {
         size="compact"
         onClick={() => {
           startTransition(() => {
-            setDialog(
-              <Dialog title="Model Configuration" size="M">
-                <Suspense>
-                  <ModelConfigDialogContent {...props} />
-                </Suspense>
-              </Dialog>
-            );
+            setDialog(<ModelConfigDialog {...props} />);
           });
         }}
       >
@@ -156,18 +158,75 @@ export function ModelConfigButton(props: ModelConfigButtonProps) {
   );
 }
 
-interface ModelConfigDialogContentProps extends ModelConfigButtonProps {}
-function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
-  const { playgroundInstanceId } = props;
-  const updateModel = usePlaygroundContext((state) => state.updateModel);
+interface ModelConfigDialogProps extends ModelConfigButtonProps {}
+function ModelConfigDialog(props: ModelConfigDialogProps) {
   const instance = usePlaygroundContext((state) =>
-    state.instances.find((instance) => instance.id === playgroundInstanceId)
+    state.instances.find(
+      (instance) => instance.id === props.playgroundInstanceId
+    )
   );
+
   if (!instance) {
     throw new Error(
       `Playground instance ${props.playgroundInstanceId} not found`
     );
   }
+  const setModelConfigForProvider = usePreferencesContext(
+    (state) => state.setModelConfigForProvider
+  );
+
+  const notifySuccess = useNotifySuccess();
+  const onSaveConfig = useCallback(() => {
+    setModelConfigForProvider({
+      provider: instance.model.provider,
+      modelConfig: instance.model,
+    });
+    notifySuccess({
+      title: "Model Configuration Saved",
+      message: `${ModelProviders[instance.model.provider]} model configuration saved`,
+      expireMs: 3000,
+    });
+  }, [instance.model, notifySuccess, setModelConfigForProvider]);
+  return (
+    <Dialog
+      title="Model Configuration"
+      size="M"
+      extra={
+        <TooltipTrigger delay={0} offset={5}>
+          <Button size={"compact"} variant="default" onClick={onSaveConfig}>
+            Save Config
+          </Button>
+          <Tooltip>
+            Save {ModelProviders[instance.model.provider]} configuration to
+            local storage.
+          </Tooltip>
+        </TooltipTrigger>
+      }
+    >
+      <Suspense>
+        <ModelConfigDialogContent {...props} />
+      </Suspense>
+    </Dialog>
+  );
+}
+
+interface ModelConfigDialogContentProps extends ModelConfigButtonProps {}
+function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
+  const { playgroundInstanceId } = props;
+  const instance = usePlaygroundContext((state) =>
+    state.instances.find((instance) => instance.id === playgroundInstanceId)
+  );
+
+  if (!instance) {
+    throw new Error(
+      `Playground instance ${props.playgroundInstanceId} not found`
+    );
+  }
+  const modelConfigByProvider = usePreferencesContext(
+    (state) => state.modelConfigByProvider
+  );
+  const updateModel = usePlaygroundContext((state) => state.updateModel);
+
   const query = useLazyLoadQuery<ModelConfigButtonDialogQuery>(
     graphql`
       query ModelConfigButtonDialogQuery($providerKey: GenerativeProviderKey!) {
@@ -186,9 +245,15 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
           provider: instance.model.provider,
           modelName,
         },
+        modelConfigByProvider,
       });
     },
-    [instance.model.provider, playgroundInstanceId, updateModel]
+    [
+      instance.model.provider,
+      modelConfigByProvider,
+      playgroundInstanceId,
+      updateModel,
+    ]
   );
 
   const onInvocationParametersChange: InvocationParametersChangeHandler =
@@ -203,9 +268,10 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
               [parameter]: value,
             },
           },
+          modelConfigByProvider,
         });
       },
-      [instance.model, playgroundInstanceId, updateModel]
+      [instance.model, modelConfigByProvider, playgroundInstanceId, updateModel]
     );
 
   return (
@@ -221,6 +287,7 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
                 provider,
                 modelName: null,
               },
+              modelConfigByProvider,
             });
           }}
         />

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -20,7 +20,8 @@ import {
   PlaygroundProvider,
   usePlaygroundContext,
 } from "@phoenix/contexts/PlaygroundContext";
-import { InitialPlaygroundState } from "@phoenix/store";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+import { PlaygroundProps } from "@phoenix/store";
 
 import { NUM_MAX_PLAYGROUND_INSTANCES } from "./constants";
 import { PlaygroundCredentialsDropdown } from "./PlaygroundCredentialsDropdown";
@@ -39,7 +40,10 @@ const playgroundWrapCSS = css`
   height: 100%;
 `;
 
-export function Playground(props: InitialPlaygroundState) {
+export function Playground(props: Partial<PlaygroundProps>) {
+  const modelConfigByProvider = usePreferencesContext(
+    (state) => state.modelConfigByProvider
+  );
   const showStreamToggle = useFeatureFlag("playgroundNonStreaming");
   const [, setSearchParams] = useSearchParams();
 
@@ -56,7 +60,10 @@ export function Playground(props: InitialPlaygroundState) {
   }, [setSearchParams]);
 
   return (
-    <PlaygroundProvider {...props}>
+    <PlaygroundProvider
+      {...props}
+      modelConfigByProvider={modelConfigByProvider}
+    >
       <div css={playgroundWrapCSS}>
         <View
           borderBottomColor="dark"

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -2,6 +2,8 @@ import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { InvocationParameters } from "@phoenix/pages/playground/__generated__/PlaygroundOutputSubscription.graphql";
 import { OpenAIToolCall, OpenAIToolDefinition } from "@phoenix/schemas";
 
+import { ModelConfigByProvider } from "../preferencesStore";
+
 export type GenAIOperationType = "chat" | "text_completion";
 /**
  * The input mode for the playground
@@ -163,7 +165,9 @@ export interface PlaygroundProps {
   streaming: boolean;
 }
 
-export type InitialPlaygroundState = Partial<PlaygroundProps>;
+export type InitialPlaygroundState = Partial<PlaygroundProps> & {
+  modelConfigByProvider: ModelConfigByProvider;
+};
 
 export interface PlaygroundState extends PlaygroundProps {
   /**
@@ -201,6 +205,10 @@ export interface PlaygroundState extends PlaygroundProps {
   updateModel: (params: {
     instanceId: number;
     model: Partial<ModelConfig>;
+    /**
+     * The saved model configurations for providers will be used as the default parameters for the new provider if the provider is changed
+     */
+    modelConfigByProvider: Partial<Record<ModelProvider, ModelConfig>>;
   }) => void;
   /**
    * Run all the active playground Instances

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -3,7 +3,11 @@ import { devtools, persist } from "zustand/middleware";
 
 import { LastNTimeRangeKey } from "@phoenix/components/datetime/types";
 
+import { ModelConfig } from "./playground";
+
 export type MarkdownDisplayMode = "text" | "markdown";
+
+export type ModelConfigByProvider = Partial<Record<ModelProvider, ModelConfig>>;
 
 export interface PreferencesProps {
   /**
@@ -34,6 +38,10 @@ export interface PreferencesProps {
    * Whether or not the trace tree shows metrics
    */
   showMetricsInTraceTree: boolean;
+  /**
+   * {@link ModelConfig|ModelConfigs} for llm providers will be used as the default parameters for the provider
+   */
+  modelConfigByProvider: ModelConfigByProvider;
 }
 
 export interface PreferencesState extends PreferencesProps {
@@ -66,6 +74,16 @@ export interface PreferencesState extends PreferencesProps {
    * @param showMetricsInTraceTree
    */
   setShowMetricsInTraceTree: (showMetricsInTraceTree: boolean) => void;
+  /**
+   * Setter for the model configs by provider
+   */
+  setModelConfigForProvider: ({
+    provider,
+    modelConfig,
+  }: {
+    provider: ModelProvider;
+    modelConfig: ModelConfig;
+  }) => void;
 }
 
 export const createPreferencesStore = (
@@ -95,6 +113,17 @@ export const createPreferencesStore = (
     showMetricsInTraceTree: true,
     setShowMetricsInTraceTree: (showMetricsInTraceTree) => {
       set({ showMetricsInTraceTree });
+    },
+    modelConfigByProvider: {},
+    setModelConfigForProvider: ({ provider, modelConfig }) => {
+      set((state) => {
+        return {
+          modelConfigByProvider: {
+            ...state.modelConfigByProvider,
+            [provider]: modelConfig,
+          },
+        };
+      });
     },
     ...initialProps,
   });


### PR DESCRIPTION
resolves #5069 

- allows for saving a model configuration by provider in the preferences store, persisted to local storage
Behavior:
- will attempt to pull from local storage when navigating to the default playground with no instances passed in (i.e., not from a span)
  - this will attempt to pull from the default provider for the playground (i.e., openai)
  - if an openai config is not save din local storage it will pull from the first provider in local storage if one exists, otherwise falling back to default model config
- when switching between providers within a playground instance it will pull from local storage for the provider switched to
  - it will populate the model or model like fields for azure
  - it will not populate invocation params from the config in local storage (this can be changed but seems a little bit counter to testing flows

 

https://github.com/user-attachments/assets/ea19b800-d7d0-49e4-a023-4de697d5fd3a

