### PR TITLE
fix(playground): ensure playground timeout errors are displayed

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -132,7 +132,7 @@ class PlaygroundRateLimiter(RateLimiter, KeyedSingleton):
                 request_start_time = time.time()
                 maybe_coroutine = fn(*args, **kwargs)
                 if inspect.isawaitable(maybe_coroutine):
-                    return await maybe_coroutine  # type: ignore
+                    return await maybe_coroutine  # type: ignore[no-any-return]
                 else:
                     return maybe_coroutine
             except self._rate_limit_error:
@@ -144,10 +144,11 @@ class PlaygroundRateLimiter(RateLimiter, KeyedSingleton):
                             try:
                                 request_start_time = time.time()
                                 await self._throttler.async_wait_until_ready()
-                                if inspect.iscoroutinefunction(fn):
-                                    return await fn(*args, **kwargs)  # type: ignore
+                                maybe_coroutine = fn(*args, **kwargs)
+                                if inspect.isawaitable(maybe_coroutine):
+                                    return await maybe_coroutine  # type: ignore[no-any-return]
                                 else:
-                                    return fn(*args, **kwargs)
+                                    return maybe_coroutine
                             except self._rate_limit_error:
                                 self._throttler.on_rate_limit_error(
                                     request_start_time, verbose=self._verbose

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -471,8 +471,8 @@ async def _wait_for(
     A function that imitates asyncio.wait_for, but allows the task to be
     cancelled with a custom message.
     """
-    future = asyncio.ensure_future(coro)
-    done, pending = await asyncio.wait([future], timeout=timeout)
+    task = create_task(coro)
+    done, pending = await asyncio.wait([task], timeout=timeout)
     assert len(done) + len(pending) == 1
     if done:
         task = done.pop()

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -333,7 +333,7 @@ class Subscription:
                     del in_progress[idx]  # removes timed-out stream
                     if example_id is not None:
                         yield ChatCompletionSubscriptionError(
-                            message="Timed out", dataset_example_id=example_id
+                            message="Playground task timed out", dataset_example_id=example_id
                         )
                 except Exception as error:
                     del in_progress[idx]  # removes failed stream
@@ -478,7 +478,11 @@ def _create_task_with_timeout(
     iterable: AsyncIterator[GenericType], timeout_in_seconds: int = 90
 ) -> asyncio.Task[GenericType]:
     return asyncio.create_task(
-        _wait_for(_as_coroutine(iterable), timeout=timeout_in_seconds, timeout_message="Timed out")
+        _wait_for(
+            _as_coroutine(iterable),
+            timeout=timeout_in_seconds,
+            timeout_message="Playground task timed out",
+        )
     )
 
 

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -495,8 +495,7 @@ async def _wait_for(
     try:
         return await task
     except asyncio.CancelledError:
-        pass
-    raise asyncio.TimeoutError()
+        raise asyncio.TimeoutError()
 
 
 async def _drain(queue: asyncio.Queue[GenericType]) -> list[GenericType]:

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -329,11 +329,18 @@ class Subscription:
                     yield completed_task.result()
                 except StopAsyncIteration:
                     del in_progress[idx]  # removes exhausted stream
+                except asyncio.TimeoutError:
+                    del in_progress[idx]  # removes timed-out stream
+                    if example_id is not None:
+                        yield ChatCompletionSubscriptionError(
+                            message="Timed out", dataset_example_id=example_id
+                        )
                 except Exception as error:
                     del in_progress[idx]  # removes failed stream
-                    yield ChatCompletionSubscriptionError(
-                        message="An unexpected error occurred", dataset_example_id=example_id
-                    )
+                    if example_id is not None:
+                        yield ChatCompletionSubscriptionError(
+                            message="An unexpected error occurred", dataset_example_id=example_id
+                        )
                     logger.exception(error)
                 else:
                     task = _create_task_with_timeout(stream)


### PR DESCRIPTION
`asyncio.wait_for` raises an `asyncio.CancelledError` inside of the wrapped coroutine when a timeout happens. However, that cancellation error has no message content. As a result, tasks that time out when hitting the 90-second limit result in spans with an error status code but an empty status message. This PR implements a helper function that behaves like `asyncio.wait_for`, but allows sending `asyncio.CancelledError` with a custom message to the wrapped coroutine that will then be recorded in the span and displayed in the UI.

resolves #5454
resolves #5499
