### PR TITLE
fix(prompts): nest json schema fields in discriminated union

### DIFF
--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2030,15 +2030,15 @@
             "const": "json-schema-draft-7-object-schema",
             "title": "Type"
           },
-          "content": {
+          "json": {
             "type": "object",
-            "title": "Content"
+            "title": "Json"
           }
         },
         "type": "object",
         "required": [
           "type",
-          "content"
+          "json"
         ],
         "title": "JSONSchemaDraft7ObjectSchema"
       },

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2023,6 +2023,25 @@
         ],
         "title": "InsertedSpanAnnotation"
       },
+      "JSONSchemaDraft7ObjectSchema": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "json-schema-draft-7-object-schema",
+            "title": "Type"
+          },
+          "content": {
+            "type": "object",
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "content"
+        ],
+        "title": "JSONSchemaDraft7ObjectSchema"
+      },
       "ListDatasetExamplesData": {
         "properties": {
           "dataset_id": {
@@ -2214,8 +2233,18 @@
             "title": "Description"
           },
           "schema": {
-            "type": "object",
-            "title": "Schema"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/JSONSchemaDraft7ObjectSchema"
+              }
+            ],
+            "title": "Schema",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "json-schema-draft-7-object-schema": "#/components/schemas/JSONSchemaDraft7ObjectSchema"
+              }
+            }
           },
           "extra_parameters": {
             "type": "object",
@@ -2299,8 +2328,18 @@
             "title": "Description"
           },
           "schema": {
-            "type": "object",
-            "title": "Schema"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/JSONSchemaDraft7ObjectSchema"
+              }
+            ],
+            "title": "Schema",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "json-schema-draft-7-object-schema": "#/components/schemas/JSONSchemaDraft7ObjectSchema"
+              }
+            }
           },
           "extra_parameters": {
             "type": "object",

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2351,6 +2351,7 @@
         "required": [
           "type",
           "name",
+          "schema",
           "extra_parameters"
         ],
         "title": "PromptOutputSchema"

--- a/src/phoenix/server/api/helpers/jsonschema.py
+++ b/src/phoenix/server/api/helpers/jsonschema.py
@@ -1,7 +1,7 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, Union
 
 from jsonschema import Draft7Validator, ValidationError
-from pydantic import AfterValidator
+from pydantic import AfterValidator, BaseModel, Field
 from typing_extensions import TypeAlias
 
 # This meta-schema describes valid JSON schemas according to the JSON Schema Draft 7 specification.
@@ -101,9 +101,10 @@ Draft7Validator.check_schema(JSON_SCHEMA_DRAFT_7_META_SCHEMA)  # ensure the sche
 JSON_SCHEMA_DRAFT_7_VALIDATOR = Draft7Validator(JSON_SCHEMA_DRAFT_7_META_SCHEMA)
 
 
-def validate_json_schema_object_definition(schema: dict[str, Any]) -> dict[str, Any]:
+def validate_json_schema_draft_7_object(schema: dict[str, Any]) -> dict[str, Any]:
     """
-    Validates that a dictionary is a valid JSON schema object property.
+    Validates that a dictionary is a valid JSON schema according to the JSON
+    Schema Draft 7 specification.
     """
     try:
         JSON_SCHEMA_DRAFT_7_VALIDATOR.validate(schema)
@@ -114,7 +115,18 @@ def validate_json_schema_object_definition(schema: dict[str, Any]) -> dict[str, 
     return schema
 
 
-# Pydantic type with built-in validation for JSON schemas
-JSONSchemaObjectDefinition: TypeAlias = Annotated[
-    dict[str, Any], AfterValidator(validate_json_schema_object_definition)
+JSONSchemaDraft7ObjectSchemaContent: TypeAlias = Annotated[
+    dict[str, Any],
+    AfterValidator(validate_json_schema_draft_7_object),
+]
+
+
+class JSONSchemaDraft7ObjectSchema(BaseModel):
+    type: Literal["json-schema-draft-7-object-schema"]
+    content: JSONSchemaDraft7ObjectSchemaContent
+
+
+JSONSchemaObjectSchema: TypeAlias = Annotated[
+    Union[JSONSchemaDraft7ObjectSchema],
+    Field(discriminator="type"),
 ]

--- a/src/phoenix/server/api/helpers/jsonschema.py
+++ b/src/phoenix/server/api/helpers/jsonschema.py
@@ -123,7 +123,10 @@ JSONSchemaDraft7ObjectSchemaContent: TypeAlias = Annotated[
 
 class JSONSchemaDraft7ObjectSchema(BaseModel):
     type: Literal["json-schema-draft-7-object-schema"]
-    content: JSONSchemaDraft7ObjectSchemaContent
+    json_: JSONSchemaDraft7ObjectSchemaContent = Field(
+        ...,
+        alias="json",  # avoid conflict with pydantic json method
+    )
 
 
 JSONSchemaObjectSchema: TypeAlias = Annotated[

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -225,7 +225,7 @@ def _openai_to_prompt_output_schema(
         description=json_schema.description,
         schema=JSONSchemaDraft7ObjectSchema(
             type="json-schema-draft-7-object-schema",
-            content=json_schema.schema_,
+            json=json_schema.schema_,
         )
         if json_schema is not UNDEFINED
         else UNDEFINED,
@@ -247,7 +247,7 @@ def _prompt_to_openai_output_schema(
         json_schema=PromptOpenAIJSONSchema(
             name=name,
             description=description,
-            schema=schema.content,
+            schema=schema.json_,
             strict=strict,
         )
         if schema is not UNDEFINED
@@ -354,7 +354,7 @@ def _openai_to_prompt_tool(
         description=description,
         schema=JSONSchemaDraft7ObjectSchema(
             type="json-schema-draft-7-object-schema",
-            content=schema_content,
+            json=schema_content,
         )
         if (schema_content := function_definition.parameters) is not UNDEFINED
         else UNDEFINED,
@@ -370,7 +370,7 @@ def _prompt_to_openai_tool(
         function=OpenAIFunctionDefinition(
             name=tool.name,
             description=tool.description,
-            parameters=schema.content if (schema := tool.schema_) is not UNDEFINED else UNDEFINED,
+            parameters=schema.json_ if (schema := tool.schema_) is not UNDEFINED else UNDEFINED,
             strict=tool.extra_parameters.get("strict", UNDEFINED),
         ),
     )
@@ -393,7 +393,7 @@ def _anthropic_to_prompt_tool(
         description=tool.description,
         schema=JSONSchemaDraft7ObjectSchema(
             type="json-schema-draft-7-object-schema",
-            content=tool.input_schema,
+            json=tool.input_schema,
         ),
         extra_parameters=extra_parameters,
     )
@@ -411,7 +411,7 @@ def _prompt_to_anthropic_tool(
     else:
         anthropic_cache_control = AnthropicCacheControlParam.model_validate(cache_control)
     return AnthropicToolDefinition(
-        input_schema=tool.schema_.content,
+        input_schema=tool.schema_.json_,
         name=tool.name,
         description=tool.description,
         cache_control=anthropic_cache_control,

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -190,7 +190,7 @@ class PromptOutputSchema(PromptModel):
     name: str
     description: str = UNDEFINED
     schema_: JSONSchemaObjectSchema = Field(
-        default=UNDEFINED,
+        ...,
         alias="schema",  # an alias is used to avoid conflict with the pydantic schema class method
     )
     extra_parameters: dict[str, Any]
@@ -226,9 +226,7 @@ def _openai_to_prompt_output_schema(
         schema=JSONSchemaDraft7ObjectSchema(
             type="json-schema-draft-7-object-schema",
             json=json_schema.schema_,
-        )
-        if json_schema is not UNDEFINED
-        else UNDEFINED,
+        ),
         extra_parameters=extra_parameters,
     )
 
@@ -249,9 +247,7 @@ def _prompt_to_openai_output_schema(
             description=description,
             schema=schema.json_,
             strict=strict,
-        )
-        if schema is not UNDEFINED
-        else None,
+        ),
     )
 
 

--- a/tests/unit/server/api/helpers/prompts/test_models.py
+++ b/tests/unit/server/api/helpers/prompts/test_models.py
@@ -36,7 +36,7 @@ from phoenix.server.types import DbSessionFactory
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -68,7 +68,7 @@ from phoenix.server.types import DbSessionFactory
                 "description": "Gets the current weather for a given city",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -101,7 +101,7 @@ from phoenix.server.types import DbSessionFactory
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -136,7 +136,7 @@ from phoenix.server.types import DbSessionFactory
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -241,7 +241,7 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -276,7 +276,7 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "description": "Gets current weather for a given city",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -326,7 +326,7 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -366,7 +366,7 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "name": "get_weather",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "city": {
@@ -478,7 +478,7 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "name": "classify_user_intent",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "user_intent": {
@@ -526,7 +526,7 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "name": "classify_user_intent",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "user_intent": {
@@ -580,7 +580,7 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "name": "classify_user_intent",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "user_intent": {
@@ -634,7 +634,7 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "description": "Classifies the user's intent into one of several categories",
                 "schema": {
                     "type": "json-schema-draft-7-object-schema",
-                    "content": {
+                    "json": {
                         "type": "object",
                         "properties": {
                             "user_intent": {

--- a/tests/unit/server/api/helpers/prompts/test_models.py
+++ b/tests/unit/server/api/helpers/prompts/test_models.py
@@ -35,10 +35,13 @@ from phoenix.server.types import DbSessionFactory
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            },
                         },
                     },
                 },
@@ -64,10 +67,13 @@ from phoenix.server.types import DbSessionFactory
                 "name": "get_weather",
                 "description": "Gets the current weather for a given city",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            },
                         },
                     },
                 },
@@ -94,10 +100,13 @@ from phoenix.server.types import DbSessionFactory
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            },
                         },
                     },
                 },
@@ -126,10 +135,13 @@ from phoenix.server.types import DbSessionFactory
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            },
                         },
                     },
                 },
@@ -228,11 +240,14 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            }
+                        },
                     },
                 },
                 "extra_parameters": {},
@@ -260,11 +275,14 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "name": "get_weather",
                 "description": "Gets current weather for a given city",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            }
+                        },
                     },
                 },
                 "extra_parameters": {},
@@ -307,14 +325,17 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            }
+                        },
+                        "required": ["city"],
+                        "additionalProperties": False,
                     },
-                    "required": ["city"],
-                    "additionalProperties": False,
                 },
                 "extra_parameters": {
                     "strict": True,
@@ -344,14 +365,17 @@ async def test_anthropic_tool_are_round_tripped_without_data_loss(
                 "type": "function-tool-v1",
                 "name": "get_weather",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "city": {
-                            "type": "string",
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                            }
+                        },
+                        "required": ["city"],
+                        "additionalProperties": False,
                     },
-                    "required": ["city"],
-                    "additionalProperties": False,
                 },
                 "extra_parameters": {
                     "strict": None,
@@ -453,16 +477,19 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "type": "output-schema-v1",
                 "name": "classify_user_intent",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "user_intent": {
-                            "type": "string",
-                            "enum": [
-                                "complaint",
-                                "query",
-                                "other",
-                            ],
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "user_intent": {
+                                "type": "string",
+                                "enum": [
+                                    "complaint",
+                                    "query",
+                                    "other",
+                                ],
+                            }
+                        },
                     },
                 },
                 "extra_parameters": {},
@@ -498,21 +525,24 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "type": "output-schema-v1",
                 "name": "classify_user_intent",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "user_intent": {
-                            "type": "string",
-                            "enum": [
-                                "complaint",
-                                "query",
-                                "other",
-                            ],
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "user_intent": {
+                                "type": "string",
+                                "enum": [
+                                    "complaint",
+                                    "query",
+                                    "other",
+                                ],
+                            },
                         },
+                        "required": [
+                            "user_intent",
+                        ],
+                        "additionalProperties": False,
                     },
-                    "required": [
-                        "user_intent",
-                    ],
-                    "additionalProperties": False,
                 },
                 "extra_parameters": {
                     "strict": True,
@@ -549,21 +579,24 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "type": "output-schema-v1",
                 "name": "classify_user_intent",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "user_intent": {
-                            "type": "string",
-                            "enum": [
-                                "complaint",
-                                "query",
-                                "other",
-                            ],
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "user_intent": {
+                                "type": "string",
+                                "enum": [
+                                    "complaint",
+                                    "query",
+                                    "other",
+                                ],
+                            },
                         },
+                        "required": [
+                            "user_intent",
+                        ],
+                        "additionalProperties": False,
                     },
-                    "required": [
-                        "user_intent",
-                    ],
-                    "additionalProperties": False,
                 },
                 "extra_parameters": {
                     "strict": None,
@@ -600,19 +633,22 @@ async def test_openai_tool_are_round_tripped_without_data_loss(
                 "name": "classify_user_intent",
                 "description": "Classifies the user's intent into one of several categories",
                 "schema": {
-                    "type": "object",
-                    "properties": {
-                        "user_intent": {
-                            "type": "string",
-                            "enum": [
-                                "complaint",
-                                "query",
-                                "other",
-                            ],
-                        }
+                    "type": "json-schema-draft-7-object-schema",
+                    "content": {
+                        "type": "object",
+                        "properties": {
+                            "user_intent": {
+                                "type": "string",
+                                "enum": [
+                                    "complaint",
+                                    "query",
+                                    "other",
+                                ],
+                            }
+                        },
+                        "required": ["user_intent"],
+                        "additionalProperties": False,
                     },
-                    "required": ["user_intent"],
-                    "additionalProperties": False,
                 },
                 "extra_parameters": {
                     "strict": True,

--- a/tests/unit/server/api/helpers/test_models.py
+++ b/tests/unit/server/api/helpers/test_models.py
@@ -3,11 +3,14 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from phoenix.server.api.helpers.prompts.models import AnthropicToolDefinition, OpenAIToolDefinition
+from phoenix.server.api.helpers.prompts.models import (
+    denormalize_tools,
+    normalize_tools,
+)
 
 
 @pytest.mark.parametrize(
-    "tool_definition",
+    "tool_schema",
     [
         pytest.param(
             {
@@ -498,12 +501,17 @@ from phoenix.server.api.helpers.prompts.models import AnthropicToolDefinition, O
         ),
     ],
 )
-def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[str, Any]) -> None:
-    OpenAIToolDefinition.model_validate(tool_definition)
+def test_valid_openai_tool_schemas_can_be_normalized_and_denormalized_without_data_loss(
+    tool_schema: dict[str, Any],
+) -> None:
+    normalized_tools = normalize_tools([tool_schema], "openai")
+    denormalized_tools = denormalize_tools(normalized_tools, "openai")
+    assert len(denormalized_tools) == 1
+    assert denormalized_tools[0] == tool_schema
 
 
 @pytest.mark.parametrize(
-    "tool_definition",
+    "tool_schema",
     [
         pytest.param(
             {
@@ -583,13 +591,15 @@ def test_openai_tool_definition_passes_valid_tool_schemas(tool_definition: dict[
         ),
     ],
 )
-def test_openai_tool_definition_fails_invalid_tool_schemas(tool_definition: dict[str, Any]) -> None:
+def test_invalid_openai_tool_schemas_raise_validation_error_when_normalized(
+    tool_schema: dict[str, Any],
+) -> None:
     with pytest.raises(ValidationError):
-        OpenAIToolDefinition.model_validate(tool_definition)
+        normalize_tools([tool_schema], "openai")
 
 
 @pytest.mark.parametrize(
-    "tool_definition",
+    "tool_schema",
     [
         pytest.param(
             {
@@ -703,7 +713,10 @@ def test_openai_tool_definition_fails_invalid_tool_schemas(tool_definition: dict
         ),
     ],
 )
-def test_anthropic_tool_definition_passes_valid_tool_schemas(
-    tool_definition: dict[str, Any],
+def test_valid_anthropic_tool_schemas_can_be_normalized_and_denormalized_without_data_loss(
+    tool_schema: dict[str, Any],
 ) -> None:
-    AnthropicToolDefinition.model_validate(tool_definition)
+    normalized_tools = normalize_tools([tool_schema], "anthropic")
+    denormalized_tools = denormalize_tools(normalized_tools, "anthropic")
+    assert len(denormalized_tools) == 1
+    assert denormalized_tools[0] == tool_schema


### PR DESCRIPTION
When storing JSON schema fields in the DB, nests them under a discriminated union to include the version of JSON schema that was used to validate them. This way, we can easily support new versions of the JSON schema standard in the future.
