### PR TITLE
feat(prompts): Implement prompts as code examples beneath prompt

### DIFF
--- a/app/src/components/code/PythonBlock.tsx
+++ b/app/src/components/code/PythonBlock.tsx
@@ -24,7 +24,7 @@ export function PythonBlock(props: PythonBlockProps) {
       {...props}
       basicSetup={{
         lineNumbers: false,
-        foldGutter: false,
+        foldGutter: true,
         bracketMatching: true,
         syntaxHighlighting: true,
         highlightActiveLine: false,

--- a/app/src/pages/prompt/PromptCodeExportCard.tsx
+++ b/app/src/pages/prompt/PromptCodeExportCard.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useState } from "react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import { Card } from "@arizeai/components";
+
+import {
+  CodeLanguage,
+  CodeLanguageRadioGroup,
+  PythonBlock,
+  TypeScriptBlock,
+} from "@phoenix/components/code";
+
+import { PromptCodeExportCard__main$key } from "./__generated__/PromptCodeExportCard__main.graphql";
+import { mapPromptToSnippet } from "./promptCodeSnippets";
+
+export function PromptCodeExportCard({
+  promptVersion,
+}: {
+  promptVersion: PromptCodeExportCard__main$key;
+}) {
+  const [language, setLanguage] = useState<CodeLanguage>("Python");
+  const data = useFragment<PromptCodeExportCard__main$key>(
+    graphql`
+      fragment PromptCodeExportCard__main on PromptVersion {
+        invocationParameters
+        modelName
+        modelProvider
+        outputSchema {
+          schema
+        }
+        tools {
+          definition
+        }
+        template {
+          __typename
+          ... on PromptChatTemplate {
+            messages {
+              ... on JSONPromptMessage {
+                role
+                jsonContent: content
+              }
+              ... on TextPromptMessage {
+                role
+                content
+              }
+            }
+          }
+          ... on PromptStringTemplate {
+            template
+          }
+        }
+        templateFormat
+        templateType
+      }
+    `,
+    promptVersion
+  );
+  const snippet = useMemo(
+    () => mapPromptToSnippet({ promptVersion: data, language }),
+    [data, language]
+  );
+  return (
+    <Card
+      title="Code"
+      variant="compact"
+      extra={
+        <CodeLanguageRadioGroup language={language} onChange={setLanguage} />
+      }
+    >
+      {language === "Python" ? (
+        <PythonBlock value={snippet} />
+      ) : language === "TypeScript" ? (
+        <TypeScriptBlock value={snippet} />
+      ) : null}
+    </Card>
+  );
+}

--- a/app/src/pages/prompt/PromptCodeExportCard.tsx
+++ b/app/src/pages/prompt/PromptCodeExportCard.tsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { Card } from "@arizeai/components";
+import { Accordion, AccordionItem, Card } from "@arizeai/components";
 
-import { CopyToClipboardButton, Flex } from "@phoenix/components";
+import { CopyToClipboardButton, Flex, View } from "@phoenix/components";
 import {
   CodeLanguage,
   CodeLanguageRadioGroup,
@@ -65,6 +65,7 @@ export function PromptCodeExportCard({
     <Card
       title="Code"
       variant="compact"
+      bodyStyle={{ padding: 0 }}
       extra={
         <Flex gap="size-100">
           <CodeLanguageRadioGroup language={language} onChange={setLanguage} />
@@ -72,11 +73,17 @@ export function PromptCodeExportCard({
         </Flex>
       }
     >
-      {language === "Python" ? (
-        <PythonBlock value={snippet} />
-      ) : language === "TypeScript" ? (
-        <TypeScriptBlock value={snippet} />
-      ) : null}
+      <Accordion>
+        <AccordionItem title="Snippet" id="snippet">
+          <View padding="size-100">
+            {language === "Python" ? (
+              <PythonBlock value={snippet} />
+            ) : language === "TypeScript" ? (
+              <TypeScriptBlock value={snippet} />
+            ) : null}
+          </View>
+        </AccordionItem>
+      </Accordion>
     </Card>
   );
 }

--- a/app/src/pages/prompt/PromptCodeExportCard.tsx
+++ b/app/src/pages/prompt/PromptCodeExportCard.tsx
@@ -4,6 +4,7 @@ import { graphql } from "relay-runtime";
 
 import { Card } from "@arizeai/components";
 
+import { CopyToClipboardButton, Flex } from "@phoenix/components";
 import {
   CodeLanguage,
   CodeLanguageRadioGroup,
@@ -65,7 +66,10 @@ export function PromptCodeExportCard({
       title="Code"
       variant="compact"
       extra={
-        <CodeLanguageRadioGroup language={language} onChange={setLanguage} />
+        <Flex gap="size-100">
+          <CodeLanguageRadioGroup language={language} onChange={setLanguage} />
+          <CopyToClipboardButton text={snippet} />
+        </Flex>
       }
     >
       {language === "Python" ? (

--- a/app/src/pages/prompt/PromptIndexPage.tsx
+++ b/app/src/pages/prompt/PromptIndexPage.tsx
@@ -1,19 +1,15 @@
-import React, { useState } from "react";
+import React from "react";
 import { Heading } from "react-aria-components";
 import { graphql, useFragment } from "react-relay";
 
 import { Accordion, AccordionItem, Card } from "@arizeai/components";
 
 import { Flex, View } from "@phoenix/components";
-import {
-  CodeLanguage,
-  CodeLanguageRadioGroup,
-  PythonBlock,
-} from "@phoenix/components/code";
 
 import { PromptIndexPage__aside$key } from "./__generated__/PromptIndexPage__aside.graphql";
 import { PromptIndexPage__main$key } from "./__generated__/PromptIndexPage__main.graphql";
 import { PromptChatMessages } from "./PromptChatMessages";
+import { PromptCodeExportCard } from "./PromptCodeExportCard";
 import { PromptInvocationParameters } from "./PromptInvocationParameters";
 import { PromptLatestVersionsList } from "./PromptLatestVersionsList";
 import { usePromptIdLoader } from "./usePromptIdLoader";
@@ -28,7 +24,6 @@ export function PromptIndexPageContent({
 }: {
   prompt: PromptIndexPage__main$key;
 }) {
-  const [language, setLanguage] = useState<CodeLanguage>("Python");
   const data = useFragment<PromptIndexPage__main$key>(
     graphql`
       fragment PromptIndexPage__main on Prompt {
@@ -37,6 +32,7 @@ export function PromptIndexPageContent({
             node {
               ...PromptInvocationParameters__main
               ...PromptChatMessages__main
+              ...PromptCodeExportCard__main
             }
           }
         }
@@ -84,18 +80,7 @@ export function PromptIndexPageContent({
                 </AccordionItem>
               </Accordion>
             </Card>
-            <Card
-              title="Code"
-              variant="compact"
-              extra={
-                <CodeLanguageRadioGroup
-                  language={language}
-                  onChange={setLanguage}
-                />
-              }
-            >
-              <PythonBlock value="Hello world" />
-            </Card>
+            <PromptCodeExportCard promptVersion={latestVersion} />
           </Flex>
         </View>
       </View>

--- a/app/src/pages/prompt/PromptVersionDetailsPage.tsx
+++ b/app/src/pages/prompt/PromptVersionDetailsPage.tsx
@@ -7,6 +7,7 @@ import { Flex, View } from "@phoenix/components";
 
 import { promptVersionLoaderQuery$data } from "./__generated__/promptVersionLoaderQuery.graphql";
 import { PromptChatMessages } from "./PromptChatMessages";
+import { PromptCodeExportCard } from "./PromptCodeExportCard";
 import { PromptInvocationParameters } from "./PromptInvocationParameters";
 
 export function PromptVersionDetailsPage() {
@@ -45,6 +46,7 @@ function PromptVersionDetailsPageContent({
             </AccordionItem>
           </Accordion>
         </Card>
+        <PromptCodeExportCard promptVersion={promptVersion} />
       </Flex>
     </View>
   );

--- a/app/src/pages/prompt/PromptVersionDetailsPage.tsx
+++ b/app/src/pages/prompt/PromptVersionDetailsPage.tsx
@@ -21,7 +21,7 @@ function PromptVersionDetailsPageContent({
   promptVersion: promptVersionLoaderQuery$data["promptVersion"];
 }) {
   return (
-    <View padding="size-200" width="100%">
+    <View padding="size-200" width="100%" overflow="auto">
       <Flex
         direction="column"
         gap="size-200"

--- a/app/src/pages/prompt/__generated__/PromptCodeExportCard__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptCodeExportCard__main.graphql.ts
@@ -1,0 +1,223 @@
+/**
+ * @generated SignedSource<<4955a8471cbd8cc7ab7fd47d6329c9a3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+export type PromptMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
+export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
+export type PromptTemplateType = "CHAT" | "STRING";
+import { FragmentRefs } from "relay-runtime";
+export type PromptCodeExportCard__main$data = {
+  readonly invocationParameters: any | null;
+  readonly modelName: string;
+  readonly modelProvider: string;
+  readonly outputSchema: {
+    readonly schema: any;
+  } | null;
+  readonly template: {
+    readonly __typename: "PromptChatTemplate";
+    readonly messages: ReadonlyArray<{
+      readonly content?: string;
+      readonly jsonContent?: any;
+      readonly role?: PromptMessageRole;
+    }>;
+  } | {
+    readonly __typename: "PromptStringTemplate";
+    readonly template: string;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+  readonly templateFormat: PromptTemplateFormat;
+  readonly templateType: PromptTemplateType;
+  readonly tools: ReadonlyArray<{
+    readonly definition: any;
+  }>;
+  readonly " $fragmentType": "PromptCodeExportCard__main";
+};
+export type PromptCodeExportCard__main$key = {
+  readonly " $data"?: PromptCodeExportCard__main$data;
+  readonly " $fragmentSpreads": FragmentRefs<"PromptCodeExportCard__main">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "role",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PromptCodeExportCard__main",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "invocationParameters",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "modelName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "modelProvider",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "JSONSchema",
+      "kind": "LinkedField",
+      "name": "outputSchema",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "schema",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ToolDefinition",
+      "kind": "LinkedField",
+      "name": "tools",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "definition",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "template",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "messages",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/),
+                    {
+                      "alias": "jsonContent",
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "content",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "JSONPromptMessage",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v0/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "content",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "TextPromptMessage",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "PromptChatTemplate",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "template",
+              "storageKey": null
+            }
+          ],
+          "type": "PromptStringTemplate",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "templateFormat",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "templateType",
+      "storageKey": null
+    }
+  ],
+  "type": "PromptVersion",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "f6305f2188d6170391baf5bce0277c69";
+
+export default node;

--- a/app/src/pages/prompt/__generated__/PromptIndexPage__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptIndexPage__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e499062a95936b7eccc8d91c8f6dd096>>
+ * @generated SignedSource<<2f228aa566d95f140a047b30ae4091a2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type PromptIndexPage__main$data = {
   readonly promptVersions: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly " $fragmentSpreads": FragmentRefs<"PromptChatMessages__main" | "PromptInvocationParameters__main">;
+        readonly " $fragmentSpreads": FragmentRefs<"PromptChatMessages__main" | "PromptCodeExportCard__main" | "PromptInvocationParameters__main">;
       };
     }>;
   };
@@ -65,6 +65,11 @@ const node: ReaderFragment = {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "PromptChatMessages__main"
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "PromptCodeExportCard__main"
                 }
               ],
               "storageKey": null
@@ -85,6 +90,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "272d9002d4e1031d850f68a838d7af35";
+(node as any).hash = "bad8124cb99a783012034d1cfffa5beb";
 
 export default node;

--- a/app/src/pages/prompt/__generated__/promptLoaderQuery.graphql.ts
+++ b/app/src/pages/prompt/__generated__/promptLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<77a2a97237b09726a5449b9e87b324f1>>
+ * @generated SignedSource<<484a77fe30a3963a0e17f423f5014342>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -276,6 +276,56 @@ return {
                             "name": "templateFormat",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "modelName",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "modelProvider",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "JSONSchema",
+                            "kind": "LinkedField",
+                            "name": "outputSchema",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "schema",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ToolDefinition",
+                            "kind": "LinkedField",
+                            "name": "tools",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "definition",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
                           (v3/*: any*/)
                         ],
                         "storageKey": null
@@ -327,12 +377,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cc52d3c66ae43601b24f5f3dc620ccbf",
+    "cacheID": "79dc8ffe092f21960ec4b3e483af541f",
     "id": null,
     "metadata": {},
     "name": "promptLoaderQuery",
     "operationKind": "query",
-    "text": "query promptLoaderQuery(\n  $id: GlobalID!\n) {\n  prompt: node(id: $id) {\n    __typename\n    id\n    ... on Prompt {\n      name\n      ...PromptIndexPage__main\n      ...PromptVersionsPageContent__main\n      ...PromptLayout__main\n    }\n  }\n}\n\nfragment PromptChatMessages__main on PromptVersion {\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptIndexPage__aside on Prompt {\n  description\n  ...PromptLatestVersionsListFragment\n}\n\nfragment PromptIndexPage__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        ...PromptInvocationParameters__main\n        ...PromptChatMessages__main\n      }\n    }\n  }\n  ...PromptIndexPage__aside\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n\nfragment PromptLatestVersionsListFragment on Prompt {\n  latestVersions: promptVersions(first: 5) {\n    edges {\n      version: node {\n        id\n        description\n      }\n    }\n  }\n}\n\nfragment PromptLayout__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n\nfragment PromptVersionsList__main on Prompt {\n  promptVersions {\n    edges {\n      version: node {\n        id\n        description\n      }\n    }\n  }\n}\n\nfragment PromptVersionsPageContent__main on Prompt {\n  ...PromptVersionsList__main\n}\n"
+    "text": "query promptLoaderQuery(\n  $id: GlobalID!\n) {\n  prompt: node(id: $id) {\n    __typename\n    id\n    ... on Prompt {\n      name\n      ...PromptIndexPage__main\n      ...PromptVersionsPageContent__main\n      ...PromptLayout__main\n    }\n  }\n}\n\nfragment PromptChatMessages__main on PromptVersion {\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptCodeExportCard__main on PromptVersion {\n  invocationParameters\n  modelName\n  modelProvider\n  outputSchema {\n    schema\n  }\n  tools {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateFormat\n  templateType\n}\n\nfragment PromptIndexPage__aside on Prompt {\n  description\n  ...PromptLatestVersionsListFragment\n}\n\nfragment PromptIndexPage__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        ...PromptInvocationParameters__main\n        ...PromptChatMessages__main\n        ...PromptCodeExportCard__main\n      }\n    }\n  }\n  ...PromptIndexPage__aside\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n\nfragment PromptLatestVersionsListFragment on Prompt {\n  latestVersions: promptVersions(first: 5) {\n    edges {\n      version: node {\n        id\n        description\n      }\n    }\n  }\n}\n\nfragment PromptLayout__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n\nfragment PromptVersionsList__main on Prompt {\n  promptVersions {\n    edges {\n      version: node {\n        id\n        description\n      }\n    }\n  }\n}\n\nfragment PromptVersionsPageContent__main on Prompt {\n  ...PromptVersionsList__main\n}\n"
   }
 };
 })();

--- a/app/src/pages/prompt/__generated__/promptVersionLoaderQuery.graphql.ts
+++ b/app/src/pages/prompt/__generated__/promptVersionLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c2994fc8df019c1e562af9548883e3d>>
+ * @generated SignedSource<<e76ec250e8c9ef2f02b841a2ef8f5609>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,7 +24,7 @@ export type promptVersionLoaderQuery$data = {
       readonly definition: any;
     }>;
     readonly user?: string | null;
-    readonly " $fragmentSpreads": FragmentRefs<"PromptChatMessages__main" | "PromptInvocationParameters__main">;
+    readonly " $fragmentSpreads": FragmentRefs<"PromptChatMessages__main" | "PromptCodeExportCard__main" | "PromptInvocationParameters__main">;
   };
 };
 export type promptVersionLoaderQuery = {
@@ -143,6 +143,11 @@ return {
                 "args": null,
                 "kind": "FragmentSpread",
                 "name": "PromptChatMessages__main"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "PromptCodeExportCard__main"
               },
               (v4/*: any*/),
               (v5/*: any*/),
@@ -269,9 +274,34 @@ return {
                 "name": "templateFormat",
                 "storageKey": null
               },
-              (v4/*: any*/),
               (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "modelProvider",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "JSONSchema",
+                "kind": "LinkedField",
+                "name": "outputSchema",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "schema",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v7/*: any*/),
+              (v4/*: any*/),
               (v8/*: any*/)
             ],
             "type": "PromptVersion",
@@ -283,16 +313,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a0bbd9435b68c46f99e884efea87a0bf",
+    "cacheID": "ca612db6a8c270e44675d56c67a78f04",
     "id": null,
     "metadata": {},
     "name": "promptVersionLoaderQuery",
     "operationKind": "query",
-    "text": "query promptVersionLoaderQuery(\n  $id: GlobalID!\n) {\n  promptVersion: node(id: $id) {\n    __typename\n    id\n    ... on PromptVersion {\n      ...PromptInvocationParameters__main\n      ...PromptChatMessages__main\n      description\n      invocationParameters\n      modelName\n      tools {\n        definition\n      }\n      user\n    }\n  }\n}\n\nfragment PromptChatMessages__main on PromptVersion {\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n"
+    "text": "query promptVersionLoaderQuery(\n  $id: GlobalID!\n) {\n  promptVersion: node(id: $id) {\n    __typename\n    id\n    ... on PromptVersion {\n      ...PromptInvocationParameters__main\n      ...PromptChatMessages__main\n      ...PromptCodeExportCard__main\n      description\n      invocationParameters\n      modelName\n      tools {\n        definition\n      }\n      user\n    }\n  }\n}\n\nfragment PromptChatMessages__main on PromptVersion {\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptCodeExportCard__main on PromptVersion {\n  invocationParameters\n  modelName\n  modelProvider\n  outputSchema {\n    schema\n  }\n  tools {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        __typename\n        ... on JSONPromptMessage {\n          role\n          jsonContent: content\n        }\n        ... on TextPromptMessage {\n          role\n          content\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateFormat\n  templateType\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n"
   }
 };
 })();
 
-(node as any).hash = "695fd26b98b3ee3026952b6d82e17372";
+(node as any).hash = "c3d7a33362c62c6db87bda93909e0a61";
 
 export default node;

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -20,7 +20,7 @@ export type PromptToSnippet = ({
   | "template"
 >) => string;
 
-const TABS = "    ";
+const TABS = "  ";
 
 /**
  * Indentation-aware JSON formatter
@@ -117,9 +117,9 @@ export const promptCodeSnippets: Record<
         });
         args.push(`tools=${fmt}`);
       }
-      if (prompt.outputSchema) {
+      if (prompt.outputSchema && "output_schema" in prompt.outputSchema) {
         const fmt = jsonFormatter({
-          json: prompt.outputSchema,
+          json: prompt.outputSchema.output_schema,
           level: 1,
         });
         args.push(`response_format=${fmt}`);
@@ -178,9 +178,9 @@ print(completion.choices[0].message)
         });
         args.push(`tools: ${fmt}`);
       }
-      if (prompt.outputSchema) {
+      if (prompt.outputSchema && "output_schema" in prompt.outputSchema) {
         const fmt = jsonFormatter({
-          json: prompt.outputSchema,
+          json: prompt.outputSchema.output_schema,
           level: 1,
           removeKeyQuotes: true,
         });

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -1,0 +1,110 @@
+import { CodeLanguage } from "@phoenix/components/code";
+import { isObject } from "@phoenix/typeUtils";
+
+import type { PromptCodeExportCard__main$data as PromptVersion } from "./__generated__/PromptCodeExportCard__main.graphql";
+
+export type PromptToSnippet = ({
+  invocationParameters,
+  modelName,
+  modelProvider,
+  outputSchema,
+  tools,
+  template,
+}: Pick<
+  PromptVersion,
+  | "invocationParameters"
+  | "modelName"
+  | "modelProvider"
+  | "outputSchema"
+  | "tools"
+  | "template"
+>) => string;
+
+const TABS = "    ";
+
+const jsonFormatter = (json: unknown, level: number) => {
+  const tabsWithLevel = TABS.repeat(level);
+  let fmt = JSON.stringify(json, null, TABS);
+  // add TABS before every line except the first
+  // this allows you to add additional indentation to the emitted JSON
+  fmt = fmt
+    .split("\n")
+    .map((line, index) => (index > 0 ? tabsWithLevel + line : line))
+    .join("\n");
+  return fmt;
+};
+
+export const promptCodeSnippets: Record<
+  CodeLanguage,
+  Record<string, PromptToSnippet>
+> = {
+  Python: {
+    openai: (prompt) => {
+      if (!("messages" in prompt.template)) {
+        throw new Error("Prompt template does not contain messages");
+      }
+      const args: string[] = [];
+      if (prompt.modelName) {
+        args.push(`model="${prompt.modelName}"`);
+      }
+      if (prompt.invocationParameters) {
+        const invocationArgs = Object.entries(prompt.invocationParameters).map(
+          ([key, value]) => `${key}=${value}`
+        );
+        args.push(`${invocationArgs.join(",\n")}`);
+      }
+      let messages = "";
+      if (prompt.template.messages.length > 0) {
+        const fmt = jsonFormatter(prompt.template.messages, 0);
+        messages = `${fmt}`;
+        args.push(`messages=messages`);
+      }
+      if (isObject(prompt.tools) && "tools" in prompt.tools) {
+        const fmt = jsonFormatter(prompt.tools.tools, 1);
+        args.push(`tools=${fmt}`);
+      }
+      if (prompt.outputSchema) {
+        const fmt = jsonFormatter(prompt.outputSchema, 1);
+        args.push(`response_format=${fmt}`);
+      }
+
+      return `
+from openai import OpenAI
+client = OpenAI()
+${
+  messages
+    ? `
+messages=${messages}
+# ^ apply additional templating to messages if needed
+`
+    : ""
+}
+completion = client.chat.completions.create(
+${TABS}${args.join(",\n" + TABS)}
+)
+
+print(completion.choices[0].message)
+`.trim();
+    },
+  },
+  TypeScript: {
+    openai: () => {
+      return `
+`.trim();
+    },
+  },
+};
+
+export const mapPromptToSnippet = ({
+  promptVersion,
+  language,
+}: {
+  promptVersion: PromptVersion;
+  language: CodeLanguage;
+}) => {
+  const generator = promptCodeSnippets[language][promptVersion.modelProvider];
+  if (!generator) {
+    return `We do not have a code snippet for ${language} and ${promptVersion.modelProvider}`;
+  }
+  return generator(promptVersion);
+};

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -22,7 +22,29 @@ export type PromptToSnippet = ({
 
 const TABS = "    ";
 
-const jsonFormatter = (json: unknown, level: number) => {
+/**
+ * Indentation-aware JSON formatter
+ *
+ * @returns The formatted JSON string
+ */
+const jsonFormatter = ({
+  json,
+  level,
+  removeKeyQuotes = false,
+}: {
+  /**
+   * The JSON object to format
+   */
+  json: unknown;
+  /**
+   * The indentation level
+   */
+  level: number;
+  /**
+   * Whether to remove quotes from keys
+   */
+  removeKeyQuotes?: boolean;
+}) => {
   const tabsWithLevel = TABS.repeat(level);
   let fmt = JSON.stringify(json, null, TABS);
   // add TABS before every line except the first
@@ -31,6 +53,12 @@ const jsonFormatter = (json: unknown, level: number) => {
     .split("\n")
     .map((line, index) => (index > 0 ? tabsWithLevel + line : line))
     .join("\n");
+
+  if (removeKeyQuotes) {
+    // Replace quoted keys with unquoted keys, but only when they're valid identifiers
+    fmt = fmt.replace(/"([a-zA-Z_$][a-zA-Z0-9_$]*)"\s*:/g, "$1:");
+  }
+
   return fmt;
 };
 
@@ -55,16 +83,25 @@ export const promptCodeSnippets: Record<
       }
       let messages = "";
       if (prompt.template.messages.length > 0) {
-        const fmt = jsonFormatter(prompt.template.messages, 0);
+        const fmt = jsonFormatter({
+          json: prompt.template.messages,
+          level: 0,
+        });
         messages = `${fmt}`;
         args.push(`messages=messages`);
       }
       if (isObject(prompt.tools) && "tools" in prompt.tools) {
-        const fmt = jsonFormatter(prompt.tools.tools, 1);
+        const fmt = jsonFormatter({
+          json: prompt.tools.tools,
+          level: 1,
+        });
         args.push(`tools=${fmt}`);
       }
       if (prompt.outputSchema) {
-        const fmt = jsonFormatter(prompt.outputSchema, 1);
+        const fmt = jsonFormatter({
+          json: prompt.outputSchema,
+          level: 1,
+        });
         args.push(`response_format=${fmt}`);
       }
 
@@ -88,8 +125,63 @@ print(completion.choices[0].message)
     },
   },
   TypeScript: {
-    openai: () => {
+    openai: (prompt) => {
+      if (!("messages" in prompt.template)) {
+        throw new Error("Prompt template does not contain messages");
+      }
+      const args: string[] = [];
+      if (prompt.modelName) {
+        args.push(`model: "${prompt.modelName}"`);
+      }
+      if (prompt.invocationParameters) {
+        const invocationArgs = Object.entries(prompt.invocationParameters).map(
+          ([key, value]) => `${key}: ${value}`
+        );
+        args.push(`${invocationArgs.join(",\n")}`);
+      }
+      let messages = "";
+      if (prompt.template.messages.length > 0) {
+        const fmt = jsonFormatter({
+          json: prompt.template.messages,
+          level: 0,
+          removeKeyQuotes: true,
+        });
+        messages = `${fmt}`;
+        args.push(`messages`);
+      }
+      if (isObject(prompt.tools) && "tools" in prompt.tools) {
+        const fmt = jsonFormatter({
+          json: prompt.tools.tools,
+          level: 1,
+          removeKeyQuotes: true,
+        });
+        args.push(`tools: ${fmt}`);
+      }
+      if (prompt.outputSchema) {
+        const fmt = jsonFormatter({
+          json: prompt.outputSchema,
+          level: 1,
+          removeKeyQuotes: true,
+        });
+        args.push(`response_format: ${fmt}`);
+      }
+
       return `
+import OpenAI from "openai";
+const client = new OpenAI();
+${
+  messages
+    ? `
+const messages = ${messages};
+// ^ apply additional templating to messages if needed
+`
+    : ""
+}
+const response = client.chat.completions.create({
+${TABS}${args.join(",\n" + TABS)}
+});
+
+response.then((completion) => console.log(completion.choices[0].message));
 `.trim();
     },
   },

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -1,5 +1,4 @@
 import { CodeLanguage } from "@phoenix/components/code";
-import { isObject } from "@phoenix/typeUtils";
 
 import type { PromptCodeExportCard__main$data as PromptVersion } from "./__generated__/PromptCodeExportCard__main.graphql";
 
@@ -110,16 +109,16 @@ export const promptCodeSnippets: Record<
         messages = `${fmt}`;
         args.push(`messages=messages`);
       }
-      if (isObject(prompt.tools) && "tools" in prompt.tools) {
+      if (prompt.tools) {
         const fmt = jsonFormatter({
-          json: prompt.tools.tools,
+          json: prompt.tools.map((tool) => tool.definition),
           level: 1,
         });
         args.push(`tools=${fmt}`);
       }
-      if (prompt.outputSchema && "output_schema" in prompt.outputSchema) {
+      if (prompt.outputSchema && "schema" in prompt.outputSchema) {
         const fmt = jsonFormatter({
-          json: prompt.outputSchema.output_schema,
+          json: prompt.outputSchema.schema,
           level: 1,
         });
         args.push(`response_format=${fmt}`);
@@ -170,17 +169,17 @@ print(completion.choices[0].message)
         messages = `${fmt}`;
         args.push(`messages`);
       }
-      if (isObject(prompt.tools) && "tools" in prompt.tools) {
+      if (prompt.tools) {
         const fmt = jsonFormatter({
-          json: prompt.tools.tools,
+          json: prompt.tools.map((tool) => tool.definition),
           level: 1,
           removeKeyQuotes: true,
         });
         args.push(`tools: ${fmt}`);
       }
-      if (prompt.outputSchema && "output_schema" in prompt.outputSchema) {
+      if (prompt.outputSchema && "schema" in prompt.outputSchema) {
         const fmt = jsonFormatter({
-          json: prompt.outputSchema.output_schema,
+          json: prompt.outputSchema.schema,
           level: 1,
           removeKeyQuotes: true,
         });

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -107,6 +107,7 @@ export const promptCodeSnippets: Record<
 
       return `
 from openai import OpenAI
+
 client = OpenAI()
 ${
   messages
@@ -168,7 +169,8 @@ print(completion.choices[0].message)
 
       return `
 import OpenAI from "openai";
-const client = new OpenAI();
+
+const openai = new OpenAI();
 ${
   messages
     ? `
@@ -177,7 +179,7 @@ const messages = ${messages};
 `
     : ""
 }
-const response = client.chat.completions.create({
+const response = openai.chat.completions.create({
 ${TABS}${args.join(",\n" + TABS)}
 });
 

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -62,6 +62,26 @@ const jsonFormatter = ({
   return fmt;
 };
 
+/**
+ * A map of languages to model providers to code snippets
+ *
+ * @todo replace with a react-like DSL, for example something like the following:
+ * @example
+ * ```tsx
+ * code(
+ *   { language, provider },
+ *   [
+ *     openai(),
+ *     messages({messages}),
+ *     completion(null, [argument(null, tools({ tools }))
+ *   ]
+ * )
+ * ```
+ * where each function takes a props object and optional children, and returns a string.
+ *
+ * That way, each component can manage how to emit its portion of the string based on language and model provider,
+ * accessible via context from the top level code component.
+ */
 export const promptCodeSnippets: Record<
   CodeLanguage,
   Record<string, PromptToSnippet>

--- a/app/src/pages/prompt/promptCodeSnippets.tsx
+++ b/app/src/pages/prompt/promptCodeSnippets.tsx
@@ -70,9 +70,9 @@ const jsonFormatter = ({
  * code(
  *   { language, provider },
  *   [
- *     openai(),
+ *     providerSetup(),
  *     messages({messages}),
- *     completion(null, [argument(null, tools({ tools }))
+ *     providerCompletion(null, [argument({messages}), argument({tools}), argument({response_format})])
  *   ]
  * )
  * ```

--- a/app/src/pages/prompt/promptVersionLoader.tsx
+++ b/app/src/pages/prompt/promptVersionLoader.tsx
@@ -22,6 +22,7 @@ export async function promptVersionLoader(args: LoaderFunctionArgs) {
           ... on PromptVersion {
             ...PromptInvocationParameters__main
             ...PromptChatMessages__main
+            ...PromptCodeExportCard__main
             description
             invocationParameters
             modelName

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -62,10 +62,7 @@ from phoenix.server.api.types.PromptVersion import (
     PromptTemplateType,
     PromptVersion,
 )
-from phoenix.server.api.types.PromptVersionTemplate import (
-    PromptChatTemplate,
-    TextPromptMessage,
-)
+from phoenix.server.api.types.PromptVersionTemplate import PromptChatTemplate, TextPromptMessage
 from phoenix.server.api.types.SortDir import SortDir
 from phoenix.server.api.types.Span import Span, to_gql_span
 from phoenix.server.api.types.SystemApiKey import SystemApiKey
@@ -587,7 +584,21 @@ class Query:
                             }
                         )
                     ],
-                    output_schema=None,
+                    output_schema={
+                        "_version": "output-schema-v1",
+                        "output_schema": {
+                            "type": "json_schema",
+                            "json_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "temperature": {"type": "number"},
+                                    "location": {"type": "string"},
+                                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                                },
+                                "required": ["temperature", "location", "unit"],
+                            },
+                        },
+                    },
                     model_name="gpt-4o",
                     model_provider="openai",
                 )

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -51,6 +51,7 @@ from phoenix.server.api.types.Functionality import Functionality
 from phoenix.server.api.types.GenerativeModel import GenerativeModel
 from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
 from phoenix.server.api.types.InferencesRole import AncillaryInferencesRole, InferencesRole
+from phoenix.server.api.types.JSONSchema import JSONSchema
 from phoenix.server.api.types.Model import Model
 from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, connection_from_list
@@ -563,30 +564,32 @@ class Query:
                     tools=[
                         ToolDefinition(
                             definition={
-                                "name": "get_current_weather",
-                                "description": "Get the current weather in a given location",
-                                "parameters": {
-                                    "type": "object",
-                                    "properties": {
-                                        "location": {
-                                            "type": "string",
-                                            "description": "A location in the world",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_current_weather",
+                                    "description": "Get the current weather in a given location",
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                            "location": {
+                                                "type": "string",
+                                                "description": "A location in the world",
+                                            },
+                                            "unit": {
+                                                "type": "string",
+                                                "enum": ["celsius", "fahrenheit"],
+                                                "default": "fahrenheit",
+                                                "description": "The unit of temperature",
+                                            },
                                         },
-                                        "unit": {
-                                            "type": "string",
-                                            "enum": ["celsius", "fahrenheit"],
-                                            "default": "fahrenheit",
-                                            "description": "The unit of temperature",
-                                        },
+                                        "required": ["location"],
                                     },
-                                    "required": ["location"],
                                 },
                             }
                         )
                     ],
-                    output_schema={
-                        "_version": "output-schema-v1",
-                        "output_schema": {
+                    output_schema=JSONSchema(
+                        schema={
                             "type": "json_schema",
                             "json_schema": {
                                 "type": "object",
@@ -598,7 +601,7 @@ class Query:
                                 "required": ["temperature", "location", "unit"],
                             },
                         },
-                    },
+                    ),
                     model_name="gpt-4o",
                     model_provider="openai",
                 )

--- a/src/phoenix/server/api/types/Prompt.py
+++ b/src/phoenix/server/api/types/Prompt.py
@@ -10,15 +10,8 @@ from strawberry.types import Info
 
 from phoenix.server.api.context import Context
 from phoenix.server.api.helpers.prompts.models import PromptMessageRole
-from phoenix.server.api.types.pagination import (
-    ConnectionArgs,
-    CursorString,
-    connection_from_list,
-)
-from phoenix.server.api.types.PromptVersionTemplate import (
-    PromptChatTemplate,
-    TextPromptMessage,
-)
+from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, connection_from_list
+from phoenix.server.api.types.PromptVersionTemplate import PromptChatTemplate, TextPromptMessage
 
 from .JSONSchema import JSONSchema
 from .PromptVersion import PromptTemplateFormat, PromptTemplateType, PromptVersion
@@ -90,6 +83,21 @@ class Prompt(Node):
                         }
                     )
                 ],
+                output_schema={
+                    "_version": "output-schema-v1",
+                    "output_schema": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "type": "object",
+                            "properties": {
+                                "temperature": {"type": "number"},
+                                "location": {"type": "string"},
+                                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                            },
+                            "required": ["temperature", "location", "unit"],
+                        },
+                    },
+                },
                 model_name="gpt-4o",
                 model_provider="openai",
             ),

--- a/src/phoenix/server/api/types/Prompt.py
+++ b/src/phoenix/server/api/types/Prompt.py
@@ -62,30 +62,32 @@ class Prompt(Node):
                 tools=[
                     ToolDefinition(
                         definition={
-                            "name": "get_current_weather",
-                            "description": "Get the current weather in a given location",
-                            "parameters": {
-                                "type": "object",
-                                "properties": {
-                                    "location": {
-                                        "type": "string",
-                                        "description": "A location in the world",
+                            "type": "function",
+                            "function": {
+                                "name": "get_current_weather",
+                                "description": "Get the current weather in a given location",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "location": {
+                                            "type": "string",
+                                            "description": "A location in the world",
+                                        },
+                                        "unit": {
+                                            "type": "string",
+                                            "enum": ["celsius", "fahrenheit"],
+                                            "default": "fahrenheit",
+                                            "description": "The unit of temperature",
+                                        },
                                     },
-                                    "unit": {
-                                        "type": "string",
-                                        "enum": ["celsius", "fahrenheit"],
-                                        "default": "fahrenheit",
-                                        "description": "The unit of temperature",
-                                    },
+                                    "required": ["location"],
                                 },
-                                "required": ["location"],
                             },
                         }
                     )
                 ],
-                output_schema={
-                    "_version": "output-schema-v1",
-                    "output_schema": {
+                output_schema=JSONSchema(
+                    schema={
                         "type": "json_schema",
                         "json_schema": {
                             "type": "object",
@@ -97,7 +99,7 @@ class Prompt(Node):
                             "required": ["temperature", "location", "unit"],
                         },
                     },
-                },
+                ),
                 model_name="gpt-4o",
                 model_provider="openai",
             ),


### PR DESCRIPTION
https://github.com/user-attachments/assets/a171b067-d6b2-439c-b111-384a9c9482ff


- [x] Collapsible code accordion

![2024-12-30 14 12 18](https://github.com/user-attachments/assets/94ed052f-e73d-45cd-8c99-ac31f743fc66)

### openai

- [x] python prompts as code
- [x] typescript prompts as code

Resolves #5776 