### PR TITLE
chore(dx): add uv to tox allowlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -140,6 +140,8 @@ commands =
 
 [testenv:phoenix_main]
 description = Run Phoenix server
+allowlist_externals =
+  uv
 pass_env=
   PHOENIX_PORT
   PHOENIX_GRPC_PORT


### PR DESCRIPTION
tox invokes uv, which needs to be explicitly allowed in the latest tox from what I can tell.