### PR TITLE
feat(prompts): Add support for Vercel AI sdk to TS phoenix-client

### DIFF
--- a/js/packages/phoenix-client/examples/apply_prompt_vercel.ts
+++ b/js/packages/phoenix-client/examples/apply_prompt_vercel.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+import { createClient } from "../src";
+import { getPrompt, toSDK } from "../src/prompts";
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { PromptSelector } from "../src/types/prompts";
+
+const PROMPT_NAME = process.env.PROMPT_NAME!;
+const PROMPT_TAG = process.env.PROMPT_TAG!;
+const PROMPT_VERSION_ID = process.env.PROMPT_VERSION_ID!;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+
+// get first argument from command line
+const question = process.argv[2];
+
+if (!question) {
+  throw new Error(
+    "Usage: pnpx tsx examples/apply_prompt.ts 'What is the capital of France?'\nAssumes that the prompt has a variable named 'question'\nAssumes that the prompt is openai with an openai model"
+  );
+}
+
+if (!OPENAI_API_KEY) {
+  throw new Error("OPENAI_API_KEY must be provided in the environment");
+}
+
+const client = createClient({
+  options: {
+    baseUrl: "http://localhost:6006",
+  },
+});
+
+const main = async () => {
+  const promptArgument: PromptSelector | null = PROMPT_VERSION_ID
+    ? { versionId: PROMPT_VERSION_ID }
+    : PROMPT_TAG && PROMPT_NAME
+      ? { name: PROMPT_NAME, tag: PROMPT_TAG }
+      : PROMPT_NAME
+        ? { name: PROMPT_NAME }
+        : null;
+  if (!promptArgument) {
+    throw new Error(
+      `Either PROMPT_VERSION_ID, PROMPT_TAG and PROMPT_NAME, or PROMPT_NAME must be provided in the environment`
+    );
+  }
+  console.log(`Getting prompt ${JSON.stringify(promptArgument)}`);
+
+  const prompt = await getPrompt({
+    client,
+    prompt: promptArgument,
+  });
+
+  if (!prompt) {
+    throw new Error("Prompt not found");
+  }
+
+  const aiParams = toSDK({
+    prompt,
+    sdk: "ai",
+    variables: {
+      question,
+    },
+  });
+
+  if (!aiParams) {
+    throw new Error("Prompt could not be converted to OpenAI params");
+  }
+
+  const { text } = await generateText({
+    model: openai("gpt-4o"),
+    ...aiParams,
+    messages: [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            result: "test",
+            toolCallId: "1",
+            toolName: "1",
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(text);
+};
+
+main();

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -45,9 +45,10 @@
   "author": "",
   "license": "ELv2",
   "devDependencies": {
+    "@ai-sdk/openai": "^1.1.9",
     "@anthropic-ai/sdk": "^0.35.0",
     "@types/node": "^20.14.11",
-    "ai": "^4.1.0",
+    "ai": "^4.1.24",
     "openai": "^4.77.0",
     "openapi-typescript": "^7.4.1",
     "tsx": "^4.19.1",
@@ -65,7 +66,7 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/sdk": "^0.35.0",
-    "ai": "^4.1.0",
+    "ai": "^4.1.24",
     "openai": "^4.77.0"
   }
 }

--- a/js/packages/phoenix-client/src/prompts/sdks/constants.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/constants.ts
@@ -1,0 +1,10 @@
+import { PromptModelProvider } from "../../types/prompts";
+
+export const SUPPORTED_SDKS = ["openai", "anthropic", "ai"] as const;
+
+export const SUPPORTED_SDK_TO_PROMPT_MODEL_PROVIDER = {
+  openai: "OPENAI",
+  anthropic: "ANTHROPIC",
+} satisfies Partial<
+  Record<(typeof SUPPORTED_SDKS)[number], PromptModelProvider>
+>;

--- a/js/packages/phoenix-client/src/prompts/sdks/toAI.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/toAI.ts
@@ -1,18 +1,90 @@
-import { toSDKParamsBase } from "./types";
-import { type streamText } from "ai";
+import {
+  openAIMessageToAI,
+  promptMessageToOpenAI,
+} from "../../schemas/llm/messageSchemas";
+import {
+  openAIToolChoiceToVercelToolChoice,
+  phoenixToolChoiceToOpenaiToolChoice,
+} from "../../schemas/llm/toolChoiceSchemas";
+import { formatPromptMessages } from "../../utils/formatPromptMessages";
+import { Variables, toSDKParamsBase } from "./types";
+import type { streamText, generateText, ToolSet, Tool } from "ai";
 
 export type PartialStreamTextParams = Omit<
-  Parameters<typeof streamText>[0],
+  Parameters<typeof streamText>[0] | Parameters<typeof generateText>[0],
   "model"
 >;
 
-export type ToAIParams = toSDKParamsBase;
+export type ToAIParams<V extends Variables> = toSDKParamsBase<V>;
 
 /**
  * @todo
  */
-export const toAI = ({
-  prompt: _prompt,
-}: ToAIParams): PartialStreamTextParams | null => {
-  return null;
+export const toAI = <V extends Variables>({
+  prompt,
+  variables,
+}: ToAIParams<V>): PartialStreamTextParams | null => {
+  try {
+    // parts of the prompt that can be directly converted to OpenAI params
+    const baseCompletionParams = {
+      // Invocation parameters are validated on the phoenix-side
+      ...prompt.invocation_parameters,
+    } satisfies Partial<PartialStreamTextParams>;
+
+    if (!("messages" in prompt.template)) {
+      return null;
+    }
+
+    let formattedMessages = prompt.template.messages;
+
+    if (variables) {
+      formattedMessages = formatPromptMessages(
+        prompt.template_format,
+        formattedMessages,
+        variables
+      );
+    }
+
+    const messages = formattedMessages.map((message) =>
+      openAIMessageToAI.parse(promptMessageToOpenAI.parse(message))
+    );
+
+    let tools: ToolSet | undefined = prompt.tools?.tools.reduce((acc, tool) => {
+      acc[tool.name] = {
+        parameters: tool.schema?.json,
+        description: tool.description,
+      } satisfies Tool;
+      return acc;
+    }, {} as ToolSet);
+    const hasTools = Object.keys(tools ?? {}).length > 0;
+    tools = hasTools ? tools : undefined;
+
+    // const response_format = prompt.response_format
+    //   ? phoenixResponseFormatToOpenAI.parse(prompt.response_format)
+    //   : undefined;
+
+    const toolChoice =
+      hasTools && prompt.tools?.tool_choice
+        ? openAIToolChoiceToVercelToolChoice.parse(
+            phoenixToolChoiceToOpenaiToolChoice.parse(prompt.tools?.tool_choice)
+          )
+        : undefined;
+
+    // combine base and computed params
+    const completionParams = {
+      ...baseCompletionParams,
+      messages,
+      tools,
+      toolChoice,
+      // response_format,
+    } satisfies Partial<PartialStreamTextParams>;
+
+    return completionParams;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`Failed to convert prompt to Anthropic params`);
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return null;
+  }
 };

--- a/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
@@ -2,11 +2,8 @@ import invariant from "tiny-invariant";
 import { toAI } from "./toAI";
 import { toAnthropic } from "./toAnthropic";
 import { toOpenAI } from "./toOpenAI";
-import { Variables, toSDKParamsBase } from "./types";
+import { SupportedSDK, Variables, toSDKParamsBase } from "./types";
 import { assertUnreachable } from "../../utils/assertUnreachable";
-
-const SUPPORTED_SDKS = ["openai", "anthropic", "ai"] as const;
-type SupportedSDK = (typeof SUPPORTED_SDKS)[number];
 
 /**
  * Parameters for an SDK conversion function

--- a/js/packages/phoenix-client/src/prompts/sdks/types.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/types.ts
@@ -1,4 +1,5 @@
-import { PromptVersion } from "../../types/prompts";
+import type { PromptVersion } from "../../types/prompts";
+import type { SUPPORTED_SDKS } from "./constants";
 
 /**
  * Variables to pass to the prompt
@@ -20,3 +21,8 @@ export type toSDKParamsBase<V extends Variables = Variables> = {
    */
   variables?: V;
 };
+
+/**
+ * Supported SDK conversion targets for prompt conversion
+ */
+export type SupportedSDK = (typeof SUPPORTED_SDKS)[number];

--- a/js/packages/phoenix-client/src/schemas/llm/messagePartSchemas.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/messagePartSchemas.ts
@@ -3,6 +3,59 @@ import { anthropicToolCallSchema } from "./toolCallSchemas";
 import { assertUnreachable } from "../../utils/assertUnreachable";
 import { PromptModelProvider } from "../../types/prompts";
 import { promptPartSchema } from "./promptSchemas";
+import { jsonLiteralSchema } from "./jsonLiteralSchema";
+
+/*
+ *
+ * Vercel AI SDK Message Part Schemas
+ *
+ */
+
+export const vercelAIChatPartTextSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+export type VercelAIChatPartText = z.infer<typeof vercelAIChatPartTextSchema>;
+
+export const vercelAIChatPartImageSchema = z.object({
+  type: z.literal("image"),
+  image: z.string(), // ai supports more, but we will just support base64 for now
+  mimeType: z.string().optional(),
+});
+
+export type VercelAIChatPartImage = z.infer<typeof vercelAIChatPartImageSchema>;
+
+export const vercelAIChatPartToolCallSchema = z.object({
+  type: z.literal("tool-call"),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  args: jsonLiteralSchema, // json serializable parameters
+});
+
+export type VercelAIChatPartToolCall = z.infer<
+  typeof vercelAIChatPartToolCallSchema
+>;
+
+export const vercelAIChatPartToolResultSchema = z.object({
+  type: z.literal("tool-result"),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  result: jsonLiteralSchema, // json serializable result
+});
+
+export type VercelAIChatPartToolResult = z.infer<
+  typeof vercelAIChatPartToolResultSchema
+>;
+
+export const vercelAIChatPartSchema = z.discriminatedUnion("type", [
+  vercelAIChatPartTextSchema,
+  vercelAIChatPartImageSchema,
+  vercelAIChatPartToolCallSchema,
+  vercelAIChatPartToolResultSchema,
+]);
+
+export type VercelAIChatPart = z.infer<typeof vercelAIChatPartSchema>;
 
 /*
  *

--- a/js/packages/phoenix-client/src/schemas/llm/toolChoiceSchemas.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/toolChoiceSchemas.ts
@@ -4,6 +4,21 @@ import { assertUnreachable } from "../../utils/assertUnreachable";
 import { isObject } from "../../utils/isObject";
 
 /**
+ * Vercel AI SDK Tool Choice Schema
+ */
+export const vercelAIToolChoiceSchema = z.union([
+  z.literal("auto"),
+  z.literal("none"),
+  z.literal("required"),
+  z.object({
+    type: z.literal("tool"),
+    toolName: z.string(),
+  }),
+]);
+
+export type VercelAIToolChoice = z.infer<typeof vercelAIToolChoiceSchema>;
+
+/**
  * Phoenix's tool choice schema
  */
 export const phoenixToolChoiceSchema = z.union([
@@ -116,6 +131,23 @@ export const openAIToolChoiceToAnthropicToolChoice =
         return { type: "auto" };
       case "required":
         return { type: "any" };
+      default:
+        assertUnreachable(openAI);
+    }
+  });
+
+export const openAIToolChoiceToVercelToolChoice =
+  openAIToolChoiceSchema.transform((openAI): VercelAIToolChoice => {
+    if (isObject(openAI)) {
+      return { type: "tool", toolName: openAI.function.name };
+    }
+    switch (openAI) {
+      case "auto":
+        return "auto";
+      case "none":
+        return "none";
+      case "required":
+        return "required";
       default:
         assertUnreachable(openAI);
     }

--- a/js/packages/phoenix-client/test/prompts/sdks/toAI.test.ts
+++ b/js/packages/phoenix-client/test/prompts/sdks/toAI.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, assertType, expect } from "vitest";
+import {
+  describe,
+  it,
+  assertType,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { toSDK } from "../../../src/prompts/sdks/toSDK";
 import { PromptVersion } from "../../../src/types/prompts";
 import invariant from "tiny-invariant";
@@ -6,13 +14,35 @@ import {
   toAI,
   type PartialStreamTextParams,
 } from "../../../src/prompts/sdks/toAI";
-import {
-  BASE_MOCK_PROMPT_VERSION,
-  BASE_MOCK_PROMPT_VERSION_TOOLS,
-  BASE_MOCK_PROMPT_VERSION_RESPONSE_FORMAT,
-} from "./data";
+import { BASE_MOCK_PROMPT_VERSION } from "./data";
+import { generateObject, generateText, streamObject, streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
 
 describe("toAI type compatibility", () => {
+  beforeEach(() => {
+    // replace calls to openai with a mock
+    vi.mock("@ai-sdk/openai", () => ({
+      openai: vi.fn(),
+    }));
+
+    // replace calls to streamText, generateText, streamObject, and generateObject with a mock
+    vi.mock(import("ai"), async (importOriginal) => {
+      const mod = await importOriginal();
+      return {
+        ...mod,
+        streamText: vi.fn(),
+        generateText: vi.fn(),
+        streamObject: vi.fn(),
+        generateObject: vi.fn(),
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("toAI output should be assignable to AI message params", () => {
     const mockPrompt = {
       ...BASE_MOCK_PROMPT_VERSION,
@@ -40,5 +70,256 @@ describe("toAI type compatibility", () => {
     invariant(result, "Expected non-null result");
 
     assertType<PartialStreamTextParams>(result);
+  });
+
+  it("should handle typed variables", () => {
+    const mockPrompt = {
+      ...BASE_MOCK_PROMPT_VERSION,
+    };
+
+    // variables are still inferred, as normal
+    // no type error occurs as long as variable is stringable
+    toAI({
+      prompt: mockPrompt,
+      variables: {
+        question: true,
+        answer: 42,
+      },
+    });
+
+    // using toOpenAI should take a single generic argument
+    toAI<{ question: number }>({
+      prompt: mockPrompt,
+      variables: {
+        question: 1,
+      },
+    });
+
+    // using toSDK should take two generic arguments
+    toSDK<"ai", { question: number }>({
+      sdk: "ai",
+      prompt: mockPrompt,
+      variables: {
+        question: 1,
+      },
+    });
+
+    // This test just checks that the types are compatible
+    // it will fail in pnpm type:check if the types break in the future
+  });
+
+  it("should handle complex message types", () => {
+    const mockPrompt = {
+      ...BASE_MOCK_PROMPT_VERSION,
+      tools: {
+        type: "tools-v1",
+        tool_choice: {
+          type: "specific-function-tool",
+          function_name: "edit_image",
+        },
+        tools: [
+          {
+            type: "function-tool-v1",
+            name: "edit_image",
+            description: "edit an image",
+            schema: {
+              type: "json-schema-draft-7-object-schema",
+              json: {
+                type: "object",
+                properties: {
+                  image_url: {
+                    type: "string",
+                    description: "the url of the image to edit",
+                  },
+                  edit_type: {
+                    type: "string",
+                    description: "the type of edit to perform",
+                  },
+                },
+                required: ["image_url", "edit_type"],
+              },
+            },
+          },
+        ],
+      },
+      template: {
+        version: "chat-template-v1",
+        messages: [
+          {
+            role: "USER",
+            content: [
+              { type: "text", text: { text: "Can you edit this image?" } },
+              {
+                type: "image",
+                image: {
+                  // Anthropic only supports base64 images
+                  // if this is any other url, image parts will be dropped
+                  url: "data:image/jpeg;base64,test.jpg",
+                },
+              },
+            ],
+          },
+          {
+            role: "AI",
+            content: [
+              { type: "text", text: { text: "Yes I can edit this image" } },
+              {
+                type: "tool_call",
+                tool_call: {
+                  tool_call_id: "123",
+                  tool_call: {
+                    type: "function",
+                    name: "edit_image",
+                    arguments: JSON.stringify({
+                      image_url: "test.jpg",
+                      edit_type: "blur",
+                    }),
+                  },
+                },
+              },
+            ],
+          },
+          {
+            role: "TOOL",
+            content: [
+              {
+                type: "tool_result",
+                tool_result: {
+                  tool_call_id: "123",
+                  result: JSON.stringify({
+                    new_image_url: "test_edited.jpg",
+                  }),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } satisfies PromptVersion;
+
+    const result = toSDK({
+      sdk: "ai",
+      prompt: mockPrompt,
+    });
+
+    expect(result).not.toBeNull();
+    invariant(result, "Expected non-null result");
+
+    assertType<PartialStreamTextParams>(result);
+
+    expect(result).toMatchObject({
+      messages: [
+        {
+          content: [
+            {
+              text: "Can you edit this image?",
+              type: "text",
+            },
+            {
+              image: "data:image/jpeg;base64,test.jpg",
+              type: "image",
+            },
+          ],
+          role: "user",
+        },
+        {
+          content: [
+            {
+              text: "Yes I can edit this image",
+              type: "text",
+            },
+            {
+              args: '{"image_url":"test.jpg","edit_type":"blur"}',
+              toolCallId: "123",
+              toolName: "edit_image",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [
+            {
+              result: '{"new_image_url":"test_edited.jpg"}',
+              toolCallId: "123",
+              toolName: "",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ],
+      temperature: 0.7,
+      toolChoice: {
+        toolName: "edit_image",
+        type: "tool",
+      },
+      tools: {
+        edit_image: {
+          description: "edit an image",
+          parameters: {
+            _type: undefined,
+            jsonSchema: {
+              properties: {
+                edit_type: {
+                  description: "the type of edit to perform",
+                  type: "string",
+                },
+                image_url: {
+                  description: "the url of the image to edit",
+                  type: "string",
+                },
+              },
+              required: ["image_url", "edit_type"],
+              type: "object",
+            },
+            validate: undefined,
+          },
+          type: "function",
+        },
+      },
+    });
+  });
+
+  it("should convert and spread into streamText without type errors", () => {
+    const mockPrompt = {
+      ...BASE_MOCK_PROMPT_VERSION,
+    } satisfies PromptVersion;
+
+    const result = toAI({
+      prompt: mockPrompt,
+      variables: {
+        question: "What is the capital of France?",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    invariant(result, "Expected non-null result");
+
+    assertType<PartialStreamTextParams>(result);
+
+    const model = openai("gpt-4o");
+
+    streamText({
+      model,
+      ...result,
+    });
+
+    generateText({
+      model,
+      ...result,
+    });
+
+    streamObject({
+      schema: z.object({ test: z.string() }),
+      model,
+      ...result,
+    });
+
+    generateObject({
+      schema: z.object({ test: z.string() }),
+      model,
+      ...result,
+    });
   });
 });

--- a/js/packages/phoenix-client/test/prompts/sdks/toAI.test.ts
+++ b/js/packages/phoenix-client/test/prompts/sdks/toAI.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, assertType, expect } from "vitest";
+import { toSDK } from "../../../src/prompts/sdks/toSDK";
+import { PromptVersion } from "../../../src/types/prompts";
+import invariant from "tiny-invariant";
+import {
+  toAI,
+  type PartialStreamTextParams,
+} from "../../../src/prompts/sdks/toAI";
+import {
+  BASE_MOCK_PROMPT_VERSION,
+  BASE_MOCK_PROMPT_VERSION_TOOLS,
+  BASE_MOCK_PROMPT_VERSION_RESPONSE_FORMAT,
+} from "./data";
+
+describe("toAI type compatibility", () => {
+  it("toAI output should be assignable to AI message params", () => {
+    const mockPrompt = {
+      ...BASE_MOCK_PROMPT_VERSION,
+    } satisfies PromptVersion;
+
+    const result = toAI({ prompt: mockPrompt });
+
+    expect(result).not.toBeNull();
+    invariant(result, "Expected non-null result");
+
+    assertType<PartialStreamTextParams>(result);
+  });
+
+  it("toSDK with ai should be assignable to AI message params", () => {
+    const mockPrompt = {
+      ...BASE_MOCK_PROMPT_VERSION,
+    } satisfies PromptVersion;
+
+    const result = toSDK({
+      sdk: "ai",
+      prompt: mockPrompt,
+    });
+
+    expect(result).not.toBeNull();
+    invariant(result, "Expected non-null result");
+
+    assertType<PartialStreamTextParams>(result);
+  });
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1(zod@3.24.1)
     devDependencies:
+      '@ai-sdk/openai':
+        specifier: ^1.1.9
+        version: 1.1.9(zod@3.24.1)
       '@types/node':
         specifier: ^20.14.11
         version: 20.17.9
@@ -105,16 +108,22 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0
       ai:
-        specifier: ^4.1.0
-        version: 4.1.0(react@19.0.0)(zod@3.24.1)
+        specifier: ^4.1.24
+        version: 4.1.24(react@19.0.0)(zod@3.24.1)
       openai:
         specifier: ^4.77.0
         version: 4.77.0(zod@3.24.1)
 
 packages:
 
-  '@ai-sdk/provider-utils@2.1.0':
-    resolution: {integrity: sha512-rBUabNoyB25PBUjaiMSk86fHNSCqTngNZVvXxv8+6mvw47JX5OexW+ZHRsEw8XKTE8+hqvNFVzctaOrRZ2i9Zw==}
+  '@ai-sdk/openai@1.1.9':
+    resolution: {integrity: sha512-t/CpC4TLipdbgBJTMX/otzzqzCMBSPQwUOkYPGbT/jyuC86F+YO9o+LS0Ty2pGUE1kyT+B3WmJ318B16ZCg4hw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/provider-utils@2.1.6':
+    resolution: {integrity: sha512-Pfyaj0QZS22qyVn5Iz7IXcJ8nKIKlu2MeSAdKJzTwkAks7zdLaKVB+396Rqcp1bfQnxl7vaduQVMQiXUrgK8Gw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -122,12 +131,12 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/provider@1.0.4':
-    resolution: {integrity: sha512-lJi5zwDosvvZER3e/pB8lj1MN3o3S7zJliQq56BRr4e9V3fcRyFtwP0JRxaRS5vHYX3OJ154VezVoQNrk0eaKw==}
+  '@ai-sdk/provider@1.0.7':
+    resolution: {integrity: sha512-q1PJEZ0qD9rVR+8JFEd01/QM++csMT5UVwYXSN2u54BrVw/D8TZLTeg2FEfKK00DgAx0UtWd8XOhhwITP9BT5g==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@1.1.0':
-    resolution: {integrity: sha512-U5lBbLyf1pw79xsk5dgHSkBv9Jta3xzWlOLpxsmHlxh1X94QOH3e1gm+nioQ/JvTuHLm23j2tz3i4MpMdchwXQ==}
+  '@ai-sdk/react@1.1.10':
+    resolution: {integrity: sha512-RTkEVYKq7qO6Ct3XdVTgbaCTyjX+q1HLqb+t2YvZigimzMCQbHkpZCtt2H2Fgpt1UOTqnAAlXjEAgTW3X60Y9g==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -138,8 +147,8 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/ui-utils@1.1.0':
-    resolution: {integrity: sha512-ETXwdHaHwzC7NIehbthDFGwsTFk+gNtRL/lm85nR4WDFvvYQptoM/7wTANs0p0H7zumB3Ep5hKzv0Encu8vSRw==}
+  '@ai-sdk/ui-utils@1.1.10':
+    resolution: {integrity: sha512-x+A1Nfy8RTSatdCe+7nRpHAZVzPFB6H+r+2JKoapSvrwsu9mw2pAbmFgV8Zaj94TsmUdTlO0/j97e63f+yYuWg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -878,8 +887,8 @@ packages:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
     engines: {node: '>= 8.0.0'}
 
-  ai@4.1.0:
-    resolution: {integrity: sha512-95nI9hBSSAKPrMnpJbaB3yqvh+G8BS4/EtFz3HR0HgEDJpxC0R6JAlB8+B/BXHd/roNGBrS08Z3Zain/6OFSYA==}
+  ai@4.1.24:
+    resolution: {integrity: sha512-QJLU9lIrwxZqNz6C3m+MLbtklPyBVUNWDHmk38M8ZstHhHezHGEo0FLjDlKYo3cysshdSz8TFXBvXh+429Yopw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -2172,25 +2181,29 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/provider-utils@2.1.0(zod@3.24.1)':
+  '@ai-sdk/openai@1.1.9(zod@3.24.1)':
     dependencies:
-      '@ai-sdk/provider': 1.0.4
+      '@ai-sdk/provider': 1.0.7
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
+      zod: 3.24.1
+
+  '@ai-sdk/provider-utils@2.1.6(zod@3.24.1)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.7
       eventsource-parser: 3.0.0
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
     optionalDependencies:
       zod: 3.24.1
-    optional: true
 
-  '@ai-sdk/provider@1.0.4':
+  '@ai-sdk/provider@1.0.7':
     dependencies:
       json-schema: 0.4.0
-    optional: true
 
-  '@ai-sdk/react@1.1.0(react@19.0.0)(zod@3.24.1)':
+  '@ai-sdk/react@1.1.10(react@19.0.0)(zod@3.24.1)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.1.0(zod@3.24.1)
-      '@ai-sdk/ui-utils': 1.1.0(zod@3.24.1)
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
+      '@ai-sdk/ui-utils': 1.1.10(zod@3.24.1)
       swr: 2.3.0(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
@@ -2198,10 +2211,10 @@ snapshots:
       zod: 3.24.1
     optional: true
 
-  '@ai-sdk/ui-utils@1.1.0(zod@3.24.1)':
+  '@ai-sdk/ui-utils@1.1.10(zod@3.24.1)':
     dependencies:
-      '@ai-sdk/provider': 1.0.4
-      '@ai-sdk/provider-utils': 2.1.0(zod@3.24.1)
+      '@ai-sdk/provider': 1.0.7
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
       zod-to-json-schema: 3.24.1(zod@3.24.1)
     optionalDependencies:
       zod: 3.24.1
@@ -2947,12 +2960,12 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@4.1.0(react@19.0.0)(zod@3.24.1):
+  ai@4.1.24(react@19.0.0)(zod@3.24.1):
     dependencies:
-      '@ai-sdk/provider': 1.0.4
-      '@ai-sdk/provider-utils': 2.1.0(zod@3.24.1)
-      '@ai-sdk/react': 1.1.0(react@19.0.0)(zod@3.24.1)
-      '@ai-sdk/ui-utils': 1.1.0(zod@3.24.1)
+      '@ai-sdk/provider': 1.0.7
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
+      '@ai-sdk/react': 1.1.10(react@19.0.0)(zod@3.24.1)
+      '@ai-sdk/ui-utils': 1.1.10(zod@3.24.1)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
     optionalDependencies:
@@ -3308,8 +3321,7 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  eventsource-parser@3.0.0:
-    optional: true
+  eventsource-parser@3.0.0: {}
 
   expect-type@1.1.0: {}
 
@@ -3549,8 +3561,7 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema@0.4.0:
-    optional: true
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3960,8 +3971,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  secure-json-parse@2.7.0:
-    optional: true
+  secure-json-parse@2.7.0: {}
 
   semver@7.6.3: {}
 


### PR DESCRIPTION
- [x] Convert prompt to `ai`
- [x] Add tests
- [x] Add / test example

See that it supports tool calls, and object generation (response format)

<img width="801" alt="image" src="https://github.com/user-attachments/assets/3fe36956-e9ab-4322-93e2-b427ae6f5a91" />
