### PR TITLE
feat(prompts): show the tags that can be set on a promt version

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1412,6 +1412,7 @@ type Prompt implements Node {
   name: String!
   description: String
   createdAt: DateTime!
+  versionTags: [PromptVersionTag!]!
   promptVersions(first: Int = 50, last: Int, after: String, before: String): PromptVersionConnection!
 }
 

--- a/app/src/pages/prompt/TagPromptVersionButton.tsx
+++ b/app/src/pages/prompt/TagPromptVersionButton.tsx
@@ -1,17 +1,31 @@
-import React from "react";
+import React, { Suspense } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { useParams } from "react-router";
 
 import {
   Button,
   Dialog,
   DialogTrigger,
+  Flex,
   Icon,
   Icons,
+  Loading,
   Popover,
   PopoverArrow,
   View,
 } from "@phoenix/components";
 
+import { TagPromptVersionButtonTagsQuery } from "./__generated__/TagPromptVersionButtonTagsQuery.graphql";
+
 export function TagPromptVersionButton() {
+  const { promptId, versionId } = useParams();
+  if (!promptId) {
+    throw new Error("Expected promptId to be defined");
+  }
+  if (!versionId) {
+    throw new Error("Expected versionId to be defined");
+  }
+
   return (
     <DialogTrigger>
       <Button size="S" icon={<Icon svg={<Icons.PriceTagsOutline />} />}>
@@ -20,6 +34,15 @@ export function TagPromptVersionButton() {
       <Popover placement="bottom end">
         <PopoverArrow />
         <Dialog>
+          <Suspense
+            fallback={
+              <View padding="size-100">
+                <Loading size="S" />
+              </View>
+            }
+          >
+            <TagList promptId={promptId} versionId={versionId} />
+          </Suspense>
           <View padding="size-100" width="250px">
             <Button
               icon={<Icon svg={<Icons.PlusOutline />} />}
@@ -32,5 +55,66 @@ export function TagPromptVersionButton() {
         </Dialog>
       </Popover>
     </DialogTrigger>
+  );
+}
+
+function TagList({
+  promptId,
+  versionId,
+}: {
+  promptId: string;
+  versionId: string;
+}) {
+  const data = useLazyLoadQuery<TagPromptVersionButtonTagsQuery>(
+    graphql`
+      query TagPromptVersionButtonTagsQuery(
+        $promptId: GlobalID!
+        $versionId: GlobalID!
+      ) {
+        prompt: node(id: $promptId) {
+          ... on Prompt {
+            versionTags {
+              name
+            }
+          }
+        }
+        promptVersion: node(id: $versionId) {
+          ... on PromptVersion {
+            tags {
+              name
+            }
+          }
+        }
+      }
+    `,
+    { promptId, versionId }
+  );
+  const allVersionTags =
+    data?.prompt?.versionTags?.map((tag) => tag.name) || [];
+  const versionTags = data?.promptVersion?.tags?.map((tag) => tag.name) || [];
+  return (
+    <ul>
+      {allVersionTags.map((tagName) => {
+        return (
+          <li key={tagName}>
+            <View
+              paddingY="size-100"
+              paddingX="size-200"
+              borderBottomColor="light"
+              borderBottomWidth="thin"
+            >
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <input
+                  type="checkbox"
+                  name={tagName}
+                  checked={versionTags.includes(tagName)}
+                />
+                {tagName}
+              </Flex>
+            </View>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/app/src/pages/prompt/__generated__/TagPromptVersionButtonTagsQuery.graphql.ts
+++ b/app/src/pages/prompt/__generated__/TagPromptVersionButtonTagsQuery.graphql.ts
@@ -1,0 +1,207 @@
+/**
+ * @generated SignedSource<<cee7c2adddc62ddcfee89f8cf89ea117>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type TagPromptVersionButtonTagsQuery$variables = {
+  promptId: string;
+  versionId: string;
+};
+export type TagPromptVersionButtonTagsQuery$data = {
+  readonly prompt: {
+    readonly versionTags?: ReadonlyArray<{
+      readonly name: string;
+    }>;
+  };
+  readonly promptVersion: {
+    readonly tags?: ReadonlyArray<{
+      readonly name: string;
+    }>;
+  };
+};
+export type TagPromptVersionButtonTagsQuery = {
+  response: TagPromptVersionButtonTagsQuery$data;
+  variables: TagPromptVersionButtonTagsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "promptId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "versionId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "promptId"
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+],
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PromptVersionTag",
+      "kind": "LinkedField",
+      "name": "versionTags",
+      "plural": true,
+      "selections": (v2/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "Prompt",
+  "abstractKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "versionId"
+  }
+],
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "PromptVersionTag",
+      "kind": "LinkedField",
+      "name": "tags",
+      "plural": true,
+      "selections": (v2/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "PromptVersion",
+  "abstractKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v7 = {
+  "kind": "TypeDiscriminator",
+  "abstractKey": "__isNode"
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TagPromptVersionButtonTagsQuery",
+    "selections": [
+      {
+        "alias": "prompt",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "promptVersion",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TagPromptVersionButtonTagsQuery",
+    "selections": [
+      {
+        "alias": "prompt",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v3/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "promptVersion",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v6/*: any*/),
+          (v5/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b48470da2466dee71014e5298fe3c154",
+    "id": null,
+    "metadata": {},
+    "name": "TagPromptVersionButtonTagsQuery",
+    "operationKind": "query",
+    "text": "query TagPromptVersionButtonTagsQuery(\n  $promptId: GlobalID!\n  $versionId: GlobalID!\n) {\n  prompt: node(id: $promptId) {\n    __typename\n    ... on Prompt {\n      versionTags {\n        name\n      }\n    }\n    __isNode: __typename\n    id\n  }\n  promptVersion: node(id: $versionId) {\n    __typename\n    ... on PromptVersion {\n      tags {\n        name\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cf7f23baada0854d6f6fd67fb234239f";
+
+export default node;

--- a/src/phoenix/server/api/types/Prompt.py
+++ b/src/phoenix/server/api/types/Prompt.py
@@ -20,6 +20,7 @@ from .PromptVersion import (
     PromptVersion,
     to_gql_prompt_version,
 )
+from .PromptVersionTag import PromptVersionTag
 
 
 @strawberry.type
@@ -28,6 +29,22 @@ class Prompt(Node):
     name: str
     description: Optional[str]
     created_at: datetime
+
+    @strawberry.field
+    async def version_tags(self, info: Info[Context, None]) -> list[PromptVersionTag]:
+        # TODO fill out details to pull tags from the database for the given prompt
+        return [
+            PromptVersionTag(
+                id_attr=1,
+                name="tag 1",
+                description="tag 1 description",
+            ),
+            PromptVersionTag(
+                id_attr=2,
+                name="tag 2",
+                description="tag 2 description",
+            ),
+        ]
 
     @strawberry.field
     async def prompt_versions(


### PR DESCRIPTION
resolves #5906 

Show the prompt version tags that can be set on a particular version
<img width="375" alt="Screenshot 2025-01-06 at 2 31 42 PM" src="https://github.com/user-attachments/assets/beca079c-0023-4142-9226-1177fcfa6f2d" />
