### PR TITLE
fix: Replace corepack with pinned pnpm version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot
 FROM node:20-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# pin corepack to known good version with updated signatures
+# Mitigates https://github.com/nodejs/corepack/issues/612
+RUN npm i -g corepack@0.31.0
 RUN corepack enable
 WORKDIR /phoenix/app/
 COPY ./app /phoenix/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,7 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot
 FROM node:20-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# pin corepack to known good version with updated signatures
-# Mitigates https://github.com/nodejs/corepack/issues/612
-RUN npm i -g corepack@0.31.0
-RUN corepack enable
+RUN npm i -g pnpm@9.15.5
 WORKDIR /phoenix/app/
 COPY ./app /phoenix/app
 RUN pnpm install

--- a/app/package.json
+++ b/app/package.json
@@ -137,7 +137,7 @@
     "build-storybook": "storybook build",
     "chromatic": "source .env && npx chromatic"
   },
-  "packageManager": "pnpm@9.8.0",
+  "packageManager": "pnpm@9.15.5",
   "pnpm": {
     "overrides": {
       "braces@<3.0.3": ">=3.0.3"


### PR DESCRIPTION
The `corepack` package included with node-20:slim is too old to fetch package managers.

This PR replaces corepack with a direct installation of pnpm in the image.

Issue is discussed https://github.com/nodejs/corepack/issues/612

Resolves #6247