### PR TITLE
feat(playground): block navigation when runs are in progress

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@arizeai/components": "^1.8.9",
+    "@arizeai/components": "^1.8.11",
     "@arizeai/openinference-semantic-conventions": "^0.12.0",
     "@arizeai/point-cloud": "^3.0.6",
     "@codemirror/autocomplete": "6.12.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@arizeai/components':
-        specifier: ^1.8.9
-        version: 1.8.9(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.8.11
+        version: 1.8.11(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@arizeai/openinference-semantic-conventions':
         specifier: ^0.12.0
         version: 0.12.0
@@ -283,8 +283,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@arizeai/components@1.8.9':
-    resolution: {integrity: sha512-K3SgaLuDoAYVOC+4gsETCEewmN7ni2LLrvUyWYqzm9xXR68EXkJs544cPOrEJ6dNWV0ES96H72NRjvGzZGMBsA==}
+  '@arizeai/components@1.8.11':
+    resolution: {integrity: sha512-PhiP7odjdtXB/9y0oODWpaWP60BbQ8bDoUATovY2Ip3nq4W3xz9Oadwc4nsOnspFdxxkMatyuqAMfZFnIb4U6A==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=18'
@@ -3999,7 +3999,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@arizeai/components@1.8.9(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@arizeai/components@1.8.11(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@emotion/react': 11.11.4(@types/react@18.3.10)(react@18.3.1)
       '@react-aria/breadcrumbs': 3.5.13(react@18.3.1)

--- a/app/src/components/ConfirmNavigation.tsx
+++ b/app/src/components/ConfirmNavigation.tsx
@@ -1,0 +1,59 @@
+import React, { ReactNode } from "react";
+import { Blocker } from "react-router";
+
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  Flex,
+  Text,
+  View,
+} from "@arizeai/components";
+
+function ConfirmNavigationDialogFooter({ blocker }: { blocker: Blocker }) {
+  return (
+    <View padding={"size-100"} borderTopColor={"dark"} borderTopWidth={"thin"}>
+      <Flex justifyContent={"end"} gap={"size-100"}>
+        <Button
+          variant={"default"}
+          onClick={() => blocker.reset && blocker.reset()}
+          size={"compact"}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant={"primary"}
+          onClick={() => blocker.proceed && blocker.proceed()}
+          size={"compact"}
+        >
+          Confirm
+        </Button>
+      </Flex>
+    </View>
+  );
+}
+
+export function ConfirmNavigationDialog({
+  blocker,
+  message = "Are you sure you want to leave the page? Some changes may not be saved.",
+}: {
+  blocker: Blocker;
+  message?: ReactNode;
+}) {
+  if (blocker.state === "blocked") {
+    return (
+      <DialogContainer
+        type="modal"
+        isDismissable={true}
+        onDismiss={() => blocker.reset()}
+      >
+        <Dialog title={"Confirm Navigation"} size="S">
+          <View padding={"size-200"}>
+            <Text>{message}</Text>
+          </View>
+          <ConfirmNavigationDialogFooter blocker={blocker} />
+        </Dialog>
+      </DialogContainer>
+    );
+  }
+}

--- a/app/src/pages/playground/InvocationParametersFormFields.tsx
+++ b/app/src/pages/playground/InvocationParametersFormFields.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback, useEffect } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { Flex, Slider, Switch, TextField } from "@arizeai/components";
+import { Slider, Switch, TextField } from "@arizeai/components";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { Mutable } from "@phoenix/typeUtils";
 
 import {
-  InvocationParametersFormQuery,
-  InvocationParametersFormQuery$data,
-} from "./__generated__/InvocationParametersFormQuery.graphql";
+  InvocationParametersFormFieldsQuery,
+  InvocationParametersFormFieldsQuery$data,
+} from "./__generated__/InvocationParametersFormFieldsQuery.graphql";
 import { InvocationParameterInput } from "./__generated__/PlaygroundOutputSubscription.graphql";
 import { paramsToIgnoreInInvocationParametersForm } from "./constants";
 import { InvocationParameterJsonEditor } from "./InvocationParameterJsonEditor";
@@ -20,7 +20,7 @@ import {
 } from "./playgroundUtils";
 
 export type InvocationParameter = Mutable<
-  InvocationParametersFormQuery$data["modelInvocationParameters"]
+  InvocationParametersFormFieldsQuery$data["modelInvocationParameters"]
 >[number];
 
 export type HandleInvocationParameterChange = (
@@ -192,7 +192,7 @@ type InvocationParametersFormProps = {
   instanceId: number;
 };
 
-export const InvocationParametersForm = ({
+export const InvocationParametersFormFields = ({
   instanceId,
 }: InvocationParametersFormProps) => {
   const instance = usePlaygroundContext((state) =>
@@ -216,9 +216,9 @@ export const InvocationParametersForm = ({
   const modelNameToQuery =
     model.provider !== "AZURE_OPENAI" ? model.modelName : null;
   const { modelInvocationParameters } =
-    useLazyLoadQuery<InvocationParametersFormQuery>(
+    useLazyLoadQuery<InvocationParametersFormFieldsQuery>(
       graphql`
-        query InvocationParametersFormQuery($input: ModelsInput!) {
+        query InvocationParametersFormFieldsQuery($input: ModelsInput!) {
           modelInvocationParameters(input: $input) {
             __typename
             ... on InvocationParameterBase {
@@ -359,9 +359,5 @@ export const InvocationParametersForm = ({
       );
     });
 
-  return (
-    <Flex direction="column" gap="size-200">
-      {fieldsForSchema}
-    </Flex>
-  );
+  return fieldsForSchema;
 };

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -9,20 +9,21 @@ import React, {
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import debounce from "lodash/debounce";
+import { css } from "@emotion/react";
 
 import {
   Button,
   Dialog,
   DialogContainer,
   Flex,
-  Form,
+  Icon,
+  Icons,
   Item,
   Picker,
   Text,
   TextField,
   Tooltip,
   TooltipTrigger,
-  View,
 } from "@arizeai/components";
 
 import {
@@ -35,7 +36,7 @@ import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 import { PlaygroundInstance } from "@phoenix/store";
 
 import { ModelConfigButtonDialogQuery } from "./__generated__/ModelConfigButtonDialogQuery.graphql";
-import { InvocationParametersForm } from "./InvocationParametersForm";
+import { InvocationParametersFormFields } from "./InvocationParametersFormFields";
 import { ModelPicker } from "./ModelPicker";
 import { ModelProviderPicker } from "./ModelProviderPicker";
 import {
@@ -43,6 +44,24 @@ import {
   convertMessageToolCallsToProvider,
 } from "./playgroundUtils";
 import { PlaygroundInstanceProps } from "./types";
+
+const modelConfigFormCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-global-dimension-size-200);
+  .ac-field,
+  .ac-dropdown,
+  .ac-dropdown-button,
+  .ac-slider {
+    width: 100%;
+  }
+  // Makes the filled slider track blue
+  .ac-slider-controls > .ac-slider-track:first-child::before {
+    background: var(--ac-global-color-primary);
+  }
+  padding: var(--ac-global-dimension-size-200);
+  overflow: auto;
+`;
 
 function AzureOpenAiModelConfigFormField({
   instance,
@@ -194,7 +213,7 @@ function ModelConfigDialog(props: ModelConfigDialogProps) {
     });
     notifySuccess({
       title: "Model Configuration Saved",
-      message: `${ModelProviders[instance.model.provider]} model configuration saved`,
+      message: `${ModelProviders[instance.model.provider]} model configuration saved as default for later use.`,
       expireMs: 3000,
     });
   }, [instance.model, notifySuccess, setModelConfigForProvider]);
@@ -204,12 +223,18 @@ function ModelConfigDialog(props: ModelConfigDialogProps) {
       size="M"
       extra={
         <TooltipTrigger delay={0} offset={5}>
-          <Button size={"compact"} variant="default" onClick={onSaveConfig}>
-            Save Config
+          <Button
+            size={"compact"}
+            variant="default"
+            onClick={onSaveConfig}
+            icon={<Icon svg={<Icons.SaveOutline />} />}
+          >
+            Save as Default
           </Button>
           <Tooltip>
-            Remember configuration for{" "}
-            {ModelProviders[instance.model.provider] ?? "this provider"}.
+            Saves the current configuration as the default for{" "}
+            {ModelProviders[instance.model.provider] ?? "this provider"} for
+            later use.
           </Tooltip>
         </TooltipTrigger>
       }
@@ -322,29 +347,30 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
   );
 
   return (
-    <View padding="size-200" overflow="auto">
-      <Form>
-        <Flex direction="column" gap="size-200">
-          <ModelProviderPicker
-            provider={instance.model.provider}
-            query={query}
-            onChange={updateProvider}
-          />
-          {instance.model.provider === "AZURE_OPENAI" ? (
-            <AzureOpenAiModelConfigFormField instance={instance} />
-          ) : (
-            <ModelPicker
-              modelName={instance.model.modelName}
-              provider={instance.model.provider}
-              query={query}
-              onChange={onModelNameChange}
-            />
-          )}
-          <Suspense>
-            <InvocationParametersForm instanceId={playgroundInstanceId} />
-          </Suspense>
-        </Flex>
-      </Form>
-    </View>
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+      }}
+      css={modelConfigFormCSS}
+    >
+      <ModelProviderPicker
+        provider={instance.model.provider}
+        query={query}
+        onChange={updateProvider}
+      />
+      {instance.model.provider === "AZURE_OPENAI" ? (
+        <AzureOpenAiModelConfigFormField instance={instance} />
+      ) : (
+        <ModelPicker
+          modelName={instance.model.modelName}
+          provider={instance.model.provider}
+          query={query}
+          onChange={onModelNameChange}
+        />
+      )}
+      <Suspense>
+        <InvocationParametersFormFields instanceId={playgroundInstanceId} />
+      </Suspense>
+    </form>
   );
 }

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -233,8 +233,7 @@ function ModelConfigDialog(props: ModelConfigDialogProps) {
           </Button>
           <Tooltip>
             Saves the current configuration as the default for{" "}
-            {ModelProviders[instance.model.provider] ?? "this provider"} for
-            later use.
+            {ModelProviders[instance.model.provider] ?? "this provider"}.
           </Tooltip>
         </TooltipTrigger>
       }
@@ -347,12 +346,7 @@ function ModelConfigDialogContent(props: ModelConfigDialogContentProps) {
   );
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-      }}
-      css={modelConfigFormCSS}
-    >
+    <form css={modelConfigFormCSS}>
       <ModelProviderPicker
         provider={instance.model.provider}
         query={query}

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
 import { css } from "@emotion/react";

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
+import { css } from "@emotion/react";
 
 import { Button, Flex, Icon, Icons, Text, View } from "@arizeai/components";
 
@@ -8,6 +9,46 @@ import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 
 import { PlaygroundDatasetSectionQuery } from "./__generated__/PlaygroundDatasetSectionQuery.graphql";
 import { PlaygroundDatasetExamplesTable } from "./PlaygroundDatasetExamplesTable";
+
+function RunInProgressText() {
+  return (
+    <span
+      css={css`
+        color: var(--ac-global-text-color-700);
+        display: inline-flex;
+        .dots {
+          display: inline-block;
+          width: 3ch;
+          overflow: hidden;
+        }
+
+        .dots::after {
+          content: "...";
+          display: inline-block;
+          animation: dots 1.5s steps(4) infinite;
+        }
+
+        @keyframes dots {
+          0% {
+            content: "";
+          }
+          25% {
+            content: ".";
+          }
+          50% {
+            content: "..";
+          }
+          75% {
+            content: "...";
+          }
+        }
+      `}
+    >
+      Run in progress
+      <span className="dots" />
+    </span>
+  );
+}
 
 export function PlaygroundDatasetSection({ datasetId }: { datasetId: string }) {
   const experimentId = usePlaygroundContext((state) => state.experimentId);
@@ -49,12 +90,7 @@ export function PlaygroundDatasetSection({ datasetId }: { datasetId: string }) {
             ) : null}
           </Flex>
           <Flex gap={"size-100"} alignItems={"center"}>
-            {isRunning && (
-              <Text color="text-700">
-                Run in progress, navigating away from the page could result in
-                data loss.
-              </Text>
-            )}
+            {isRunning && <RunInProgressText />}
             {experimentId != null && (
               <Button
                 size={"compact"}

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -14,6 +14,7 @@ export function PlaygroundDatasetSection({ datasetId }: { datasetId: string }) {
   const instances = usePlaygroundContext((state) => state.instances);
   const isRunning = instances.some((instance) => instance.activeRunId != null);
   const navigate = useNavigate();
+
   const data = useLazyLoadQuery<PlaygroundDatasetSectionQuery>(
     graphql`
       query PlaygroundDatasetSectionQuery($datasetId: GlobalID!) {
@@ -47,21 +48,30 @@ export function PlaygroundDatasetSection({ datasetId }: { datasetId: string }) {
               </Text>
             ) : null}
           </Flex>
-          {experimentId != null && (
-            <Button
-              size={"compact"}
-              variant="default"
-              disabled={isRunning}
-              icon={<Icon svg={<Icons.ExperimentOutline />} />}
-              onClick={() => {
-                navigate(
-                  `/datasets/${datasetId}/compare?experimentId=${experimentId}`
-                );
-              }}
-            >
-              View Experiment
-            </Button>
-          )}
+          <Flex gap={"size-100"} alignItems={"center"}>
+            {isRunning && (
+              <Text color="text-700">
+                Run in progress, navigating away from the page could result in
+                data loss.
+              </Text>
+            )}
+            {experimentId != null && (
+              <Button
+                size={"compact"}
+                variant="default"
+                disabled={isRunning}
+                loading={isRunning}
+                icon={<Icon svg={<Icons.ExperimentOutline />} />}
+                onClick={() => {
+                  navigate(
+                    `/datasets/${datasetId}/compare?experimentId=${experimentId}`
+                  );
+                }}
+              >
+                View Experiment
+              </Button>
+            )}
+          </Flex>
         </Flex>
       </View>
       <PlaygroundDatasetExamplesTable datasetId={datasetId} />

--- a/app/src/pages/playground/PlaygroundStreamToggle.tsx
+++ b/app/src/pages/playground/PlaygroundStreamToggle.tsx
@@ -3,14 +3,23 @@ import React from "react";
 import { Switch } from "@arizeai/components";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
 export function PlaygroundStreamToggle() {
   const streaming = usePlaygroundContext((state) => state.streaming);
   const setStreaming = usePlaygroundContext((state) => state.setStreaming);
+  const setPlaygroundStreamingEnabled = usePreferencesContext(
+    (state) => state.setPlaygroundStreamingEnabled
+  );
 
   const isRunning = usePlaygroundContext((state) =>
     state.instances.some((instance) => instance.activeRunId != null)
   );
+
+  // This toggle should never be shown if websockets are disabled
+  if (window.Config.websocketsEnabled === false) {
+    return null;
+  }
 
   return (
     <Switch
@@ -18,6 +27,7 @@ export function PlaygroundStreamToggle() {
       isSelected={streaming}
       onChange={() => {
         setStreaming(!streaming);
+        setPlaygroundStreamingEnabled(!streaming);
       }}
       isDisabled={isRunning}
     >

--- a/app/src/pages/playground/__generated__/InvocationParametersFormFieldsQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/InvocationParametersFormFieldsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9c8435262691e589c039d8052a312930>>
+ * @generated SignedSource<<fadfae4fd345704382afb0820cdff3a5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,10 +16,10 @@ export type ModelsInput = {
   modelName?: string | null;
   providerKey?: GenerativeProviderKey | null;
 };
-export type InvocationParametersFormQuery$variables = {
+export type InvocationParametersFormFieldsQuery$variables = {
   input: ModelsInput;
 };
-export type InvocationParametersFormQuery$data = {
+export type InvocationParametersFormFieldsQuery$data = {
   readonly modelInvocationParameters: ReadonlyArray<{
     readonly __typename: string;
     readonly booleanDefaultValue?: boolean | null;
@@ -37,9 +37,9 @@ export type InvocationParametersFormQuery$data = {
     readonly stringListDefaultValue?: ReadonlyArray<string> | null;
   }>;
 };
-export type InvocationParametersFormQuery = {
-  response: InvocationParametersFormQuery$data;
-  variables: InvocationParametersFormQuery$variables;
+export type InvocationParametersFormFieldsQuery = {
+  response: InvocationParametersFormFieldsQuery$data;
+  variables: InvocationParametersFormFieldsQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -237,7 +237,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "InvocationParametersFormQuery",
+    "name": "InvocationParametersFormFieldsQuery",
     "selections": (v3/*: any*/),
     "type": "Query",
     "abstractKey": null
@@ -246,20 +246,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "InvocationParametersFormQuery",
+    "name": "InvocationParametersFormFieldsQuery",
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "56e31957e89e73349ff41fc66455df1f",
+    "cacheID": "4a9a1e8947463e43020c173fb6ca0418",
     "id": null,
     "metadata": {},
-    "name": "InvocationParametersFormQuery",
+    "name": "InvocationParametersFormFieldsQuery",
     "operationKind": "query",
-    "text": "query InvocationParametersFormQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      label\n      required\n      canonicalName\n    }\n    ... on BoundedFloatInvocationParameter {\n      minValue\n      maxValue\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on FloatInvocationParameter {\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on IntInvocationParameter {\n      invocationInputField\n      intDefaultValue: defaultValue\n    }\n    ... on StringInvocationParameter {\n      invocationInputField\n      stringDefaultValue: defaultValue\n    }\n    ... on StringListInvocationParameter {\n      invocationInputField\n      stringListDefaultValue: defaultValue\n    }\n    ... on BooleanInvocationParameter {\n      invocationInputField\n      booleanDefaultValue: defaultValue\n    }\n    ... on JSONInvocationParameter {\n      invocationInputField\n      jsonDefaultValue: defaultValue\n    }\n  }\n}\n"
+    "text": "query InvocationParametersFormFieldsQuery(\n  $input: ModelsInput!\n) {\n  modelInvocationParameters(input: $input) {\n    __typename\n    ... on InvocationParameterBase {\n      __isInvocationParameterBase: __typename\n      invocationName\n      label\n      required\n      canonicalName\n    }\n    ... on BoundedFloatInvocationParameter {\n      minValue\n      maxValue\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on FloatInvocationParameter {\n      invocationInputField\n      floatDefaultValue: defaultValue\n    }\n    ... on IntInvocationParameter {\n      invocationInputField\n      intDefaultValue: defaultValue\n    }\n    ... on StringInvocationParameter {\n      invocationInputField\n      stringDefaultValue: defaultValue\n    }\n    ... on StringListInvocationParameter {\n      invocationInputField\n      stringListDefaultValue: defaultValue\n    }\n    ... on BooleanInvocationParameter {\n      invocationInputField\n      booleanDefaultValue: defaultValue\n    }\n    ... on JSONInvocationParameter {\n      invocationInputField\n      jsonDefaultValue: defaultValue\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "583498af6dd9d28f63d53bcece9f2b7d";
+(node as any).hash = "7114c972ca9a2449585281bdd7e6211c";
 
 export default node;

--- a/app/src/pages/playground/constants.tsx
+++ b/app/src/pages/playground/constants.tsx
@@ -1,4 +1,4 @@
-import { CanonicalParameterName } from "./__generated__/InvocationParametersFormQuery.graphql";
+import { CanonicalParameterName } from "./__generated__/InvocationParametersFormFieldsQuery.graphql";
 
 export const NUM_MAX_PLAYGROUND_INSTANCES = 4;
 

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -62,7 +62,7 @@ import {
   TOOL_CHOICE_PARAM_NAME,
   TOOLS_PARSING_ERROR,
 } from "./constants";
-import { InvocationParameter } from "./InvocationParametersForm";
+import { InvocationParameter } from "./InvocationParametersFormFields";
 import {
   chatMessageRolesSchema,
   chatMessagesSchema,

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -1,6 +1,6 @@
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { InvocationParameterInput } from "@phoenix/pages/playground/__generated__/PlaygroundOutputSubscription.graphql";
-import { InvocationParameter } from "@phoenix/pages/playground/InvocationParametersForm";
+import { InvocationParameter } from "@phoenix/pages/playground/InvocationParametersFormFields";
 import {
   LlmProviderToolCall,
   LlmProviderToolDefinition,

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -42,6 +42,11 @@ export interface PreferencesProps {
    * {@link ModelConfig|ModelConfigs} for llm providers will be used as the default parameters for the provider
    */
   modelConfigByProvider: ModelConfigByProvider;
+  /**
+   * Whether or not the playground is in streaming mode
+   * Note: this is always false in environments that do not support streaming
+   */
+  playgroundStreamingEnabled: boolean;
 }
 
 export interface PreferencesState extends PreferencesProps {
@@ -84,6 +89,10 @@ export interface PreferencesState extends PreferencesProps {
     provider: ModelProvider;
     modelConfig: ModelConfig;
   }) => void;
+  /**
+   * Setter for enabling/disabling playground streaming
+   */
+  setPlaygroundStreamingEnabled: (playgroundStreamingEnabled: boolean) => void;
 }
 
 export const createPreferencesStore = (
@@ -124,6 +133,10 @@ export const createPreferencesStore = (
           },
         };
       });
+    },
+    playgroundStreamingEnabled: true,
+    setPlaygroundStreamingEnabled: (playgroundStreamingEnabled) => {
+      set({ playgroundStreamingEnabled });
     },
     ...initialProps,
   });


### PR DESCRIPTION
resolves #5464 
resolves #5460
resolves #5466 

- remembers streaming setting from playground in preferences store
- adds text to inform users that playground is still running and navigating may result in data los
- updates save config button and icon to be more clear as to its purpose (saving config as default, not applying the config to the current run
- small style tweaks on model config form

### Remember streaming preference

https://github.com/user-attachments/assets/48ef1ea0-cecf-47a0-a703-04588acbd656

### Run in progress warnings
Any feedback on wording here is much appreciated

https://github.com/user-attachments/assets/76f1910f-562a-4836-ad14-f10f747049b1

### Save config button

![image](https://github.com/user-attachments/assets/c389e900-08e4-4794-8c1e-4525ee28275b)


### Model config style tweaks

![Screenshot 2024-11-20 at 3 55 06 PM](https://github.com/user-attachments/assets/86a9a0a9-8532-4757-939b-e3cf43b0863a)

