### PR TITLE
fix(docs): updated conda create python version example to meet requirements of arize-phoneix package

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ For non-mac users, you can follow the instruction [here](https://github.com/cond
 Create a new virtual environment with a Phoenix-compatible Python version. For example,
 
 ```bash
-conda create --name phoenix python=3.8
+conda create --name phoenix python=3.12
 ```
 
 Install web build dependencies


### PR DESCRIPTION
The current published instructions suggest python=3.8, but the actual requirement in the arize-phoenix package is >=3.9, <3.14. In other words, the example is out of sync with the project’s required Python versions.