### PR TITLE
fix(playground): fix wording on missing input variable in playground over a dataset

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -198,7 +198,7 @@ function EmptyExampleOutput({
   }
   return (
     <PlaygroundErrorWrap>
-      {`Missing output for variable${missingVariables.length > 1 ? "s" : ""}: ${missingVariables.join(
+      {`Missing input for variable${missingVariables.length > 1 ? "s" : ""}: ${missingVariables.join(
         ", "
       )}`}
     </PlaygroundErrorWrap>


### PR DESCRIPTION
the variable values come from the input, not the output