### PR TITLE
fix: coerce to string when output.value is not None (e.g. bool)

### DIFF
--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -290,8 +290,14 @@ class Span(Node):
 
 def to_gql_span(span: models.Span) -> Span:
     events: list[SpanEvent] = list(map(SpanEvent.from_dict, span.events))
-    input_value = cast(Optional[str], get_attribute_value(span.attributes, INPUT_VALUE))
-    output_value = cast(Optional[str], get_attribute_value(span.attributes, OUTPUT_VALUE))
+    input_value = get_attribute_value(span.attributes, INPUT_VALUE)
+    if input_value is not None:
+        input_value = str(input_value)
+    assert input_value is None or isinstance(input_value, str)
+    output_value = get_attribute_value(span.attributes, OUTPUT_VALUE)
+    if output_value is not None:
+        output_value = str(output_value)
+    assert output_value is None or isinstance(output_value, str)
     retrieval_documents = get_attribute_value(span.attributes, RETRIEVAL_DOCUMENTS)
     num_documents = len(retrieval_documents) if isinstance(retrieval_documents, Sized) else None
     return Span(


### PR DESCRIPTION
resolves #5891

<img width="284" alt="Screenshot 2025-01-03 at 1 29 41 PM" src="https://github.com/user-attachments/assets/15f28b6d-b5fc-44e7-9b5a-98996993a22a" />

<img width="272" alt="Screenshot 2025-01-03 at 1 29 35 PM" src="https://github.com/user-attachments/assets/8c7c5a01-160a-4395-b26b-2f35629634eb" />

<img width="650" alt="Screenshot 2025-01-03 at 1 32 58 PM" src="https://github.com/user-attachments/assets/7af52da1-fff0-4905-b56c-797796d8a9b1" />
