### PR TITLE
docs: add support for hiding LLM invocation parameters in masking span attributes

### DIFF
--- a/docs/tracing/how-to-tracing/customize-spans/masking-span-attributes.md
+++ b/docs/tracing/how-to-tracing/customize-spans/masking-span-attributes.md
@@ -6,7 +6,7 @@ The OpenInference Specification defines a set of environment variables you can c
 
 The possible settings are:
 
-<table data-full-width="false"><thead><tr><th width="298">Environment Variable Name</th><th width="281">Effect</th><th width="86">Type</th><th>Default</th></tr></thead><tbody><tr><td>OPENINFERENCE_HIDE_INPUTS</td><td>Hides input value, all input messages &#x26; embedding input text</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUTS</td><td>Hides output value &#x26; all output messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_INPUT_MESSAGES</td><td>Hides all input messages &#x26; embedding input text</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUT_MESSAGES</td><td>Hides all output messages</td><td>bool</td><td>False</td></tr><tr><td>PENINFERENCE_HIDE_INPUT_IMAGES</td><td>Hides images from input messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_INPUT_TEXT</td><td>Hides text from input messages &#x26; input embeddings</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUT_TEXT</td><td>Hides text from output messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_EMBEDDING_VECTORS</td><td>Hides returned embedding vectors</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH</td><td>Limits characters of a base64 encoding of an image</td><td>int</td><td>32,000</td></tr></tbody></table>
+<table data-full-width="false"><thead><tr><th width="298">Environment Variable Name</th><th width="281">Effect</th><th width="86">Type</th><th>Default</th></tr></thead><tbody><tr><td>OPENINFERENCE_HIDE_INPUTS</td><td>Hides input value, all input messages &#x26; embedding input text</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUTS</td><td>Hides output value &#x26; all output messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_INPUT_MESSAGES</td><td>Hides all input messages &#x26; embedding input text</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUT_MESSAGES</td><td>Hides all output messages</td><td>bool</td><td>False</td></tr><tr><td>PENINFERENCE_HIDE_INPUT_IMAGES</td><td>Hides images from input messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_INPUT_TEXT</td><td>Hides text from input messages &#x26; input embeddings</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_OUTPUT_TEXT</td><td>Hides text from output messages</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_EMBEDDING_VECTORS</td><td>Hides returned embedding vectors</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS</td><td>Hides LLM invocation parameters</td><td>bool</td><td>False</td></tr><tr><td>OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH</td><td>Limits characters of a base64 encoding of an image</td><td>int</td><td>32,000</td></tr></tbody></table>
 
 To set up this configuration you can either:
 
@@ -33,6 +33,7 @@ config = TraceConfig(
     hide_input_text=...,
     hide_output_text=...,
     hide_embedding_vectors=...,
+    hide_llm_invocation_parameters=...,
     base64_image_max_length=...,
 )
 


### PR DESCRIPTION
The latest release of `python-openinference-instrumentation`: [v0.1.20](https://github.com/Arize-ai/openinference/releases/tag/python-openinference-instrumentation-v0.1.20) now supports masking invocation params with the `TraceConfig`. (related PR - https://github.com/Arize-ai/openinference/pull/1171)

This PR updates the [`Masking Span Attributes` ](https://github.com/Arize-ai/phoenix/blob/docs/docs/tracing/how-to-tracing/customize-spans/masking-span-attributes.md) page from the docs for the same.