### PR TITLE
fix: Prevent error when parsing invalid json out of tool calls

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -605,7 +605,8 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
   const hasOutputMessages = outputMessages.length > 0;
   const hasPrompts = prompts.length > 0;
   const hasInvocationParams =
-    Object.keys(JSON.parse(invocation_parameters_str)).length > 0;
+    Object.keys(safelyParseJSON(invocation_parameters_str).json || {}).length >
+    0;
   const hasPromptTemplateObject = promptTemplateObject != null;
 
   return (
@@ -1323,6 +1324,10 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
           ) : null}
           {toolCalls.length > 0
             ? toolCalls.map((toolCall, idx) => {
+                const parsedArguments = safelyParseJSON(
+                  toolCall?.function?.arguments as string
+                );
+
                 return (
                   <pre
                     key={idx}
@@ -1332,13 +1337,9 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
                     `}
                   >
                     {toolCall?.function?.name as string}(
-                    {typeof toolCall?.function?.arguments === "string"
-                      ? JSON.stringify(
-                          JSON.parse(toolCall?.function?.arguments as string),
-                          null,
-                          2
-                        )
-                      : ""}
+                    {parsedArguments.json
+                      ? JSON.stringify(parsedArguments.json, null, 2)
+                      : `${toolCall?.function?.arguments}`}
                     )
                   </pre>
                 );


### PR DESCRIPTION
If an LLM produces tool call arguments that are not valid json, we now fallback to rendering the arguments as a string, instead of throwing an unparse-able error.

While we could render a specialized error in this case, I am not sure that every LLM will have a requirement for tool call arguments to be json parseable, so we may as well just display whatever is produced by the llm.

## Before

<img width="2413" alt="image" src="https://github.com/user-attachments/assets/ea1e1875-99d2-4e49-bd85-8b6f50f54d4a" />


## After

<img width="2413" alt="image" src="https://github.com/user-attachments/assets/d60c3e93-c18f-438b-bf63-e3b8a354c59b" />

Resolves #6202 
