### PR TITLE
feat: show a breakdown of tokens in the project header

### DIFF
--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -2,10 +2,12 @@ import React, { ReactNode, startTransition, useEffect } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 import { css } from "@emotion/react";
 
+import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
+
 import { Flex, Text, View } from "@phoenix/components";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
-import { intFormatter } from "@phoenix/utils/numberFormatUtils";
+import { formatInt, intFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import { ProjectPageHeader_stats$key } from "./__generated__/ProjectPageHeader_stats.graphql";
 import { ProjectPageHeaderQuery } from "./__generated__/ProjectPageHeaderQuery.graphql";
@@ -30,6 +32,8 @@ export function ProjectPageHeader(props: {
       @refetchable(queryName: "ProjectPageHeaderQuery") {
         traceCount(timeRange: $timeRange)
         tokenCountTotal(timeRange: $timeRange)
+        tokenCountPrompt(timeRange: $timeRange)
+        tokenCountCompletion(timeRange: $timeRange)
         latencyMsP50: latencyMsQuantile(
           probability: 0.50
           timeRange: $timeRange
@@ -55,6 +59,8 @@ export function ProjectPageHeader(props: {
   const latencyMsP50 = data?.latencyMsP50;
   const latencyMsP99 = data?.latencyMsP99;
   const tokenCountTotal = data?.tokenCountTotal;
+  const tokenCountPrompt = data?.tokenCountPrompt;
+  const tokenCountCompletion = data?.tokenCountCompletion;
   const spanAnnotationNames = data?.spanAnnotationNames;
   const documentEvaluationNames = data?.documentEvaluationNames;
 
@@ -117,7 +123,41 @@ export function ProjectPageHeader(props: {
               <Text elementType="h3" size="S" color="text-700">
                 Total Tokens
               </Text>
-              <Text size="L">{intFormatter(tokenCountTotal)}</Text>
+              <TooltipTrigger delay={0} placement="bottom">
+                <TriggerWrap>
+                  <Text size="L">{intFormatter(tokenCountTotal)}</Text>
+                </TriggerWrap>
+                <HelpTooltip>
+                  <View width="size-2400">
+                    <Flex direction="column">
+                      <Flex justifyContent="space-between">
+                        <Text>Prompt Tokens</Text>
+                        <Text>
+                          {typeof tokenCountPrompt === "number"
+                            ? formatInt(tokenCountPrompt)
+                            : "--"}
+                        </Text>
+                      </Flex>
+                      <Flex justifyContent="space-between">
+                        <Text>Completion Tokens</Text>
+                        <Text>
+                          {typeof tokenCountCompletion === "number"
+                            ? formatInt(tokenCountCompletion)
+                            : "--"}
+                        </Text>
+                      </Flex>
+                      <Flex justifyContent="space-between">
+                        <Text>Total Tokens</Text>
+                        <Text>
+                          {typeof tokenCountTotal === "number"
+                            ? formatInt(tokenCountTotal)
+                            : "--"}
+                        </Text>
+                      </Flex>
+                    </Flex>
+                  </View>
+                </HelpTooltip>
+              </TooltipTrigger>
             </Flex>
             <Flex direction="column" flex="none">
               <Text elementType="h3" size="S" color="text-700">

--- a/app/src/pages/project/__generated__/ProjectPageHeaderQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageHeaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6b001dbe5b9d15be3f6150ab7da10a21>>
+ * @generated SignedSource<<1517a98e932d0779c7cfeeabb87e0c2b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -137,6 +137,20 @@ return {
                 "storageKey": null
               },
               {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "kind": "ScalarField",
+                "name": "tokenCountPrompt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "kind": "ScalarField",
+                "name": "tokenCountCompletion",
+                "storageKey": null
+              },
+              {
                 "alias": "latencyMsP50",
                 "args": [
                   {
@@ -188,16 +202,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "264a748e3bb636d71fb6b75523a612fe",
+    "cacheID": "2b81cd60d6a8a82b6814df7a5a658114",
     "id": null,
     "metadata": {},
     "name": "ProjectPageHeaderQuery",
     "operationKind": "query",
-    "text": "query ProjectPageHeaderQuery(\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectPageHeader_stats\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n"
+    "text": "query ProjectPageHeaderQuery(\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...ProjectPageHeader_stats\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  tokenCountPrompt(timeRange: $timeRange)\n  tokenCountCompletion(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dcce9d160db90e2b5c51eef9971101a4";
+(node as any).hash = "e110b84031cc6bfa6bb37751b9c69765";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageHeader_stats.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd80b6efb4b67da91ba9add83415d3f7>>
+ * @generated SignedSource<<1e5e785003c8513a63755f3bc760005d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,8 @@ export type ProjectPageHeader_stats$data = {
   readonly latencyMsP50: number | null;
   readonly latencyMsP99: number | null;
   readonly spanAnnotationNames: ReadonlyArray<string>;
+  readonly tokenCountCompletion: number;
+  readonly tokenCountPrompt: number;
   readonly tokenCountTotal: number;
   readonly traceCount: number;
   readonly " $fragmentType": "ProjectPageHeader_stats";
@@ -74,6 +76,20 @@ return {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "tokenCountPrompt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "kind": "ScalarField",
+      "name": "tokenCountCompletion",
+      "storageKey": null
+    },
+    {
       "alias": "latencyMsP50",
       "args": [
         {
@@ -128,6 +144,6 @@ return {
 };
 })();
 
-(node as any).hash = "dcce9d160db90e2b5c51eef9971101a4";
+(node as any).hash = "e110b84031cc6bfa6bb37751b9c69765";
 
 export default node;

--- a/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3cec29ec59900ad2e70b8c605a7da9e>>
+ * @generated SignedSource<<b9b47c11ac57a909d6e9527ecd49a514>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -517,6 +517,20 @@ return {
                 "storageKey": null
               },
               {
+                "alias": null,
+                "args": (v18/*: any*/),
+                "kind": "ScalarField",
+                "name": "tokenCountPrompt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v18/*: any*/),
+                "kind": "ScalarField",
+                "name": "tokenCountCompletion",
+                "storageKey": null
+              },
+              {
                 "alias": "latencyMsP50",
                 "args": [
                   {
@@ -568,12 +582,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "400e3bc8456d6d9eb0f4f85fc862ad57",
+    "cacheID": "6cc5e26d63252f86d25c9365c15f55ec",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: 50, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          id\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value: truncatedValue\n          }\n          output {\n            value: truncatedValue\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanAnnotations {\n            name\n            label\n            score\n            annotatorKind\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...TracesTable_spans\n    ...ProjectPageHeader_stats\n    ...StreamToggle_data\n    __isNode: __typename\n    id\n  }\n}\n\nfragment ProjectPageHeader_stats on Project {\n  traceCount(timeRange: $timeRange)\n  tokenCountTotal(timeRange: $timeRange)\n  tokenCountPrompt(timeRange: $timeRange)\n  tokenCountCompletion(timeRange: $timeRange)\n  latencyMsP50: latencyMsQuantile(probability: 0.5, timeRange: $timeRange)\n  latencyMsP99: latencyMsQuantile(probability: 0.99, timeRange: $timeRange)\n  spanAnnotationNames\n  documentEvaluationNames\n  id\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment StreamToggle_data on Project {\n  streamingLastUpdatedAt\n  id\n}\n\nfragment TracesTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: 50, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        context {\n          spanId\n          traceId\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants {\n          id\n          spanKind\n          name\n          statusCode: propagatedStatusCode\n          startTime\n          latencyMs\n          parentId\n          cumulativeTokenCountTotal: tokenCountTotal\n          cumulativeTokenCountPrompt: tokenCountPrompt\n          cumulativeTokenCountCompletion: tokenCountCompletion\n          input {\n            value: truncatedValue\n          }\n          output {\n            value: truncatedValue\n          }\n          context {\n            spanId\n            traceId\n          }\n          spanAnnotations {\n            name\n            label\n            score\n            annotatorKind\n          }\n          documentRetrievalMetrics {\n            evaluationName\n            ndcg\n            precision\n            hit\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
resolves #5872 

Adds a breakdown of token counts to the header

<img width="387" alt="Screenshot 2025-01-02 at 4 20 23 PM" src="https://github.com/user-attachments/assets/47745342-5f3b-4bae-9744-8d68484d0e17" />
