### PR TITLE
feat: Add environment configuration for fastapi + gql extensions

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -146,6 +146,10 @@ ENV_PHOENIX_SMTP_VALIDATE_CERTS = "PHOENIX_SMTP_VALIDATE_CERTS"
 Whether to validate SMTP server certificates. Defaults to true.
 """
 
+# FastAPI and GQL extension settings
+ENV_PHOENIX_FASTAPI_MIDDLEWARE_PATHS = "PHOENIX_FAST_EXTENSIONS"
+ENV_PHOENIX_GQL_EXTENSION_PATHS = "PHOENIX_GQL_EXTENSIONS"
+
 
 def server_instrumentation_is_enabled() -> bool:
     return bool(
@@ -649,6 +653,32 @@ def get_env_db_logging_level() -> int:
         env_var=ENV_DB_LOGGING_LEVEL,
         default_level=logging.WARNING,
     )
+
+
+def get_env_fastapi_middleware_paths() -> list[tuple[str, str]]:
+    env_value = os.getenv('PHOENIX_FASTAPI_MIDDLEWARE_PATHS', '')
+    paths = []
+    for entry in env_value.split(','):
+        entry = entry.strip()
+        if entry:
+            if ':' not in entry:
+                raise ValueError(f"Invalid middleware entry '{entry}'. Expected format 'file_path:ClassName'.")
+            file_path, object_name = entry.split(':', 1)
+            paths.append((file_path.strip(), object_name.strip()))
+    return paths
+
+
+def get_env_gql_extension_paths() -> list[tuple[str, str]]:
+    env_value = os.getenv('PHOENIX_GQL_EXTENSION_PATHS', '')
+    paths = []
+    for entry in env_value.split(','):
+        entry = entry.strip()
+        if entry:
+            if ':' not in entry:
+                raise ValueError(f"Invalid extension entry '{entry}'. Expected format 'file_path:ClassName'.")
+            file_path, object_name = entry.split(':', 1)
+            paths.append((file_path.strip(), object_name.strip()))
+    return paths
 
 
 def _get_logging_level(env_var: str, default_level: int) -> int:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -147,8 +147,8 @@ Whether to validate SMTP server certificates. Defaults to true.
 """
 
 # FastAPI and GQL extension settings
-ENV_PHOENIX_FASTAPI_MIDDLEWARE_PATHS = "PHOENIX_FAST_EXTENSIONS"
-ENV_PHOENIX_GQL_EXTENSION_PATHS = "PHOENIX_GQL_EXTENSIONS"
+ENV_PHOENIX_FASTAPI_MIDDLEWARE_PATHS = "PHOENIX_FASTAPI_MIDDLEWARE_PATHS"
+ENV_PHOENIX_GQL_EXTENSION_PATHS = "PHOENIX_GQL_EXTENSION_PATHS"
 
 
 def server_instrumentation_is_enabled() -> bool:
@@ -656,27 +656,31 @@ def get_env_db_logging_level() -> int:
 
 
 def get_env_fastapi_middleware_paths() -> list[tuple[str, str]]:
-    env_value = os.getenv('PHOENIX_FASTAPI_MIDDLEWARE_PATHS', '')
+    env_value = os.getenv("PHOENIX_FASTAPI_MIDDLEWARE_PATHS", "")
     paths = []
-    for entry in env_value.split(','):
+    for entry in env_value.split(","):
         entry = entry.strip()
         if entry:
-            if ':' not in entry:
-                raise ValueError(f"Invalid middleware entry '{entry}'. Expected format 'file_path:ClassName'.")
-            file_path, object_name = entry.split(':', 1)
+            if ":" not in entry:
+                raise ValueError(
+                    f"Invalid middleware entry '{entry}'. Expected format 'file_path:ClassName'."
+                )
+            file_path, object_name = entry.split(":", 1)
             paths.append((file_path.strip(), object_name.strip()))
     return paths
 
 
 def get_env_gql_extension_paths() -> list[tuple[str, str]]:
-    env_value = os.getenv('PHOENIX_GQL_EXTENSION_PATHS', '')
+    env_value = os.getenv("PHOENIX_GQL_EXTENSION_PATHS", "")
     paths = []
-    for entry in env_value.split(','):
+    for entry in env_value.split(","):
         entry = entry.strip()
         if entry:
-            if ':' not in entry:
-                raise ValueError(f"Invalid extension entry '{entry}'. Expected format 'file_path:ClassName'.")
-            file_path, object_name = entry.split(':', 1)
+            if ":" not in entry:
+                raise ValueError(
+                    f"Invalid extension entry '{entry}'. Expected format 'file_path:ClassName'."
+                )
+            file_path, object_name = entry.split(":", 1)
             paths.append((file_path.strip(), object_name.strip()))
     return paths
 


### PR DESCRIPTION
This enables specifying a list of:
- `FastAPI` [middleware](https://fastapi.tiangolo.com/tutorial/middleware/): `export PHOENIX_FASTAPI_MIDDLEWARE_PATHS=/path/to/module:middleware,/path/to/module:middleware2`
- `Strawberry` [Extensions](https://strawberry.rocks/docs/guides/custom-extensions#custom-extensions): `export PHOENIX_GQL_EXTENSION_PATHS=/path/to/extensions:extension`

- FastAPI middleware will be loaded for all REST API routes
- GQL extensions will be loaded for GQL resolvers

These can be used to extend the behavior of phoenix routes