### PR TITLE
feat: PromptLabel gql interface

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -285,6 +285,11 @@ input CreateDatasetInput {
   metadata: JSON
 }
 
+input CreatePromptLabelInput {
+  name: Identifier!
+  description: String = null
+}
+
 input CreateSpanAnnotationInput {
   spanId: GlobalID!
   name: String!
@@ -534,6 +539,10 @@ input DeleteExperimentsInput {
 
 input DeletePromptInput {
   promptId: GlobalID!
+}
+
+input DeletePromptLabelInput {
+  promptLabelId: GlobalID!
 }
 
 type DeletePromptMutationPayload {
@@ -1242,6 +1251,11 @@ type Mutation {
   patchPrompt(input: PatchPromptInput!): Prompt!
   deletePromptVersionTag(input: DeletePromptVersionTagInput!): PromptVersionTagMutationPayload!
   setPromptVersionTag(input: SetPromptVersionTagInput!): PromptVersionTagMutationPayload!
+  createPromptLabel(input: CreatePromptLabelInput!): PromptLabelMutationPayload!
+  patchPromptLabel(input: PatchPromptLabelInput!): PromptLabelMutationPayload!
+  deletePromptLabel(input: DeletePromptLabelInput!): PromptLabelMutationPayload!
+  setPromptLabelSingleQuery(input: SetPromptLabelInput!): PromptLabelMutationPayload!
+  removePromptLabel(input: RemovePromptLabelInput!): PromptLabelMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
   patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
@@ -1312,6 +1326,12 @@ input PatchDatasetInput {
 input PatchPromptInput {
   promptId: GlobalID!
   description: String!
+}
+
+input PatchPromptLabelInput {
+  promptLabelId: GlobalID!
+  name: Identifier = null
+  description: String = null
 }
 
 input PatchUserInput {
@@ -1494,6 +1514,19 @@ type PromptEdge {
   node: Prompt!
 }
 
+type PromptLabel implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  name: Identifier!
+  description: String
+  prompts: [Prompt!]!
+}
+
+type PromptLabelMutationPayload {
+  promptLabel: PromptLabel
+  query: Query!
+}
+
 type PromptMessage {
   role: PromptMessageRole!
   content: [ContentPart!]!
@@ -1632,6 +1665,11 @@ type Query {
   ): [Cluster!]!
 }
 
+input RemovePromptLabelInput {
+  promptId: GlobalID!
+  promptLabelId: GlobalID!
+}
+
 type Retrieval {
   queryId: ID!
   documentId: ID!
@@ -1663,6 +1701,11 @@ type Segment {
 type Segments {
   segments: [Segment!]!
   totalCounts: DatasetValues!
+}
+
+input SetPromptLabelInput {
+  promptId: GlobalID!
+  promptLabelId: GlobalID!
 }
 
 input SetPromptVersionTagInput {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1522,6 +1522,24 @@ type PromptLabel implements Node {
   prompts: [Prompt!]!
 }
 
+"""A connection to a list of items."""
+type PromptLabelConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [PromptLabelEdge!]!
+}
+
+"""An edge in a connection."""
+type PromptLabelEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: PromptLabel!
+}
+
 type PromptLabelMutationPayload {
   promptLabel: PromptLabel
   query: Query!
@@ -1643,6 +1661,7 @@ type Query {
   node(id: GlobalID!): Node!
   viewer: User
   prompts(first: Int = 50, last: Int, after: String, before: String): PromptConnection!
+  promptLabels(first: Int = 50, last: Int, after: String, before: String): PromptLabelConnection!
   clusters(clusters: [ClusterInput!]!): [Cluster!]!
   hdbscanClustering(
     """Event ID of the coordinates"""

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1254,8 +1254,8 @@ type Mutation {
   createPromptLabel(input: CreatePromptLabelInput!): PromptLabelMutationPayload!
   patchPromptLabel(input: PatchPromptLabelInput!): PromptLabelMutationPayload!
   deletePromptLabel(input: DeletePromptLabelInput!): PromptLabelMutationPayload!
-  setPromptLabelSingleQuery(input: SetPromptLabelInput!): PromptLabelMutationPayload!
-  removePromptLabel(input: RemovePromptLabelInput!): PromptLabelMutationPayload!
+  setPromptLabel(input: SetPromptLabelInput!): PromptLabelMutationPayload!
+  unsetPromptLabel(input: UnsetPromptLabelInput!): PromptLabelMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
   patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
@@ -1682,11 +1682,6 @@ type Query {
     """HDBSCAN cluster selection epsilon"""
     clusterSelectionEpsilon: Float! = 0
   ): [Cluster!]!
-}
-
-input RemovePromptLabelInput {
-  promptId: GlobalID!
-  promptLabelId: GlobalID!
 }
 
 type Retrieval {
@@ -2162,6 +2157,11 @@ type UMAPPoints {
   clusters: [Cluster!]!
   corpusData: [UMAPPoint!]!
   contextRetrievals: [Retrieval!]!
+}
+
+input UnsetPromptLabelInput {
+  promptId: GlobalID!
+  promptLabelId: GlobalID!
 }
 
 type User implements Node {

--- a/src/phoenix/db/migrations/versions/bc8fea3c2bc8_add_prompt_tables.py
+++ b/src/phoenix/db/migrations/versions/bc8fea3c2bc8_add_prompt_tables.py
@@ -96,6 +96,10 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
+        sa.UniqueConstraint(
+            "prompt_label_id",
+            "prompt_id",
+        ),
     )
 
     op.create_table(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -895,6 +895,8 @@ class PromptPromptLabel(Base):
     )
     prompt: Mapped["Prompt"] = relationship("Prompt", back_populates="prompts_prompt_labels")
 
+    __table_args__ = (UniqueConstraint("prompt_label_id", "prompt_id"),)
+
 
 class PromptVersion(Base):
     __tablename__ = "prompt_versions"

--- a/src/phoenix/server/api/mutations/__init__.py
+++ b/src/phoenix/server/api/mutations/__init__.py
@@ -8,6 +8,7 @@ from phoenix.server.api.mutations.dataset_mutations import DatasetMutationMixin
 from phoenix.server.api.mutations.experiment_mutations import ExperimentMutationMixin
 from phoenix.server.api.mutations.export_events_mutations import ExportEventsMutationMixin
 from phoenix.server.api.mutations.project_mutations import ProjectMutationMixin
+from phoenix.server.api.mutations.prompt_label_mutations import PromptLabelMutationMixin
 from phoenix.server.api.mutations.prompt_mutations import PromptMutationMixin
 from phoenix.server.api.mutations.prompt_version_tag_mutations import PromptVersionTagMutationMixin
 from phoenix.server.api.mutations.span_annotations_mutations import SpanAnnotationMutationMixin
@@ -24,6 +25,7 @@ class Mutation(
     ProjectMutationMixin,
     PromptMutationMixin,
     PromptVersionTagMutationMixin,
+    PromptLabelMutationMixin,
     SpanAnnotationMutationMixin,
     TraceAnnotationMutationMixin,
     UserMutationMixin,

--- a/src/phoenix/server/api/mutations/prompt_label_mutations.py
+++ b/src/phoenix/server/api/mutations/prompt_label_mutations.py
@@ -1,0 +1,194 @@
+# file: PromptLabelMutations.py
+
+# file: PromptLabelMutations.py
+from typing import Optional
+
+import strawberry
+from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
+from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
+from strawberry.relay import GlobalID
+from strawberry.types import Info
+
+from phoenix.db import models
+from phoenix.db.types.identifier import Identifier as IdentifierModel
+from phoenix.server.api.context import Context
+from phoenix.server.api.exceptions import Conflict, NotFound
+from phoenix.server.api.queries import Query
+from phoenix.server.api.types.Identifier import Identifier
+from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.Prompt import Prompt
+from phoenix.server.api.types.PromptLabel import PromptLabel, to_gql_prompt_label
+
+
+@strawberry.input
+class CreatePromptLabelInput:
+    name: Identifier
+    description: Optional[str] = None
+
+
+@strawberry.input
+class PatchPromptLabelInput:
+    prompt_label_id: GlobalID
+    name: Optional[Identifier] = None
+    description: Optional[str] = None
+
+
+@strawberry.input
+class DeletePromptLabelInput:
+    prompt_label_id: GlobalID
+
+
+@strawberry.input
+class SetPromptLabelInput:
+    prompt_id: GlobalID
+    prompt_label_id: GlobalID
+
+
+@strawberry.input
+class RemovePromptLabelInput:
+    prompt_id: GlobalID
+    prompt_label_id: GlobalID
+
+
+@strawberry.type
+class PromptLabelMutationPayload:
+    prompt_label: Optional["PromptLabel"]
+    query: "Query"
+
+
+@strawberry.type
+class PromptLabelMutationMixin:
+    @strawberry.mutation
+    async def create_prompt_label(
+        self, info: Info[Context, None], input: CreatePromptLabelInput
+    ) -> PromptLabelMutationPayload:
+        async with info.context.db() as session:
+            name = IdentifierModel.model_validate(str(input.name))
+            label_orm = models.PromptLabel(name=name, description=input.description)
+            session.add(label_orm)
+
+            try:
+                await session.commit()
+            except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+                raise Conflict(f"A prompt label named '{name}' already exists.")
+
+            return PromptLabelMutationPayload(
+                prompt_label=to_gql_prompt_label(label_orm),
+                query=Query(),
+            )
+
+    @strawberry.mutation
+    async def patch_prompt_label(
+        self, info: Info[Context, None], input: PatchPromptLabelInput
+    ) -> PromptLabelMutationPayload:
+        """
+        Updates (patches) an existing PromptLabel by ID.
+        """
+        validated_name = IdentifierModel.model_validate(str(input.name)) if input.name else None
+        async with info.context.db() as session:
+            label_id = from_global_id_with_expected_type(
+                input.prompt_label_id, PromptLabel.__name__
+            )
+
+            label_orm = await session.get(models.PromptLabel, label_id)
+            if not label_orm:
+                raise NotFound(f"PromptLabel with ID {input.prompt_label_id} not found")
+
+            if validated_name is not None:
+                label_orm.name = validated_name.root
+            if input.description is not None:
+                label_orm.description = input.description
+
+            try:
+                await session.commit()
+            except (PostgreSQLIntegrityError, SQLiteIntegrityError):
+                raise Conflict("Error patching PromptLabel. Possibly a name conflict?")
+
+            return PromptLabelMutationPayload(
+                prompt_label=to_gql_prompt_label(label_orm),
+                query=Query(),
+            )
+
+    @strawberry.mutation
+    async def delete_prompt_label(
+        self, info: Info[Context, None], input: DeletePromptLabelInput
+    ) -> PromptLabelMutationPayload:
+        """
+        Deletes a PromptLabel (and any crosswalk references).
+        """
+        async with info.context.db() as session:
+            label_id = from_global_id_with_expected_type(
+                input.prompt_label_id, PromptLabel.__name__
+            )
+            label_orm = await session.get(models.PromptLabel, label_id)
+            if not label_orm:
+                raise NotFound(f"PromptLabel with ID {input.prompt_label_id} not found")
+
+            await session.delete(label_orm)
+            await session.commit()
+
+            return PromptLabelMutationPayload(
+                prompt_label=None,
+                query=Query(),
+            )
+
+    @strawberry.mutation
+    async def set_prompt_label_single_query(
+        self, info: Info[Context, None], input: SetPromptLabelInput
+    ) -> PromptLabelMutationPayload:
+        async with info.context.db() as session:
+            prompt_id = from_global_id_with_expected_type(input.prompt_id, Prompt.__name__)
+            label_id = from_global_id_with_expected_type(
+                input.prompt_label_id, PromptLabel.__name__
+            )
+
+            crosswalk = models.PromptPromptLabel(prompt_id=prompt_id, prompt_label_id=label_id)
+            session.add(crosswalk)
+
+            try:
+                await session.commit()
+            except (PostgreSQLIntegrityError, SQLiteIntegrityError) as e:
+                # The error could be:
+                # - Unique constraint violation => row already exists
+                # - Foreign key violation => prompt_id or label_id doesn't exist
+                raise Conflict("Failed to associate PromptLabel with Prompt.") from e
+
+            label_orm = await session.get(models.PromptLabel, label_id)
+            if not label_orm:
+                raise NotFound(f"PromptLabel with ID {input.prompt_label_id} not found")
+
+            return PromptLabelMutationPayload(
+                prompt_label=to_gql_prompt_label(label_orm),
+                query=Query(),
+            )
+
+    @strawberry.mutation
+    async def remove_prompt_label(
+        self, info: Info[Context, None], input: RemovePromptLabelInput
+    ) -> PromptLabelMutationPayload:
+        """
+        Removes a PromptLabel from a Prompt by removing the row in the crosswalk.
+        """
+        async with info.context.db() as session:
+            prompt_id = from_global_id_with_expected_type(input.prompt_id, Prompt.__name__)
+            label_id = from_global_id_with_expected_type(
+                input.prompt_label_id, PromptLabel.__name__
+            )
+
+            stmt = delete(models.PromptPromptLabel).where(
+                (models.PromptPromptLabel.prompt_id == prompt_id)
+                & (models.PromptPromptLabel.prompt_label_id == label_id)
+            )
+            result = await session.execute(stmt)
+
+            if result.rowcount == 0:
+                raise NotFound(f"No association between prompt={prompt_id} and label={label_id}.")
+
+            await session.commit()
+
+            label_orm = await session.get(models.PromptLabel, label_id)
+            return PromptLabelMutationPayload(
+                prompt_label=to_gql_prompt_label(label_orm) if label_orm else None,
+                query=Query(),
+            )

--- a/src/phoenix/server/api/mutations/prompt_label_mutations.py
+++ b/src/phoenix/server/api/mutations/prompt_label_mutations.py
@@ -82,9 +82,6 @@ class PromptLabelMutationMixin:
     async def patch_prompt_label(
         self, info: Info[Context, None], input: PatchPromptLabelInput
     ) -> PromptLabelMutationPayload:
-        """
-        Updates (patches) an existing PromptLabel by ID.
-        """
         validated_name = IdentifierModel.model_validate(str(input.name)) if input.name else None
         async with info.context.db() as session:
             label_id = from_global_id_with_expected_type(

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -640,6 +640,29 @@ class Query:
             )
 
     @strawberry.field
+    async def prompt_labels(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+    ) -> Connection[PromptLabel]:
+        args = ConnectionArgs(
+            first=first,
+            after=after if isinstance(after, CursorString) else None,
+            last=last,
+            before=before if isinstance(before, CursorString) else None,
+        )
+        async with info.context.db() as session:
+            prompt_labels = await session.stream_scalars(select(models.PromptLabel))
+        data = [to_gql_prompt_label(prompt_label) async for prompt_label in prompt_labels]
+        return connection_from_list(
+            data=data,
+            args=args,
+        )
+
+    @strawberry.field
     def clusters(
         self,
         clusters: list[ClusterInput],

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -61,6 +61,7 @@ from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, co
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.ProjectSession import ProjectSession, to_gql_project_session
 from phoenix.server.api.types.Prompt import Prompt, to_gql_prompt_from_orm
+from phoenix.server.api.types.PromptLabel import PromptLabel, to_gql_prompt_label
 from phoenix.server.api.types.PromptVersion import PromptVersion, to_gql_prompt_version
 from phoenix.server.api.types.SortDir import SortDir
 from phoenix.server.api.types.Span import Span, to_gql_span
@@ -583,6 +584,15 @@ class Query:
                     return to_gql_prompt_version(orm_prompt_version)
                 else:
                     raise NotFound(f"Unknown prompt version: {id}")
+        elif type_name == PromptLabel.__name__:
+            async with info.context.db() as session:
+                if not (
+                    prompt_label := await session.scalar(
+                        select(models.PromptLabel).where(models.PromptLabel.id == node_id)
+                    )
+                ):
+                    raise NotFound(f"Unknown prompt label: {id}")
+            return to_gql_prompt_label(prompt_label)
         raise NotFound(f"Unknown node type: {type_name}")
 
     @strawberry.field

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -656,11 +656,11 @@ class Query:
         )
         async with info.context.db() as session:
             prompt_labels = await session.stream_scalars(select(models.PromptLabel))
-        data = [to_gql_prompt_label(prompt_label) async for prompt_label in prompt_labels]
-        return connection_from_list(
-            data=data,
-            args=args,
-        )
+            data = [to_gql_prompt_label(prompt_label) async for prompt_label in prompt_labels]
+            return connection_from_list(
+                data=data,
+                args=args,
+            )
 
     @strawberry.field
     def clusters(

--- a/src/phoenix/server/api/types/PromptLabel.py
+++ b/src/phoenix/server/api/types/PromptLabel.py
@@ -1,10 +1,14 @@
 from typing import Optional
 
 import strawberry
+from sqlalchemy import select
 from strawberry.relay import Node, NodeID
+from strawberry.types import Info
 
 from phoenix.db import models
+from phoenix.server.api.context import Context
 from phoenix.server.api.types.Identifier import Identifier
+from phoenix.server.api.types.Prompt import Prompt, to_gql_prompt_from_orm
 
 
 @strawberry.type
@@ -12,6 +16,21 @@ class PromptLabel(Node):
     id_attr: NodeID[int]
     name: Identifier
     description: Optional[str] = None
+
+    @strawberry.field
+    async def prompts(self, info: Info[Context, None]) -> list[Prompt]:
+        async with info.context.db() as session:
+            statement = (
+                select(models.Prompt)
+                .join(
+                    models.PromptPromptLabel, models.Prompt.id == models.PromptPromptLabel.prompt_id
+                )
+                .where(models.PromptPromptLabel.prompt_label_id == self.id_attr)
+            )
+            return [
+                to_gql_prompt_from_orm(prompt_orm)
+                async for prompt_orm in await session.stream_scalars(statement)
+            ]
 
 
 def to_gql_prompt_label(label_orm: models.PromptLabel) -> PromptLabel:

--- a/src/phoenix/server/api/types/PromptLabel.py
+++ b/src/phoenix/server/api/types/PromptLabel.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+import strawberry
+from strawberry.relay import Node, NodeID
+
+from phoenix.db import models
+from phoenix.server.api.types.Identifier import Identifier
+
+
+@strawberry.type
+class PromptLabel(Node):
+    id_attr: NodeID[int]
+    name: Identifier
+    description: Optional[str] = None
+
+
+def to_gql_prompt_label(label_orm: models.PromptLabel) -> PromptLabel:
+    return PromptLabel(
+        id_attr=label_orm.id,
+        name=Identifier(label_orm.name),
+        description=label_orm.description,
+    )


### PR DESCRIPTION
resolves #6041 

- adds `PromptLabel` node
- adds `Prompts` resolver to `PromptLabel` node
- adds `PromptLabel` to node interface
- adds `PromptLabel` query
- adds `createPromptLabel` mutation
- adds `patchPromptLabel` mutation
- adds `deletePromptLabel` mutation
- adds `setPromptLabel` mutation <- associates a Prompt with a PromptLabel
- adds `removePromptLabel` mutation <- disassociates a Prompt with a PromptLabel