### PR TITLE
feat: add regex rule for identifier pattern on ui forms for prompt and tag names

### DIFF
--- a/app/src/pages/playground/SavePromptForm.tsx
+++ b/app/src/pages/playground/SavePromptForm.tsx
@@ -8,6 +8,8 @@ import { Button, Flex, View } from "@phoenix/components";
 import { SavePromptFormQuery } from "@phoenix/pages/playground/__generated__/SavePromptFormQuery.graphql";
 import { PromptComboBox } from "@phoenix/pages/playground/PromptComboBox";
 
+import { identifierPattern } from "../../utils/identifierUtils";
+
 export type SavePromptSubmitHandler = (params: SavePromptFormParams) => void;
 
 export type SavePromptFormParams = {
@@ -100,6 +102,7 @@ export function SavePromptForm({
               message: "Prompt is required",
               value: true,
             },
+            pattern: identifierPattern,
           }}
           render={({ field: { onBlur, onChange } }) => (
             <PromptComboBox

--- a/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
+++ b/app/src/pages/prompt/NewPromptVersionTagDialog.tsx
@@ -21,6 +21,8 @@ import {
   View,
 } from "@phoenix/components";
 
+import { identifierPattern } from "../../utils/identifierUtils";
+
 type PromptVersionTagFormParams = {
   name: string;
   description: string;
@@ -99,11 +101,7 @@ export function NewPromptVersionDialog({
               control={control}
               rules={{
                 required: "Name is required",
-                pattern: {
-                  value: /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
-                  message:
-                    "Invalid identifier. Must be alphanumeric and with dashes",
-                },
+                pattern: identifierPattern,
               }}
               render={({
                 field: { name, onChange, onBlur, value },

--- a/app/src/utils/identifierUtils.ts
+++ b/app/src/utils/identifierUtils.ts
@@ -1,0 +1,7 @@
+const identifierRegex = /^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$/;
+
+export const identifierPattern = {
+  value: identifierRegex,
+  message:
+    "Invalid identifier. Must be alphanumeric and with dashes or underscores",
+};

--- a/src/phoenix/db/types/identifier.py
+++ b/src/phoenix/db/types/identifier.py
@@ -4,4 +4,4 @@ from pydantic import Field, RootModel
 
 
 class Identifier(RootModel[str]):
-    root: Annotated[str, Field(pattern=r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")]
+    root: Annotated[str, Field(pattern=r"^[a-z0-9]([_a-z0-9-]*[a-z0-9])?$")]

--- a/tests/unit/db/types/test_identifier.py
+++ b/tests/unit/db/types/test_identifier.py
@@ -12,7 +12,7 @@ from phoenix.db.types.identifier import Identifier
         "a b c",
         "αβγ",
         *string.punctuation,
-        *(f"x{p}y" for p in string.punctuation if p not in ("-")),
+        *(f"x{p}y" for p in string.punctuation if p not in ("_", "-")),
     ],
 )
 def test_invalid_identifier(name: str) -> None:

--- a/tests/unit/server/api/routers/v1/test_prompts.py
+++ b/tests/unit/server/api/routers/v1/test_prompts.py
@@ -65,7 +65,7 @@ class TestPrompts:
             "a b c",
             "αβγ",
             *(p for p in string.punctuation if p not in (".", "/")),
-            *(f"x{p}y" for p in string.punctuation if p not in ("-", ".", "/")),
+            *(f"x{p}y" for p in string.punctuation if p not in ("_", "-", ".", "/")),
         ],
     )
     async def test_invalid_identifier(


### PR DESCRIPTION
resolves #6089 

Also relaxed rule to include underscores.