### PR TITLE
fix: stop propagation on playground button

### DIFF
--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -11,6 +11,7 @@ import {
 import { css } from "@emotion/react";
 
 import { Flex, Icon, Icons, Link, LinkButton } from "@phoenix/components";
+import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { TextCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
@@ -123,14 +124,16 @@ export function PromptsTable(props: PromptsTableProps) {
               justifyContent="end"
               width="100%"
             >
-              <LinkButton
-                icon={<Icon svg={<Icons.PlayCircleOutline />} />}
-                size="S"
-                aria-label="Open in playground"
-                to={`${row.original.id}/playground`}
-              >
-                Playground
-              </LinkButton>
+              <StopPropagation>
+                <LinkButton
+                  icon={<Icon svg={<Icons.PlayCircleOutline />} />}
+                  size="S"
+                  aria-label="Open in playground"
+                  to={`${row.original.id}/playground`}
+                >
+                  Playground
+                </LinkButton>
+              </StopPropagation>
               <PromptActionMenu
                 promptId={row.original.id}
                 onDeleted={() => {


### PR DESCRIPTION
Stops propagation on the link button so that the onClick handler on the row doesn't fire and take over.