### PR TITLE
fix(sessions): remove end_time from db and ui table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1327,11 +1327,7 @@ type ProjectSession implements Node {
   sessionId: String!
   sessionUser: String
   startTime: DateTime!
-  endTime: DateTime!
   projectId: GlobalID!
-
-  """Duration of the session in seconds"""
-  durationS: Float!
   numTraces: Int!
   numTracesWithError: Int!
   firstInput: SpanIOValue
@@ -1344,7 +1340,6 @@ type ProjectSession implements Node {
 
 enum ProjectSessionColumn {
   startTime
-  endTime
   tokenCountTotal
   numTraces
 }

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -82,7 +82,6 @@ export function SessionsTable(props: SessionsTableProps) {
                 sessionId
                 numTraces
                 startTime
-                endTime
                 firstInput {
                   value
                 }
@@ -133,12 +132,6 @@ export function SessionsTable(props: SessionsTableProps) {
     {
       header: "start time",
       accessorKey: "startTime",
-      enableSorting: true,
-      cell: TimestampCell,
-    },
-    {
-      header: "end time",
-      accessorKey: "endTime",
       enableSorting: true,
       cell: TimestampCell,
     },

--- a/app/src/pages/project/__generated__/ProjectPageSessionsQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageSessionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4cc33a6a642aad726483755c2fef32d5>>
+ * @generated SignedSource<<dc87b59ef0bc9f961a33ec0eadfac6f9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -197,13 +197,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "endTime",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": "SpanIOValue",
                             "kind": "LinkedField",
                             "name": "firstInput",
@@ -362,12 +355,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "491cbda957aeb7d4ca55f4beb61bed44",
+    "cacheID": "77cac97b026fa918e2ac911978860632",
     "id": null,
     "metadata": {},
     "name": "ProjectPageSessionsQuery",
     "operationKind": "query",
-    "text": "query ProjectPageSessionsQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SessionsTable_sessions\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SessionsTable_sessions on Project {\n  name\n  sessions(first: 50, sort: {col: startTime, dir: desc}, timeRange: $timeRange) {\n    edges {\n      session: node {\n        id\n        sessionId\n        numTraces\n        startTime\n        endTime\n        firstInput {\n          value\n        }\n        lastOutput {\n          value\n        }\n        lastTraceStartTime\n        tokenUsage {\n          prompt\n          completion\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageSessionsQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SessionsTable_sessions\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SessionsTable_sessions on Project {\n  name\n  sessions(first: 50, sort: {col: startTime, dir: desc}, timeRange: $timeRange) {\n    edges {\n      session: node {\n        id\n        sessionId\n        numTraces\n        startTime\n        firstInput {\n          value\n        }\n        lastOutput {\n          value\n        }\n        lastTraceStartTime\n        tokenUsage {\n          prompt\n          completion\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f50df0e22d0d7d12ce22c208b022aba>>
+ * @generated SignedSource<<08d99f7e208f9a95e9fc6025a64595eb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -258,13 +258,6 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "kind": "ScalarField",
-                            "name": "endTime",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
                             "concreteType": "SpanIOValue",
                             "kind": "LinkedField",
                             "name": "firstInput",
@@ -423,16 +416,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3f39f279542f03c04c50a1e7fc42e302",
+    "cacheID": "83d16c4a9e232d8b631ac4954afe78ce",
     "id": null,
     "metadata": {},
     "name": "SessionsTableQuery",
     "operationKind": "query",
-    "text": "query SessionsTableQuery(\n  $after: String = null\n  $filterIoSubstring: String = null\n  $first: Int = 50\n  $sort: ProjectSessionSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionsTable_sessions_2MhLSo\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SessionsTable_sessions_2MhLSo on Project {\n  name\n  sessions(first: $first, after: $after, sort: $sort, filterIoSubstring: $filterIoSubstring, timeRange: $timeRange) {\n    edges {\n      session: node {\n        id\n        sessionId\n        numTraces\n        startTime\n        endTime\n        firstInput {\n          value\n        }\n        lastOutput {\n          value\n        }\n        lastTraceStartTime\n        tokenUsage {\n          prompt\n          completion\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SessionsTableQuery(\n  $after: String = null\n  $filterIoSubstring: String = null\n  $first: Int = 50\n  $sort: ProjectSessionSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionsTable_sessions_2MhLSo\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SessionsTable_sessions_2MhLSo on Project {\n  name\n  sessions(first: $first, after: $after, sort: $sort, filterIoSubstring: $filterIoSubstring, timeRange: $timeRange) {\n    edges {\n      session: node {\n        id\n        sessionId\n        numTraces\n        startTime\n        firstInput {\n          value\n        }\n        lastOutput {\n          value\n        }\n        lastTraceStartTime\n        tokenUsage {\n          prompt\n          completion\n          total\n        }\n        traceLatencyMsP50: traceLatencyMsQuantile(probability: 0.5)\n        traceLatencyMsP99: traceLatencyMsQuantile(probability: 0.99)\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dc4a3ba4422ee61ecd9d4142063517b5";
+(node as any).hash = "0a37384d107cc67791ff9b05f85b48f1";
 
 export default node;

--- a/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<08d99f7e208f9a95e9fc6025a64595eb>>
+ * @generated SignedSource<<15f426fc91f1e8e4e251f32ed446f684>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ProjectSessionColumn = "endTime" | "numTraces" | "startTime" | "tokenCountTotal";
+export type ProjectSessionColumn = "numTraces" | "startTime" | "tokenCountTotal";
 export type SortDir = "asc" | "desc";
 export type ProjectSessionSort = {
   col: ProjectSessionColumn;

--- a/app/src/pages/project/__generated__/SessionsTable_sessions.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTable_sessions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ec0e7f2b0274fd7ef774424abbbfc78f>>
+ * @generated SignedSource<<67ff1a198341dfb472d4d063fdc8a590>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,6 @@ export type SessionsTable_sessions$data = {
   readonly sessions: {
     readonly edges: ReadonlyArray<{
       readonly session: {
-        readonly endTime: string;
         readonly firstInput: {
           readonly value: string;
         } | null;
@@ -200,13 +199,6 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "kind": "ScalarField",
-                  "name": "endTime",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
                   "concreteType": "SpanIOValue",
                   "kind": "LinkedField",
                   "name": "firstInput",
@@ -355,6 +347,6 @@ return {
 };
 })();
 
-(node as any).hash = "dc4a3ba4422ee61ecd9d4142063517b5";
+(node as any).hash = "0a37384d107cc67791ff9b05f85b48f1";
 
 export default node;

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -76,7 +76,6 @@ export function SessionDetails(props: SessionDetailsProps) {
         session: node(id: $id) {
           ... on ProjectSession {
             numTraces
-            durationS
             tokenUsage {
               total
               completion

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<28282f75d4f26db4127e9335922e5241>>
+ * @generated SignedSource<<2936a595788abc904b28a90301ba78fc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,7 +15,6 @@ export type SessionDetailsQuery$variables = {
 };
 export type SessionDetailsQuery$data = {
   readonly session: {
-    readonly durationS?: number;
     readonly latencyP50?: number | null;
     readonly numTraces?: number;
     readonly sessionId?: string;
@@ -105,13 +104,6 @@ v4 = {
       "args": null,
       "kind": "ScalarField",
       "name": "numTraces",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "durationS",
       "storageKey": null
     },
     {
@@ -416,16 +408,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e55d7e6a04298907a625a98adc9a7fb0",
+    "cacheID": "44f2433d50767bdcd9eb7c62d1f2cbb7",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      durationS\n      tokenUsage {\n        total\n        completion\n        prompt\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              id\n              attributes\n              project {\n                id\n              }\n              input {\n                value\n              }\n              output {\n                value\n              }\n              cumulativeTokenCountTotal\n              cumulativeTokenCountCompletion\n              cumulativeTokenCountPrompt\n              latencyMs\n              startTime\n              spanAnnotations {\n                name\n                label\n                score\n                explanation\n                annotatorKind\n              }\n              context {\n                traceId\n                spanId\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: GlobalID!\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n        completion\n        prompt\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      traces {\n        edges {\n          trace: node {\n            rootSpan {\n              id\n              attributes\n              project {\n                id\n              }\n              input {\n                value\n              }\n              output {\n                value\n              }\n              cumulativeTokenCountTotal\n              cumulativeTokenCountCompletion\n              cumulativeTokenCountPrompt\n              latencyMs\n              startTime\n              spanAnnotations {\n                name\n                label\n                score\n                explanation\n                annotatorKind\n              }\n              context {\n                traceId\n                spanId\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "97585857fc11e3e32278d27c935f2017";
+(node as any).hash = "4cf37bedf6f6d9f7b373d019055a89f4";
 
 export default node;

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -50,11 +50,11 @@ async def insert_span(
                 select(models.ProjectSession).filter_by(session_id=session_id)
             )
             if project_session:
-                if project_session.start_time < span.end_time:
-                    project_session.project_id = project_rowid
                 if span.start_time < project_session.start_time:
                     project_session.start_time = span.start_time
-                    if session_user and project_session.session_user != session_user:
+                    if project_session.project_id != project_rowid:
+                        project_session.project_id = project_rowid
+                    if project_session.session_user != session_user:
                         project_session.session_user = session_user
             else:
                 project_session = models.ProjectSession(

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -50,8 +50,7 @@ async def insert_span(
                 select(models.ProjectSession).filter_by(session_id=session_id)
             )
             if project_session:
-                if project_session.end_time < span.end_time:
-                    project_session.end_time = span.end_time
+                if project_session.start_time < span.end_time:
                     project_session.project_id = project_rowid
                 if span.start_time < project_session.start_time:
                     project_session.start_time = span.start_time
@@ -63,7 +62,6 @@ async def insert_span(
                     session_id=session_id,
                     session_user=session_user if session_user else None,
                     start_time=span.start_time,
-                    end_time=span.end_time,
                 )
                 session.add(project_session)
             if project_session in session.dirty:

--- a/src/phoenix/db/migrations/versions/4ded9e43755f_create_project_sessions_table.py
+++ b/src/phoenix/db/migrations/versions/4ded9e43755f_create_project_sessions_table.py
@@ -31,7 +31,6 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("start_time", sa.TIMESTAMP(timezone=True), index=True, nullable=False),
-        sa.Column("end_time", sa.TIMESTAMP(timezone=True), nullable=False),
     )
     with op.batch_alter_table("traces") as batch_op:
         batch_op.add_column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -167,7 +167,6 @@ class ProjectSession(Base):
         index=True,
     )
     start_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
-    end_time: Mapped[datetime] = mapped_column(UtcTimeStamp, index=True)
     traces: Mapped[list["Trace"]] = relationship(
         "Trace",
         back_populates="project_session",

--- a/src/phoenix/server/api/input_types/ProjectSessionSort.py
+++ b/src/phoenix/server/api/input_types/ProjectSessionSort.py
@@ -10,7 +10,6 @@ from phoenix.server.api.types.SortDir import SortDir
 @strawberry.enum
 class ProjectSessionColumn(Enum):
     startTime = auto()
-    endTime = auto()
     tokenCountTotal = auto()
     numTraces = auto()
 
@@ -18,7 +17,7 @@ class ProjectSessionColumn(Enum):
     def data_type(self) -> CursorSortColumnDataType:
         if self is ProjectSessionColumn.tokenCountTotal or self is ProjectSessionColumn.numTraces:
             return CursorSortColumnDataType.INT
-        if self is ProjectSessionColumn.startTime or self is ProjectSessionColumn.endTime:
+        if self is ProjectSessionColumn.startTime:
             return CursorSortColumnDataType.DATETIME
         assert_never(self)
 

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -298,8 +298,6 @@ class Project(Node):
             key: ColumnElement[Any]
             if sort.col is ProjectSessionColumn.startTime:
                 key = table.start_time.label("key")
-            elif sort.col is ProjectSessionColumn.endTime:
-                key = table.end_time.label("key")
             elif (
                 sort.col is ProjectSessionColumn.tokenCountTotal
                 or sort.col is ProjectSessionColumn.numTraces

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -26,17 +26,12 @@ class ProjectSession(Node):
     session_id: str
     session_user: Optional[str]
     start_time: datetime
-    end_time: datetime
 
     @strawberry.field
     async def project_id(self) -> GlobalID:
         from phoenix.server.api.types.Project import Project
 
         return GlobalID(type_name=Project.__name__, node_id=str(self.project_rowid))
-
-    @strawberry.field(description="Duration of the session in seconds")  # type: ignore
-    async def duration_s(self) -> float:
-        return (self.end_time - self.start_time).total_seconds()
 
     @strawberry.field
     async def num_traces(
@@ -141,7 +136,6 @@ def to_gql_project_session(project_session: models.ProjectSession) -> ProjectSes
         session_id=project_session.session_id,
         session_user=project_session.session_user,
         start_time=project_session.start_time,
-        end_time=project_session.end_time,
         project_rowid=project_session.project_id,
     )
 

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -86,12 +86,6 @@ def test_up_and_down_migrations(
         assert isinstance(column.type, TIMESTAMP)
         del column
 
-        column = columns.pop("end_time", None)
-        assert column is not None
-        assert not column.nullable
-        assert isinstance(column.type, TIMESTAMP)
-        del column
-
         assert not columns
         del columns
 

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -135,16 +135,13 @@ async def _add_project_session(
     session_id: Optional[str] = None,
     session_user: Optional[str] = None,
     start_time: Optional[datetime] = None,
-    end_time: Optional[datetime] = None,
 ) -> models.ProjectSession:
     start_time = start_time or datetime.now(timezone.utc)
-    end_time = end_time or (start_time + timedelta(seconds=10))
     project_session = models.ProjectSession(
         session_id=session_id or token_hex(4),
         session_user=session_user,
         project_id=project.id,
         start_time=start_time,
-        end_time=end_time,
     )
     session.add(project_session)
     await session.flush()

--- a/tests/unit/server/api/dataloaders/conftest.py
+++ b/tests/unit/server/api/dataloaders/conftest.py
@@ -26,14 +26,12 @@ async def data_for_testing_dataloaders(
             for l in range(num_sessions_per_project):  # noqa: E741
                 seconds = randint(1, 1000)
                 start_time = orig_time + timedelta(seconds=seconds)
-                end_time = orig_time + timedelta(seconds=seconds * l * 2)
                 session_row_id = await session.scalar(
                     insert(models.ProjectSession)
                     .values(
                         session_id=f"proj{i}_sess{l}",
                         project_id=project_row_id,
                         start_time=start_time,
-                        end_time=end_time,
                     )
                     .returning(models.ProjectSession.id)
                 )


### PR DESCRIPTION
resolves #5355
resolves #5354 

Also, populate `project_id` and `session_user` using only the values from the earliest root span. These values should remain unchanged for the session, even if later spans modify them. The earliest `session_user` is likely the user who initiated the conversation, making it a more accurate identifier. Similarly, the earliest `project_id` ensures consistency, preventing the session from shifting between projects.