### PR TITLE
feat: Propagate prompt id to playground spans metadata

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -110,7 +110,7 @@ input ChatCompletionInput {
   tools: [JSON!]
   apiKey: String = null
   template: TemplateOptions
-  promptId: GlobalID = null
+  promptName: Identifier = null
 }
 
 input ChatCompletionMessageInput {
@@ -160,7 +160,7 @@ input ChatCompletionOverDatasetInput {
   experimentName: String = null
   experimentDescription: String = null
   experimentMetadata: JSON = {}
-  promptId: GlobalID = null
+  promptName: Identifier = null
 }
 
 type ChatCompletionOverDatasetMutationExamplePayload {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -110,6 +110,7 @@ input ChatCompletionInput {
   tools: [JSON!]
   apiKey: String = null
   template: TemplateOptions
+  promptId: GlobalID = null
 }
 
 input ChatCompletionMessageInput {
@@ -159,6 +160,7 @@ input ChatCompletionOverDatasetInput {
   experimentName: String = null
   experimentDescription: String = null
   experimentMetadata: JSON = {}
+  promptId: GlobalID = null
 }
 
 type ChatCompletionOverDatasetMutationExamplePayload {

--- a/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -82,7 +82,7 @@ export const UpsertPromptFromTemplateDialog = ({
     `);
   // tasks to complete after either mutation completes successfully
   const onSuccess = useCallback(
-    (promptId: string) => {
+    (promptId: string, promptName: string) => {
       const state = store.getState();
       const instance = state.instances.find(
         (instance) => instance.id === instanceId
@@ -95,6 +95,7 @@ export const UpsertPromptFromTemplateDialog = ({
         patch: {
           prompt: {
             id: promptId,
+            name: promptName,
           },
         },
         dirty: false,
@@ -129,7 +130,10 @@ export const UpsertPromptFromTemplateDialog = ({
               },
             },
           });
-          onSuccess(response.createChatPrompt.id);
+          onSuccess(
+            response.createChatPrompt.id,
+            response.createChatPrompt.name
+          );
           setDialog(null);
         },
         onError: (error) => {
@@ -183,7 +187,10 @@ export const UpsertPromptFromTemplateDialog = ({
               },
             },
           });
-          onSuccess(response.createChatPromptVersion.id);
+          onSuccess(
+            response.createChatPromptVersion.id,
+            response.createChatPromptVersion.name
+          );
           setDialog(null);
         },
         onError: (error) => {

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f171a9bb81595411ceecd5cac5d0628b>>
+ * @generated SignedSource<<38e74819211a23203c221e576045b9d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,7 +23,7 @@ export type ChatCompletionOverDatasetInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
-  promptId?: string | null;
+  promptName?: string | null;
   templateLanguage: TemplateLanguage;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<83115a7d0cd41610c964392fd634b548>>
+ * @generated SignedSource<<f171a9bb81595411ceecd5cac5d0628b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type ChatCompletionOverDatasetInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
+  promptId?: string | null;
   templateLanguage: TemplateLanguage;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b17e988a27514700d46b8c52d113da76>>
+ * @generated SignedSource<<b49596911c175aafd6ad3c35ef1da8f1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,7 +23,7 @@ export type ChatCompletionOverDatasetInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
-  promptId?: string | null;
+  promptName?: string | null;
   templateLanguage: TemplateLanguage;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8e709a5628ea7235eacc28dfa5bb7277>>
+ * @generated SignedSource<<b17e988a27514700d46b8c52d113da76>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type ChatCompletionOverDatasetInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
+  promptId?: string | null;
   templateLanguage: TemplateLanguage;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d03a65e67d61773ec8552496e2a1c3bb>>
+ * @generated SignedSource<<ec347d90d3222e9ec7fc70597ef82660>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type ChatCompletionInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
+  promptId?: string | null;
   template?: TemplateOptions | null;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ec347d90d3222e9ec7fc70597ef82660>>
+ * @generated SignedSource<<1bf290aeab3642310c94df54feaca058>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,7 @@ export type ChatCompletionInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
-  promptId?: string | null;
+  promptName?: string | null;
   template?: TemplateOptions | null;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3274cb65871ec27834fd3163e1e79dea>>
+ * @generated SignedSource<<d7b1fea75c51d3d18b6551aaea59d906>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type ChatCompletionInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
+  promptId?: string | null;
   template?: TemplateOptions | null;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d7b1fea75c51d3d18b6551aaea59d906>>
+ * @generated SignedSource<<1617bba6b57fae7a848a5a660cacb4f8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,7 @@ export type ChatCompletionInput = {
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
-  promptId?: string | null;
+  promptName?: string | null;
   template?: TemplateOptions | null;
   tools?: ReadonlyArray<any> | null;
 };

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -136,16 +136,18 @@ export const objectToInvocationParameters = (
  */
 export const promptVersionToInstance = ({
   promptId,
+  promptName,
   promptVersion,
   supportedInvocationParameters,
 }: {
   promptId: string;
+  promptName: string;
   promptVersion: PromptVersion;
   supportedInvocationParameters?: PlaygroundInstance["model"]["supportedInvocationParameters"];
 }) => {
   const newInstance = {
     ...DEFAULT_INSTANCE_PARAMS(),
-    prompt: { id: promptId },
+    prompt: { id: promptId, name: promptName },
   } satisfies Partial<PlaygroundInstance>;
 
   const modelName = promptVersion.modelName;
@@ -601,8 +603,13 @@ export const fetchPlaygroundPromptAsInstance = async (
           latestPromptVersion.modelProvider
         ),
       });
+    const promptName = response?.prompt?.name;
+    if (!promptName) {
+      throw new Error("Prompt name is required");
+    }
     const newInstance = promptVersionToInstance({
       promptId,
+      promptName,
       promptVersion: latestPromptVersion,
       supportedInvocationParameters,
     });

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -980,7 +980,7 @@ const getBaseChatCompletionInput = ({
       ? instance.tools.map((tool) => tool.definition)
       : undefined,
     apiKey: credentials[instance.model.provider] || null,
-    promptId: instance.prompt?.id,
+    promptName: instance.prompt?.name,
   } satisfies Partial<ChatCompletionInput>;
 };
 

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -980,7 +980,8 @@ const getBaseChatCompletionInput = ({
       ? instance.tools.map((tool) => tool.definition)
       : undefined,
     apiKey: credentials[instance.model.provider] || null,
-  } as const;
+    promptId: instance.prompt?.id,
+  } satisfies Partial<ChatCompletionInput>;
 };
 
 /**

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -86,9 +86,13 @@ export type Tool = {
 
 export type PlaygroundInstancePrompt = {
   /**
-   * The id of the prompt
+   * The relay global id of the prompt
    */
   id: string;
+  /**
+   * The name (Identifier) of the prompt
+   */
+  name: string;
   /**
    * The version of the prompt. Assumes latest version if not provided.
    */

--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -26,7 +26,6 @@ from openinference.semconv.trace import (
 )
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator as DefaultOTelIDGenerator
 from opentelemetry.trace import StatusCode
-from strawberry.relay.types import GlobalID
 from strawberry.scalars import JSON as JSONScalarType
 from typing_extensions import Self, TypeAlias, assert_never
 
@@ -42,6 +41,7 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
     TextChunk,
     ToolCallChunk,
 )
+from phoenix.server.api.types.Identifier import Identifier
 from phoenix.trace.attributes import get_attribute_value, unflatten
 from phoenix.trace.schemas import (
     SpanEvent,
@@ -72,8 +72,8 @@ class streaming_llm_span:
         self._input = input
         self._attributes: dict[str, Any] = attributes if attributes is not None else {}
 
-        if input.prompt_id:
-            self._attributes.update(*prompt_id_metadata(input.prompt_id))
+        if input.prompt_identifier:
+            self._attributes.update(*prompt_id_metadata(input.prompt_identifier))
 
         self._attributes.update(
             chain(
@@ -269,8 +269,8 @@ def input_value_and_mime_type(
     yield INPUT_VALUE, safe_json_dumps(input_data)
 
 
-def prompt_id_metadata(prompt_id: Optional[GlobalID]) -> Iterator[tuple[str, Any]]:
-    yield METADATA, {"phoenix-prompt-id": str(prompt_id)}
+def prompt_id_metadata(prompt_identifier: Optional[Identifier]) -> Iterator[tuple[str, Any]]:
+    yield METADATA, {"phoenixPromptId": prompt_identifier}
 
 
 def _merge_tool_call_chunks(

--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -72,8 +72,8 @@ class streaming_llm_span:
         self._input = input
         self._attributes: dict[str, Any] = attributes if attributes is not None else {}
 
-        if input.prompt_identifier:
-            self._attributes.update(*prompt_id_metadata(input.prompt_identifier))
+        if input.prompt_name:
+            self._attributes.update(*prompt_id_metadata(input.prompt_name))
 
         self._attributes.update(
             chain(
@@ -269,8 +269,8 @@ def input_value_and_mime_type(
     yield INPUT_VALUE, safe_json_dumps(input_data)
 
 
-def prompt_id_metadata(prompt_identifier: Optional[Identifier]) -> Iterator[tuple[str, Any]]:
-    yield METADATA, {"phoenixPromptId": prompt_identifier}
+def prompt_id_metadata(prompt_name: Optional[Identifier]) -> Iterator[tuple[str, Any]]:
+    yield METADATA, {"phoenixPromptId": prompt_name}
 
 
 def _merge_tool_call_chunks(

--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -72,9 +72,11 @@ class streaming_llm_span:
         self._input = input
         self._attributes: dict[str, Any] = attributes if attributes is not None else {}
 
+        if input.prompt_id:
+            self._attributes.update(*prompt_id_metadata(input.prompt_id))
+
         self._attributes.update(
             chain(
-                prompt_id_metadata(input.prompt_id),
                 llm_span_kind(),
                 llm_model_name(input.model.name),
                 llm_tools(input.tools or []),

--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -71,9 +71,7 @@ class streaming_llm_span:
     ) -> None:
         self._input = input
         self._attributes: dict[str, Any] = attributes if attributes is not None else {}
-
-        if input.prompt_name:
-            self._attributes.update(*prompt_id_metadata(input.prompt_name))
+        self._attributes.update(dict(prompt_metadata(input.prompt_name)))
 
         self._attributes.update(
             chain(
@@ -269,8 +267,9 @@ def input_value_and_mime_type(
     yield INPUT_VALUE, safe_json_dumps(input_data)
 
 
-def prompt_id_metadata(prompt_name: Optional[Identifier]) -> Iterator[tuple[str, Any]]:
-    yield METADATA, {"phoenixPromptId": prompt_name}
+def prompt_metadata(prompt_name: Optional[Identifier]) -> Iterator[tuple[str, Any]]:
+    if prompt_name:
+        yield METADATA, {"phoenixPromptId": prompt_name}
 
 
 def _merge_tool_call_chunks(

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -21,6 +21,7 @@ class ChatCompletionInput:
     tools: Optional[list[JSON]] = UNSET
     api_key: Optional[str] = strawberry.field(default=None)
     template: Optional[TemplateOptions] = UNSET
+    prompt_id: Optional[GlobalID] = None
 
 
 @strawberry.input
@@ -36,3 +37,4 @@ class ChatCompletionOverDatasetInput:
     experiment_name: Optional[str] = None
     experiment_description: Optional[str] = None
     experiment_metadata: Optional[JSON] = strawberry.field(default_factory=dict)
+    prompt_id: Optional[GlobalID] = None

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -22,7 +22,7 @@ class ChatCompletionInput:
     tools: Optional[list[JSON]] = UNSET
     api_key: Optional[str] = strawberry.field(default=None)
     template: Optional[TemplateOptions] = UNSET
-    prompt_identifier: Optional[Identifier] = None
+    prompt_name: Optional[Identifier] = None
 
 
 @strawberry.input
@@ -38,4 +38,4 @@ class ChatCompletionOverDatasetInput:
     experiment_name: Optional[str] = None
     experiment_description: Optional[str] = None
     experiment_metadata: Optional[JSON] = strawberry.field(default_factory=dict)
-    prompt_identifier: Optional[Identifier] = None
+    prompt_name: Optional[Identifier] = None

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -5,6 +5,7 @@ from strawberry import UNSET
 from strawberry.relay.types import GlobalID
 from strawberry.scalars import JSON
 
+from phoenix.server.api.types.Identifier import Identifier
 from phoenix.server.api.types.TemplateLanguage import TemplateLanguage
 
 from .ChatCompletionMessageInput import ChatCompletionMessageInput
@@ -21,7 +22,7 @@ class ChatCompletionInput:
     tools: Optional[list[JSON]] = UNSET
     api_key: Optional[str] = strawberry.field(default=None)
     template: Optional[TemplateOptions] = UNSET
-    prompt_id: Optional[GlobalID] = None
+    prompt_identifier: Optional[Identifier] = None
 
 
 @strawberry.input
@@ -37,4 +38,4 @@ class ChatCompletionOverDatasetInput:
     experiment_name: Optional[str] = None
     experiment_description: Optional[str] = None
     experiment_metadata: Optional[JSON] = strawberry.field(default_factory=dict)
-    prompt_id: Optional[GlobalID] = None
+    prompt_identifier: Optional[Identifier] = None

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -214,7 +214,7 @@ class ChatCompletionMutationMixin:
                                 language=input.template_language,
                                 variables=revision.input,
                             ),
-                            prompt_identifier=input.prompt_identifier,
+                            prompt_name=input.prompt_name,
                         ),
                     )
                     for revision in batch
@@ -309,8 +309,8 @@ class ChatCompletionMutationMixin:
     ) -> ChatCompletionMutationPayload:
         attributes: dict[str, Any] = {}
 
-        if input.prompt_identifier:
-            attributes.update(*prompt_id_metadata(input.prompt_identifier))
+        if input.prompt_name:
+            attributes.update(*prompt_id_metadata(input.prompt_name))
 
         messages = [
             (

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -214,7 +214,7 @@ class ChatCompletionMutationMixin:
                                 language=input.template_language,
                                 variables=revision.input,
                             ),
-                            prompt_id=input.prompt_id,
+                            prompt_identifier=input.prompt_identifier,
                         ),
                     )
                     for revision in batch
@@ -309,8 +309,8 @@ class ChatCompletionMutationMixin:
     ) -> ChatCompletionMutationPayload:
         attributes: dict[str, Any] = {}
 
-        if input.prompt_id:
-            attributes.update(*prompt_id_metadata(input.prompt_id))
+        if input.prompt_identifier:
+            attributes.update(*prompt_id_metadata(input.prompt_identifier))
 
         messages = [
             (

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -41,6 +41,7 @@ from phoenix.server.api.helpers.playground_spans import (
     llm_model_name,
     llm_span_kind,
     llm_tools,
+    prompt_id_metadata,
 )
 from phoenix.server.api.input_types.ChatCompletionInput import (
     ChatCompletionInput,
@@ -213,6 +214,7 @@ class ChatCompletionMutationMixin:
                                 language=input.template_language,
                                 variables=revision.input,
                             ),
+                            prompt_id=input.prompt_id,
                         ),
                     )
                     for revision in batch
@@ -306,6 +308,10 @@ class ChatCompletionMutationMixin:
         input: ChatCompletionInput,
     ) -> ChatCompletionMutationPayload:
         attributes: dict[str, Any] = {}
+
+
+        if input.prompt_id:
+            attributes.update(*prompt_id_metadata(input.prompt_id))
 
         messages = [
             (

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -41,7 +41,7 @@ from phoenix.server.api.helpers.playground_spans import (
     llm_model_name,
     llm_span_kind,
     llm_tools,
-    prompt_id_metadata,
+    prompt_metadata,
 )
 from phoenix.server.api.input_types.ChatCompletionInput import (
     ChatCompletionInput,
@@ -308,9 +308,7 @@ class ChatCompletionMutationMixin:
         input: ChatCompletionInput,
     ) -> ChatCompletionMutationPayload:
         attributes: dict[str, Any] = {}
-
-        if input.prompt_name:
-            attributes.update(*prompt_id_metadata(input.prompt_name))
+        attributes.update(dict(prompt_metadata(input.prompt_name)))
 
         messages = [
             (

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -309,7 +309,6 @@ class ChatCompletionMutationMixin:
     ) -> ChatCompletionMutationPayload:
         attributes: dict[str, Any] = {}
 
-
         if input.prompt_id:
             attributes.update(*prompt_id_metadata(input.prompt_id))
 


### PR DESCRIPTION
resolves #6151 

- `prompt_id` can now be optionally passed to playground `ChatCompletionInput` and `ChatCompletionOverDatasetInput`
- This `prompt_id` will be propagated to playground-generated spans