### PR TITLE
feat(playground): central ai provider config

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -972,7 +972,7 @@ type GenerativeProvider {
   dependenciesInstalled: Boolean!
 
   """The API key for the provider"""
-  apiKey: String!
+  apiKeyEnvVar: String!
 
   """Whether the credentials are set on the server for the provider"""
   apiKeySet: Boolean!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -970,6 +970,12 @@ type GenerativeProvider {
   key: GenerativeProviderKey!
   dependencies: [String!]!
   dependenciesInstalled: Boolean!
+
+  """The API key for the provider"""
+  apiKey: String!
+
+  """Whether the credentials are set on the server for the provider"""
+  apiKeySet: Boolean!
 }
 
 enum GenerativeProviderKey {

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -44,6 +44,7 @@ import {
   ResetPasswordPage,
   ResetPasswordWithTokenPage,
   SettingsPage,
+  settingsPageLoader,
   SpanPlaygroundPage,
   spanPlaygroundPageLoader,
   SupportPage,
@@ -211,6 +212,7 @@ const router = createBrowserRouter(
           <Route
             path="/settings"
             element={<SettingsPage />}
+            loader={settingsPageLoader}
             handle={{
               crumb: () => "Settings",
             }}

--- a/app/src/components/generative/GenerativeProviderIcon.tsx
+++ b/app/src/components/generative/GenerativeProviderIcon.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useTheme } from "@phoenix/contexts";
 
 export type GenerativeProviderIconProps = {
-  provider: "openai" | "anthropic" | "gemini" | "azure";
+  provider: ModelProvider;
   height?: number;
 };
 
@@ -15,15 +15,19 @@ export function GenerativeProviderIcon({
   height = 18,
 }: GenerativeProviderIconProps) {
   const { theme } = useTheme();
+  let providerKey: string = provider.toLowerCase();
+  if (provider === "AZURE_OPENAI") {
+    providerKey = "azure";
+  }
   return (
     <picture>
       <source
         media={`(prefers-color-scheme: ${theme})`}
-        srcSet={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${provider}.png`}
+        srcSet={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${providerKey}.png`}
       />
       <img
         height={height}
-        src={`https://unpkg.com/@lobehub/icons-static-png@latest/light/${provider}.png`}
+        src={`https://unpkg.com/@lobehub/icons-static-png@latest/light/${providerKey}.png`}
       />
     </picture>
   );

--- a/app/src/components/generative/GenerativeProviderIcon.tsx
+++ b/app/src/components/generative/GenerativeProviderIcon.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { useTheme } from "@phoenix/contexts";
+
+export type GenerativeProviderIconProps = {
+  provider: "openai" | "anthropic" | "gemini" | "azure";
+  height?: number;
+};
+
+/**
+ * A component that renders an icon for a generative provider
+ */
+export function GenerativeProviderIcon({
+  provider,
+  height = 18,
+}: GenerativeProviderIconProps) {
+  const { theme } = useTheme();
+  return (
+    <picture>
+      <source
+        media={`(prefers-color-scheme: ${theme})`}
+        srcSet={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${provider}.png`}
+      />
+      <img
+        height={height}
+        src={`https://unpkg.com/@lobehub/icons-static-png@latest/light/${provider}.png`}
+      />
+    </picture>
+  );
+}

--- a/app/src/components/generative/GenerativeProviderIcon.tsx
+++ b/app/src/components/generative/GenerativeProviderIcon.tsx
@@ -1,12 +1,93 @@
 import React from "react";
 
-import { useTheme } from "@phoenix/contexts";
+/**
+ * Icons from https://icons.lobehub.com/
+ */
+const AzureSVG = ({ height }: { height: number }) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={height}
+    height={height}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Azure</title>
+    <path d="M11.49 2H2v9.492h9.492V2h-.002z" fill="#F25022"></path>
+    <path d="M22 2h-9.492v9.492H22V2z" fill="#7FBA00"></path>
+    <path d="M11.49 12.508H2V22h9.492v-9.492h-.002z" fill="#00A4EF"></path>
+    <path d="M22 12.508h-9.492V22H22v-9.492z" fill="#FFB900"></path>
+  </svg>
+);
+const GeminiSVG = ({ height }: { height: number }) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={height}
+    height={height}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Gemini</title>
+    <defs>
+      <linearGradient
+        id="lobe-icons-gemini-fill"
+        x1="0%"
+        x2="68.73%"
+        y1="100%"
+        y2="30.395%"
+      >
+        <stop offset="0%" stopColor="#1C7DFF"></stop>
+        <stop offset="52.021%" stopColor="#1C69FF"></stop>
+        <stop offset="100%" stopColor="#F0DCD6"></stop>
+      </linearGradient>
+    </defs>
+    <path
+      d="M12 24A14.304 14.304 0 000 12 14.304 14.304 0 0012 0a14.305 14.305 0 0012 12 14.305 14.305 0 00-12 12"
+      fill="url(#lobe-icons-gemini-fill)"
+      fillRule="nonzero"
+    ></path>
+  </svg>
+);
+
+const OpenAISVG = ({ height }: { height: number }) => (
+  <svg
+    fill="var(--ac-global-text-color-900)"
+    fillRule="evenodd"
+    viewBox="0 0 24 24"
+    width={height}
+    height={height}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>OpenAI</title>
+    <path d="M21.55 10.004a5.416 5.416 0 00-.478-4.501c-1.217-2.09-3.662-3.166-6.05-2.66A5.59 5.59 0 0010.831 1C8.39.995 6.224 2.546 5.473 4.838A5.553 5.553 0 001.76 7.496a5.487 5.487 0 00.691 6.5 5.416 5.416 0 00.477 4.502c1.217 2.09 3.662 3.165 6.05 2.66A5.586 5.586 0 0013.168 23c2.443.006 4.61-1.546 5.361-3.84a5.553 5.553 0 003.715-2.66 5.488 5.488 0 00-.693-6.497v.001zm-8.381 11.558a4.199 4.199 0 01-2.675-.954c.034-.018.093-.05.132-.074l4.44-2.53a.71.71 0 00.364-.623v-6.176l1.877 1.069c.02.01.033.029.036.05v5.115c-.003 2.274-1.87 4.118-4.174 4.123zM4.192 17.78a4.059 4.059 0 01-.498-2.763c.032.02.09.055.131.078l4.44 2.53c.225.13.504.13.73 0l5.42-3.088v2.138a.068.068 0 01-.027.057L9.9 19.288c-1.999 1.136-4.552.46-5.707-1.51h-.001zM3.023 8.216A4.15 4.15 0 015.198 6.41l-.002.151v5.06a.711.711 0 00.364.624l5.42 3.087-1.876 1.07a.067.067 0 01-.063.005l-4.489-2.559c-1.995-1.14-2.679-3.658-1.53-5.63h.001zm15.417 3.54l-5.42-3.088L14.896 7.6a.067.067 0 01.063-.006l4.489 2.557c1.998 1.14 2.683 3.662 1.529 5.633a4.163 4.163 0 01-2.174 1.807V12.38a.71.71 0 00-.363-.623zm1.867-2.773a6.04 6.04 0 00-.132-.078l-4.44-2.53a.731.731 0 00-.729 0l-5.42 3.088V7.325a.068.068 0 01.027-.057L14.1 4.713c2-1.137 4.555-.46 5.707 1.513.487.833.664 1.809.499 2.757h.001zm-11.741 3.81l-1.877-1.068a.065.065 0 01-.036-.051V6.559c.001-2.277 1.873-4.122 4.181-4.12.976 0 1.92.338 2.671.954-.034.018-.092.05-.131.073l-4.44 2.53a.71.71 0 00-.365.623l-.003 6.173v.002zm1.02-2.168L12 9.25l2.414 1.375v2.75L12 14.75l-2.415-1.375v-2.75z"></path>
+  </svg>
+);
+
+const AnthropicSVG = ({ height }: { height: number }) => (
+  <svg
+    fill="var(--ac-global-text-color-900)"
+    fillRule="evenodd"
+    viewBox="0 0 24 24"
+    width={height}
+    height={height}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Anthropic</title>
+    <path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z"></path>
+  </svg>
+);
+
+const PROVIDER_ICONS: Record<
+  ModelProvider,
+  ({ height }: { height: number }) => React.ReactNode
+> = {
+  AZURE_OPENAI: AzureSVG,
+  GEMINI: GeminiSVG,
+  OPENAI: OpenAISVG,
+  ANTHROPIC: AnthropicSVG,
+};
 
 export type GenerativeProviderIconProps = {
   provider: ModelProvider;
   height?: number;
 };
-
 /**
  * A component that renders an icon for a generative provider
  */
@@ -14,21 +95,5 @@ export function GenerativeProviderIcon({
   provider,
   height = 18,
 }: GenerativeProviderIconProps) {
-  const { theme } = useTheme();
-  let providerKey: string = provider.toLowerCase();
-  if (provider === "AZURE_OPENAI") {
-    providerKey = "azure";
-  }
-  return (
-    <picture>
-      <source
-        media={`(prefers-color-scheme: ${theme})`}
-        srcSet={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${providerKey}.png`}
-      />
-      <img
-        height={height}
-        src={`https://unpkg.com/@lobehub/icons-static-png@latest/light/${providerKey}.png`}
-      />
-    </picture>
-  );
+  return PROVIDER_ICONS[provider]({ height });
 }

--- a/app/src/components/generative/index.ts
+++ b/app/src/components/generative/index.ts
@@ -1,1 +1,2 @@
 export * from "./ToolChoiceSelector";
+export * from "./GenerativeProviderIcon";

--- a/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
+++ b/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
@@ -9,7 +9,7 @@ import {
   TextField,
 } from "@arizeai/components";
 
-import { Flex, Heading, Text, View } from "@phoenix/components";
+import { ExternalLink, Flex, Heading, Text, View } from "@phoenix/components";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 export const ProviderToCredentialNameMap: Record<ModelProvider, string> = {
@@ -60,10 +60,12 @@ export function PlaygroundCredentialsDropdown() {
               <Heading level={2} weight="heavy">
                 API Keys
               </Heading>
-              <Text color="text-700">
-                API keys are stored in your browser and used to communicate with
-                their respective API&apos;s.
-              </Text>
+              <View paddingY="size-50">
+                <Text color="text-700" size="XS">
+                  API keys are stored in your browser and used to communicate
+                  with their respective API&apos;s.
+                </Text>
+              </View>
               <Flex direction="column" gap="size-100">
                 {currentProviders.map((provider) => {
                   const credentialName = ProviderToCredentialNameMap[provider];
@@ -82,6 +84,18 @@ export function PlaygroundCredentialsDropdown() {
                   );
                 })}
               </Flex>
+              <View paddingTop="size-100">
+                <Flex
+                  direction="row"
+                  gap="size-100"
+                  width="100%"
+                  justifyContent="end"
+                >
+                  <ExternalLink href="/settings">
+                    View all AI povider configurations
+                  </ExternalLink>
+                </Flex>
+              </View>
             </Form>
           </View>
         </DropdownMenu>

--- a/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
+++ b/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
@@ -92,7 +92,7 @@ export function PlaygroundCredentialsDropdown() {
                   justifyContent="end"
                 >
                   <ExternalLink href="/settings">
-                    View all AI povider configurations
+                    View all AI provider configurations
                   </ExternalLink>
                 </Flex>
               </View>

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -21,42 +21,14 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import {
-  GenerativeProviderIcon,
-  GenerativeProviderIconProps,
-} from "@phoenix/components/generative";
+import { GenerativeProviderIcon } from "@phoenix/components/generative";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
-import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
   GenerativeProvidersCard_data$data,
   GenerativeProvidersCard_data$key,
 } from "./__generated__/GenerativeProvidersCard_data.graphql";
-
-type ProviderKey =
-  GenerativeProvidersCard_data$data["modelProviders"][number]["key"];
-
-function ProviderIcon({ providerKey }: { providerKey: ProviderKey }) {
-  let provider: GenerativeProviderIconProps["provider"];
-  switch (providerKey) {
-    case "OPENAI":
-      provider = "OPENAI";
-      break;
-    case "ANTHROPIC":
-      provider = "ANTHROPIC";
-      break;
-    case "GEMINI":
-      provider = "GEMINI";
-      break;
-    case "AZURE_OPENAI":
-      provider = "AZURE_OPENAI";
-      break;
-    default:
-      assertUnreachable(providerKey);
-  }
-  return <GenerativeProviderIcon provider={provider} height={18} />;
-}
 
 export function GenerativeProvidersCard({
   query,
@@ -94,7 +66,7 @@ export function GenerativeProvidersCard({
         cell: ({ row }) => {
           return (
             <Flex direction="row" alignItems="center" gap="size-100">
-              <ProviderIcon providerKey={row.original.key} />
+              <GenerativeProviderIcon provider={row.original.key} height={18} />
               {row.original.name}
             </Flex>
           );
@@ -114,11 +86,11 @@ export function GenerativeProvidersCard({
           if (!row.original.dependenciesInstalled) {
             return <Text color="warning">missing dependencies</Text>;
           }
-          if (row.original.apiKeySet) {
-            return <Text color="success">configured on the server</Text>;
-          }
           if (credentials[row.original.key]) {
             return <Text color="success">local</Text>;
+          }
+          if (row.original.apiKeySet) {
+            return <Text color="success">configured on the server</Text>;
           }
           return <Text color="text-700">not configured</Text>;
         },

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -30,16 +30,16 @@ function ProviderIcon({ providerKey }: { providerKey: ProviderKey }) {
   let provider: GenerativeProviderIconProps["provider"];
   switch (providerKey) {
     case "OPENAI":
-      provider = "openai";
+      provider = "OPENAI";
       break;
     case "ANTHROPIC":
-      provider = "anthropic";
+      provider = "ANTHROPIC";
       break;
     case "GEMINI":
-      provider = "gemini";
+      provider = "GEMINI";
       break;
     case "AZURE_OPENAI":
-      provider = "azure";
+      provider = "AZURE_OPENAI";
       break;
     default:
       assertUnreachable(providerKey);

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from "react";
+import { graphql, useFragment } from "react-relay";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import { Card } from "@arizeai/components";
+
+import { Flex } from "@phoenix/components";
+import {
+  GenerativeProviderIcon,
+  GenerativeProviderIconProps,
+} from "@phoenix/components/generative";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { assertUnreachable } from "@phoenix/typeUtils";
+
+import {
+  GenerativeProvidersCard_data$data,
+  GenerativeProvidersCard_data$key,
+} from "./__generated__/GenerativeProvidersCard_data.graphql";
+
+type ProviderKey =
+  GenerativeProvidersCard_data$data["modelProviders"][number]["key"];
+
+function ProviderIcon({ providerKey }: { providerKey: ProviderKey }) {
+  let provider: GenerativeProviderIconProps["provider"];
+  switch (providerKey) {
+    case "OPENAI":
+      provider = "openai";
+      break;
+    case "ANTHROPIC":
+      provider = "anthropic";
+      break;
+    case "GEMINI":
+      provider = "gemini";
+      break;
+    case "AZURE_OPENAI":
+      provider = "azure";
+      break;
+    default:
+      assertUnreachable(providerKey);
+  }
+  return <GenerativeProviderIcon provider={provider} height={18} />;
+}
+export function GenerativeProvidersCard({
+  query,
+}: {
+  query: GenerativeProvidersCard_data$key;
+}) {
+  const data = useFragment<GenerativeProvidersCard_data$key>(
+    graphql`
+      fragment GenerativeProvidersCard_data on Query {
+        modelProviders {
+          name
+          key
+          dependenciesInstalled
+          dependencies
+          apiKeyEnvVar
+          apiKeySet
+        }
+      }
+    `,
+    query
+  );
+
+  const tableData = useMemo(() => [...data.modelProviders], [data]);
+  type DataRow = (typeof tableData)[number];
+  const columns = useMemo(() => {
+    return [
+      {
+        header: "Name",
+        accessorKey: "name",
+        cell: ({ row }) => {
+          return (
+            <Flex direction="row" alignItems="center" gap="size-100">
+              <ProviderIcon providerKey={row.original.key} />
+              {row.original.name}
+            </Flex>
+          );
+        },
+      },
+
+      {
+        header: "configuration",
+        accessorKey: "apiKeySet",
+        cell: ({ row }) => {
+          if (!row.original.dependenciesInstalled) {
+            return "missing deps";
+          }
+          if (row.original.apiKeySet) {
+            return "configured on the server";
+          }
+          return "not configured";
+        },
+      },
+    ] satisfies ColumnDef<DataRow>[];
+  }, []);
+
+  const table = useReactTable<(typeof tableData)[number]>({
+    columns,
+    data: tableData,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const rows = table.getRowModel().rows;
+
+  return (
+    <Card title="AI Providers" bodyStyle={{ padding: 0 }} variant="compact">
+      <table css={tableCSS}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th colSpan={header.colSpan} key={header.id}>
+                  {header.isPlaceholder ? null : (
+                    <div>
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                    </div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -117,7 +117,7 @@ export function GenerativeProvidersCard({
           if (row.original.apiKeySet) {
             return <Text color="success">configured on the server</Text>;
           }
-          if (credentials[row.original.key] != null) {
+          if (credentials[row.original.key]) {
             return <Text color="success">local</Text>;
           }
           return <Text color="text-700">not configured</Text>;

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { graphql, useFragment } from "react-relay";
 import {
   ColumnDef,
@@ -8,14 +8,25 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { Card } from "@arizeai/components";
+import { Card, Dialog, DialogContainer } from "@arizeai/components";
 
-import { Flex } from "@phoenix/components";
+import {
+  Button,
+  Flex,
+  Icon,
+  Icons,
+  Input,
+  Label,
+  Text,
+  TextField,
+  View,
+} from "@phoenix/components";
 import {
   GenerativeProviderIcon,
   GenerativeProviderIconProps,
 } from "@phoenix/components/generative";
 import { tableCSS } from "@phoenix/components/table/styles";
+import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 import {
@@ -46,11 +57,17 @@ function ProviderIcon({ providerKey }: { providerKey: ProviderKey }) {
   }
   return <GenerativeProviderIcon provider={provider} height={18} />;
 }
+
 export function GenerativeProvidersCard({
   query,
 }: {
   query: GenerativeProvidersCard_data$key;
 }) {
+  const [selectedProvider, setSelectedProvider] = useState<
+    GenerativeProvidersCard_data$data["modelProviders"][number] | null
+  >(null);
+  const credentials = useCredentialsContext((state) => state);
+  const setCredential = useCredentialsContext((state) => state.setCredential);
   const data = useFragment<GenerativeProvidersCard_data$key>(
     graphql`
       fragment GenerativeProvidersCard_data on Query {
@@ -83,22 +100,53 @@ export function GenerativeProvidersCard({
           );
         },
       },
-
+      {
+        header: "Environment Variable",
+        accessorKey: "apiKeyEnvVar",
+        cell: ({ row }) => {
+          return <Text>{row.original.apiKeyEnvVar}</Text>;
+        },
+      },
       {
         header: "configuration",
         accessorKey: "apiKeySet",
         cell: ({ row }) => {
           if (!row.original.dependenciesInstalled) {
-            return "missing deps";
+            return <Text color="warning">missing dependencies</Text>;
           }
           if (row.original.apiKeySet) {
-            return "configured on the server";
+            return <Text color="success">configured on the server</Text>;
           }
-          return "not configured";
+          if (credentials[row.original.key] != null) {
+            return <Text color="success">local</Text>;
+          }
+          return <Text color="text-700">not configured</Text>;
+        },
+      },
+      {
+        header: "",
+        accessorKey: "id",
+        cell: ({ row }) => {
+          return (
+            <Flex
+              direction="row"
+              justifyContent="end"
+              gap="size-100"
+              width="100%"
+            >
+              <Button
+                size="S"
+                icon={<Icon svg={<Icons.EditOutline />} />}
+                onPress={() => {
+                  setSelectedProvider(row.original);
+                }}
+              />
+            </Flex>
+          );
         },
       },
     ] satisfies ColumnDef<DataRow>[];
-  }, []);
+  }, [credentials]);
 
   const table = useReactTable<(typeof tableData)[number]>({
     columns,
@@ -149,6 +197,60 @@ export function GenerativeProvidersCard({
           })}
         </tbody>
       </table>
+      <DialogContainer
+        type="modal"
+        isDismissable={true}
+        onDismiss={() => setSelectedProvider(null)}
+      >
+        {selectedProvider && (
+          <Dialog title={`Set ${selectedProvider.name} API Key`} size="S">
+            <View padding="size-200">
+              <View paddingBottom="size-100">
+                <Text size="XS">
+                  Set the credentials for the {selectedProvider.name} API. These
+                  credentials will be stored entirely in your browser and will
+                  only be sent to the server during API requests.
+                </Text>
+              </View>
+              <TextField
+                onChange={(value) => {
+                  setCredential({
+                    provider: selectedProvider.key,
+                    value,
+                  });
+                }}
+                value={credentials[selectedProvider.key]}
+                type="password"
+              >
+                <Label>{`${selectedProvider.name} API Key`}</Label>
+                <Input placeholder={`e.g. ${selectedProvider.apiKeyEnvVar}`} />
+
+                <Text slot="description">
+                  The API key will be stored locally in your browser
+                </Text>
+              </TextField>
+            </View>
+            <View
+              paddingX="size-200"
+              paddingY="size-100"
+              borderTopWidth="thin"
+              borderColor="light"
+            >
+              <Flex direction="row" justifyContent="end" gap="size-100">
+                <Button
+                  variant="primary"
+                  size="S"
+                  onPress={() => {
+                    setSelectedProvider(null);
+                  }}
+                >
+                  Set API Key
+                </Button>
+              </Flex>
+            </View>
+          </Dialog>
+        )}
+      </DialogContainer>
     </Card>
   );
 }

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useLoaderData } from "react-router";
 import { css } from "@emotion/react";
 
 import { Card, TextField } from "@arizeai/components";
@@ -7,7 +8,9 @@ import { CopyToClipboardButton, Flex, View } from "@phoenix/components";
 import { IsAdmin } from "@phoenix/components/auth";
 import { BASE_URL, VERSION } from "@phoenix/config";
 
+import { settingsPageLoaderQuery$data } from "./__generated__/settingsPageLoaderQuery.graphql";
 import { APIKeysCard } from "./APIKeysCard";
+import { GenerativeProvidersCard } from "./GenerativeProvidersCard";
 import { UsersCard } from "./UsersCard";
 
 const settingsPageCSS = css`
@@ -32,6 +35,8 @@ const formCSS = css`
 `;
 
 export function SettingsPage() {
+  const data = useLoaderData() as settingsPageLoaderQuery$data;
+
   return (
     <main css={settingsPageCSS}>
       <div css={settingsPageInnerCSS}>
@@ -78,6 +83,7 @@ export function SettingsPage() {
               <UsersCard />
             </>
           </IsAdmin>
+          <GenerativeProvidersCard query={data} />
         </Flex>
       </div>
     </main>

--- a/app/src/pages/settings/__generated__/GenerativeProvidersCard_data.graphql.ts
+++ b/app/src/pages/settings/__generated__/GenerativeProvidersCard_data.graphql.ts
@@ -1,0 +1,96 @@
+/**
+ * @generated SignedSource<<47b05fc34779dfd9a809473c5e383365>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
+import { FragmentRefs } from "relay-runtime";
+export type GenerativeProvidersCard_data$data = {
+  readonly modelProviders: ReadonlyArray<{
+    readonly apiKeyEnvVar: string;
+    readonly apiKeySet: boolean;
+    readonly dependencies: ReadonlyArray<string>;
+    readonly dependenciesInstalled: boolean;
+    readonly key: GenerativeProviderKey;
+    readonly name: string;
+  }>;
+  readonly " $fragmentType": "GenerativeProvidersCard_data";
+};
+export type GenerativeProvidersCard_data$key = {
+  readonly " $data"?: GenerativeProvidersCard_data$data;
+  readonly " $fragmentSpreads": FragmentRefs<"GenerativeProvidersCard_data">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "GenerativeProvidersCard_data",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GenerativeProvider",
+      "kind": "LinkedField",
+      "name": "modelProviders",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "key",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "dependenciesInstalled",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "dependencies",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "apiKeyEnvVar",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "apiKeySet",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "0168d590171b96e7a2e41449a41754be";
+
+export default node;

--- a/app/src/pages/settings/__generated__/settingsPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsPageLoaderQuery.graphql.ts
@@ -1,0 +1,111 @@
+/**
+ * @generated SignedSource<<bb2f3bdbb94d8a60d508f6588b374af6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type settingsPageLoaderQuery$variables = Record<PropertyKey, never>;
+export type settingsPageLoaderQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"GenerativeProvidersCard_data">;
+};
+export type settingsPageLoaderQuery = {
+  response: settingsPageLoaderQuery$data;
+  variables: settingsPageLoaderQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "settingsPageLoaderQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "GenerativeProvidersCard_data"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "settingsPageLoaderQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "GenerativeProvider",
+        "kind": "LinkedField",
+        "name": "modelProviders",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "key",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dependenciesInstalled",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dependencies",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "apiKeyEnvVar",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "apiKeySet",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bc46c0b83314efc75f5723890a95ca29",
+    "id": null,
+    "metadata": {},
+    "name": "settingsPageLoaderQuery",
+    "operationKind": "query",
+    "text": "query settingsPageLoaderQuery {\n  ...GenerativeProvidersCard_data\n}\n\nfragment GenerativeProvidersCard_data on Query {\n  modelProviders {\n    name\n    key\n    dependenciesInstalled\n    dependencies\n    apiKeyEnvVar\n    apiKeySet\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "e63f789fe54d58eb540bf0ab1c8d6a7f";
+
+export default node;

--- a/app/src/pages/settings/index.tsx
+++ b/app/src/pages/settings/index.tsx
@@ -1,1 +1,2 @@
 export * from "./SettingsPage";
+export * from "./settingsPageLoader";

--- a/app/src/pages/settings/settingsPageLoader.ts
+++ b/app/src/pages/settings/settingsPageLoader.ts
@@ -1,0 +1,17 @@
+import { fetchQuery, graphql } from "react-relay";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import { settingsPageLoaderQuery } from "./__generated__/settingsPageLoaderQuery.graphql";
+
+export async function settingsPageLoader() {
+  return await fetchQuery<settingsPageLoaderQuery>(
+    RelayEnvironment,
+    graphql`
+      query settingsPageLoaderQuery {
+        ...GenerativeProvidersCard_data
+      }
+    `,
+    {}
+  ).toPromise();
+}

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -67,7 +67,7 @@ class GenerativeProvider:
         return False
 
     @strawberry.field(description="The API key for the provider")
-    async def api_key(self) -> str:
+    async def api_key_env_var(self) -> str:
         return self.model_provider_to_api_key_env_var_map[self.key]
 
     @strawberry.field(description="Whether the credentials are set on the server for the provider")

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -66,11 +66,11 @@ class GenerativeProvider:
             return default_client.dependencies_are_installed()
         return False
 
-    @strawberry.field(description="The API key for the provider")
+    @strawberry.field(description="The API key for the provider")  # type: ignore
     async def api_key_env_var(self) -> str:
         return self.model_provider_to_api_key_env_var_map[self.key]
 
-    @strawberry.field(description="Whether the credentials are set on the server for the provider")
+    @strawberry.field(description="Whether the credentials are set on the server for the provider")  # type: ignore
     async def api_key_set(self) -> bool:
         return os.environ.get(self.model_provider_to_api_key_env_var_map[self.key]) is not None
 

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 from typing import Any, ClassVar, Optional, Union
 
@@ -34,6 +35,13 @@ class GenerativeProvider:
         OpenInferenceLLMProviderValues.GOOGLE.value: GenerativeProviderKey.GEMINI,
     }
 
+    model_provider_to_api_key_env_var_map: ClassVar[dict[GenerativeProviderKey, str]] = {
+        GenerativeProviderKey.AZURE_OPENAI: "AZURE_OPENAI_API_KEY",
+        GenerativeProviderKey.ANTHROPIC: "ANTHROPIC_API_KEY",
+        GenerativeProviderKey.OPENAI: "OPENAI_API_KEY",
+        GenerativeProviderKey.GEMINI: "GEMINI_API_KEY",
+    }
+
     @strawberry.field
     async def dependencies(self) -> list[str]:
         from phoenix.server.api.helpers.playground_registry import (
@@ -57,6 +65,14 @@ class GenerativeProvider:
         if default_client:
             return default_client.dependencies_are_installed()
         return False
+
+    @strawberry.field(description="The API key for the provider")
+    async def api_key(self) -> str:
+        return self.model_provider_to_api_key_env_var_map[self.key]
+
+    @strawberry.field(description="Whether the credentials are set on the server for the provider")
+    async def api_key_set(self) -> bool:
+        return os.environ.get(self.model_provider_to_api_key_env_var_map[self.key]) is not None
 
     @classmethod
     def _infer_model_provider_from_model_name(


### PR DESCRIPTION
resolves #6123 
Adds a central AI provider configuration that can be used to see how all the providers are configured.

<img width="705" alt="Screenshot 2025-02-04 at 3 11 09 PM" src="https://github.com/user-attachments/assets/a4093be2-5fb9-4bdf-9851-a971b570ad19" />
<img width="806" alt="Screenshot 2025-02-04 at 3 08 27 PM" src="https://github.com/user-attachments/assets/47d6162d-b5ff-435c-a075-c1ddfe042db3" />
<img width="1235" alt="Screenshot 2025-02-04 at 3 02 40 PM" src="https://github.com/user-attachments/assets/e19e6176-3ac6-4d84-8cd4-997c3edc4541" />
