### PR TITLE
fix: Remove deadzone when hovering example table cells

### DIFF
--- a/app/src/components/table/CellWithControlsWrapper.tsx
+++ b/app/src/components/table/CellWithControlsWrapper.tsx
@@ -3,7 +3,12 @@ import { css } from "@emotion/react";
 
 const cellWithControlsWrapCSS = css`
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
   min-height: 75px;
+  padding: var(--ac-global-dimension-static-size-200);
   .controls {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;
@@ -22,7 +27,7 @@ const cellWithControlsWrapCSS = css`
 
 const cellControlsCSS = css`
   position: absolute;
-  top: -23px;
+  top: -4px;
   right: 0px;
   display: flex;
   flex-direction: row;

--- a/app/src/components/table/CellWithControlsWrapper.tsx
+++ b/app/src/components/table/CellWithControlsWrapper.tsx
@@ -3,12 +3,7 @@ import { css } from "@emotion/react";
 
 const cellWithControlsWrapCSS = css`
   position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  height: 100%;
   min-height: 75px;
-  padding: var(--ac-global-dimension-static-size-200);
   .controls {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;
@@ -27,7 +22,7 @@ const cellWithControlsWrapCSS = css`
 
 const cellControlsCSS = css`
   position: absolute;
-  top: -4px;
+  top: -23px;
   right: 0px;
   display: flex;
   flex-direction: row;

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1,5 +1,6 @@
 import React, {
   memo,
+  PropsWithChildren,
   ReactNode,
   startTransition,
   useCallback,
@@ -46,7 +47,6 @@ import {
 import { Loading } from "@phoenix/components";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
 import { JSONText } from "@phoenix/components/code/JSONText";
-import { CellWithControlsWrap } from "@phoenix/components/table";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
@@ -145,6 +145,55 @@ const createExampleResponsesForInstance = (
     {}
   );
 };
+
+const cellWithControlsWrapCSS = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  min-height: 75px;
+  padding: var(--ac-global-dimension-static-size-200);
+  .controls {
+    transition: opacity 0.2s ease-in-out;
+    opacity: 0;
+    display: none;
+    z-index: 1;
+  }
+  &:hover .controls {
+    opacity: 1;
+    display: flex;
+    // make them stand out
+    .ac-button {
+      border-color: var(--ac-global-color-primary);
+    }
+  }
+`;
+
+const cellControlsCSS = css`
+  position: absolute;
+  top: -4px;
+  right: 0px;
+  display: flex;
+  flex-direction: row;
+  gap: var(--ac-global-dimension-static-size-100);
+`;
+
+/**
+ * Wraps a cell to provides space for controls that are shown on hover.
+ */
+export function CellWithControlsWrap(
+  props: PropsWithChildren<{ controls: ReactNode }>
+) {
+  return (
+    <div css={cellWithControlsWrapCSS}>
+      {props.children}
+      <div css={cellControlsCSS} className="controls">
+        {props.controls}
+      </div>
+    </div>
+  );
+}
 
 function LargeTextWrap({ children }: { children: ReactNode }) {
   return (
@@ -349,6 +398,8 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
+                  // the cell still grows to fit, we just need some height declared
+                  // so that height: 100% works in children elements
                   padding: 0,
                   height: 1,
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -152,6 +152,8 @@ function LargeTextWrap({ children }: { children: ReactNode }) {
       css={css`
         max-height: 300px;
         overflow-y: auto;
+        padding: var(--ac-global-dimension-static-size-100)
+          var(--ac-global-dimension-static-size-200);
       `}
     >
       {children}
@@ -347,6 +349,8 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
+                  padding: 0,
+                  height: 1,
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                   // allow long text with no symbols or spaces to wrap
                   // otherwise, it will prevent the cell from shrinking

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -173,7 +173,7 @@ const cellWithControlsWrapCSS = css`
 const cellControlsCSS = css`
   position: absolute;
   top: -4px;
-  right: 0px;
+  right: var(--ac-global-dimension-static-size-100);
   display: flex;
   flex-direction: row;
   gap: var(--ac-global-dimension-static-size-100);


### PR DESCRIPTION
There was a deadzone on the control hovering styles caused by padding in the parent td element.
Now cell contents control their own padding, and fill available td space, so that the hover target matches the visible cell area.

### Before

![2024-11-14 09 43 55](https://github.com/user-attachments/assets/80a7efe2-3d84-4198-88ad-a87c1913de82)

### After

![2024-11-14 09 44 28](https://github.com/user-attachments/assets/6cb46f8b-1340-4477-b691-bd2739e2ec7f)

Resolves #5554
