### PR TITLE
feat: Only show providers if dependencies are installed

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -905,7 +905,7 @@ type GenerativeProvider {
   name: String!
   key: GenerativeProviderKey!
   dependencies: [String!]!
-  dependenciesAreInstalled: Boolean!
+  dependenciesInstalled: Boolean!
 }
 
 enum GenerativeProviderKey {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -904,6 +904,8 @@ input GenerativeModelInput {
 type GenerativeProvider {
   name: String!
   key: GenerativeProviderKey!
+  dependencies: [String!]!
+  supportedModels: Boolean!
 }
 
 enum GenerativeProviderKey {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -905,7 +905,7 @@ type GenerativeProvider {
   name: String!
   key: GenerativeProviderKey!
   dependencies: [String!]!
-  supportedModels: Boolean!
+  dependenciesAreInstalled: Boolean!
 }
 
 enum GenerativeProviderKey {

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -106,13 +106,14 @@ class PlaygroundStreamingClient(ABC):
         return formatted_invocation_parameters
 
     @classmethod
-    def dependencies_are_available(cls) -> bool:
+    def dependencies_are_installed(cls) -> bool:
         try:
             for dependency in cls.dependencies():
                 if importlib.util.find_spec(dependency) is None:
                     return False
             return True
-        except Exception:
+        except ValueError:
+            # happens in some cases if the spec is None
             return False
 
 

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1,3 +1,4 @@
+import importlib.util
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Iterator
 from typing import (
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
         ChatCompletionMessageToolCallParam,
     )
 
+DependencyName: TypeAlias = str
 SetSpanAttributesFn: TypeAlias = Callable[[Mapping[str, Any]], None]
 ChatCompletionChunk: TypeAlias = Union[TextChunk, ToolCallChunk]
 
@@ -58,6 +60,12 @@ class PlaygroundStreamingClient(ABC):
         set_span_attributes: Optional[SetSpanAttributesFn] = None,
     ) -> None:
         self._set_span_attributes = set_span_attributes
+
+    @classmethod
+    @abstractmethod
+    def dependencies(cls) -> list[DependencyName]:
+        # A list of dependency names this client needs to run
+        ...
 
     @classmethod
     @abstractmethod
@@ -97,6 +105,16 @@ class PlaygroundStreamingClient(ABC):
         validate_invocation_parameters(supported_params, formatted_invocation_parameters)
         return formatted_invocation_parameters
 
+    @classmethod
+    def dependencies_are_available(cls) -> bool:
+        try:
+            for dependency in cls.dependencies():
+                if importlib.util.find_spec(dependency) is None:
+                    return False
+            return True
+        except Exception:
+            return False
+
 
 @register_llm_client(
     provider_key=GenerativeProviderKey.OPENAI,
@@ -133,6 +151,10 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
         super().__init__(model=model, api_key=api_key, set_span_attributes=set_span_attributes)
         self.client = AsyncOpenAI(api_key=api_key)
         self.model_name = model.name
+
+    @classmethod
+    def dependencies(cls) -> list[DependencyName]:
+        return ["openai"]
 
     @classmethod
     def supported_invocation_parameters(cls) -> list[InvocationParameter]:
@@ -521,6 +543,10 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
         super().__init__(model=model, api_key=api_key, set_span_attributes=set_span_attributes)
         self.client = anthropic.AsyncAnthropic(api_key=api_key)
         self.model_name = model.name
+
+    @classmethod
+    def dependencies(cls) -> list[DependencyName]:
+        return ["anthropic"]
 
     @classmethod
     def supported_invocation_parameters(cls) -> list[InvocationParameter]:

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -37,17 +37,10 @@ class PlaygroundClientRegistry(metaclass=SingletonMeta):
             client_class = provider_registry[PROVIDER_DEFAULT]  # Fallback to provider default
         return client_class
 
-    def list_available_providers(
+    def list_all_providers(
         self,
     ) -> list[GenerativeProviderKey]:
-        return [
-            provider_key
-            for provider_key, provider_registry in self._registry.items()
-            if (
-                (default_client := provider_registry.get(PROVIDER_DEFAULT)) is not None
-                and default_client.dependencies_are_available()
-            )
-        ]
+        return [provider_key for provider_key in self._registry]
 
     def list_models(self, provider_key: GenerativeProviderKey) -> list[str]:
         provider_registry = self._registry.get(provider_key, {})

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -44,8 +44,8 @@ class PlaygroundClientRegistry(metaclass=SingletonMeta):
             provider_key
             for provider_key, provider_registry in self._registry.items()
             if (
-                provider_registry.get(PROVIDER_DEFAULT) is not None
-                and provider_registry.get(PROVIDER_DEFAULT).dependencies_are_available()
+                (default_client := provider_registry.get(PROVIDER_DEFAULT)) is not None
+                and default_client.dependencies_are_available()
             )
         ]
 

--- a/src/phoenix/server/api/helpers/playground_registry.py
+++ b/src/phoenix/server/api/helpers/playground_registry.py
@@ -37,6 +37,18 @@ class PlaygroundClientRegistry(metaclass=SingletonMeta):
             client_class = provider_registry[PROVIDER_DEFAULT]  # Fallback to provider default
         return client_class
 
+    def list_available_providers(
+        self,
+    ) -> list[GenerativeProviderKey]:
+        return [
+            provider_key
+            for provider_key, provider_registry in self._registry.items()
+            if (
+                provider_registry.get(PROVIDER_DEFAULT) is not None
+                and provider_registry.get(PROVIDER_DEFAULT).dependencies_are_available()
+            )
+        ]
+
     def list_models(self, provider_key: GenerativeProviderKey) -> list[str]:
         provider_registry = self._registry.get(provider_key, {})
         return [model_name for model_name in provider_registry.keys() if model_name is not None]

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -98,7 +98,7 @@ class ModelsInput:
 class Query:
     @strawberry.field
     async def model_providers(self) -> list[GenerativeProvider]:
-        available_providers = PLAYGROUND_CLIENT_REGISTRY.list_available_providers()
+        available_providers = PLAYGROUND_CLIENT_REGISTRY.list_all_providers()
         return [
             GenerativeProvider(
                 name=provider_key.value,

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -37,6 +37,7 @@ from phoenix.server.api.auth import MSG_ADMIN_ONLY, IsAdmin
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound, Unauthorized
 from phoenix.server.api.helpers import ensure_list
+from phoenix.server.api.helpers.playground_clients import initialize_playground_clients
 from phoenix.server.api.helpers.playground_registry import PLAYGROUND_CLIENT_REGISTRY
 from phoenix.server.api.input_types.ClusterInput import ClusterInput
 from phoenix.server.api.input_types.Coordinates import (
@@ -84,6 +85,8 @@ from phoenix.server.api.types.User import User, to_gql_user
 from phoenix.server.api.types.UserApiKey import UserApiKey, to_gql_api_key
 from phoenix.server.api.types.UserRole import UserRole
 
+initialize_playground_clients()
+
 
 @strawberry.input
 class ModelsInput:
@@ -95,19 +98,13 @@ class ModelsInput:
 class Query:
     @strawberry.field
     async def model_providers(self) -> list[GenerativeProvider]:
+        available_providers = PLAYGROUND_CLIENT_REGISTRY.list_available_providers()
         return [
             GenerativeProvider(
-                name="OpenAI",
-                key=GenerativeProviderKey.OPENAI,
-            ),
-            GenerativeProvider(
-                name="Azure OpenAI",
-                key=GenerativeProviderKey.AZURE_OPENAI,
-            ),
-            GenerativeProvider(
-                name="Anthropic",
-                key=GenerativeProviderKey.ANTHROPIC,
-            ),
+                name=provider_key.value,
+                key=provider_key,
+            )
+            for provider_key in available_providers
         ]
 
     @strawberry.field

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -5,9 +5,9 @@ import strawberry
 
 @strawberry.enum
 class GenerativeProviderKey(Enum):
-    OPENAI = "OPENAI"
-    ANTHROPIC = "ANTHROPIC"
-    AZURE_OPENAI = "AZURE_OPENAI"
+    OPENAI = "OpenAI"
+    ANTHROPIC = "Anthropic"
+    AZURE_OPENAI = "Azure OpenAI"
 
 
 @strawberry.type

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -28,7 +28,7 @@ class GenerativeProvider:
         return []
 
     @strawberry.field
-    async def dependencies_are_installed(self) -> bool:
+    async def dependencies_installed(self) -> bool:
         from phoenix.server.api.helpers.playground_registry import (
             PLAYGROUND_CLIENT_REGISTRY,
             PROVIDER_DEFAULT,
@@ -36,5 +36,5 @@ class GenerativeProvider:
 
         default_client = PLAYGROUND_CLIENT_REGISTRY.get_client(self.key, PROVIDER_DEFAULT)
         if default_client:
-            return default_client.dependencies_are_available()
+            return default_client.dependencies_are_installed()
         return False

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -14,3 +14,27 @@ class GenerativeProviderKey(Enum):
 class GenerativeProvider:
     name: str
     key: GenerativeProviderKey
+
+    @strawberry.field
+    async def dependencies(self) -> list[str]:
+        from phoenix.server.api.helpers.playground_registry import (
+            PLAYGROUND_CLIENT_REGISTRY,
+            PROVIDER_DEFAULT,
+        )
+
+        default_client = PLAYGROUND_CLIENT_REGISTRY.get_client(self.key, PROVIDER_DEFAULT)
+        if default_client:
+            return default_client.dependencies()
+        return []
+
+    @strawberry.field
+    async def supported_models(self) -> bool:
+        from phoenix.server.api.helpers.playground_registry import (
+            PLAYGROUND_CLIENT_REGISTRY,
+            PROVIDER_DEFAULT,
+        )
+
+        default_client = PLAYGROUND_CLIENT_REGISTRY.get_client(self.key, PROVIDER_DEFAULT)
+        if default_client:
+            return default_client.dependencies_are_available()
+        return False

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -28,7 +28,7 @@ class GenerativeProvider:
         return []
 
     @strawberry.field
-    async def supported_models(self) -> bool:
+    async def dependencies_are_installed(self) -> bool:
         from phoenix.server.api.helpers.playground_registry import (
             PLAYGROUND_CLIENT_REGISTRY,
             PROVIDER_DEFAULT,


### PR DESCRIPTION
resolves #5116 

`GenerativeProvider` will now have a `dependencies` field and `dependencies_installed` field that can be used to filter down to show only available providers