### PR TITLE
feat(prompts): add open in playground action button on the table

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -204,7 +204,7 @@ const router = createBrowserRouter(
           <Route
             path="/prompts"
             handle={{
-              crumb: () => "Prompts",
+              crumb: () => "prompts",
             }}
           >
             <Route index element={<PromptsPage />} loader={promptsLoader} />
@@ -247,7 +247,7 @@ const router = createBrowserRouter(
                 element={<PromptPlaygroundPage />}
                 loader={promptPlaygroundLoader}
                 handle={{
-                  crumb: () => "Playground",
+                  crumb: () => "playground",
                 }}
               />
             </Route>
@@ -263,14 +263,14 @@ const router = createBrowserRouter(
             path="/support"
             element={<SupportPage />}
             handle={{
-              crumb: () => "Support",
+              crumb: () => "support",
             }}
           />
           <Route
             path="/settings"
             element={<SettingsPage />}
             handle={{
-              crumb: () => "Settings",
+              crumb: () => "settings",
             }}
           />
         </Route>

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
+  ColumnDef,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
@@ -9,7 +10,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
-import { Flex, Icon, Icons, Link } from "@phoenix/components";
+import { Button, Flex, Icon, Icons, Link } from "@phoenix/components";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -73,8 +74,10 @@ export function PromptsTable(props: PromptsTableProps) {
     },
     [hasNext, isLoadingNext, loadNext]
   );
-  const table = useReactTable({
-    columns: [
+
+  type TableRow = (typeof tableData)[number];
+  const columns = useMemo(() => {
+    const cols: ColumnDef<TableRow>[] = [
       {
         header: "name",
         accessorKey: "name",
@@ -100,6 +103,14 @@ export function PromptsTable(props: PromptsTableProps) {
               justifyContent="end"
               width="100%"
             >
+              <Button
+                icon={<Icon svg={<Icons.PlayCircleOutline />} />}
+                size="S"
+                aria-label="Open in playground"
+                onPress={() => {
+                  navigate(`${row.original.id}/playground`);
+                }}
+              />
               <PromptActionMenu
                 promptId={row.original.id}
                 onDeleted={() => {
@@ -110,7 +121,11 @@ export function PromptsTable(props: PromptsTableProps) {
           );
         },
       },
-    ],
+    ];
+    return cols;
+  }, [refetch, navigate]);
+  const table = useReactTable({
+    columns,
     data: tableData,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -110,7 +110,9 @@ export function PromptsTable(props: PromptsTableProps) {
                 onPress={() => {
                   navigate(`${row.original.id}/playground`);
                 }}
-              />
+              >
+                Playground
+              </Button>
               <PromptActionMenu
                 promptId={row.original.id}
                 onDeleted={() => {


### PR DESCRIPTION

<img width="1920" alt="Screenshot 2025-01-27 at 1 28 24 PM" src="https://github.com/user-attachments/assets/7117c363-123f-48a9-83f0-c54e76fbbb47" />
Adds a quick link to open the prompt from the listing