### PR TITLE
ci: put upper bound on httpx version because it's breaking existing …

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -5,7 +5,7 @@ arize
 asgi-lifespan
 asyncpg
 grpc-interceptor[testing]
-httpx # For OpenAI testing
+httpx<0.28
 httpx-ws
 litellm>=1.0.3
 nest-asyncio # for executor testing


### PR DESCRIPTION
…unit tests