### PR TITLE
fix: skip json parse if tool call function arguments attribute doesn't exist

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1331,11 +1331,13 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
                     `}
                   >
                     {toolCall?.function?.name as string}(
-                    {JSON.stringify(
-                      JSON.parse(toolCall?.function?.arguments as string),
-                      null,
-                      2
-                    )}
+                    {toolCall?.function?.arguments
+                      ? JSON.stringify(
+                          JSON.parse(toolCall?.function?.arguments as string),
+                          null,
+                          2
+                        )
+                      : ""}
                     )
                   </pre>
                 );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1331,7 +1331,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
                     `}
                   >
                     {toolCall?.function?.name as string}(
-                    {toolCall?.function?.arguments
+                    {typeof toolCall?.function?.arguments === "string"
                       ? JSON.stringify(
                           JSON.parse(toolCall?.function?.arguments as string),
                           null,


### PR DESCRIPTION
<img width="232" alt="Screenshot 2025-01-02 at 2 04 08 PM" src="https://github.com/user-attachments/assets/c1f01676-a3ad-4615-ad18-711a511b30fc" />

# To reproduce
```python
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk import trace as trace_sdk
from opentelemetry.sdk.trace.export import SimpleSpanProcessor

endpoint = "http://127.0.0.1:6006/v1/traces"
tracer_provider = trace_sdk.TracerProvider()
tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))

with tracer_provider.get_tracer(__name__).start_as_current_span("test") as span:
    span.set_attribute("openinference.span.kind", "LLM")
    span.set_attribute("llm.input_messages.0.message.role", "assistant")
    span.set_attribute("llm.input_messages.0.message.tool_calls.0.tool_call.function.name", "xyz")
```