### PR TITLE
feat: `phoenix.otel` infers GRPC port from env

### DIFF
--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -7,6 +7,7 @@ These defaults are aware of environment variables you may have set to configure 
 - `PHOENIX_PROJECT_NAME`
 - `PHOENIX_CLIENT_HEADERS`
 - `PHOENIX_API_KEY`
+- `PHOENIX_GRPC_PORT`
 
 # Examples
 
@@ -52,7 +53,8 @@ tracer_provider = register()
 
 When passing in the `endpoint` argument, **you must specify the fully qualified endpoint**. For
 example, in order to export spans via HTTP to localhost, use Pheonix's HTTP collector endpoint:
-`http://localhost:6006/v1/traces`. The gRPC endpoint is different: `http://localhost:4317`.
+`http://localhost:6006/v1/traces`. The default gRPC endpoint is different: `http://localhost:4317`.
+If the `PHOENIX_GRPC_PORT` environment variable is set, it will override the default gRPC port.
 
 ```
 from phoenix.otel import register

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -23,13 +23,12 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from .settings import (
     get_env_client_headers,
     get_env_collector_endpoint,
+    get_env_grpc_port,
     get_env_phoenix_auth_header,
     get_env_project_name,
 )
 
 PROJECT_NAME = _ResourceAttributes.PROJECT_NAME
-
-_DEFAULT_GRPC_PORT = 4317
 
 
 def register(
@@ -388,7 +387,7 @@ def _maybe_http_endpoint(parsed_endpoint: ParseResult) -> bool:
 
 
 def _maybe_grpc_endpoint(parsed_endpoint: ParseResult) -> bool:
-    if not parsed_endpoint.path and parsed_endpoint.port == 4317:
+    if not parsed_endpoint.path and parsed_endpoint.port == get_env_grpc_port():
         return True
     return False
 
@@ -413,7 +412,7 @@ def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
 
 
 def _construct_grpc_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
-    return parsed_endpoint._replace(netloc=f"{parsed_endpoint.hostname}:{_DEFAULT_GRPC_PORT}")
+    return parsed_endpoint._replace(netloc=f"{parsed_endpoint.hostname}:{get_env_grpc_port()}")
 
 
 _KNOWN_PROVIDERS = {

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -8,9 +8,15 @@ logger = logging.getLogger(__name__)
 
 # Environment variables specific to the subpackage
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
+ENV_PHOENIX_GRPC_PORT = "PHOENIX_GRPC_PORT"
 ENV_PHOENIX_PROJECT_NAME = "PHOENIX_PROJECT_NAME"
 ENV_PHOENIX_CLIENT_HEADERS = "PHOENIX_CLIENT_HEADERS"
 ENV_PHOENIX_API_KEY = "PHOENIX_API_KEY"
+
+GRPC_PORT = 4317
+"""The port the gRPC server will run on after launch_app is called.
+The default network port for OTLP/gRPC is 4317.
+See https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-default-port"""
 
 
 def get_env_collector_endpoint() -> Optional[str]:
@@ -33,6 +39,17 @@ def get_env_phoenix_auth_header() -> Optional[Dict[str, str]]:
         return dict(authorization=f"Bearer {api_key}")
     else:
         return None
+
+
+def get_env_grpc_port() -> int:
+    if not (port := os.getenv(ENV_PHOENIX_GRPC_PORT)):
+        return GRPC_PORT
+    if port.isnumeric():
+        return int(port)
+    raise ValueError(
+        f"Invalid value for environment variable {ENV_PHOENIX_GRPC_PORT}: "
+        f"{port}. Value must be an integer."
+    )
 
 
 # Optional whitespace


### PR DESCRIPTION
- resolves #5955 

While `PHOENIX_GRPC_PORT` is typically a server-side variable, this provides an intuitive mechanism to improve the port-inference logic used in `phoenix-otel`.

We should consider also adding an explicit override that will force using either gRPC or HTTP regardless of endpoint (which would be easier than our original proposed solution of explicitly setting the exporter).