### PR TITLE
feat(prompts): Improve post-save prompt ux

### DIFF
--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -220,13 +220,17 @@ function PlaygroundContent() {
   const numInstances = instances.length;
   const isSingleInstance = numInstances === 1;
   const isRunning = instances.some((instance) => instance.activeRunId != null);
+  const anyDirtyInstances = instances.some((instance) => instance.dirty);
 
   // Handles blocking navigation when a run is in progress
   const shouldBlockUnload = useCallback(
     ({ currentLocation, nextLocation }: Parameters<BlockerFunction>[0]) => {
-      return isRunning && currentLocation.pathname !== nextLocation.pathname;
+      return (
+        (isRunning && currentLocation.pathname !== nextLocation.pathname) ||
+        anyDirtyInstances
+      );
     },
-    [isRunning]
+    [isRunning, anyDirtyInstances]
   );
   const blocker = useBlocker(shouldBlockUnload);
 
@@ -341,7 +345,11 @@ function PlaygroundContent() {
       {blocker != null && (
         <ConfirmNavigationDialog
           blocker={blocker}
-          message="Playground run is still in progress, leaving the page may result in incomplete runs. Are you sure you want to leave?"
+          message={
+            isRunning
+              ? "Playground run is still in progress, leaving the page may result in incomplete runs. Are you sure you want to leave?"
+              : "You have unsaved changes. Are you sure you want to leave?"
+          }
         />
       )}
     </>

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -237,7 +237,7 @@ function PlaygroundContent() {
   // Handles blocking page reloads when a run is in progress
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (isRunning) {
+      if (isRunning || anyDirtyInstances) {
         e.preventDefault();
         // This is deprecated but still necessary for cross-browser compatibility
         e.returnValue = true;
@@ -247,7 +247,7 @@ function PlaygroundContent() {
     window.addEventListener("beforeunload", handleBeforeUnload);
 
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [isRunning]);
+  }, [isRunning, anyDirtyInstances]);
 
   return (
     <>

--- a/app/src/pages/playground/PromptComboBox.tsx
+++ b/app/src/pages/playground/PromptComboBox.tsx
@@ -39,7 +39,7 @@ export function PromptComboBox({
       }
     `,
     {},
-    { fetchPolicy: "network-only" }
+    { fetchPolicy: "store-and-network", fetchKey: promptId ?? undefined }
   );
   const prompts = data.prompts.edges;
   const items = useMemo(() => {

--- a/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -80,6 +80,28 @@ export const UpsertPromptFromTemplateDialog = ({
         }
       }
     `);
+  // tasks to complete after either mutation completes successfully
+  const onSuccess = useCallback(
+    (promptId: string) => {
+      const state = store.getState();
+      const instance = state.instances.find(
+        (instance) => instance.id === instanceId
+      );
+      if (!instance) {
+        return;
+      }
+      state.updateInstance({
+        instanceId,
+        patch: {
+          prompt: {
+            id: promptId,
+          },
+        },
+        dirty: false,
+      });
+    },
+    [store, instanceId]
+  );
   const onCreate: SavePromptSubmitHandler = useCallback(
     (params) => {
       const { promptInput, templateFormat } = getInstancePromptParamsFromStore(
@@ -116,6 +138,7 @@ export const UpsertPromptFromTemplateDialog = ({
               },
             },
           });
+          onSuccess(response.createChatPrompt.id);
           setDialog(null);
         },
         onError: (error) => {
@@ -134,6 +157,7 @@ export const UpsertPromptFromTemplateDialog = ({
       navigate,
       notifyError,
       notifySuccess,
+      onSuccess,
       setDialog,
       store,
     ]
@@ -177,6 +201,7 @@ export const UpsertPromptFromTemplateDialog = ({
               },
             },
           });
+          onSuccess(response.createChatPromptVersion.id);
           setDialog(null);
         },
         onError: (error) => {
@@ -197,6 +222,7 @@ export const UpsertPromptFromTemplateDialog = ({
       setDialog,
       store,
       updatePrompt,
+      onSuccess,
     ]
   );
   return (


### PR DESCRIPTION

https://github.com/user-attachments/assets/0e083cfe-a1be-47d3-b76d-91f0a221cb32

Resolves #6074
Resolves #6092

- Update prompt in combobox with newly created or updated prompt
- Reset dirty state when prompt is saved / created
- Warn before navigations / tab close when any instance has a dirty state