### PR TITLE
fix: Ensure prompt accordion interactables are always visible

### DIFF
--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -169,10 +169,22 @@ export function ModelConfigButton(props: ModelConfigButtonProps) {
             setDialog(<ModelConfigDialog {...props} />);
           });
         }}
+        title={`${ModelProviders[instance.model.provider]} ${
+          instance.model.modelName || "--"
+        }`}
       >
         <Flex direction="row" gap="size-100" alignItems="center">
           <Text weight="heavy">{ModelProviders[instance.model.provider]}</Text>
-          <Text>{instance.model.modelName || "--"}</Text>
+          <div
+            css={css`
+              max-width: 150px;
+              text-overflow: ellipsis;
+              overflow: hidden;
+              white-space: nowrap;
+            `}
+          >
+            <Text>{instance.model.modelName || "--"}</Text>
+          </div>
         </Flex>
       </Button>
       <DialogContainer

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -24,6 +24,7 @@ import {
 import { Loading } from "@phoenix/components";
 import { ConfirmNavigationDialog } from "@phoenix/components/ConfirmNavigation";
 import { resizeHandleCSS } from "@phoenix/components/resize";
+import { TemplateLanguages } from "@phoenix/components/templateEditor/constants";
 import {
   PlaygroundProvider,
   usePlaygroundContext,
@@ -212,6 +213,9 @@ const playgroundInputOutputPanelContentCSS = css`
 
 function PlaygroundContent() {
   const instances = usePlaygroundContext((state) => state.instances);
+  const templateLanguage = usePlaygroundContext(
+    (state) => state.templateLanguage
+  );
   const { datasetId } = useParams<{ datasetId: string }>();
   const isDatasetMode = datasetId != null;
   const numInstances = instances.length;
@@ -267,9 +271,15 @@ function PlaygroundContent() {
               >
                 {/* No padding on the right of the accordion item, it is handled by the stable scrollbar gutter */}
                 <View height="100%" paddingY="size-200" paddingStart="size-200">
-                  <Flex direction="row" gap="size-200">
+                  <Flex direction="row" gap="size-200" maxWidth="100%">
                     {instances.map((instance) => (
-                      <View key={instance.id} flex="1 1 0px">
+                      <View
+                        key={instance.id}
+                        // This width accomodates the model config button min-width, as well as chat message accordion
+                        // header contents such as the chat message mode radio group for AI messages
+                        minWidth="475px"
+                        flex="1 1 0px"
+                      >
                         <PlaygroundTemplate
                           key={instance.id}
                           playgroundInstanceId={instance.id}
@@ -291,11 +301,13 @@ function PlaygroundContent() {
           ) : (
             <div css={playgroundInputOutputPanelContentCSS}>
               <Accordion arrowPosition="start" size="L">
-                <AccordionItem title="Inputs" id="input">
-                  <View padding="size-200" height={"100%"}>
-                    <PlaygroundInput />
-                  </View>
-                </AccordionItem>
+                {templateLanguage !== TemplateLanguages.NONE ? (
+                  <AccordionItem title="Inputs" id="input">
+                    <View padding="size-200" height={"100%"}>
+                      <PlaygroundInput />
+                    </View>
+                  </AccordionItem>
+                ) : null}
                 <AccordionItem title="Output" id="output">
                   <View padding="size-200" height="100%">
                     <Flex direction="row" gap="size-200">

--- a/app/src/pages/playground/TemplateLanguageRadioGroup.tsx
+++ b/app/src/pages/playground/TemplateLanguageRadioGroup.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { css } from "@emotion/react";
 
 import { Radio, RadioGroup } from "@arizeai/components";
 
@@ -12,26 +13,34 @@ export function TemplateLanguageRadioGroup() {
     (state) => state.setTemplateLanguage
   );
   return (
-    <RadioGroup
-      value={language}
-      variant="inline-button"
-      aria-label="Template Language"
-      size="compact"
-      onChange={(v) => {
-        if (isTemplateLanguage(v)) {
-          setLanguage(v);
+    <div
+      css={css`
+        & * {
+          white-space: nowrap;
         }
-      }}
+      `}
     >
-      <Radio label="None" value={TemplateLanguages.NONE}>
-        None
-      </Radio>
-      <Radio label="Mustache" value={TemplateLanguages.Mustache}>
-        Mustache
-      </Radio>
-      <Radio label="F-String" value={TemplateLanguages.FString}>
-        F-String
-      </Radio>
-    </RadioGroup>
+      <RadioGroup
+        value={language}
+        variant="inline-button"
+        aria-label="Template Language"
+        size="compact"
+        onChange={(v) => {
+          if (isTemplateLanguage(v)) {
+            setLanguage(v);
+          }
+        }}
+      >
+        <Radio label="None" value={TemplateLanguages.NONE}>
+          None
+        </Radio>
+        <Radio label="Mustache" value={TemplateLanguages.Mustache}>
+          Mustache
+        </Radio>
+        <Radio label="F-String" value={TemplateLanguages.FString}>
+          F-String
+        </Radio>
+      </RadioGroup>
+    </div>
   );
 }


### PR DESCRIPTION
- Make prompts accordion section responsive via min-widths, scrolling, truncated button texts

https://github.com/user-attachments/assets/108c470b-51a5-478e-9cc3-215727a26a13

- Hide Inputs section of playground when template language is None


![2024-11-25 11 35 52](https://github.com/user-attachments/assets/586c0c22-9e3f-487e-a3f3-cdfcfe30279b)


Resolves #5485