### PR TITLE
fix(playground): simplify default messages

### DIFF
--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -82,14 +82,14 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
   spanId: "fake-id",
   template: {
     __type: "chat",
-    // These id's are not 0, 1, 2, because we create a playground instance (including messages) at the top of the transformSpanAttributesToPlaygroundInstance function
+    // These id's are not 0 because we create a playground instance (including messages) at the top of the transformSpanAttributesToPlaygroundInstance function
     // Doing so increments the message id counter
     messages: [
-      { id: 2, content: "You are a chatbot", role: "system" },
-      { id: 3, content: "hello?", role: "user" },
+      { id: 1, content: "You are a chatbot", role: "system" },
+      { id: 2, content: "hello?", role: "user" },
     ],
   },
-  output: [{ id: 4, content: "This is an AI Answer", role: "ai" }],
+  output: [{ id: 3, content: "This is an AI Answer", role: "ai" }],
 };
 
 const defaultTemplate = {
@@ -97,13 +97,8 @@ const defaultTemplate = {
   messages: [
     {
       id: 0,
-      role: "system",
-      content: "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.",
-    },
-    {
-      id: 1,
       role: "user",
-      content: "Answer the question: {{question}}",
+      content: `How many r's in "{{fruit}}"?`,
     },
   ],
 };
@@ -258,14 +253,14 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
           __type: "chat",
           messages: [
             {
-              id: 2,
+              id: 1,
               role: "user",
               content: "You are a chatbot",
               toolCalls: [expectedTestOpenAIToolCall],
             },
           ],
         },
-        output: [{ id: 3, content: "This is an AI Answer", role: "ai" }],
+        output: [{ id: 2, content: "This is an AI Answer", role: "ai" }],
       },
       parsingErrors: [],
     });
@@ -309,14 +304,14 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
           __type: "chat",
           messages: [
             {
-              id: 2,
+              id: 1,
               role: "user",
               content: "You are a chatbot",
               toolCalls: [expectedAnthropicToolCall],
             },
           ],
         },
-        output: [{ id: 3, content: "This is an AI Answer", role: "ai" }],
+        output: [{ id: 2, content: "This is an AI Answer", role: "ai" }],
       },
       parsingErrors: [],
     });
@@ -363,7 +358,7 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
             definition: testSpanOpenAIToolJsonSchema,
           },
         ],
-        output: [{ id: 4, content: "This is an AI Answer", role: "ai" }],
+        output: [{ id: 3, content: "This is an AI Answer", role: "ai" }],
       },
       parsingErrors: [],
     });

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -98,12 +98,12 @@ const defaultTemplate = {
     {
       id: 0,
       role: "system",
-      content: "You are a chatbot",
+      content: "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.",
     },
     {
       id: 1,
       role: "user",
-      content: "{{question}}",
+      content: "Answer the question: {{question}}",
     },
   ],
 };

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -85,21 +85,15 @@ const generateChatCompletionTemplate = (): PlaygroundChatTemplate => ({
   messages: [
     {
       id: generateMessageId(),
-      role: "system",
-      content: "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.",
-    },
-    {
-      id: generateMessageId(),
       role: "user",
-      content: "Answer the question: {{question}}",
+      content: `How many r's in "{{fruit}}"?`,
     },
   ],
 });
 
 const DEFAULT_TEXT_COMPLETION_TEMPLATE: PlaygroundTextCompletionTemplate = {
   __type: "text_completion",
-  prompt:
-    "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.\n\nAnswer the question: {{question}}",
+  prompt: `How many r's in "{{fruit}}"?`,
 };
 
 export function createPlaygroundInstance(): PlaygroundInstance {
@@ -177,7 +171,7 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
       // manual input mode. It is indexed by the variable key. It keeps old
       // values when variables are removed or when switching to dataset input so that they can be restored.
       variablesValueCache: {
-        question: `How many r's in "strawberry"?`,
+        fruit: "strawberry",
       },
     },
     templateLanguage: TemplateLanguages.Mustache,

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -86,19 +86,20 @@ const generateChatCompletionTemplate = (): PlaygroundChatTemplate => ({
     {
       id: generateMessageId(),
       role: "system",
-      content: "You are a chatbot",
+      content: "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.",
     },
     {
       id: generateMessageId(),
       role: "user",
-      content: "{{question}}",
+      content: "Answer the question: {{question}}",
     },
   ],
 });
 
 const DEFAULT_TEXT_COMPLETION_TEMPLATE: PlaygroundTextCompletionTemplate = {
   __type: "text_completion",
-  prompt: "{{question}}",
+  prompt:
+    "Welcome to Phoenix Playground!\n\nYou are a helpful assistant.\n\nAnswer the question: {{question}}",
 };
 
 export function createPlaygroundInstance(): PlaygroundInstance {
@@ -175,7 +176,9 @@ export const createPlaygroundStore = (initialProps: InitialPlaygroundState) => {
       // variablesValueCache is used to store the values of variables for the
       // manual input mode. It is indexed by the variable key. It keeps old
       // values when variables are removed or when switching to dataset input so that they can be restored.
-      variablesValueCache: {},
+      variablesValueCache: {
+        question: `How many r's in "strawberry"?`,
+      },
     },
     templateLanguage: TemplateLanguages.Mustache,
     instances: getInitialInstances(initialProps),


### PR DESCRIPTION
<img width="1003" alt="Screenshot 2024-11-26 at 5 18 42 PM" src="https://github.com/user-attachments/assets/0255b67a-f35e-4b84-8425-4e8e8fe414d9">

- I find myself frequently deleting the default system prompt when testing out playground
- Gemini requires non-empty message content, so you can't just hit run with `{{question}}` and an empty template variable
- Seeing for the first time, I think it helps to have other content aside from the template variable in the prompt to grok the connection between template variables in the prompt and values in the right panel.

resolves #5533
