### PR TITLE
feat: Enable `phoenix.evals` to handle multimodal message templates

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -27,6 +27,7 @@ from phoenix.evals.executors import ExecutionStatus, get_executor_on_sync_contex
 from phoenix.evals.models import BaseModel, OpenAIModel, set_verbosity
 from phoenix.evals.templates import (
     ClassificationTemplate,
+    PromptMessage,
     PromptOptions,
     PromptTemplate,
     normalize_classification_template,
@@ -177,7 +178,7 @@ def llm_classify(
     if generation_info := model.verbose_generation_info():
         printif(verbose, generation_info)
 
-    def _map_template(data: pd.Series[Any]) -> str:
+    def _map_template(data: pd.Series[Any]) -> List[PromptMessage]:
         try:
             variables = {var: data[var] for var in eval_template.variables}
             empty_keys = [k for k, v in variables.items() if v is None]

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -27,7 +27,7 @@ from phoenix.evals.executors import ExecutionStatus, get_executor_on_sync_contex
 from phoenix.evals.models import BaseModel, OpenAIModel, set_verbosity
 from phoenix.evals.templates import (
     ClassificationTemplate,
-    PromptMessage,
+    PromptMessages,
     PromptOptions,
     PromptTemplate,
     normalize_classification_template,
@@ -178,7 +178,7 @@ def llm_classify(
     if generation_info := model.verbose_generation_info():
         printif(verbose, generation_info)
 
-    def _map_template(data: pd.Series[Any]) -> List[PromptMessage]:
+    def _map_template(data: pd.Series[Any]) -> PromptMessages:
         try:
             variables = {var: data[var] for var in eval_template.variables}
             empty_keys = [k for k, v in variables.items() if v is None]
@@ -218,7 +218,7 @@ def llm_classify(
                 prompt, instruction=system_instruction, **model_kwargs
             )
         inference, explanation = _process_response(response)
-        return inference, explanation, response, prompt
+        return inference, explanation, response, str(prompt)
 
     def _run_llm_classification_sync(input_data: pd.Series[Any]) -> ParsedLLMResponse:
         with set_verbosity(model, verbose) as verbose_model:
@@ -227,7 +227,7 @@ def llm_classify(
                 prompt, instruction=system_instruction, **model_kwargs
             )
         inference, explanation = _process_response(response)
-        return inference, explanation, response, prompt
+        return inference, explanation, response, str(prompt)
 
     fallback_return_value: ParsedLLMResponse = (None, None, "", "")
 

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -27,7 +27,7 @@ from phoenix.evals.executors import ExecutionStatus, get_executor_on_sync_contex
 from phoenix.evals.models import BaseModel, OpenAIModel, set_verbosity
 from phoenix.evals.templates import (
     ClassificationTemplate,
-    PromptMessages,
+    MultimodalPrompt,
     PromptOptions,
     PromptTemplate,
     normalize_classification_template,
@@ -178,7 +178,7 @@ def llm_classify(
     if generation_info := model.verbose_generation_info():
         printif(verbose, generation_info)
 
-    def _map_template(data: pd.Series[Any]) -> PromptMessages:
+    def _map_template(data: pd.Series[Any]) -> MultimodalPrompt:
         try:
             variables = {var: data[var] for var in eval_template.variables}
             empty_keys = [k for k, v in variables.items() if v is None]

--- a/packages/phoenix-evals/src/phoenix/evals/generate.py
+++ b/packages/phoenix-evals/src/phoenix/evals/generate.py
@@ -133,5 +133,5 @@ def llm_generate(
         exit_on_error=True,
         fallback_return_value=fallback_return_value,
     )
-    results, _ = executor.run(list(enumerate(prompts.tolist())))
+    results, _ = executor.run(list(enumerate(prompts)))
     return pd.DataFrame.from_records(results, index=dataframe.index)

--- a/packages/phoenix-evals/src/phoenix/evals/generate.py
+++ b/packages/phoenix-evals/src/phoenix/evals/generate.py
@@ -8,7 +8,7 @@ from phoenix.evals.executors import (
 )
 from phoenix.evals.models import BaseModel, set_verbosity
 from phoenix.evals.templates import (
-    PromptMessage,
+    PromptMessages,
     PromptTemplate,
     map_template,
     normalize_prompt_template,
@@ -92,7 +92,7 @@ def llm_generate(
     prompts = map_template(dataframe, template)
 
     async def _run_llm_generation_async(
-        enumerated_prompt: Tuple[int, list[PromptMessage]],
+        enumerated_prompt: Tuple[int, PromptMessages],
     ) -> Dict[str, Any]:
         index, prompt = enumerated_prompt
         with set_verbosity(model, verbose) as verbose_model:
@@ -102,13 +102,13 @@ def llm_generate(
             )
         parsed_response = output_parser(response, index)
         if include_prompt:
-            parsed_response["prompt"] = "\n\n".join([msg.content for msg in prompt])
+            parsed_response["prompt"] = str(prompt)
         if include_response:
             parsed_response["response"] = response
         return parsed_response
 
     def _run_llm_generation_sync(
-        enumerated_prompt: Tuple[int, list[PromptMessage]],
+        enumerated_prompt: Tuple[int, PromptMessages],
     ) -> Dict[str, Any]:
         index, prompt = enumerated_prompt
         with set_verbosity(model, verbose) as verbose_model:
@@ -118,7 +118,7 @@ def llm_generate(
             )
         parsed_response = output_parser(response, index)
         if include_prompt:
-            parsed_response["prompt"] = "\n\n".join([msg.content for msg in prompt])
+            parsed_response["prompt"] = str(prompt)
         if include_response:
             parsed_response["response"] = response
         return parsed_response

--- a/packages/phoenix-evals/src/phoenix/evals/generate.py
+++ b/packages/phoenix-evals/src/phoenix/evals/generate.py
@@ -8,7 +8,7 @@ from phoenix.evals.executors import (
 )
 from phoenix.evals.models import BaseModel, set_verbosity
 from phoenix.evals.templates import (
-    PromptMessages,
+    MultimodalPrompt,
     PromptTemplate,
     map_template,
     normalize_prompt_template,
@@ -92,7 +92,7 @@ def llm_generate(
     prompts = map_template(dataframe, template)
 
     async def _run_llm_generation_async(
-        enumerated_prompt: Tuple[int, PromptMessages],
+        enumerated_prompt: Tuple[int, MultimodalPrompt],
     ) -> Dict[str, Any]:
         index, prompt = enumerated_prompt
         with set_verbosity(model, verbose) as verbose_model:
@@ -108,7 +108,7 @@ def llm_generate(
         return parsed_response
 
     def _run_llm_generation_sync(
-        enumerated_prompt: Tuple[int, PromptMessages],
+        enumerated_prompt: Tuple[int, MultimodalPrompt],
     ) -> Dict[str, Any]:
         index, prompt = enumerated_prompt
         with set_verbosity(model, verbose) as verbose_model:

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptPartContentType, MultimodalPrompt
+from phoenix.evals.templates import MultimodalPrompt, PromptPartContentType
 
 MINIMUM_ANTHROPIC_VERSION = "0.18.0"
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Optional, Sequence
 from typing_extensions import TypeVar, Union
 
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptMessages
+from phoenix.evals.templates import MultimodalPrompt
 
 T = TypeVar("T", bound=type)
 
@@ -63,10 +63,10 @@ class BaseModel(ABC):
         pass
 
     def __call__(
-        self, prompt: Union[str, PromptMessages], instruction: Optional[str] = None, **kwargs: Any
+        self, prompt: Union[str, MultimodalPrompt], instruction: Optional[str] = None, **kwargs: Any
     ) -> str:
         """Run the LLM on the given prompt."""
-        if not isinstance(prompt, (str, PromptMessages)):
+        if not isinstance(prompt, (str, MultimodalPrompt)):
             raise TypeError(
                 "Invalid type for argument `prompt`. Expected a string or PromptMessages but found "
                 f"{type(prompt)}. If you want to run the LLM on multiple prompts, use "
@@ -86,11 +86,11 @@ class BaseModel(ABC):
         return ""
 
     @abstractmethod
-    async def _async_generate(self, prompt: Union[str, PromptMessages], **kwargs: Any) -> str:
+    async def _async_generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Any) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def _generate(self, prompt: Union[str, PromptMessages], **kwargs: Any) -> str:
+    def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Any) -> str:
         raise NotImplementedError
 
     @staticmethod

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -7,6 +7,7 @@ from typing import Any, Generator, Optional, Sequence
 from typing_extensions import TypeVar
 
 from phoenix.evals.models.rate_limiters import RateLimiter
+from phoenix.evals.templates import PromptMessage, PromptMessageContentType
 
 T = TypeVar("T", bound=type)
 
@@ -74,7 +75,10 @@ class BaseModel(ABC):
                 "Invalid type for argument `instruction`. Expected a string but found "
                 f"{type(instruction)}."
             )
-        return self._generate(prompt=prompt, instruction=instruction, **kwargs)
+        prompt_messages = [
+            PromptMessage(content_type=PromptMessageContentType.TEXT, content=prompt)
+        ]
+        return self._generate(prompt=prompt_messages, instruction=instruction, **kwargs)
 
     def verbose_generation_info(self) -> str:
         # if defined, returns additional model-specific information to display if `generate` is
@@ -82,11 +86,11 @@ class BaseModel(ABC):
         return ""
 
     @abstractmethod
-    async def _async_generate(self, prompt: str, **kwargs: Any) -> str:
+    async def _async_generate(self, prompt: list[PromptMessage], **kwargs: Any) -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def _generate(self, prompt: str, **kwargs: Any) -> str:
+    def _generate(self, prompt: list[PromptMessage], **kwargs: Any) -> str:
         raise NotImplementedError
 
     @staticmethod

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -66,9 +66,9 @@ class BaseModel(ABC):
         self, prompt: Union[str, PromptMessages], instruction: Optional[str] = None, **kwargs: Any
     ) -> str:
         """Run the LLM on the given prompt."""
-        if not isinstance(prompt, str):
+        if not isinstance(prompt, (str, PromptMessages)):
             raise TypeError(
-                "Invalid type for argument `prompt`. Expected a string but found "
+                "Invalid type for argument `prompt`. Expected a string or PromptMessages but found "
                 f"{type(prompt)}. If you want to run the LLM on multiple prompts, use "
                 "`generate` instead."
             )

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptMessage, PromptMessageContentType, PromptMessages
+from phoenix.evals.templates import PromptMessages
 
 logger = logging.getLogger(__name__)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -155,14 +155,14 @@ class BedrockModel(BaseModel):
 
         # TODO: Migrate to using the bedrock `converse` API
         # https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html
-        prompt = "\n\n".join(
+        prompt_str = "\n\n".join(
             [msg.content for msg in prompt if msg.content_type == PromptMessageContentType.TEXT]
         )
 
         if self.model_id.startswith("ai21"):
             return {
                 **{
-                    "prompt": prompt,
+                    "prompt": prompt_str,
                     "temperature": self.temperature,
                     "topP": self.top_p,
                     "maxTokens": self.max_tokens,
@@ -174,7 +174,7 @@ class BedrockModel(BaseModel):
             return {
                 **{
                     "anthropic_version": "bedrock-2023-05-31",
-                    "messages": self._format_prompt_for_claude(prompt),
+                    "messages": self._format_prompt_for_claude(prompt_str),
                     "temperature": self.temperature,
                     "top_p": self.top_p,
                     "top_k": self.top_k,
@@ -186,7 +186,7 @@ class BedrockModel(BaseModel):
         elif self.model_id.startswith("mistral"):
             return {
                 **{
-                    "prompt": prompt,
+                    "prompt": prompt_str,
                     "max_tokens": self.max_tokens,
                     "temperature": self.temperature,
                     "stop": self.stop_sequences,
@@ -200,7 +200,7 @@ class BedrockModel(BaseModel):
                 logger.warn(f"Unknown format for model {self.model_id}, returning titan format...")
             return {
                 **{
-                    "inputText": prompt,
+                    "inputText": prompt_str,
                     "textGenerationConfig": {
                         "temperature": self.temperature,
                         "topP": self.top_p,

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
+from phoenix.evals.templates import PromptMessage, PromptMessageContentType
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class BedrockModel(BaseModel):
             enforcement_window_minutes=1,
         )
 
-    def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
+    def _generate(self, prompt: list[PromptMessage], **kwargs: Dict[str, Any]) -> str:
         body = json.dumps(self._create_request_body(prompt))
         accept = "application/json"
         contentType = "application/json"
@@ -113,7 +114,7 @@ class BedrockModel(BaseModel):
 
         return self._parse_output(response) or ""
 
-    async def _async_generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
+    async def _async_generate(self, prompt: list[PromptMessage], **kwargs: Dict[str, Any]) -> str:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, partial(self._generate, prompt, **kwargs))
 
@@ -148,9 +149,16 @@ class BedrockModel(BaseModel):
             {"role": "user", "content": prompt},
         ]
 
-    def _create_request_body(self, prompt: str) -> Dict[str, Any]:
+    def _create_request_body(self, prompt: list[PromptMessage]) -> Dict[str, Any]:
         # The request formats for bedrock models differ
         # see https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html
+
+        # TODO: Migrate to using the bedrock `converse` API
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html
+        prompt = "\n\n".join(
+            [msg.content for msg in prompt if msg.content_type == PromptMessageContentType.TEXT]
+        )
+
         if self.model_id.startswith("ai21"):
             return {
                 **{

--- a/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 from phoenix.evals.models.base import BaseModel
-from phoenix.evals.templates import PromptPartContentType, MultimodalPrompt
+from phoenix.evals.templates import MultimodalPrompt, PromptPartContentType
 
 logger = logging.getLogger(__name__)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptMessageContentType, PromptMessages
+from phoenix.evals.templates import PromptPartContentType, MultimodalPrompt
 
 if TYPE_CHECKING:
     from mistralai.models.chat_completion import ChatMessage
@@ -107,11 +107,11 @@ class MistralAIModel(BaseModel):
         # Mistral is strict about not passing None values to the API
         return {k: v for k, v in params.items() if v is not None}
 
-    def _generate(self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]) -> str:
+    def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]) -> str:
         # instruction is an invalid input to Mistral models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
         kwargs.pop("instruction", None)
         invocation_parameters = self.invocation_parameters()
@@ -139,12 +139,12 @@ class MistralAIModel(BaseModel):
         return _completion(**kwargs)
 
     async def _async_generate(
-        self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]
+        self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
     ) -> str:
         # instruction is an invalid input to Mistral models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
         kwargs.pop("instruction", None)
         invocation_parameters = self.invocation_parameters()
@@ -172,12 +172,12 @@ class MistralAIModel(BaseModel):
 
         return await _async_completion(**kwargs)
 
-    def _format_prompt(self, prompt: PromptMessages) -> List["ChatMessage"]:
+    def _format_prompt(self, prompt: MultimodalPrompt) -> List["ChatMessage"]:
         ChatMessage = self._ChatMessage
         messages = []
-        for msg in prompt.messages:
-            if msg.content_type == PromptMessageContentType.TEXT:
-                messages.append(ChatMessage(role="user", content=msg.content))
+        for part in prompt.parts:
+            if part.content_type == PromptPartContentType.TEXT:
+                messages.append(ChatMessage(role="user", content=part.content))
             else:
-                raise ValueError(f"Unsupported content type: {msg.content_type}")
+                raise ValueError(f"Unsupported content type: {part.content_type}")
         return messages

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptPartContentType, MultimodalPrompt
+from phoenix.evals.templates import MultimodalPrompt, PromptPartContentType
 
 if TYPE_CHECKING:
     from mistralai.models.chat_completion import ChatMessage

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -17,7 +17,7 @@ from typing import (
 from phoenix.evals.exceptions import PhoenixContextLimitExceeded
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptPartContentType, MultimodalPrompt
+from phoenix.evals.templates import MultimodalPrompt, PromptPartContentType
 
 MINIMUM_OPENAI_VERSION = "1.0.0"
 MODEL_TOKEN_LIMIT_MAPPING = {

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from phoenix.evals.models.base import BaseModel
 from phoenix.evals.models.rate_limiters import RateLimiter
-from phoenix.evals.templates import PromptMessages
+from phoenix.evals.templates import MultimodalPrompt
 from phoenix.evals.utils import printif
 
 if TYPE_CHECKING:
@@ -136,17 +136,17 @@ class GeminiModel(BaseModel):
             "credentials": self.credentials,
         }
 
-    def _generate(self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]) -> str:
+    def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]) -> str:
         # instruction is an invalid input to Gemini models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         kwargs.pop("instruction", None)
 
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
         @self._rate_limiter.limit
         def _rate_limited_completion(
-            prompt: PromptMessages, generation_config: Dict[str, Any], **kwargs: Any
+            prompt: MultimodalPrompt, generation_config: Dict[str, Any], **kwargs: Any
         ) -> Any:
             prompt_str = self._construct_prompt(prompt)
             response = self._model.generate_content(
@@ -163,18 +163,18 @@ class GeminiModel(BaseModel):
         return str(response)
 
     async def _async_generate(
-        self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]
+        self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
     ) -> str:
         # instruction is an invalid input to Gemini models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         kwargs.pop("instruction", None)
 
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
         @self._rate_limiter.alimit
         async def _rate_limited_completion(
-            prompt: PromptMessages, generation_config: Dict[str, Any], **kwargs: Any
+            prompt: MultimodalPrompt, generation_config: Dict[str, Any], **kwargs: Any
         ) -> Any:
             prompt_str = self._construct_prompt(prompt)
             response = await self._model.generate_content_async(
@@ -213,5 +213,5 @@ class GeminiModel(BaseModel):
             candidate = ""
         return candidate
 
-    def _construct_prompt(self, prompt: PromptMessages) -> str:
-        return prompt.to_prompt_string()
+    def _construct_prompt(self, prompt: MultimodalPrompt) -> str:
+        return prompt.to_text_only_prompt()

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from phoenix.evals.models.base import BaseModel
-from phoenix.evals.templates import PromptMessages
+from phoenix.evals.templates import MultimodalPrompt
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -151,18 +151,18 @@ class VertexAIModel(BaseModel):
         return f"VertexAI invocation parameters: {self.invocation_params}"
 
     async def _async_generate(
-        self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]
+        self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
     ) -> str:
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
         return self._generate(prompt, **kwargs)
 
-    def _generate(self, prompt: Union[str, PromptMessages], **kwargs: Dict[str, Any]) -> str:
+    def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]) -> str:
         if isinstance(prompt, str):
-            prompt = PromptMessages.from_string(prompt)
+            prompt = MultimodalPrompt.from_string(prompt)
 
-        prompt_str = prompt.to_prompt_string()
+        prompt_str = prompt.to_text_only_prompt()
         invoke_params = self.invocation_params
         response = self._model.predict(
             prompt=prompt_str,

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from phoenix.evals.models.base import BaseModel
+from phoenix.evals.templates import PromptMessage, PromptMessageContentType
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
@@ -152,10 +153,13 @@ class VertexAIModel(BaseModel):
     async def _async_generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
         return self._generate(prompt, **kwargs)
 
-    def _generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
+    def _generate(self, prompt: list[PromptMessage], **kwargs: Dict[str, Any]) -> str:
+        prompt_str = "\n\n".join(
+            [msg.content for msg in prompt if msg.content_type == PromptMessageContentType.TEXT]
+        )
         invoke_params = self.invocation_params
         response = self._model.predict(
-            prompt=prompt,
+            prompt=prompt_str,
             **invoke_params,
         )
         return str(response.text)

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertexai.py
@@ -150,7 +150,7 @@ class VertexAIModel(BaseModel):
     def verbose_generation_info(self) -> str:
         return f"VertexAI invocation parameters: {self.invocation_params}"
 
-    async def _async_generate(self, prompt: str, **kwargs: Dict[str, Any]) -> str:
+    async def _async_generate(self, prompt: list[PromptMessage], **kwargs: Dict[str, Any]) -> str:
         return self._generate(prompt, **kwargs)
 
     def _generate(self, prompt: list[PromptMessage], **kwargs: Dict[str, Any]) -> str:

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from string import Formatter
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 
@@ -45,8 +45,8 @@ class PromptMessageTemplate:
 
 
 class PromptTemplate:
-    template: str | List[PromptMessageTemplate]
-    variables: List[str]
+    template: str | list[PromptMessageTemplate]
+    variables: list[str]
 
     def __init__(
         self,
@@ -64,7 +64,7 @@ class PromptTemplate:
         self,
         variable_values: Mapping[str, Union[bool, int, float, str]],
         options: Optional[PromptOptions] = None,
-    ) -> List[PromptMessage]:
+    ) -> list[PromptMessage]:
         prompt = self.prompt(options)
         prompt_messages = []
         for template_message in self.template:
@@ -82,7 +82,7 @@ class PromptTemplate:
             )
         return prompt_messages
 
-    def _parse_variables(self, template: List[PromptMessageTemplate]) -> List[str]:
+    def _parse_variables(self, template: list[PromptMessageTemplate]) -> list[str]:
         start = re.escape(self._start_delim)
         end = re.escape(self._end_delim)
         pattern = rf"{start}(.*?){end}"
@@ -92,8 +92,8 @@ class PromptTemplate:
         return variables
 
     def _normalize_template(
-        self, template: str | List[PromptMessageTemplate]
-    ) -> List[PromptMessageTemplate]:
+        self, template: str | list[PromptMessageTemplate]
+    ) -> list[PromptMessageTemplate]:
         if isinstance(template, str):
             return [
                 PromptMessageTemplate(content_type=PromptMessageContentType.TEXT, template=template)
@@ -104,12 +104,12 @@ class PromptTemplate:
 class ClassificationTemplate(PromptTemplate):
     def __init__(
         self,
-        rails: List[str],
-        template: str | List[PromptMessageTemplate],
-        explanation_template: Optional[str | List[PromptMessageTemplate]] = None,
+        rails: list[str],
+        template: str | list[PromptMessageTemplate],
+        explanation_template: Optional[str | list[PromptMessageTemplate]] = None,
         explanation_label_parser: Optional[Callable[[str], str]] = None,
         delimiters: Tuple[str, str] = (DEFAULT_START_DELIM, DEFAULT_END_DELIM),
-        scores: Optional[List[float]] = None,
+        scores: Optional[list[float]] = None,
     ):
         if scores is not None and len(rails) != len(scores):
             raise InvalidClassificationTemplateError(
@@ -121,7 +121,7 @@ class ClassificationTemplate(PromptTemplate):
         self.explanation_template = self._normalize_template(explanation_template)
         self.explanation_label_parser = explanation_label_parser
         self._start_delim, self._end_delim = delimiters
-        self.variables: List[str] = []
+        self.variables: list[str] = []
         for _template in [template, explanation_template]:
             if _template:
                 self.variables += self._parse_variables(template=_template)
@@ -162,7 +162,7 @@ def parse_label_from_chain_of_thought_response(raw_string: str) -> str:
 
 
 def normalize_classification_template(
-    rails: List[str], template: Union[PromptTemplate, ClassificationTemplate, str]
+    rails: list[str], template: Union[PromptTemplate, ClassificationTemplate, str]
 ) -> ClassificationTemplate:
     """
     Normalizes a template to a ClassificationTemplate object.
@@ -210,7 +210,7 @@ def map_template(
     dataframe: pd.DataFrame,
     template: PromptTemplate,
     options: Optional[PromptOptions] = None,
-) -> "pd.Series[List[PromptMessage]]":
+) -> "pd.Series[list[PromptMessage]]":
     """
     Maps over a dataframe to construct a list of prompts from a template and a dataframe.
     """

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -34,31 +34,33 @@ class PromptMessageContentType(str, Enum):
     AUDIO_URL = "audio_url"
 
 
+@dataclass
 class PromptMessage:
     content_type: PromptMessageContentType
     content: str
 
 
+@dataclass
 class PromptMessageTemplate:
     content_type: PromptMessageContentType
     template: str
 
 
 class PromptTemplate:
-    template: str | list[PromptMessageTemplate]
+    template: list[PromptMessageTemplate]
     variables: list[str]
 
     def __init__(
         self,
-        template: str,
+        template: Union[str, list[PromptMessageTemplate]],
         delimiters: Tuple[str, str] = (DEFAULT_START_DELIM, DEFAULT_END_DELIM),
     ):
-        self.template = self._normalize_template(template)
+        self.template: list[PromptMessageTemplate] = self._normalize_template(template)
         self._start_delim, self._end_delim = delimiters
         self.variables = self._parse_variables(self.template)
 
     def prompt(self, options: Optional[PromptOptions] = None) -> str:
-        return self.template
+        return "\n\n".join([template_message.template for template_message in self.template])
 
     def format(
         self,
@@ -92,7 +94,7 @@ class PromptTemplate:
         return variables
 
     def _normalize_template(
-        self, template: str | list[PromptMessageTemplate]
+        self, template: Union[str, list[PromptMessageTemplate]]
     ) -> list[PromptMessageTemplate]:
         if isinstance(template, str):
             return [
@@ -105,8 +107,8 @@ class ClassificationTemplate(PromptTemplate):
     def __init__(
         self,
         rails: list[str],
-        template: str | list[PromptMessageTemplate],
-        explanation_template: Optional[str | list[PromptMessageTemplate]] = None,
+        template: Union[str, list[PromptMessageTemplate]],
+        explanation_template: Optional[Union[str, list[PromptMessageTemplate]]] = None,
         explanation_label_parser: Optional[Callable[[str], str]] = None,
         delimiters: Tuple[str, str] = (DEFAULT_START_DELIM, DEFAULT_END_DELIM),
         scores: Optional[list[float]] = None,

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -53,18 +53,12 @@ class MultimodalPrompt:
     @staticmethod
     def from_string(string_prompt: str) -> "MultimodalPrompt":
         return MultimodalPrompt(
-            parts=[
-                PromptPart(content_type=PromptPartContentType.TEXT, content=string_prompt)
-            ]
+            parts=[PromptPart(content_type=PromptPartContentType.TEXT, content=string_prompt)]
         )
 
     def to_text_only_prompt(self) -> str:
         return "\n\n".join(
-            [
-                part.content
-                for part in self.parts
-                if part.content_type == PromptPartContentType.TEXT
-            ]
+            [part.content for part in self.parts if part.content_type == PromptPartContentType.TEXT]
         )
 
     def __str__(self) -> str:
@@ -122,9 +116,7 @@ class PromptTemplate:
         self, template: Union[str, List[PromptPartTemplate]]
     ) -> List[PromptPartTemplate]:
         if isinstance(template, str):
-            return [
-                PromptPartTemplate(content_type=PromptPartContentType.TEXT, template=template)
-            ]
+            return [PromptPartTemplate(content_type=PromptPartContentType.TEXT, template=template)]
         return template
 
 

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from string import Formatter
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 
@@ -48,7 +48,7 @@ class PromptMessageTemplate:
 
 @dataclass
 class PromptMessages:
-    messages: list[PromptMessage]
+    messages: List[PromptMessage]
 
     @staticmethod
     def from_string(string_prompt: str) -> "PromptMessages":
@@ -72,19 +72,19 @@ class PromptMessages:
 
 
 class PromptTemplate:
-    template: list[PromptMessageTemplate]
-    variables: list[str]
+    template: List[PromptMessageTemplate]
+    variables: List[str]
 
     def __init__(
         self,
-        template: Union[str, list[PromptMessageTemplate]],
+        template: Union[str, List[PromptMessageTemplate]],
         delimiters: Tuple[str, str] = (DEFAULT_START_DELIM, DEFAULT_END_DELIM),
     ):
-        self.template: list[PromptMessageTemplate] = self._normalize_template(template)
+        self.template: List[PromptMessageTemplate] = self._normalize_template(template)
         self._start_delim, self._end_delim = delimiters
         self.variables = self._parse_variables(self.template)
 
-    def prompt(self, options: Optional[PromptOptions] = None) -> list[PromptMessageTemplate]:
+    def prompt(self, options: Optional[PromptOptions] = None) -> List[PromptMessageTemplate]:
         return self.template
 
     def format(
@@ -109,7 +109,7 @@ class PromptTemplate:
             )
         return PromptMessages(messages=prompt_messages)
 
-    def _parse_variables(self, template: list[PromptMessageTemplate]) -> list[str]:
+    def _parse_variables(self, template: List[PromptMessageTemplate]) -> List[str]:
         start = re.escape(self._start_delim)
         end = re.escape(self._end_delim)
         pattern = rf"{start}(.*?){end}"
@@ -119,8 +119,8 @@ class PromptTemplate:
         return variables
 
     def _normalize_template(
-        self, template: Union[str, list[PromptMessageTemplate]]
-    ) -> list[PromptMessageTemplate]:
+        self, template: Union[str, List[PromptMessageTemplate]]
+    ) -> List[PromptMessageTemplate]:
         if isinstance(template, str):
             return [
                 PromptMessageTemplate(content_type=PromptMessageContentType.TEXT, template=template)
@@ -131,12 +131,12 @@ class PromptTemplate:
 class ClassificationTemplate(PromptTemplate):
     def __init__(
         self,
-        rails: list[str],
-        template: Union[str, list[PromptMessageTemplate]],
-        explanation_template: Optional[Union[str, list[PromptMessageTemplate]]] = None,
+        rails: List[str],
+        template: Union[str, List[PromptMessageTemplate]],
+        explanation_template: Optional[Union[str, List[PromptMessageTemplate]]] = None,
         explanation_label_parser: Optional[Callable[[str], str]] = None,
         delimiters: Tuple[str, str] = (DEFAULT_START_DELIM, DEFAULT_END_DELIM),
-        scores: Optional[list[float]] = None,
+        scores: Optional[List[float]] = None,
     ):
         if scores is not None and len(rails) != len(scores):
             raise InvalidClassificationTemplateError(
@@ -149,7 +149,7 @@ class ClassificationTemplate(PromptTemplate):
             self.explanation_template = self._normalize_template(explanation_template)
         self.explanation_label_parser = explanation_label_parser
         self._start_delim, self._end_delim = delimiters
-        self.variables: list[str] = []
+        self.variables: List[str] = []
         for _template in [self.template, self.explanation_template]:
             if _template:
                 self.variables.extend(self._parse_variables(template=_template))
@@ -158,7 +158,7 @@ class ClassificationTemplate(PromptTemplate):
     def __repr__(self) -> str:
         return "\n\n".join([template.template for template in self.template])
 
-    def prompt(self, options: Optional[PromptOptions] = None) -> list[PromptMessageTemplate]:
+    def prompt(self, options: Optional[PromptOptions] = None) -> List[PromptMessageTemplate]:
         if options is None:
             return self.template
 
@@ -190,7 +190,7 @@ def parse_label_from_chain_of_thought_response(raw_string: str) -> str:
 
 
 def normalize_classification_template(
-    rails: list[str], template: Union[PromptTemplate, ClassificationTemplate, str]
+    rails: List[str], template: Union[PromptTemplate, ClassificationTemplate, str]
 ) -> ClassificationTemplate:
     """
     Normalizes a template to a ClassificationTemplate object.
@@ -238,7 +238,7 @@ def map_template(
     dataframe: pd.DataFrame,
     template: PromptTemplate,
     options: Optional[PromptOptions] = None,
-) -> list[PromptMessages]:
+) -> List[PromptMessages]:
     """
     Maps over a dataframe to construct a list of prompts from a template and a dataframe.
     """

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -28,7 +28,7 @@ def test_classification_template_score_returns_zero_for_missing_rail():
 def test_template_with_default_delimiters_uses_python_string_formatting():
     template = PromptTemplate(template='Hello, {name}! Look at this JSON {{ "hello": "world" }}')
     assert (
-        template.format(variable_values={"name": "world"})
+        str(template.format(variable_values={"name": "world"}))
         == 'Hello, world! Look at this JSON { "hello": "world" }'
     )
 
@@ -36,6 +36,6 @@ def test_template_with_default_delimiters_uses_python_string_formatting():
 def test_template_with_default_delimiters_accepts_keys_with_dots():
     template = PromptTemplate(template='Hello, {my.name}! Look at this JSON {{ "hello": "world" }}')
     assert (
-        template.format(variable_values={"my.name": "world"})
+        str(template.format(variable_values={"my.name": "world"}))
         == 'Hello, world! Look at this JSON { "hello": "world" }'
     )


### PR DESCRIPTION
This refactor enables the creation of `PromptTemplate` objects that include multiple messages that include mixed media types (e.g. audio, images, links, etc) and leave the handling of the message prompts to each model wrapper.

Should be fully backwards compatible