### PR TITLE
fix: Coerce incoming span token counts to int

### DIFF
--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -100,19 +100,30 @@ async def insert_span(
     )
 
     cumulative_error_count = int(span.status_code is SpanStatusCode.ERROR)
-    cumulative_llm_token_count_prompt = cast(
-        int, get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
-    )
-    cumulative_llm_token_count_completion = cast(
-        int, get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
-    )
-    llm_token_count_prompt = cast(
-        Optional[int], get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT)
-    )
-    llm_token_count_completion = cast(
-        Optional[int],
-        get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION),
-    )
+    try:
+        cumulative_llm_token_count_prompt = int(
+            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
+        )
+    except ValueError:
+        cumulative_llm_token_count_prompt = 0
+    try:
+        cumulative_llm_token_count_completion = int(
+            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
+        )
+    except ValueError:
+        cumulative_llm_token_count_completion = 0
+    try:
+        llm_token_count_prompt = int(
+            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
+        )
+    except ValueError:
+        llm_token_count_prompt = 0
+    try:
+        llm_token_count_completion = int(
+            get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
+        )
+    except ValueError:
+        llm_token_count_completion = 0
     if accumulation := (
         await session.execute(
             select(

--- a/src/phoenix/db/insertion/span.py
+++ b/src/phoenix/db/insertion/span.py
@@ -104,25 +104,25 @@ async def insert_span(
         cumulative_llm_token_count_prompt = int(
             get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
         )
-    except ValueError:
+    except BaseException:
         cumulative_llm_token_count_prompt = 0
     try:
         cumulative_llm_token_count_completion = int(
             get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
         )
-    except ValueError:
+    except BaseException:
         cumulative_llm_token_count_completion = 0
     try:
         llm_token_count_prompt = int(
             get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_PROMPT) or 0
         )
-    except ValueError:
+    except BaseException:
         llm_token_count_prompt = 0
     try:
         llm_token_count_completion = int(
             get_attribute_value(span.attributes, SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) or 0
         )
-    except ValueError:
+    except BaseException:
         llm_token_count_completion = 0
     if accumulation := (
         await session.execute(

--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -57,28 +57,13 @@ LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL
 def coerce_otlp_span_attributes(
     decoded_attributes: Iterator[tuple[str, Any]],
 ) -> Iterator[tuple[str, Any]]:
-    new_attributes: list[tuple[str, Any]] = []
-
     for key, value in decoded_attributes:
-        if key == LLM_TOKEN_COUNT_PROMPT:
+        if key in (LLM_TOKEN_COUNT_PROMPT, LLM_TOKEN_COUNT_COMPLETION, LLM_TOKEN_COUNT_TOTAL):
             try:
-                new_attributes.append((LLM_TOKEN_COUNT_PROMPT, int(value)))
+                value = int(value)
             except BaseException:
-                new_attributes.append((LLM_TOKEN_COUNT_PROMPT, value))
-        elif key == LLM_TOKEN_COUNT_COMPLETION:
-            try:
-                new_attributes.append((LLM_TOKEN_COUNT_COMPLETION, int(value)))
-            except BaseException:
-                new_attributes.append((LLM_TOKEN_COUNT_COMPLETION, value))
-        elif key == LLM_TOKEN_COUNT_TOTAL:
-            try:
-                new_attributes.append((LLM_TOKEN_COUNT_TOTAL, int(value)))
-            except BaseException:
-                new_attributes.append((LLM_TOKEN_COUNT_TOTAL, value))
-        else:
-            new_attributes.append((key, value))
-
-    return iter(new_attributes)
+                pass
+        yield key, value
 
 
 def decode_otlp_span(otlp_span: otlp.Span) -> Span:

--- a/src/phoenix/trace/otel.py
+++ b/src/phoenix/trace/otel.py
@@ -55,7 +55,7 @@ LLM_TOKEN_COUNT_TOTAL = SpanAttributes.LLM_TOKEN_COUNT_TOTAL
 
 
 def coerce_otlp_span_attributes(
-    decoded_attributes: Iterator[tuple[str, Any]],
+    decoded_attributes: Iterable[tuple[str, Any]],
 ) -> Iterator[tuple[str, Any]]:
     for key, value in decoded_attributes:
         if key in (LLM_TOKEN_COUNT_PROMPT, LLM_TOKEN_COUNT_COMPLETION, LLM_TOKEN_COUNT_TOTAL):

--- a/tests/unit/trace/test_otel.py
+++ b/tests/unit/trace/test_otel.py
@@ -474,7 +474,7 @@ def test_coerce_otlp_span_attributes() -> None:
         ("llm.other.field", "world"),
     ]
 
-    result = list(coerce_otlp_span_attributes(iter(input_attrs)))
+    result = list(coerce_otlp_span_attributes(input_attrs))
 
     expected = [
         ("llm.token_count.prompt", 123),
@@ -494,7 +494,7 @@ def test_coerce_otlp_span_attributes() -> None:
         ("llm.token_count.total", ""),
     ]
 
-    result = list(coerce_otlp_span_attributes(iter(invalid_attrs)))
+    result = list(coerce_otlp_span_attributes(invalid_attrs))
 
     assert result == invalid_attrs
 

--- a/tests/unit/trace/test_otel.py
+++ b/tests/unit/trace/test_otel.py
@@ -8,15 +8,14 @@ import numpy as np
 import opentelemetry.proto.trace.v1.trace_pb2 as otlp
 import pytest
 from google.protobuf.json_format import MessageToJson  # type: ignore[import-untyped]
-from openinference.semconv.trace import (
-    SpanAttributes,
-)
+from openinference.semconv.trace import SpanAttributes
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, ArrayValue, KeyValue
 from pytest import approx
 
 from phoenix.trace.otel import (
     _decode_identifier,
     _encode_identifier,
+    coerce_otlp_span_attributes,
     decode_otlp_span,
     encode_span_to_otlp,
 )
@@ -461,6 +460,43 @@ def test_decode_encode_tool_parameters(span: Span) -> None:
     assert set(map(MessageToJson, otlp_span.attributes)) == set(map(MessageToJson, otlp_attributes))
     decoded_span = decode_otlp_span(otlp_span)
     assert decoded_span.attributes["tool"]["parameters"] == span.attributes["tool"]["parameters"]
+
+
+def test_coerce_otlp_span_attributes() -> None:
+    # Test attributes that should be coerced
+    input_attrs = [
+        ("llm.token_count.prompt", "123"),
+        ("llm.token_count.completion", "456"),
+        ("llm.token_count.total", "579"),
+        # Test attributes that should not be modified
+        ("other.number", "789"),
+        ("some.string", "hello"),
+        ("llm.other.field", "world"),
+    ]
+
+    result = list(coerce_otlp_span_attributes(iter(input_attrs)))
+
+    expected = [
+        ("llm.token_count.prompt", 123),
+        ("llm.token_count.completion", 456),
+        ("llm.token_count.total", 579),
+        ("other.number", "789"),
+        ("some.string", "hello"),
+        ("llm.other.field", "world"),
+    ]
+
+    assert result == expected
+
+    # Test that invalid number strings remain as strings
+    invalid_attrs = [
+        ("llm.token_count.prompt", "not_a_number"),
+        ("llm.token_count.completion", "invalid"),
+        ("llm.token_count.total", ""),
+    ]
+
+    result = list(coerce_otlp_span_attributes(iter(invalid_attrs)))
+
+    assert result == invalid_attrs
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes cases where the instrumentor accidentally exports spans with string typed token counts, like llama-index + bedrock

<img width="463" alt="image" src="https://github.com/user-attachments/assets/836284ec-b8b8-472b-8521-67517d6d4026" />
