### PR TITLE
fix(playground): compare invocationName and canonical name in all places where we try to find invocation params

### DIFF
--- a/app/src/pages/playground/InvocationParametersForm.tsx
+++ b/app/src/pages/playground/InvocationParametersForm.tsx
@@ -14,6 +14,7 @@ import { InvocationParameterInput } from "./__generated__/PlaygroundOutputSubscr
 import { paramsToIgnoreInInvocationParametersForm } from "./constants";
 import { InvocationParameterJsonEditor } from "./InvocationParameterJsonEditor";
 import {
+  areInvocationParamsEqual,
   constrainInvocationParameterInputsToDefinition,
   toCamelCase,
 } from "./playgroundUtils";
@@ -265,8 +266,8 @@ export const InvocationParametersForm = ({
 
   const onChange = useCallback(
     (field: InvocationParameter, value: unknown) => {
-      const existingParameter = instance.model.invocationParameters.find(
-        (p) => p.invocationName === field.invocationName
+      const existingParameter = instance.model.invocationParameters.find((p) =>
+        areInvocationParamsEqual(p, field)
       );
 
       if (existingParameter) {
@@ -275,7 +276,7 @@ export const InvocationParametersForm = ({
           updateInstanceModelInvocationParameters({
             instanceId: instance.id,
             invocationParameters: instance.model.invocationParameters.map(
-              (p) => (p.invocationName === field.invocationName ? input : p)
+              (p) => (areInvocationParamsEqual(p, field) ? input : p)
             ),
           });
         }
@@ -304,12 +305,13 @@ export const InvocationParametersForm = ({
         )
     )
     .map((field) => {
-      const existingParameter = instance.model.invocationParameters.find(
-        (p) => p.invocationName === field.invocationName
+      const existingParameter = instance.model.invocationParameters.find((p) =>
+        areInvocationParamsEqual(p, field)
       );
       const value = existingParameter
         ? getInvocationParameterValue(field, existingParameter)
         : undefined;
+
       return (
         <InvocationParameterFormField
           key={field.invocationName}

--- a/app/src/pages/playground/InvocationParametersForm.tsx
+++ b/app/src/pages/playground/InvocationParametersForm.tsx
@@ -76,6 +76,7 @@ const InvocationParameterFormField = ({
           isRequired={field.required}
           defaultValue={value?.join(", ") || ""}
           onChange={(value) => onChange(value.split(/, */g))}
+          description={"A comma separated list of strings"}
         />
       );
     case "StringInvocationParameter":

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -50,7 +50,9 @@ export function PlaygroundResponseFormat({
   }
 
   const responseFormat = instance.model.invocationParameters.find(
-    (p) => p.invocationName === RESPONSE_FORMAT_PARAM_NAME
+    (p) =>
+      p.invocationName === RESPONSE_FORMAT_PARAM_NAME ||
+      p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME
   );
 
   const [responseFormatDefinition, setResponseFormatDefinition] = useState(

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -29,6 +29,7 @@ import {
   TOOLS_PARSING_ERROR,
 } from "../constants";
 import {
+  areInvocationParamsEqual,
   convertInstanceToolsToProvider,
   convertMessageToolCallsToProvider,
   extractVariablesFromInstances,
@@ -1171,6 +1172,77 @@ describe("getToolsFromAttributes", () => {
       tools: null,
       parsingErrors: [],
     });
+  });
+});
+describe("areInvocationParamsEqual", () => {
+  it("should return true if invocation names are equal", () => {
+    const paramA = {
+      invocationName: "max_tokens",
+      canonicalName: null,
+      valueInt: 100,
+    };
+    const paramB = {
+      invocationName: "max_tokens",
+      canonicalName: null,
+      valueInt: 200,
+    };
+    expect(areInvocationParamsEqual(paramA, paramB)).toBe(true);
+  });
+
+  it("should return true if canonical names are equal", () => {
+    const paramA = {
+      invocationName: "max_tokens",
+      canonicalName: "MAX_COMPLETION_TOKENS" as const,
+      valueInt: 100,
+    };
+    const paramB = {
+      invocationName: "max_tokens_alt",
+      canonicalName: "MAX_COMPLETION_TOKENS" as const,
+      valueInt: 200,
+    };
+    expect(areInvocationParamsEqual(paramA, paramB)).toBe(true);
+  });
+
+  it("should return false if neither invocation names nor canonical names are equal", () => {
+    const paramA = {
+      invocationName: "max_tokens",
+      canonicalName: "MAX_COMPLETION_TOKENS" as const,
+      valueInt: 100,
+    };
+    const paramB = {
+      invocationName: "top_p",
+      canonicalName: "TOP_P" as const,
+      valueFloat: 0.9,
+    };
+    expect(areInvocationParamsEqual(paramA, paramB)).toBe(false);
+  });
+
+  it("should return false if one canonical name is null and invocation names are not equal", () => {
+    const paramA = {
+      invocationName: "max_tokens",
+      canonicalName: null,
+      valueInt: 100,
+    };
+    const paramB = {
+      invocationName: "top_p",
+      canonicalName: "TOP_P" as const,
+      valueFloat: 0.9,
+    };
+    expect(areInvocationParamsEqual(paramA, paramB)).toBe(false);
+  });
+
+  it("should return false if both canonical names are null and invocation names are not equal", () => {
+    const paramA = {
+      invocationName: "max_tokens",
+      canonicalName: null,
+      valueInt: 100,
+    };
+    const paramB = {
+      invocationName: "top_p",
+      canonicalName: null,
+      valueFloat: 0.9,
+    };
+    expect(areInvocationParamsEqual(paramA, paramB)).toBe(false);
   });
 });
 

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -615,6 +615,19 @@ export const getVariablesMapFromInstances = ({
   return { variablesMap, variableKeys };
 };
 
+export function areInvocationParamsEqual(
+  paramA: InvocationParameter | InvocationParameterInput,
+  paramB: InvocationParameter | InvocationParameterInput
+) {
+  return (
+    paramA.invocationName === paramB.invocationName ||
+    // loose null comparison to catch undefined and null
+    (paramA.canonicalName != null &&
+      paramB.canonicalName != null &&
+      paramA.canonicalName === paramB.canonicalName)
+  );
+}
+
 /**
  * Filter out parameters that are not supported by a model's invocation parameter schema definitions.
  */
@@ -626,14 +639,7 @@ export const constrainInvocationParameterInputsToDefinition = (
     .filter((ip) =>
       // An input should be kept if it matches an invocation name in the definitions
       // or if it has a canonical name that matches a canonical name in the definitions.
-      definitions.some(
-        (mp) =>
-          mp.invocationName === ip.invocationName ||
-          // loosey null comparison to catch undefined and null
-          (mp.canonicalName != null &&
-            ip.canonicalName != null &&
-            mp.canonicalName === ip.canonicalName)
-      )
+      definitions.some((mp) => areInvocationParamsEqual(mp, ip))
     )
     .map((ip) => ({
       // Transform the invocationName to match the new name from the incoming

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_MODEL_NAME,
   DEFAULT_MODEL_PROVIDER,
 } from "@phoenix/constants/generativeConstants";
+import { areInvocationParamsEqual } from "@phoenix/pages/playground/playgroundUtils";
 import { OpenAIResponseFormat } from "@phoenix/pages/playground/schemas";
 
 import {
@@ -395,8 +396,8 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
         return;
       }
       const currentInvocationParameterInput =
-        instance.model.invocationParameters.find(
-          (p) => p.invocationName === invocationParameterInput.invocationName
+        instance.model.invocationParameters.find((p) =>
+          areInvocationParamsEqual(p, invocationParameterInput)
         );
 
       if (currentInvocationParameterInput) {
@@ -409,8 +410,7 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
                   ...instance.model,
                   invocationParameters: instance.model.invocationParameters.map(
                     (p) =>
-                      p.invocationName ===
-                      invocationParameterInput.invocationName
+                      areInvocationParamsEqual(p, invocationParameterInput)
                         ? invocationParameterInput
                         : p
                   ),

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -1,6 +1,10 @@
 from enum import Enum
+from typing import Any, ClassVar, Optional, Union
 
 import strawberry
+from openinference.semconv.trace import OpenInferenceLLMProviderValues, SpanAttributes
+
+from phoenix.trace.attributes import get_attribute_value
 
 
 @strawberry.enum
@@ -15,6 +19,20 @@ class GenerativeProviderKey(Enum):
 class GenerativeProvider:
     name: str
     key: GenerativeProviderKey
+
+    model_provider_to_model_prefix_map: ClassVar[dict[GenerativeProviderKey, list[str]]] = {
+        GenerativeProviderKey.AZURE_OPENAI: [],
+        GenerativeProviderKey.ANTHROPIC: ["claude"],
+        GenerativeProviderKey.OPENAI: ["gpt", "o1"],
+        GenerativeProviderKey.GEMINI: ["gemini"],
+    }
+
+    attribute_provider_to_generative_provider_map: ClassVar[dict[str, GenerativeProviderKey]] = {
+        OpenInferenceLLMProviderValues.OPENAI.value: GenerativeProviderKey.OPENAI,
+        OpenInferenceLLMProviderValues.ANTHROPIC.value: GenerativeProviderKey.ANTHROPIC,
+        OpenInferenceLLMProviderValues.AZURE.value: GenerativeProviderKey.AZURE_OPENAI,
+        OpenInferenceLLMProviderValues.GOOGLE.value: GenerativeProviderKey.GEMINI,
+    }
 
     @strawberry.field
     async def dependencies(self) -> list[str]:
@@ -39,3 +57,29 @@ class GenerativeProvider:
         if default_client:
             return default_client.dependencies_are_installed()
         return False
+
+    @classmethod
+    def _infer_model_provider_from_model_name(
+        cls,
+        model_name: str,
+    ) -> Union[GenerativeProviderKey, None]:
+        for provider, prefixes in cls.model_provider_to_model_prefix_map.items():
+            if any(prefix.lower() in model_name.lower() for prefix in prefixes):
+                return provider
+        return None
+
+    @classmethod
+    def get_model_provider_from_attributes(
+        cls,
+        attributes: dict[str, Any],
+    ) -> Union[GenerativeProviderKey, None]:
+        llm_provider: Optional[str] = get_attribute_value(attributes, SpanAttributes.LLM_PROVIDER)
+
+        if isinstance(llm_provider, str) and (
+            provider := cls.attribute_provider_to_generative_provider_map.get(llm_provider)
+        ):
+            return provider
+        llm_model = get_attribute_value(attributes, SpanAttributes.LLM_MODEL_NAME)
+        if isinstance(llm_model, str):
+            return cls._infer_model_provider_from_model_name(llm_model)
+        return None

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -461,7 +461,7 @@ model_provider_to_model_prefix_map: dict[GenerativeProviderKey, list[str]] = {
 }
 
 
-def _infer_model_provider_from_model_name(model_name: str) -> Union[GenerativeProviderKey | None]:
+def _infer_model_provider_from_model_name(model_name: str) -> Union[GenerativeProviderKey, None]:
     for provider, prefixes in model_provider_to_model_prefix_map.items():
         if any(prefix in model_name for prefix in prefixes):
             return provider

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sized
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
 import strawberry
@@ -25,7 +25,7 @@ from phoenix.server.api.input_types.SpanAnnotationSort import (
     SpanAnnotationColumn,
     SpanAnnotationSort,
 )
-from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
+from phoenix.server.api.types.GenerativeProvider import GenerativeProvider
 from phoenix.server.api.types.SortDir import SortDir
 from phoenix.server.api.types.SpanAnnotation import to_gql_span_annotation
 from phoenix.trace.attributes import get_attribute_value

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sized
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
 import strawberry
@@ -461,18 +461,20 @@ model_provider_to_model_prefix_map: dict[GenerativeProviderKey, list[str]] = {
 }
 
 
-def _infer_model_provider_from_model_name(model_name: str) -> GenerativeProviderKey | None:
+def _infer_model_provider_from_model_name(model_name: str) -> Union[GenerativeProviderKey | None]:
     for provider, prefixes in model_provider_to_model_prefix_map.items():
         if any(prefix in model_name for prefix in prefixes):
             return provider
     return None
 
 
-def _get_model_provider_from_attributes(attributes: dict[str, Any]) -> GenerativeProviderKey | None:
-    llm_provider: GenerativeProviderKey | None = get_attribute_value(
+def _get_model_provider_from_attributes(
+    attributes: dict[str, Any],
+) -> Union[GenerativeProviderKey, None]:
+    llm_provider: Union[GenerativeProviderKey, None] = get_attribute_value(
         attributes, SpanAttributes.LLM_PROVIDER
     )
-    if isinstance(llm_provider, GenerativeProviderKey):
+    if llm_provider in GenerativeProviderKey:
         return llm_provider
     llm_model = get_attribute_value(attributes, SpanAttributes.LLM_MODEL_NAME)
     if isinstance(llm_model, str):

--- a/tests/unit/server/api/types/test_GenerativeProvider.py
+++ b/tests/unit/server/api/types/test_GenerativeProvider.py
@@ -1,0 +1,28 @@
+from openinference.semconv.trace import OpenInferenceLLMProviderValues
+
+from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
+
+
+class TestGenerativeProvider:
+    def test_infer_model_provider_from_model_name(self) -> None:
+        provider = GenerativeProvider._infer_model_provider_from_model_name("gpt-3")
+        assert provider == GenerativeProviderKey.OPENAI
+
+        provider = GenerativeProvider._infer_model_provider_from_model_name("claude-v1")
+        assert provider == GenerativeProviderKey.ANTHROPIC
+
+        provider = GenerativeProvider._infer_model_provider_from_model_name("unknown-model")
+        assert provider is None
+
+    def test_get_model_provider_from_attributes(self) -> None:
+        attributes = {"llm": {"provider": OpenInferenceLLMProviderValues.OPENAI.value}}
+        provider = GenerativeProvider.get_model_provider_from_attributes(attributes)
+        assert provider == GenerativeProviderKey.OPENAI
+
+        attributes = {"llm": {"model_name": "claude-v1"}}
+        provider = GenerativeProvider.get_model_provider_from_attributes(attributes)
+        assert provider == GenerativeProviderKey.ANTHROPIC
+
+        attributes = {"llm": {"provider": "UnknownProvider"}}
+        provider = GenerativeProvider.get_model_provider_from_attributes(attributes)
+        assert provider is None


### PR DESCRIPTION
resolves #5409 

The bug was happening because the parameter `invocationName` was `stop`, on the instance in the front end and the parameter `invocationName` was `stop_sequence` coming from the api. Until the values were filtered and coerced to match our api. (happened on first opening but did not cause an update to the form). Not sure why the form wasn't updating when the value got coerced however.

- makes invocation parameter comparison uniform

https://github.com/user-attachments/assets/54a26e57-d8b2-4005-97d6-2cbed947a10c

