### PR TITLE
fix(playground): if base url is provided but not api key, use fake api key for openai client

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -478,8 +478,10 @@ class OpenAIStreamingClient(OpenAIBaseStreamingClient):
         from openai import AsyncOpenAI
 
         base_url = model.base_url or os.environ.get("OPENAI_BASE_URL")
-        if not (api_key := api_key or os.environ.get("OPENAI_API_KEY")) and not base_url:
-            raise BadRequest("An API key is required for OpenAI models")
+        if not (api_key := api_key or os.environ.get("OPENAI_API_KEY")):
+            if not base_url:
+                raise BadRequest("An API key is required for OpenAI models")
+            api_key = "sk-fake-api-key"
         client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         super().__init__(client=client, model=model, api_key=api_key)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.OPENAI.value


### PR DESCRIPTION
resolves #6258 