### PR TITLE
fix(evals): only allow keyword arguments for model instantiation

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -45,7 +45,7 @@ class BaseModel(ABC):
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "BaseModel":
         assert not args, (
-            "Model instantiation via positional arguments is not allowed. "
+            f"{cls.__name__} instantiation via positional arguments is not allowed. "
             "Please use keyword arguments only."
         )
         return super().__new__(cls)

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -43,6 +43,13 @@ class BaseModel(ABC):
     _verbose: bool = False
     _rate_limiter: RateLimiter = field(default_factory=RateLimiter)
 
+    def __new__(cls, *args: Any, **kwargs: Any) -> "BaseModel":
+        assert not args, (
+            "Model instantiation via positional arguments is not allowed. "
+            "Please use keyword arguments only."
+        )
+        return super().__new__(cls)
+
     @property
     @abstractmethod
     def _model_name(self) -> str:

--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_bedrock.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_bedrock.py
@@ -6,6 +6,12 @@ import pytest
 from phoenix.evals import BedrockModel
 
 
+def test_instantiation_by_positional_args_is_not_allowed():
+    session = boto3.Session(region_name="us-west-2")
+    with pytest.raises(AssertionError, match="positional arguments"):
+        BedrockModel(session)
+
+
 def test_bedrock_model_can_be_instantiated():
     session = boto3.Session(region_name="us-west-2")
     model = BedrockModel(session=session)

--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_litellm.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_litellm.py
@@ -8,6 +8,11 @@ import pytest
 from phoenix.evals import LiteLLMModel
 
 
+def test_instantiation_by_positional_args_is_not_allowed():
+    with pytest.raises(AssertionError, match="positional arguments"):
+        LiteLLMModel("ollama/monstral")
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 9),
     reason="https://github.com/BerriAI/litellm/issues/2005",

--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_mistralai.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_mistralai.py
@@ -1,6 +1,12 @@
+import pytest
 from mistralai.client import MistralClient
 
 from phoenix.evals.models.mistralai import MistralAIModel
+
+
+def test_instantiation_by_positional_args_is_not_allowed():
+    with pytest.raises(AssertionError, match="positional arguments"):
+        MistralAIModel("mistral-large-latest")
 
 
 def test_mistral_model(monkeypatch):

--- a/packages/phoenix-evals/tests/phoenix/evals/models/test_openai.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/models/test_openai.py
@@ -9,6 +9,11 @@ OPENAI_API_KEY_ENVVAR_NAME = "OPENAI_API_KEY"
 AZURE_OPENAI_API_KEY_ENVVAR_NAME = "AZURE_OPENAI_API_KEY"
 
 
+def test_instantiation_by_positional_args_is_not_allowed():
+    with pytest.raises(AssertionError, match="positional arguments"):
+        OpenAIModel("gpt-4-turbo-preview")
+
+
 def test_openai_model(monkeypatch):
     """
     Sanity check of the initialization of OpenAI wrapper


### PR DESCRIPTION
resolves #5240 