### PR TITLE
ci: remove version pin on typing extensions

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -22,7 +22,7 @@ respx # For OpenAI testing
 tenacity
 tiktoken
 types-pytz
-typing-extensions==4.7.0
+typing-extensions
 vcrpy
 aiohttp>=3.0; python_version < "3.10"
 urllib3<2.0; python_version < "3.10"


### PR DESCRIPTION
- need openai 1.55.3 to [this issue](https://community.openai.com/t/client-openai-returns-error-client-init-got-an-unexpected-keyword-argument-proxies/1035249)
    - https://github.com/openai/openai-python/pull/1904/files
    - openai==1.55.3 depends on typing-extensions>=4.11,<5
