### PR TITLE
fix: make playground prompts accordion the proper size when collapsed

### DIFF
--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -144,7 +144,6 @@ function AddPromptButton() {
 const playgroundPromptPanelContentCSS = css`
   display: flex;
   flex-direction: column;
-  height: 100%;
   overflow: hidden;
   & > .ac-accordion {
     display: flex;


### PR DESCRIPTION
Before

![Screenshot 2024-11-11 at 12 17 07 PM](https://github.com/user-attachments/assets/6f51b664-afd0-4e6d-a5dd-0b5998636090)

After

![Screenshot 2024-11-11 at 12 16 55 PM](https://github.com/user-attachments/assets/70cdb7a4-6a46-4764-bef2-231bde7c23e3)

resolves #5317 