### PR TITLE
feat: Name experiments after prompts

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -807,8 +807,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                 elif isinstance(event, anthropic_streaming._types.CitationEvent):
                     raise NotImplementedError
                 else:
-                    # 2025-01-28 Unix CI fails due to unhandled "CitationEvent"
-                    assert_never(event)  # type: ignore
+                    assert_never(event)
 
     def _build_anthropic_messages(
         self,

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -179,7 +179,8 @@ class ChatCompletionMutationMixin:
             experiment = models.Experiment(
                 dataset_id=from_global_id_with_expected_type(input.dataset_id, Dataset.__name__),
                 dataset_version_id=resolved_version_id,
-                name=input.experiment_name or _default_playground_experiment_name(),
+                name=input.experiment_name
+                or _default_playground_experiment_name(input.prompt_name),
                 description=input.experiment_description
                 or _default_playground_experiment_description(dataset_name=dataset.name),
                 repetitions=1,

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -274,7 +274,8 @@ class Subscription:
             experiment = models.Experiment(
                 dataset_id=from_global_id_with_expected_type(input.dataset_id, Dataset.__name__),
                 dataset_version_id=resolved_version_id,
-                name=input.experiment_name or _default_playground_experiment_name(),
+                name=input.experiment_name
+                or _default_playground_experiment_name(input.prompt_name),
                 description=input.experiment_description
                 or _default_playground_experiment_description(dataset_name=dataset.name),
                 repetitions=1,
@@ -568,7 +569,9 @@ def _template_formatter(template_language: TemplateLanguage) -> TemplateFormatte
     assert_never(template_language)
 
 
-def _default_playground_experiment_name() -> str:
+def _default_playground_experiment_name(prompt_name: Optional[str] = None) -> str:
+    if prompt_name:
+        return f"prompt:{prompt_name}-playground-experiment"
     return "playground-experiment"
 
 


### PR DESCRIPTION
resolves #5972 

If a prompt was used to run a playground experiment, the prompt name will be included in the experiment name:

`prompt:{prompt_name}-playground-experiment`