### PR TITLE
feat(prompts): use generative provider icon

### DIFF
--- a/app/src/pages/playground/ModelConfigButton.tsx
+++ b/app/src/pages/playground/ModelConfigButton.tsx
@@ -23,6 +23,7 @@ import {
 } from "@arizeai/components";
 
 import { Button, Flex, Icon, Icons, Text } from "@phoenix/components";
+import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import {
   AZURE_OPENAI_API_VERSIONS,
@@ -239,9 +240,14 @@ export function ModelConfigButton(props: ModelConfigButtonProps) {
             setDialog(<ModelConfigDialog {...props} />);
           });
         }}
+        leadingVisual={
+          <GenerativeProviderIcon
+            provider={instance.model.provider}
+            height={16}
+          />
+        }
       >
-        <Flex direction="row" gap="size-100" alignItems="center">
-          <Text weight="heavy">{ModelProviders[instance.model.provider]}</Text>
+        <Flex direction="row" gap="size-100" alignItems="center" height="100%">
           <Truncate maxWidth={MODEL_CONFIG_NAME_BUTTON_MAX_WIDTH}>
             <Text>{instance.model.modelName || "--"}</Text>
           </Truncate>

--- a/app/src/pages/playground/ModelProviderPicker.tsx
+++ b/app/src/pages/playground/ModelProviderPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@arizeai/components";
 
 import { Flex, Icon, Icons } from "@phoenix/components";
+import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
 import { isModelProvider } from "@phoenix/utils/generativeUtils";
 
 import type { ModelProviderPickerFragment$key } from "./__generated__/ModelProviderPickerFragment.graphql";
@@ -68,7 +69,14 @@ export function ModelProviderPicker({
         {...props}
       >
         {data.modelProviders.map((provider) => {
-          return <Item key={provider.key}>{provider.name}</Item>;
+          return (
+            <Item key={provider.key}>
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <GenerativeProviderIcon provider={provider.key} height={16} />
+                {provider.name}
+              </Flex>
+            </Item>
+          );
         })}
       </Picker>
       {selectedProviderNotInstalled ? (


### PR DESCRIPTION
<img width="798" alt="Screenshot 2025-02-11 at 10 56 32 PM" src="https://github.com/user-attachments/assets/5ad3dade-6dfd-48b9-bf66-d92745f3b85d" />
