### PR TITLE
chore: Upgrade pnpm version

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [ 3.9, 3.12, 3.13 ]
-        os: [ ubuntu-latest, macos-latest, macos-13 ]
+        py: [3.9, 3.12, 3.13]
+        os: [ubuntu-latest, macos-latest, macos-13]
         exclude:
           - py: 3.13
             os: macos-13
@@ -29,7 +29,7 @@ jobs:
       - name: Install PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9.12.0
+          version: 10.2.0
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install PNPM
         uses: pnpm/action-setup@v3
         with:
-          version: 9.8.0
+          version: 10.2.0
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: lts/*
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9.15.0
+          version: 10.2.0
       - name: Install Dependencies
         working-directory: ./js
         run: pnpm install --frozen-lockfile -r

--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: lts/*
           registry-url: https://registry.npmjs.org/
           scope: "@arizeai"
         env:

--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9.8.0
+          version: 10.2.0
       - name: setup pnpm config
         run: pnpm config set store-dir $PNPM_CACHE_FOLDER
       - name: Install Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot
 # ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot-arm64
 
 # This Dockerfile is a multi-stage build. The first stage builds the frontend.
-FROM node:20-slim AS frontend-builder
+FROM node:22-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm i -g corepack

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ ARG BASE_IMAGE=gcr.io/distroless/python3-debian12:nonroot
 FROM node:20-slim AS frontend-builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm i -g pnpm@9.15.5
+RUN npm i -g corepack
+RUN corepack enable
+RUN corepack use pnpm
 WORKDIR /phoenix/app/
 COPY ./app /phoenix/app
 RUN pnpm install

--- a/app/package.json
+++ b/app/package.json
@@ -137,10 +137,13 @@
     "build-storybook": "storybook build",
     "chromatic": "source .env && npx chromatic"
   },
-  "packageManager": "pnpm@9.15.5",
+  "packageManager": "pnpm@10.2.0",
   "pnpm": {
     "overrides": {
       "braces@<3.0.3": ">=3.0.3"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -137,6 +137,9 @@
     "build-storybook": "storybook build",
     "chromatic": "source .env && npx chromatic"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "packageManager": "pnpm@10.2.0",
   "pnpm": {
     "overrides": {

--- a/js/package.json
+++ b/js/package.json
@@ -38,7 +38,7 @@
     "node": ">=10",
     "pnpm": ">=3"
   },
-  "packageManager": "pnpm@9.8.0",
+  "packageManager": "pnpm@10.2.0",
   "eslintIgnore": [
     "examples/**/*"
   ]


### PR DESCRIPTION
Something is segfaulting in docker builds when we build the frontend.

I suspect it may be pnpm 9.15.5 as that released only 3 days ago.

Will try bringing pnpm up to latest, node to latest lts