### PR TITLE
feat: Add rate limiters to playground clients

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -65,9 +65,17 @@ ChatCompletionChunk: TypeAlias = Union[TextChunk, ToolCallChunk]
 
 
 class KeyedSingleton:
-    _instances: dict[tuple[type, Hashable], Any] = {}
+    _instances = {}
 
-    def __new__(cls, singleton_key: Hashable) -> Any:
+    def __new__(cls, *args, **kwargs):
+        if 'singleton_key' in kwargs:
+            singleton_key = kwargs.pop('singleton_key')
+        elif args:
+            singleton_key = args[0]
+            args = args[1:]
+        else:
+            raise ValueError("singleton_key must be provided")
+
         instance_key = (cls, singleton_key)
         if instance_key not in cls._instances:
             instance = super().__new__(cls)

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -68,8 +68,8 @@ class KeyedSingleton:
     _instances: dict[Hashable, "KeyedSingleton"] = {}
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "KeyedSingleton":
-        if 'singleton_key' in kwargs:
-            singleton_key = kwargs.pop('singleton_key')
+        if "singleton_key" in kwargs:
+            singleton_key = kwargs.pop("singleton_key")
         elif args:
             singleton_key = args[0]
             args = args[1:]

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -710,7 +710,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
             **invocation_parameters,
         }
         throttled_stream = self.rate_limiter._alimit(self.client.messages.stream)
-        async with throttled_stream(**anthropic_params) as stream:
+        async with await throttled_stream(**anthropic_params) as stream:
             async for event in stream:
                 if isinstance(event, anthropic_types.RawMessageStartEvent):
                     self._attributes.update(

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -65,9 +65,9 @@ ChatCompletionChunk: TypeAlias = Union[TextChunk, ToolCallChunk]
 
 
 class KeyedSingleton:
-    _instances = {}
+    _instances: dict[Hashable, "KeyedSingleton"] = {}
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> "KeyedSingleton":
         if 'singleton_key' in kwargs:
             singleton_key = kwargs.pop('singleton_key')
         elif args:


### PR DESCRIPTION
resolves #5238 

Adds a singleton rate-limiter per playground provider. These are set to throttle at a fairly low rate to prevent playground activity from monopolizing server CPU.

Notably, because the `Anthropic` SDK stream API has a synchronous entry point, I reused the synchronous version of the rate limiter. This might be problematic because in our old version sync throttles will be blocking (since we assumed sync functions would always be run in a sync context), severely impacting server performance.

I'll work on updating that method to accept a sync entry point but still allow the sleeps to yield control of the event loop. @axiomofjoy 