### PR TITLE
fix: ensure retrieval documents are unnested when converting from span to dataset example

### DIFF
--- a/src/phoenix/server/api/helpers/dataset_helpers.py
+++ b/src/phoenix/server/api/helpers/dataset_helpers.py
@@ -83,10 +83,7 @@ def _get_llm_span_input(
     if not input:
         input = _get_generic_io_value(io_value=input_value, mime_type=input_mime_type, kind="input")
     if prompt_template_variables_data := _safely_json_decode(prompt_template_variables):
-        input = {
-            **input,
-            "prompt_template_variables": prompt_template_variables_data,
-        }
+        input["prompt_template_variables"] = prompt_template_variables_data
     return input
 
 

--- a/src/phoenix/server/api/helpers/dataset_helpers.py
+++ b/src/phoenix/server/api/helpers/dataset_helpers.py
@@ -1,54 +1,45 @@
 import json
 from collections.abc import Mapping
-from typing import Any, Literal, Optional, Protocol
+from typing import Any, Literal, Optional
 
 from openinference.semconv.trace import (
     MessageAttributes,
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
+    SpanAttributes,
     ToolCallAttributes,
 )
 
+from phoenix.db.models import Span
 from phoenix.trace.attributes import get_attribute_value
 
 
-class HasSpanIO(Protocol):
-    """
-    An interface that contains the information needed to extract dataset example
-    input and output values from a span.
-    """
-
-    span_kind: Optional[str]
-    input_value: Any
-    input_mime_type: Optional[str]
-    output_value: Any
-    output_mime_type: Optional[str]
-    llm_prompt_template_variables: Any
-    llm_input_messages: Any
-    llm_output_messages: Any
-    retrieval_documents: Any
-
-
-def get_dataset_example_input(span: HasSpanIO) -> dict[str, Any]:
+def get_dataset_example_input(span: Span) -> dict[str, Any]:
     """
     Extracts the input value from a span and returns it as a dictionary. Input
     values from LLM spans are extracted from the input messages and prompt
     template variables (if present). For other span kinds, the input is
     extracted from the input value and input mime type attributes.
     """
-    input_value = span.input_value
-    input_mime_type = span.input_mime_type
-    if span.span_kind == OpenInferenceSpanKindValues.LLM.value:
+    span_kind = span.span_kind
+    attributes = span.attributes
+    input_value = get_attribute_value(attributes, INPUT_VALUE)
+    input_mime_type = get_attribute_value(attributes, INPUT_MIME_TYPE)
+    prompt_template_variables = _safely_json_decode(
+        get_attribute_value(attributes, LLM_PROMPT_TEMPLATE_VARIABLES)
+    )
+    input_messages = get_attribute_value(attributes, LLM_INPUT_MESSAGES)
+    if span_kind == LLM:
         return _get_llm_span_input(
-            input_messages=span.llm_input_messages,
+            input_messages=input_messages,
             input_value=input_value,
             input_mime_type=input_mime_type,
-            prompt_template_variables=span.llm_prompt_template_variables,
+            prompt_template_variables=prompt_template_variables,
         )
     return _get_generic_io_value(io_value=input_value, mime_type=input_mime_type, kind="input")
 
 
-def get_dataset_example_output(span: HasSpanIO) -> dict[str, Any]:
+def get_dataset_example_output(span: Span) -> dict[str, Any]:
     """
     Extracts the output value from a span and returns it as a dictionary. Output
     values from LLM spans are extracted from the output messages (if present).
@@ -56,18 +47,21 @@ def get_dataset_example_output(span: HasSpanIO) -> dict[str, Any]:
     present). For other span kinds, the output is extracted from the output
     value and output mime type attributes.
     """
-
-    output_value = span.output_value
-    output_mime_type = span.output_mime_type
-    if (span_kind := span.span_kind) == OpenInferenceSpanKindValues.LLM.value:
+    span_kind = span.span_kind
+    attributes = span.attributes
+    output_value = get_attribute_value(attributes, OUTPUT_VALUE)
+    output_mime_type = get_attribute_value(attributes, OUTPUT_MIME_TYPE)
+    output_messages = get_attribute_value(attributes, LLM_OUTPUT_MESSAGES)
+    retrieval_documents = get_attribute_value(attributes, RETRIEVAL_DOCUMENTS)
+    if span_kind == LLM:
         return _get_llm_span_output(
-            output_messages=span.llm_output_messages,
+            output_messages=output_messages,
             output_value=output_value,
             output_mime_type=output_mime_type,
         )
     if span_kind == OpenInferenceSpanKindValues.RETRIEVER.value:
         return _get_retriever_span_output(
-            retrieval_documents=span.retrieval_documents,
+            retrieval_documents=retrieval_documents,
             output_value=output_value,
             output_mime_type=output_mime_type,
         )
@@ -91,7 +85,10 @@ def _get_llm_span_input(
     if not input:
         input = _get_generic_io_value(io_value=input_value, mime_type=input_mime_type, kind="input")
     if prompt_template_variables:
-        input = {**input, "prompt_template_variables": prompt_template_variables}
+        input = {
+            **input,
+            "prompt_template_variables": prompt_template_variables,
+        }
     return input
 
 
@@ -169,6 +166,19 @@ def _get_message(message: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _safely_json_decode(value: Any) -> Any:
+    """
+    Safely decodes a JSON-encoded value.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+# MessageAttributes
 MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
 MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
 MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME
@@ -176,5 +186,19 @@ MESSAGE_NAME = MessageAttributes.MESSAGE_NAME
 MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
 MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
 
-TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
+# OpenInferenceSpanKindValues
+LLM = OpenInferenceSpanKindValues.LLM.value
+
+# SpanAttributes
+INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+INPUT_VALUE = SpanAttributes.INPUT_VALUE
+LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
+LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
+LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+RETRIEVAL_DOCUMENTS = SpanAttributes.RETRIEVAL_DOCUMENTS
+
+# ToolCallAttributes
 TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON
+TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -136,23 +136,7 @@ class DatasetMutationMixin:
                 .returning(models.DatasetVersion.id)
             )
             spans = (
-                await session.execute(
-                    select(
-                        models.Span.id,
-                        models.Span.span_kind,
-                        models.Span.attributes,
-                        _span_attribute(INPUT_MIME_TYPE),
-                        _span_attribute(INPUT_VALUE),
-                        _span_attribute(OUTPUT_MIME_TYPE),
-                        _span_attribute(OUTPUT_VALUE),
-                        _span_attribute(LLM_PROMPT_TEMPLATE_VARIABLES),
-                        _span_attribute(LLM_INPUT_MESSAGES),
-                        _span_attribute(LLM_OUTPUT_MESSAGES),
-                        _span_attribute(RETRIEVAL_DOCUMENTS),
-                    )
-                    .select_from(models.Span)
-                    .where(models.Span.id.in_(span_rowids))
-                )
+                await session.scalars(select(models.Span).where(models.Span.id.in_(span_rowids)))
             ).all()
             if missing_span_rowids := span_rowids - {span.id for span in spans}:
                 raise ValueError(
@@ -160,18 +144,10 @@ class DatasetMutationMixin:
                 )  # todo: implement error handling types https://github.com/Arize-ai/phoenix/issues/3221
 
             span_annotations = (
-                await session.execute(
-                    select(
-                        models.SpanAnnotation.span_rowid,
-                        models.SpanAnnotation.name,
-                        models.SpanAnnotation.label,
-                        models.SpanAnnotation.score,
-                        models.SpanAnnotation.explanation,
-                        models.SpanAnnotation.metadata_,
-                        models.SpanAnnotation.annotator_kind,
+                await session.scalars(
+                    select(models.SpanAnnotation).where(
+                        models.SpanAnnotation.span_rowid.in_(span_rowids)
                     )
-                    .select_from(models.SpanAnnotation)
-                    .where(models.SpanAnnotation.span_rowid.in_(span_rowids))
                 )
             ).all()
 

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -191,7 +191,11 @@ class DatasetMutationMixin:
                         DatasetExampleRevision.output.key: get_dataset_example_output(span),
                         DatasetExampleRevision.metadata_.key: {
                             "span_kind": span.span_kind,
-                            "annotations": span_annotations_by_span[span.id],
+                            **(
+                                {"annotations": annotations}
+                                if (annotations := span_annotations_by_span[span.id])
+                                else {}
+                            ),
                         },
                         DatasetExampleRevision.revision_kind.key: "CREATE",
                     }

--- a/src/phoenix/server/api/mutations/dataset_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_mutations.py
@@ -190,7 +190,7 @@ class DatasetMutationMixin:
                         DatasetExampleRevision.input.key: get_dataset_example_input(span),
                         DatasetExampleRevision.output.key: get_dataset_example_output(span),
                         DatasetExampleRevision.metadata_.key: {
-                            **span.attributes,
+                            "span_kind": span.span_kind,
                             "annotations": span_annotations_by_span[span.id],
                         },
                         DatasetExampleRevision.revision_kind.key: "CREATE",

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -1,13 +1,12 @@
 import json
 from collections.abc import Mapping, Sized
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
 import strawberry
-from openinference.semconv.trace import EmbeddingAttributes, SpanAttributes
+from openinference.semconv.trace import SpanAttributes
 from strawberry import ID, UNSET
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
@@ -38,18 +37,6 @@ from .SpanAnnotation import SpanAnnotation
 
 if TYPE_CHECKING:
     from phoenix.server.api.types.Project import Project
-
-EMBEDDING_EMBEDDINGS = SpanAttributes.EMBEDDING_EMBEDDINGS
-EMBEDDING_VECTOR = EmbeddingAttributes.EMBEDDING_VECTOR
-INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
-INPUT_VALUE = SpanAttributes.INPUT_VALUE
-LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
-LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
-LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
-METADATA = SpanAttributes.METADATA
-OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
-OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
-RETRIEVAL_DOCUMENTS = SpanAttributes.RETRIEVAL_DOCUMENTS
 
 
 @strawberry.enum
@@ -236,21 +223,8 @@ class Span(Node):
         description="The span's attributes translated into an example revision for a dataset",
     )  # type: ignore
     async def as_example_revision(self, info: Info[Context, None]) -> SpanAsExampleRevision:
-        db_span = self.db_span
-        attributes = db_span.attributes
-        span_io = _SpanIO(
-            span_kind=db_span.span_kind,
-            input_value=get_attribute_value(attributes, INPUT_VALUE),
-            input_mime_type=get_attribute_value(attributes, INPUT_MIME_TYPE),
-            output_value=get_attribute_value(attributes, OUTPUT_VALUE),
-            output_mime_type=get_attribute_value(attributes, OUTPUT_MIME_TYPE),
-            llm_prompt_template_variables=get_attribute_value(
-                attributes, LLM_PROMPT_TEMPLATE_VARIABLES
-            ),
-            llm_input_messages=get_attribute_value(attributes, LLM_INPUT_MESSAGES),
-            llm_output_messages=get_attribute_value(attributes, LLM_OUTPUT_MESSAGES),
-            retrieval_documents=get_attribute_value(attributes, RETRIEVAL_DOCUMENTS),
-        )
+        span = self.db_span
+        attributes = span.attributes
 
         # Fetch annotations associated with this span
         span_annotations = await self.span_annotations(info)
@@ -270,8 +244,8 @@ class Span(Node):
         }
 
         return SpanAsExampleRevision(
-            input=get_dataset_example_input(span_io),
-            output=get_dataset_example_output(span_io),
+            input=get_dataset_example_input(span),
+            output=get_dataset_example_output(span),
             metadata=metadata,
         )
 
@@ -435,19 +409,9 @@ def _convert_metadata_to_string(metadata: Any) -> Optional[str]:
         return str(metadata)
 
 
-@dataclass
-class _SpanIO:
-    """
-    An class that contains the information needed to extract dataset example
-    input and output values from a span.
-    """
-
-    span_kind: Optional[str]
-    input_value: Any
-    input_mime_type: Optional[str]
-    output_value: Any
-    output_mime_type: Optional[str]
-    llm_prompt_template_variables: Any
-    llm_input_messages: Any
-    llm_output_messages: Any
-    retrieval_documents: Any
+INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+INPUT_VALUE = SpanAttributes.INPUT_VALUE
+METADATA = SpanAttributes.METADATA
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+RETRIEVAL_DOCUMENTS = SpanAttributes.RETRIEVAL_DOCUMENTS

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -239,7 +239,7 @@ class Span(Node):
         # Merge annotations into the metadata
         metadata = {
             "span_kind": span.span_kind,
-            "annotations": annotations,
+            **({"annotations": annotations} if annotations else {}),
         }
 
         return SpanAsExampleRevision(

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -224,7 +224,6 @@ class Span(Node):
     )  # type: ignore
     async def as_example_revision(self, info: Info[Context, None]) -> SpanAsExampleRevision:
         span = self.db_span
-        attributes = span.attributes
 
         # Fetch annotations associated with this span
         span_annotations = await self.span_annotations(info)
@@ -239,7 +238,7 @@ class Span(Node):
             }
         # Merge annotations into the metadata
         metadata = {
-            **attributes,
+            "span_kind": span.span_kind,
             "annotations": annotations,
         }
 

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -3,11 +3,21 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import pytest
+from openinference.semconv.trace import (
+    MessageAttributes,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolAttributes,
+    ToolCallAttributes,
+)
 
+from phoenix.db.models import Span
 from phoenix.server.api.helpers.dataset_helpers import (
     get_dataset_example_input,
     get_dataset_example_output,
 )
+from phoenix.trace.attributes import unflatten
 
 
 @dataclass
@@ -23,56 +33,82 @@ class MockSpan:
     retrieval_documents: Any
 
 
+LLM = OpenInferenceSpanKindValues.LLM.value
+INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
+INPUT_VALUE = SpanAttributes.INPUT_VALUE
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+TEXT = OpenInferenceMimeTypeValues.TEXT.value
+LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
+LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
+LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
+MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
+MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
+MESSAGE_NAME = MessageAttributes.MESSAGE_NAME
+MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
+MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME
+MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
+TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON
+TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
+TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
+
+
 @pytest.mark.parametrize(
     "span, expected_input_value",
     [
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables={"variable_name": "variable-value"},
-                llm_input_messages=[
-                    {"message": {"content": "123", "role": "assistant", "name": "xyz"}},
-                    {"message": {"content": "user-message", "role": "user"}},
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "function_call_name": "add",
-                            "function_call_arguments_json": '{"a": 363, "b": 42}',
-                        }
-                    },
-                    {"message": {"content": "user-message", "role": "user"}},
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "tool_calls": [
-                                {
-                                    "tool_call": {
-                                        "function": {
-                                            "name": "multiply",
-                                            "arguments": '{"a": 121, "b": 3}',
-                                        }
-                                    }
-                                },
-                                {
-                                    "tool_call": {
-                                        "function": {
-                                            "name": "add",
-                                            "arguments": '{"a": 363, "b": 42}',
-                                        }
-                                    }
-                                },
-                            ],
-                        }
-                    },
-                ],
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (OPENINFERENCE_SPAN_KIND, LLM),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (INPUT_VALUE, "plain-text-input"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (
+                            LLM_PROMPT_TEMPLATE_VARIABLES,
+                            json.dumps({"variable_name": "variable-value"}),
+                        ),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "123"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_NAME}", "xyz"),
+                        (f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_CONTENT}", "user-message"),
+                        (f"{LLM_INPUT_MESSAGES}.1.{MESSAGE_ROLE}", "user"),
+                        (f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_ROLE}", "assistant"),
+                        (f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_FUNCTION_CALL_NAME}", "add"),
+                        (
+                            f"{LLM_INPUT_MESSAGES}.2.{MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON}",
+                            json.dumps({"a": 363, "b": 42}),
+                        ),
+                        (f"{LLM_INPUT_MESSAGES}.3.{MESSAGE_CONTENT}", "user-message"),
+                        (f"{LLM_INPUT_MESSAGES}.3.{MESSAGE_ROLE}", "user"),
+                        (f"{LLM_INPUT_MESSAGES}.4.{MESSAGE_ROLE}", "assistant"),
+                        (
+                            f"{LLM_INPUT_MESSAGES}.4.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_NAME}",
+                            "multiply",
+                        ),  # noqa: E501
+                        (
+                            f"{LLM_INPUT_MESSAGES}.4.{MESSAGE_TOOL_CALLS}.0.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                            json.dumps(  # noqa: E501
+                                {"a": 121, "b": 3}
+                            ),
+                        ),
+                        (
+                            f"{LLM_INPUT_MESSAGES}.4.{MESSAGE_TOOL_CALLS}.1.{TOOL_CALL_FUNCTION_NAME}",
+                            "add",
+                        ),  # noqa: E501
+                        (
+                            f"{LLM_INPUT_MESSAGES}.4.{MESSAGE_TOOL_CALLS}.1.{TOOL_CALL_FUNCTION_ARGUMENTS_JSON}",
+                            json.dumps(  # noqa: E501
+                                {"a": 363, "b": 42}
+                            ),
+                        ),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {
                 "messages": [
@@ -204,7 +240,7 @@ class MockSpan:
         ),
     ],
 )
-def test_get_dataset_example_input(span: MockSpan, expected_input_value: dict[str, Any]) -> None:
+def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, Any]) -> None:
     input_value = get_dataset_example_input(span)
     assert expected_input_value == input_value
 

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -138,9 +138,9 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
                 attributes=unflatten(
                     (
                         (INPUT_VALUE, "plain-text-input"),
-                        (INPUT_MIME_TYPE, "text/plain"),
+                        (INPUT_MIME_TYPE, TEXT),
                         (OUTPUT_VALUE, "plain-text-output"),
-                        (OUTPUT_MIME_TYPE, "text/plain"),
+                        (OUTPUT_MIME_TYPE, TEXT),
                         (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "user-message"),
                         (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "user"),
                         (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
@@ -159,9 +159,9 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
                 attributes=unflatten(
                     (
                         (INPUT_VALUE, "plain-text-input"),
-                        (INPUT_MIME_TYPE, "text/plain"),
+                        (INPUT_MIME_TYPE, TEXT),
                         (OUTPUT_VALUE, "plain-text-output"),
-                        (OUTPUT_MIME_TYPE, "text/plain"),
+                        (OUTPUT_MIME_TYPE, TEXT),
                         (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
                         (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
                     )
@@ -256,37 +256,43 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
     "span, expected_output_value",
     [
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables={"variable_name": "variable-value"},
-                llm_input_messages=[{"message": {"content": "user-message", "role": "user"}}],
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (
+                            LLM_PROMPT_TEMPLATE_VARIABLES,
+                            json.dumps({"variable_name": "variable-value"}),
+                        ),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "user-message"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "user"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {"messages": [{"content": "assistant-message", "role": "assistant"}]},
             id="llm-span-with-output-messages",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=[{"message": {"content": "user-message", "role": "user"}}],
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "user-message"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "user"),
+                    )
+                ),
             ),
-            {
-                "output": "plain-text-output",
-            },
+            {"output": "plain-text-output"},
             id="llm-span-with-no-output-messages-but-with-plain-text-output",
         ),
         pytest.param(
@@ -381,6 +387,6 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
         ),
     ],
 )
-def test_get_dataset_example_output(span: MockSpan, expected_output_value: dict[str, Any]) -> None:
+def test_get_dataset_example_output(span: Span, expected_output_value: dict[str, Any]) -> None:
     output_value = get_dataset_example_output(span)
     assert expected_output_value == output_value

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -40,6 +40,7 @@ OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
 OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
 OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
 TEXT = OpenInferenceMimeTypeValues.TEXT.value
+JSON = OpenInferenceMimeTypeValues.JSON.value
 LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
@@ -170,18 +171,22 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
             id="llm-span-with-no-input-messages-and-plain-text-input",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables={"variable_name": "variable-value"},
-                llm_input_messages=None,
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (
+                            LLM_PROMPT_TEMPLATE_VARIABLES,
+                            json.dumps({"variable_name": "variable-value"}),
+                        ),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {
                 "input": "plain-text-input",
@@ -190,52 +195,52 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
             id="llm-span-with-no-input-messages-and-plain-text-input-with-prompt-template-variables",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value=json.dumps({"llm-span-input": "llm-input"}),
-                input_mime_type="application/json",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"llm-span-input": "llm-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {"llm-span-input": "llm-input"},
             id="llm-span-with-no-input-messages-and-json-input",
         ),
         pytest.param(
-            MockSpan(
+            Span(
                 span_kind="CHAIN",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {"input": "plain-text-input"},
             id="chain-span-with-plain-text-input",
         ),
         pytest.param(
-            MockSpan(
+            Span(
                 span_kind="CHAIN",
-                input_value=json.dumps({"chain_input": "chain-input"}),
-                input_mime_type="application/json",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"chain_input": "chain-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {"chain_input": "chain-input"},
             id="chain-span-with-json-input",
@@ -290,7 +295,7 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
                 input_value="plain-text-input",
                 input_mime_type="text/plain",
                 output_value=json.dumps({"llm-span-output": "value"}),
-                output_mime_type="application/json",
+                output_mime_type=JSON,
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,
                 llm_output_messages=None,
@@ -303,7 +308,7 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             MockSpan(
                 span_kind="RETRIEVER",
                 input_value={"retriever-input": "retriever-input"},
-                input_mime_type="application/json",
+                input_mime_type=JSON,
                 output_value="plain-text-output",
                 output_mime_type="text/plain",
                 llm_prompt_template_variables=None,
@@ -318,7 +323,7 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             MockSpan(
                 span_kind="RETRIEVER",
                 input_value={"retriever-input": "retriever-input"},
-                input_mime_type="application/json",
+                input_mime_type=JSON,
                 output_value="plain-text-output",
                 output_mime_type="text/plain",
                 llm_prompt_template_variables=None,
@@ -333,9 +338,9 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             MockSpan(
                 span_kind="RETRIEVER",
                 input_value=json.dumps({"retriever-input": "retriever-input"}),
-                input_mime_type="application/json",
+                input_mime_type=JSON,
                 output_value=json.dumps({"retriever_output": "retriever-output"}),
-                output_mime_type="application/json",
+                output_mime_type=JSON,
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,
                 llm_output_messages=None,
@@ -348,7 +353,7 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             MockSpan(
                 span_kind="CHAIN",
                 input_value={"chain_input": "chain-input"},
-                input_mime_type="application/json",
+                input_mime_type=JSON,
                 output_value="plain-text-output",
                 output_mime_type="text/plain",
                 llm_prompt_template_variables=None,
@@ -363,9 +368,9 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             MockSpan(
                 span_kind="CHAIN",
                 input_value=json.dumps({"chain_input": "chain-input"}),
-                input_mime_type="application/json",
+                input_mime_type=JSON,
                 output_value=json.dumps({"chain_output": "chain-output"}),
-                output_mime_type="application/json",
+                output_mime_type=JSON,
                 llm_prompt_template_variables=None,
                 llm_input_messages=None,
                 llm_output_messages=None,

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -132,18 +132,20 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
             id="llm-span-with-input-messages-and-prompt-template-variables",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=[{"message": {"content": "user-message", "role": "user"}}],
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, "text/plain"),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, "text/plain"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "user-message"),
+                        (f"{LLM_INPUT_MESSAGES}.0.{MESSAGE_ROLE}", "user"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {
                 "messages": [{"content": "user-message", "role": "user"}],
@@ -151,18 +153,18 @@ TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
             id="llm-span-with-input-messages-and-no-prompt-template-variables",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=[
-                    {"message": {"content": "assistant-message", "role": "assistant"}}
-                ],
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, "text/plain"),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, "text/plain"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_CONTENT}", "assistant-message"),
+                        (f"{LLM_OUTPUT_MESSAGES}.0.{MESSAGE_ROLE}", "assistant"),
+                    )
+                ),
             ),
             {"input": "plain-text-input"},
             id="llm-span-with-no-input-messages-and-plain-text-input",

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -296,16 +296,16 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             id="llm-span-with-no-output-messages-but-with-plain-text-output",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="LLM",
-                input_value="plain-text-input",
-                input_mime_type="text/plain",
-                output_value=json.dumps({"llm-span-output": "value"}),
-                output_mime_type=JSON,
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=LLM,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, "plain-text-input"),
+                        (INPUT_MIME_TYPE, TEXT),
+                        (OUTPUT_VALUE, json.dumps({"llm-span-output": "value"})),
+                        (OUTPUT_MIME_TYPE, JSON),
+                    )
+                ),
             ),
             {"llm-span-output": "value"},
             id="llm-span-with-no-output-messages-and-json-output",

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -34,6 +34,7 @@ class MockSpan:
     retrieval_documents: Any
 
 
+CHAIN = OpenInferenceSpanKindValues.CHAIN.value
 LLM = OpenInferenceSpanKindValues.LLM.value
 RETRIEVER = OpenInferenceSpanKindValues.RETRIEVER.value
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
@@ -335,61 +336,61 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             id="retriever-span-with-retrieval-documents",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="RETRIEVER",
-                input_value={"retriever-input": "retriever-input"},
-                input_mime_type=JSON,
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=RETRIEVER,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"retriever-input": "retriever-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                    )
+                ),
             ),
             {"output": "plain-text-output"},
             id="retriever-span-with-plain-text-output-and-no-retrieval-documents",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="RETRIEVER",
-                input_value=json.dumps({"retriever-input": "retriever-input"}),
-                input_mime_type=JSON,
-                output_value=json.dumps({"retriever_output": "retriever-output"}),
-                output_mime_type=JSON,
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=RETRIEVER,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"retriever-input": "retriever-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, json.dumps({"retriever_output": "retriever-output"})),
+                        (OUTPUT_MIME_TYPE, JSON),
+                    )
+                ),
             ),
             {"retriever_output": "retriever-output"},
             id="retriever-span-with-json-output-and-no-retrieval-documents",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="CHAIN",
-                input_value={"chain_input": "chain-input"},
-                input_mime_type=JSON,
-                output_value="plain-text-output",
-                output_mime_type="text/plain",
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=CHAIN,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"chain_input": "chain-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
+                    )
+                ),
             ),
             {"output": "plain-text-output"},
             id="chain-span-with-plain-text-output",
         ),
         pytest.param(
-            MockSpan(
-                span_kind="CHAIN",
-                input_value=json.dumps({"chain_input": "chain-input"}),
-                input_mime_type=JSON,
-                output_value=json.dumps({"chain_output": "chain-output"}),
-                output_mime_type=JSON,
-                llm_prompt_template_variables=None,
-                llm_input_messages=None,
-                llm_output_messages=None,
-                retrieval_documents=None,
+            Span(
+                span_kind=CHAIN,
+                attributes=unflatten(
+                    (
+                        (INPUT_VALUE, json.dumps({"chain_input": "chain-input"})),
+                        (INPUT_MIME_TYPE, JSON),
+                        (OUTPUT_VALUE, json.dumps({"chain_output": "chain-output"})),
+                        (OUTPUT_MIME_TYPE, JSON),
+                    )
+                ),
             ),
             {"chain_output": "chain-output"},
             id="chain-span-with-json-output",

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -1,6 +1,5 @@
 import json
-from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from openinference.semconv.trace import (
@@ -19,20 +18,6 @@ from phoenix.server.api.helpers.dataset_helpers import (
     get_dataset_example_output,
 )
 from phoenix.trace.attributes import unflatten
-
-
-@dataclass
-class MockSpan:
-    span_kind: Optional[str]
-    input_value: Any
-    input_mime_type: Optional[str]
-    output_value: Any
-    output_mime_type: Optional[str]
-    llm_prompt_template_variables: Any
-    llm_input_messages: Any
-    llm_output_messages: Any
-    retrieval_documents: Any
-
 
 CHAIN = OpenInferenceSpanKindValues.CHAIN.value
 LLM = OpenInferenceSpanKindValues.LLM.value

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -8,7 +8,6 @@ from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
     OpenInferenceSpanKindValues,
     SpanAttributes,
-    ToolAttributes,
     ToolCallAttributes,
 )
 
@@ -19,32 +18,42 @@ from phoenix.server.api.helpers.dataset_helpers import (
 )
 from phoenix.trace.attributes import unflatten
 
+# DocumentAttributes
+DOCUMENT_CONTENT = DocumentAttributes.DOCUMENT_CONTENT
+DOCUMENT_ID = DocumentAttributes.DOCUMENT_ID
+DOCUMENT_SCORE = DocumentAttributes.DOCUMENT_SCORE
+
+# MessageAttributes
+MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
+MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
+MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME
+MESSAGE_NAME = MessageAttributes.MESSAGE_NAME
+MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
+MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
+
+# OpenInferenceMimeTypeValues
+JSON = OpenInferenceMimeTypeValues.JSON.value
+TEXT = OpenInferenceMimeTypeValues.TEXT.value
+
+# OpenInferenceSpanKindValues
 CHAIN = OpenInferenceSpanKindValues.CHAIN.value
 LLM = OpenInferenceSpanKindValues.LLM.value
 RETRIEVER = OpenInferenceSpanKindValues.RETRIEVER.value
+
+# SpanAttributes
 INPUT_MIME_TYPE = SpanAttributes.INPUT_MIME_TYPE
 INPUT_VALUE = SpanAttributes.INPUT_VALUE
-OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
-OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
-OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
-TEXT = OpenInferenceMimeTypeValues.TEXT.value
-JSON = OpenInferenceMimeTypeValues.JSON.value
-LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
 LLM_INPUT_MESSAGES = SpanAttributes.LLM_INPUT_MESSAGES
 LLM_OUTPUT_MESSAGES = SpanAttributes.LLM_OUTPUT_MESSAGES
-MESSAGE_CONTENT = MessageAttributes.MESSAGE_CONTENT
-MESSAGE_ROLE = MessageAttributes.MESSAGE_ROLE
-MESSAGE_NAME = MessageAttributes.MESSAGE_NAME
-MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON = MessageAttributes.MESSAGE_FUNCTION_CALL_ARGUMENTS_JSON
-MESSAGE_FUNCTION_CALL_NAME = MessageAttributes.MESSAGE_FUNCTION_CALL_NAME
-MESSAGE_TOOL_CALLS = MessageAttributes.MESSAGE_TOOL_CALLS
+LLM_PROMPT_TEMPLATE_VARIABLES = SpanAttributes.LLM_PROMPT_TEMPLATE_VARIABLES
+OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+OUTPUT_MIME_TYPE = SpanAttributes.OUTPUT_MIME_TYPE
+OUTPUT_VALUE = SpanAttributes.OUTPUT_VALUE
+RETRIEVAL_DOCUMENTS = SpanAttributes.RETRIEVAL_DOCUMENTS
+
+# ToolCallAttributes
 TOOL_CALL_FUNCTION_ARGUMENTS_JSON = ToolCallAttributes.TOOL_CALL_FUNCTION_ARGUMENTS_JSON
 TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
-TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
-RETRIEVAL_DOCUMENTS = SpanAttributes.RETRIEVAL_DOCUMENTS
-DOCUMENT_ID = DocumentAttributes.DOCUMENT_ID
-DOCUMENT_SCORE = DocumentAttributes.DOCUMENT_SCORE
-DOCUMENT_CONTENT = DocumentAttributes.DOCUMENT_CONTENT
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -65,10 +65,10 @@ TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
                 attributes=unflatten(
                     (
                         (OPENINFERENCE_SPAN_KIND, LLM),
-                        (INPUT_MIME_TYPE, TEXT),
                         (INPUT_VALUE, "plain-text-input"),
-                        (OUTPUT_MIME_TYPE, TEXT),
+                        (INPUT_MIME_TYPE, TEXT),
                         (OUTPUT_VALUE, "plain-text-output"),
+                        (OUTPUT_MIME_TYPE, TEXT),
                         (
                             LLM_PROMPT_TEMPLATE_VARIABLES,
                             json.dumps({"variable_name": "variable-value"}),

--- a/tests/unit/server/api/mutations/test_dataset_mutations.py
+++ b/tests/unit/server/api/mutations/test_dataset_mutations.py
@@ -237,10 +237,8 @@ async def test_add_span_to_dataset(
                                     "output": {
                                         "documents": [
                                             {
-                                                "document": {
-                                                    "content": "retrieved-document-content",
-                                                    "score": 1,
-                                                }
+                                                "content": "retrieved-document-content",
+                                                "score": 1,
                                             }
                                         ]
                                     },

--- a/tests/unit/server/api/mutations/test_dataset_mutations.py
+++ b/tests/unit/server/api/mutations/test_dataset_mutations.py
@@ -198,25 +198,7 @@ async def test_add_span_to_dataset(
                                         ]
                                     },
                                     "metadata": {
-                                        "llm": {
-                                            "input_messages": [
-                                                {
-                                                    "message": {
-                                                        "content": "user-message-content",
-                                                        "role": "user",
-                                                    }
-                                                }
-                                            ],
-                                            "invocation_parameters": {"temperature": 1},
-                                            "output_messages": [
-                                                {
-                                                    "message": {
-                                                        "content": "assistant-message-content",
-                                                        "role": "assistant",
-                                                    }
-                                                }
-                                            ],
-                                        },
+                                        "span_kind": "LLM",
                                         "annotations": {},
                                     },
                                     "output": {
@@ -243,20 +225,7 @@ async def test_add_span_to_dataset(
                                         ]
                                     },
                                     "metadata": {
-                                        "input": {
-                                            "value": "retriever-span-input",
-                                            "mime_type": "text/plain",
-                                        },
-                                        "retrieval": {
-                                            "documents": [
-                                                {
-                                                    "document": {
-                                                        "content": "retrieved-document-content",
-                                                        "score": 1,
-                                                    }
-                                                }
-                                            ]
-                                        },
+                                        "span_kind": "RETRIEVER",
                                         "annotations": {},
                                     },
                                 }
@@ -268,14 +237,7 @@ async def test_add_span_to_dataset(
                                     "input": {"input": "chain-span-input-value"},
                                     "output": {"output": "chain-span-output-value"},
                                     "metadata": {
-                                        "input": {
-                                            "value": "chain-span-input-value",
-                                            "mime_type": "text/plain",
-                                        },
-                                        "output": {
-                                            "value": "chain-span-output-value",
-                                            "mime_type": "text/plain",
-                                        },
+                                        "span_kind": "CHAIN",
                                         "annotations": {
                                             "test annotation": {
                                                 "label": "ambiguous",

--- a/tests/unit/server/api/mutations/test_dataset_mutations.py
+++ b/tests/unit/server/api/mutations/test_dataset_mutations.py
@@ -199,7 +199,6 @@ async def test_add_span_to_dataset(
                                     },
                                     "metadata": {
                                         "span_kind": "LLM",
-                                        "annotations": {},
                                     },
                                     "output": {
                                         "messages": [
@@ -226,7 +225,6 @@ async def test_add_span_to_dataset(
                                     },
                                     "metadata": {
                                         "span_kind": "RETRIEVER",
-                                        "annotations": {},
                                     },
                                 }
                             }


### PR DESCRIPTION
- unnest retrieval documents
- write less metadata to revisions when converting from spans
- removes unnecessary internal span interface

resolves #5526