### PR TITLE
fix: Allow shrinking of playground dataset table cells that have long text

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -448,6 +448,11 @@ function TableBody<T>({ table }: { table: Table<T> }) {
                 key={cell.id}
                 style={{
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
+                  // allow long text with no symbols or spaces to wrap
+                  // otherwise, it will prevent the cell from shrinking
+                  // an alternative solution would be to set a max-width and allow
+                  // the cell to scroll itself
+                  wordBreak: "break-all",
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
### Before


https://github.com/user-attachments/assets/76e0bbd9-8633-49c6-bfd1-2bbae5724265



### After


https://github.com/user-attachments/assets/c61eb200-bbda-43f1-aa11-9e810e28880e



Resolves #5444