### PR TITLE
fix(prompts): Save tool calls from playground message into prompt

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2056,6 +2056,7 @@ type ToolCallFunction {
 }
 
 input ToolCallFunctionInput {
+  type: String = "function"
   name: String!
   arguments: String!
 }

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2ec25f9c2f7d790a93fc796dedd2ba27>>
+ * @generated SignedSource<<bb3a6ca4638cc993cc09a030defe1b77>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -48,6 +48,7 @@ export type ToolCallContentValueInput = {
 export type ToolCallFunctionInput = {
   arguments: string;
   name: string;
+  type?: string | null;
 };
 export type ToolResultContentValueInput = {
   result: any;

--- a/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<87c08f21a849e8e800405879ec6269bd>>
+ * @generated SignedSource<<2933fcb227a57098829643367b8ed68a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -48,6 +48,7 @@ export type ToolCallContentValueInput = {
 export type ToolCallFunctionInput = {
   arguments: string;
   name: string;
+  type?: string | null;
 };
 export type ToolResultContentValueInput = {
   result: any;

--- a/app/src/pages/playground/__tests__/fixtures.ts
+++ b/app/src/pages/playground/__tests__/fixtures.ts
@@ -109,6 +109,7 @@ export const testSpanToolCall: SpanToolCall = {
 
 export const expectedTestOpenAIToolCall: OpenAIToolCall = {
   id: "1",
+  type: "function",
   function: {
     name: "functionName",
     arguments: { arg1: "value1" },

--- a/app/src/pages/playground/__tests__/fixtures.ts
+++ b/app/src/pages/playground/__tests__/fixtures.ts
@@ -107,6 +107,14 @@ export const testSpanToolCall: SpanToolCall = {
   },
 };
 
+export const expectedUnknownToolCall = {
+  id: "1",
+  function: {
+    name: "functionName",
+    arguments: { arg1: "value1" },
+  },
+};
+
 export const expectedTestOpenAIToolCall: OpenAIToolCall = {
   id: "1",
   type: "function",

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -47,6 +47,7 @@ import {
   basePlaygroundSpan,
   expectedAnthropicToolCall,
   expectedTestOpenAIToolCall,
+  expectedUnknownToolCall,
   spanAttributesWithInputMessages,
   SpanTool,
   SpanToolCall,
@@ -702,7 +703,7 @@ describe("processAttributeToolCalls", () => {
       expectedTestOpenAIToolCall,
     ],
     // TODO(apowell): #5348 Add Gemini tool tests
-    GEMINI: ["GEMINI", testSpanToolCall, expectedTestOpenAIToolCall],
+    GEMINI: ["GEMINI", testSpanToolCall, expectedUnknownToolCall],
   };
   test.for(Object.values(ProviderToToolCallTestMap))(
     "should return %s tools, if they are valid",

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -11,10 +11,13 @@ import {
   createOpenAIToolDefinition,
   detectToolDefinitionProvider,
 } from "@phoenix/schemas";
+import { JSONLiteral } from "@phoenix/schemas/jsonLiteralSchema";
 import {
+  AnthropicToolCall,
   createAnthropicToolCall,
   createOpenAIToolCall,
   LlmProviderToolCall,
+  OpenAIToolCall,
 } from "@phoenix/schemas/toolCallSchemas";
 import { safelyConvertToolChoiceToProvider } from "@phoenix/schemas/toolChoiceSchemas";
 import {
@@ -150,18 +153,19 @@ export function processAttributeToolCalls({
         case "AZURE_OPENAI":
           return {
             id: tool_call.id ?? "",
+            type: "function" as const,
             function: {
               name: tool_call.function?.name ?? "",
               arguments: toolCallArgs,
             },
-          };
+          } satisfies OpenAIToolCall;
         case "ANTHROPIC": {
           return {
             id: tool_call.id ?? "",
             type: "tool_use" as const,
             name: tool_call.function?.name ?? "",
             input: toolCallArgs,
-          };
+          } satisfies AnthropicToolCall;
         }
         // TODO(apowell): #5348 Add Gemini tool call
         case "GEMINI":
@@ -171,7 +175,7 @@ export function processAttributeToolCalls({
               name: tool_call.function?.name ?? "",
               arguments: toolCallArgs,
             },
-          };
+          } as JSONLiteral;
         default:
           assertUnreachable(provider);
       }

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -14,7 +14,6 @@ import {
   jsonLiteralSchema,
 } from "@phoenix/schemas/jsonLiteralSchema";
 import { llmProviderToolCallSchema } from "@phoenix/schemas/toolCallSchemas";
-import { ChatMessage } from "@phoenix/store";
 import {
   isObject,
   isStringKeyedObject,
@@ -100,16 +99,14 @@ export const chatMessageRolesSchema = schemaForType<ChatMessageRole>()(
   z.enum(["user", "ai", "system", "tool"])
 );
 
-const chatMessageSchema = schemaForType<ChatMessage>()(
-  z.object({
-    id: z.number(),
-    role: chatMessageRolesSchema,
-    // Tool call messages may not have content
-    content: z.string().optional(),
-    toolCallId: z.string().optional(),
-    toolCalls: z.array(llmProviderToolCallSchema).optional(),
-  })
-);
+export const chatMessageSchema = z.object({
+  id: z.number(),
+  role: chatMessageRolesSchema,
+  // Tool call messages may not have content
+  content: z.string().optional(),
+  toolCallId: z.string().optional(),
+  toolCalls: z.array(llmProviderToolCallSchema).optional(),
+});
 
 /**
  * The zod schema for ChatMessages

--- a/app/src/schemas/messageSchemas.ts
+++ b/app/src/schemas/messageSchemas.ts
@@ -266,6 +266,7 @@ export const promptMessageToOpenAI = promptMessageSchema.transform(
       .filter((part): part is ToolCallPart => !!part)
       .map((part) => ({
         id: part.toolCall.toolCallId,
+        type: "function" as const,
         function: {
           name: part.toolCall.toolCall.name,
           arguments:

--- a/app/src/schemas/toolCallSchemas.ts
+++ b/app/src/schemas/toolCallSchemas.ts
@@ -16,11 +16,16 @@ import { JSONLiteral, jsonLiteralSchema } from "./jsonLiteralSchema";
  */
 export const openAIToolCallSchema = z.object({
   id: z.string().describe("The ID of the tool call"),
+  type: z
+    .literal("function")
+    .describe("The type of the tool call")
+    .default("function"),
   function: z
     .object({
       name: z.string().describe("The name of the function"),
       // TODO(Parker): The arguments here should not actually be a string, however this is a relic from the current way we stream tool calls where the chunks will come in as strings of partial json objects fix this here: https://github.com/Arize-ai/phoenix/issues/5269
       arguments: z
+        // TODO(apowell): This is dishonest. OpenAI and our backend expects a string, but we stringify it behind the scenes.
         .record(z.unknown())
         .describe("The arguments for the function"),
     })
@@ -103,6 +108,7 @@ export const anthropicToolCallsJSONSchema = zodToJsonSchema(
 export const anthropicToolCallToOpenAI = anthropicToolCallSchema.transform(
   (anthropic): OpenAIToolCall => ({
     id: anthropic.id,
+    type: "function",
     function: {
       name: anthropic.name,
       arguments: anthropic.input,
@@ -266,6 +272,7 @@ export const fromPromptToolCallPart = (
 export function createOpenAIToolCall(): OpenAIToolCall {
   return {
     id: "",
+    type: "function",
     function: {
       name: "",
       arguments: {},

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -1,10 +1,10 @@
+import { z } from "zod";
+
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import { InvocationParameterInput } from "@phoenix/pages/playground/__generated__/PlaygroundOutputSubscription.graphql";
 import { InvocationParameter } from "@phoenix/pages/playground/InvocationParametersFormFields";
-import {
-  LlmProviderToolCall,
-  LlmProviderToolDefinition,
-} from "@phoenix/schemas";
+import type { chatMessageSchema } from "@phoenix/pages/playground/schemas";
+import { LlmProviderToolDefinition } from "@phoenix/schemas";
 import {
   AnthropicToolChoice,
   OpenaiToolChoice,
@@ -32,14 +32,7 @@ export type GenAIOperationType = "chat" | "text_completion";
  * }
  * ```
  */
-export type ChatMessage = {
-  id: number;
-  role: ChatMessageRole;
-  // Tool call messages may not have content
-  content?: string;
-  toolCalls?: LlmProviderToolCall[];
-  toolCallId?: string;
-};
+export type ChatMessage = z.infer<typeof chatMessageSchema>;
 
 /**
  * A template for a chat completion playground

--- a/src/phoenix/server/api/input_types/PromptVersionInput.py
+++ b/src/phoenix/server/api/input_types/PromptVersionInput.py
@@ -14,7 +14,6 @@ from phoenix.server.api.helpers.prompts.models import (
     TextContentValue,
     ToolCallContentPart,
     ToolCallContentValue,
-    ToolCallFunction,
     ToolResultContentPart,
     ToolResultContentValue,
 )
@@ -44,10 +43,11 @@ class ToolResultContentValueInput:
     result: JSON
 
 
-@strawberry.experimental.pydantic.input(ToolCallFunction)
+@strawberry.input
 class ToolCallFunctionInput:
-    name: strawberry.auto
-    arguments: strawberry.auto
+    type: Optional[str] = strawberry.field(default="function")
+    name: str
+    arguments: str
 
 
 @strawberry.experimental.pydantic.input(ToolCallContentValue)


### PR DESCRIPTION
Additionally fixes the openai code snippet on the prompt page. The playground does not require you to stringify tool call arguments, but openai sdk does...

Resolves #6313