### PR TITLE
refactor(prompts): Normalize playground instance messages

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -57,7 +57,7 @@
     "three": "~0.139.2",
     "three-stdlib": "^2.30.4",
     "use-deep-compare-effect": "^1.8.1",
-    "use-zustand": "^0.0.4",
+    "use-zustand": "^0.2.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.3",
     "zustand": "^4.5.4"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1(react@18.3.1)
       use-zustand:
-        specifier: ^0.0.4
-        version: 0.0.4(react@18.3.1)
+        specifier: ^0.2.0
+        version: 0.2.0(react@18.3.1)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -4492,10 +4492,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  use-zustand@0.0.4:
-    resolution: {integrity: sha512-UkuONsZoniFoDsm5Xp/gEA1579UOn/ZgKbaE48gHhK+pmBx//PX4UlKdrbaWPpUnORnVTd4/0CvI/rv+1tmn4g==}
+  use-zustand@0.2.0:
+    resolution: {integrity: sha512-6BPw170RLVGe57ifpuKOS1j7VbufYX3xHByNaqmLzQYPnhWjzF+lEfmESnaVLCWyOzH6kVDIeVF3kEPsFd9pvw==}
     peerDependencies:
-      react: '*'
+      react: '>=18.0.0'
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -10232,7 +10232,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  use-zustand@0.0.4(react@18.3.1):
+  use-zustand@0.2.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/app/src/components/templateEditor/TemplateEditor.tsx
+++ b/app/src/components/templateEditor/TemplateEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { githubLight } from "@uiw/codemirror-theme-github";
 import { nord } from "@uiw/codemirror-theme-nord";
 import CodeMirror, {
@@ -16,8 +16,9 @@ import { MustacheLikeTemplating } from "./language/mustacheLike";
 import { TemplateLanguages } from "./constants";
 import { TemplateLanguage } from "./types";
 
-type TemplateEditorProps = ReactCodeMirrorProps & {
+type TemplateEditorProps = Omit<ReactCodeMirrorProps, "value"> & {
   templateLanguage: TemplateLanguage;
+  defaultValue: string;
 };
 
 const basicSetupOptions: BasicSetupOptions = {
@@ -28,10 +29,22 @@ const basicSetupOptions: BasicSetupOptions = {
   bracketMatching: false,
 };
 
+/**
+ * A template editor that is used to edit the template of a tool.
+ *
+ * This is an uncontrolled editor.
+ * You can only reset the value of the editor by triggering a re-mount, like with the `key` prop,
+ * or, when the readOnly prop is true, the editor will reset on all value changes.
+ * This is necessary because controlled react-codemirror editors incessantly reset
+ * cursor position when value is updated.
+ */
 export const TemplateEditor = ({
   templateLanguage,
+  defaultValue,
+  readOnly,
   ...props
 }: TemplateEditorProps) => {
+  const [value, setValue] = useState(() => defaultValue);
   const { theme } = useTheme();
   const codeMirrorTheme = theme === "light" ? githubLight : nord;
   const extensions = useMemo(() => {
@@ -51,12 +64,20 @@ export const TemplateEditor = ({
     return ext;
   }, [templateLanguage]);
 
+  useEffect(() => {
+    if (readOnly) {
+      setValue(defaultValue);
+    }
+  }, [readOnly, defaultValue]);
+
   return (
     <CodeMirror
       theme={codeMirrorTheme}
       extensions={extensions}
       basicSetup={basicSetupOptions}
+      readOnly={readOnly}
       {...props}
+      value={value}
     />
   );
 };

--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -31,7 +31,10 @@ import {
 import { useNotifySuccess } from "@phoenix/contexts";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
-import { PlaygroundInstance } from "@phoenix/store";
+import {
+  PlaygroundInstance,
+  PlaygroundNormalizedInstance,
+} from "@phoenix/store";
 
 import { ModelConfigButtonDialogQuery } from "./__generated__/ModelConfigButtonDialogQuery.graphql";
 import { InvocationParametersFormFields } from "./InvocationParametersFormFields";
@@ -67,7 +70,7 @@ const modelConfigFormCSS = css`
 function AzureOpenAiModelConfigFormField({
   instance,
 }: {
-  instance: PlaygroundInstance;
+  instance: PlaygroundNormalizedInstance;
 }) {
   const updateModel = usePlaygroundContext((state) => state.updateModel);
   const updateModelConfig = useCallback(

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useEffect } from "react";
+import React, { Fragment, Suspense, useCallback, useEffect } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { BlockerFunction, useBlocker, useSearchParams } from "react-router-dom";
@@ -205,6 +205,9 @@ const playgroundInputOutputPanelContentCSS = css`
  */
 const PLAYGROUND_PROMPT_PANEL_MIN_WIDTH = 632;
 
+const DEFAULT_EXPANDED_PROMPTS = ["prompts"];
+const DEFAULT_EXPANDED_PARAMS = ["input", "output"];
+
 function PlaygroundContent() {
   const instances = usePlaygroundContext((state) => state.instances);
   const templateLanguage = usePlaygroundContext(
@@ -246,7 +249,7 @@ function PlaygroundContent() {
   }, [isRunning, anyDirtyInstances]);
 
   return (
-    <>
+    <Fragment key="playground-content">
       <PanelGroup
         direction={
           isSingleInstance && !isDatasetMode ? "horizontal" : "vertical"
@@ -257,7 +260,7 @@ function PlaygroundContent() {
       >
         <Panel>
           <div css={playgroundPromptPanelContentCSS}>
-            <DisclosureGroup defaultExpandedKeys={["prompts"]}>
+            <DisclosureGroup defaultExpandedKeys={DEFAULT_EXPANDED_PROMPTS}>
               <Disclosure id="prompts" size="L">
                 <DisclosureTrigger
                   arrowPosition="start"
@@ -277,11 +280,10 @@ function PlaygroundContent() {
                       {instances.map((instance) => (
                         <View
                           flex="1 1 0px"
-                          key={instance.id}
+                          key={`${instance.id}-prompt`}
                           minWidth={PLAYGROUND_PROMPT_PANEL_MIN_WIDTH}
                         >
                           <PlaygroundTemplate
-                            key={instance.id}
                             playgroundInstanceId={instance.id}
                           />
                         </View>
@@ -301,7 +303,7 @@ function PlaygroundContent() {
             </Suspense>
           ) : (
             <div css={playgroundInputOutputPanelContentCSS}>
-              <DisclosureGroup defaultExpandedKeys={["input", "output"]}>
+              <DisclosureGroup defaultExpandedKeys={DEFAULT_EXPANDED_PARAMS}>
                 {templateLanguage !== TemplateLanguages.NONE ? (
                   <Disclosure id="input" size="L">
                     <DisclosureTrigger arrowPosition="start">
@@ -321,10 +323,9 @@ function PlaygroundContent() {
                   <DisclosurePanel>
                     <View padding="size-200" height="100%">
                       <Flex direction="row" gap="size-200">
-                        {instances.map((instance, i) => (
-                          <View key={i} flex="1 1 0px">
+                        {instances.map((instance) => (
+                          <View key={`${instance.id}-output`} flex="1 1 0px">
                             <PlaygroundOutput
-                              key={i}
                               playgroundInstanceId={instance.id}
                             />
                           </View>
@@ -348,6 +349,6 @@ function PlaygroundContent() {
           }
         />
       )}
-    </>
+    </Fragment>
   );
 }

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -199,6 +199,12 @@ function MessageEditor({
   updateMessage: (patch: Partial<ChatMessage>) => void;
   messageMode: MessageMode;
 }) {
+  const onChange = useCallback(
+    (val: string) => {
+      updateMessage({ content: val });
+    },
+    [updateMessage]
+  );
   if (messageMode === "toolCalls") {
     return (
       <View
@@ -262,18 +268,15 @@ function MessageEditor({
       </Form>
     );
   }
+
   return (
     <TemplateEditorWrap>
       <TemplateEditor
         height="100%"
-        value={
-          typeof message.content === "string"
-            ? message.content
-            : JSON.stringify(message.content, null, 2)
-        }
+        defaultValue={message.content || ""}
         aria-label="Message content"
         templateLanguage={templateLanguage}
-        onChange={(val) => updateMessage({ content: val })}
+        onChange={onChange}
         placeholder={
           message.role === "system"
             ? "You are a helpful assistant"

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -128,13 +128,13 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
         const overIndex = messageIds.findIndex(
           (messageId) => messageId === over.id
         );
-        const newMessages = arrayMove(messageIds, activeIndex, overIndex);
+        const newMessageIds = arrayMove(messageIds, activeIndex, overIndex);
         updateInstance({
           instanceId: id,
           patch: {
             template: {
               __type: "chat",
-              messageIds: newMessages,
+              messageIds: newMessageIds,
             },
           },
           dirty: true,
@@ -352,7 +352,7 @@ function SortableMessageItem({
     ChatMessage["toolCalls"]
   >(message.toolCalls);
 
-  const updateThisMessage = useCallback(
+  const onMessageUpdate = useCallback(
     (patch: Partial<ChatMessage>) => {
       updateMessage({
         instanceId: playgroundInstanceId,
@@ -481,7 +481,7 @@ function SortableMessageItem({
             messageMode={aiMessageMode}
             playgroundInstanceId={playgroundInstanceId}
             templateLanguage={templateLanguage}
-            updateMessage={updateThisMessage}
+            updateMessage={onMessageUpdate}
           />
         </div>
       </Card>

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -1,4 +1,9 @@
-import React, { PropsWithChildren, useCallback, useState } from "react";
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import {
   DndContext,
   KeyboardSensor,
@@ -35,12 +40,12 @@ import {
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
-import {
-  ChatMessage,
-  PlaygroundChatTemplate as PlaygroundChatTemplateType,
-  PlaygroundInstance,
-} from "@phoenix/store";
+import { ChatMessage, PlaygroundState } from "@phoenix/store";
 import { convertMessageToolCallsToProvider } from "@phoenix/store/playground/playgroundStoreUtils";
+import {
+  selectPlaygroundInstance,
+  selectPlaygroundInstanceMessage,
+} from "@phoenix/store/playground/selectors";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
@@ -81,10 +86,9 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
-  const instances = usePlaygroundContext((state) => state.instances);
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
-
-  const playgroundInstance = instances.find((instance) => instance.id === id);
+  const instanceSelector = useMemo(() => selectPlaygroundInstance(id), [id]);
+  const playgroundInstance = usePlaygroundContext(instanceSelector);
   if (!playgroundInstance) {
     throw new Error(`Playground instance ${id} not found`);
   }
@@ -102,6 +106,8 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
     throw new Error(`Invalid template type ${template.__type}`);
   }
 
+  const messageIds = template.messageIds;
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -116,30 +122,26 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
         if (!over || active.id === over.id) {
           return;
         }
-        const activeIndex = template.messages.findIndex(
-          (message) => message.id === active.id
+        const activeIndex = messageIds.findIndex(
+          (messageId) => messageId === active.id
         );
-        const overIndex = template.messages.findIndex(
-          (message) => message.id === over.id
+        const overIndex = messageIds.findIndex(
+          (messageId) => messageId === over.id
         );
-        const newMessages = arrayMove(
-          template.messages,
-          activeIndex,
-          overIndex
-        );
+        const newMessages = arrayMove(messageIds, activeIndex, overIndex);
         updateInstance({
           instanceId: id,
           patch: {
             template: {
               __type: "chat",
-              messages: newMessages,
+              messageIds: newMessages,
             },
           },
           dirty: true,
         });
       }}
     >
-      <SortableContext items={template.messages}>
+      <SortableContext items={messageIds}>
         <ul
           css={css`
             display: flex;
@@ -148,16 +150,13 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
             padding: var(--ac-global-dimension-size-200);
           `}
         >
-          {template.messages.map((message, index) => {
+          {messageIds.map((messageId) => {
             return (
               <SortableMessageItem
                 playgroundInstanceId={id}
-                instance={playgroundInstance}
                 templateLanguage={templateLanguage}
-                template={template}
-                key={message.id}
-                message={message}
-                index={index}
+                key={messageId}
+                messageId={messageId}
               />
             );
           })}
@@ -192,12 +191,10 @@ function MessageEditor({
   updateMessage,
   templateLanguage,
   playgroundInstanceId,
-  template,
   messageMode,
 }: {
   playgroundInstanceId: number;
   message: ChatMessage;
-  template: PlaygroundChatTemplateType;
   templateLanguage: TemplateLanguage;
   updateMessage: (patch: Partial<ChatMessage>) => void;
   messageMode: MessageMode;
@@ -214,8 +211,6 @@ function MessageEditor({
           <CodeWrap width={"100%"}>
             <ChatMessageToolCallsEditor
               playgroundInstanceId={playgroundInstanceId}
-              toolCalls={message.toolCalls}
-              templateMessages={template.messages}
               messageId={message.id}
             />
           </CodeWrap>
@@ -294,19 +289,14 @@ function MessageEditor({
 function SortableMessageItem({
   playgroundInstanceId,
   templateLanguage,
-  template,
-  message,
-  instance,
-}: PropsWithChildren<
-  PlaygroundInstanceProps & {
-    template: PlaygroundChatTemplateType;
-    message: ChatMessage;
-    templateLanguage: TemplateLanguage;
-    index: number;
-    instance: PlaygroundInstance;
-  }
->) {
-  const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  messageId,
+}: PropsWithChildren<{
+  playgroundInstanceId: number;
+  messageId: number;
+  templateLanguage: TemplateLanguage;
+}>) {
+  const updateMessage = usePlaygroundContext((state) => state.updateMessage);
+  const deleteMessage = usePlaygroundContext((state) => state.deleteMessage);
   const {
     attributes,
     listeners,
@@ -316,9 +306,25 @@ function SortableMessageItem({
     setActivatorNodeRef,
     isDragging,
   } = useSortable({
-    id: message.id,
+    id: messageId,
   });
-
+  const instanceModelSelector = useMemo(
+    () => (state: PlaygroundState) =>
+      state.instances.find((instance) => instance.id === playgroundInstanceId)
+        ?.model,
+    [playgroundInstanceId]
+  );
+  const instanceModel = usePlaygroundContext(instanceModelSelector);
+  if (!instanceModel) {
+    throw new Error(
+      `Instance model not found for instance ${playgroundInstanceId}`
+    );
+  }
+  const messageSelector = useMemo(
+    () => selectPlaygroundInstanceMessage(messageId),
+    [messageId]
+  );
+  const message = usePlaygroundContext(messageSelector);
   const messageCardStyles = useChatMessageStyles(message.role);
   const dragAndDropLiStyles = {
     transform: CSS.Translate.toString(transform),
@@ -332,24 +338,6 @@ function SortableMessageItem({
     hasTools ? "toolCalls" : "text"
   );
 
-  const updateMessage = useCallback(
-    (patch: Partial<ChatMessage>) => {
-      updateInstance({
-        instanceId: playgroundInstanceId,
-        patch: {
-          template: {
-            __type: "chat",
-            messages: template.messages.map((msg) =>
-              msg.id === message.id ? { ...msg, ...patch } : msg
-            ),
-          },
-        },
-        dirty: true,
-      });
-    },
-    [message.id, playgroundInstanceId, template.messages, updateInstance]
-  );
-
   // Preserves the content of the message before switching message modes
   // Enables the user to switch back to text mode and restore the previous content
   const [previousMessageContent, setPreviousMessageContent] = useState<
@@ -360,6 +348,17 @@ function SortableMessageItem({
   const [previousMessageToolCalls, setPreviousMessageToolCalls] = useState<
     ChatMessage["toolCalls"]
   >(message.toolCalls);
+
+  const updateThisMessage = useCallback(
+    (patch: Partial<ChatMessage>) => {
+      updateMessage({
+        instanceId: playgroundInstanceId,
+        messageId,
+        patch,
+      });
+    },
+    [playgroundInstanceId, messageId, updateMessage]
+  );
 
   return (
     <li ref={setNodeRef} style={dragAndDropLiStyles}>
@@ -386,19 +385,13 @@ function SortableMessageItem({
                   toolCalls = undefined;
                   setAIMessageMode("text");
                 }
-                updateInstance({
+                updateMessage({
                   instanceId: playgroundInstanceId,
+                  messageId,
                   patch: {
-                    template: {
-                      __type: "chat",
-                      messages: template.messages.map((msg) =>
-                        msg.id === message.id
-                          ? { ...msg, role, toolCalls }
-                          : msg
-                      ),
-                    },
+                    role,
+                    toolCalls,
                   },
-                  dirty: true,
                 });
               }}
             />
@@ -417,25 +410,33 @@ function SortableMessageItem({
                       case "text":
                         setPreviousMessageToolCalls(message.toolCalls);
                         updateMessage({
-                          content: previousMessageContent,
-                          toolCalls: undefined,
+                          instanceId: playgroundInstanceId,
+                          messageId,
+                          patch: {
+                            content: previousMessageContent,
+                            toolCalls: undefined,
+                          },
                         });
                         break;
                       case "toolCalls":
                         setPreviousMessageContent(message.content);
                         updateMessage({
-                          content: "",
-                          toolCalls:
-                            previousMessageToolCalls != null
-                              ? convertMessageToolCallsToProvider({
-                                  toolCalls: previousMessageToolCalls,
-                                  provider: instance.model.provider,
-                                })
-                              : [
-                                  createToolCallForProvider(
-                                    instance.model.provider
-                                  ),
-                                ],
+                          instanceId: playgroundInstanceId,
+                          messageId,
+                          patch: {
+                            content: "",
+                            toolCalls:
+                              previousMessageToolCalls != null
+                                ? convertMessageToolCallsToProvider({
+                                    toolCalls: previousMessageToolCalls,
+                                    provider: instanceModel.provider,
+                                  })
+                                : [
+                                    createToolCallForProvider(
+                                      instanceModel.provider
+                                    ),
+                                  ],
+                          },
                         });
                         break;
                       default:
@@ -457,17 +458,9 @@ function SortableMessageItem({
               icon={<Icon svg={<Icons.TrashOutline />} />}
               size="S"
               onPress={() => {
-                updateInstance({
+                deleteMessage({
                   instanceId: playgroundInstanceId,
-                  patch: {
-                    template: {
-                      __type: "chat",
-                      messages: template.messages.filter(
-                        (msg) => msg.id !== message.id
-                      ),
-                    },
-                  },
-                  dirty: true,
+                  messageId,
                 });
               }}
             />
@@ -484,9 +477,8 @@ function SortableMessageItem({
             message={message}
             messageMode={aiMessageMode}
             playgroundInstanceId={playgroundInstanceId}
-            template={template}
             templateLanguage={templateLanguage}
-            updateMessage={updateMessage}
+            updateMessage={updateThisMessage}
           />
         </div>
       </Card>

--- a/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
@@ -32,6 +32,7 @@ export function PlaygroundChatTemplateFooter({
 }: PlaygroundChatTemplateFooterProps) {
   const instances = usePlaygroundContext((state) => state.instances);
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  const addMessage = usePlaygroundContext((state) => state.addMessage);
   const upsertInvocationParameterInput = usePlaygroundContext(
     (state) => state.upsertInvocationParameterInput
   );
@@ -129,22 +130,13 @@ export function PlaygroundChatTemplateFooter({
         size="S"
         icon={<Icon svg={<Icons.PlusOutline />} />}
         onPress={() => {
-          updateInstance({
-            instanceId,
-            patch: {
-              template: {
-                __type: "chat",
-                messages: [
-                  ...template.messages,
-                  {
-                    id: generateMessageId(),
-                    role: "user",
-                    content: "",
-                  },
-                ],
-              },
+          addMessage({
+            playgroundInstanceId: instanceId,
+            messages: {
+              id: generateMessageId(),
+              role: "user",
+              content: "",
             },
-            dirty: true,
           });
         }}
       >

--- a/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
@@ -132,11 +132,13 @@ export function PlaygroundChatTemplateFooter({
         onPress={() => {
           addMessage({
             playgroundInstanceId: instanceId,
-            messages: {
-              id: generateMessageId(),
-              role: "user",
-              content: "",
-            },
+            messages: [
+              {
+                id: generateMessageId(),
+                role: "user",
+                content: "",
+              },
+            ],
           });
         }}
       >

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -418,8 +418,8 @@ export function PlaygroundDatasetExamplesTable({
 }) {
   const environment = useRelayEnvironment();
   const instances = usePlaygroundContext((state) => state.instances);
-  const instanceMessages = usePlaygroundContext(
-    (state) => state.instanceMessages
+  const allInstanceMessages = usePlaygroundContext(
+    (state) => state.allInstanceMessages
   );
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
@@ -762,7 +762,7 @@ export function PlaygroundDatasetExamplesTable({
     return instances.map((instance, index) => {
       const enrichedInstance = denormalizePlaygroundInstance(
         instance,
-        instanceMessages
+        allInstanceMessages
       );
       const instanceVariables = extractVariablesFromInstance({
         instance: enrichedInstance,
@@ -792,7 +792,7 @@ export function PlaygroundDatasetExamplesTable({
         size: 500,
       };
     });
-  }, [hasSomeRunIds, instances, templateLanguage, instanceMessages]);
+  }, [hasSomeRunIds, instances, templateLanguage, allInstanceMessages]);
 
   const columns: ColumnDef<TableRow>[] = [
     {

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -79,6 +79,7 @@ import {
   PlaygroundToolCall,
 } from "./PlaygroundToolCall";
 import {
+  denormalizePlaygroundInstance,
   extractVariablesFromInstance,
   getChatCompletionOverDatasetInput,
 } from "./playgroundUtils";
@@ -417,6 +418,9 @@ export function PlaygroundDatasetExamplesTable({
 }) {
   const environment = useRelayEnvironment();
   const instances = usePlaygroundContext((state) => state.instances);
+  const instanceMessages = usePlaygroundContext(
+    (state) => state.instanceMessages
+  );
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
@@ -756,8 +760,12 @@ export function PlaygroundDatasetExamplesTable({
 
   const playgroundInstanceOutputColumns = useMemo((): ColumnDef<TableRow>[] => {
     return instances.map((instance, index) => {
-      const instanceVariables = extractVariablesFromInstance({
+      const enrichedInstance = denormalizePlaygroundInstance(
         instance,
+        instanceMessages
+      );
+      const instanceVariables = extractVariablesFromInstance({
+        instance: enrichedInstance,
         templateLanguage,
       });
       return {
@@ -784,7 +792,7 @@ export function PlaygroundDatasetExamplesTable({
         size: 500,
       };
     });
-  }, [hasSomeRunIds, instances, templateLanguage]);
+  }, [hasSomeRunIds, instances, templateLanguage, instanceMessages]);
 
   const columns: ColumnDef<TableRow>[] = [
     {

--- a/app/src/pages/playground/PlaygroundInput.tsx
+++ b/app/src/pages/playground/PlaygroundInput.tsx
@@ -56,7 +56,7 @@ export function PlaygroundInput() {
             // change rapidly for a given variable
             key={i}
             label={variableKey}
-            value={variablesMap[variableKey]}
+            defaultValue={variablesMap[variableKey] ?? ""}
             onChange={(value) => setVariableValue(variableKey, value)}
           />
         );

--- a/app/src/pages/playground/PlaygroundOutputMoveButton.tsx
+++ b/app/src/pages/playground/PlaygroundOutputMoveButton.tsx
@@ -7,7 +7,7 @@ import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import {
   ChatMessage,
   generateMessageId,
-  PlaygroundInstance,
+  PlaygroundNormalizedInstance,
 } from "@phoenix/store";
 import { convertMessageToolCallsToProvider } from "@phoenix/store/playground/playgroundStoreUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
@@ -21,13 +21,13 @@ export const PlaygroundOutputMoveButton = ({
   toolCalls,
   cleanupOutput,
 }: {
-  instance: PlaygroundInstance;
+  instance: PlaygroundNormalizedInstance;
   outputContent?: string | ChatMessage[];
   toolCalls: PartialOutputToolCall[];
   cleanupOutput: () => void;
 }) => {
   const instanceId = instance.id;
-  const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  const addMessage = usePlaygroundContext((state) => state.addMessage);
   return (
     <TooltipTrigger delay={500} offset={10}>
       <Button
@@ -67,15 +67,9 @@ export const PlaygroundOutputMoveButton = ({
               }),
             });
           }
-          updateInstance({
-            instanceId,
-            patch: {
-              template: {
-                __type: "chat",
-                messages: [...instance.template.messages, ...messages],
-              },
-            },
-            dirty: true,
+          addMessage({
+            playgroundInstanceId: instanceId,
+            messages,
           });
           cleanupOutput();
         }}

--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -27,6 +27,7 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
   const [dialog, setDialog] = useState<React.ReactNode>(null);
   const instanceId = props.playgroundInstanceId;
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
+  const addMessage = usePlaygroundContext((state) => state.addMessage);
   const instances = usePlaygroundContext((state) => state.instances);
   const instance = instances.find((instance) => instance.id === instanceId);
   const index = instances.findIndex((instance) => instance.id === instanceId);
@@ -44,16 +45,26 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
 
       const response = await fetchPlaygroundPromptAsInstance(promptId);
       if (response) {
+        // delete all message references from the instance
         updateInstance({
           instanceId,
           patch: {
             ...response.instance,
+            template: {
+              __type: "chat",
+              messageIds: [],
+            },
           },
           dirty: false,
         });
+        // normalize messages and add their references to the instance
+        addMessage({
+          playgroundInstanceId: instanceId,
+          messages: response.instance.template.messages,
+        });
       }
     },
-    [instanceId, updateInstance]
+    [instanceId, updateInstance, addMessage]
   );
 
   if (!instance) {

--- a/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -28,7 +28,7 @@ const getInstancePromptParamsFromStore = (
   store: ReturnType<typeof usePlaygroundStore>
 ) => {
   const state = store.getState();
-  const instanceMessages = state.instanceMessages;
+  const allInstanceMessages = state.allInstanceMessages;
   const instance = state.instances.find(
     (instance) => instance.id === instanceId
   );
@@ -37,7 +37,7 @@ const getInstancePromptParamsFromStore = (
   }
   const enrichedInstance = denormalizePlaygroundInstance(
     instance,
-    instanceMessages
+    allInstanceMessages
   );
   const promptInput = instanceToPromptVersion(enrichedInstance);
   if (!promptInput) {

--- a/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -10,6 +10,7 @@ import { usePlaygroundStore } from "@phoenix/contexts/PlaygroundContext";
 import { UpsertPromptFromTemplateDialogCreateMutation } from "@phoenix/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql";
 import { UpsertPromptFromTemplateDialogUpdateMutation } from "@phoenix/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql";
 import { instanceToPromptVersion } from "@phoenix/pages/playground/fetchPlaygroundPrompt";
+import { denormalizePlaygroundInstance } from "@phoenix/pages/playground/playgroundUtils";
 import {
   SavePromptForm,
   SavePromptSubmitHandler,
@@ -27,13 +28,18 @@ const getInstancePromptParamsFromStore = (
   store: ReturnType<typeof usePlaygroundStore>
 ) => {
   const state = store.getState();
+  const instanceMessages = state.instanceMessages;
   const instance = state.instances.find(
     (instance) => instance.id === instanceId
   );
   if (!instance) {
     throw new Error(`Instance ${instanceId} not found`);
   }
-  const promptInput = instanceToPromptVersion(instance);
+  const enrichedInstance = denormalizePlaygroundInstance(
+    instance,
+    instanceMessages
+  );
+  const promptInput = instanceToPromptVersion(enrichedInstance);
   if (!promptInput) {
     throw new Error(`Could not convert instance ${instanceId} to prompt`);
   }

--- a/app/src/pages/playground/VariableEditor.tsx
+++ b/app/src/pages/playground/VariableEditor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { githubLight } from "@uiw/codemirror-theme-github";
 import { nord } from "@uiw/codemirror-theme-nord";
 import ReactCodeMirror, {
@@ -13,7 +13,7 @@ import { useTheme } from "@phoenix/contexts";
 
 type VariableEditorProps = {
   label?: string;
-  value?: string;
+  defaultValue: string;
   onChange?: (value: string) => void;
 };
 
@@ -28,20 +28,43 @@ const basicSetupOptions: BasicSetupOptions = {
 
 const extensions = [EditorView.lineWrapping];
 
+/**
+ * A mostly uncontrolled editor that re-mounts when the label changes.
+ *
+ * The re-mount ensures that value is reset to the initial value when the label (variable name) changes.
+ *
+ * This is necessary because controlled react-codemirror editors incessantly remount and reset
+ * cursor position when value is updated.
+ */
 export const VariableEditor = ({
   label,
-  value,
+  defaultValue,
   onChange,
 }: VariableEditorProps) => {
   const { theme } = useTheme();
+  const valueRef = useRef(defaultValue);
+  const [version, setVersion] = useState(0);
+  const [initialValue, setInitialValue] = useState(() => defaultValue);
+  useEffect(() => {
+    if (defaultValue == null) {
+      setInitialValue("");
+      setVersion((prev) => prev + 1);
+    }
+    valueRef.current = defaultValue;
+  }, [defaultValue]);
+  useEffect(() => {
+    setInitialValue(valueRef.current);
+    setVersion((prev) => prev + 1);
+  }, [label]);
   const codeMirrorTheme = theme === "light" ? githubLight : nord;
   return (
     <Field label={label}>
       <CodeWrap width="100%">
         <ReactCodeMirror
+          key={version}
           theme={codeMirrorTheme}
           basicSetup={basicSetupOptions}
-          value={value}
+          value={initialValue}
           extensions={extensions}
           onChange={onChange}
         />

--- a/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
+++ b/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
@@ -16,17 +16,17 @@ import {
 export const useDerivedPlaygroundVariables = () => {
   const input = usePlaygroundContext((state) => state.input);
   const instances = usePlaygroundContext((state) => state.instances);
-  const instanceMessages = usePlaygroundContext(
-    (state) => state.instanceMessages
+  const allInstanceMessages = usePlaygroundContext(
+    (state) => state.allInstanceMessages
   );
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
   const enrichedInstances = useMemo(() => {
     return instances.map((instance) =>
-      denormalizePlaygroundInstance(instance, instanceMessages)
+      denormalizePlaygroundInstance(instance, allInstanceMessages)
     );
-  }, [instances, instanceMessages]);
+  }, [instances, allInstanceMessages]);
   const { variableKeys, variablesMap } = useMemo(() => {
     return getVariablesMapFromInstances({
       instances: enrichedInstances,

--- a/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
+++ b/app/src/pages/playground/useDerivedPlaygroundVariables.tsx
@@ -2,7 +2,10 @@ import { useMemo } from "react";
 
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 
-import { getVariablesMapFromInstances } from "./playgroundUtils";
+import {
+  denormalizePlaygroundInstance,
+  getVariablesMapFromInstances,
+} from "./playgroundUtils";
 
 /**
  * Get the variable values and keys from all instances in the playground
@@ -13,16 +16,24 @@ import { getVariablesMapFromInstances } from "./playgroundUtils";
 export const useDerivedPlaygroundVariables = () => {
   const input = usePlaygroundContext((state) => state.input);
   const instances = usePlaygroundContext((state) => state.instances);
+  const instanceMessages = usePlaygroundContext(
+    (state) => state.instanceMessages
+  );
   const templateLanguage = usePlaygroundContext(
     (state) => state.templateLanguage
   );
+  const enrichedInstances = useMemo(() => {
+    return instances.map((instance) =>
+      denormalizePlaygroundInstance(instance, instanceMessages)
+    );
+  }, [instances, instanceMessages]);
   const { variableKeys, variablesMap } = useMemo(() => {
     return getVariablesMapFromInstances({
-      instances,
+      instances: enrichedInstances,
       templateLanguage,
       input,
     });
-  }, [input, instances, templateLanguage]);
+  }, [input, enrichedInstances, templateLanguage]);
 
   return { variableKeys, variablesMap };
 };

--- a/app/src/pages/prompt/ChatTemplateMessageCard.tsx
+++ b/app/src/pages/prompt/ChatTemplateMessageCard.tsx
@@ -69,7 +69,7 @@ export function ChatTemplateMessageToolResultPart({
             <TemplateEditor
               readOnly
               height="100%"
-              value={value}
+              defaultValue={value}
               templateLanguage={TemplateLanguages.NONE}
             />
           </TemplateEditorWrap>
@@ -103,7 +103,7 @@ export function ChatTemplateMessageToolCallPart({
         <TemplateEditor
           readOnly
           height="100%"
-          value={value}
+          defaultValue={value}
           templateLanguage={TemplateLanguages.NONE}
         />
       </TemplateEditorWrap>
@@ -130,7 +130,7 @@ export function ChatTemplateMessageTextPart(
         <TemplateEditor
           readOnly
           height="100%"
-          value={text}
+          defaultValue={text}
           templateLanguage={templateFormat}
         />
       </TemplateEditorWrap>

--- a/app/src/pages/prompt/PromptPlaygroundPage.tsx
+++ b/app/src/pages/prompt/PromptPlaygroundPage.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from "react";
 import { useLoaderData } from "react-router";
 
 import { PromptPlaygroundLoaderData } from "@phoenix/pages/prompt/promptPlaygroundLoader";
-import { createPlaygroundInstance } from "@phoenix/store";
+import {
+  createNormalizedPlaygroundInstance,
+  PlaygroundInstance,
+} from "@phoenix/store";
 
 import { Playground } from "../playground/Playground";
 
@@ -12,12 +15,18 @@ export function PromptPlaygroundPage() {
   // create a playground instance with the prompt details configured
   // When the playground component mounts and sees the prompt id in the instance,
   // it will automatically load the latest prompt version into the instance
-  const playgroundInstance = useMemo(() => {
-    return {
-      ...createPlaygroundInstance(),
+  const { instance } = useMemo(() => {
+    const { instance: defaultInstance } = createNormalizedPlaygroundInstance();
+
+    const instance = {
+      ...defaultInstance,
       ...instanceWithPrompt,
-    };
+      // we don't want default messages in the instance, just the prompt messages
+      template: instanceWithPrompt.template,
+    } satisfies PlaygroundInstance;
+
+    return { instance };
   }, [instanceWithPrompt]);
 
-  return <Playground instances={[playgroundInstance]} />;
+  return <Playground instances={[instance]} />;
 }

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -510,7 +510,7 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
         }),
       });
     },
-    updateMessage: ({ messageId, patch }) => {
+    updateMessage: ({ messageId, patch, instanceId }) => {
       const allInstanceMessages = get().allInstanceMessages;
       set({
         allInstanceMessages: {
@@ -520,6 +520,11 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
             ...patch,
           },
         },
+      });
+      get().updateInstance({
+        instanceId,
+        patch: {},
+        dirty: true,
       });
     },
     deleteMessage: ({ instanceId, messageId }) => {

--- a/app/src/store/playground/selectors.ts
+++ b/app/src/store/playground/selectors.ts
@@ -16,16 +16,16 @@ export const selectPlaygroundInstance =
  */
 export const selectPlaygroundInstanceMessages =
   (instanceId: number) => (state: PlaygroundState) => {
-    const instance = state.instances.find(
-      (instance) => instance.id === instanceId
-    );
+    const instance = selectPlaygroundInstance(instanceId)(state);
     if (!instance) {
       return [];
     }
     if (instance.template.__type !== "chat") {
       return [];
     }
-    return instance.template.messageIds.map((id) => state.instanceMessages[id]);
+    return instance.template.messageIds.map(
+      (id) => state.allInstanceMessages[id]
+    );
   };
 
 /**
@@ -35,5 +35,5 @@ export const selectPlaygroundInstanceMessages =
  */
 export const selectPlaygroundInstanceMessage =
   (messageId: number) => (state: PlaygroundState) => {
-    return state.instanceMessages[messageId];
+    return state.allInstanceMessages[messageId];
   };

--- a/app/src/store/playground/selectors.ts
+++ b/app/src/store/playground/selectors.ts
@@ -1,0 +1,39 @@
+import { PlaygroundState } from "./types";
+
+/**
+ * Curried selector to get an instance by id
+ * @param instanceId
+ * @returns selector function that returns the instance for the given id
+ */
+export const selectPlaygroundInstance =
+  (instanceId: number) => (state: PlaygroundState) =>
+    state.instances.find((instance) => instance.id === instanceId);
+
+/**
+ * Curried selector to get all messages for a given instance
+ * @param instanceId
+ * @returns selector function that returns all messages for the given instance
+ */
+export const selectPlaygroundInstanceMessages =
+  (instanceId: number) => (state: PlaygroundState) => {
+    const instance = state.instances.find(
+      (instance) => instance.id === instanceId
+    );
+    if (!instance) {
+      return [];
+    }
+    if (instance.template.__type !== "chat") {
+      return [];
+    }
+    return instance.template.messageIds.map((id) => state.instanceMessages[id]);
+  };
+
+/**
+ * Curried selector to get a message of a given id
+ * @param messageId
+ * @returns selector function that returns the message for the given id
+ */
+export const selectPlaygroundInstanceMessage =
+  (messageId: number) => (state: PlaygroundState) => {
+    return state.instanceMessages[messageId];
+  };

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -142,7 +142,7 @@ export interface AddMessageParams extends PlaygroundInstanceActionParams {
   /**
    * If not provided, a default empty message will be added
    */
-  messages?: ChatMessage | ChatMessage[];
+  messages?: ChatMessage[];
 }
 
 export interface PlaygroundProps {
@@ -208,7 +208,7 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
    *
    * message ids must be globally unique across all instances
    */
-  instanceMessages: Record<number, ChatMessage>;
+  allInstanceMessages: Record<number, ChatMessage>;
 
   /**
    * Setter for the invocation mode

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -138,7 +138,12 @@ interface PlaygroundInstanceActionParams {
   playgroundInstanceId: number;
 }
 
-export interface AddMessageParams extends PlaygroundInstanceActionParams {}
+export interface AddMessageParams extends PlaygroundInstanceActionParams {
+  /**
+   * If not provided, a default empty message will be added
+   */
+  messages?: ChatMessage | ChatMessage[];
+}
 
 export interface PlaygroundProps {
   /**
@@ -172,7 +177,39 @@ export type InitialPlaygroundState = Partial<PlaygroundProps> & {
   modelConfigByProvider: ModelConfigByProvider;
 };
 
-export interface PlaygroundState extends PlaygroundProps {
+/**
+ * A chat completion template, with normalized message ids
+ *
+ * The chat template only contains references to message ids, which are normalized to be unique
+ * and stored elsewhere in the state
+ */
+export type PlaygroundNormalizedChatTemplate = Omit<
+  PlaygroundChatTemplate,
+  "messages"
+> & {
+  messageIds: number[];
+};
+
+/**
+ * A playground instance, with normalized chat completion template messages
+ */
+export type PlaygroundNormalizedInstance = Omit<
+  PlaygroundInstance,
+  "template"
+> & {
+  template: PlaygroundTextCompletionTemplate | PlaygroundNormalizedChatTemplate;
+};
+
+export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
+  instances: Array<PlaygroundNormalizedInstance>;
+
+  /**
+   * A map of message id to message
+   *
+   * message ids must be globally unique across all instances
+   */
+  instanceMessages: Record<number, ChatMessage>;
+
   /**
    * Setter for the invocation mode
    * @param operationType
@@ -202,11 +239,24 @@ export interface PlaygroundState extends PlaygroundProps {
    */
   addMessage: (params: AddMessageParams) => void;
   /**
+   * Update a message in a playground instance
+   */
+  updateMessage: (params: {
+    instanceId: number;
+    messageId: number;
+    patch: Partial<ChatMessage>;
+  }) => void;
+  /**
+   * Delete a message from a playground instance
+   */
+  deleteMessage: (params: { instanceId: number; messageId: number }) => void;
+
+  /**
    * Update an instance of the playground
    */
   updateInstance: (params: {
     instanceId: number;
-    patch: Partial<PlaygroundInstance>;
+    patch: Partial<PlaygroundNormalizedInstance>;
     /**
      * Should this update mark the instance as dirty?
      *


### PR DESCRIPTION
Resolves: #6191

This PR contains two major changes, and should be viewed by-commit.


### Normalize playground instance messages
---

There is now a split in instance types:
- PlaygroundInstance
- PlaygroundNormalizedInstance

The main difference is that chat templates within a normalized instance only contain messageIds instead of message objects.

The PlaygroundStore now only deals in PlaygroundNormalizedInstance, and handles conversion from PlaygroundInstance to PlaygroundNormalizedInstance during initialization.

### Convert code mirror editors on playground to be uncontrolled
---

- TemplateEditor
- VariableEditor
- PlaygroundTool (editor)

---


All of this is in service of fixing a react-codemirror bug that breaks rendering when updates take too long, which was occurring because messages were stored deeply within an instance causing a cascade of re-renders on every keystroke. 