### PR TITLE
fix(auth): enable non-https OpenID Connect config URLs for development with local IDPs

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -424,9 +424,9 @@ class OAuth2ClientConfig:
                 f"An OpenID Connect configuration URL must be set for the {idp_name} OAuth2 IDP "
                 f"via the {oidc_config_url_env_var} environment variable"
             )
-        if urlparse(oidc_config_url).scheme != "https":
+        if urlparse(oidc_config_url).scheme != "https" and urlparse(oidc_config_url).hostname != "localhost":
             raise ValueError(
-                f"Server metadata URL for {idp_name} OAuth2 IDP "
+                f"Server metadata URL for {idp_name} OAuth2 IDP which is not localhost"
                 "must be a valid URL using the https protocol"
             )
         return cls(

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -424,7 +424,9 @@ class OAuth2ClientConfig:
                 f"An OpenID Connect configuration URL must be set for the {idp_name} OAuth2 IDP "
                 f"via the {oidc_config_url_env_var} environment variable"
             )
-        if urlparse(oidc_config_url).scheme != "https" and urlparse(oidc_config_url).hostname != "localhost":
+        parsed_oidc_config_url = urlparse(oidc_config_url)
+        is_local_oidc_config_url = parsed_oidc_config_url.hostname in ("localhost", "127.0.0.1")
+        if parsed_oidc_config_url.scheme != "https" and not is_local_oidc_config_url:
             raise ValueError(
                 f"Server metadata URL for {idp_name} OAuth2 IDP which is not localhost"
                 "must be a valid URL using the https protocol"

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -428,7 +428,7 @@ class OAuth2ClientConfig:
         is_local_oidc_config_url = parsed_oidc_config_url.hostname in ("localhost", "127.0.0.1")
         if parsed_oidc_config_url.scheme != "https" and not is_local_oidc_config_url:
             raise ValueError(
-                f"Server metadata URL for {idp_name} OAuth2 IDP which is not localhost"
+                f"Server metadata URL for {idp_name} OAuth2 IDP "
                 "must be a valid URL using the https protocol"
             )
         return cls(


### PR DESCRIPTION
When using open-source identity services such as Keycloak, users want to be able to run the identity service locally and point Phoenix toward a local OpenID Connect config URL during development.

resolves #5417