### PR TITLE
fix(docs): update legacy imports from phoenix.trace

### DIFF
--- a/tutorials/evals/evaluate_human_vs_ai_classifications.ipynb
+++ b/tutorials/evals/evaluate_human_vs_ai_classifications.ipynb
@@ -29,12 +29,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Requires arize-phoenix as it usees UI / tracing\n",
-    "!pip install -qq \"arize-phoenix-evals\" \"arize-phoenix\" \"openai>=1\" ipython matplotlib pycm scikit-learn tiktoken"
+    "!pip install -qq \"arize-phoenix\" \"openai>=1\" ipython matplotlib pycm scikit-learn tiktoken openinference-instrumentation-openai"
    ]
   },
   {
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -322,12 +322,15 @@
     }
    ],
    "source": [
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
     "import phoenix as px\n",
-    "from phoenix.trace.openai import OpenAIInstrumentor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "px.launch_app().view()\n",
     "\n",
-    "OpenAIInstrumentor().instrument()"
+    "tracer_provider = register()\n",
+    "OpenAIInstrumentor(tracer_provider=tracer_provider).instrument()"
    ]
   },
   {

--- a/tutorials/evals/evaluate_reference_link_correctness_classifications.ipynb
+++ b/tutorials/evals/evaluate_reference_link_correctness_classifications.ipynb
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -94,7 +94,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qq \"arize-phoenix[llama-index]\" \"arize-phoenix-evals>=0.0.5\" ipython matplotlib \"openai>1\" pycm scikit-learn tiktoken playwright nest_asyncio"
+    "!pip install -qq \"arize-phoenix\" \"arize-phoenix-evals>=0.0.5\" ipython matplotlib \"openai>1\" pycm scikit-learn tiktoken playwright nest_asyncio openinference-instrumentation-openai"
    ]
   },
   {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "dTi-Neb78Utj"
    },
@@ -131,6 +131,7 @@
     "import matplotlib.pyplot as plt\n",
     "import openai\n",
     "import pandas as pd\n",
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
     "from pycm import ConfusionMatrix\n",
     "from sklearn.metrics import classification_report\n",
     "\n",
@@ -141,14 +142,14 @@
     "    OpenAIModel,\n",
     "    llm_classify,\n",
     ")\n",
-    "from phoenix.trace.openai import OpenAIInstrumentor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "pd.set_option(\"display.max_colwidth\", None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -170,7 +171,8 @@
    ],
    "source": [
     "px.launch_app().view()\n",
-    "OpenAIInstrumentor().instrument()"
+    "tracer_provider = register()\n",
+    "OpenAIInstrumentor(tracer_provider=tracer_provider).instrument()"
    ]
   },
   {

--- a/tutorials/evals/evaluate_tool_calling.ipynb
+++ b/tutorials/evals/evaluate_tool_calling.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -qq \"arize-phoenix[llama-index]\" \"arize-phoenix[evals]>=0.14.0\" \"llama-index-llms-openai\" \"openai>=1\" gcsfs nest_asyncio langchain langchain-openai"
+    "%pip install -qq \"arize-phoenix[evals]>=0.14.0\" \"llama-index-llms-openai\" \"openai>=1\" gcsfs nest_asyncio langchain langchain-openai openinference-instrumentation-langchain"
    ]
   },
   {
@@ -201,9 +201,10 @@
     "from langchain.prompts.chat import ChatPromptTemplate, MessagesPlaceholder\n",
     "from langchain.tools import tool\n",
     "from langchain_openai import ChatOpenAI\n",
+    "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "\n",
     "import phoenix as px\n",
-    "from phoenix.trace.langchain import LangChainInstrumentor"
+    "from phoenix.otel import register"
    ]
   },
   {
@@ -227,7 +228,8 @@
    "outputs": [],
    "source": [
     "(session := px.launch_app()).view()\n",
-    "LangChainInstrumentor().instrument(skip_dep_check=True)"
+    "tracer_provider = register()\n",
+    "LangChainInstrumentor(tracer_provider=tracer_provider).instrument(skip_dep_check=True)"
    ]
   },
   {
@@ -789,7 +791,8 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -802,7 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.2"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/tutorials/evals/evaluate_user_frustration_classifications.ipynb
+++ b/tutorials/evals/evaluate_user_frustration_classifications.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -59,18 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qqq \"arize-phoenix\" \"openai>=1\" ipython matplotlib pycm scikit-learn tiktoken"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "P1eMMKBhxPBE"
-   },
-   "outputs": [],
-   "source": [
-    "!pip -qqq install 'arize-phoenix[evals]'"
+    "!pip install -qqq \"arize-phoenix\" \"openai>=1\" ipython matplotlib pycm scikit-learn tiktoken openinference-instrumentation-openai"
    ]
   },
   {
@@ -245,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -266,11 +255,14 @@
     }
    ],
    "source": [
+    "from openinference.instrumentation.openai import OpenAIInstrumentor\n",
+    "\n",
     "import phoenix as px\n",
-    "from phoenix.trace.openai import OpenAIInstrumentor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "(session := px.launch_app()).view()\n",
-    "OpenAIInstrumentor().instrument()"
+    "tracer_provider = register()\n",
+    "OpenAIInstrumentor(tracer_provider=tracer_provider).instrument()"
    ]
   },
   {

--- a/tutorials/qdrant_langchain_instrumentation_search_and_retrieval_tutorial.ipynb
+++ b/tutorials/qdrant_langchain_instrumentation_search_and_retrieval_tutorial.ipynb
@@ -242,7 +242,7 @@
    "outputs": [],
    "source": [
     "tracer_provider = register()\n",
-    "LangChainInstrumentor(tracer_provider).instrument(skip_dep_check=True)"
+    "LangChainInstrumentor(tracer_provider=tracer_provider).instrument(skip_dep_check=True)"
    ]
   },
   {

--- a/tutorials/qdrant_langchain_instrumentation_search_and_retrieval_tutorial.ipynb
+++ b/tutorials/qdrant_langchain_instrumentation_search_and_retrieval_tutorial.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -Uq langchain qdrant-client langchain_community tiktoken cohere langchain-openai \"protobuf>=3.20.3\" \"arize-phoenix[evals,llama-index,embeddings]\" \"openai>=1\""
+    "%pip install -Uq langchain qdrant-client langchain_community tiktoken cohere langchain-openai \"protobuf>=3.20.3\" \"arize-phoenix[evals,embeddings]\" \"openai>=1\" openinference-instrumentation-langchain"
    ]
   },
   {
@@ -112,9 +112,12 @@
     "from langchain_community.vectorstores import Qdrant\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",
-    "# Phoenix imports\n",
+    "# OpenInference imports\n",
+    "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
+    "\n",
+    "# Phoenix and OpenInference imports\n",
     "import phoenix as px\n",
-    "from phoenix.trace.langchain import LangChainInstrumentor\n",
+    "from phoenix.otel import register\n",
     "\n",
     "# Miscellaneous imports\n",
     "\n",
@@ -238,7 +241,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LangChainInstrumentor().instrument(skip_dep_check=True)"
+    "tracer_provider = register()\n",
+    "LangChainInstrumentor(tracer_provider).instrument(skip_dep_check=True)"
    ]
   },
   {

--- a/tutorials/tracing/bedrock_claude_tracing_tutorial.ipynb
+++ b/tutorials/tracing/bedrock_claude_tracing_tutorial.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.1.0\" \"arize-phoenix[evals]\" tiktoken nest-asyncio boto3 -q"
+    "!pip install \"langchain>=0.1.0\" \"arize-phoenix[evals]\" tiktoken nest-asyncio boto3 openinference-instrumentation-langchain -q"
    ]
   },
   {
@@ -77,6 +77,7 @@
     "from langchain.retrievers import KNNRetriever\n",
     "from langchain_community.chat_models import BedrockChat\n",
     "from langchain_community.embeddings import BedrockEmbeddings\n",
+    "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "from tqdm import tqdm\n",
     "\n",
     "import phoenix as px\n",
@@ -87,9 +88,9 @@
     "    RelevanceEvaluator,\n",
     "    run_evals,\n",
     ")\n",
+    "from phoenix.otel import register\n",
     "from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents\n",
     "from phoenix.trace import DocumentEvaluations, SpanEvaluations\n",
-    "from phoenix.trace.langchain import LangChainInstrumentor\n",
     "\n",
     "nest_asyncio.apply()  # needed for concurrent evals in notebook environments\n",
     "\n",
@@ -207,7 +208,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LangChainInstrumentor().instrument(skip_dep_check=True)"
+    "tracer_provider = register()\n",
+    "LangChainInstrumentor(tracer_provider=tracer_provider).instrument(skip_dep_check=True)"
    ]
   },
   {

--- a/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.0.334\" langchain-community \"openai>=1\" numexpr arize-phoenix"
+    "!pip install \"langchain>=0.0.334\" langchain-community \"openai>=1\" numexpr arize-phoenix openinference-instrumentation-langchain"
    ]
   },
   {
@@ -65,9 +65,10 @@
     "from langchain.chains import LLMMathChain\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder\n",
+    "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "\n",
     "import phoenix as px\n",
-    "from phoenix.trace.langchain import LangChainInstrumentor"
+    "from phoenix.otel import register"
    ]
   },
   {
@@ -135,7 +136,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LangChainInstrumentor().instrument(skip_dep_check=True)"
+    "tracer_provider = register()\n",
+    "LangChainInstrumentor(tracer_provider=tracer_provider).instrument(skip_dep_check=True)"
    ]
   },
   {

--- a/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
+++ b/tutorials/tracing/langchain_agent_tracing_tutorial.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"langchain>=0.0.334\" langchain-community \"openai>=1\" numexpr arize-phoenix openinference-instrumentation-langchain"
+    "!pip install langchain langchain-community langchain-openai openai numexpr arize-phoenix openinference-instrumentation-langchain"
    ]
   },
   {
@@ -63,8 +63,8 @@
     "import openai\n",
     "from langchain.agents import AgentType, Tool, initialize_agent\n",
     "from langchain.chains import LLMMathChain\n",
-    "from langchain.chat_models import ChatOpenAI\n",
     "from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder\n",
+    "from langchain_openai import ChatOpenAI\n",
     "from openinference.instrumentation.langchain import LangChainInstrumentor\n",
     "\n",
     "import phoenix as px\n",
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = ChatOpenAI(temperature=0, model=\"gpt-3.5-turbo-0613\")"
+    "llm = ChatOpenAI(temperature=0)"
    ]
   },
   {
@@ -233,7 +233,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = ChatOpenAI(temperature=0, model=\"gpt-3.5-turbo-0613\")\n",
     "agent_executor = initialize_agent(tools, llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=True)"
    ]
   },


### PR DESCRIPTION
Several of our notebooks are breaking due to deprecated imports from `phoenix.trace.openai` and `phoenix.trace.langchain`.

resolves #5217
