### PR TITLE
fix: local variable 'prompt_message' referenced before assignment

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -92,9 +92,11 @@ class PromptTemplate:
         prompt = self.prompt(options)
         prompt_messages = []
         for template_message in prompt:
+            prompt_message = template_message.template
+
             if self._start_delim == "{" and self._end_delim == "}":
                 self.formatter = DotKeyFormatter()
-                prompt_message = self.formatter.format(template_message.template, **variable_values)
+                prompt_message = self.formatter.format(prompt_message, **variable_values)
             else:
                 for variable_name in self.variables:
                     prompt_message = prompt_message.replace(


### PR DESCRIPTION
Reproduce:
```
>>> from phoenix.evals import PromptTemplate
>>>
>>> template = PromptTemplate("Hello {{var}}.", delimiters=["{{", "}}"])
>>> template.format({"var": "world"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/james/work/prompt-library/.venv/lib/python3.10/site-packages/phoenix/evals/templates.py", line 100, in format
    prompt_message = prompt_message.replace(
UnboundLocalError: local variable 'prompt_message' referenced before assignment
```