### PR TITLE
feat: Prettify mutations with user facing errors

### DIFF
--- a/app/src/components/dataset/CreateDatasetForm.tsx
+++ b/app/src/components/dataset/CreateDatasetForm.tsx
@@ -65,7 +65,6 @@ export function CreateDatasetForm(props: CreateDatasetFormProps) {
           }
         },
         onError: (error) => {
-          // TODO(datasets): cleanup error handling to show human friendly error
           onDatasetCreateError(error);
         },
       });

--- a/app/src/components/dataset/NewDatasetButton.tsx
+++ b/app/src/components/dataset/NewDatasetButton.tsx
@@ -4,6 +4,7 @@ import { Alert, Card, PopoverTrigger } from "@arizeai/components";
 
 import { Button, Icon, Icons, View } from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { CreateDatasetForm } from "./CreateDatasetForm";
 
@@ -39,7 +40,11 @@ export function NewDatasetButton({
         <View width="500px">
           {error ? <Alert variant="danger">{error}</Alert> : null}
           <CreateDatasetForm
-            onDatasetCreateError={(error) => setError(error.message)}
+            onDatasetCreateError={(error) => {
+              const formattedError =
+                getErrorMessagesFromRelayMutationError(error);
+              setError(formattedError?.[0] ?? error.message);
+            }}
             onDatasetCreated={({ id, name }) => {
               setError(null);
               setIsOpen(false);

--- a/app/src/pages/dataset/AddDatasetExampleDialog.tsx
+++ b/app/src/pages/dataset/AddDatasetExampleDialog.tsx
@@ -7,6 +7,7 @@ import { Alert, Card, CardProps, Dialog, TextArea } from "@arizeai/components";
 
 import { Button, Flex, Icon, Icons, View } from "@phoenix/components";
 import { JSONEditor } from "@phoenix/components/code";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import { isJSONObjectString } from "@phoenix/utils/jsonUtils";
 
 import { AddDatasetExampleDialogMutation } from "./__generated__/AddDatasetExampleDialogMutation.graphql";
@@ -94,7 +95,8 @@ export function AddDatasetExampleDialog(props: AddDatasetExampleDialogProps) {
           onCompleted();
         },
         onError: (error) => {
-          setSubmitError(error.message);
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
+          setSubmitError(formattedError?.[0] ?? error.message);
         },
       });
     },

--- a/app/src/pages/datasets/DatasetsPage.tsx
+++ b/app/src/pages/datasets/DatasetsPage.tsx
@@ -7,6 +7,7 @@ import { ActionMenu, Dialog, DialogContainer, Item } from "@arizeai/components";
 import { Flex, Heading, Icon, Icons, Loading, View } from "@phoenix/components";
 import { CreateDatasetForm } from "@phoenix/components/dataset/CreateDatasetForm";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { DatasetsPageQuery } from "./__generated__/DatasetsPageQuery.graphql";
 import { DatasetFromCSVForm } from "./DatasetFromCSVForm";
@@ -91,9 +92,11 @@ function CreateDatasetActionMenu({
             onDatasetCreated();
           }}
           onDatasetCreateError={(error) => {
+            const formattedError =
+              getErrorMessagesFromRelayMutationError(error);
             notifyError({
               title: "Dataset creation failed",
-              message: error.message,
+              message: formattedError?.[0] ?? error.message,
             });
           }}
         />
@@ -119,9 +122,11 @@ function CreateDatasetActionMenu({
             onDatasetCreated();
           }}
           onDatasetCreateError={(error) => {
+            const formattedError =
+              getErrorMessagesFromRelayMutationError(error);
             notifyError({
               title: "Dataset creation failed",
-              message: error.message,
+              message: formattedError?.[0] ?? error.message,
             });
           }}
         />

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -22,6 +22,7 @@ import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { DatasetsTable_datasets$key } from "./__generated__/DatasetsTable_datasets.graphql";
 import {
@@ -173,9 +174,11 @@ export function DatasetsTable(props: DatasetsTableProps) {
                 refetch({}, { fetchPolicy: "store-and-network" });
               }}
               onDatasetEditError={(error) => {
+                const formattedError =
+                  getErrorMessagesFromRelayMutationError(error);
                 notifyError({
                   title: "Dataset update failed",
-                  message: error.message,
+                  message: formattedError?.[0] ?? error.message,
                 });
               }}
               onDatasetDelete={() => {
@@ -186,9 +189,11 @@ export function DatasetsTable(props: DatasetsTableProps) {
                 refetch({}, { fetchPolicy: "store-and-network" });
               }}
               onDatasetDeleteError={(error) => {
+                const formattedError =
+                  getErrorMessagesFromRelayMutationError(error);
                 notifyError({
                   title: "Dataset deletion failed",
-                  message: error.message,
+                  message: formattedError?.[0] ?? error.message,
                 });
               }}
             />

--- a/app/src/pages/examples/ExampleSelectionToolbar.tsx
+++ b/app/src/pages/examples/ExampleSelectionToolbar.tsx
@@ -7,6 +7,7 @@ import { DialogContainer } from "@arizeai/components";
 import { Button, Flex, Icon, Icons, Text, View } from "@phoenix/components";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 import { useDatasetContext } from "@phoenix/contexts/DatasetContext";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 interface SelectedExample {
   id: string;
@@ -57,9 +58,10 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
         refreshLatestVersion();
       },
       onError: (error) => {
+        const formattedError = getErrorMessagesFromRelayMutationError(error);
         notifyError({
           title: "An error occurred",
-          message: `Failed to delete examples: ${error.message}`,
+          message: `Failed to delete examples: ${formattedError?.[0] ?? error.message}`,
         });
       },
     });

--- a/app/src/pages/experiments/ExperimentSelectionToolbar.tsx
+++ b/app/src/pages/experiments/ExperimentSelectionToolbar.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContainer } from "@arizeai/components";
 
 import { Button, Flex, Icon, Icons, Text, View } from "@phoenix/components";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 interface SelectedExperiment {
   id: string;
@@ -52,7 +53,7 @@ export function ExperimentSelectionToolbar(
       },
       onCompleted: () => {
         notifySuccess({
-          title: "Examples Deleted",
+          title: "Experiments Deleted",
           message: `${selectedExperiments.length} experiment${isPlural ? "s" : ""} have been deleted.`,
         });
         // Clear the selection
@@ -60,9 +61,10 @@ export function ExperimentSelectionToolbar(
         onClearSelection();
       },
       onError: (error) => {
+        const formattedError = getErrorMessagesFromRelayMutationError(error);
         notifyError({
           title: "An error occurred",
-          message: `Failed to delete examples: ${error.message}`,
+          message: `Failed to delete experiments: ${formattedError?.[0] ?? error.message}`,
         });
       },
     });

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from "@phoenix/components";
 import { CreateDatasetForm } from "@phoenix/components/dataset/CreateDatasetForm";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { DatasetSelectorPopoverContent } from "./DatasetSelectorPopoverContent";
 
@@ -75,9 +76,10 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
           onClearSelection();
         },
         onError: (error) => {
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
           notifyError({
             title: "An error occurred",
-            message: `Failed to add spans to dataset: ${error.message}`,
+            message: `Failed to add spans to dataset: ${formattedError?.[0] ?? error.message}`,
           });
         },
       });
@@ -162,10 +164,12 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
                         onDismiss={() => setDialog(null)}
                       >
                         <CreateDatasetForm
-                          onDatasetCreateError={() => {
+                          onDatasetCreateError={(error) => {
+                            const formattedError =
+                              getErrorMessagesFromRelayMutationError(error);
                             notifyError({
                               title: "Dataset creation failed",
-                              message: "Failed to create dataset.",
+                              message: `Failed to create dataset: ${formattedError?.[0] ?? error.message}`,
                             });
                           }}
                           onDatasetCreated={(dataset) => {

--- a/app/src/pages/settings/DeleteUserDialog.tsx
+++ b/app/src/pages/settings/DeleteUserDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "@arizeai/components";
 
 import { Button, Flex, Text, View } from "@phoenix/components";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 export function DeleteUserDialog({
   userId,
@@ -40,9 +41,10 @@ export function DeleteUserDialog({
         onClose();
       },
       onError: (error) => {
+        const formattedError = getErrorMessagesFromRelayMutationError(error);
         notifyError({
           title: "Failed to delete user",
-          message: error.message,
+          message: formattedError?.[0] ?? error.message,
         });
       },
     });

--- a/app/src/pages/settings/SystemAPIKeysTable.tsx
+++ b/app/src/pages/settings/SystemAPIKeysTable.tsx
@@ -14,6 +14,7 @@ import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { SystemAPIKeysTableFragment$key } from "./__generated__/SystemAPIKeysTableFragment.graphql";
 import { SystemAPIKeysTableQuery } from "./__generated__/SystemAPIKeysTableQuery.graphql";
@@ -77,9 +78,10 @@ export function SystemAPIKeysTable({
           });
         },
         onError: (error) => {
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
           notifyError({
             title: "Error deleting system key",
-            message: error.message,
+            message: formattedError?.[0] ?? error.message,
           });
         },
       });

--- a/app/src/pages/settings/UserAPIKeysTable.tsx
+++ b/app/src/pages/settings/UserAPIKeysTable.tsx
@@ -14,6 +14,7 @@ import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { UserAPIKeysTableFragment$key } from "./__generated__/UserAPIKeysTableFragment.graphql";
 import { UserAPIKeysTableQuery } from "./__generated__/UserAPIKeysTableQuery.graphql";
@@ -80,9 +81,10 @@ export function UserAPIKeysTable({
           });
         },
         onError: (error) => {
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
           notifyError({
             title: "Error deleting user key",
-            message: error.message,
+            message: formattedError?.[0] ?? error.message,
           });
         },
       });

--- a/app/src/pages/settings/UsersCard.tsx
+++ b/app/src/pages/settings/UsersCard.tsx
@@ -5,6 +5,7 @@ import { Card, DialogContainer } from "@arizeai/components";
 
 import { Button, Icon, Icons, Loading, View } from "@phoenix/components";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { UsersCardQuery } from "./__generated__/UsersCardQuery.graphql";
 import { NewUserDialog } from "./NewUserDialog";
@@ -52,9 +53,11 @@ export function UsersCard() {
                   setFetchKey((prev) => prev + 1);
                 }}
                 onNewUserCreationError={(error) => {
+                  const formattedError =
+                    getErrorMessagesFromRelayMutationError(error);
                   notifyError({
                     title: "Error adding user",
-                    message: error.message,
+                    message: formattedError?.[0] ?? error.message,
                   });
                 }}
               />

--- a/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
+++ b/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
@@ -8,6 +8,7 @@ import { Alert, Card, CardProps, Dialog } from "@arizeai/components";
 import { Button, Flex, Icon, Icons, View } from "@phoenix/components";
 import { JSONEditor } from "@phoenix/components/code";
 import { DatasetPicker, NewDatasetButton } from "@phoenix/components/dataset";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 import { isJSONObjectString } from "@phoenix/utils/jsonUtils";
 
 import { SpanToDatasetExampleDialogQuery } from "./__generated__/SpanToDatasetExampleDialogQuery.graphql";
@@ -119,7 +120,8 @@ export function SpanToDatasetExampleDialog({
           onCompleted(newExample.datasetId);
         },
         onError: (error) => {
-          setSubmitError(error.message);
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
+          setSubmitError(formattedError?.[0] ?? error.message);
         },
       });
     },


### PR DESCRIPTION
I searched the codebase for gql mutations that handle errors, and then prettified the errors before passing them through to notify, etc.

resolves: #6035 