### PR TITLE
ci: remove windows for playwright tests

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         py: [ 3.9, 3.12, 3.13 ]
-        os: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, macos-latest, macos-13 ]
         exclude:
           - py: 3.13
             os: macos-13


### PR DESCRIPTION
It's unclear why it timed out.

```
[WebServer] INFO:     Started server process [7932]
[WebServer] INFO:     Waiting for application startup.
[WebServer] INFO:     Application startup complete.
[WebServer] INFO:     Uvicorn running on http://0.0.0.0:6006/ (Press CTRL+C to quit)

Error: Timed out waiting 60000ms from config.webServer.
```