### PR TITLE
feat: Enable explanations even w/o explanation template

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -180,9 +180,8 @@ class ClassificationTemplate(PromptTemplate):
             return self.template
 
     def extract_label_from_explanation(self, raw_string: str) -> str:
-        if parser := self.explanation_label_parser:
-            return parser(raw_string)
-        return parse_label_from_chain_of_thought_response(raw_string)
+        parser = self.explanation_parser
+        return parser(raw_string)
 
     def score(self, rail: str) -> float:
         if self._scores is None:

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -33,10 +33,14 @@ def test_classification_template_can_beinstantiated_with_no_explanation_template
     template = ClassificationTemplate(
         rails=["relevant", "irrelevant"], template="is this irrelevant?"
     )
-    assert template.explanation_template is None
+    assert template.explanation_template is not None
+    assert len(template.explanation_template) == 2
 
     explanation_options = PromptOptions(provide_explanation=True)
     assert template.prompt(options=explanation_options)[0].template == "is this irrelevant?"
+    assert (
+        "provide a concise explanation" in template.prompt(options=explanation_options)[1].template
+    )
 
 
 def test_template_with_default_delimiters_uses_python_string_formatting():


### PR DESCRIPTION
- Previously, when passing in a custom template string to `llm_classify`, `provide_explanation` doesn't do anything unless a user uses a custom `ClassificationTemplate` object
- This PR will append another part to the template that adds an instruction to explain itself