### PR TITLE
ci: unpin litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
   "arize[AutoEmbeddings, LLM_Evaluation]",
   "llama-index>=0.10.3",
   "langchain>=0.0.334",
-  "litellm>=1.0.3,<1.57.5", # windows compatibility broken on 1.57.5 (https://github.com/BerriAI/litellm/issues/7677)
+  "litellm>=1.0.3",
   "google-cloud-aiplatform>=1.3",
   "anthropic",
   "prometheus_client",

--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -7,7 +7,7 @@ asyncpg
 grpc-interceptor[testing]
 httpx
 httpx-ws
-litellm>=1.0.3,<1.57.5
+litellm>=1.0.3
 nest-asyncio # for executor testing
 numpy
 openai>=1.0.0


### PR DESCRIPTION
LiteLLM fixed on Windows: https://github.com/BerriAI/litellm/issues/7677#issuecomment-2584658205

resolves #6005
