### PR TITLE
fix: Allow ClassificationTemplate w/o explanation template

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -137,7 +137,10 @@ class ClassificationTemplate(PromptTemplate):
             )
         self.rails = rails
         self.template = self._normalize_template(template)
-        self.explanation_template = self._normalize_template(explanation_template)
+        if explanation_template:
+            self.explanation_template = self._normalize_template(explanation_template)
+        else:
+            self.explanation_template = None
         self.explanation_label_parser = explanation_label_parser
         self._start_delim, self._end_delim = delimiters
         self.variables: List[str] = []

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -137,6 +137,7 @@ class ClassificationTemplate(PromptTemplate):
             )
         self.rails = rails
         self.template = self._normalize_template(template)
+        self.explanation_template: Optional[List[PromptPartTemplate]]
         if explanation_template:
             self.explanation_template = self._normalize_template(explanation_template)
         else:

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -137,8 +137,7 @@ class ClassificationTemplate(PromptTemplate):
             )
         self.rails = rails
         self.template = self._normalize_template(template)
-        if explanation_template:
-            self.explanation_template = self._normalize_template(explanation_template)
+        self.explanation_template = self._normalize_template(explanation_template)
         self.explanation_label_parser = explanation_label_parser
         self._start_delim, self._end_delim = delimiters
         self.variables: List[str] = []

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -36,7 +36,7 @@ def test_classification_template_can_beinstantiated_with_no_explanation_template
     assert template.explanation_template is None
 
     explanation_options = PromptOptions(provide_explanation=True)
-    assert template.prompt(options=explanation_options) == template.explanation_template
+    assert template.prompt(options=explanation_options)[0].template == "is this irrelevant?"
 
 
 def test_template_with_default_delimiters_uses_python_string_formatting():

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -3,7 +3,11 @@ import math
 import pytest
 
 from phoenix.evals import RAG_RELEVANCY_PROMPT_TEMPLATE, ClassificationTemplate
-from phoenix.evals.templates import InvalidClassificationTemplateError, PromptTemplate
+from phoenix.evals.templates import (
+    InvalidClassificationTemplateError,
+    PromptOptions,
+    PromptTemplate,
+)
 
 
 def test_classification_template_raises_error_when_initialized_with_mismatched_labels_and_scores():
@@ -23,6 +27,16 @@ def test_classification_template_score_returns_correct_score_for_present_rail():
 def test_classification_template_score_returns_zero_for_missing_rail():
     score = RAG_RELEVANCY_PROMPT_TEMPLATE.score("missing")
     assert math.isclose(score, 0.0)
+
+
+def test_classification_template_can_beinstantiated_with_no_explanation_template():
+    template = ClassificationTemplate(
+        rails=["relevant", "irrelevant"], template="is this irrelevant?"
+    )
+    assert template.explanation_template is None
+
+    explanation_options = PromptOptions(provide_explanation=True)
+    assert template.prompt(options=explanation_options) == template.explanation_template
 
 
 def test_template_with_default_delimiters_uses_python_string_formatting():


### PR DESCRIPTION
resolves #5815

- ClassificationTemplate instantiation would fail if not passed an explanation template
- Always set `explanation_template` even if not provided
- The fallback if `provide_explanation` is True will be the standard template