### PR TITLE
fix: copy output contents on run example slideover

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -755,7 +755,7 @@ function SelectedExampleDialog({
                     {...defaultCardProps}
                     extra={
                       <CopyToClipboardButton
-                        text={JSON.stringify(selectedExample.input)}
+                        text={JSON.stringify(selectedExample.referenceOutput)}
                       />
                     }
                     bodyStyle={{


### PR DESCRIPTION
We were previously copying the incorrect contents.