### PR TITLE
ci: update unit tests dependency respx>=0.22 for httpx>=0.28

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -5,7 +5,7 @@ arize
 asgi-lifespan
 asyncpg
 grpc-interceptor[testing]
-httpx<0.28
+httpx
 httpx-ws
 litellm>=1.0.3
 nest-asyncio # for executor testing
@@ -18,7 +18,7 @@ psycopg[binary,pool]
 pyarrow-stubs
 pytest-postgresql
 responses
-respx # For OpenAI testing
+respx>=0.22.0
 syrupy
 tenacity
 tiktoken


### PR DESCRIPTION
resolves #5575 