### PR TITLE
chore(js): add rudamentary types for experiments

### DIFF
--- a/js/packages/phoenix-client/src/types/annotations.ts
+++ b/js/packages/phoenix-client/src/types/annotations.ts
@@ -1,0 +1,1 @@
+export type AnnotatorKind = "HUMAN" | "LLM";

--- a/js/packages/phoenix-client/src/types/core.ts
+++ b/js/packages/phoenix-client/src/types/core.ts
@@ -1,0 +1,6 @@
+/**
+ * A uniquely identifiable node in Phoenix
+ */
+export interface Node {
+  id: string;
+}

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -1,0 +1,21 @@
+import { Node } from "./core";
+
+/**
+ * An example is a record to feed into an AI task
+ */
+export interface Example extends Node {
+  id: string;
+  updatedAt: Date;
+  input: Record<string, unknown>;
+  output: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * A dataset is a collection of examples for an AI task
+ */
+export interface Dataset extends Node {
+  id: string;
+  versionId: string;
+  examples: Example[];
+}

--- a/js/packages/phoenix-client/src/types/experiments.ts
+++ b/js/packages/phoenix-client/src/types/experiments.ts
@@ -27,7 +27,7 @@ export interface ExperimentRun extends Node {
   experimentId: string;
   datasetExampleId: string;
   repetitionNumber: number;
-  output?: string | {} | null;
+  output?: string | Record<string, unknown> | null;
   error: string | null;
   traceId: string | null;
 }

--- a/js/packages/phoenix-client/src/types/experiments.ts
+++ b/js/packages/phoenix-client/src/types/experiments.ts
@@ -1,6 +1,7 @@
 import { AnnotatorKind } from "./annotations";
 import { Node } from "./core";
 import { Example } from "./datasets";
+
 /**
  * An experiment is a set of task runs on a dataset version
  */

--- a/js/packages/phoenix-client/src/types/experiments.ts
+++ b/js/packages/phoenix-client/src/types/experiments.ts
@@ -6,7 +6,6 @@ import { Example } from "./datasets";
  * An experiment is a set of task runs on a dataset version
  */
 export interface Experiment extends Node {
-  id: string;
   datasetId: string;
   datasetVersionId: string;
   repetitions: number;
@@ -20,7 +19,6 @@ export interface Experiment extends Node {
  * The result of running an experiment on a single example
  */
 export interface ExperimentRun extends Node {
-  id: string;
   startTime: Date;
   endTime: Date;
   /**

--- a/js/packages/phoenix-client/src/types/experiments.ts
+++ b/js/packages/phoenix-client/src/types/experiments.ts
@@ -1,0 +1,77 @@
+import { AnnotatorKind } from "./annotations";
+import { Node } from "./core";
+import { Example } from "./datasets";
+/**
+ * An experiment is a set of task runs on a dataset version
+ */
+export interface Experiment extends Node {
+  id: string;
+  datasetId: string;
+  datasetVersionId: string;
+  repetitions: number;
+  /**
+   * The project under which the experiment task traces are recorded
+   */
+  projectName: string;
+}
+
+/**
+ * The result of running an experiment on a single example
+ */
+export interface ExperimentRun extends Node {
+  id: string;
+  startTime: Date;
+  endTime: Date;
+  /**
+   * What experiment the run belongs to
+   */
+  experimentId: string;
+  datasetExampleId: string;
+  repetitionNumber: number;
+  output?: string | {} | null;
+  error: string | null;
+  traceId: string | null;
+}
+
+export type EvaluationResult = {
+  score: number | null;
+  label: string | null;
+  metadata: Record<string, unknown>;
+  explanation: string | null;
+};
+
+export interface ExperimentEvaluationRun extends Node {
+  experimentRunId: string;
+  startTime: Date;
+  endTime: Date;
+  /**
+   * THe name of the evaluation
+   */
+  name: string;
+  annotatorKind: AnnotatorKind;
+  error: string | null;
+  result: EvaluationResult | null;
+  /**
+   * The trace id of the evaluation
+   * This is null if the trace is deleted or never recorded
+   */
+  trace_id: string | null;
+}
+
+export type TaskOutput = string | boolean | number | object | null;
+
+export type ExperimentTask =
+  | ((example: Example) => Promise<TaskOutput>)
+  | ((example: Example) => TaskOutput);
+
+export interface ExperimentParameters {
+  /**
+   * The number of examples to run the experiment on
+   */
+  nExamples: number;
+  /**
+   * The number of repetitions to run the experiment
+   * e.g. the number of times to run the task
+   */
+  nRepetitions: number;
+}


### PR DESCRIPTION
Adds types under client for now to get the abstractions right under the client.