### PR TITLE
feat: Render field for JSON invocation params

### DIFF
--- a/app/src/components/code/JSONEditor.tsx
+++ b/app/src/components/code/JSONEditor.tsx
@@ -42,15 +42,12 @@ export function JSONEditor(props: JSONEditorProps) {
   }, [jsonSchema]);
   const contentLength = props.value?.length;
   // When optionalLint is false, this value will always be true
-  // This prevents the extensions useMemo from needlessly re-running when optionalLint is false
-  const hasContent = !optionalLint || (contentLength && contentLength > 0);
+  // If optionalLint is true, we only lint when there is content to allow for empty json values
+  const shouldLint = !optionalLint || (contentLength && contentLength > 0);
   const extensions = useMemo(() => {
     const baseExtensions = [json(), EditorView.lineWrapping];
 
-    // Lint when:
-    // - optionalLint is false
-    // - optionalLint is true and there is content
-    if (!optionalLint || (optionalLint && hasContent)) {
+    if (shouldLint) {
       baseExtensions.push(linter(jsonParseLinter()));
     }
 
@@ -65,7 +62,7 @@ export function JSONEditor(props: JSONEditorProps) {
       );
     }
     return baseExtensions;
-  }, [jsonSchema, hasContent, optionalLint]);
+  }, [jsonSchema, shouldLint]);
 
   return (
     <CodeMirror

--- a/app/src/pages/playground/InvocationParameterJsonEditor.tsx
+++ b/app/src/pages/playground/InvocationParameterJsonEditor.tsx
@@ -41,7 +41,6 @@ export function InvocationParameterJsonEditor({
       css={css`
         & .ac-view {
           width: 100%;
-          z-index: 1000;
         }
       `}
     >

--- a/app/src/pages/playground/InvocationParameterJsonEditor.tsx
+++ b/app/src/pages/playground/InvocationParameterJsonEditor.tsx
@@ -21,7 +21,7 @@ export function InvocationParameterJsonEditor({
   label: string;
 }) {
   const [editorValue, setEditorValue] = useState(
-    initialValue == null ? "" : (safelyStringifyJSON(initialValue) ?? "")
+    initialValue == null ? "" : (safelyStringifyJSON(initialValue).json ?? "")
   );
 
   const onChange = useCallback(

--- a/app/src/pages/playground/InvocationParameterJsonEditor.tsx
+++ b/app/src/pages/playground/InvocationParameterJsonEditor.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useState } from "react";
+import { css } from "@emotion/react";
+
+import { Field } from "@arizeai/components";
+
+import { CodeWrap, JSONEditor } from "@phoenix/components/code";
+import { safelyParseJSON, safelyStringifyJSON } from "@phoenix/utils/jsonUtils";
+
+/**
+ * Editor for message tool calls
+ */
+export function InvocationParameterJsonEditor({
+  initialValue,
+  onChange: handleChange,
+  label,
+}: {
+  initialValue: unknown;
+  // jsonValue is typed as any on the gql side to allow any json value to be set
+  // we can mostly assume this any is safe because we are safely parsing and stringifying incoming and outgoing json
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onChange: (value: any) => void;
+  label: string;
+}) {
+  const [editorValue, setEditorValue] = useState(
+    initialValue == null ? "" : (safelyStringifyJSON(initialValue) ?? "")
+  );
+
+  const onChange = useCallback(
+    (value: string) => {
+      setEditorValue(value);
+      const { json: parsedValue } = safelyParseJSON(value);
+      if (parsedValue == null && value !== "") {
+        return;
+      }
+      handleChange(parsedValue);
+    },
+    [handleChange]
+  );
+
+  return (
+    <div
+      css={css`
+        & .ac-view {
+          width: 100%;
+          z-index: 1000;
+        }
+      `}
+    >
+      <Field label={label}>
+        <CodeWrap>
+          <JSONEditor value={editorValue} onChange={onChange} optionalLint />
+        </CodeWrap>
+      </Field>
+    </div>
+  );
+}

--- a/app/src/pages/playground/InvocationParameterJsonEditor.tsx
+++ b/app/src/pages/playground/InvocationParameterJsonEditor.tsx
@@ -17,8 +17,7 @@ export function InvocationParameterJsonEditor({
   initialValue: unknown;
   // jsonValue is typed as any on the gql side to allow any json value to be set
   // we can mostly assume this any is safe because we are safely parsing and stringifying incoming and outgoing json
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onChange: (value: any) => void;
+  onChange: (value: unknown) => void;
   label: string;
 }) {
   const [editorValue, setEditorValue] = useState(

--- a/app/src/pages/playground/InvocationParametersForm.tsx
+++ b/app/src/pages/playground/InvocationParametersForm.tsx
@@ -36,8 +36,8 @@ const InvocationParameterFormField = ({
   onChange,
 }: {
   field: InvocationParameter;
-  value: string | number | readonly string[] | boolean | undefined;
-  onChange: (value: string | number | string[] | boolean | undefined) => void;
+  value: unknown;
+  onChange: (value: unknown) => void;
 }) => {
   const { __typename } = field;
   switch (__typename) {
@@ -110,7 +110,15 @@ const InvocationParameterFormField = ({
 const getInvocationParameterValue = (
   field: InvocationParameter,
   parameterInput: InvocationParameterInput
-): string | number | readonly string[] | boolean | null | undefined => {
+):
+  | string
+  | number
+  | readonly string[]
+  | boolean
+  | null
+  | Record<string, unknown>
+  | unknown[]
+  | undefined => {
   if (field.invocationInputField === undefined) {
     throw new Error("Invocation input field is required");
   }
@@ -145,7 +153,7 @@ const getInvocationParameterValue = (
 
 const makeInvocationParameterInput = (
   field: InvocationParameter,
-  value: string | number | string[] | boolean | undefined
+  value: unknown
 ): InvocationParameterInput | null => {
   if (field.invocationName === undefined) {
     throw new Error("Invocation name is required");
@@ -243,10 +251,7 @@ export const InvocationParametersForm = ({
   ]);
 
   const onChange = useCallback(
-    (
-      field: InvocationParameter,
-      value: string | number | string[] | boolean | undefined
-    ) => {
+    (field: InvocationParameter, value: unknown) => {
       const existingParameter = instance.model.invocationParameters.find(
         (p) => p.invocationName === field.invocationName
       );

--- a/app/src/pages/playground/InvocationParametersForm.tsx
+++ b/app/src/pages/playground/InvocationParametersForm.tsx
@@ -12,6 +12,7 @@ import {
 } from "./__generated__/InvocationParametersFormQuery.graphql";
 import { InvocationParameterInput } from "./__generated__/PlaygroundOutputSubscription.graphql";
 import { paramsToIgnoreInInvocationParametersForm } from "./constants";
+import { InvocationParameterJsonEditor } from "./InvocationParameterJsonEditor";
 import {
   constrainInvocationParameterInputsToDefinition,
   toCamelCase,
@@ -92,6 +93,15 @@ const InvocationParameterFormField = ({
           {field.label}
         </Switch>
       );
+    case "JSONInvocationParameter": {
+      return (
+        <InvocationParameterJsonEditor
+          initialValue={value}
+          onChange={onChange}
+          label={field.label ?? field.invocationName ?? ""}
+        />
+      );
+    }
     default:
       return null;
   }
@@ -125,6 +135,8 @@ const getInvocationParameterValue = (
       return field.stringDefaultValue;
     case "BooleanInvocationParameter":
       return field.booleanDefaultValue;
+    case "JSONInvocationParameter":
+      return field.jsonDefaultValue;
     default: {
       return null;
     }
@@ -201,6 +213,10 @@ export const InvocationParametersForm = ({
             ... on BooleanInvocationParameter {
               invocationInputField
               booleanDefaultValue: defaultValue
+            }
+            ... on JSONInvocationParameter {
+              invocationInputField
+              jsonDefaultValue: defaultValue
             }
           }
         }

--- a/app/src/pages/playground/__generated__/InvocationParametersFormQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/InvocationParametersFormQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1e7d574479ac5b7b9fde941f3231cba0>>
+ * @generated SignedSource<<9b7bf8d80d79db107e7afad6492650a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type InvocationParametersFormQuery$data = {
     readonly intDefaultValue?: number | null;
     readonly invocationInputField?: InvocationInputField;
     readonly invocationName?: string;
+    readonly jsonDefaultValue?: any | null;
     readonly label?: string;
     readonly maxValue?: number;
     readonly minValue?: number;
@@ -201,6 +202,21 @@ v2 = [
         ],
         "type": "BooleanInvocationParameter",
         "abstractKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": "jsonDefaultValue",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "defaultValue",
+            "storageKey": null
+          }
+        ],
+        "type": "JSONInvocationParameter",
+        "abstractKey": null
       }
     ],
     "storageKey": null
@@ -224,16 +240,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "3cb8a2f44047c49a75b02fa75d245cd0",
+    "cacheID": "d0f0f7961fc9bc2ccc4a558c5a4ab98a",
     "id": null,
     "metadata": {},
     "name": "InvocationParametersFormQuery",
     "operationKind": "query",
-    "text": "query InvocationParametersFormQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      label\n      required\n      canonicalName\n    }\n    ... on BoundedFloatInvocationParameter {\n      minValue\n      maxValue\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on IntInvocationParameter {\n      invocationInputField\n      intDefaultValue: defaultValue\n    }\n    ... on StringInvocationParameter {\n      invocationInputField\n      stringDefaultValue: defaultValue\n    }\n    ... on StringListInvocationParameter {\n      invocationInputField\n      stringListDefaultValue: defaultValue\n    }\n    ... on BooleanInvocationParameter {\n      invocationInputField\n      booleanDefaultValue: defaultValue\n    }\n  }\n}\n"
+    "text": "query InvocationParametersFormQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      label\n      required\n      canonicalName\n    }\n    ... on BoundedFloatInvocationParameter {\n      minValue\n      maxValue\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on IntInvocationParameter {\n      invocationInputField\n      intDefaultValue: defaultValue\n    }\n    ... on StringInvocationParameter {\n      invocationInputField\n      stringDefaultValue: defaultValue\n    }\n    ... on StringListInvocationParameter {\n      invocationInputField\n      stringListDefaultValue: defaultValue\n    }\n    ... on BooleanInvocationParameter {\n      invocationInputField\n      booleanDefaultValue: defaultValue\n    }\n    ... on JSONInvocationParameter {\n      invocationInputField\n      jsonDefaultValue: defaultValue\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "83e597b9bb0c07647c9fb9b7873be073";
+(node as any).hash = "7d5fd6c5574552d91f3f6e4df531d907";
 
 export default node;

--- a/app/src/utils/jsonUtils.ts
+++ b/app/src/utils/jsonUtils.ts
@@ -45,8 +45,8 @@ export function safelyStringifyJSON(
   ...args: Parameters<typeof JSON.stringify>
 ) {
   try {
-    return JSON.stringify(...args);
+    return { json: JSON.stringify(...args) };
   } catch (e) {
-    return null;
+    return { json: null, stringifyError: e };
   }
 }

--- a/app/src/utils/jsonUtils.ts
+++ b/app/src/utils/jsonUtils.ts
@@ -40,3 +40,13 @@ export function safelyParseJSON(str: string) {
     return { json: null, parseError: e };
   }
 }
+
+export function safelyStringifyJSON(
+  ...args: Parameters<typeof JSON.stringify>
+) {
+  try {
+    return JSON.stringify(...args);
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
Future proof the InvocationParamsForm with support for future json invocation params, so that they can be rendered automatically should any be defined on the backend.

> [!IMPORTANT]
> Fields displayed in the video are just for demonstration, and will not appear in production. We do not currently ship any JSON invocation parameters that are not handled elsewhere in the UI.


https://github.com/user-attachments/assets/233ad520-71d7-4d09-980d-3078ae335bdd


Resolves #5252