### PR TITLE
fix: Allow dot key values in templates

### DIFF
--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -31,3 +31,10 @@ def test_template_with_default_delimiters_uses_python_string_formatting():
         template.format(variable_values={"name": "world"})
         == 'Hello, world! Look at this JSON { "hello": "world" }'
     )
+
+def test_template_with_default_delimiters_accepts_keys_with_dots():
+    template = PromptTemplate(template='Hello, {my.name}! Look at this JSON {{ "hello": "world" }}')
+    assert (
+        template.format(variable_values={"my.name": "world"})
+        == 'Hello, world! Look at this JSON { "hello": "world" }'
+    )

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -32,6 +32,7 @@ def test_template_with_default_delimiters_uses_python_string_formatting():
         == 'Hello, world! Look at this JSON { "hello": "world" }'
     )
 
+
 def test_template_with_default_delimiters_accepts_keys_with_dots():
     template = PromptTemplate(template='Hello, {my.name}! Look at this JSON {{ "hello": "world" }}')
     assert (


### PR DESCRIPTION
This allows template variable names that includes dots e.g. `{my.key}`