### PR TITLE
fix: tighten up playground throttling

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -128,10 +128,11 @@ class PlaygroundRateLimiter(RateLimiter, KeyedSingleton):
                     self._rate_limit_handling.set()  # Set the event as a failsafe
                 await self._throttler.async_wait_until_ready()
                 request_start_time = time.time()
-                if inspect.iscoroutinefunction(fn):
-                    return await fn(*args, **kwargs)  # type: ignore
+                maybe_coroutine = fn(*args, **kwargs)
+                if inspect.iscoroutine(maybe_coroutine):
+                    return await maybe_coroutine  # type: ignore
                 else:
-                    return fn(*args, **kwargs)
+                    return maybe_coroutine
             except self._rate_limit_error:
                 async with self._rate_limit_handling_lock:
                     self._rate_limit_handling.clear()  # prevent new requests from starting
@@ -341,7 +342,7 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
         openai_messages = [self.to_openai_chat_completion_param(*message) for message in messages]
         tool_call_ids: dict[int, str] = {}
         token_usage: Optional["CompletionUsage"] = None
-        throttled_create = self.rate_limiter.alimit(self.client.chat.completions.create)
+        throttled_create = self.rate_limiter._alimit(self.client.chat.completions.create)
         async for chunk in await throttled_create(
             messages=openai_messages,
             model=self.model_name,
@@ -510,7 +511,7 @@ class OpenAIO1StreamingClient(OpenAIStreamingClient):
 
         tool_call_ids: dict[int, str] = {}
 
-        throttled_create = self.rate_limiter.alimit(self.client.chat.completions.create)
+        throttled_create = self.rate_limiter._alimit(self.client.chat.completions.create)
         response = await throttled_create(
             messages=openai_messages,
             model=self.model_name,

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -99,9 +99,9 @@ class PlaygroundRateLimiter(RateLimiter, KeyedSingleton):
         super().__init__(
             rate_limit_error=rate_limit_error,
             max_rate_limit_retries=3,
-            initial_per_second_request_rate=2.0,
-            maximum_per_second_request_rate=10.0,
-            enforcement_window_minutes=1,
+            initial_per_second_request_rate=1.0,
+            maximum_per_second_request_rate=3.0,
+            enforcement_window_minutes=0.05,
             rate_reduction_factor=0.5,
             rate_increase_factor=0.01,
             cooldown_seconds=5,

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -282,19 +282,22 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
                 max_value=2.0,
             ),
             IntInvocationParameter(
-                invocation_name="max_tokens",
+                invocation_name="max_completion_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Tokens",
+                default_value=1024,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="frequency_penalty",
                 label="Frequency Penalty",
+                default_value=0.0,
                 min_value=-2.0,
                 max_value=2.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="presence_penalty",
                 label="Presence Penalty",
+                default_value=0.0,
                 min_value=-2.0,
                 max_value=2.0,
             ),
@@ -307,12 +310,14 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
+                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
             IntInvocationParameter(
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
+                default_value=0,
                 label="Seed",
             ),
             JSONInvocationParameter(
@@ -476,11 +481,13 @@ class OpenAIO1StreamingClient(OpenAIStreamingClient):
                 invocation_name="max_completion_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Completion Tokens",
+                default_value=1024,
             ),
             IntInvocationParameter(
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
                 label="Seed",
+                default_value=0,
             ),
             JSONInvocationParameter(
                 invocation_name="tool_choice",
@@ -632,10 +639,10 @@ class AzureOpenAIStreamingClient(OpenAIStreamingClient):
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
         PROVIDER_DEFAULT,
-        "claude-3-5-sonnet-20240620",
-        "claude-3-opus-20240229",
-        "claude-3-sonnet-20240229",
-        "claude-3-haiku-20240307",
+        "claude-3-5-sonnet-latest",
+        "claude-3-opus-latest",
+        "claude-3-sonnet-latest",
+        "claude-3-haiku-latest",
     ],
 )
 class AnthropicStreamingClient(PlaygroundStreamingClient):
@@ -664,12 +671,14 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                 invocation_name="max_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Tokens",
+                default_value=1024,
                 required=True,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="temperature",
                 canonical_name=CanonicalParameterName.TEMPERATURE,
                 label="Temperature",
+                default_value=0.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -682,6 +691,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
+                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -851,21 +861,25 @@ class GeminiStreamingClient(PlaygroundStreamingClient):
             FloatInvocationParameter(
                 invocation_name="presence_penalty",
                 label="Presence Penalty",
+                default_value=0.0,
             ),
             FloatInvocationParameter(
                 invocation_name="frequency_penalty",
                 label="Frequency Penalty",
+                default_value=0.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
+                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="top_k",
                 label="Top K",
+                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -873,6 +887,7 @@ class GeminiStreamingClient(PlaygroundStreamingClient):
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
                 label="Seed",
+                default_value=0,
             ),
         ]
 

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -282,22 +282,19 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
                 max_value=2.0,
             ),
             IntInvocationParameter(
-                invocation_name="max_completion_tokens",
+                invocation_name="max_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Tokens",
-                default_value=1024,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="frequency_penalty",
                 label="Frequency Penalty",
-                default_value=0.0,
                 min_value=-2.0,
                 max_value=2.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="presence_penalty",
                 label="Presence Penalty",
-                default_value=0.0,
                 min_value=-2.0,
                 max_value=2.0,
             ),
@@ -310,14 +307,12 @@ class OpenAIStreamingClient(PlaygroundStreamingClient):
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
-                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
             IntInvocationParameter(
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
-                default_value=0,
                 label="Seed",
             ),
             JSONInvocationParameter(
@@ -481,13 +476,11 @@ class OpenAIO1StreamingClient(OpenAIStreamingClient):
                 invocation_name="max_completion_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Completion Tokens",
-                default_value=1024,
             ),
             IntInvocationParameter(
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
                 label="Seed",
-                default_value=0,
             ),
             JSONInvocationParameter(
                 invocation_name="tool_choice",
@@ -639,10 +632,10 @@ class AzureOpenAIStreamingClient(OpenAIStreamingClient):
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
         PROVIDER_DEFAULT,
-        "claude-3-5-sonnet-latest",
-        "claude-3-opus-latest",
-        "claude-3-sonnet-latest",
-        "claude-3-haiku-latest",
+        "claude-3-5-sonnet-20240620",
+        "claude-3-opus-20240229",
+        "claude-3-sonnet-20240229",
+        "claude-3-haiku-20240307",
     ],
 )
 class AnthropicStreamingClient(PlaygroundStreamingClient):
@@ -671,14 +664,12 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                 invocation_name="max_tokens",
                 canonical_name=CanonicalParameterName.MAX_COMPLETION_TOKENS,
                 label="Max Tokens",
-                default_value=1024,
                 required=True,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="temperature",
                 canonical_name=CanonicalParameterName.TEMPERATURE,
                 label="Temperature",
-                default_value=0.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -691,7 +682,6 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
-                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -861,25 +851,21 @@ class GeminiStreamingClient(PlaygroundStreamingClient):
             FloatInvocationParameter(
                 invocation_name="presence_penalty",
                 label="Presence Penalty",
-                default_value=0.0,
             ),
             FloatInvocationParameter(
                 invocation_name="frequency_penalty",
                 label="Frequency Penalty",
-                default_value=0.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="top_p",
                 canonical_name=CanonicalParameterName.TOP_P,
                 label="Top P",
-                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
             BoundedFloatInvocationParameter(
                 invocation_name="top_k",
                 label="Top K",
-                default_value=1.0,
                 min_value=0.0,
                 max_value=1.0,
             ),
@@ -887,7 +873,6 @@ class GeminiStreamingClient(PlaygroundStreamingClient):
                 invocation_name="seed",
                 canonical_name=CanonicalParameterName.RANDOM_SEED,
                 label="Seed",
-                default_value=0,
             ),
         ]
 

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -300,7 +300,7 @@ class Subscription:
         in_progress: list[
             tuple[Optional[DatasetExampleID], ChatStream, Task[ChatCompletionSubscriptionPayload]]
         ] = []
-        max_in_progress = 10
+        max_in_progress = 3
         write_batch_size = 10
         write_interval = timedelta(seconds=10)
         last_write_time = datetime.now()


### PR DESCRIPTION
resvoles #5457

The throttler was too permissive to ensure that the backend was successfully limiting playground streams. Because we are trying to optimize for backend availability instead of attempting to submit as many requests as possible without hitting rate limits, we should drop the enforcement window to near-zero.