### PR TITLE
fix(prompts): Fix code disclosure width on prompts ui

### DIFF
--- a/app/src/pages/prompt/PromptCodeExportCard.tsx
+++ b/app/src/pages/prompt/PromptCodeExportCard.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import { DisclosureGroup } from "react-aria-components";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
@@ -8,6 +7,7 @@ import { Card } from "@arizeai/components";
 import {
   CopyToClipboardButton,
   Disclosure,
+  DisclosureGroup,
   DisclosurePanel,
   DisclosureTrigger,
   Flex,


### PR DESCRIPTION
## Before

<img width="929" alt="image" src="https://github.com/user-attachments/assets/4a842fd6-244d-44ab-bd89-8fca782ed862" />

## After

<img width="916" alt="image" src="https://github.com/user-attachments/assets/c0adf414-a5ee-4d91-8218-2c4e6255bb81" />
