### PR TITLE
fix(playground): for Azure, handle initial chunk with no choices

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -347,6 +347,9 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
             if (usage := chunk.usage) is not None:
                 token_usage = usage
                 continue
+            if not chunk.choices:
+                # for Azure, initial chunk contains the content filter
+                continue
             choice = chunk.choices[0]
             delta = choice.delta
             if choice.finish_reason is None:


### PR DESCRIPTION
<img width="577" alt="Screenshot 2024-11-18 at 12 33 22 PM" src="https://github.com/user-attachments/assets/cace9947-a624-4545-83f4-16958725f806">
