### PR TITLE
feat: Display playground chat completion errors within output card

### DIFF
--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -7,7 +7,7 @@ import {
   requestSubscription,
 } from "relay-runtime";
 
-import { Alert, Card, Flex, Text, View } from "@arizeai/components";
+import { Alert, Card, Flex, View } from "@arizeai/components";
 
 import { Loading } from "@phoenix/components";
 import {


### PR DESCRIPTION
Still need better error messages themselves, but now they render until the next completion is kicked off.

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/3d8a4a00-577f-4e6c-b9b2-e45d96a7e1a7">


<img width="1283" alt="image" src="https://github.com/user-attachments/assets/6cd69b71-c223-4706-a672-5f6add35987d">

Resolves #5383 
