### PR TITLE
fix(playground): improve error handling when instantiating playground llm clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ pg = [
 ]
 container = [
   "anthropic",
+  "google-generativeai",
   "prometheus-client",
   "openai>=1.0.0",
   "opentelemetry-sdk",

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -26,7 +26,7 @@ from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import get_dataset_example_revisions
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
 from phoenix.server.api.helpers.playground_clients import (
     PlaygroundStreamingClient,
     initialize_playground_clients,
@@ -127,16 +127,18 @@ class ChatCompletionMutationMixin:
         provider_key = input.model.provider_key
         llm_client_class = PLAYGROUND_CLIENT_REGISTRY.get_client(provider_key, input.model.name)
         if llm_client_class is None:
-            raise BadRequest(f"No LLM client registered for provider '{provider_key}'")
+            raise BadRequest(f"Unknown LLM provider: '{provider_key.value}'")
         try:
             llm_client = llm_client_class(
                 model=input.model,
                 api_key=input.api_key,
             )
-        except Exception:
+        except CustomGraphQLError:
+            raise
+        except Exception as error:
             raise BadRequest(
-                f"Failed to initialize the LLM client for {provider_key.value} "
-                f"{input.model.name}. Have you set a valid API key?"
+                f"Failed to connect to LLM API for {provider_key.value} {input.model.name}: "
+                f"{str(error)}"
             )
         dataset_id = from_global_id_with_expected_type(input.dataset_id, Dataset.__name__)
         dataset_version_id = (
@@ -278,16 +280,18 @@ class ChatCompletionMutationMixin:
         provider_key = input.model.provider_key
         llm_client_class = PLAYGROUND_CLIENT_REGISTRY.get_client(provider_key, input.model.name)
         if llm_client_class is None:
-            raise BadRequest(f"No LLM client registered for provider '{provider_key}'")
+            raise BadRequest(f"Unknown LLM provider: '{provider_key.value}'")
         try:
             llm_client = llm_client_class(
                 model=input.model,
                 api_key=input.api_key,
             )
-        except Exception:
+        except CustomGraphQLError:
+            raise
+        except Exception as error:
             raise BadRequest(
-                f"Failed to initialize the LLM client for {provider_key.value} "
-                f"{input.model.name}. Have you set a valid API key?"
+                f"Failed to connect to LLM API for {provider_key.value} {input.model.name}: "
+                f"{str(error)}"
             )
         return await cls._chat_completion(info, llm_client, input)
 


### PR DESCRIPTION
Improves error handling to surface up actionable messages to the user for missing API keys and other configuration.

resolves #5461
