### PR TITLE
feat: Add support for o1 dev messages + reasoning param

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -93,6 +93,7 @@ enum CanonicalParameterName {
   RANDOM_SEED
   TOOL_CHOICE
   RESPONSE_FORMAT
+  REASONING_EFFORT
 }
 
 type ChatCompletionFunctionCall {

--- a/app/src/pages/playground/__generated__/ModelSupportedParamsFetcherQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/ModelSupportedParamsFetcherQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<26d21fbf166aaf1fc39865c19bf40479>>
+ * @generated SignedSource<<b515d2d229ac652ec43c1cc10d9d76fa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type InvocationInputField = "value_bool" | "value_boolean" | "value_float" | "value_int" | "value_json" | "value_string" | "value_string_list";
 export type ModelsInput = {

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fb8767ca8940fd71d617146eb52b1292>>
+ * @generated SignedSource<<83115a7d0cd41610c964392fd634b548>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type TemplateLanguage = "F_STRING" | "MUSTACHE" | "NONE";

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3e504e38941a8f03594af12b1525ad1>>
+ * @generated SignedSource<<8e709a5628ea7235eacc28dfa5bb7277>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, GraphQLSubscription } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type TemplateLanguage = "F_STRING" | "MUSTACHE" | "NONE";

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<665bb02d564885ad9728c51f4267bd0a>>
+ * @generated SignedSource<<d03a65e67d61773ec8552496e2a1c3bb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type TemplateLanguage = "F_STRING" | "MUSTACHE" | "NONE";

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<23b1d95400eb05227f7edd4c2bde7d75>>
+ * @generated SignedSource<<3274cb65871ec27834fd3163e1e79dea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, GraphQLSubscription } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type TemplateLanguage = "F_STRING" | "MUSTACHE" | "NONE";

--- a/app/src/pages/playground/__generated__/spanPlaygroundPageLoaderQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/spanPlaygroundPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1de0c5eaf9f5783a2197d1e209cb961f>>
+ * @generated SignedSource<<b72f89d6b090a502c883cf36e1775cde>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
+export type CanonicalParameterName = "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type InvocationInputField = "value_bool" | "value_boolean" | "value_float" | "value_int" | "value_json" | "value_string" | "value_string_list";
 export type spanPlaygroundPageLoaderQuery$variables = {
   spanId: string;

--- a/src/phoenix/server/api/input_types/InvocationParameters.py
+++ b/src/phoenix/server/api/input_types/InvocationParameters.py
@@ -15,6 +15,7 @@ class CanonicalParameterName(str, Enum):
     RANDOM_SEED = "random_seed"
     TOOL_CHOICE = "tool_choice"
     RESPONSE_FORMAT = "response_format"
+    REASONING_EFFORT = "reasoning_effort"
 
 
 @strawberry.enum

--- a/tox.ini
+++ b/tox.ini
@@ -193,7 +193,7 @@ pass_env=
   PHOENIX_SMTP_USERNAME
   PHOENIX_SMTP_PASSWORD
 commands_pre =
-  uv tool install arize-phoenix@. \
+  uv tool install -U --force arize-phoenix@. \
     --reinstall-package arize-phoenix \
     --with-requirements requirements/dev.txt \
     --compile-bytecode


### PR DESCRIPTION
- o1 now supports "system" messages by converting them to "developer" before sending to openai
- o1 now supports "reasoning effort" parameter of values "low" "medium" and "high"

Limitations:
- o1 models no longer support streaming. Unclear if temporary regression.
- o1-mini does not support "developer" messages or "system" messages
- o1-mini does not support "reasoning effort"