### PR TITLE
fix(prompts): make prompts and configuration collapsible

### DIFF
--- a/app/src/pages/prompt/ChatTemplateMessageCard.tsx
+++ b/app/src/pages/prompt/ChatTemplateMessageCard.tsx
@@ -181,7 +181,13 @@ export function ChatTemplateMessageCard(props: ChatTemplateMessageProps) {
   const { role, children } = props;
   const styles = useChatMessageStyles(role);
   return (
-    <Card title={role} variant="compact" {...styles} bodyStyle={{ padding: 0 }}>
+    <Card
+      title={role}
+      variant="compact"
+      {...styles}
+      bodyStyle={{ padding: 0 }}
+      collapsible
+    >
       <DisclosureGroup defaultExpandedKeys={PART_TYPE_TITLES}>
         {children}
       </DisclosureGroup>

--- a/app/src/pages/prompt/PromptChatMessagesCard.tsx
+++ b/app/src/pages/prompt/PromptChatMessagesCard.tsx
@@ -207,7 +207,7 @@ export function PromptChatMessagesCard({
   promptVersion: PromptChatMessagesCard__main$key;
 }) {
   return (
-    <Card title={title} variant="compact">
+    <Card title={title} variant="compact" collapsible>
       <PromptChatMessages promptVersion={promptVersion} />
     </Card>
   );

--- a/app/src/pages/prompt/PromptModelConfigurationCard.tsx
+++ b/app/src/pages/prompt/PromptModelConfigurationCard.tsx
@@ -38,6 +38,7 @@ export function PromptModelConfigurationCard({
       title="Model Configuration"
       variant="compact"
       bodyStyle={{ padding: 0 }}
+      collapsible
     >
       <DisclosureGroup
         defaultExpandedKeys={[


### PR DESCRIPTION
Sometimes prompts and messages can get really long. This makes it easier to get to the bottom.