### PR TITLE
refactor(prompts): validate jsonschema using third-party library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dev = [
   "arize[AutoEmbeddings, LLM_Evaluation]",
   "llama-index>=0.10.3",
   "langchain>=0.0.334",
-  "litellm>=1.0.3",
+  "litellm>=1.0.3,<1.57.5", # windows compatibility broken on 1.57.5 (https://github.com/BerriAI/litellm/issues/7677)
   "google-cloud-aiplatform>=1.3",
   "anthropic",
   "prometheus_client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "pydantic>=1.0,!=2.0.*,<3", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",
   "websockets",
-  "jsonschema",
+  "jsonschema>=4.0.0,<=4.23.0", # the upper bound is to keep us off the bleeding edge in case there's a regression since this controls what gets written to the database
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "pydantic>=1.0,!=2.0.*,<3", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",
   "websockets",
+  "jsonschema",
 ]
 dynamic = ["version"]
 
@@ -102,6 +103,7 @@ dev = [
   "portpicker",
   "uvloop; platform_system != 'Windows'",
   "grpc-interceptor[testing]",
+  "types-jsonschema",
 ]
 embeddings = [
   "fast-hdbscan>=0.2.0",

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -21,6 +21,7 @@ requests  # this is needed to type-check third-party packages
 strawberry-graphql[opentelemetry]==0.253.1  # need to pin version because we're monkey-patching
 tenacity
 types-cachetools
+types-jsonschema
 types-protobuf
 types-psutil
 types-requests

--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -7,7 +7,7 @@ asyncpg
 grpc-interceptor[testing]
 httpx<0.28
 httpx-ws
-litellm>=1.0.3
+litellm>=1.0.3,<1.57.5
 nest-asyncio # for executor testing
 numpy
 openai>=1.0.0

--- a/src/phoenix/server/api/helpers/jsonschema.py
+++ b/src/phoenix/server/api/helpers/jsonschema.py
@@ -101,16 +101,20 @@ Draft7Validator.check_schema(JSON_SCHEMA_DRAFT_7_META_SCHEMA)  # ensure the sche
 JSON_SCHEMA_DRAFT_7_VALIDATOR = Draft7Validator(JSON_SCHEMA_DRAFT_7_META_SCHEMA)
 
 
-def validate_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+def validate_json_schema_object_definition(schema: dict[str, Any]) -> dict[str, Any]:
     """
-    Validates that a dictionary is a valid JSON schema.
+    Validates that a dictionary is a valid JSON schema object property.
     """
     try:
         JSON_SCHEMA_DRAFT_7_VALIDATOR.validate(schema)
     except ValidationError as error:
         raise ValueError(str(error))
+    if schema.get("type") != "object":
+        raise ValueError("The 'type' property must be 'object'")
     return schema
 
 
 # Pydantic type with built-in validation for JSON schemas
-JSONSchema: TypeAlias = Annotated[dict[str, Any], AfterValidator(validate_json_schema)]
+JSONSchemaObjectDefinition: TypeAlias = Annotated[
+    dict[str, Any], AfterValidator(validate_json_schema_object_definition)
+]

--- a/src/phoenix/server/api/helpers/jsonschema.py
+++ b/src/phoenix/server/api/helpers/jsonschema.py
@@ -1,0 +1,116 @@
+from typing import Annotated, Any
+
+from jsonschema import Draft7Validator, ValidationError
+from pydantic import AfterValidator
+from typing_extensions import TypeAlias
+
+# This meta-schema describes valid JSON schemas according to the JSON Schema Draft 7 specification.
+# It is copied from https://json-schema.org/draft-07/schema#
+JSON_SCHEMA_DRAFT_7_META_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {"type": "array", "minItems": 1, "items": {"$ref": "#"}},
+        "nonNegativeInteger": {"type": "integer", "minimum": 0},
+        "nonNegativeIntegerDefault0": {
+            "allOf": [{"$ref": "#/definitions/nonNegativeInteger"}, {"default": 0}]
+        },
+        "simpleTypes": {
+            "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": True,
+            "default": [],
+        },
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {"type": "string", "format": "uri-reference"},
+        "$schema": {"type": "string", "format": "uri"},
+        "$ref": {"type": "string", "format": "uri-reference"},
+        "$comment": {"type": "string"},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "default": True,
+        "readOnly": {"type": "boolean", "default": False},
+        "writeOnly": {"type": "boolean", "default": False},
+        "examples": {"type": "array", "items": True},
+        "multipleOf": {"type": "number", "exclusiveMinimum": 0},
+        "maximum": {"type": "number"},
+        "exclusiveMaximum": {"type": "number"},
+        "minimum": {"type": "number"},
+        "exclusiveMinimum": {"type": "number"},
+        "maxLength": {"$ref": "#/definitions/nonNegativeInteger"},
+        "minLength": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "pattern": {"type": "string", "format": "regex"},
+        "additionalItems": {"$ref": "#"},
+        "items": {"anyOf": [{"$ref": "#"}, {"$ref": "#/definitions/schemaArray"}], "default": True},
+        "maxItems": {"$ref": "#/definitions/nonNegativeInteger"},
+        "minItems": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "uniqueItems": {"type": "boolean", "default": False},
+        "contains": {"$ref": "#"},
+        "maxProperties": {"$ref": "#/definitions/nonNegativeInteger"},
+        "minProperties": {"$ref": "#/definitions/nonNegativeIntegerDefault0"},
+        "required": {"$ref": "#/definitions/stringArray"},
+        "additionalProperties": {"$ref": "#"},
+        "definitions": {"type": "object", "additionalProperties": {"$ref": "#"}, "default": {}},
+        "properties": {"type": "object", "additionalProperties": {"$ref": "#"}, "default": {}},
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#"},
+            "propertyNames": {"format": "regex"},
+            "default": {},
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [{"$ref": "#"}, {"$ref": "#/definitions/stringArray"}]
+            },
+        },
+        "propertyNames": {"$ref": "#"},
+        "const": True,
+        "enum": {"type": "array", "items": True, "minItems": 1, "uniqueItems": True},
+        "type": {
+            "anyOf": [
+                {"$ref": "#/definitions/simpleTypes"},
+                {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/simpleTypes"},
+                    "minItems": 1,
+                    "uniqueItems": True,
+                },
+            ]
+        },
+        "format": {"type": "string"},
+        "contentMediaType": {"type": "string"},
+        "contentEncoding": {"type": "string"},
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": {"$ref": "#/definitions/schemaArray"},
+        "anyOf": {"$ref": "#/definitions/schemaArray"},
+        "oneOf": {"$ref": "#/definitions/schemaArray"},
+        "not": {"$ref": "#"},
+    },
+    "default": True,
+}
+Draft7Validator.check_schema(JSON_SCHEMA_DRAFT_7_META_SCHEMA)  # ensure the schema is valid
+JSON_SCHEMA_DRAFT_7_VALIDATOR = Draft7Validator(JSON_SCHEMA_DRAFT_7_META_SCHEMA)
+
+
+def validate_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validates that a dictionary is a valid JSON schema.
+    """
+    try:
+        JSON_SCHEMA_DRAFT_7_VALIDATOR.validate(schema)
+    except ValidationError as error:
+        raise ValueError(str(error))
+    return schema
+
+
+# Pydantic type with built-in validation for JSON schemas
+JSONSchema: TypeAlias = Annotated[dict[str, Any], AfterValidator(validate_json_schema)]

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 from typing_extensions import TypeAlias
 
-from phoenix.server.api.helpers.jsonschema import JSONSchema
+from phoenix.server.api.helpers.jsonschema import JSONSchemaObjectDefinition
 
 JSONSerializable = Union[None, bool, int, float, str, dict[str, Any], list[Any]]
 
@@ -132,7 +132,7 @@ class OpenAIFunctionDefinition(PromptModel):
 
     name: str
     description: str = UNDEFINED
-    parameters: JSONSchema = UNDEFINED
+    parameters: JSONSchemaObjectDefinition = UNDEFINED
     strict: Optional[bool] = UNDEFINED
 
 
@@ -159,7 +159,7 @@ class AnthropicToolDefinition(PromptModel):
     Based on https://github.com/anthropics/anthropic-sdk-python/blob/93cbbbde964e244f02bf1bd2b579c5fabce4e267/src/anthropic/types/tool_param.py#L22
     """
 
-    input_schema: JSONSchema
+    input_schema: JSONSchemaObjectDefinition
     name: str
     cache_control: Optional[AnthropicCacheControlEphemeralParam] = UNDEFINED
     description: str = UNDEFINED

--- a/tests/unit/server/api/helpers/test_models.py
+++ b/tests/unit/server/api/helpers/test_models.py
@@ -568,6 +568,19 @@ def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[
             },
             id="invalid-schema-ref",
         ),
+        pytest.param(
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_status",
+                    "description": "Get system status",
+                    "parameters": {
+                        "type": "string",
+                    },
+                },
+            },
+            id="non-object-parameters",
+        ),
     ],
 )
 def test_openai_tool_definition_fails_invalid_tool_schemas(tool_definition: dict[str, Any]) -> None:

--- a/tests/unit/server/api/helpers/test_models.py
+++ b/tests/unit/server/api/helpers/test_models.py
@@ -658,7 +658,7 @@ def test_openai_tool_definition_fails_invalid_tool_schemas(tool_definition: dict
                                     "b": {"type": "number", "description": "blue value [0.0, 1.0]"},
                                     "name": {
                                         "type": "string",
-                                        "description": 'Human-readable color name in snake_case, e.g. "olive_green" or "turquoise"',  # noqa: E501
+                                        "description": 'Human-readable color name in snake_case, e.g., "olive_green" or "turquoise"',  # noqa: E501
                                     },
                                 },
                                 "required": ["r", "g", "b", "name"],

--- a/tests/unit/server/api/helpers/test_models.py
+++ b/tests/unit/server/api/helpers/test_models.py
@@ -496,136 +496,6 @@ from phoenix.server.api.helpers.prompts.models import AnthropicToolDefinition, O
             },
             id="pick-tshirt-size-function",
         ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "test_primitives",
-                    "description": "Test all primitive types",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "string_field": {"type": "string", "description": "A string field"},
-                            "number_field": {"type": "number", "description": "A number field"},
-                            "integer_field": {"type": "integer", "description": "An integer field"},
-                            "boolean_field": {"type": "boolean", "description": "A boolean field"},
-                            "null_field": {"type": "null", "description": "A null field"},
-                        },
-                        "required": [
-                            "string_field",
-                            "number_field",
-                            "integer_field",
-                            "boolean_field",
-                            "null_field",
-                        ],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="primitive-types-function",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "update_user_profile",
-                    "description": "Updates a user's profile information",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "user_id": {
-                                "type": "string",
-                                "description": "The ID of the user to update",
-                            },
-                            "nickname": {
-                                "description": "Optional nickname that can be null or a string",
-                                "anyOf": [{"type": "string"}, {"type": "null"}],
-                            },
-                        },
-                        "required": ["user_id"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="optional-anyof-parameter",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "categorize_colors",
-                    "description": "Categorize colors into warm, cool, or neutral tones, with null for uncertain cases",  # noqa: E501
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "colors": {
-                                "type": "array",
-                                "description": "List of color categories, with null for uncertain colors",  # noqa: E501
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "type": "string",
-                                            "enum": ["warm", "cool", "neutral"],
-                                            "description": "Color category",
-                                        },
-                                        {"type": "null"},
-                                    ]
-                                },
-                            }
-                        },
-                        "required": ["colors"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="array-of-optional-enums",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "set_temperature",
-                    "description": "Set temperature within valid range",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "temp": {
-                                "type": "integer",
-                                "minimum": 0,
-                                "maximum": 100,
-                                "description": "Temperature in Fahrenheit (0-100)",
-                            }
-                        },
-                        "required": ["temp"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="integer-min-max-constraints",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "set_temperature",
-                    "description": "Set temperature within valid range",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "temp": {
-                                "type": "number",
-                                "minimum": 0.5,  # float min
-                                "maximum": 100,  # integer max
-                                "description": "Temperature in Fahrenheit (0-100)",
-                            }
-                        },
-                        "required": ["temp"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="number-min-max-constraints",
-        ),
     ],
 )
 def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[str, Any]) -> None:
@@ -661,89 +531,6 @@ def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[
             {
                 "type": "function",
                 "function": {
-                    "name": "set_temperature",
-                    "description": "Sets the temperature for the thermostat",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "temp": {
-                                "type": "number",
-                                "enum": ["70", "72", "74"],  # only string properties can have enums
-                                "description": "The temperature to set in Fahrenheit",
-                            }
-                        },
-                        "required": ["temp"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="number-property-with-invalid-enum",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "get_weather",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"location": {"type": "string"}},
-                        "extra": "extra",  # extra properties are not allowed
-                    },
-                },
-            },
-            id="extra-properties",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "update_user",
-                    "description": "Updates user information",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string"},
-                        },
-                        "required": [
-                            "name",
-                            "email",  # email is not in properties
-                        ],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="required-field-not-in-properties",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "set_preferences",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "priority": {
-                                "type": "string",
-                                "enum": [
-                                    0,  # integer enum values not allowed
-                                    "low",
-                                    "medium",
-                                    "high",
-                                ],
-                                "description": "The priority level to set",
-                            }
-                        },
-                        "required": ["priority"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="string-property-with-priority-enum",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
                     "name": "select_color",
                     "description": "Select a color from the available options",
                     "parameters": {
@@ -771,68 +558,15 @@ def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[
                 "type": "function",
                 "function": {
                     "name": "set_temperature",
-                    "description": "Set temperature with invalid range",
+                    "description": "Set temperature with invalid schema",
                     "parameters": {
                         "type": "object",
-                        "properties": {
-                            "temp": {
-                                "type": "integer",
-                                "minimum": 100,
-                                "maximum": 0,  # min > max
-                                "description": "Temperature in Celsius",
-                            }
-                        },
-                        "required": ["temp"],
-                        "additionalProperties": False,
+                        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                        "required": "name",
                     },
                 },
             },
-            id="integer-min-max-range",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "set_count",
-                    "description": "Set an integer count with float bounds",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "count": {
-                                "type": "integer",
-                                "minimum": 1.4,  # float not allowed for integer property
-                                "description": "Count value",
-                            }
-                        },
-                        "required": ["count"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="integer-float-bounds",
-        ),
-        pytest.param(
-            {
-                "type": "function",
-                "function": {
-                    "name": "set_temperature",
-                    "description": "Set temperature with invalid range",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "temp": {
-                                "type": "number",
-                                "minimum": 100,
-                                "maximum": 0,  # min > max
-                                "description": "Temperature in Celsius",
-                            }
-                        },
-                        "required": ["temp"],
-                        "additionalProperties": False,
-                    },
-                },
-            },
-            id="number-min-max-range",
+            id="invalid-schema-ref",
         ),
     ],
 )

--- a/tests/unit/server/api/mutations/test_prompt_mutations.py
+++ b/tests/unit/server/api/mutations/test_prompt_mutations.py
@@ -295,7 +295,7 @@ class TestPromptMutations:
         assert result.data is None
 
     @pytest.mark.parametrize(
-        "variables,expected_error",
+        "variables",
         [
             pytest.param(
                 {
@@ -316,7 +316,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "Input should be a valid dictionary",
                 id="invalid-tools",
             ),
             pytest.param(
@@ -338,7 +337,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "Input should be a valid dictionary",
                 id="invalid-output-schema",
             ),
             pytest.param(
@@ -371,7 +369,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "function.parameters.type",
                 id="with-invalid-openai-tools",
             ),
             pytest.param(
@@ -416,17 +413,15 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "cache_control.type",
                 id="with-invalid-anthropic-tools",
             ),
         ],
     )
     async def test_create_chat_prompt_fails_with_invalid_input(
-        self, gql_client: AsyncGraphQLClient, variables: dict[str, Any], expected_error: str
+        self, gql_client: AsyncGraphQLClient, variables: dict[str, Any]
     ) -> None:
         result = await gql_client.execute(self.CREATE_CHAT_PROMPT_MUTATION, variables)
         assert len(result.errors) == 1
-        assert expected_error in result.errors[0].message
         assert result.data is None
 
     @pytest.mark.parametrize(
@@ -646,7 +641,7 @@ class TestPromptMutations:
         assert result.data is None
 
     @pytest.mark.parametrize(
-        "variables,expected_error",
+        "variables",
         [
             pytest.param(
                 {
@@ -666,7 +661,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "Input should be a valid dictionary",
                 id="invalid-tools",
             ),
             pytest.param(
@@ -687,7 +681,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "Input should be a valid dictionary",
                 id="invalid-output-schema",
             ),
             pytest.param(
@@ -719,7 +712,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "function.parameters.type",
                 id="with-invalid-openai-tools",
             ),
             pytest.param(
@@ -763,7 +755,6 @@ class TestPromptMutations:
                         },
                     }
                 },
-                "cache_control.type",
                 id="with-invalid-anthropic-tools",
             ),
         ],
@@ -773,7 +764,6 @@ class TestPromptMutations:
         db: DbSessionFactory,
         gql_client: AsyncGraphQLClient,
         variables: dict[str, Any],
-        expected_error: str,
     ) -> None:
         # Create initial prompt
         create_prompt_result = await gql_client.execute(
@@ -799,5 +789,4 @@ class TestPromptMutations:
         # Try to create invalid prompt version
         result = await gql_client.execute(self.CREATE_CHAT_PROMPT_VERSION_MUTATION, variables)
         assert len(result.errors) == 1
-        assert expected_error in result.errors[0].message
         assert result.data is None


### PR DESCRIPTION
LLM API providers support relatively advanced features of JSON schema for tools and response formats (e.g., recursive schemas) that are complex to implement in Pydantic. So this PR simplifies things and introduces a third-party library.

There are two main choices for third-party libraries in the Python ecosystem, `jsonschema` and `fastjsonschema`. As the name suggests, the latter is significantly faster (>10x in my benchmarking), but seems to be less actively maintained (no support for more recent formats and less overall activity in the repo). It also has a few quirks in implementation that deviate from the standard spec and make it more lax than other implementations in a way that could make it difficult to migrate to `jsonschema`. So I chose `jsonschema` to start.

I am relying on JSON Schema draft 7, a relatively old version of the spec that is also supported in `fastjsonschema` to give us flexibility to switch (in theory). It also fully supports all the code snippets I've found in OpenAI's and Anthropic's documentation so far. The implementation is open to adding support for additional versions.

I've added a max version to the `jsonschema` version so that we are not on the bleeding edge in case there is a regression.

resolves #5987
