### PR TITLE
feat: Add `previous_version` resolver on `PromptVersion`

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1492,6 +1492,7 @@ type PromptVersion implements Node {
   createdAt: DateTime!
   tags: [PromptVersionTag!]!
   user: User
+  previousVersion: PromptVersion
 }
 
 """A connection to a list of items."""

--- a/src/phoenix/server/api/types/PromptVersion.py
+++ b/src/phoenix/server/api/types/PromptVersion.py
@@ -67,12 +67,11 @@ class PromptVersion(Node):
                 return None
 
             prompt_id = current_version.prompt_id
-            created_at = current_version.created_at
 
             stmt = (
                 select(models.PromptVersion)
                 .where(models.PromptVersion.prompt_id == prompt_id)
-                .where(models.PromptVersion.created_at < created_at)
+                .where(models.PromptVersion.id < self.id_attr)
                 .order_by(models.PromptVersion.created_at.desc())
                 .limit(1)
             )

--- a/src/phoenix/server/api/types/PromptVersion.py
+++ b/src/phoenix/server/api/types/PromptVersion.py
@@ -59,7 +59,6 @@ class PromptVersion(Node):
             user = await session.get(models.User, self.user_id)
         return to_gql_user(user) if user is not None else None
 
-
     @strawberry.field
     async def previous_version(self, info: Info[Context, None]) -> Optional["PromptVersion"]:
         async with info.context.db() as session:


### PR DESCRIPTION
resolves #5908 

Returns the last created PromptVersion on a specific Prompt