### PR TITLE
fix: Prevent over-fetching when typing azure deployment name

### DIFF
--- a/app/src/pages/playground/InvocationParametersForm.tsx
+++ b/app/src/pages/playground/InvocationParametersForm.tsx
@@ -172,6 +172,13 @@ type InvocationParametersFormProps = {
   instanceId: number;
 };
 
+/**
+ * Azure openai has user defined model names but our invocation parameters query will never know
+ * what they are. We will just pass in a stub model name and the query will fallback to the set
+ * of invocation parameters that are defaults to our azure client.
+ */
+const AZURE_MODEL_NAME = "AZURE_DEPLOYMENT";
+
 export const InvocationParametersForm = ({
   instanceId,
 }: InvocationParametersFormProps) => {
@@ -188,6 +195,8 @@ export const InvocationParametersForm = ({
   const filterInstanceModelInvocationParameters = usePlaygroundContext(
     (state) => state.filterInstanceModelInvocationParameters
   );
+  const modelNameToQuery =
+    model.provider !== "AZURE_OPENAI" ? model.modelName : AZURE_MODEL_NAME;
   const { modelInvocationParameters } =
     useLazyLoadQuery<InvocationParametersFormQuery>(
       graphql`
@@ -233,7 +242,7 @@ export const InvocationParametersForm = ({
           }
         }
       `,
-      { input: { providerKey: model.provider, modelName: model.modelName } }
+      { input: { providerKey: model.provider, modelName: modelNameToQuery } }
     );
 
   useEffect(() => {

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -4,9 +4,11 @@ import React, {
   startTransition,
   Suspense,
   useCallback,
+  useMemo,
   useState,
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
+import debounce from "lodash/debounce";
 
 import {
   Button,
@@ -72,16 +74,24 @@ function AzureOpenAiModelConfigFormField({
     [instance.id, instance.model, modelConfigByProvider, updateModel]
   );
 
+  const debouncedUpdateModelName = useMemo(
+    () =>
+      debounce((value: string) => {
+        updateModelConfig({
+          configKey: "modelName",
+          value,
+        });
+      }, 250),
+    [updateModelConfig]
+  );
+
   return (
     <>
       <TextField
         label="Deployment Name"
-        value={instance.model.modelName ?? ""}
+        defaultValue={instance.model.modelName ?? ""}
         onChange={(value) => {
-          updateModelConfig({
-            configKey: "modelName",
-            value,
-          });
+          debouncedUpdateModelName(value);
         }}
       />
       <TextField


### PR DESCRIPTION
Send a hardcoded model name to the invocation params query in order to obtain the fallback set of invocation parameters for openai.

Additionally debounce the deployment name field so that it does not trigger modelName updates on each keystroke. There are a lot of effects and memoizations that are tied to modelName and cause the page to chug if it changes on keystroke. It typically only changes from a dropdown selection.


https://github.com/user-attachments/assets/d14fc808-932d-4d7e-b8cc-7575662bcb28

Note that only one network request is made for invocation parameters, the first time that model name is updated to _something_

Resolves #5386 