### PR TITLE
fix(prompts): Restore azure openai params from prompt into playground

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -208,7 +208,7 @@ input ChatPromptVersionInput {
   invocationParameters: JSON! = {}
   tools: [ToolDefinitionInput!]! = []
   responseFormat: ResponseFormatInput = null
-  modelProvider: String!
+  modelProvider: ModelProvider!
   modelName: String!
 }
 
@@ -1202,6 +1202,13 @@ type Model {
   ): PerformanceTimeSeries!
 }
 
+enum ModelProvider {
+  OPENAI
+  AZURE_OPENAI
+  ANTHROPIC
+  GEMINI
+}
+
 input ModelsInput {
   providerKey: GenerativeProviderKey
   modelName: String = null
@@ -1586,7 +1593,7 @@ type PromptVersion implements Node {
   tools: [ToolDefinition!]!
   responseFormat: ResponseFormat
   modelName: String!
-  modelProvider: String!
+  modelProvider: ModelProvider!
   metadata: JSON!
   createdAt: DateTime!
   tags: [PromptVersionTag!]!

--- a/app/src/pages/playground/ModelSupportedParamsFetcher.tsx
+++ b/app/src/pages/playground/ModelSupportedParamsFetcher.tsx
@@ -92,6 +92,7 @@ export const ModelSupportedParamsFetcher = ({
       supportedInvocationParameters: modelInvocationParameters as Mutable<
         typeof modelInvocationParameters
       >,
+      modelConfigByProvider,
     });
   }, [
     modelInvocationParameters,

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98143f312471481e4b61d9c238b91ca2>>
+ * @generated SignedSource<<2ec25f9c2f7d790a93fc796dedd2ba27>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
 export type CreateChatPromptInput = {
   description?: string | null;
@@ -19,7 +20,7 @@ export type ChatPromptVersionInput = {
   description?: string | null;
   invocationParameters?: any;
   modelName: string;
-  modelProvider: string;
+  modelProvider: ModelProvider;
   responseFormat?: ResponseFormatInput | null;
   template: PromptChatTemplateInput;
   templateFormat: PromptTemplateFormat;

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66058dfaeffd13acd63e348585ba331f>>
+ * @generated SignedSource<<87c08f21a849e8e800405879ec6269bd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
 export type CreateChatPromptVersionInput = {
   promptId: string;
@@ -19,7 +20,7 @@ export type ChatPromptVersionInput = {
   description?: string | null;
   invocationParameters?: any;
   modelName: string;
-  modelProvider: string;
+  modelProvider: ModelProvider;
   responseFormat?: ResponseFormatInput | null;
   template: PromptChatTemplateInput;
   templateFormat: PromptTemplateFormat;

--- a/app/src/pages/playground/__generated__/fetchPlaygroundPromptQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/fetchPlaygroundPromptQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b9ab07fb61de5d9ba0af2dc890d7297>>
+ * @generated SignedSource<<f40ab576e0b77c8118665cf631707595>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type PromptMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
 export type PromptTemplateType = "CHAT" | "STRING";
@@ -28,7 +29,7 @@ export type fetchPlaygroundPromptQuery$data = {
           readonly id: string;
           readonly invocationParameters: any | null;
           readonly modelName: string;
-          readonly modelProvider: string;
+          readonly modelProvider: ModelProvider;
           readonly responseFormat: {
             readonly definition: any;
           } | null;

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -1,9 +1,6 @@
 import { fetchQuery, graphql } from "react-relay";
 
-import {
-  DEFAULT_MODEL_NAME,
-  DEFAULT_MODEL_PROVIDER,
-} from "@phoenix/constants/generativeConstants";
+import { DEFAULT_MODEL_NAME } from "@phoenix/constants/generativeConstants";
 import { fetchPlaygroundPromptSupportedInvocationParametersQuery } from "@phoenix/pages/playground/__generated__/fetchPlaygroundPromptSupportedInvocationParametersQuery.graphql";
 import { GenerativeProviderKey } from "@phoenix/pages/playground/__generated__/ModelSupportedParamsFetcherQuery.graphql";
 import { ChatPromptVersionInput } from "@phoenix/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql";
@@ -152,10 +149,7 @@ export const promptVersionToInstance = ({
   } satisfies Partial<PlaygroundInstance>;
 
   const modelName = promptVersion.modelName;
-  const provider =
-    openInferenceModelProviderToPhoenixModelProvider(
-      promptVersion.modelProvider
-    ) || DEFAULT_MODEL_PROVIDER;
+  const provider = promptVersion.modelProvider;
   const toolChoice =
     safelyConvertToolChoiceToProvider({
       toolChoice: promptVersion.invocationParameters?.tool_choice,

--- a/app/src/pages/prompt/__generated__/PromptChatMessagesCard__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptChatMessagesCard__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ce3679f6bd8692abb0458faa5ede8231>>
+ * @generated SignedSource<<720d6d757ab57b8bdd05bd92d1042663>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,12 +9,13 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type PromptMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
 export type PromptTemplateType = "CHAT" | "STRING";
 import { FragmentRefs } from "relay-runtime";
 export type PromptChatMessagesCard__main$data = {
-  readonly provider: string;
+  readonly provider: ModelProvider;
   readonly template: {
     readonly __typename: "PromptChatTemplate";
     readonly messages: ReadonlyArray<{

--- a/app/src/pages/prompt/__generated__/PromptCodeExportCard__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptCodeExportCard__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d6f0b6d44e5a652a6eae70f8359580cc>>
+ * @generated SignedSource<<df4905af759ce476c010a7b1d249154b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 export type PromptMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type PromptTemplateFormat = "FSTRING" | "MUSTACHE" | "NONE";
 export type PromptTemplateType = "CHAT" | "STRING";
@@ -16,7 +17,7 @@ import { FragmentRefs } from "relay-runtime";
 export type PromptCodeExportCard__main$data = {
   readonly invocationParameters: any | null;
   readonly modelName: string;
-  readonly modelProvider: string;
+  readonly modelProvider: ModelProvider;
   readonly responseFormat: {
     readonly definition: any;
   } | null;

--- a/app/src/pages/prompt/__generated__/PromptLLM__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptLLM__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2336c07c556c0885df2ecde7caef0e37>>
+ * @generated SignedSource<<e3ae651126d6b99e2833c6d01a8ed27d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,11 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 import { FragmentRefs } from "relay-runtime";
 export type PromptLLM__main$data = {
   readonly model: string;
-  readonly provider: string;
+  readonly provider: ModelProvider;
   readonly " $fragmentType": "PromptLLM__main";
 };
 export type PromptLLM__main$key = {

--- a/app/src/pages/prompt/__generated__/PromptModelConfigurationCard__main.graphql.ts
+++ b/app/src/pages/prompt/__generated__/PromptModelConfigurationCard__main.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f9f70fbb8589fdd124633a04931b5a36>>
+ * @generated SignedSource<<d548ea93d304f99bb0992271a2219f73>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,11 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AZURE_OPENAI" | "GEMINI" | "OPENAI";
 import { FragmentRefs } from "relay-runtime";
 export type PromptModelConfigurationCard__main$data = {
   readonly model: string;
-  readonly provider: string;
+  readonly provider: ModelProvider;
   readonly " $fragmentSpreads": FragmentRefs<"PromptInvocationParameters__main" | "PromptLLM__main" | "PromptResponseFormatFragment" | "PromptTools__main">;
   readonly " $fragmentType": "PromptModelConfigurationCard__main";
 };

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -335,15 +335,24 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
     updateModelSupportedInvocationParameters: ({
       instanceId,
       supportedInvocationParameters,
+      modelConfigByProvider,
     }) => {
       const instances = get().instances;
       set({
         instances: instances.map((instance) => {
           if (instance.id === instanceId) {
+            // if we have top level model config for the provider, merge it in
+            // this allows us to populate default values for baseUrl, endpoint, and apiVersion
+            // when the user has saved an azure prompt and we load it back in
+            const { baseUrl, endpoint, apiVersion } =
+              modelConfigByProvider[instance.model.provider] ?? {};
             return {
               ...instance,
               model: {
                 ...instance.model,
+                baseUrl: instance.model.baseUrl ?? baseUrl,
+                endpoint: instance.model.endpoint ?? endpoint,
+                apiVersion: instance.model.apiVersion ?? apiVersion,
                 supportedInvocationParameters,
                 // merge the current invocation parameters with the defaults defined in supportedInvocationParameters
                 invocationParameters: mergeInvocationParametersWithDefaults(

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -300,6 +300,7 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
   updateModelSupportedInvocationParameters: (params: {
     instanceId: number;
     supportedInvocationParameters: InvocationParameter[];
+    modelConfigByProvider: ModelConfigByProvider;
   }) => void;
   /**
    * Update an instances model provider, transforming various aspects about the instance to fit the new provider if possible

--- a/src/phoenix/server/api/input_types/PromptVersionInput.py
+++ b/src/phoenix/server/api/input_types/PromptVersionInput.py
@@ -4,6 +4,7 @@ import strawberry
 from strawberry import UNSET
 from strawberry.scalars import JSON
 
+from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.api.helpers.prompts.models import (
     ContentPart,
     PromptChatTemplate,
@@ -81,7 +82,7 @@ class ChatPromptVersionInput:
     invocation_parameters: JSON = strawberry.field(default_factory=dict)
     tools: list[ToolDefinitionInput] = strawberry.field(default_factory=list)
     response_format: Optional[ResponseFormatInput] = None
-    model_provider: str
+    model_provider: ModelProvider
     model_name: str
 
 

--- a/src/phoenix/server/api/types/PromptVersion.py
+++ b/src/phoenix/server/api/types/PromptVersion.py
@@ -9,6 +9,7 @@ from strawberry.scalars import JSON
 from strawberry.types import Info
 
 from phoenix.db import models
+from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.api.context import Context
 from phoenix.server.api.helpers.prompts.models import (
     PromptTemplateFormat,
@@ -39,7 +40,7 @@ class PromptVersion(Node):
     tools: list[ToolDefinition]
     response_format: Optional[ResponseFormat] = None
     model_name: str
-    model_provider: str
+    model_provider: ModelProvider
     metadata: JSON
     created_at: datetime
     cached_sequence_number: Private[Optional[int]] = None
@@ -133,7 +134,7 @@ def to_gql_prompt_version(
         tools=tools,
         response_format=response_format,
         model_name=prompt_version.model_name,
-        model_provider=prompt_version.model_provider.value,
+        model_provider=prompt_version.model_provider,
         metadata=prompt_version.metadata_,
         created_at=prompt_version.created_at,
         cached_sequence_number=sequence_number,


### PR DESCRIPTION
If you saved an azure openai provider prompt, and then tried to load it back into playground, it would load as "openai" and you would lose your endpoint, and base url settings.

Now we properly carry over azure_openai, and we will restore any saved azure (or openai) specific settings when loading prompt into playground

![2025-02-11 15 13 08](https://github.com/user-attachments/assets/7003af7a-ec65-457f-98bb-bcecafed7e9e)

Resolves #6304