### PR TITLE
Introducing Phoenix Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
     <a target="_blank" href="https://hub.docker.com/r/arizephoenix/phoenix/tags">
         <img src="https://img.shields.io/docker/v/arizephoenix/phoenix?sort=semver&logo=docker&label=image&color=blue">
     </a>
+    <a target="_blank" href="https://gurubase.io/g/phoenix">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Phoenix%20Guru-006BFF">
+    </a>
 </p>
 
 Phoenix is an open-source AI observability platform designed for experimentation, evaluation, and troubleshooting. It provides:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
         <img src="https://img.shields.io/docker/v/arizephoenix/phoenix?sort=semver&logo=docker&label=image&color=blue">
     </a>
     <a target="_blank" href="https://gurubase.io/g/phoenix">
-        <img src="https://img.shields.io/badge/Gurubase-Ask%20Phoenix%20Guru-006BFF">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Phoenix%20Guru-blue">
     </a>
 </p>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Phoenix Guru](https://gurubase.io/g/phoenix) to Gurubase. Phoenix Guru uses the data from this repo and data from the [docs](https://docs.arize.com/phoenix/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Phoenix Guru", which highlights that Phoenix now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Phoenix Guru in Gurubase, just let me know that's totally fine.
