### PR TITLE
fix(components): Add class names to Disclosure for backwards compatibility with Accordion

### DIFF
--- a/app/src/components/disclosure/Disclosure.tsx
+++ b/app/src/components/disclosure/Disclosure.tsx
@@ -31,7 +31,7 @@ export const DisclosureGroup = ({
   return (
     <AriaDisclosureGroup
       allowsMultipleExpanded
-      className={classNames("rac-disclosure-group", className)}
+      className={classNames("ac-disclosure-group", className)}
       css={disclosureGroupCSS}
       {...props}
     />
@@ -48,7 +48,7 @@ export type DisclosureProps = AriaDisclosureProps & SizingProps;
 export const Disclosure = ({ size, className, ...props }: DisclosureProps) => {
   return (
     <AriaDisclosure
-      className={classNames("rac-disclosure", className)}
+      className={classNames("ac-disclosure", className)}
       css={disclosureCSS}
       data-size={size}
       defaultExpanded
@@ -70,7 +70,7 @@ export const DisclosurePanel = ({
 }: DisclosurePanelProps) => {
   return (
     <AriaDisclosurePanel
-      className={classNames("rac-disclosure-panel", className)}
+      className={classNames("ac-disclosure-panel", className)}
       {...props}
     />
   );

--- a/app/src/components/disclosure/Disclosure.tsx
+++ b/app/src/components/disclosure/Disclosure.tsx
@@ -10,7 +10,7 @@ import {
   Heading,
 } from "react-aria-components";
 
-import { Flex, Icon, Icons } from "@phoenix/components";
+import { classNames, Flex, Icon, Icons } from "@phoenix/components";
 
 import { FlexStyleProps, SizingProps } from "../types";
 
@@ -24,10 +24,14 @@ export type DisclosureGroupProps = AriaDisclosureGroupProps;
  *
  * AKA Accordion with one or more items
  */
-export const DisclosureGroup = (props: DisclosureGroupProps) => {
+export const DisclosureGroup = ({
+  className,
+  ...props
+}: DisclosureGroupProps) => {
   return (
     <AriaDisclosureGroup
       allowsMultipleExpanded
+      className={classNames("rac-disclosure-group", className)}
       css={disclosureGroupCSS}
       {...props}
     />
@@ -41,9 +45,10 @@ export type DisclosureProps = AriaDisclosureProps & SizingProps;
  *
  * AKA Accordion (with a single item) / Accordion Item
  */
-export const Disclosure = ({ size, ...props }: DisclosureProps) => {
+export const Disclosure = ({ size, className, ...props }: DisclosureProps) => {
   return (
     <AriaDisclosure
+      className={classNames("rac-disclosure", className)}
       css={disclosureCSS}
       data-size={size}
       defaultExpanded
@@ -59,8 +64,16 @@ export type DisclosurePanelProps = AriaDisclosurePanelProps;
  *
  * AKA Accordion Content
  */
-export const DisclosurePanel = (props: DisclosurePanelProps) => {
-  return <AriaDisclosurePanel {...props} />;
+export const DisclosurePanel = ({
+  className,
+  ...props
+}: DisclosurePanelProps) => {
+  return (
+    <AriaDisclosurePanel
+      className={classNames("rac-disclosure-panel", className)}
+      {...props}
+    />
+  );
 };
 
 export type DisclosureTriggerProps = PropsWithChildren<{

--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -5,6 +5,7 @@ export type {
   LabelProps,
   FieldErrorProps,
 } from "react-aria-components";
+export { classNames } from "@arizeai/components";
 
 export * from "./Link";
 export * from "./LinkButton";

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -162,13 +162,13 @@ const playgroundPromptPanelContentCSS = css`
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  & > .rac-disclosure-group {
+  & > .ac-disclosure-group {
     display: flex;
     flex-direction: column;
     height: 100%;
     overflow: hidden;
     flex: 1 1 auto;
-    & > .rac-disclosure {
+    & > .ac-disclosure {
       height: 100%;
       display: flex;
       flex-direction: column;
@@ -181,7 +181,7 @@ const playgroundPromptPanelContentCSS = css`
       & > #prompts-heading {
         flex: 0 0 auto;
       }
-      .rac-disclosure-panel {
+      .ac-disclosure-panel {
         height: 100%;
         overflow: hidden;
         flex: 1 1 auto;

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -162,13 +162,13 @@ const playgroundPromptPanelContentCSS = css`
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  & > .ac-accordion {
+  & > .rac-disclosure-group {
     display: flex;
     flex-direction: column;
     height: 100%;
     overflow: hidden;
     flex: 1 1 auto;
-    & > .ac-accordion-item {
+    & > .rac-disclosure {
       height: 100%;
       display: flex;
       flex-direction: column;
@@ -181,7 +181,7 @@ const playgroundPromptPanelContentCSS = css`
       & > #prompts-heading {
         flex: 0 0 auto;
       }
-      .ac-accordion-itemContent {
+      .rac-disclosure-panel {
         height: 100%;
         overflow: hidden;
         flex: 1 1 auto;


### PR DESCRIPTION
You can scroll once again on the Playground page now that these class names are exposed on Disclosure components

![2025-01-03 13 40 05](https://github.com/user-attachments/assets/140d8b7d-ac7d-4ef0-afb4-2dc11a0549d9)
