### PR TITLE
chore(prompts): add prompt version tags graphql schema with mocks

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1452,6 +1452,7 @@ type PromptVersion implements Node {
   outputSchema: JSON
   modelName: String!
   modelProvider: String!
+  tags: [PromptVersionTag!]!
 }
 
 """A connection to a list of items."""
@@ -1470,6 +1471,13 @@ type PromptVersionEdge {
 
   """The item at the end of the edge"""
   node: PromptVersion!
+}
+
+type PromptVersionTag implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  name: String!
+  description: String
 }
 
 type Query {

--- a/src/phoenix/server/api/types/PromptVersion.py
+++ b/src/phoenix/server/api/types/PromptVersion.py
@@ -6,8 +6,12 @@ from typing import Optional
 import strawberry
 from strawberry.relay import Node, NodeID
 from strawberry.scalars import JSON
+from strawberry.types import Info
 
+from phoenix.server.api.context import Context
 from phoenix.server.api.types.PromptVersionTemplate import PromptTemplate
+
+from .PromptVersionTag import PromptVersionTag
 
 
 @strawberry.enum
@@ -36,3 +40,19 @@ class PromptVersion(Node):
     output_schema: Optional[JSON] = None
     model_name: str
     model_provider: str
+
+    @strawberry.field
+    def tags(self, info: Info[Context, None]) -> list[PromptVersionTag]:
+        # TODO fill out details
+        return [
+            PromptVersionTag(
+                id_attr=1,
+                name="tag 1",
+                description="tag 1 description",
+            ),
+            PromptVersionTag(
+                id_attr=2,
+                name="tag 2",
+                description="tag 2 description",
+            ),
+        ]

--- a/src/phoenix/server/api/types/PromptVersionTag.py
+++ b/src/phoenix/server/api/types/PromptVersionTag.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+import strawberry
+from strawberry.relay import Node, NodeID
+
+
+@strawberry.type
+class PromptVersionTag(Node):
+    id_attr: NodeID[int]
+    name: str
+    description: Optional[str] = None


### PR DESCRIPTION
resolves #5846 

Adds a strawman prompt_version_tag type

```graphql
{
  prompts {
    edges {
      prompt: node {
        id
        promptVersions {
          edges {
            node {
              tags {
                id
                name
              }
            }
          }
        }
      }
    }
  }
}
```