### PR TITLE
feat(prompts): display the cloned prompt in header

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -946,7 +946,7 @@ export const derivedCSS = (theme: ThemeContextType["theme"]) => css`
     --ac-focus-ring-color: var(--ac-global-color-primary-500);
 
     // Text
-    --ac-text-color-placeholder: var(--ac-global-color-grey-700);
+    --ac-text-color-placeholder: var(--ac-global-color-grey-400);
 
     // Styles for text fields etc
     --ac-global-input-field-border-color: var(--ac-global-color-grey-400);

--- a/app/src/pages/prompt/ClonePromptDialog.tsx
+++ b/app/src/pages/prompt/ClonePromptDialog.tsx
@@ -47,7 +47,7 @@ export const ClonePromptDialog = ({
     reValidateMode: "onBlur",
     mode: "onChange",
     defaultValues: {
-      name: `${promptName} (Clone)`,
+      name: `${promptName}-clone`,
       description: promptDescription,
     },
   });

--- a/app/src/pages/prompt/PromptLayout.tsx
+++ b/app/src/pages/prompt/PromptLayout.tsx
@@ -6,7 +6,16 @@ import { css } from "@emotion/react";
 
 import { Counter, DialogContainer, TabPane, Tabs } from "@arizeai/components";
 
-import { Button, Flex, Heading, Icon, Icons, View } from "@phoenix/components";
+import {
+  Button,
+  Flex,
+  Heading,
+  Icon,
+  Icons,
+  Link,
+  Text,
+  View,
+} from "@phoenix/components";
 import { ClonePromptDialog } from "@phoenix/pages/prompt/ClonePromptDialog";
 
 import { PromptLayout__main$key } from "./__generated__/PromptLayout__main.graphql";
@@ -58,6 +67,10 @@ export function PromptLayout() {
         id
         name
         description
+        sourcePrompt {
+          id
+          name
+        }
         promptVersions {
           edges {
             node {
@@ -84,7 +97,18 @@ export function PromptLayout() {
           justifyContent="space-between"
           alignItems="center"
         >
-          <Heading level={1}>{loaderData.prompt.name}</Heading>
+          <Flex direction="column">
+            <Heading level={1}>{loaderData.prompt.name}</Heading>
+            {data.sourcePrompt && (
+              <Text color="text-700">
+                cloned from{" "}
+                <Link to={`/prompts/${data.sourcePrompt.id}`}>
+                  {data.sourcePrompt.name}
+                </Link>
+              </Text>
+            )}
+          </Flex>
+
           <Flex direction="row" gap="size-100">
             <Button
               size="S"

--- a/app/src/pages/prompt/__generated__/PromptLayout__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptLayout__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9bb0b567dbba35e8d71a077f77a57bf4>>
+ * @generated SignedSource<<0b6bc301be121efc3ca6c938bebdbeb9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,10 @@ export type PromptLayout__main$data = {
       };
     }>;
   };
+  readonly sourcePrompt: {
+    readonly id: string;
+    readonly name: string;
+  } | null;
   readonly " $fragmentType": "PromptLayout__main";
 };
 export type PromptLayout__main$key = {
@@ -35,6 +39,13 @@ var v0 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
 };
 return {
   "argumentDefinitions": [],
@@ -43,18 +54,25 @@ return {
   "name": "PromptLayout__main",
   "selections": [
     (v0/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
+    (v1/*: any*/),
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Prompt",
+      "kind": "LinkedField",
+      "name": "sourcePrompt",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        (v1/*: any*/)
+      ],
       "storageKey": null
     },
     {
@@ -97,6 +115,6 @@ return {
 };
 })();
 
-(node as any).hash = "6431d40ed67848e82e6dd5e826d11ed3";
+(node as any).hash = "3f2a7eb87a4a433362def455a9151d45";
 
 export default node;

--- a/app/src/pages/prompt/__generated__/promptLoaderQuery.graphql.ts
+++ b/app/src/pages/prompt/__generated__/promptLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92e4bb29bf827023540ddb9552af48a2>>
+ * @generated SignedSource<<3acbef24e8a4183b2ef59b255575c561>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -125,17 +125,18 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = {
+v11 = [
+  (v3/*: any*/),
+  (v4/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "PromptVersionTag",
   "kind": "LinkedField",
   "name": "tags",
   "plural": true,
-  "selections": [
-    (v3/*: any*/),
-    (v4/*: any*/)
-  ],
+  "selections": (v11/*: any*/),
   "storageKey": null
 };
 return {
@@ -492,7 +493,7 @@ return {
                           (v8/*: any*/),
                           (v9/*: any*/),
                           (v10/*: any*/),
-                          (v11/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -538,7 +539,7 @@ return {
                           (v9/*: any*/),
                           (v8/*: any*/),
                           (v10/*: any*/),
-                          (v11/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -547,6 +548,16 @@ return {
                   }
                 ],
                 "storageKey": "promptVersions(first:5)"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Prompt",
+                "kind": "LinkedField",
+                "name": "sourcePrompt",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": null
               }
             ],
             "type": "Prompt",
@@ -558,12 +569,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fd1bef15bea754ac5630e135df2d65ed",
+    "cacheID": "2deb23460202a4b49d1ca836b0ec44a9",
     "id": null,
     "metadata": {},
     "name": "promptLoaderQuery",
     "operationKind": "query",
-    "text": "query promptLoaderQuery(\n  $id: GlobalID!\n) {\n  prompt: node(id: $id) {\n    __typename\n    id\n    ... on Prompt {\n      name\n      ...PromptIndexPage__main\n      ...PromptVersionsPageContent__main\n      ...PromptLayout__main\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ImageContentPart {\n            image {\n              url\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptCodeExportCard__main on PromptVersion {\n  invocationParameters\n  modelName\n  modelProvider\n  outputSchema {\n    definition\n  }\n  tools {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            __typename\n            text {\n              text\n            }\n          }\n          ... on ImageContentPart {\n            __typename\n            image {\n              url\n            }\n          }\n          ... on ToolCallContentPart {\n            __typename\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            __typename\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateFormat\n  templateType\n}\n\nfragment PromptIndexPage__aside on Prompt {\n  description\n  ...PromptLatestVersionsListFragment\n}\n\nfragment PromptIndexPage__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        ...PromptInvocationParameters__main\n        ...PromptChatMessagesCard__main\n        ...PromptCodeExportCard__main\n        ...PromptModelConfigurationCard__main\n      }\n    }\n  }\n  ...PromptIndexPage__aside\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n\nfragment PromptLLM__main on PromptVersion {\n  model: modelName\n  provider: modelProvider\n}\n\nfragment PromptLatestVersionsListFragment on Prompt {\n  latestVersions: promptVersions(first: 5) {\n    edges {\n      version: node {\n        id\n        description\n        createdAt\n        sequenceNumber\n        ...PromptVersionSummaryFragment\n      }\n    }\n  }\n}\n\nfragment PromptLayout__main on Prompt {\n  id\n  name\n  description\n  promptVersions {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n\nfragment PromptModelConfigurationCard__main on PromptVersion {\n  model: modelName\n  provider: modelProvider\n  ...PromptLLM__main\n  ...PromptInvocationParameters__main\n  ...PromptTools__main\n  ...PromptOutputSchemaFragment\n}\n\nfragment PromptOutputSchemaFragment on PromptVersion {\n  outputSchema {\n    definition\n  }\n}\n\nfragment PromptTools__main on PromptVersion {\n  tools {\n    definition\n  }\n}\n\nfragment PromptVersionSummaryFragment on PromptVersion {\n  id\n  description\n  sequenceNumber\n  createdAt\n  user {\n    id\n    username\n    profilePictureUrl\n  }\n  ...PromptVersionTagsList_data\n}\n\nfragment PromptVersionTagsList_data on PromptVersion {\n  tags {\n    id\n    name\n  }\n}\n\nfragment PromptVersionsList__main on Prompt {\n  promptVersions {\n    edges {\n      version: node {\n        id\n        ...PromptVersionSummaryFragment\n      }\n    }\n  }\n}\n\nfragment PromptVersionsPageContent__main on Prompt {\n  ...PromptVersionsList__main\n}\n"
+    "text": "query promptLoaderQuery(\n  $id: GlobalID!\n) {\n  prompt: node(id: $id) {\n    __typename\n    id\n    ... on Prompt {\n      name\n      ...PromptIndexPage__main\n      ...PromptVersionsPageContent__main\n      ...PromptLayout__main\n    }\n  }\n}\n\nfragment PromptChatMessagesCard__main on PromptVersion {\n  provider: modelProvider\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ImageContentPart {\n            image {\n              url\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                arguments\n                name\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateType\n  templateFormat\n}\n\nfragment PromptCodeExportCard__main on PromptVersion {\n  invocationParameters\n  modelName\n  modelProvider\n  outputSchema {\n    definition\n  }\n  tools {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            __typename\n            text {\n              text\n            }\n          }\n          ... on ImageContentPart {\n            __typename\n            image {\n              url\n            }\n          }\n          ... on ToolCallContentPart {\n            __typename\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            __typename\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  templateFormat\n  templateType\n}\n\nfragment PromptIndexPage__aside on Prompt {\n  description\n  ...PromptLatestVersionsListFragment\n}\n\nfragment PromptIndexPage__main on Prompt {\n  promptVersions {\n    edges {\n      node {\n        ...PromptInvocationParameters__main\n        ...PromptChatMessagesCard__main\n        ...PromptCodeExportCard__main\n        ...PromptModelConfigurationCard__main\n      }\n    }\n  }\n  ...PromptIndexPage__aside\n}\n\nfragment PromptInvocationParameters__main on PromptVersion {\n  invocationParameters\n}\n\nfragment PromptLLM__main on PromptVersion {\n  model: modelName\n  provider: modelProvider\n}\n\nfragment PromptLatestVersionsListFragment on Prompt {\n  latestVersions: promptVersions(first: 5) {\n    edges {\n      version: node {\n        id\n        description\n        createdAt\n        sequenceNumber\n        ...PromptVersionSummaryFragment\n      }\n    }\n  }\n}\n\nfragment PromptLayout__main on Prompt {\n  id\n  name\n  description\n  sourcePrompt {\n    id\n    name\n  }\n  promptVersions {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n\nfragment PromptModelConfigurationCard__main on PromptVersion {\n  model: modelName\n  provider: modelProvider\n  ...PromptLLM__main\n  ...PromptInvocationParameters__main\n  ...PromptTools__main\n  ...PromptOutputSchemaFragment\n}\n\nfragment PromptOutputSchemaFragment on PromptVersion {\n  outputSchema {\n    definition\n  }\n}\n\nfragment PromptTools__main on PromptVersion {\n  tools {\n    definition\n  }\n}\n\nfragment PromptVersionSummaryFragment on PromptVersion {\n  id\n  description\n  sequenceNumber\n  createdAt\n  user {\n    id\n    username\n    profilePictureUrl\n  }\n  ...PromptVersionTagsList_data\n}\n\nfragment PromptVersionTagsList_data on PromptVersion {\n  tags {\n    id\n    name\n  }\n}\n\nfragment PromptVersionsList__main on Prompt {\n  promptVersions {\n    edges {\n      version: node {\n        id\n        ...PromptVersionSummaryFragment\n      }\n    }\n  }\n}\n\nfragment PromptVersionsPageContent__main on Prompt {\n  ...PromptVersionsList__main\n}\n"
   }
 };
 })();


### PR DESCRIPTION
resolves #6029 

Display the clone source prompt in the header
<img width="1097" alt="Screenshot 2025-01-31 at 2 35 58 PM" src="https://github.com/user-attachments/assets/6d8e3b85-e6cd-4604-afa5-2548968dd217" />
