### PR TITLE
fix: Handle empty events array in trace dataset loading refs: #4720

### DIFF
--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -207,7 +207,7 @@ class TraceDataset:
                     "status_code": row["status_code"],
                     "status_message": row.get("status_message") or "",
                     "attributes": attributes,
-                    "events": row.get("events") or [],
+                    "events": row.get("events").tolist() if isinstance(row.get("events"), np.ndarray) else row.get("events") or [],
                     "conversation": row.get("conversation"),
                 }
             )

--- a/src/phoenix/trace/trace_dataset.py
+++ b/src/phoenix/trace/trace_dataset.py
@@ -207,7 +207,9 @@ class TraceDataset:
                     "status_code": row["status_code"],
                     "status_message": row.get("status_message") or "",
                     "attributes": attributes,
-                    "events": row.get("events").tolist() if isinstance(row.get("events"), np.ndarray) else row.get("events") or [],
+                    "events": row.get("events").tolist()
+                    if isinstance(row.get("events"), np.ndarray)
+                    else row.get("events") or [],
                     "conversation": row.get("conversation"),
                 }
             )


### PR DESCRIPTION
This PR addresses the issue described in BUG attempting to load parquet tracing file throws ValueError #4720. 

The `Type` of `row.get("events")` is `numpy.ndarray` when reading in a trace dataset that was previously saved.

The changes made ensure that the `events` field in the trace dataset is handled correctly, preventing errors related to ambiguous truth values when processing empty arrays.

Key Changes:
- Type Handling: The `events` field is now explicitly checked for its type. 
- If it is a NumPy array, it is converted to a standard Python list using `.tolist()`. 

This ensures consistent behavior and avoids `TypeError` when evaluating empty lists.