### PR TITLE
fix(auth): refresh tokens on websockets

### DIFF
--- a/app/src/authFetch.ts
+++ b/app/src/authFetch.ts
@@ -42,7 +42,7 @@ export async function authFetch(
 
 let refreshPromise: Promise<Response> | null = null;
 
-async function refreshTokens(): Promise<Response> {
+export async function refreshTokens(): Promise<Response> {
   if (refreshPromise) {
     // There is already a refresh request in progress, so we should wait for it
     return refreshPromise;

--- a/tox.ini
+++ b/tox.ini
@@ -192,6 +192,7 @@ pass_env=
   PHOENIX_SMTP_PORT
   PHOENIX_SMTP_USERNAME
   PHOENIX_SMTP_PASSWORD
+  PHOENIX_ACCESS_TOKEN_EXPIRY_MINUTES
 commands_pre =
   uv tool install -U --force arize-phoenix@. \
     --reinstall-package arize-phoenix \


### PR DESCRIPTION
resolves #6124 

Adds retry logic to the websockets via `shouldRetry` and inserts refreshing the tokens.