### PR TITLE
fix: compute trace latency rather than relying on root span latency

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1746,6 +1746,7 @@ type Trace implements Node {
   traceId: String!
   startTime: DateTime!
   endTime: DateTime!
+  latencyMs: Float
   projectId: GlobalID!
   projectSessionId: GlobalID
   session: ProjectSession

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -91,6 +91,7 @@ export function TraceDetails(props: TraceDetailsProps) {
                   }
                 }
               }
+              latencyMs
             }
           }
         }
@@ -101,6 +102,8 @@ export function TraceDetails(props: TraceDetailsProps) {
       fetchPolicy: "store-and-network",
     }
   );
+  const traceLatencyMs =
+    data.project.trace?.latencyMs != null ? data.project.trace.latencyMs : null;
   const spansList: Span[] = useMemo(() => {
     const gqlSpans = data.project.trace?.spans.edges || [];
     return gqlSpans.map((node) => node.span);
@@ -134,6 +137,7 @@ export function TraceDetails(props: TraceDetailsProps) {
     >
       <TraceHeader
         rootSpan={rootSpan}
+        latencyMs={traceLatencyMs}
         sessionId={data.project.trace?.projectSessionId}
       />
       <PanelGroup
@@ -181,14 +185,15 @@ export function TraceDetails(props: TraceDetailsProps) {
 
 function TraceHeader({
   rootSpan,
+  latencyMs,
   sessionId,
 }: {
   rootSpan: Span | null;
+  latencyMs: number | null;
   sessionId?: string | null;
 }) {
   const { projectId } = useParams();
-  const { latencyMs, statusCode, spanAnnotations } = rootSpan ?? {
-    latencyMs: null,
+  const { statusCode, spanAnnotations } = rootSpan ?? {
     statusCode: "UNSET",
     spanAnnotations: [],
   };

--- a/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<05ddaf3cf129db9abc342c1c612a4b46>>
+ * @generated SignedSource<<9dd908cc052bd3956f853158bf2f9b99>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type TraceDetailsQuery$variables = {
 export type TraceDetailsQuery$data = {
   readonly project: {
     readonly trace?: {
+      readonly latencyMs: number | null;
       readonly projectSessionId: string | null;
       readonly spans: {
         readonly edges: ReadonlyArray<{
@@ -87,6 +88,13 @@ v4 = {
   "storageKey": null
 },
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "latencyMs",
+  "storageKey": null
+},
+v6 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -195,13 +203,7 @@ v5 = {
                       "name": "parentId",
                       "storageKey": null
                     },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "latencyMs",
-                      "storageKey": null
-                    },
+                    (v5/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -264,7 +266,8 @@ v5 = {
             }
           ],
           "storageKey": "spans(first:1000)"
-        }
+        },
+        (v5/*: any*/)
       ],
       "storageKey": null
     }
@@ -290,7 +293,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
@@ -322,7 +325,7 @@ return {
             "name": "__typename",
             "storageKey": null
           },
-          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
@@ -334,16 +337,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5ac539f9f161693ada371b5d0e55f17f",
+    "cacheID": "7d3725cc8aaa73d8aace29a3c6bba171",
     "id": null,
     "metadata": {},
     "name": "TraceDetailsQuery",
     "operationKind": "query",
-    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        projectSessionId\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              context {\n                spanId\n                traceId\n              }\n              name\n              spanKind\n              statusCode: propagatedStatusCode\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n              spanAnnotations {\n                name\n                label\n                score\n                annotatorKind\n              }\n            }\n          }\n        }\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        projectSessionId\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              context {\n                spanId\n                traceId\n              }\n              name\n              spanKind\n              statusCode: propagatedStatusCode\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n              spanAnnotations {\n                name\n                label\n                score\n                annotatorKind\n              }\n            }\n          }\n        }\n        latencyMs\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "69f82cff480af6a8d9e0cc0bb393d3e3";
+(node as any).hash = "540621a43dd4aa451855cb81219f0fdf";
 
 export default node;

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Annotated, Optional, Union
 
 import strawberry
 from openinference.semconv.trace import SpanAttributes
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, select
 from sqlalchemy.orm import contains_eager
 from strawberry import UNSET, Private, lazy
 from strawberry.relay import Connection, GlobalID, Node, NodeID
@@ -45,17 +45,17 @@ class Trace(Node):
             result = (
                 await session.execute(
                     select(
-                        func.max(models.Span.end_time).label("last_end_time"),
-                        func.min(models.Span.start_time).label("first_start_time"),
-                    ).where(models.Span.trace_rowid == self.id_attr)
+                        models.Trace.start_time,
+                        models.Trace.end_time,
+                    ).where(models.Trace.id == self.id_attr)
                 )
             ).first()
         if result is None:
             return None
-        last_end_time, first_start_time = result
-        if not isinstance(last_end_time, datetime) or not isinstance(first_start_time, datetime):
+        start_time, end_time = result
+        if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
             return None
-        return (last_end_time - first_start_time).total_seconds() * 1000
+        return (end_time - start_time).total_seconds() * 1000
 
     @strawberry.field
     async def project_id(self) -> GlobalID:

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -42,20 +42,12 @@ class Trace(Node):
         info: Info[Context, None],
     ) -> Optional[float]:
         async with info.context.db() as session:
-            result = (
-                await session.execute(
-                    select(
-                        models.Trace.start_time,
-                        models.Trace.end_time,
-                    ).where(models.Trace.id == self.id_attr)
-                )
-            ).first()
-        if result is None:
-            return None
-        start_time, end_time = result
-        if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
-            return None
-        return (end_time - start_time).total_seconds() * 1000
+            latency = await session.scalar(
+                select(
+                    models.Trace.latency_ms,
+                ).where(models.Trace.id == self.id_attr)
+            )
+        return latency
 
     @strawberry.field
     async def project_id(self) -> GlobalID:


### PR DESCRIPTION
The latency of the trace is not always the same as the latency of the root span, e.g., when a root span returns a coroutine that is executed later.

resolves #5337
