### PR TITLE
feat(prompts): Denormalize tool choice in playground

### DIFF
--- a/app/src/components/generative/ToolChoiceSelector.tsx
+++ b/app/src/components/generative/ToolChoiceSelector.tsx
@@ -3,11 +3,61 @@ import React from "react";
 import { Item, Label, Picker } from "@arizeai/components";
 
 import { Flex } from "@phoenix/components";
+import {
+  AnthropicToolChoice,
+  findToolChoiceName,
+  makeAnthropicToolChoice,
+  makeOpenAIToolChoice,
+  OpenaiToolChoice,
+  safelyConvertToolChoiceToProvider,
+} from "@phoenix/schemas/toolChoiceSchemas";
+import { assertUnreachable, isObject } from "@phoenix/typeUtils";
 
-type DefaultToolChoice = Extract<ToolChoice, "auto" | "required" | "none">;
+export const DEFAULT_TOOL_CHOICES_BY_PROVIDER = {
+  OPENAI: ["auto", "required", "none"] as const,
+  AZURE_OPENAI: ["auto", "required", "none"] as const,
+  ANTHROPIC: ["auto", "any"] as const,
+} satisfies Partial<
+  Record<ModelProvider, (string | Record<string, unknown>)[]>
+>;
 
-const isDefaultToolChoice = (choice: string): choice is DefaultToolChoice => {
-  return choice === "auto" || choice === "required" || choice === "none";
+export const getToolChoiceType = (provider: ModelProvider, choice: unknown) => {
+  switch (provider) {
+    case "AZURE_OPENAI":
+    case "OPENAI":
+      if (isObject(choice) && "type" in choice) {
+        return choice.type;
+      }
+      return choice;
+    case "ANTHROPIC":
+      if (isObject(choice) && "type" in choice) {
+        return choice.type;
+      }
+      return choice;
+    case "GEMINI":
+      // TODO(apowell): #5348 Add Gemini tool choice schema
+      return "auto";
+    default:
+      assertUnreachable(provider);
+  }
+};
+
+export const isSupportedToolChoiceProvider = (
+  provider: ModelProvider
+): provider is keyof typeof DEFAULT_TOOL_CHOICES_BY_PROVIDER => {
+  return provider in DEFAULT_TOOL_CHOICES_BY_PROVIDER;
+};
+
+const isDefaultToolChoice = <
+  T extends keyof typeof DEFAULT_TOOL_CHOICES_BY_PROVIDER,
+>(
+  provider: T,
+  choice: unknown
+): choice is (typeof DEFAULT_TOOL_CHOICES_BY_PROVIDER)[T][number] => {
+  return (
+    DEFAULT_TOOL_CHOICES_BY_PROVIDER[provider]?.includes(choice as "auto") ??
+    false
+  );
 };
 
 /**
@@ -33,30 +83,32 @@ const removeToolNamePrefix = (toolName: string) =>
     ? toolName.slice(TOOL_NAME_PREFIX.length)
     : toolName;
 
-type ToolChoicePickerProps = {
+type ToolChoicePickerProps<
+  T extends keyof typeof DEFAULT_TOOL_CHOICES_BY_PROVIDER,
+> = {
+  provider: T;
   /**
    * The current choice including the default {@link ToolChoice} and any user defined tools
    */
-  choice: ToolChoice | undefined;
+  choice: OpenaiToolChoice | AnthropicToolChoice | undefined;
   /**
    * Callback for when the tool choice changes
    */
-  onChange: (choice: ToolChoice) => void;
+  onChange: (choice: OpenaiToolChoice | AnthropicToolChoice) => void;
   /**
    * A list of user defined tool names
    */
   toolNames: string[];
 };
 
-export function ToolChoicePicker({
-  choice,
-  onChange,
-  toolNames,
-}: ToolChoicePickerProps) {
-  const currentKey =
-    choice == null || typeof choice === "string"
-      ? choice
-      : addToolNamePrefix(choice.function.name);
+export function ToolChoicePicker<
+  T extends keyof typeof DEFAULT_TOOL_CHOICES_BY_PROVIDER,
+>({ choice, onChange, toolNames, provider }: ToolChoicePickerProps<T>) {
+  const currentChoiceType = getToolChoiceType(provider, choice);
+  const inDefaultToolChoices = isDefaultToolChoice(provider, currentChoiceType);
+  const currentKey = inDefaultToolChoices
+    ? currentChoiceType
+    : addToolNamePrefix(findToolChoiceName(choice) ?? "");
   return (
     <Picker
       selectedKey={currentKey}
@@ -67,33 +119,63 @@ export function ToolChoicePicker({
           return;
         }
         if (choice.startsWith(TOOL_NAME_PREFIX)) {
-          onChange({
-            type: "function",
-            function: {
-              name: removeToolNamePrefix(choice),
-            },
+          switch (provider) {
+            case "AZURE_OPENAI":
+            case "OPENAI":
+              onChange(
+                makeOpenAIToolChoice({
+                  type: "function",
+                  function: {
+                    name: removeToolNamePrefix(choice),
+                  },
+                })
+              );
+              break;
+            case "ANTHROPIC":
+              onChange(
+                makeAnthropicToolChoice({
+                  type: "tool",
+                  name: removeToolNamePrefix(choice),
+                })
+              );
+              break;
+            default:
+              assertUnreachable(provider);
+          }
+        } else if (isDefaultToolChoice(provider, choice)) {
+          const convertedChoice = safelyConvertToolChoiceToProvider({
+            toolChoice: choice,
+            targetProvider: provider,
           });
-        } else if (isDefaultToolChoice(choice)) {
-          onChange(choice);
+          if (convertedChoice) {
+            onChange(convertedChoice);
+          }
         }
       }}
     >
       {[
-        <Item key="auto" textValue="auto">
-          <Flex gap={"size-100"}>
-            Tools auto-selected by LLM <Label color="grey-900">auto</Label>
-          </Flex>
-        </Item>,
-        <Item key="required" textValue="required">
-          <Flex gap={"size-100"}>
-            Use at least one tool <Label color="grey-900">required</Label>
-          </Flex>
-        </Item>,
-        <Item key="none" textValue="none">
-          <Flex gap={"size-100"}>
-            Don&apos;t use any tools <Label color="grey-900">none</Label>
-          </Flex>
-        </Item>,
+        // <Item key="auto" textValue="auto">
+        //   <Flex gap={"size-100"}>
+        //     Tools auto-selected by LLM <Label color="grey-900">auto</Label>
+        //   </Flex>
+        // </Item>,
+        // <Item key="required" textValue="required">
+        //   <Flex gap={"size-100"}>
+        //     Use at least one tool <Label color="grey-900">required</Label>
+        //   </Flex>
+        // </Item>,
+        // <Item key="none" textValue="none">
+        //   <Flex gap={"size-100"}>
+        //     Don&apos;t use any tools <Label color="grey-900">none</Label>
+        //   </Flex>
+        // </Item>,
+        ...(DEFAULT_TOOL_CHOICES_BY_PROVIDER[provider]
+          ? DEFAULT_TOOL_CHOICES_BY_PROVIDER[provider].map((choice) => (
+              <Item key={choice} textValue={choice}>
+                {choice}
+              </Item>
+            ))
+          : []),
         // Add "TOOL_NAME_PREFIX" prefix to user defined tool names to avoid conflicts with default keys
         ...toolNames.map((toolName) => (
           <Item key={addToolNamePrefix(toolName)} textValue={toolName}>

--- a/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplateFooter.tsx
@@ -2,10 +2,11 @@ import React from "react";
 
 import { Button, Flex, Icon, Icons } from "@phoenix/components";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { safelyConvertToolChoiceToProvider } from "@phoenix/schemas/toolChoiceSchemas";
 import {
   createOpenAIResponseFormat,
   generateMessageId,
-  PlaygroundInstance,
+  PlaygroundNormalizedInstance,
 } from "@phoenix/store";
 
 import {
@@ -95,7 +96,7 @@ export function PlaygroundChatTemplateFooter({
           size="S"
           icon={<Icon svg={<Icons.PlusOutline />} />}
           onPress={() => {
-            const patch: Partial<PlaygroundInstance> = {
+            const patch: Partial<PlaygroundNormalizedInstance> = {
               tools: [
                 ...playgroundInstance.tools,
                 createToolForProvider({
@@ -105,19 +106,18 @@ export function PlaygroundChatTemplateFooter({
               ],
             };
             if (playgroundInstance.tools.length === 0) {
-              patch.toolChoice = "auto";
+              const convertedChoice = safelyConvertToolChoiceToProvider({
+                toolChoice: "auto",
+                targetProvider: playgroundInstance.model.provider,
+              });
+              // set a new default tool choice that is appropriate for the provider
+              if (convertedChoice) {
+                patch.toolChoice = convertedChoice;
+              }
             }
             updateInstance({
               instanceId,
-              patch: {
-                tools: [
-                  ...playgroundInstance.tools,
-                  createToolForProvider({
-                    provider: playgroundInstance.model.provider,
-                    toolNumber: playgroundInstance.tools.length + 1,
-                  }),
-                ],
-              },
+              patch,
               dirty: true,
             });
           }}

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -20,6 +20,7 @@ import {
   llmProviderToolDefinitionSchema,
   openAIToolDefinitionJSONSchema,
 } from "@phoenix/schemas";
+import { findToolChoiceName } from "@phoenix/schemas/toolChoiceSchemas";
 import { Tool } from "@phoenix/store";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
@@ -159,11 +160,10 @@ export function PlaygroundTool({
             size="S"
             onPress={() => {
               const newTools = instanceTools.filter((t) => t.id !== tool.id);
-              const toolName = getToolName(tool);
               const deletingToolChoice =
                 typeof instance.toolChoice === "object" &&
                 toolName != null &&
-                instance.toolChoice.function.name === getToolName(tool);
+                findToolChoiceName(instance.toolChoice) === toolName;
 
               let toolChoice = instance.toolChoice;
               if (newTools.length === 0) {

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -9,7 +9,10 @@ import {
   Flex,
   View,
 } from "@phoenix/components";
-import { ToolChoicePicker } from "@phoenix/components/generative";
+import {
+  isSupportedToolChoiceProvider,
+  ToolChoicePicker,
+} from "@phoenix/components/generative";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 
 import { PlaygroundTool } from "./PlaygroundTool";
@@ -42,6 +45,12 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
     [tools]
   );
 
+  const provider = instance.model.provider;
+
+  if (!isSupportedToolChoiceProvider(provider)) {
+    return null;
+  }
+
   return (
     <Disclosure id="tools">
       <DisclosureTrigger arrowPosition="start">
@@ -53,6 +62,7 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
           <Flex direction="column">
             <Form>
               <ToolChoicePicker
+                provider={provider}
                 choice={instance.toolChoice}
                 onChange={(choice) => {
                   updateInstance({

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 import {
   isSupportedToolChoiceProvider,
-  ToolChoicePicker,
+  ToolChoiceSelector,
 } from "@phoenix/components/generative";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 
@@ -61,7 +61,7 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
         <View padding="size-200">
           <Flex direction="column">
             <Form>
-              <ToolChoicePicker
+              <ToolChoiceSelector
                 provider={provider}
                 choice={instance.toolChoice}
                 onChange={(choice) => {

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -353,6 +353,11 @@ export const instanceToPromptVersion = (instance: PlaygroundInstance) => {
     // we do a proper typecheck above to ensure that this cast is safe
   }) as ChatPromptVersionInput["template"]["messages"];
 
+  const convertedToolChoice = safelyConvertToolChoiceToProvider({
+    toolChoice: instance.toolChoice,
+    targetProvider: instance.model.provider,
+  });
+
   const newPromptVersion = {
     modelName: instance.model.modelName || DEFAULT_MODEL_NAME,
     modelProvider: instance.model.provider,
@@ -383,11 +388,11 @@ export const instanceToPromptVersion = (instance: PlaygroundInstance) => {
             )
         )
         .concat(
-          instance.toolChoice
+          convertedToolChoice
             ? [
                 {
                   invocationName: TOOL_CHOICE_PARAM_NAME,
-                  valueJson: instance.toolChoice,
+                  valueJson: convertedToolChoice,
                   canonicalName: TOOL_CHOICE_PARAM_CANONICAL_NAME,
                 },
               ]

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -26,6 +26,7 @@ import {
   ToolResultPart,
 } from "@phoenix/schemas/promptSchemas";
 import { fromPromptToolCallPart } from "@phoenix/schemas/toolCallSchemas";
+import { safelyConvertToolChoiceToProvider } from "@phoenix/schemas/toolChoiceSchemas";
 import {
   DEFAULT_INSTANCE_PARAMS,
   generateMessageId,
@@ -155,6 +156,11 @@ export const promptVersionToInstance = ({
     openInferenceModelProviderToPhoenixModelProvider(
       promptVersion.modelProvider
     ) || DEFAULT_MODEL_PROVIDER;
+  const toolChoice =
+    safelyConvertToolChoiceToProvider({
+      toolChoice: promptVersion.invocationParameters?.tool_choice,
+      targetProvider: provider,
+    }) ?? undefined;
 
   return {
     ...newInstance,
@@ -237,7 +243,7 @@ export const promptVersionToInstance = ({
       id: generateToolId(),
       definition: t.definition,
     })),
-    toolChoice: promptVersion.invocationParameters?.tool_choice || undefined,
+    toolChoice,
   } satisfies Partial<PlaygroundInstance>;
 };
 

--- a/app/src/schemas/toolChoiceSchemas.ts
+++ b/app/src/schemas/toolChoiceSchemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { assertUnreachable, schemaForType } from "@phoenix/typeUtils";
+import { assertUnreachable, isObject, schemaForType } from "@phoenix/typeUtils";
 
 /**
  * OpenAI's tool choice schema
@@ -26,11 +26,21 @@ export type OpenaiToolChoice = z.infer<typeof openAIToolChoiceSchema>;
  *
  * @see https://docs.anthropic.com/en/api/messages
  */
-export const anthropicToolChoiceSchema = z.object({
-  type: z.union([z.literal("auto"), z.literal("any"), z.literal("tool")]),
-  disable_parallel_tool_use: z.boolean().optional(),
-  name: z.string().optional(),
-});
+export const anthropicToolChoiceSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("auto"),
+    disable_parallel_tool_use: z.boolean().optional(),
+  }),
+  z.object({
+    type: z.literal("any"),
+    disable_parallel_tool_use: z.boolean().optional(),
+  }),
+  z.object({
+    type: z.literal("tool"),
+    name: z.string(),
+    disable_parallel_tool_use: z.boolean().optional(),
+  }),
+]);
 
 export type AnthropicToolChoice = z.infer<typeof anthropicToolChoiceSchema>;
 
@@ -55,13 +65,18 @@ export const anthropicToolChoiceToOpenaiToolChoice =
 
 export const openAIToolChoiceToAnthropicToolChoice =
   openAIToolChoiceSchema.transform((openAI): AnthropicToolChoice => {
-    if (typeof openAI === "string") {
-      return { type: "auto" };
+    if (isObject(openAI)) {
+      return { type: "tool", name: openAI.function.name };
     }
-    return {
-      type: "tool",
-      name: openAI.function.name,
-    };
+    switch (openAI) {
+      case "none":
+      case "auto":
+        return { type: "auto" };
+      case "required":
+        return { type: "any" };
+      default:
+        assertUnreachable(openAI);
+    }
   });
 
 export const llmProviderToolChoiceSchema = z.union([
@@ -178,4 +193,34 @@ export const safelyConvertToolChoiceToProvider = <T extends ModelProvider>({
   } catch (e) {
     return null;
   }
+};
+
+export const makeOpenAIToolChoice = (
+  toolChoice: OpenaiToolChoice
+): OpenaiToolChoice => {
+  return toolChoice;
+};
+
+export const makeAnthropicToolChoice = (
+  toolChoice: AnthropicToolChoice
+): AnthropicToolChoice => {
+  return toolChoice;
+};
+
+export const findToolChoiceName = (toolChoice: unknown): string | null => {
+  if (isObject(toolChoice)) {
+    if (
+      "function" in toolChoice &&
+      isObject(toolChoice.function) &&
+      "name" in toolChoice.function &&
+      typeof toolChoice.function.name === "string"
+    ) {
+      return toolChoice.function.name;
+    }
+    if ("name" in toolChoice && typeof toolChoice.name === "string") {
+      return toolChoice.name;
+    }
+    return null;
+  }
+  return null;
 };

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -14,6 +14,7 @@ import {
   mergeInvocationParametersWithDefaults,
 } from "@phoenix/pages/playground/playgroundUtils";
 import { OpenAIResponseFormat } from "@phoenix/pages/playground/schemas";
+import { safelyConvertToolChoiceToProvider } from "@phoenix/schemas/toolChoiceSchemas";
 
 import {
   convertInstanceToolsToProvider,
@@ -395,6 +396,11 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
               endpoint: null,
               provider,
             },
+        toolChoice:
+          safelyConvertToolChoiceToProvider({
+            toolChoice: instance.toolChoice,
+            targetProvider: provider,
+          }) ?? undefined,
         tools: convertInstanceToolsToProvider({
           instanceTools: instance.tools,
           provider,

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -5,6 +5,10 @@ import {
   LlmProviderToolCall,
   LlmProviderToolDefinition,
 } from "@phoenix/schemas";
+import {
+  AnthropicToolChoice,
+  OpenaiToolChoice,
+} from "@phoenix/schemas/toolChoiceSchemas";
 
 import { ModelConfigByProvider } from "../preferencesStore";
 export type GenAIOperationType = "chat" | "text_completion";
@@ -117,7 +121,7 @@ export interface PlaygroundInstance {
    * How the LLM should choose the tool to use
    * @default "auto"
    */
-  toolChoice?: ToolChoice;
+  toolChoice?: OpenaiToolChoice | AnthropicToolChoice;
   model: ModelConfig;
   output?: ChatMessage[] | string;
   spanId: string | null;


### PR DESCRIPTION
We were essentially normalizing tool choice as openai, while later assuming that it would be in the correct provider shape before usage / saving.

This meant tool_choice was being ignored in anthropic invocations, and could not be validated correctly into a normalized prompt version format.

Now, we perform tool choice conversions before saving, before using in completions, and when switching models.

This feels a little messy because of code sprawl, the openai assumption has been long lived in playground code.

![2025-02-07 10 20 10](https://github.com/user-attachments/assets/7d5f6860-9ecf-4d66-917c-77ac307ac54b)
