### PR TITLE
fix(playground): ignore span parsing errors for output when starting playground from existing span

### DIFF
--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -159,8 +159,6 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       },
       parsingErrors: [
         INPUT_MESSAGES_PARSING_ERROR,
-        OUTPUT_MESSAGES_PARSING_ERROR,
-        OUTPUT_VALUE_PARSING_ERROR,
         MODEL_CONFIG_PARSING_ERROR,
         MODEL_CONFIG_WITH_INVOCATION_PARAMETERS_PARSING_ERROR,
         MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR,
@@ -184,10 +182,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
         ...expectedPlaygroundInstanceWithIO,
         output: undefined,
       },
-      parsingErrors: [
-        OUTPUT_MESSAGES_PARSING_ERROR,
-        OUTPUT_VALUE_PARSING_ERROR,
-      ],
+      parsingErrors: [],
     });
   });
 
@@ -212,7 +207,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
 
         output: "This is an AI Answer",
       },
-      parsingErrors: [OUTPUT_MESSAGES_PARSING_ERROR],
+      parsingErrors: [],
     });
   });
 

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -464,7 +464,7 @@ export function transformSpanAttributesToPlaygroundInstance(
     provider: modelConfig?.provider ?? basePlaygroundInstance.model.provider,
     parsedAttributes,
   });
-  const { output, outputParsingErrors } = getOutputFromAttributes({
+  const { output } = getOutputFromAttributes({
     provider: modelConfig?.provider ?? basePlaygroundInstance.model.provider,
     parsedAttributes,
   });
@@ -520,7 +520,6 @@ export function transformSpanAttributesToPlaygroundInstance(
     },
     parsingErrors: [
       ...messageParsingErrors,
-      ...outputParsingErrors,
       ...modelConfigParsingErrors,
       ...toolsParsingErrors,
       ...invocationParametersParsingErrors,


### PR DESCRIPTION
because output is not a prerequisite for playground