### PR TITLE
fix: Hide Output Schema (response format) button on unsupported provider instances

### DIFF
--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -331,11 +331,9 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
               onChange={onModelNameChange}
             />
           )}
-          {instance.model.modelName ? (
+          <Suspense>
             <InvocationParametersForm instanceId={playgroundInstanceId} />
-          ) : (
-            <></>
-          )}
+          </Suspense>
         </Flex>
       </Form>
     </View>

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -1,5 +1,9 @@
-import React, { PropsWithChildren, useCallback, useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
+import React, {
+  PropsWithChildren,
+  Suspense,
+  useCallback,
+  useState,
+} from "react";
 import {
   DndContext,
   KeyboardSensor,
@@ -14,7 +18,6 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { graphql } from "relay-runtime";
 import { css } from "@emotion/react";
 
 import {
@@ -38,31 +41,26 @@ import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
 import {
   ChatMessage,
-  createOpenAIResponseFormat,
-  generateMessageId,
   PlaygroundChatTemplate as PlaygroundChatTemplateType,
   PlaygroundInstance,
 } from "@phoenix/store";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
-import { PlaygroundChatTemplateResponseFormatQuery } from "./__generated__/PlaygroundChatTemplateResponseFormatQuery.graphql";
 import { ChatMessageToolCallsEditor } from "./ChatMessageToolCallsEditor";
-import {
-  RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
-  RESPONSE_FORMAT_PARAM_NAME,
-} from "./constants";
+import { RESPONSE_FORMAT_PARAM_CANONICAL_NAME } from "./constants";
 import {
   MessageContentRadioGroup,
   MessageMode,
 } from "./MessageContentRadioGroup";
 import { MessageRolePicker } from "./MessageRolePicker";
+import {
+  PlaygroundChatTemplateFooter,
+  PlaygroundChatTemplateFooterFallback,
+} from "./PlaygroundChatTemplateFooter";
 import { PlaygroundResponseFormat } from "./PlaygroundResponseFormat";
 import { PlaygroundTools } from "./PlaygroundTools";
-import {
-  createToolCallForProvider,
-  createToolForProvider,
-} from "./playgroundUtils";
+import { createToolCallForProvider } from "./playgroundUtils";
 import { PlaygroundInstanceProps } from "./types";
 
 const MESSAGE_Z_INDEX = 1;
@@ -83,44 +81,12 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
   );
   const instances = usePlaygroundContext((state) => state.instances);
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
-  const upsertInvocationParameterInput = usePlaygroundContext(
-    (state) => state.upsertInvocationParameterInput
-  );
+
   const playgroundInstance = instances.find((instance) => instance.id === id);
   if (!playgroundInstance) {
     throw new Error(`Playground instance ${id} not found`);
   }
-  // We don't care about the model name for Azure OpenAI
-  const modelNameQueryInput =
-    playgroundInstance.model.provider !== "AZURE_OPENAI"
-      ? (playgroundInstance.model?.modelName ?? null)
-      : null;
-  const { modelInvocationParameters } =
-    useLazyLoadQuery<PlaygroundChatTemplateResponseFormatQuery>(
-      graphql`
-        query PlaygroundChatTemplateResponseFormatQuery($input: ModelsInput!) {
-          modelInvocationParameters(input: $input) {
-            __typename
-            ... on InvocationParameterBase {
-              invocationName
-              canonicalName
-            }
-          }
-        }
-      `,
-      {
-        input: {
-          providerKey: playgroundInstance.model.provider,
-          modelName: modelNameQueryInput,
-        },
-      }
-    );
 
-  const supportsResponseFormat = modelInvocationParameters?.some(
-    (p) =>
-      p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME ||
-      p.invocationName === RESPONSE_FORMAT_PARAM_NAME
-  );
   const hasTools = playgroundInstance.tools.length > 0;
   const hasResponseFormat =
     playgroundInstance.model.invocationParameters.find(
@@ -200,89 +166,12 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
         borderTopWidth="thin"
         borderBottomWidth={hasTools || hasResponseFormat ? "thin" : undefined}
       >
-        <Flex direction="row" justifyContent="end" gap="size-100">
-          {supportsResponseFormat ? (
-            <Button
-              variant="default"
-              size="compact"
-              aria-label="output schema"
-              icon={<Icon svg={<Icons.PlusOutline />} />}
-              disabled={hasResponseFormat}
-              onClick={() => {
-                upsertInvocationParameterInput({
-                  instanceId: id,
-                  invocationParameterInput: {
-                    valueJson: createOpenAIResponseFormat(),
-                    invocationName: RESPONSE_FORMAT_PARAM_NAME,
-                    canonicalName: RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
-                  },
-                });
-              }}
-            >
-              Output Schema
-            </Button>
-          ) : null}
-          <Button
-            variant="default"
-            aria-label="add tool"
-            size="compact"
-            icon={<Icon svg={<Icons.PlusOutline />} />}
-            onClick={() => {
-              const patch: Partial<PlaygroundInstance> = {
-                tools: [
-                  ...playgroundInstance.tools,
-                  createToolForProvider({
-                    provider: playgroundInstance.model.provider,
-                    toolNumber: playgroundInstance.tools.length + 1,
-                  }),
-                ],
-              };
-              if (playgroundInstance.tools.length === 0) {
-                patch.toolChoice = "auto";
-              }
-              updateInstance({
-                instanceId: id,
-                patch: {
-                  tools: [
-                    ...playgroundInstance.tools,
-                    createToolForProvider({
-                      provider: playgroundInstance.model.provider,
-                      toolNumber: playgroundInstance.tools.length + 1,
-                    }),
-                  ],
-                },
-              });
-            }}
-          >
-            Tool
-          </Button>
-          <Button
-            variant="default"
-            aria-label="add message"
-            size="compact"
-            icon={<Icon svg={<Icons.PlusOutline />} />}
-            onClick={() => {
-              updateInstance({
-                instanceId: id,
-                patch: {
-                  template: {
-                    __type: "chat",
-                    messages: [
-                      ...template.messages,
-                      {
-                        id: generateMessageId(),
-                        role: "user",
-                        content: "",
-                      },
-                    ],
-                  },
-                },
-              });
-            }}
-          >
-            Message
-          </Button>
-        </Flex>
+        <Suspense fallback={<PlaygroundChatTemplateFooterFallback />}>
+          <PlaygroundChatTemplateFooter
+            instanceId={id}
+            hasResponseFormat={hasResponseFormat}
+          />
+        </Suspense>
       </View>
       {hasTools ? <PlaygroundTools {...props} /> : null}
       {hasResponseFormat ? <PlaygroundResponseFormat {...props} /> : null}

--- a/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { css, keyframes } from "@emotion/react";
+
+import { Button, Flex, Icon, Icons } from "@arizeai/components";
+
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import {
+  createOpenAIResponseFormat,
+  generateMessageId,
+  PlaygroundInstance,
+} from "@phoenix/store";
+
+import { PlaygroundChatTemplateFooterResponseFormatQuery } from "./__generated__/PlaygroundChatTemplateFooterResponseFormatQuery.graphql";
+import {
+  RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
+  RESPONSE_FORMAT_PARAM_NAME,
+} from "./constants";
+import { createToolForProvider } from "./playgroundUtils";
+
+type PlaygroundChatTemplateFooterProps = {
+  instanceId: number;
+  hasResponseFormat: boolean;
+};
+
+const FOOTER_MIN_HEIGHT = 32;
+
+export function PlaygroundChatTemplateFooter({
+  instanceId,
+  hasResponseFormat,
+}: PlaygroundChatTemplateFooterProps) {
+  const instances = usePlaygroundContext((state) => state.instances);
+  const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  const upsertInvocationParameterInput = usePlaygroundContext(
+    (state) => state.upsertInvocationParameterInput
+  );
+  const playgroundInstance = instances.find(
+    (instance) => instance.id === instanceId
+  );
+  if (!playgroundInstance) {
+    throw new Error(`Playground instance ${instanceId} not found`);
+  }
+  const { template } = playgroundInstance;
+  if (template.__type !== "chat") {
+    throw new Error(`Invalid template type ${template.__type}`);
+  }
+
+  // We don't care about the model name for Azure OpenAI
+  const modelNameQueryInput =
+    playgroundInstance.model.provider !== "AZURE_OPENAI"
+      ? (playgroundInstance.model?.modelName ?? null)
+      : null;
+  const { modelInvocationParameters } =
+    useLazyLoadQuery<PlaygroundChatTemplateFooterResponseFormatQuery>(
+      graphql`
+        query PlaygroundChatTemplateFooterResponseFormatQuery(
+          $input: ModelsInput!
+        ) {
+          modelInvocationParameters(input: $input) {
+            __typename
+            ... on InvocationParameterBase {
+              invocationName
+              canonicalName
+            }
+          }
+        }
+      `,
+      {
+        input: {
+          providerKey: playgroundInstance.model.provider,
+          modelName: modelNameQueryInput,
+        },
+      }
+    );
+
+  const supportsResponseFormat = modelInvocationParameters?.some(
+    (p) =>
+      p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME ||
+      p.invocationName === RESPONSE_FORMAT_PARAM_NAME
+  );
+  return (
+    <Flex
+      direction="row"
+      justifyContent="end"
+      gap="size-100"
+      minHeight={FOOTER_MIN_HEIGHT}
+    >
+      {supportsResponseFormat ? (
+        <Button
+          variant="default"
+          size="compact"
+          aria-label="output schema"
+          icon={<Icon svg={<Icons.PlusOutline />} />}
+          disabled={hasResponseFormat}
+          onClick={() => {
+            upsertInvocationParameterInput({
+              instanceId,
+              invocationParameterInput: {
+                valueJson: createOpenAIResponseFormat(),
+                invocationName: RESPONSE_FORMAT_PARAM_NAME,
+                canonicalName: RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
+              },
+            });
+          }}
+        >
+          Output Schema
+        </Button>
+      ) : null}
+      <Button
+        variant="default"
+        aria-label="add tool"
+        size="compact"
+        icon={<Icon svg={<Icons.PlusOutline />} />}
+        onClick={() => {
+          const patch: Partial<PlaygroundInstance> = {
+            tools: [
+              ...playgroundInstance.tools,
+              createToolForProvider({
+                provider: playgroundInstance.model.provider,
+                toolNumber: playgroundInstance.tools.length + 1,
+              }),
+            ],
+          };
+          if (playgroundInstance.tools.length === 0) {
+            patch.toolChoice = "auto";
+          }
+          updateInstance({
+            instanceId,
+            patch: {
+              tools: [
+                ...playgroundInstance.tools,
+                createToolForProvider({
+                  provider: playgroundInstance.model.provider,
+                  toolNumber: playgroundInstance.tools.length + 1,
+                }),
+              ],
+            },
+          });
+        }}
+      >
+        Tool
+      </Button>
+      <Button
+        variant="default"
+        aria-label="add message"
+        size="compact"
+        icon={<Icon svg={<Icons.PlusOutline />} />}
+        onClick={() => {
+          updateInstance({
+            instanceId,
+            patch: {
+              template: {
+                __type: "chat",
+                messages: [
+                  ...template.messages,
+                  {
+                    id: generateMessageId(),
+                    role: "user",
+                    content: "",
+                  },
+                ],
+              },
+            },
+          });
+        }}
+      >
+        Message
+      </Button>
+    </Flex>
+  );
+}
+
+const pulse = keyframes`
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 0.1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
+const loadingStyles = css`
+  background-color: var(--ac-global-color-gray-100);
+  animation: ${pulse} 1.7s infinite ease-in-out;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+`;
+
+export function PlaygroundChatTemplateFooterFallback() {
+  return (
+    <Flex minHeight={FOOTER_MIN_HEIGHT} width="100%" height={FOOTER_MIN_HEIGHT}>
+      <div css={loadingStyles}></div>
+    </Flex>
+  );
+}

--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 
 import {
   Button,
@@ -50,7 +50,9 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
       }
     >
       {template.__type === "chat" ? (
-        <PlaygroundChatTemplate {...props} />
+        <Suspense>
+          <PlaygroundChatTemplate {...props} />
+        </Suspense>
       ) : (
         "Completion Template"
       )}

--- a/app/src/pages/playground/__generated__/PlaygroundChatTemplateFooterResponseFormatQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundChatTemplateFooterResponseFormatQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<93057944b5f33e489d2dd2cfb700ce68>>
+ * @generated SignedSource<<2003431f2625c180cb4afcf408201b62>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,19 +15,19 @@ export type ModelsInput = {
   modelName?: string | null;
   providerKey?: GenerativeProviderKey | null;
 };
-export type PlaygroundChatTemplateResponseFormatQuery$variables = {
+export type PlaygroundChatTemplateFooterResponseFormatQuery$variables = {
   input: ModelsInput;
 };
-export type PlaygroundChatTemplateResponseFormatQuery$data = {
+export type PlaygroundChatTemplateFooterResponseFormatQuery$data = {
   readonly modelInvocationParameters: ReadonlyArray<{
     readonly __typename: string;
     readonly canonicalName?: CanonicalParameterName | null;
     readonly invocationName?: string;
   }>;
 };
-export type PlaygroundChatTemplateResponseFormatQuery = {
-  response: PlaygroundChatTemplateResponseFormatQuery$data;
-  variables: PlaygroundChatTemplateResponseFormatQuery$variables;
+export type PlaygroundChatTemplateFooterResponseFormatQuery = {
+  response: PlaygroundChatTemplateFooterResponseFormatQuery$data;
+  variables: PlaygroundChatTemplateFooterResponseFormatQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -90,7 +90,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "name": "PlaygroundChatTemplateFooterResponseFormatQuery",
     "selections": (v1/*: any*/),
     "type": "Query",
     "abstractKey": null
@@ -99,20 +99,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "name": "PlaygroundChatTemplateFooterResponseFormatQuery",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "d477ae472b8e2377c17187780c70f7a5",
+    "cacheID": "01a450b6ebf674efd1c63a87f81d527c",
     "id": null,
     "metadata": {},
-    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "name": "PlaygroundChatTemplateFooterResponseFormatQuery",
     "operationKind": "query",
-    "text": "query PlaygroundChatTemplateResponseFormatQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      canonicalName\n    }\n  }\n}\n"
+    "text": "query PlaygroundChatTemplateFooterResponseFormatQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      canonicalName\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d83ce7cbdb4ff58ed9662f4a0e03414c";
+(node as any).hash = "f66d71a8f3f680d4f0a4ec0edf0b6332";
 
 export default node;

--- a/app/src/pages/playground/__generated__/PlaygroundChatTemplateResponseFormatQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundChatTemplateResponseFormatQuery.graphql.ts
@@ -1,0 +1,118 @@
+/**
+ * @generated SignedSource<<93057944b5f33e489d2dd2cfb700ce68>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
+export type ModelsInput = {
+  modelName?: string | null;
+  providerKey?: GenerativeProviderKey | null;
+};
+export type PlaygroundChatTemplateResponseFormatQuery$variables = {
+  input: ModelsInput;
+};
+export type PlaygroundChatTemplateResponseFormatQuery$data = {
+  readonly modelInvocationParameters: ReadonlyArray<{
+    readonly __typename: string;
+    readonly canonicalName?: CanonicalParameterName | null;
+    readonly invocationName?: string;
+  }>;
+};
+export type PlaygroundChatTemplateResponseFormatQuery = {
+  response: PlaygroundChatTemplateResponseFormatQuery$data;
+  variables: PlaygroundChatTemplateResponseFormatQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "modelInvocationParameters",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "invocationName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "canonicalName",
+            "storageKey": null
+          }
+        ],
+        "type": "InvocationParameterBase",
+        "abstractKey": "__isInvocationParameterBase"
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d477ae472b8e2377c17187780c70f7a5",
+    "id": null,
+    "metadata": {},
+    "name": "PlaygroundChatTemplateResponseFormatQuery",
+    "operationKind": "query",
+    "text": "query PlaygroundChatTemplateResponseFormatQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      canonicalName\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d83ce7cbdb4ff58ed9662f4a0e03414c";
+
+export default node;


### PR DESCRIPTION


https://github.com/user-attachments/assets/35405368-3b07-4dc6-957a-d1c164ca62fb



Resolves #5385
Resolves #5384


