### PR TITLE
fix: sanitize db urls in launch_app

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -31,6 +31,7 @@ from phoenix.config import (
     get_working_dir,
 )
 from phoenix.core.model_schema_adapter import create_model_from_inferences
+from phoenix.db import get_printable_db_url
 from phoenix.inferences.inferences import EMPTY_INFERENCES, Inferences
 from phoenix.pointcloud.umap_parameters import get_umap_parameters
 from phoenix.server.app import (
@@ -48,7 +49,6 @@ from phoenix.session.evaluation import encode_evaluations
 from phoenix.trace import Evaluations
 from phoenix.trace.dsl.query import SpanQuery
 from phoenix.trace.trace_dataset import TraceDataset
-from phoenix.db import get_printable_db_url
 
 try:
     from IPython.display import IFrame  # type: ignore

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -48,6 +48,7 @@ from phoenix.session.evaluation import encode_evaluations
 from phoenix.trace import Evaluations
 from phoenix.trace.dsl.query import SpanQuery
 from phoenix.trace.trace_dataset import TraceDataset
+from phoenix.db import get_printable_db_url
 
 try:
     from IPython.display import IFrame  # type: ignore
@@ -604,7 +605,7 @@ def launch_app(
 
     print(f"🌍 To view the Phoenix app in your browser, visit {_session.url}")
     if not use_temp_dir:
-        print(f"💽 Your data is being persisted to {database_url}")
+        print(f"💽 Your data is being persisted to {get_printable_db_url(database_url)}")
     print("📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix")
     return _session
 


### PR DESCRIPTION
resolves #6193

In general we don't really support attaching to postgres via launch_app. But it seems that this is being done in some capacity so this at least sanitizes the url just in case.