### PR TITLE
fix(playground): return error messages for timeouts and unexpected errors during chat completion over dataset subscription

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -341,8 +341,10 @@ class Subscription:
                     _is_result_payloads_stream(stream) for _, stream, _ in in_progress
                 )
                 if (
-                    exceeded_write_batch_size or exceeded_write_interval
-                ) and not write_already_in_progress:
+                    not results.empty()
+                    and (exceeded_write_batch_size or exceeded_write_interval)
+                    and not write_already_in_progress
+                ):
                     result_payloads_stream = _chat_completion_result_payloads(
                         db=info.context.db, results=_drain_no_wait(results)
                     )


### PR DESCRIPTION
- returns errors for timeouts and unexpected errors during chat completion over dataset subscription
- improves experience of writes to cap the amount of time a user has to wait to see token counts and latency in the ui

resolves #5448