### PR TITLE
feat(sesions): add session details page

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -7,6 +7,7 @@ import { embeddingLoaderQuery$data } from "./pages/embedding/__generated__/embed
 import { Layout } from "./pages/Layout";
 import { spanPlaygroundPageLoaderQuery$data } from "./pages/playground/__generated__/spanPlaygroundPageLoaderQuery.graphql";
 import { projectLoaderQuery$data } from "./pages/project/__generated__/projectLoaderQuery.graphql";
+import { sessionLoader } from "./pages/trace/sessionLoader";
 import { SessionPage } from "./pages/trace/SessionPage";
 import {
   APIsPage,
@@ -118,7 +119,11 @@ const router = createBrowserRouter(
               <Route index element={<ProjectPage />} />
               <Route element={<ProjectPage />}>
                 <Route path="traces/:traceId" element={<TracePage />} />
-                <Route path="sessions/:sessionId" element={<SessionPage />} />
+                <Route
+                  path="sessions/:sessionId"
+                  element={<SessionPage />}
+                  loader={sessionLoader}
+                />
               </Route>
             </Route>
           </Route>

--- a/app/src/components/table/TimestampCell.tsx
+++ b/app/src/components/table/TimestampCell.tsx
@@ -11,7 +11,7 @@ export function TimestampCell<TData extends object, TValue>({
 }: CellContext<TData, TValue>) {
   const value = getValue();
   if (!isStringOrNull(value)) {
-    throw new Error("TimestampCell only supports number or null values.");
+    throw new Error("TimestampCell only supports string or null values.");
   }
   const timestamp =
     value != null

--- a/app/src/pages/trace/EditSpanAnnotationsButton.tsx
+++ b/app/src/pages/trace/EditSpanAnnotationsButton.tsx
@@ -1,19 +1,34 @@
 import React, { ReactNode, useState } from "react";
 
-import { Button, DialogContainer, Icon, Icons } from "@arizeai/components";
+import {
+  Button,
+  ButtonProps,
+  DialogContainer,
+  Icon,
+  Icons,
+} from "@arizeai/components";
 
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
 
-export function EditSpanAnnotationsButton(props: {
+export function EditSpanAnnotationsButton({
+  spanNodeId,
+  projectId,
+  size = "default",
+}: {
   spanNodeId: string;
   projectId: string;
+  /**
+   * The size of the button
+   * @default default
+   */
+  size?: ButtonProps["size"];
 }) {
-  const { spanNodeId, projectId } = props;
   const [dialog, setDialog] = useState<ReactNode>(null);
   return (
     <>
       <Button
         variant="default"
+        size={size}
         icon={<Icon svg={<Icons.EditOutline />} />}
         onClick={() =>
           setDialog(

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -2,7 +2,53 @@ import React, { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
-import { SessionDetailsQuery } from "./__generated__/SessionDetailsQuery.graphql";
+import { Flex, Text, View } from "@arizeai/components";
+
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
+
+import {
+  SessionDetailsQuery,
+  SessionDetailsQuery$data,
+} from "./__generated__/SessionDetailsQuery.graphql";
+import { SessionDetailsTraceList } from "./SessionDetailsTraceList";
+
+function SessionDetailsHeader({
+  traceCount,
+  tokenUsage,
+}: {
+  traceCount: number;
+  tokenUsage?: NonNullable<SessionDetailsQuery$data["session"]>["tokenUsage"];
+}) {
+  return (
+    <View
+      padding={"size-200"}
+      borderBottomWidth={"thin"}
+      borderBottomColor={"dark"}
+    >
+      <Flex direction={"row"} gap={"size-400"}>
+        <Flex direction={"column"}>
+          <Text elementType={"h3"} textSize={"medium"} color={"text-700"}>
+            Traces Count
+          </Text>
+          <Text textSize={"xlarge"}>{traceCount}</Text>
+        </Flex>
+        {tokenUsage != null ? (
+          <Flex direction={"column"}>
+            <Text elementType={"h3"} textSize={"medium"} color={"text-700"}>
+              Total Tokens
+            </Text>
+            <TokenCount
+              tokenCountTotal={tokenUsage.total}
+              tokenCountCompletion={tokenUsage.completion}
+              tokenCountPrompt={tokenUsage.prompt}
+              textSize={"xlarge"}
+            />
+          </Flex>
+        ) : null}
+      </Flex>
+    </View>
+  );
+}
 
 export type SessionDetailsProps = {
   sessionId: string;
@@ -18,15 +64,44 @@ export function SessionDetails(props: SessionDetailsProps) {
       query SessionDetailsQuery($id: GlobalID!) {
         session: node(id: $id) {
           ... on ProjectSession {
+            numTraces
+            durationS
+            tokenUsage {
+              total
+              completion
+              prompt
+            }
+            sessionId
+            sessionUser
             traces {
               edges {
                 trace: node {
                   rootSpan {
+                    id
+                    project {
+                      id
+                    }
                     input {
                       value
                     }
                     output {
                       value
+                    }
+                    cumulativeTokenCountTotal
+                    cumulativeTokenCountCompletion
+                    cumulativeTokenCountPrompt
+                    latencyMs
+                    startTime
+                    spanAnnotations {
+                      name
+                      label
+                      score
+                      explanation
+                      annotatorKind
+                    }
+                    context {
+                      traceId
+                      spanId
                     }
                   }
                 }
@@ -43,37 +118,28 @@ export function SessionDetails(props: SessionDetailsProps) {
       fetchPolicy: "store-and-network",
     }
   );
-  const spansList = useMemo(() => {
-    const gqlSpans = data.session?.traces?.edges || [];
-    return gqlSpans.map(({ trace }) => trace);
-  }, [data]);
+
+  if (data.session == null) {
+    throw new Error("Session not found");
+  }
   return (
     <main
       css={css`
         flex: 1 1 auto;
-        overflow: hidden;
         display: flex;
         flex-direction: column;
+        height: 100%;
+        overflow: hidden;
       `}
     >
-      <table border={1} cellPadding={20}>
-        <thead>
-          <tr>
-            <th>#</th>
-            <th>User</th>
-            <th>Assistant</th>
-          </tr>
-        </thead>
-        <tbody>
-          {spansList.map((trace, index) => (
-            <tr key={index}>
-              <td>{index + 1}</td>
-              <td>{trace.rootSpan?.input?.value}</td>
-              <td>{trace.rootSpan?.output?.value}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <SessionDetailsHeader
+        traceCount={data.session.numTraces ?? 0}
+        tokenUsage={data.session.tokenUsage}
+      />
+      <SessionDetailsTraceList
+        traces={data.session.traces}
+        user={data.session.sessionUser}
+      />
     </main>
   );
 }

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -72,12 +72,12 @@ export function SessionDetails(props: SessionDetailsProps) {
               prompt
             }
             sessionId
-            sessionUser
             traces {
               edges {
                 trace: node {
                   rootSpan {
                     id
+                    attributes
                     project {
                       id
                     }
@@ -136,10 +136,7 @@ export function SessionDetails(props: SessionDetailsProps) {
         traceCount={data.session.numTraces ?? 0}
         tokenUsage={data.session.tokenUsage}
       />
-      <SessionDetailsTraceList
-        traces={data.session.traces}
-        user={data.session.sessionUser}
-      />
+      <SessionDetailsTraceList traces={data.session.traces} />
     </main>
   );
 }

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -1,0 +1,182 @@
+import React, { useMemo } from "react";
+
+import { Flex, Icon, Icons, Text, View } from "@arizeai/components";
+
+import { Link } from "@phoenix/components";
+import {
+  AnnotationLabel,
+  AnnotationTooltip,
+} from "@phoenix/components/annotation";
+import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { fullTimeFormatter } from "@phoenix/utils/timeFormatUtils";
+
+import { SessionDetailsQuery$data } from "./__generated__/SessionDetailsQuery.graphql";
+import { EditSpanAnnotationsButton } from "./EditSpanAnnotationsButton";
+
+function RootSpanMessage({
+  role,
+  value,
+}: {
+  role: "HUMAN" | "AI";
+  value: string;
+}) {
+  return (
+    <View
+      alignSelf={role === "HUMAN" ? "start" : "end"}
+      borderRadius={"medium"}
+      borderColor={"dark"}
+      borderWidth={"thin"}
+      padding={"size-100"}
+      maxWidth={"70%"}
+    >
+      <Flex direction={"column"} gap={"size-100"}>
+        <Text color="text-700" textSize="medium">
+          {role}
+        </Text>
+        <Text>{value}</Text>
+      </Flex>
+    </View>
+  );
+}
+
+type SessionTraceRootSpan = NonNullable<
+  NonNullable<
+    SessionDetailsQuery$data["session"]["traces"]
+  >["edges"][number]["trace"]["rootSpan"]
+>;
+
+type RootSpanProps = {
+  rootSpan: SessionTraceRootSpan;
+};
+
+function RootSpanDetails({
+  rootSpan,
+  user,
+}: RootSpanProps & { user?: string | null }) {
+  const startDate = useMemo(() => {
+    return new Date(rootSpan.startTime);
+  }, [rootSpan.startTime]);
+  return (
+    <View height={"100%"}>
+      <Flex
+        direction={"column"}
+        justifyContent={"space-between"}
+        height={"100%"}
+      >
+        <Flex direction={"column"} gap={"size-200"}>
+          <Flex direction={"row"} justifyContent={"space-between"}>
+            <Text>Trace ID: {rootSpan.context.traceId}</Text>
+            <Link
+              to={`/projects/${rootSpan.project.id}/traces/${rootSpan.context.traceId}`}
+            >
+              <Flex alignItems={"center"}>
+                View Trace
+                <Icon svg={<Icons.ArrowIosForwardOutline />} />
+              </Flex>
+            </Link>
+          </Flex>
+          <Flex direction={"row"} justifyContent={"space-between"}>
+            {user != null ? <Text color="text-700">user: {user}</Text> : null}
+            <Text color="text-700" flex={"end"} marginStart={"auto"}>
+              {fullTimeFormatter(startDate)}
+            </Text>
+          </Flex>
+          <Flex direction={"row"} gap={"size-100"}>
+            <TokenCount
+              tokenCountTotal={rootSpan.cumulativeTokenCountTotal ?? 0}
+              tokenCountCompletion={
+                rootSpan.cumulativeTokenCountCompletion ?? 0
+              }
+              tokenCountPrompt={rootSpan.cumulativeTokenCountPrompt ?? 0}
+            />
+            {rootSpan.latencyMs != null ? (
+              <LatencyText latencyMs={rootSpan.latencyMs} />
+            ) : (
+              "--"
+            )}
+          </Flex>
+        </Flex>
+        <Flex direction={"row"} justifyContent={"space-between"}>
+          <Flex direction={"column"} gap={"size-100"} maxWidth={"50%"}>
+            <Text textSize="medium">Feedback</Text>
+            <Flex gap={"size-50"} direction={"column"}>
+              {rootSpan.spanAnnotations.length > 0
+                ? rootSpan.spanAnnotations.map((annotation) => (
+                    <AnnotationTooltip
+                      key={annotation.name}
+                      annotation={annotation}
+                    >
+                      <AnnotationLabel
+                        annotation={annotation}
+                        annotationDisplayPreference="label"
+                      />
+                    </AnnotationTooltip>
+                  ))
+                : "--"}
+            </Flex>
+          </Flex>
+          <span>
+            <EditSpanAnnotationsButton
+              size={"compact"}
+              spanNodeId={rootSpan.id}
+              projectId={rootSpan.project.id}
+            />
+          </span>
+        </Flex>
+      </Flex>
+    </View>
+  );
+}
+
+function RootSpanInputOutput({ rootSpan }: RootSpanProps) {
+  return (
+    <Flex direction={"column"} gap={"size-100"}>
+      <RootSpanMessage role={"HUMAN"} value={rootSpan.input?.value ?? "--"} />
+      <RootSpanMessage role={"AI"} value={rootSpan.output?.value ?? "--"} />
+    </Flex>
+  );
+}
+
+export function SessionDetailsTraceList({
+  traces,
+  user,
+}: {
+  traces: SessionDetailsQuery$data["session"]["traces"];
+  user?: string | null;
+}) {
+  const sessionRootSpans = useMemo(() => {
+    const edges = traces?.edges || [];
+    return edges
+      .map(({ trace }) => trace.rootSpan)
+      .filter(
+        (rootSpan): rootSpan is NonNullable<typeof rootSpan> => rootSpan != null
+      );
+  }, [traces]);
+
+  return (
+    <View height={"100%"} flex={"1 1 auto"} overflow={"auto"}>
+      {sessionRootSpans.map((rootSpan) => (
+        <View
+          borderBottomColor={"dark"}
+          borderBottomWidth={"thin"}
+          key={rootSpan.context.spanId}
+        >
+          <Flex direction={"row"}>
+            <View
+              width={"67%"}
+              borderRightWidth={"thin"}
+              borderEndColor={"dark"}
+              padding={"size-200"}
+            >
+              <RootSpanInputOutput rootSpan={rootSpan} />
+            </View>
+            <View width={"33%"} padding={"size-200"}>
+              <RootSpanDetails rootSpan={rootSpan} user={user} />
+            </View>
+          </Flex>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/app/src/pages/trace/SessionPage.tsx
+++ b/app/src/pages/trace/SessionPage.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router";
+import { useLoaderData, useNavigate, useParams } from "react-router";
 
 import { Dialog, DialogContainer } from "@arizeai/components";
 
+import { sessionLoaderQuery$data } from "./__generated__/sessionLoaderQuery.graphql";
 import { SessionDetails } from "./SessionDetails";
 
 /**
  * A component that shows the details of a session
  */
 export function SessionPage() {
+  const loaderData = useLoaderData() as sessionLoaderQuery$data;
   const { sessionId, projectId } = useParams();
   const navigate = useNavigate();
   return (
@@ -17,7 +19,10 @@ export function SessionPage() {
       isDismissable
       onDismiss={() => navigate(`/projects/${projectId}`)}
     >
-      <Dialog size="fullscreen" title="Session Details">
+      <Dialog
+        size="fullscreen"
+        title={`Session ID: ${loaderData.session?.sessionId ?? "--"}`}
+      >
         <SessionDetails sessionId={sessionId as string} />
       </Dialog>
     </DialogContainer>

--- a/app/src/pages/trace/SessionPage.tsx
+++ b/app/src/pages/trace/SessionPage.tsx
@@ -3,6 +3,8 @@ import { useLoaderData, useNavigate, useParams } from "react-router";
 
 import { Dialog, DialogContainer } from "@arizeai/components";
 
+import { ErrorBoundary } from "@phoenix/components/ErrorBoundary";
+
 import { sessionLoaderQuery$data } from "./__generated__/sessionLoaderQuery.graphql";
 import { SessionDetails } from "./SessionDetails";
 
@@ -23,7 +25,9 @@ export function SessionPage() {
         size="fullscreen"
         title={`Session ID: ${loaderData.session?.sessionId ?? "--"}`}
       >
-        <SessionDetails sessionId={sessionId as string} />
+        <ErrorBoundary>
+          <SessionDetails sessionId={sessionId as string} />
+        </ErrorBoundary>
       </Dialog>
     </DialogContainer>
   );

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<275887cc5aefe741b782e520331fc0a3>>
+ * @generated SignedSource<<21e2acce75e3bf65e63592e7d732e7d1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,6 @@ export type SessionDetailsQuery$data = {
     readonly durationS?: number;
     readonly numTraces?: number;
     readonly sessionId?: string;
-    readonly sessionUser?: string | null;
     readonly tokenUsage?: {
       readonly completion: number;
       readonly prompt: number;
@@ -28,6 +27,7 @@ export type SessionDetailsQuery$data = {
       readonly edges: ReadonlyArray<{
         readonly trace: {
           readonly rootSpan: {
+            readonly attributes: string;
             readonly context: {
               readonly spanId: string;
               readonly traceId: string;
@@ -155,13 +155,6 @@ v4 = {
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "sessionUser",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "concreteType": "TraceConnection",
       "kind": "LinkedField",
       "name": "traces",
@@ -192,6 +185,13 @@ v4 = {
                   "plural": false,
                   "selections": [
                     (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "attributes",
+                      "storageKey": null
+                    },
                     {
                       "alias": null,
                       "args": null,
@@ -402,16 +402,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9917255f6649a8bed7c429857e867f71",
+    "cacheID": "09ca169a239c3edcc9f8908f4a0201c1",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      durationS\n      tokenUsage {\n        total\n        completion\n        prompt\n      }\n      sessionId\n      sessionUser\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              id\n              project {\n                id\n              }\n              input {\n                value\n              }\n              output {\n                value\n              }\n              cumulativeTokenCountTotal\n              cumulativeTokenCountCompletion\n              cumulativeTokenCountPrompt\n              latencyMs\n              startTime\n              spanAnnotations {\n                name\n                label\n                score\n                explanation\n                annotatorKind\n              }\n              context {\n                traceId\n                spanId\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      durationS\n      tokenUsage {\n        total\n        completion\n        prompt\n      }\n      sessionId\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              id\n              attributes\n              project {\n                id\n              }\n              input {\n                value\n              }\n              output {\n                value\n              }\n              cumulativeTokenCountTotal\n              cumulativeTokenCountCompletion\n              cumulativeTokenCountPrompt\n              latencyMs\n              startTime\n              spanAnnotations {\n                name\n                label\n                score\n                explanation\n                annotatorKind\n              }\n              context {\n                traceId\n                spanId\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4dfc958771c43238d7a1682db95ae23b";
+(node as any).hash = "62f1429817469399e053509dd1dfee4c";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09739022ca9b52d61d2eb5646d7e9906>>
+ * @generated SignedSource<<275887cc5aefe741b782e520331fc0a3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,21 +9,51 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+export type AnnotatorKind = "HUMAN" | "LLM";
 export type SessionDetailsQuery$variables = {
   id: string;
 };
 export type SessionDetailsQuery$data = {
   readonly session: {
+    readonly durationS?: number;
+    readonly numTraces?: number;
+    readonly sessionId?: string;
+    readonly sessionUser?: string | null;
+    readonly tokenUsage?: {
+      readonly completion: number;
+      readonly prompt: number;
+      readonly total: number;
+    };
     readonly traces?: {
       readonly edges: ReadonlyArray<{
         readonly trace: {
           readonly rootSpan: {
+            readonly context: {
+              readonly spanId: string;
+              readonly traceId: string;
+            };
+            readonly cumulativeTokenCountCompletion: number | null;
+            readonly cumulativeTokenCountPrompt: number | null;
+            readonly cumulativeTokenCountTotal: number | null;
+            readonly id: string;
             readonly input: {
               readonly value: string;
             } | null;
+            readonly latencyMs: number | null;
             readonly output: {
               readonly value: string;
             } | null;
+            readonly project: {
+              readonly id: string;
+            };
+            readonly spanAnnotations: ReadonlyArray<{
+              readonly annotatorKind: AnnotatorKind;
+              readonly explanation: string | null;
+              readonly label: string | null;
+              readonly name: string;
+              readonly score: number | null;
+            }>;
+            readonly startTime: string;
           } | null;
         };
       }>;
@@ -50,7 +80,14 @@ v1 = [
     "variableName": "id"
   }
 ],
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -59,9 +96,69 @@ v2 = [
     "storageKey": null
   }
 ],
-v3 = {
+v4 = {
   "kind": "InlineFragment",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "numTraces",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "durationS",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TokenUsage",
+      "kind": "LinkedField",
+      "name": "tokenUsage",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "total",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "completion",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "prompt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sessionId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sessionUser",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -94,6 +191,19 @@ v3 = {
                   "name": "rootSpan",
                   "plural": false,
                   "selections": [
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Project",
+                      "kind": "LinkedField",
+                      "name": "project",
+                      "plural": false,
+                      "selections": [
+                        (v2/*: any*/)
+                      ],
+                      "storageKey": null
+                    },
                     {
                       "alias": null,
                       "args": null,
@@ -101,7 +211,7 @@ v3 = {
                       "kind": "LinkedField",
                       "name": "input",
                       "plural": false,
-                      "selections": (v2/*: any*/),
+                      "selections": (v3/*: any*/),
                       "storageKey": null
                     },
                     {
@@ -111,7 +221,113 @@ v3 = {
                       "kind": "LinkedField",
                       "name": "output",
                       "plural": false,
-                      "selections": (v2/*: any*/),
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "cumulativeTokenCountTotal",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "cumulativeTokenCountCompletion",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "cumulativeTokenCountPrompt",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "latencyMs",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "startTime",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanAnnotation",
+                      "kind": "LinkedField",
+                      "name": "spanAnnotations",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "name",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "label",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "score",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "explanation",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "annotatorKind",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanContext",
+                      "kind": "LinkedField",
+                      "name": "context",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "traceId",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "spanId",
+                          "storageKey": null
+                        }
+                      ],
                       "storageKey": null
                     }
                   ],
@@ -145,7 +361,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
@@ -174,34 +390,28 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v2/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "8b29972b49439ce8942839cc38a0c5be",
+    "cacheID": "9917255f6649a8bed7c429857e867f71",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              input {\n                value\n              }\n              output {\n                value\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      durationS\n      tokenUsage {\n        total\n        completion\n        prompt\n      }\n      sessionId\n      sessionUser\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              id\n              project {\n                id\n              }\n              input {\n                value\n              }\n              output {\n                value\n              }\n              cumulativeTokenCountTotal\n              cumulativeTokenCountCompletion\n              cumulativeTokenCountPrompt\n              latencyMs\n              startTime\n              spanAnnotations {\n                name\n                label\n                score\n                explanation\n                annotatorKind\n              }\n              context {\n                traceId\n                spanId\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e2fd415f62c6b3af00e449a4dc383959";
+(node as any).hash = "4dfc958771c43238d7a1682db95ae23b";
 
 export default node;

--- a/app/src/pages/trace/__generated__/sessionLoaderQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/sessionLoaderQuery.graphql.ts
@@ -1,0 +1,127 @@
+/**
+ * @generated SignedSource<<6a317767fa35c0ba549716c69394ada1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type sessionLoaderQuery$variables = {
+  id: string;
+};
+export type sessionLoaderQuery$data = {
+  readonly session: {
+    readonly id: string;
+    readonly sessionId?: string;
+  };
+};
+export type sessionLoaderQuery = {
+  response: sessionLoaderQuery$data;
+  variables: sessionLoaderQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sessionId",
+      "storageKey": null
+    }
+  ],
+  "type": "ProjectSession",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "sessionLoaderQuery",
+    "selections": [
+      {
+        "alias": "session",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "sessionLoaderQuery",
+    "selections": [
+      {
+        "alias": "session",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "aa110794a0fd7ac02812e8e14196930b",
+    "id": null,
+    "metadata": {},
+    "name": "sessionLoaderQuery",
+    "operationKind": "query",
+    "text": "query sessionLoaderQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    id\n    ... on ProjectSession {\n      sessionId\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "26e5a5dbde9bd4ecfd7ae5fc1c078860";
+
+export default node;

--- a/app/src/pages/trace/sessionLoader.ts
+++ b/app/src/pages/trace/sessionLoader.ts
@@ -1,0 +1,29 @@
+import { fetchQuery, graphql } from "react-relay";
+import { LoaderFunctionArgs } from "react-router-dom";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import { sessionLoaderQuery } from "./__generated__/sessionLoaderQuery.graphql";
+
+/**
+ * Loads in the necessary page data for the dataset page
+ */
+export async function sessionLoader(args: LoaderFunctionArgs) {
+  const { sessionId } = args.params;
+  return await fetchQuery<sessionLoaderQuery>(
+    RelayEnvironment,
+    graphql`
+      query sessionLoaderQuery($id: GlobalID!) {
+        session: node(id: $id) {
+          id
+          ... on ProjectSession {
+            sessionId
+          }
+        }
+      }
+    `,
+    {
+      id: sessionId as string,
+    }
+  ).toPromise();
+}

--- a/app/src/typeUtils.ts
+++ b/app/src/typeUtils.ts
@@ -42,6 +42,18 @@ export function isObject(value: unknown): value is object {
 }
 
 /**
+ * A type guard for checking if a value is an object with string keys
+ */
+export function isObjectWithStringKeys(
+  value: unknown
+): value is Record<string, unknown> {
+  return (
+    isObject(value) &&
+    Object.keys(value).every((key) => typeof key === "string")
+  );
+}
+
+/**
  * Makes a type mutable
  */
 export type Mutable<T> = {

--- a/scripts/fixtures/multi-turn_chat_sessions.ipynb
+++ b/scripts/fixtures/multi-turn_chat_sessions.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "52b788701385cc6f",
    "metadata": {},
    "outputs": [],
@@ -46,7 +46,7 @@
    "id": "0b9e29a5",
    "metadata": {},
    "source": [
-    "# Download Data"
+    "# Download Data\n"
    ]
   },
   {
@@ -65,12 +65,12 @@
    "id": "7c62ce0f",
    "metadata": {},
    "source": [
-    "# Tracer Provider"
+    "# Tracer Provider\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "d87e76da34fee68b",
    "metadata": {},
    "outputs": [],
@@ -87,12 +87,12 @@
    "id": "df1cf375",
    "metadata": {},
    "source": [
-    "# Helpers"
+    "# Helpers\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "4f60b2ad",
    "metadata": {},
    "outputs": [],
@@ -173,7 +173,7 @@
    "id": "a2f2ac17",
    "metadata": {},
    "source": [
-    "# Genarate Sessions"
+    "# Genarate Sessions\n"
    ]
   },
   {
@@ -259,8 +259,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "phoenix",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
resolves #5008 

- adds session details page with trace list

[mocks](https://www.figma.com/design/nvX5JTTdZddvLIYEjPIEM8/Phoenix-H2-2024?node-id=230-2347&node-type=canvas&t=HXKepzqUTr6Y3UZ2-0)


https://github.com/user-attachments/assets/a8bca8dc-903c-4f47-8998-38bf071420d5

