### PR TITLE
fix(playgroun): use saved model config for default model when switching providers

### DIFF
--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -273,11 +273,19 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
 
   const updateProvider = useCallback(
     (provider: ModelProvider) => {
+      if (provider === instance.model.provider) {
+        return;
+      }
+      const savedProviderConfig = modelConfigByProvider[provider];
       const patch: Partial<PlaygroundInstance> = {
         model: {
           ...instance.model,
+          // Don't update the invocation parameters with the saved config, because the user may want to retain those params across provider changes
+          // Only update the model name
+          modelName: savedProviderConfig?.modelName ?? null,
+          apiVersion: savedProviderConfig?.apiVersion ?? null,
+          endpoint: savedProviderConfig?.endpoint ?? null,
           provider,
-          modelName: null,
         },
         tools: convertInstanceToolsToProvider({
           instanceTools: instance.tools,
@@ -307,6 +315,7 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
       instance.model,
       instance.template,
       instance.tools,
+      modelConfigByProvider,
       playgroundInstanceId,
       updateInstance,
     ]

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -227,6 +227,7 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
           newModel = {
             ...savedProviderConfig,
             provider: model.provider,
+            // Don't update the invocation parameters with the saved config, because the user may want to retain those params across provider changes
             invocationParameters: [
               ...instance.model.invocationParameters,
               // These should never be changing at the same time as the provider but spread here to be safe


### PR DESCRIPTION
resolves #5388 
resolves #5405

- uses saved config for model information when switching providers if present, clears provider model related fields if no saved config
- also switching to the same provider will not clear model selection anymore


https://github.com/user-attachments/assets/ae0857ff-1f3b-4dcc-b8d5-21c2f50ff3f8

