### PR TITLE
fix(playground): remove gpt-3.5-turbo-instruct

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -466,7 +466,6 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient):
         "gpt-3.5-turbo-0125",
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-1106",
-        "gpt-3.5-turbo-instruct",
     ],
 )
 class OpenAIStreamingClient(OpenAIBaseStreamingClient):


### PR DESCRIPTION
This model uses the legacy completions API, which we do not currently support.

resolves #6080
