### PR TITLE
fix(playground): fix dataset picker styles and error handling

### DIFF
--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -73,10 +73,8 @@ export const tableCSS = (theme: Theme) => css`
 export const borderedTableCSS = css`
   tbody:not(.is-empty) {
     tr {
-      &:not(:last-of-type) {
-        & > td {
-          border-bottom: 1px solid var(--ac-global-border-color-default);
-        }
+      & > td {
+        border-bottom: 1px solid var(--ac-global-border-color-default);
       }
       & > td:not(:last-of-type) {
         border-right: 1px solid var(--ac-global-border-color-default);

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -484,7 +484,9 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
-                  width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
+                  flexBasis: `var(--col-${cell.column.id}-size)`,
+                  flexGrow: 1,
+                  flexShrink: 1,
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -484,9 +484,7 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
-                  flexBasis: `var(--col-${cell.column.id}-size)`,
-                  flexGrow: 1,
-                  flexShrink: 1,
+                  width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -15,6 +15,7 @@ import {
   View,
 } from "@arizeai/components";
 
+import { Loading } from "@phoenix/components";
 import { resizeHandleCSS } from "@phoenix/components/resize";
 import {
   PlaygroundProvider,
@@ -232,7 +233,9 @@ function PlaygroundContent() {
       <Panel>
         <div css={playgroundInputOutputPanelContentCSS}>
           {isDatasetMode ? (
-            <PlaygroundDatasetSection datasetId={datasetId} />
+            <Suspense fallback={<Loading />}>
+              <PlaygroundDatasetSection datasetId={datasetId} />
+            </Suspense>
           ) : (
             <Accordion arrowPosition="start" size="L">
               <AccordionItem title="Inputs" id="input">

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -233,9 +233,7 @@ function PlaygroundContent() {
       <Panel>
         <div css={playgroundInputOutputPanelContentCSS}>
           {isDatasetMode ? (
-            <Suspense fallback={<Loading />}>
-              <PlaygroundDatasetSection datasetId={datasetId} />
-            </Suspense>
+            <PlaygroundDatasetSection datasetId={datasetId} />
           ) : (
             <Accordion arrowPosition="start" size="L">
               <AccordionItem title="Inputs" id="input">

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -15,7 +15,6 @@ import {
   View,
 } from "@arizeai/components";
 
-import { Loading } from "@phoenix/components";
 import { resizeHandleCSS } from "@phoenix/components/resize";
 import {
   PlaygroundProvider,

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -569,7 +569,7 @@ export function PlaygroundDatasetExamplesTable({
 
   const playgroundInstanceOutputColumns = useMemo((): ColumnDef<TableRow>[] => {
     return instances.map((instance, index) => ({
-      id: instance.id.toString(),
+      id: `instance ${instance.id}`,
       header: () => (
         <Flex direction="row" gap="size-100" alignItems="center">
           <AlphabeticIndexIcon index={index} />

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -27,6 +27,7 @@ import { GraphQLSubscriptionConfig, requestSubscription } from "relay-runtime";
 import { css } from "@emotion/react";
 
 import {
+  Alert,
   Button,
   DialogContainer,
   Flex,
@@ -73,12 +74,17 @@ const PAGE_SIZE = 100;
 
 type InstanceId = number;
 type ExampleId = string;
-type ChatCompletionResult = Extract<
+type ChatCompletionSubscriptionResult = Extract<
   PlaygroundDatasetExamplesTableSubscription$data["chatCompletionOverDataset"],
   { __typename: "ChatCompletionSubscriptionResult" }
 >;
 
-type Span = NonNullable<ChatCompletionResult["span"]>;
+type ChatCompletionSubscriptionError = Extract<
+  PlaygroundDatasetExamplesTableSubscription$data["chatCompletionOverDataset"],
+  { __typename: "ChatCompletionSubscriptionError" }
+>;
+
+type Span = NonNullable<ChatCompletionSubscriptionResult["span"]>;
 type ToolCallChunk = Extract<
   PlaygroundDatasetExamplesTableSubscription$data["chatCompletionOverDataset"],
   { __typename: "ToolCallChunk" }
@@ -92,6 +98,7 @@ type ExampleRunData = {
   content?: string;
   toolCalls?: Record<string, PartialOutputToolCall | undefined>;
   span?: Span | null;
+  errorMessage?: string;
 };
 
 type InstanceToExampleResponsesMap = Record<
@@ -121,7 +128,11 @@ const updateExampleResponsesMap = ({
   currentMap,
 }: {
   instanceId: number;
-  response: ChatCompletionResult | TextChunk | ToolCallChunk;
+  response:
+    | ChatCompletionSubscriptionResult
+    | TextChunk
+    | ToolCallChunk
+    | ChatCompletionSubscriptionError;
   currentMap: InstanceToExampleResponsesMap;
 }): InstanceToExampleResponsesMap => {
   const exampleId = response.datasetExampleId;
@@ -187,6 +198,20 @@ const updateExampleResponsesMap = ({
         [instanceId]: newInstanceExampleResponseMap,
       };
     }
+    case "ChatCompletionSubscriptionError": {
+      const { message } = response;
+      const newInstanceExampleResponseMap = {
+        ...existingInstanceResponses,
+        [exampleId]: {
+          ...existingExampleResponse,
+          errorMessage: message,
+        },
+      };
+      return {
+        ...currentMap,
+        [instanceId]: newInstanceExampleResponseMap,
+      };
+    }
     default:
       return assertUnreachable(response);
   }
@@ -232,7 +257,7 @@ function ExampleOutputCell({
   if (exampleData == null) {
     return null;
   }
-  const { span, content, toolCalls } = exampleData;
+  const { span, content, toolCalls, errorMessage } = exampleData;
   const hasSpan = span != null;
   let spanControls: ReactNode = null;
   if (hasSpan) {
@@ -287,6 +312,9 @@ function ExampleOutputCell({
   return (
     <CellWithControlsWrap controls={spanControls}>
       <Flex direction={"column"} gap={"size-200"}>
+        {errorMessage != null ? (
+          <Alert variant="danger">{errorMessage}</Alert>
+        ) : null}
         <Text>{content}</Text>
         {toolCalls != null
           ? Object.values(toolCalls).map((toolCall) =>
@@ -393,19 +421,12 @@ export function PlaygroundDatasetExamplesTable({
         }
         const chatCompletion = response.chatCompletionOverDataset;
         switch (chatCompletion.__typename) {
-          case "ChatCompletionSubscriptionError":
-            markPlaygroundInstanceComplete(instanceId);
-            notifyError({
-              title: "Chat completion failed",
-              message: chatCompletion.message,
-              expireMs: 10000,
-            });
-            break;
           case "ChatCompletionSubscriptionExperiment":
             setExperimentId(chatCompletion.experiment.id);
             break;
           case "ChatCompletionSubscriptionResult":
           case "TextChunk":
+          case "ChatCompletionSubscriptionError":
           case "ToolCallChunk": {
             setExampleResponsesMap((exampleResponsesMap) => {
               return updateExampleResponsesMap({
@@ -424,14 +445,16 @@ export function PlaygroundDatasetExamplesTable({
             return assertUnreachable(chatCompletion);
         }
       },
-    [markPlaygroundInstanceComplete, notifyError, setExperimentId]
+    [setExperimentId]
   );
 
   useEffect(() => {
     if (!hasSomeRunIds) {
       return;
     }
-    const { instances, streaming } = playgroundStore.getState();
+    const { instances, streaming, setExperimentId } =
+      playgroundStore.getState();
+    setExperimentId(null);
     if (streaming) {
       const subscriptions: Disposable[] = [];
       setExampleResponsesMap(getInitialExampleResponsesMap(instances));
@@ -565,7 +588,7 @@ export function PlaygroundDatasetExamplesTable({
           />
         );
       },
-      minSize: 500,
+      size: 500,
     }));
   }, [exampleResponsesMap, hasSomeRunIds, instances]);
 
@@ -574,14 +597,16 @@ export function PlaygroundDatasetExamplesTable({
       header: "input",
       accessorKey: "input",
       cell: (props) => JSONCell({ ...props, collapseSingleKey: false }),
+      size: 200,
     },
     {
       header: "reference output",
       accessorKey: "output",
       cell: (props) => JSONCell({ ...props, collapseSingleKey: true }),
+      size: 200,
     },
     ...playgroundInstanceOutputColumns,
-    { id: "tail", minSize: 500 },
+    { id: "tail", size: 700, minSize: 700 },
   ];
   const table = useReactTable<TableRow>({
     columns,
@@ -640,9 +665,6 @@ export function PlaygroundDatasetExamplesTable({
       css={css`
         flex: 1 1 auto;
         overflow: auto;
-        table {
-          min-width: 100%;
-        }
       `}
       ref={tableContainerRef}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -27,7 +27,6 @@ import { GraphQLSubscriptionConfig, requestSubscription } from "relay-runtime";
 import { css } from "@emotion/react";
 
 import {
-  Alert,
   Button,
   DialogContainer,
   Flex,
@@ -313,7 +312,10 @@ function ExampleOutputCell({
     <CellWithControlsWrap controls={spanControls}>
       <Flex direction={"column"} gap={"size-200"}>
         {errorMessage != null ? (
-          <Alert variant="danger">{errorMessage}</Alert>
+          <Flex direction="row" gap="size-50" alignItems="center">
+            <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
+            <Text color="danger">{errorMessage}</Text>
+          </Flex>
         ) : null}
         <Text>{content}</Text>
         {toolCalls != null

--- a/app/src/pages/playground/PlaygroundDatasetPicker.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetPicker.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router";
 import { css } from "@emotion/react";
 
@@ -43,11 +43,7 @@ export function PlaygroundDatasetPicker() {
         placeholder="Test over a dataset"
         selectedKey={selectedDatasetId}
         onSelectionChange={(datasetId) => {
-          startTransition(() => {
-            if (typeof datasetId === "string") {
-              navigate(`/playground/datasets/${datasetId}`);
-            }
-          });
+          navigate(`/playground/datasets/${datasetId}`);
         }}
       />
       <Button

--- a/app/src/pages/playground/PlaygroundDatasetPicker.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetPicker.tsx
@@ -6,17 +6,28 @@ import { Button, Icon, Icons } from "@arizeai/components";
 
 import { DatasetPicker } from "@phoenix/components/dataset";
 
+/**
+ * This is to keep the height of the picker and the button the same
+ * Our buttons have icons with size of 1.3rem, which becomes 20.8px where as the picker text has a line height of 20px with border and margins this becomes 30px
+ * so the height of the picker does not change , we just shrink the button a bit to match the height of the picker
+ * This is currently the case everywhere, where a compact button with an icon will be .8px bigger than a compact button without
+ */
+const DATASET_PICKER_BUTTON_HEIGHT = 30;
+
 const playgroundDatasetPickerCSS = css`
   display: flex;
   direction: row;
+  align-items: center;
   .ac-dropdown > button {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    height: ${DATASET_PICKER_BUTTON_HEIGHT}px;
   }
   .ac-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     border-left: none;
+    height: ${DATASET_PICKER_BUTTON_HEIGHT}px;
   }
 `;
 

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -468,7 +468,7 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
         }),
       });
     },
-    setExperimentId: (experimentId: string) => {
+    setExperimentId: (experimentId: string | null) => {
       set({ experimentId });
     },
     ...initialProps,

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -471,6 +471,9 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
     setExperimentId: (experimentId: string | null) => {
       set({ experimentId });
     },
+    getInstance: (instanceId: number) => {
+      return get().instances.find((i) => i.id === instanceId);
+    },
     ...initialProps,
   });
   return create(devtools(playgroundStore));

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -471,9 +471,6 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
     setExperimentId: (experimentId: string | null) => {
       set({ experimentId });
     },
-    getInstance: (instanceId: number) => {
-      return get().instances.find((i) => i.id === instanceId);
-    },
     ...initialProps,
   });
   return create(devtools(playgroundStore));

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -257,4 +257,8 @@ export interface PlaygroundState extends PlaygroundProps {
    * Set the value of the experiment id
    */
   setExperimentId: (experimentId: string | null) => void;
+  /**
+   * Gets a particular instance from the store by id
+   */
+  getInstance: (instanceId: number) => PlaygroundInstance | undefined;
 }

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -252,9 +252,9 @@ export interface PlaygroundState extends PlaygroundProps {
   /**
    * The id of the experiment associated with the last playground run if any
    */
-  experimentId?: string;
+  experimentId?: string | null;
   /**
    * Set the value of the experiment id
    */
-  setExperimentId: (experimentId: string) => void;
+  setExperimentId: (experimentId: string | null) => void;
 }

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -257,8 +257,4 @@ export interface PlaygroundState extends PlaygroundProps {
    * Set the value of the experiment id
    */
   setExperimentId: (experimentId: string | null) => void;
-  /**
-   * Gets a particular instance from the store by id
-   */
-  getInstance: (instanceId: number) => PlaygroundInstance | undefined;
 }

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import numpy as np
 import numpy.typing as npt
 import strawberry
-from sqlalchemy import and_, distinct, exists, func, or_, select
+from sqlalchemy import and_, distinct, func, select
 from sqlalchemy.orm import joinedload
 from starlette.authentication import UnauthenticatedUser
 from strawberry import ID, UNSET


### PR DESCRIPTION
resolves #5327 

- fixes error handling for playground on dataset
![image](https://github.com/user-attachments/assets/af349074-74ad-48f0-90d9-43750dc59508)

- fixes dataset picker and clear button styles to be the same height
- fixes issue where playground project was no longer being returned
- fixes console warning about updates in a transition by removing transition when selecting a dataset and adding suspense and loader