### PR TITLE
fix(playground): block playground runs when app is readonly

### DIFF
--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -292,6 +292,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
         },
       });
       if (errors) {
+        console.log("test--", errors);
         notifyError({
           title: "Chat completion failed",
           message: errors[0].message,
@@ -358,6 +359,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
             markPlaygroundInstanceComplete(props.playgroundInstanceId);
           },
           onError: (error) => {
+            console.log("test--", error);
             setLoading(false);
             markPlaygroundInstanceComplete(props.playgroundInstanceId);
             const errorMessages =
@@ -386,6 +388,7 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
       onError(error) {
         setLoading(false);
         markPlaygroundInstanceComplete(props.playgroundInstanceId);
+        console.log("test--", error);
         const errorMessages = getErrorMessagesFromRelayMutationError(error);
         if (errorMessages != null && errorMessages.length > 0) {
           notifyError({

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -292,7 +292,6 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
         },
       });
       if (errors) {
-        console.log("test--", errors);
         notifyError({
           title: "Chat completion failed",
           message: errors[0].message,
@@ -359,7 +358,6 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
             markPlaygroundInstanceComplete(props.playgroundInstanceId);
           },
           onError: (error) => {
-            console.log("test--", error);
             setLoading(false);
             markPlaygroundInstanceComplete(props.playgroundInstanceId);
             const errorMessages =
@@ -388,7 +386,6 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
       onError(error) {
         setLoading(false);
         markPlaygroundInstanceComplete(props.playgroundInstanceId);
-        console.log("test--", error);
         const errorMessages = getErrorMessagesFromRelayMutationError(error);
         if (errorMessages != null && errorMessages.length > 0) {
           notifyError({

--- a/app/src/utils/errorUtils.ts
+++ b/app/src/utils/errorUtils.ts
@@ -72,6 +72,18 @@ const isErrorWithSource = (error: unknown): error is ErrorWithSource => {
   );
 };
 
+const isErrorsArray = (errors: unknown): errors is { message: string }[] => {
+  return (
+    Array.isArray(errors) &&
+    errors.every(
+      (error) =>
+        typeof error === "object" &&
+        error !== null &&
+        typeof error.message === "string"
+    )
+  );
+};
+
 /**
  * Extracts the error messages from a Relay subscription error.
  * A relay subscription error contains a source property with an errors array.
@@ -95,6 +107,9 @@ export const getErrorMessagesFromRelaySubscriptionError = (
 ): string[] | null => {
   if (isErrorWithSource(error)) {
     return error.source.errors.map((error) => error.message);
+  }
+  if (isErrorsArray(error)) {
+    return error.map((error) => error.message);
   }
   return null;
 };

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -25,6 +25,7 @@ from typing_extensions import assert_never
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import get_dataset_example_revisions
+from phoenix.server.api.auth import IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
 from phoenix.server.api.helpers.playground_clients import (
@@ -118,7 +119,7 @@ class ChatCompletionOverDatasetMutationPayload:
 
 @strawberry.type
 class ChatCompletionMutationMixin:
-    @strawberry.mutation
+    @strawberry.mutation(permission_classes=[IsNotReadOnly])  # type: ignore
     @classmethod
     async def chat_completion_over_dataset(
         cls,
@@ -273,7 +274,7 @@ class ChatCompletionMutationMixin:
             payload.examples.append(example_payload)
         return payload
 
-    @strawberry.mutation
+    @strawberry.mutation(permission_classes=[IsNotReadOnly])  # type: ignore
     @classmethod
     async def chat_completion(
         cls, info: Info[Context, None], input: ChatCompletionInput

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -24,6 +24,7 @@ from typing_extensions import TypeAlias, assert_never
 
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
+from phoenix.server.api.auth import IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
 from phoenix.server.api.helpers.playground_clients import (
@@ -87,7 +88,7 @@ PLAYGROUND_PROJECT_NAME = "playground"
 
 @strawberry.type
 class Subscription:
-    @strawberry.subscription
+    @strawberry.subscription(permission_classes=[IsNotReadOnly])  # type: ignore
     async def chat_completion(
         self, info: Info[Context, None], input: ChatCompletionInput
     ) -> AsyncIterator[ChatCompletionSubscriptionPayload]:
@@ -162,7 +163,7 @@ class Subscription:
         info.context.event_queue.put(SpanInsertEvent(ids=(playground_project_id,)))
         yield ChatCompletionSubscriptionResult(span=to_gql_span(db_span))
 
-    @strawberry.subscription
+    @strawberry.subscription(permission_classes=[IsNotReadOnly])  # type: ignore
     async def chat_completion_over_dataset(
         self, info: Info[Context, None], input: ChatCompletionOverDatasetInput
     ) -> AsyncIterator[ChatCompletionSubscriptionPayload]:


### PR DESCRIPTION
Blocks playground runs when app is readonly e.g., for demo isntances

Blocks and shows intelligible error for:
- streaming dataset
- streaming no dataset
- non streaming dataset
- non streaming no dataset


![Screenshot 2024-11-25 at 9 47 06 AM](https://github.com/user-attachments/assets/ff34b4e9-fb81-4c9d-b9cb-65f45a3b0be8)