### PR TITLE
fix: Properly constrain/rename invocation params before submitting

### DIFF
--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -679,7 +679,7 @@ export const constrainInvocationParameterInputsToDefinition = (
       // modelSupportedInvocationParameters.
       ...ip,
       invocationName:
-        definitions.find((mp) => mp.canonicalName === ip.canonicalName)
+        definitions.find((mp) => areInvocationParamsEqual(mp, ip))
           ?.invocationName ?? ip.invocationName,
     }));
 };


### PR DESCRIPTION
We made a helper to prevent bad "null canonical name" comparisons but we weren't using it here.
Implementing it fixes an issue where parameters without canonical names were converted incorrectly.

## Before

![image](https://github.com/user-attachments/assets/a14cb8f9-af2f-44e3-ac3c-1bf513b21067)


## After

![image](https://github.com/user-attachments/assets/0ccb73d7-0e02-45b9-8e9f-a12ad1c13597)
