### PR TITLE
feat(playground): pre-emptively show dataset example template application errors in playground dataset table

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -396,10 +396,7 @@ function ExampleOutputCell({
     <CellWithControlsWrap controls={spanControls}>
       <Flex direction={"column"} gap={"size-200"}>
         {errorMessage != null ? (
-          <Flex direction="row" gap="size-50" alignItems="center">
-            <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
-            <Text color="danger">{errorMessage}</Text>
-          </Flex>
+          <CellErrorWrap>{errorMessage}</CellErrorWrap>
         ) : null}
         <Text>{content}</Text>
         {toolCalls != null

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -77,7 +77,7 @@ import {
   PlaygroundToolCall,
 } from "./PlaygroundToolCall";
 import {
-  extractedVariablesFromInstance,
+  extractVariablesFromInstance,
   getChatCompletionOverDatasetInput,
 } from "./playgroundUtils";
 
@@ -712,7 +712,7 @@ export function PlaygroundDatasetExamplesTable({
       cell: ({ row }) => {
         const exampleData =
           exampleResponsesMap[instance.id]?.[row.original.id] ?? null;
-        const instanceVariables = extractedVariablesFromInstance({
+        const instanceVariables = extractVariablesFromInstance({
           instance,
           templateLanguage,
         });

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -58,7 +58,7 @@ import {
   usePlaygroundStore,
 } from "@phoenix/contexts/PlaygroundContext";
 import { PlaygroundInstance } from "@phoenix/store";
-import { assertUnreachable } from "@phoenix/typeUtils";
+import { assertUnreachable, isStringKeyedObject } from "@phoenix/typeUtils";
 
 import type { PlaygroundDatasetExamplesTableFragment$key } from "./__generated__/PlaygroundDatasetExamplesTableFragment.graphql";
 import PlaygroundDatasetExamplesTableMutation, {
@@ -76,7 +76,10 @@ import {
   PartialOutputToolCall,
   PlaygroundToolCall,
 } from "./PlaygroundToolCall";
-import { getChatCompletionOverDatasetInput } from "./playgroundUtils";
+import {
+  extractedVariablesFromInstance,
+  getChatCompletionOverDatasetInput,
+} from "./playgroundUtils";
 
 const PAGE_SIZE = 100;
 
@@ -297,20 +300,45 @@ function JSONCell<TData extends object, TValue>({
   );
 }
 
+function CellErrorWrap({ children }: { children: ReactNode }) {
+  return (
+    <Flex direction="row" gap="size-50" alignItems="center">
+      <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
+      <Text color="danger">{children}</Text>
+    </Flex>
+  );
+}
+
 function ExampleOutputCell({
   exampleData,
   isRunning,
   setDialog,
+  instanceVariables,
+  datasetExampleInput,
 }: {
   exampleData: ExampleRunData | null;
   isRunning: boolean;
   setDialog(dialog: ReactNode): void;
+  instanceVariables: string[];
+  datasetExampleInput: Record<string, unknown>;
 }) {
   if (exampleData == null && isRunning) {
     return <Loading />;
   }
   if (exampleData == null) {
-    return null;
+    const missingVariables = instanceVariables.filter((variable) => {
+      return datasetExampleInput[variable] == null;
+    });
+    if (missingVariables.length === 0) {
+      return null;
+    }
+    return (
+      <CellErrorWrap>
+        {`Missing output for variable${missingVariables.length > 1 ? "s" : ""}: ${missingVariables.join(
+          ", "
+        )}`}
+      </CellErrorWrap>
+    );
   }
   const { span, content, toolCalls, errorMessage } = exampleData;
   const hasSpan = span != null;
@@ -436,6 +464,9 @@ export function PlaygroundDatasetExamplesTable({
 }) {
   const environment = useRelayEnvironment();
   const instances = usePlaygroundContext((state) => state.instances);
+  const templateLanguage = usePlaygroundContext(
+    (state) => state.templateLanguage
+  );
   const setExperimentId = usePlaygroundContext(
     (state) => state.setExperimentId
   );
@@ -684,17 +715,25 @@ export function PlaygroundDatasetExamplesTable({
       cell: ({ row }) => {
         const exampleData =
           exampleResponsesMap[instance.id]?.[row.original.id] ?? null;
+        const instanceVariables = extractedVariablesFromInstance({
+          instance,
+          templateLanguage,
+        });
         return (
           <ExampleOutputCell
             exampleData={exampleData}
             isRunning={hasSomeRunIds}
             setDialog={setDialog}
+            instanceVariables={instanceVariables}
+            datasetExampleInput={
+              isStringKeyedObject(row.original.input) ? row.original.input : {}
+            }
           />
         );
       },
       size: 500,
     }));
-  }, [exampleResponsesMap, hasSomeRunIds, instances]);
+  }, [exampleResponsesMap, hasSomeRunIds, instances, templateLanguage]);
 
   const columns: ColumnDef<TableRow>[] = [
     {

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -530,6 +530,49 @@ export const isChatMessages = (
   return chatMessagesSchema.safeParse(messages).success;
 };
 
+export const extractedVariablesFromInstance = ({
+  instance,
+  templateLanguage,
+}: {
+  instance: PlaygroundInstance;
+  templateLanguage: TemplateLanguage;
+}) => {
+  const variables = new Set<string>();
+  const instanceType = instance.template.__type;
+  const utils = getTemplateLanguageUtils(templateLanguage);
+  // this double nested loop should be okay since we don't expect more than 4 instances
+  // and a handful of messages per instance
+  switch (instanceType) {
+    case "chat": {
+      // for each chat message in the instance
+      instance.template.messages.forEach((message) => {
+        // extract variables from the message content
+        const extractedVariables =
+          message.content == null
+            ? []
+            : utils.extractVariables(message.content);
+        extractedVariables.forEach((variable) => {
+          variables.add(variable);
+        });
+      });
+      break;
+    }
+    case "text_completion": {
+      const extractedVariables = utils.extractVariables(
+        instance.template.prompt
+      );
+      extractedVariables.forEach((variable) => {
+        variables.add(variable);
+      });
+      break;
+    }
+    default: {
+      assertUnreachable(instanceType);
+    }
+  }
+  return Array.from(variables);
+};
+
 export const extractVariablesFromInstances = ({
   instances,
   templateLanguage,
@@ -537,43 +580,13 @@ export const extractVariablesFromInstances = ({
   instances: PlaygroundInstance[];
   templateLanguage: TemplateLanguage;
 }) => {
-  const variables = new Set<string>();
-  const utils = getTemplateLanguageUtils(templateLanguage);
-  instances.forEach((instance) => {
-    const instanceType = instance.template.__type;
-    // this double nested loop should be okay since we don't expect more than 4 instances
-    // and a handful of messages per instance
-    switch (instanceType) {
-      case "chat": {
-        // for each chat message in the instance
-        instance.template.messages.forEach((message) => {
-          // extract variables from the message content
-          const extractedVariables =
-            message.content == null
-              ? []
-              : utils.extractVariables(message.content);
-          extractedVariables.forEach((variable) => {
-            variables.add(variable);
-          });
-        });
-        break;
-      }
-      case "text_completion": {
-        const extractedVariables = utils.extractVariables(
-          instance.template.prompt
-        );
-        extractedVariables.forEach((variable) => {
-          variables.add(variable);
-        });
-        break;
-      }
-      default: {
-        assertUnreachable(instanceType);
-      }
-    }
-  });
-
-  return Array.from(variables);
+  return Array.from(
+    new Set(
+      instances.flatMap((instance) =>
+        extractedVariablesFromInstance({ instance, templateLanguage })
+      )
+    )
+  );
 };
 
 export const getVariablesMapFromInstances = ({

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -530,7 +530,7 @@ export const isChatMessages = (
   return chatMessagesSchema.safeParse(messages).success;
 };
 
-export const extractedVariablesFromInstance = ({
+export const extractVariablesFromInstance = ({
   instance,
   templateLanguage,
 }: {
@@ -583,7 +583,7 @@ export const extractVariablesFromInstances = ({
   return Array.from(
     new Set(
       instances.flatMap((instance) =>
-        extractedVariablesFromInstance({ instance, templateLanguage })
+        extractVariablesFromInstance({ instance, templateLanguage })
       )
     )
   );


### PR DESCRIPTION
resolves #5284 

Shows template application errors for each dataset example and instance combination before the playground is run


https://github.com/user-attachments/assets/8e6f9a19-44f3-47f1-8be4-220b4c833143

