### PR TITLE
fix: prevent useless tooltips from appearing in projects

### DIFF
--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -175,7 +175,7 @@ export function ProjectPageContent({
             );
           }}
         </TabPane>
-        <TabPane name="Spans" title="Spans">
+        <TabPane name="Spans">
           {({ isSelected }) => {
             return (
               isSelected &&
@@ -189,7 +189,7 @@ export function ProjectPageContent({
             );
           }}
         </TabPane>
-        <TabPane name="Sessions" title="Sessions">
+        <TabPane name="Sessions">
           {({ isSelected }) => {
             return (
               isSelected &&


### PR DESCRIPTION
When the `title` attr is present on TabPane, hovering any child within the pane causes a native html tooltip to appear. We don't need the `title` attr on the panes.