### PR TITLE
fix(playground): use consistent playground experiment run format

### DIFF
--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -31,6 +31,7 @@ from typing_extensions import Self, TypeAlias, assert_never
 
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
+from phoenix.server.api.helpers.dataset_helpers import get_dataset_example_output
 from phoenix.server.api.input_types.ChatCompletionInput import (
     ChatCompletionInput,
     ChatCompletionOverDatasetInput,
@@ -220,7 +221,7 @@ def get_db_experiment_run(
         dataset_example_id=example_id,
         trace_id=db_trace.trace_id,
         output=models.ExperimentRunOutput(
-            task_output=get_attribute_value(db_span.attributes, LLM_OUTPUT_MESSAGES),
+            task_output=get_dataset_example_output(db_span),
         ),
         repetition_number=1,
         start_time=db_span.start_time,

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -28,6 +28,7 @@ from phoenix.db.helpers import get_dataset_example_revisions
 from phoenix.server.api.auth import IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
+from phoenix.server.api.helpers.dataset_helpers import get_dataset_example_output
 from phoenix.server.api.helpers.playground_clients import (
     PlaygroundStreamingClient,
     initialize_playground_clients,
@@ -62,7 +63,7 @@ from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Span import Span, to_gql_span
 from phoenix.server.api.types.TemplateLanguage import TemplateLanguage
 from phoenix.server.dml_event import SpanInsertEvent
-from phoenix.trace.attributes import get_attribute_value, unflatten
+from phoenix.trace.attributes import unflatten
 from phoenix.trace.schemas import SpanException
 from phoenix.utilities.json import jsonify
 from phoenix.utilities.template_formatters import (
@@ -244,7 +245,7 @@ class ChatCompletionMutationMixin:
                     dataset_example_id=revision.dataset_example_id,
                     trace_id=str(result.span.context.trace_id),
                     output=models.ExperimentRunOutput(
-                        task_output=get_attribute_value(db_span.attributes, LLM_OUTPUT_MESSAGES),
+                        task_output=get_dataset_example_output(db_span),
                     ),
                     prompt_token_count=db_span.cumulative_llm_token_count_prompt,
                     completion_token_count=db_span.cumulative_llm_token_count_completion,

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -1230,8 +1230,8 @@ class TestChatCompletionOverDatasetSubscription:
             run.pop("endTime")
         )
         assert run.pop("error") is None
-        assert isinstance(run_output := run.pop("output"), list)
-        assert len(run_output) == 1
+        assert isinstance(run_output := run.pop("output"), dict)
+        assert set(run_output.keys()) == {"messages"}
         assert (trace_id := run.pop("traceId")) is not None
         trace = run.pop("trace")
         assert trace.pop("id")
@@ -1253,8 +1253,8 @@ class TestChatCompletionOverDatasetSubscription:
             run.pop("endTime")
         )
         assert run.pop("error") is None
-        assert isinstance(run_output := run.pop("output"), list)
-        assert len(run_output) == 1
+        assert isinstance(run_output := run.pop("output"), dict)
+        assert set(run_output.keys()) == {"messages"}
         assert (trace_id := run.pop("traceId")) is not None
         trace = run.pop("trace")
         assert trace.pop("id")


### PR DESCRIPTION
Use the same format for playground experiment run output as for dataset example revisions created from a span.

resolves #5525