### PR TITLE
feat: Enable overriding executor timeouts per model

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -320,6 +320,7 @@ def llm_classify(
         max_retries=max_retries,
         exit_on_error=exit_on_error,
         fallback_return_value=fallback_return_value,
+        timeout=model._timeout,
     )
 
     list_of_inputs: Union[Tuple[Any], List[Any]]
@@ -412,6 +413,12 @@ def run_evals(
         else:
             concurrency = min(evaluator.default_concurrency for evaluator in evaluators)
 
+    # use the maximum timeout of all the evaluators
+    timeout = None
+    for evaluator in evaluators:
+        if evaluator.model._timeout:
+            timeout = max(timeout, evaluator.model._timeout)
+
     # clients need to be reloaded to ensure that async evals work properly
     for evaluator in evaluators:
         evaluator.reload_client()
@@ -443,6 +450,7 @@ def run_evals(
         tqdm_bar_format=get_tqdm_progress_bar_formatter("run_evals"),
         exit_on_error=True,
         fallback_return_value=(None, None, None),
+        timeout=timeout,
     )
 
     total_records = len(dataframe)

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -414,13 +414,14 @@ def run_evals(
             concurrency = min(evaluator.default_concurrency for evaluator in evaluators)
 
     # use the maximum timeout of all the evaluators
-    timeout = None
-    for evaluator in evaluators:
-        if evaluator_timeout := evaluator._model._timeout:
-            if timeout is None:
-                timeout = evaluator_timeout
-            else:
-                timeout = max(timeout, evaluator_timeout)
+    timeout = max(
+        (
+            evaluator._model._timeout
+            for evaluator in evaluators
+            if evaluator._model._timeout is not None
+        ),
+        default=None,
+    )
 
     # clients need to be reloaded to ensure that async evals work properly
     for evaluator in evaluators:

--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -416,8 +416,11 @@ def run_evals(
     # use the maximum timeout of all the evaluators
     timeout = None
     for evaluator in evaluators:
-        if evaluator.model._timeout:
-            timeout = max(timeout, evaluator.model._timeout)
+        if evaluator_timeout := evaluator._model._timeout:
+            if timeout is None:
+                timeout = evaluator_timeout
+            else:
+                timeout = max(timeout, evaluator_timeout)
 
     # clients need to be reloaded to ensure that async evals work properly
     for evaluator in evaluators:

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -104,6 +104,7 @@ class AsyncExecutor(Executor):
         exit_on_error: bool = True,
         fallback_return_value: Union[Unset, Any] = _unset,
         termination_signal: signal.Signals = signal.SIGINT,
+        timeout: Optional[int] = None,
     ):
         self.generate = generation_fn
         self.fallback_return_value = fallback_return_value
@@ -113,6 +114,7 @@ class AsyncExecutor(Executor):
         self.exit_on_error = exit_on_error
         self.base_priority = 0
         self.termination_signal = termination_signal
+        self.timeout: int = timeout or 120
 
     async def producer(
         self,
@@ -165,7 +167,7 @@ class AsyncExecutor(Executor):
                 termination_event_watcher = asyncio.create_task(termination_event.wait())
                 done, pending = await asyncio.wait(
                     [generate_task, termination_event_watcher],
-                    timeout=120,
+                    timeout=self.timeout,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
 
@@ -390,6 +392,7 @@ def get_executor_on_sync_context(
     max_retries: int = 10,
     exit_on_error: bool = True,
     fallback_return_value: Union[Unset, Any] = _unset,
+    timeout: Optional[int] = None,
 ) -> Executor:
     if threading.current_thread() is not threading.main_thread():
         # run evals synchronously if not in the main thread
@@ -425,6 +428,7 @@ def get_executor_on_sync_context(
                 max_retries=max_retries,
                 exit_on_error=exit_on_error,
                 fallback_return_value=fallback_return_value,
+                timeout=timeout,
             )
         else:
             logger.warning(
@@ -447,6 +451,7 @@ def get_executor_on_sync_context(
             max_retries=max_retries,
             exit_on_error=exit_on_error,
             fallback_return_value=fallback_return_value,
+            timeout=timeout,
         )
 
 

--- a/packages/phoenix-evals/src/phoenix/evals/generate.py
+++ b/packages/phoenix-evals/src/phoenix/evals/generate.py
@@ -137,6 +137,7 @@ def llm_generate(
         tqdm_bar_format=tqdm_bar_format,
         exit_on_error=True,
         fallback_return_value=fallback_return_value,
+        timeout=model._timeout,
     )
     results, _ = executor.run(list(enumerate(prompts)))
     return pd.DataFrame.from_records(results, index=dataframe.index)

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -43,6 +43,7 @@ class AnthropicModel(BaseModel):
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 5.
+        timeout (int, optional): The timeout for completion requests in seconds. Defaults to 120.
 
     Example:
         .. code-block:: python
@@ -62,6 +63,7 @@ class AnthropicModel(BaseModel):
     extra_parameters: Dict[str, Any] = field(default_factory=dict)
     max_content_size: Optional[int] = None
     initial_rate_limit: int = 5
+    timeout: int = 120
 
     def __post_init__(self) -> None:
         self._init_client()

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -61,7 +61,7 @@ class BaseModel(ABC):
 
     @property
     def _timeout(self) -> Optional[int]:
-        return None
+        return self.getattr("timeout", None)
 
     def reload_client(self) -> None:
         pass

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -61,7 +61,7 @@ class BaseModel(ABC):
 
     @property
     def _timeout(self) -> Optional[int]:
-        return self.getattr("timeout", None)
+        return getattr(self, "timeout", None)
 
     def reload_client(self) -> None:
         pass

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -60,7 +60,6 @@ class BaseModel(ABC):
         ...
 
     @property
-    @abstractmethod
     def _timeout(self) -> Optional[int]:
         return None
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -59,6 +59,11 @@ class BaseModel(ABC):
         """
         ...
 
+    @property
+    @abstractmethod
+    def _timeout(self) -> Optional[int]:
+        return None
+
     def reload_client(self) -> None:
         pass
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -49,6 +49,7 @@ class BedrockModel(BaseModel):
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 5.
+        timeout (int, optional): The timeout for completion requests in seconds. Defaults to 120.
 
     Example:
         .. code-block:: python
@@ -71,6 +72,7 @@ class BedrockModel(BaseModel):
     max_content_size: Optional[int] = None
     extra_parameters: Dict[str, Any] = field(default_factory=dict)
     initial_rate_limit: int = 5
+    timeout: int = 120
 
     def __post_init__(self) -> None:
         self._init_client()

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -40,6 +40,7 @@ class MistralAIModel(BaseModel):
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 5.
+        timeout (int, optional): The timeout for completion requests in seconds. Defaults to 120.
 
     Example:
         .. code-block:: python
@@ -59,6 +60,7 @@ class MistralAIModel(BaseModel):
     api_key: Optional[str] = os.getenv("MISTRAL_API_KEY")
     safe_prompt: bool = False
     initial_rate_limit: int = 5
+    timeout: int = 120
 
     def __post_init__(self) -> None:
         self._init_client()

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -113,6 +113,7 @@ class OpenAIModel(BaseModel):
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 10.
+        timeout (int, optional): The timeout for completion requests in seconds. Defaults to 120.
 
     Examples:
         After setting the OPENAI_API_KEY environment variable:
@@ -146,6 +147,8 @@ class OpenAIModel(BaseModel):
     n: int = 1
     model_kwargs: Dict[str, Any] = field(default_factory=dict)
     request_timeout: Optional[Union[float, Tuple[float, float]]] = None
+    initial_rate_limit: int = 10
+    timeout: int = 120
 
     # Azure options
     api_version: Optional[str] = field(default=None)
@@ -154,7 +157,6 @@ class OpenAIModel(BaseModel):
     azure_ad_token: Optional[str] = field(default=None)
     azure_ad_token_provider: Optional[Callable[[], str]] = field(default=None)
     default_headers: Optional[Mapping[str, str]] = field(default=None)
-    initial_rate_limit: int = 10
 
     # Deprecated fields
     model_name: Optional[str] = field(default=None)
@@ -477,12 +479,6 @@ class OpenAIModel(BaseModel):
         if self._model_uses_legacy_completion_api:
             return False
         return True
-
-    @property
-    def _timeout(self) -> Optional[int]:
-        if "o1" in self.model:
-            return 240
-        return None
 
 
 def _is_url(url: str) -> bool:

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -478,6 +478,12 @@ class OpenAIModel(BaseModel):
             return False
         return True
 
+    @property
+    def _timeout(self) -> Optional[int]:
+        if "o1" in self.model:
+            return 240
+        return None
+
 
 def _is_url(url: str) -> bool:
     parsed_url = urlparse(url)

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
@@ -52,6 +52,7 @@ class GeminiModel(BaseModel):
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 5.
+        timeout (int, optional): The timeout for completion requests in seconds. Defaults to 120.
 
     Example:
         .. code-block:: python
@@ -79,6 +80,7 @@ class GeminiModel(BaseModel):
     top_k: int = 32
     stop_sequences: List[str] = field(default_factory=list)
     initial_rate_limit: int = 5
+    timeout: int = 120
 
     def __post_init__(self) -> None:
         self._init_client()


### PR DESCRIPTION
resolves #6198 

Enables a timeout override for `AsyncExecutor`s on a per-model basis. Some model wrappers now have an optional `timeout` argument that will override the internal timeout of 120s.

This original 120s timeout was determined to "feel good" when doing our initial internal throttler testing.