### PR TITLE
fix: increase python upper bound to include python 3.13

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e-test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ./app
@@ -16,6 +16,14 @@ jobs:
       # We're skipping WebKit because of recurring issues with caching,
       # despite always installing it on cache-hit.
       CI_PLAYWRIGHT_SKIP_WEBKIT: true
+    strategy:
+      fail-fast: false
+      matrix:
+        py: [ 3.9, 3.12, 3.13 ]
+        os: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
+        exclude:
+          - py: 3.13
+            os: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Install PNPM
@@ -50,20 +58,22 @@ jobs:
         run: pnpm run build
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-      - uses: astral-sh/setup-uv@v3
+          python-version: ${{ matrix.py }}
+      - uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: uv pip install --system ../. uvloop
+      - run: uv pip install --system uvloop
+        if: runner.os != 'Windows'
+      - run: uv pip install --system ../.
       - run: uv pip list
       - name: Run Playwright tests
         run: pnpm exec playwright test
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-py${{ matrix.py }}-${{ matrix.os }}
           path: app/playwright-report/
           retention-days: 30

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -97,9 +97,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
       - run: uvx --with tox-uv tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
@@ -120,9 +120,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
       - run: uvx --with tox-uv tox run -e phoenix_otel -- -ra -x
 
   #  clean-jupyter-notebooks:
@@ -131,7 +131,7 @@ jobs:
   #    if: ${{ needs.changes.outputs.ipynb == 'true' }}
   #    strategy:
   #      matrix:
-  #        py: [ 3.12 ]
+  #        py: [ 3.13 ]
   #        os: [ ubuntu-latest ]
   #    runs-on: ${{ matrix.os }}
   #    steps:
@@ -142,9 +142,9 @@ jobs:
   #        with:
   #          python-version: ${{ matrix.py }}
   #      - name: Set up `uv`
-  #        uses: astral-sh/setup-uv@v3
+  #        uses: astral-sh/setup-uv@v4
   #        with:
-  #          version: 0.5.5
+  #          version: 0.5.8
   #          enable-cache: true
   #          cache-dependency-glob: |
   #            pyproject.toml
@@ -159,8 +159,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.12]
+        py: [3.12, 3.13]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -171,9 +172,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -188,9 +189,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.12]
+        py: [3.12, 3.13]
         os: [ubuntu-latest]
+        exclude:
+          - py: 3.13
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -200,9 +204,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -229,9 +233,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -245,8 +249,9 @@ jobs:
     name: Ruff
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.12]
+        py: [3.12, 3.13]
         os: [ubuntu-latest]
     steps:
       - name: Checkout repository
@@ -256,9 +261,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
       - name: Run `ruff`
         run: uvx --with tox-uv tox run -e ruff
       - run: git diff --exit-code
@@ -269,8 +274,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: [3.9, 3.12, 3.13]
         os: [ubuntu-latest]
     steps:
       - name: Checkout repository
@@ -285,9 +291,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -303,8 +309,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: [3.9, 3.12, 3.13]
         os: [ubuntu-latest]
     steps:
       - name: Checkout repository
@@ -319,9 +326,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -337,9 +344,13 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        py: [3.9, 3.12, 3.13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        exclude:
+          - py: 3.13
+            os: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -354,9 +365,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -379,8 +390,9 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: [3.9, 3.12, 3.13]
         os: [ubuntu-latest]
     steps:
       - name: Checkout repository
@@ -395,9 +407,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -413,14 +425,20 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.phoenix == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: [3.9, 3.12, 3.13]
         db: [sqlite, postgresql]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         exclude:
           - db: postgresql
             os: windows-latest
           - db: postgresql
+            os: macos-latest
+          - db: postgresql
+            os: macos-13
+          - py: 3.13
+            db: sqlite
             os: macos-13
     env:
       CI_TEST_DB_BACKEND: ${{ matrix.db }}
@@ -450,9 +468,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v4
         with:
-          version: 0.5.5
+          version: 0.5.8
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/python-cron.yml
+++ b/.github/workflows/python-cron.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
           version: 0.5.5
           enable-cache: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix"
 description = "AI Observability and Evaluation"
 readme = "README.md"
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9, <3.14"
 license = {text="Elastic-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "scikit-learn",
@@ -28,12 +29,12 @@ dependencies = [
   "starlette",
   "uvicorn",
   "psutil",
-  "strawberry-graphql==0.247.0",  # need to pin version because we're monkey-patching
+  "strawberry-graphql==0.253.1",  # need to pin version because we're monkey-patching
   "pyarrow",
   "typing-extensions>=4.6",
   "scipy",
-  "wrapt<1.17; sys_platform == 'darwin'",
-  "wrapt; sys_platform != 'darwin'",
+  "wrapt<1.17; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+  "wrapt>=1.17; sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "protobuf>=3.20.2, <6.0",
   "grpcio",
   "grpc-interceptor",
@@ -87,7 +88,7 @@ dev = [
   "pytest-postgresql",
   "asyncpg",
   "psycopg[binary,pool]",
-  "strawberry-graphql[debug-server,opentelemetry]==0.247.0",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[debug-server,opentelemetry]==0.253.1",  # need to pin version because we're monkey-patching
   "pre-commit",
   "arize[AutoEmbeddings, LLM_Evaluation]",
   "llama-index>=0.10.3",
@@ -133,7 +134,7 @@ container = [
   "opentelemetry-instrumentation-sqlalchemy",
   "opentelemetry-instrumentation-grpc",
   "py-grpc-prometheus",
-  "strawberry-graphql[opentelemetry]==0.247.0",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[opentelemetry]==0.253.1",  # need to pin version because we're monkey-patching
   "uvloop; platform_system != 'Windows'",
   "fast-hdbscan>=0.2.0",
   "numba>=0.60.0",  # https://github.com/astral-sh/uv/issues/6281
@@ -229,7 +230,7 @@ dependencies = [
   "py-grpc-prometheus",
   "pypistats",  # this is needed to type-check third-party packages
   "requests",  # this is needed to type-check third-party packages
-  "strawberry-graphql[opentelemetry]==0.247.0",  # need to pin version because we're monkey-patching
+  "strawberry-graphql[opentelemetry]==0.253.1",  # need to pin version because we're monkey-patching
   "tenacity",
   "types-cachetools",
   "types-protobuf",

--- a/requirements/build-graphql-schema.txt
+++ b/requirements/build-graphql-schema.txt
@@ -1,1 +1,1 @@
-strawberry-graphql[cli]==0.247.0
+strawberry-graphql[cli]==0.253.1

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -18,7 +18,7 @@ psycopg[binary,pool]
 py-grpc-prometheus
 pypistats  # this is needed to type-check third-party packages
 requests  # this is needed to type-check third-party packages
-strawberry-graphql[opentelemetry]==0.247.0  # need to pin version because we're monkey-patching
+strawberry-graphql[opentelemetry]==0.253.1  # need to pin version because we're monkey-patching
 tenacity
 types-cachetools
 types-protobuf

--- a/src/phoenix/server/api/input_types/DataQualityMetricInput.py
+++ b/src/phoenix/server/api/input_types/DataQualityMetricInput.py
@@ -8,7 +8,10 @@ from typing_extensions import Annotated
 from phoenix.core.model_schema import Column
 from phoenix.metrics import Metric
 from phoenix.metrics.mixins import UnaryOperator
-from phoenix.server.api.types.DataQualityMetric import DataQualityMetric
+from phoenix.server.api.types.DataQualityMetric import (
+    DATA_QUALITY_METRIC_FACTORIES,
+    DataQualityMetric,
+)
 
 
 @strawberry.input
@@ -26,7 +29,7 @@ class DataQualityMetricInput:
     metric_instance: strawberry.Private[Metric] = field(init=False)
 
     def __post_init__(self) -> None:
-        metric_instance = self.metric.value()
+        metric_instance = DATA_QUALITY_METRIC_FACTORIES[self.metric]()
         if isinstance(metric_instance, UnaryOperator):
             if not isinstance(self.column_name, str):
                 raise ValueError(f"column name must not be null for {self.metric.name}")

--- a/src/phoenix/server/api/input_types/PerformanceMetricInput.py
+++ b/src/phoenix/server/api/input_types/PerformanceMetricInput.py
@@ -3,7 +3,10 @@ import strawberry
 from phoenix.core.model_schema import ACTUAL_LABEL, PREDICTION_LABEL, Column, Model
 from phoenix.metrics import Metric
 from phoenix.metrics.mixins import EvaluationMetric
-from phoenix.server.api.types.PerformanceMetric import PerformanceMetric
+from phoenix.server.api.types.PerformanceMetric import (
+    PERFORMANCE_METRIC_FUNCTIONS,
+    PerformanceMetric,
+)
 
 
 @strawberry.input
@@ -14,5 +17,5 @@ class PerformanceMetricInput:
         return EvaluationMetric(
             actual=Column(model[ACTUAL_LABEL].name),
             predicted=Column(model[PREDICTION_LABEL].name),
-            eval=self.metric.value,
+            eval=PERFORMANCE_METRIC_FUNCTIONS[self.metric],
         )

--- a/src/phoenix/server/api/types/DataQualityMetric.py
+++ b/src/phoenix/server/api/types/DataQualityMetric.py
@@ -1,22 +1,40 @@
-from enum import Enum
+from enum import Enum, auto
 from functools import partial
+from typing import Callable, Mapping, cast
 
 import strawberry
 
+from phoenix.metrics import Metric
 from phoenix.metrics.metrics import Cardinality, Count, Max, Mean, Min, PercentEmpty, Quantile, Sum
 
 
 @strawberry.enum
 class DataQualityMetric(Enum):
-    cardinality = Cardinality
-    percentEmpty = PercentEmpty
-    mean = Mean
-    sum = Sum
-    min = Min
-    max = Max
-    count = Count
-    p01 = partial(Quantile, probability=0.01)
-    p25 = partial(Quantile, probability=0.25)
-    p50 = partial(Quantile, probability=0.50)
-    p75 = partial(Quantile, probability=0.75)
-    p99 = partial(Quantile, probability=0.99)
+    cardinality = auto()
+    percentEmpty = auto()
+    mean = auto()
+    sum = auto()
+    min = auto()
+    max = auto()
+    count = auto()
+    p01 = auto()
+    p25 = auto()
+    p50 = auto()
+    p75 = auto()
+    p99 = auto()
+
+
+DATA_QUALITY_METRIC_FACTORIES: Mapping[DataQualityMetric, Callable[[], Metric]] = {
+    DataQualityMetric.cardinality: cast(Callable[[], Metric], Cardinality),
+    DataQualityMetric.percentEmpty: cast(Callable[[], Metric], PercentEmpty),
+    DataQualityMetric.mean: cast(Callable[[], Metric], Mean),
+    DataQualityMetric.sum: cast(Callable[[], Metric], Sum),
+    DataQualityMetric.min: cast(Callable[[], Metric], Min),
+    DataQualityMetric.max: cast(Callable[[], Metric], Max),
+    DataQualityMetric.count: cast(Callable[[], Metric], Count),
+    DataQualityMetric.p01: cast(Callable[[], Metric], partial(Quantile, probability=0.01)),
+    DataQualityMetric.p25: cast(Callable[[], Metric], partial(Quantile, probability=0.25)),
+    DataQualityMetric.p50: cast(Callable[[], Metric], partial(Quantile, probability=0.50)),
+    DataQualityMetric.p75: cast(Callable[[], Metric], partial(Quantile, probability=0.75)),
+    DataQualityMetric.p99: cast(Callable[[], Metric], partial(Quantile, probability=0.99)),
+}

--- a/src/phoenix/server/api/types/PerformanceMetric.py
+++ b/src/phoenix/server/api/types/PerformanceMetric.py
@@ -1,5 +1,5 @@
-from enum import Enum
-from functools import partial
+from enum import Enum, auto
+from typing import Callable, Mapping, cast
 
 import strawberry
 
@@ -8,6 +8,9 @@ from phoenix.metrics.wrappers import SkEval
 
 @strawberry.enum
 class PerformanceMetric(Enum):
-    # To become enum values, functions need to be wrapped in partial.
-    # See https://stackoverflow.com/a/40339397
-    accuracyScore = partial(SkEval.accuracy_score)  # type: ignore
+    accuracyScore = auto()
+
+
+PERFORMANCE_METRIC_FUNCTIONS: Mapping[PerformanceMetric, Callable[..., float]] = {
+    PerformanceMetric.accuracyScore: cast(Callable[..., float], SkEval.accuracy_score),
+}

--- a/src/phoenix/server/api/types/TimeSeries.py
+++ b/src/phoenix/server/api/types/TimeSeries.py
@@ -15,7 +15,10 @@ from phoenix.metrics.timeseries import timeseries
 from phoenix.server.api.input_types.Granularity import Granularity, to_timestamps
 from phoenix.server.api.input_types.TimeRange import TimeRange
 from phoenix.server.api.interceptor import GqlValueMediator
-from phoenix.server.api.types.DataQualityMetric import DataQualityMetric
+from phoenix.server.api.types.DataQualityMetric import (
+    DATA_QUALITY_METRIC_FACTORIES,
+    DataQualityMetric,
+)
 from phoenix.server.api.types.InferencesRole import InferencesRole
 from phoenix.server.api.types.ScalarDriftMetricEnum import ScalarDriftMetric
 from phoenix.server.api.types.VectorDriftMetricEnum import VectorDriftMetric
@@ -100,7 +103,7 @@ def get_data_quality_timeseries_data(
     granularity: Granularity,
     inferences_role: InferencesRole,
 ) -> list[TimeSeriesDataPoint]:
-    metric_instance = metric.value()
+    metric_instance = DATA_QUALITY_METRIC_FACTORIES[metric]()
     if isinstance(metric_instance, UnaryOperator):
         metric_instance = replace(
             metric_instance,

--- a/src/phoenix/server/types.py
+++ b/src/phoenix/server/types.py
@@ -219,31 +219,31 @@ class UserId(_DbId):
 
 
 @dataclass(frozen=True)
-class UserClaimSet(ClaimSet):
+class UserClaimSet(ClaimSet):  # type: ignore[override,unused-ignore]
     subject: Optional[UserId] = None
     attributes: Optional[UserTokenAttributes] = None
 
 
 @dataclass(frozen=True)
-class PasswordResetTokenClaims(UserClaimSet):
+class PasswordResetTokenClaims(UserClaimSet):  # type: ignore[override,unused-ignore]
     token_id: Optional[PasswordResetTokenId] = None
     attributes: Optional[PasswordResetTokenAttributes] = None
 
 
 @dataclass(frozen=True)
-class AccessTokenClaims(UserClaimSet):
+class AccessTokenClaims(UserClaimSet):  # type: ignore[override,unused-ignore]
     token_id: Optional[AccessTokenId] = None
     attributes: Optional[AccessTokenAttributes] = None
 
 
 @dataclass(frozen=True)
-class RefreshTokenClaims(UserClaimSet):
+class RefreshTokenClaims(UserClaimSet):  # type: ignore[override,unused-ignore]
     token_id: Optional[RefreshTokenId] = None
     attributes: Optional[RefreshTokenAttributes] = None
 
 
 @dataclass(frozen=True)
-class ApiKeyClaims(UserClaimSet):
+class ApiKeyClaims(UserClaimSet):  # type: ignore[override,unused-ignore]
     token_id: Optional[ApiKeyId] = None
     attributes: Optional[ApiKeyAttributes] = None
 


### PR DESCRIPTION
resolves #5082 

# ⚠️ Caveats
1. Python 3.13 is not supported on Intel x86_64 macOS due to issue with `wrapt`
2. `build_openapi_schema` fails `git diff` on Python 3.13 due to `Unprocessable Entity` being renamed as `Unprocessable Content`