### PR TITLE
feat: Enable OpenAIModel image support

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -182,5 +182,7 @@ class AnthropicModel(BaseModel):
             if part.content_type == PromptPartContentType.TEXT:
                 messages.append({"role": "user", "content": part.content})
             else:
-                raise ValueError(f"Unsupported content type: {part.content_type}")
+                raise ValueError(
+                    f"Unsupported content type for {AnthropicModel.__name__}: {part.content_type}"
+                )
         return messages

--- a/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
@@ -136,5 +136,7 @@ class LiteLLMModel(BaseModel):
             if part.content_type == PromptPartContentType.TEXT:
                 messages.append({"content": part.content, "role": "user"})
             else:
-                raise ValueError(f"Unsupported content type: {part.content_type}")
+                raise ValueError(
+                    f"Unsupported content type for {LiteLLMModel.__name__}: {part.content_type}"
+                )
         return messages

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -177,5 +177,7 @@ class MistralAIModel(BaseModel):
             if part.content_type == PromptPartContentType.TEXT:
                 messages.append({"role": "user", "content": part.content})
             else:
-                raise ValueError(f"Unsupported content type: {part.content_type}")
+                raise ValueError(
+                    f"Unsupported content type for {MistralAIModel.__name__}: {part.content_type}"
+                )
         return messages

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -60,6 +60,9 @@ class MultimodalPrompt:
         )
 
     def to_text_only_prompt(self) -> str:
+        if any(part.content_type != PromptPartContentType.TEXT for part in self.parts):
+            raise ValueError("This model does not support multimodal prompts")
+
         return "\n\n".join(
             [part.content for part in self.parts if part.content_type == PromptPartContentType.TEXT]
         )


### PR DESCRIPTION
- Adds image evaluation template support to `OpenAIModel`
- Improves unsupported template format message to clarify that the model doesn't support a specific mode