### PR TITLE
feat: Support Response Format in Playground

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         files: \.(jsx?|tsx?|css|.md)$
         exclude: \.*__generated__.*$
         additional_dependencies:
-          - prettier@3.2.4
+          - prettier@3.3.3
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: "8ddcbd412c0b348841f0f82c837702f432539652"
     hooks:

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -36,6 +36,7 @@ import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
 import {
   ChatMessage,
+  createOpenAIResponseFormat,
   generateMessageId,
   PlaygroundChatTemplate as PlaygroundChatTemplateType,
   PlaygroundInstance,
@@ -49,6 +50,7 @@ import {
   MessageMode,
 } from "./MessageContentRadioGroup";
 import { MessageRolePicker } from "./MessageRolePicker";
+import { PlaygroundResponseFormat } from "./PlaygroundResponseFormat";
 import { PlaygroundTools } from "./PlaygroundTools";
 import {
   createToolCallForProvider,
@@ -79,6 +81,7 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
     throw new Error(`Playground instance ${id} not found`);
   }
   const hasTools = playgroundInstance.tools.length > 0;
+  const hasResponseFormat = playgroundInstance.responseFormat != null;
   const { template } = playgroundInstance;
   if (template.__type !== "chat") {
     throw new Error(`Invalid template type ${template.__type}`);
@@ -151,9 +154,24 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
         paddingBottom="size-100"
         borderColor="dark"
         borderTopWidth="thin"
-        borderBottomWidth={hasTools ? "thin" : undefined}
+        borderBottomWidth={hasTools || hasResponseFormat ? "thin" : undefined}
       >
         <Flex direction="row" justifyContent="end" gap="size-100">
+          <Button
+            variant="default"
+            size="compact"
+            aria-label="output schema"
+            icon={<Icon svg={<Icons.Code />} />}
+            disabled={playgroundInstance.responseFormat != null}
+            onClick={() => {
+              updateInstance({
+                instanceId: id,
+                patch: { responseFormat: createOpenAIResponseFormat() },
+              });
+            }}
+          >
+            Output Schema
+          </Button>
           <Button
             variant="default"
             aria-label="add tool"
@@ -217,6 +235,12 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
         </Flex>
       </View>
       {hasTools ? <PlaygroundTools {...props} /> : null}
+      {playgroundInstance.responseFormat ? (
+        <PlaygroundResponseFormat
+          {...props}
+          responseFormat={playgroundInstance.responseFormat}
+        />
+      ) : null}
     </DndContext>
   );
 }

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -483,7 +483,7 @@ function SortableMessageItem({
               text={
                 messageMode === "toolCalls"
                   ? JSON.stringify(message.toolCalls)
-                  : message.content ?? ""
+                  : (message.content ?? "")
               }
             />
             <Button

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -171,7 +171,7 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
             variant="default"
             size="compact"
             aria-label="output schema"
-            icon={<Icon svg={<Icons.Code />} />}
+            icon={<Icon svg={<Icons.PlusOutline />} />}
             disabled={hasResponseFormat}
             onClick={() => {
               upsertInvocationParameterInput({

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -351,7 +351,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
 
   return (
     <Card
-      title={<TitleWithAlphabeticIndex index={index} title="OutputContent" />}
+      title={<TitleWithAlphabeticIndex index={index} title="Output" />}
       collapsible
       variant="compact"
       bodyStyle={{ padding: 0 }}

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -92,7 +92,6 @@ export function PlaygroundResponseFormat({
             variant="compact"
             title={
               <Flex direction="row" gap="size-100">
-                {/* <SpanKindIcon spanKind="responseFormat" /> */}
                 <Text>Schema</Text>
               </Flex>
             }

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useState } from "react";
+import { JSONSchema7 } from "json-schema";
+
+import {
+  Accordion,
+  AccordionItem,
+  Button,
+  Card,
+  Flex,
+  Icon,
+  Icons,
+  Text,
+  View,
+} from "@arizeai/components";
+
+import { CopyToClipboardButton } from "@phoenix/components";
+import { JSONEditor } from "@phoenix/components/code";
+import { LazyEditorWrapper } from "@phoenix/components/code/LazyEditorWrapper";
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
+
+import {
+  JsonObjectSchema,
+  jsonObjectSchema,
+  openAIResponseFormatJSONSchema,
+} from "./schemas";
+import { PlaygroundInstanceProps } from "./types";
+
+/**
+ * The minimum height for the editor before it is initialized.
+ * This is to ensure that the editor is properly initialized when it is rendered outside of the viewport.
+ */
+const RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT = 400;
+
+export function PlaygroundResponseFormat({
+  playgroundInstanceId,
+  responseFormat,
+}: PlaygroundInstanceProps & {
+  responseFormat: JsonObjectSchema;
+}) {
+  const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+
+  const [responseFormatDefinition, setResponseFormatDefinition] = useState(
+    JSON.stringify(responseFormat, null, 2)
+  );
+
+  const onChange = useCallback(
+    (value: string) => {
+      setResponseFormatDefinition(value);
+      const { json: format } = safelyParseJSON(value);
+      if (format == null) {
+        return;
+      }
+      // Don't use data here returned by safeParse, as we want to allow for extra keys,
+      // there is no "deepPassthrough" to allow for extra keys
+      // at all levels of the schema, so we just use the json parsed value here,
+      // knowing that it is valid with potentially extra keys
+      const { success } = jsonObjectSchema.safeParse(format);
+      if (!success) {
+        return;
+      }
+      updateInstance({
+        instanceId: playgroundInstanceId,
+        patch: {
+          responseFormat: format,
+        },
+      });
+    },
+    [playgroundInstanceId, updateInstance]
+  );
+
+  return (
+    <Accordion arrowPosition="start">
+      <AccordionItem id="response-format" title="Output Schema">
+        <View padding="size-200">
+          <Card
+            variant="compact"
+            title={
+              <Flex direction="row" gap="size-100">
+                {/* <SpanKindIcon spanKind="responseFormat" /> */}
+                <Text>Schema</Text>
+              </Flex>
+            }
+            bodyStyle={{ padding: 0 }}
+            extra={
+              <Flex direction="row" gap="size-100">
+                <CopyToClipboardButton text={responseFormatDefinition} />
+                <Button
+                  aria-label="Delete Output Schema"
+                  icon={<Icon svg={<Icons.TrashOutline />} />}
+                  variant="default"
+                  size="compact"
+                  onClick={() => {
+                    updateInstance({
+                      instanceId: playgroundInstanceId,
+                      patch: {
+                        responseFormat: undefined,
+                      },
+                    });
+                  }}
+                />
+              </Flex>
+            }
+          >
+            <LazyEditorWrapper
+              preInitializationMinHeight={
+                RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT
+              }
+            >
+              <JSONEditor
+                value={responseFormatDefinition}
+                onChange={onChange}
+                jsonSchema={openAIResponseFormatJSONSchema as JSONSchema7}
+              />
+            </LazyEditorWrapper>
+          </Card>
+        </View>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/app/src/pages/playground/__tests__/fixtures.ts
+++ b/app/src/pages/playground/__tests__/fixtures.ts
@@ -47,6 +47,12 @@ export const basePlaygroundSpan: PlaygroundSpan = {
       invocationInputField: "value_int",
       invocationName: "seed",
     },
+    {
+      __typename: "JsonInvocationParameter",
+      canonicalName: "RESPONSE_FORMAT",
+      invocationInputField: "value_json",
+      invocationName: "response_format",
+    },
   ],
 };
 export const spanAttributesWithInputMessages = {

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -20,7 +20,6 @@ import {
   SPAN_ATTRIBUTES_PARSING_ERROR,
   TOOLS_PARSING_ERROR,
 } from "../constants";
-import { InvocationParametersForm } from "../InvocationParametersForm";
 import {
   extractVariablesFromInstances,
   getBaseModelConfigFromAttributes,
@@ -28,7 +27,6 @@ import {
   getModelInvocationParametersFromAttributes,
   getModelProviderFromModelName,
   getOutputFromAttributes,
-  getResponseFormatFromAttributes,
   getTemplateMessagesFromAttributes,
   getToolsFromAttributes,
   getVariablesMapFromInstances,

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -13,6 +13,7 @@ import {
   INPUT_MESSAGES_PARSING_ERROR,
   MODEL_CONFIG_PARSING_ERROR,
   MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR,
+  MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR,
   OUTPUT_MESSAGES_PARSING_ERROR,
   OUTPUT_VALUE_PARSING_ERROR,
   SPAN_ATTRIBUTES_PARSING_ERROR,
@@ -77,6 +78,7 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
   tools: [],
   toolChoice: "auto",
   spanId: "fake-id",
+  responseFormat: undefined,
   template: {
     __type: "chat",
     // These id's are not 0, 1, 2, because we create a playground instance (including messages) at the top of the transformSpanAttributesToPlaygroundInstance function
@@ -115,9 +117,14 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       ...basePlaygroundSpan,
       attributes: "invalid json",
     };
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      responseFormat: _,
+      ...expected
+    } = expectedPlaygroundInstanceWithIO;
     expect(transformSpanAttributesToPlaygroundInstance(span)).toStrictEqual({
       playgroundInstance: {
-        ...expectedPlaygroundInstanceWithIO,
+        ...expected,
         model: {
           provider: "OPENAI",
           modelName: "gpt-4o",
@@ -144,7 +151,6 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
           modelName: "gpt-4o",
         },
         template: defaultTemplate,
-
         output: undefined,
       },
       parsingErrors: [
@@ -153,6 +159,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
         OUTPUT_VALUE_PARSING_ERROR,
         MODEL_CONFIG_PARSING_ERROR,
         MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR,
+        MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR,
       ],
     });
   });

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -555,7 +555,10 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       playgroundInstance: {
         ...expectedPlaygroundInstanceWithIO,
       },
-      parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
+      parsingErrors: [
+        MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR,
+        MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR,
+      ],
     });
   });
 
@@ -575,7 +578,10 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       playgroundInstance: {
         ...expectedPlaygroundInstanceWithIO,
       },
-      parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
+      parsingErrors: [
+        MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR,
+        MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR,
+      ],
     });
   });
 

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -20,6 +20,7 @@ import {
   SPAN_ATTRIBUTES_PARSING_ERROR,
   TOOLS_PARSING_ERROR,
 } from "../constants";
+import { InvocationParametersForm } from "../InvocationParametersForm";
 import {
   extractVariablesFromInstances,
   getBaseModelConfigFromAttributes,
@@ -27,6 +28,7 @@ import {
   getModelInvocationParametersFromAttributes,
   getModelProviderFromModelName,
   getOutputFromAttributes,
+  getResponseFormatFromAttributes,
   getTemplateMessagesFromAttributes,
   getToolsFromAttributes,
   getVariablesMapFromInstances,
@@ -610,6 +612,25 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
         invocationParameters: [],
       },
       parsingErrors: [MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR],
+    });
+  });
+
+  it("should only return response format parsing errors if response format is defined AND malformed", () => {
+    const span = {
+      ...basePlaygroundSpan,
+      attributes: JSON.stringify({
+        ...spanAttributesWithInputMessages,
+        llm: {
+          ...spanAttributesWithInputMessages.llm,
+          invocation_parameters: `{"response_format": 1234}`,
+        },
+      }),
+    };
+    expect(transformSpanAttributesToPlaygroundInstance(span)).toEqual({
+      playgroundInstance: {
+        ...expectedPlaygroundInstanceWithIO,
+      },
+      parsingErrors: [MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR],
     });
   });
 });

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -47,9 +47,25 @@ export const TOOL_CHOICE_PARAM_CANONICAL_NAME: Extract<
 
 export const TOOL_CHOICE_PARAM_NAME = "tool_choice";
 
+export const RESPONSE_FORMAT_PARAM_CANONICAL_NAME: Extract<
+  CanonicalParameterName,
+  "RESPONSE_FORMAT"
+> = "RESPONSE_FORMAT";
+
+export const RESPONSE_FORMAT_PARAM_NAME = "response_format";
+
 /**
  * List of parameter canonical names to ignore in the invocation parameters form
  * These parameters are rendered else where on the page
  */
 export const paramsToIgnoreInInvocationParametersForm: CanonicalParameterName[] =
-  [TOOL_CHOICE_PARAM_CANONICAL_NAME];
+  [TOOL_CHOICE_PARAM_CANONICAL_NAME, RESPONSE_FORMAT_PARAM_CANONICAL_NAME];
+
+/**
+ * List of parameter canonical names to ignore in the chat completion params subscription/mutation
+ *
+ * These parameters have first class keys in the schema and are handled elsewhere
+ */
+export const paramsToIgnoreInChatCompletionParams: CanonicalParameterName[] = [
+  TOOL_CHOICE_PARAM_CANONICAL_NAME,
+];

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -28,6 +28,8 @@ export const MODEL_CONFIG_PARSING_ERROR =
   "Unable to parse model config, expected llm.model_name to be present.";
 export const MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR =
   "Unable to parse model config, expected llm.invocation_parameters json string to be present.";
+export const MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR =
+  "Unable to parse invocation parameters response_format, expected llm.invocation_parameters.response_format to be a well formed json object or undefined.";
 // TODO(parker / apowell) - adjust this error message with anthropic support https://github.com/Arize-ai/phoenix/issues/5100
 export const TOOLS_PARSING_ERROR =
   "Unable to parse tools, expected tools to be an array of valid OpenAI tools.";

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -30,9 +30,8 @@ export const MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR =
   "Unable to parse model config, expected llm.invocation_parameters json string to be present.";
 export const MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR =
   "Unable to parse invocation parameters response_format, expected llm.invocation_parameters.response_format to be a well formed json object or undefined.";
-// TODO(parker / apowell) - adjust this error message with anthropic support https://github.com/Arize-ai/phoenix/issues/5100
 export const TOOLS_PARSING_ERROR =
-  "Unable to parse tools, expected tools to be an array of valid OpenAI tools.";
+  "Unable to parse tools, expected tools to be an array of valid tools.";
 
 export const modelProviderToModelPrefixMap: Record<ModelProvider, string[]> = {
   AZURE_OPENAI: [],
@@ -60,12 +59,3 @@ export const RESPONSE_FORMAT_PARAM_NAME = "response_format";
  */
 export const paramsToIgnoreInInvocationParametersForm: CanonicalParameterName[] =
   [TOOL_CHOICE_PARAM_CANONICAL_NAME, RESPONSE_FORMAT_PARAM_CANONICAL_NAME];
-
-/**
- * List of parameter canonical names to ignore in the chat completion params subscription/mutation
- *
- * These parameters have first class keys in the schema and are handled elsewhere
- */
-export const paramsToIgnoreInChatCompletionParams: CanonicalParameterName[] = [
-  TOOL_CHOICE_PARAM_CANONICAL_NAME,
-];

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -466,6 +466,7 @@ export function transformSpanAttributesToPlaygroundInstance(
     modelConfig != null
       ? {
           ...modelConfig,
+          // TODO(apowell): Remove response_format and tool related parameters from invocation parameters
           invocationParameters,
         }
       : null;

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -845,12 +845,19 @@ export const getChatCompletionVariables = ({
     targetProvider: instance.model.provider,
   });
   if (instance.tools.length > 0) {
-    invocationParameters = invocationParameters.map((param) =>
-      param.canonicalName === TOOL_CHOICE_PARAM_CANONICAL_NAME
-        ? { ...param, valueJson: convertedToolChoice }
-        : param
+    // ensure a single tool choice is added to the invocation parameters
+    invocationParameters = invocationParameters.filter(
+      (param) =>
+        param.invocationName !== TOOL_CHOICE_PARAM_NAME &&
+        param.canonicalName !== TOOL_CHOICE_PARAM_CANONICAL_NAME
     );
+    invocationParameters.push({
+      canonicalName: TOOL_CHOICE_PARAM_CANONICAL_NAME,
+      invocationName: TOOL_CHOICE_PARAM_NAME,
+      valueJson: convertedToolChoice,
+    });
   } else {
+    // remove tool choice if there are no tools
     invocationParameters = invocationParameters.filter(
       (param) =>
         param.invocationName !== TOOL_CHOICE_PARAM_NAME &&

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -55,6 +55,8 @@ import {
   modelProviderToModelPrefixMap,
   OUTPUT_MESSAGES_PARSING_ERROR,
   OUTPUT_VALUE_PARSING_ERROR,
+  RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
+  RESPONSE_FORMAT_PARAM_NAME,
   SPAN_ATTRIBUTES_PARSING_ERROR,
   TOOL_CHOICE_PARAM_CANONICAL_NAME,
   TOOL_CHOICE_PARAM_NAME,
@@ -468,8 +470,15 @@ export function transformSpanAttributesToPlaygroundInstance(
     modelConfig != null
       ? {
           ...modelConfig,
-          // TODO(apowell): Remove response_format and tool related parameters from invocation parameters
-          invocationParameters,
+          invocationParameters:
+            // remove response format from invocation parameters if there are parsing errors
+            responseFormatParsingErrors.length > 0
+              ? invocationParameters.filter(
+                  (param) =>
+                    param.invocationName !== RESPONSE_FORMAT_PARAM_NAME &&
+                    param.canonicalName !== RESPONSE_FORMAT_PARAM_CANONICAL_NAME
+                )
+              : invocationParameters,
         }
       : null;
 

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -458,7 +458,9 @@ export function transformSpanAttributesToPlaygroundInstance(
     parsedAttributes,
     modelSupportedInvocationParameters
   );
-  const { responseFormat, parsingErrors: responseFormatParsingErrors } =
+  // parse response format separately so that we can get distinct errors messages from the rest of
+  // the invocation parameters
+  const { parsingErrors: responseFormatParsingErrors } =
     getResponseFormatFromAttributes(parsedAttributes);
 
   // Merge invocation parameters into model config, if model config is present
@@ -490,7 +492,6 @@ export function transformSpanAttributesToPlaygroundInstance(
       output,
       spanId: span.id,
       tools: tools ?? basePlaygroundInstance.tools,
-      responseFormat,
     },
     parsingErrors: [
       ...messageParsingErrors,

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -105,10 +105,17 @@ const chatMessageSchema = schemaForType<ChatMessage>()(
  */
 export const chatMessagesSchema = z.array(chatMessageSchema);
 
-// https://zod.dev/?id=json-type
+/**
+ * The zod schema for JSON literal primitives
+ * @see {@link https://zod.dev/?id=json-type|Zod Documentation}
+ */
 const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
 type Literal = z.infer<typeof literalSchema>;
 type Json = Literal | { [key: string]: Json } | Json[];
+/**
+ * The zod schema for JSON
+ * @see {@link https://zod.dev/?id=json-type|Zod Documentation}
+ */
 export const jsonLiteralSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([
     literalSchema,

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -116,10 +116,18 @@ const jsonLiteralSchema: z.ZodType<Json> = z.lazy(() =>
   ])
 );
 
+export type JsonLiteralSchema = z.infer<typeof jsonLiteralSchema>;
+
+const jsonObjectSchema: z.ZodType<{ [key: string]: Json }> = z.lazy(() =>
+  z.record(jsonLiteralSchema)
+);
+
+export type JsonObjectSchema = z.infer<typeof jsonObjectSchema>;
+
 /**
  * Model generic invocation parameters schema in zod.
  */
-const invocationParameterSchema = jsonLiteralSchema;
+const invocationParameterSchema = jsonObjectSchema;
 
 /**
  * The type of the invocation parameters schema
@@ -176,6 +184,17 @@ export const modelConfigWithInvocationParametersSchema = z.object({
   [SemanticAttributePrefixes.llm]: z.object({
     [LLMAttributePostfixes.invocation_parameters]:
       stringToInvocationParametersSchema,
+  }),
+});
+
+export const modelConfigWithResponseFormatSchema = z.object({
+  [SemanticAttributePrefixes.llm]: z.object({
+    [LLMAttributePostfixes.invocation_parameters]:
+      stringToInvocationParametersSchema.pipe(
+        z.object({
+          response_format: jsonObjectSchema.optional(),
+        })
+      ),
   }),
 });
 

--- a/app/src/schemas/toolChoiceSchemas.ts
+++ b/app/src/schemas/toolChoiceSchemas.ts
@@ -5,9 +5,9 @@ import { assertUnreachable, schemaForType } from "@phoenix/typeUtils";
 /**
  * OpenAI's tool choice schema
  *
- * @see https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice
+ * @see https://platform.openAI.com/docs/api-reference/chat/create#chat-create-tool_choice
  */
-export const openaiToolChoiceSchema = schemaForType<ToolChoice>()(
+export const openAIToolChoiceSchema = schemaForType<ToolChoice>()(
   z.union([
     z.literal("auto"),
     z.literal("none"),
@@ -19,7 +19,7 @@ export const openaiToolChoiceSchema = schemaForType<ToolChoice>()(
   ])
 );
 
-export type OpenaiToolChoice = z.infer<typeof openaiToolChoiceSchema>;
+export type OpenaiToolChoice = z.infer<typeof openAIToolChoiceSchema>;
 
 /**
  * Anthropic's tool choice schema
@@ -53,19 +53,19 @@ export const anthropicToolChoiceToOpenaiToolChoice =
     }
   });
 
-export const openaiToolChoiceToAnthropicToolChoice =
-  openaiToolChoiceSchema.transform((openai): AnthropicToolChoice => {
-    if (typeof openai === "string") {
+export const openAIToolChoiceToAnthropicToolChoice =
+  openAIToolChoiceSchema.transform((openAI): AnthropicToolChoice => {
+    if (typeof openAI === "string") {
       return { type: "auto" };
     }
     return {
       type: "tool",
-      name: openai.function.name,
+      name: openAI.function.name,
     };
   });
 
 export const llmProviderToolChoiceSchema = z.union([
-  openaiToolChoiceSchema,
+  openAIToolChoiceSchema,
   anthropicToolChoiceSchema,
 ]);
 
@@ -88,10 +88,10 @@ export type ToolChoiceWithProvider =
 export const detectToolChoiceProvider = (
   toolChoice: unknown
 ): ToolChoiceWithProvider => {
-  const { success: openaiSuccess, data: openaiData } =
-    openaiToolChoiceSchema.safeParse(toolChoice);
-  if (openaiSuccess) {
-    return { provider: "OPENAI", toolChoice: openaiData };
+  const { success: openAISuccess, data: openAIData } =
+    openAIToolChoiceSchema.safeParse(toolChoice);
+  if (openAISuccess) {
+    return { provider: "OPENAI", toolChoice: openAIData };
   }
   const { success: anthropicSuccess, data: anthropicData } =
     anthropicToolChoiceSchema.safeParse(toolChoice);
@@ -147,7 +147,7 @@ export const fromOpenAIToolChoice = <T extends ModelProvider>({
     case "OPENAI":
       return toolChoice as ProviderToToolChoiceMap[T];
     case "ANTHROPIC":
-      return openaiToolChoiceToAnthropicToolChoice.parse(
+      return openAIToolChoiceToAnthropicToolChoice.parse(
         toolChoice
       ) as ProviderToToolChoiceMap[T];
     default:
@@ -164,10 +164,10 @@ export const safelyConvertToolChoiceToProvider = <T extends ModelProvider>({
 }): ProviderToToolChoiceMap[T] | null => {
   try {
     // convert incoming tool choice to the OpenAI format
-    const openaiToolChoice = toOpenAIToolChoice(toolChoice);
+    const openAIToolChoice = toOpenAIToolChoice(toolChoice);
     // convert the OpenAI format to the target provider format
     return fromOpenAIToolChoice({
-      toolChoice: openaiToolChoice,
+      toolChoice: openAIToolChoice,
       targetProvider,
     });
   } catch (e) {

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_MODEL_NAME,
   DEFAULT_MODEL_PROVIDER,
 } from "@phoenix/constants/generativeConstants";
+import { OpenAIResponseFormat } from "@phoenix/pages/playground/schemas";
 
 import {
   GenAIOperationType,
@@ -111,6 +112,22 @@ export function createPlaygroundInstance(): PlaygroundInstance {
     output: undefined,
     spanId: null,
     activeRunId: null,
+  };
+}
+
+export function createOpenAIResponseFormat(): OpenAIResponseFormat {
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: "response",
+      schema: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      strict: true,
+    },
   };
 }
 

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -390,6 +390,88 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
         }),
       });
     },
+    upsertInvocationParameterInput: ({
+      instanceId,
+      invocationParameterInput,
+    }) => {
+      const instance = get().instances.find((i) => i.id === instanceId);
+      if (!instance) {
+        return;
+      }
+      const currentInvocationParameterInput =
+        instance.model.invocationParameters.find(
+          (p) => p.invocationName === invocationParameterInput.invocationName
+        );
+
+      if (currentInvocationParameterInput) {
+        set({
+          instances: get().instances.map((instance) => {
+            if (instance.id === instanceId) {
+              return {
+                ...instance,
+                model: {
+                  ...instance.model,
+                  invocationParameters: instance.model.invocationParameters.map(
+                    (p) =>
+                      p.invocationName ===
+                      invocationParameterInput.invocationName
+                        ? invocationParameterInput
+                        : p
+                  ),
+                },
+              };
+            }
+            return instance;
+          }),
+        });
+      } else {
+        set({
+          instances: get().instances.map((instance) => {
+            if (instance.id === instanceId) {
+              return {
+                ...instance,
+                model: {
+                  ...instance.model,
+                  invocationParameters: [
+                    ...instance.model.invocationParameters,
+                    invocationParameterInput,
+                  ],
+                },
+              };
+            }
+            return instance;
+          }),
+        });
+      }
+    },
+    deleteInvocationParameterInput: ({
+      instanceId,
+      invocationParameterInputInvocationName,
+    }) => {
+      const instance = get().instances.find((i) => i.id === instanceId);
+      if (!instance) {
+        return;
+      }
+      set({
+        instances: get().instances.map((instance) => {
+          if (instance.id === instanceId) {
+            return {
+              ...instance,
+              model: {
+                ...instance.model,
+                invocationParameters:
+                  instance.model.invocationParameters.filter(
+                    (p) =>
+                      p.invocationName !==
+                      invocationParameterInputInvocationName
+                  ),
+              },
+            };
+          }
+          return instance;
+        }),
+      });
+    },
     ...initialProps,
   });
   return create(devtools(playgroundStore));

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -1,7 +1,6 @@
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { InvocationParameterInput } from "@phoenix/pages/playground/__generated__/PlaygroundOutputSubscription.graphql";
 import { InvocationParameter } from "@phoenix/pages/playground/InvocationParametersForm";
-import { JsonObjectSchema } from "@phoenix/pages/playground/schemas";
 import {
   LlmProviderToolCall,
   LlmProviderToolDefinition,
@@ -114,7 +113,6 @@ export interface PlaygroundInstance {
    * @default "auto"
    */
   toolChoice?: ToolChoice;
-  responseFormat?: JsonObjectSchema;
   input: PlaygroundInput;
   model: ModelConfig;
   output?: ChatMessage[] | string;
@@ -206,6 +204,20 @@ export interface PlaygroundState extends PlaygroundProps {
   updateInstanceModelInvocationParameters: (params: {
     instanceId: number;
     invocationParameters: InvocationParameterInput[];
+  }) => void;
+  /**
+   * Upsert an invocation parameter input for a model
+   */
+  upsertInvocationParameterInput: (params: {
+    instanceId: number;
+    invocationParameterInput: InvocationParameterInput;
+  }) => void;
+  /**
+   * Delete an invocation parameter input for a model
+   */
+  deleteInvocationParameterInput: (params: {
+    instanceId: number;
+    invocationParameterInputInvocationName: string;
   }) => void;
   /**
    * Filter the invocation parameters for a model based on the model's supported parameters

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -1,6 +1,7 @@
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { InvocationParameterInput } from "@phoenix/pages/playground/__generated__/PlaygroundOutputSubscription.graphql";
 import { InvocationParameter } from "@phoenix/pages/playground/InvocationParametersForm";
+import { JsonObjectSchema } from "@phoenix/pages/playground/schemas";
 import {
   LlmProviderToolCall,
   LlmProviderToolDefinition,
@@ -113,6 +114,7 @@ export interface PlaygroundInstance {
    * @default "auto"
    */
   toolChoice?: ToolChoice;
+  responseFormat?: JsonObjectSchema;
   input: PlaygroundInput;
   model: ModelConfig;
   output?: ChatMessage[] | string;


### PR DESCRIPTION
- [x] Add configuration editor for response_format when using openai models
- [x] Parse and load response_format from incoming spans to playground store


https://github.com/user-attachments/assets/48780f20-8f0d-4b04-90cb-0a1bd3100f79


Resolves #5247 
Resolves #5233