### PR TITLE
feat: Support image template parts in `phoenix-evals`

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -33,6 +33,7 @@ class DotKeyFormatter(Formatter):
 class PromptPartContentType(str, Enum):
     TEXT = "text"
     AUDIO = "audio"
+    IMAGE = "image"
 
 
 @dataclass


### PR DESCRIPTION
Resolves #6043 

- Allows for the creation of eval templates that include string encoded "image" parts