### PR TITLE
feat: Add env var configuration for grpc interceptor extensions

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -146,9 +146,10 @@ ENV_PHOENIX_SMTP_VALIDATE_CERTS = "PHOENIX_SMTP_VALIDATE_CERTS"
 Whether to validate SMTP server certificates. Defaults to true.
 """
 
-# FastAPI and GQL extension settings
+# API extension settings
 ENV_PHOENIX_FASTAPI_MIDDLEWARE_PATHS = "PHOENIX_FASTAPI_MIDDLEWARE_PATHS"
 ENV_PHOENIX_GQL_EXTENSION_PATHS = "PHOENIX_GQL_EXTENSION_PATHS"
+ENV_PHOENIX_GRPC_INTERCEPTOR_PATHS = "PHOENIX_GRPC_INTERCEPTOR_PATHS"
 
 
 def server_instrumentation_is_enabled() -> bool:
@@ -679,6 +680,21 @@ def get_env_gql_extension_paths() -> list[tuple[str, str]]:
             if ":" not in entry:
                 raise ValueError(
                     f"Invalid extension entry '{entry}'. Expected format 'file_path:ClassName'."
+                )
+            file_path, object_name = entry.split(":", 1)
+            paths.append((file_path.strip(), object_name.strip()))
+    return paths
+
+
+def get_env_grpc_interceptor_paths() -> list[tuple[str, str]]:
+    env_value = os.getenv("PHOENIX_GRPC_INTERCEPTOR_PATHS", "")
+    paths = []
+    for entry in env_value.split(","):
+        entry = entry.strip()
+        if entry:
+            if ":" not in entry:
+                raise ValueError(
+                    f"Invalid interceptor entry '{entry}'. Expected format 'file_path:ClassName'."
                 )
             file_path, object_name = entry.split(":", 1)
             paths.append((file_path.strip(), object_name.strip()))

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -657,7 +657,7 @@ def get_env_db_logging_level() -> int:
 
 
 def get_env_fastapi_middleware_paths() -> list[tuple[str, str]]:
-    env_value = os.getenv("PHOENIX_FASTAPI_MIDDLEWARE_PATHS", "")
+    env_value = os.getenv(ENV_PHOENIX_FASTAPI_MIDDLEWARE_PATHS, "")
     paths = []
     for entry in env_value.split(","):
         entry = entry.strip()
@@ -672,7 +672,7 @@ def get_env_fastapi_middleware_paths() -> list[tuple[str, str]]:
 
 
 def get_env_gql_extension_paths() -> list[tuple[str, str]]:
-    env_value = os.getenv("PHOENIX_GQL_EXTENSION_PATHS", "")
+    env_value = os.getenv(ENV_PHOENIX_GQL_EXTENSION_PATHS, "")
     paths = []
     for entry in env_value.split(","):
         entry = entry.strip()
@@ -687,7 +687,7 @@ def get_env_gql_extension_paths() -> list[tuple[str, str]]:
 
 
 def get_env_grpc_interceptor_paths() -> list[tuple[str, str]]:
-    env_value = os.getenv("PHOENIX_GRPC_INTERCEPTOR_PATHS", "")
+    env_value = os.getenv(ENV_PHOENIX_GRPC_INTERCEPTOR_PATHS, "")
     paths = []
     for entry in env_value.split(","):
         entry = entry.strip()

--- a/src/phoenix/server/grpc_server.py
+++ b/src/phoenix/server/grpc_server.py
@@ -56,6 +56,7 @@ class GrpcServer:
         enable_prometheus: bool = False,
         disabled: bool = False,
         token_store: Optional[CanReadToken] = None,
+        interceptors: list[ServerInterceptor] = [],
     ) -> None:
         self._callback = callback
         self._server: Optional[Server] = None
@@ -63,11 +64,12 @@ class GrpcServer:
         self._enable_prometheus = enable_prometheus
         self._disabled = disabled
         self._token_store = token_store
+        self._interceptors = interceptors
 
     async def __aenter__(self) -> None:
+        interceptors = self._interceptors
         if self._disabled:
             return
-        interceptors: list[ServerInterceptor] = []
         if self._token_store:
             interceptors.append(ApiKeyInterceptor(self._token_store))
         if self._enable_prometheus:


### PR DESCRIPTION
adds `PHOENIX_GRPC_INTERCEPTOR_PATHS` environment variable, that allows specifying
a list of `path:object`. If the object implements the [server interceptor interface](https://github.com/grpc/grpc/tree/master/examples/python/interceptors/async), they will extend our handling of all gRPC requests.