### PR TITLE
feat: Explicit OTEL protocol override

### DIFF
--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -61,6 +61,15 @@ from phoenix.otel import register
 tracer_provider = register(endpoint="http://localhost:6006/v1/traces")
 ```
 
+Additionally, the `protocol` argument can be used to enforce the OTLP transport protocol
+regardless of the endpoint specified. This might be useful in cases such as when the GRPC
+endpoint is bound to a different port than the default (4317).
+
+```
+from phoenix.otel import register
+tracer_provider = register(endpoint="http://localhost:9999", protocol="grpc")
+```
+
 ### Additional configuration
 
 `register` can be configured with different keyword arguments:

--- a/packages/phoenix-otel/README.md
+++ b/packages/phoenix-otel/README.md
@@ -63,7 +63,8 @@ tracer_provider = register(endpoint="http://localhost:6006/v1/traces")
 
 Additionally, the `protocol` argument can be used to enforce the OTLP transport protocol
 regardless of the endpoint specified. This might be useful in cases such as when the GRPC
-endpoint is bound to a different port than the default (4317).
+endpoint is bound to a different port than the default (4317). The valid protocols are:
+"http/protobuf", and "grpc".
 
 ```
 from phoenix.otel import register

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -37,7 +37,9 @@ class OTLPTransportProtocol(str, Enum):
     GRPC = "grpc"
 
     @classmethod
-    def _missing_(cls, value: str) -> "OTLPTransportProtocol":
+    def _missing_(cls, value: object) -> "OTLPTransportProtocol":
+        if not isinstance(value, str):
+            raise ValueError(f"Invalid protocol: {value}. Must be a string.")
         if "http" in value:
             raise ValueError(
                 (

--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -71,9 +71,9 @@ def register(
     tracer_provider = TracerProvider(resource=resource, verbose=False, protocol=protocol)
     span_processor: SpanProcessor
     if batch:
-        span_processor = BatchSpanProcessor(endpoint=endpoint, headers=headers)
+        span_processor = BatchSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
     else:
-        span_processor = SimpleSpanProcessor(endpoint=endpoint, headers=headers)
+        span_processor = SimpleSpanProcessor(endpoint=endpoint, headers=headers, protocol=protocol)
     tracer_provider.add_span_processor(span_processor)
     tracer_provider._default_processor = True
 


### PR DESCRIPTION
- allows a user to pass `protocl="http" | "grpc"` to either use a specific endpoint, or force the use of that exporter for the given endpoint