### PR TITLE
fix(components): fix button size and variance props

### DIFF
--- a/app/src/components/button/Button.tsx
+++ b/app/src/components/button/Button.tsx
@@ -9,6 +9,8 @@ import { SizingProps, StylableProps, Variant } from "@phoenix/components/types";
 
 import { buttonCSS } from "./styles";
 
+type ButtonVariant = Exclude<Variant, "info">;
+
 interface ButtonProps extends AriaButtonProps, SizingProps, StylableProps {
   /**
    * An optional prefixed icon for the button
@@ -18,7 +20,7 @@ interface ButtonProps extends AriaButtonProps, SizingProps, StylableProps {
    * The variant of the button
    * @default: 'default'
    */
-  variant?: Exclude<Variant, "info">;
+  variant?: ButtonVariant;
 }
 
 function Button(props: ButtonProps, ref: Ref<HTMLButtonElement>) {

--- a/app/src/components/button/Button.tsx
+++ b/app/src/components/button/Button.tsx
@@ -5,23 +5,20 @@ import {
 } from "react-aria-components";
 import { css } from "@emotion/react";
 
-import {
-  SizingProps,
-  StylableProps,
-  VarianceProps,
-} from "@phoenix/components/types";
+import { SizingProps, StylableProps, Variant } from "@phoenix/components/types";
 
 import { buttonCSS } from "./styles";
 
-interface ButtonProps
-  extends AriaButtonProps,
-    SizingProps,
-    VarianceProps,
-    StylableProps {
+interface ButtonProps extends AriaButtonProps, SizingProps, StylableProps {
   /**
    * An optional prefixed icon for the button
    */
   icon?: ReactNode;
+  /**
+   * The variant of the button
+   * @default: 'default'
+   */
+  variant?: Exclude<Variant, "info">;
 }
 
 function Button(props: ButtonProps, ref: Ref<HTMLButtonElement>) {

--- a/app/src/components/types/sizing.ts
+++ b/app/src/components/types/sizing.ts
@@ -1,6 +1,6 @@
 export type Size = "XS" | "S" | "M" | "L" | "XL" | "XXL";
 
-export type ComponentSize = Omit<Size, "XS" | "XL" | "XXL">;
+export type ComponentSize = Exclude<Size, "XS" | "XL" | "XXL">;
 
 export type TextSize = Size;
 

--- a/app/src/components/types/variance.ts
+++ b/app/src/components/types/variance.ts
@@ -3,11 +3,3 @@ export type LevelVariant = "success" | "danger" | "info";
 export type QuietVariant = "quiet";
 
 export type Variant = BaseVariant | LevelVariant | QuietVariant;
-
-export interface VarianceProps {
-  /**
-   * The variant of the component
-   * @default 'default'
-   */
-  variant?: Variant;
-}

--- a/app/src/components/types/variance.ts
+++ b/app/src/components/types/variance.ts
@@ -1,7 +1,8 @@
 export type BaseVariant = "primary" | "default";
 export type LevelVariant = "success" | "danger" | "info";
+export type QuietVariant = "quiet";
 
-export type Variant = BaseVariant | LevelVariant;
+export type Variant = BaseVariant | LevelVariant | QuietVariant;
 
 export interface VarianceProps {
   /**


### PR DESCRIPTION
- Fixes size props to use Exclude (for unions) over omit (for object keys)
- removes info variant for button
- adds quiet variant

![image](https://github.com/user-attachments/assets/aa47f8b7-ca6b-4a98-a57d-2e761241088b)
