### PR TITLE
fix: Allow experiment table resize for large inputs

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -412,7 +412,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
   }, [experimentIds, experimentInfoById, datasetId, displayFullText]);
 
   const columns = useMemo(() => {
-    return [...baseColumns, ...experimentColumns, { id: "tail", minSize: 500 }];
+    return [...baseColumns, ...experimentColumns];
   }, [baseColumns, experimentColumns]);
 
   const table = useReactTable<TableRow>({
@@ -536,6 +536,7 @@ function TableBody<T>({ table }: { table: Table<T> }) {
                 key={cell.id}
                 style={{
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
+                  wordBreak: "break-all",
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
resolves #5586

This allows text to break regardless of whitespace, allowing cells to be shrunk.

An alternative approach would be to enable horizontal overflow within a cell, but that seems cumbersome on an already scrolling page.

Or, we could consider truncating results and only displaying them in dialog

### Before

![2025-01-21 14 46 31](https://github.com/user-attachments/assets/58ca8422-4a20-4db0-9b87-20cf9a29abda)

### After

![2025-01-21 14 46 04](https://github.com/user-attachments/assets/b02ef99d-17c6-4ea3-b749-8a2f528e1687)