### PR TITLE
fix(prompts): Fix tool definition copy paste button

### DIFF
--- a/app/src/components/CopyToClipboardButton.tsx
+++ b/app/src/components/CopyToClipboardButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { Ref, RefObject, useCallback, useState } from "react";
 import copy from "copy-to-clipboard";
 
 import { Tooltip, TooltipTrigger } from "@arizeai/components";
@@ -19,7 +19,7 @@ export type CopyToClipboardButtonProps = Omit<
   /**
    * The text to copy to the clipboard
    */
-  text: string;
+  text: string | RefObject<string>;
 };
 
 /**
@@ -30,7 +30,8 @@ export function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
   const [isCopied, setIsCopied] = useState(false);
 
   const onPress = useCallback(() => {
-    copy(text);
+    const textToCopy = typeof text === "string" ? text : text.current || "";
+    copy(textToCopy);
     setIsCopied(true);
     setTimeout(() => {
       setIsCopied(false);

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { JSONSchema7 } from "json-schema";
 
 import { Card } from "@arizeai/components";
@@ -32,6 +32,11 @@ import { PlaygroundInstanceProps } from "./types";
  */
 const RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT = 400;
 
+/**
+ * This component is uncontrolled once the initial value is provided.
+ * To reset the value in response to external changes, the parent must
+ * provide a new key prop.
+ */
 export function PlaygroundResponseFormat({
   playgroundInstanceId,
 }: PlaygroundInstanceProps) {
@@ -55,13 +60,16 @@ export function PlaygroundResponseFormat({
       p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME
   );
 
-  const [responseFormatDefinition, setResponseFormatDefinition] = useState(
+  const [initialResponseFormatDefinition] = useState(
     JSON.stringify(responseFormat?.valueJson ?? {}, null, 2)
   );
 
+  const currentValueRef = useRef(initialResponseFormatDefinition);
+
   const onChange = useCallback(
     (value: string) => {
-      setResponseFormatDefinition(value);
+      // track the current value of the editor, even when it is invalid
+      currentValueRef.current = value;
       const { json: format } = safelyParseJSON(value);
       if (format == null) {
         return;
@@ -99,7 +107,7 @@ export function PlaygroundResponseFormat({
             bodyStyle={{ padding: 0 }}
             extra={
               <Flex direction="row" gap="size-100">
-                <CopyToClipboardButton text={responseFormatDefinition} />
+                <CopyToClipboardButton text={currentValueRef} />
                 <Button
                   aria-label="Delete Response Format"
                   leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
@@ -121,7 +129,7 @@ export function PlaygroundResponseFormat({
               }
             >
               <JSONEditor
-                value={responseFormatDefinition}
+                value={initialResponseFormatDefinition}
                 onChange={onChange}
                 jsonSchema={openAIResponseFormatJSONSchema as JSONSchema7}
               />

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { JSONSchema7 } from "json-schema";
 
 import { Card } from "@arizeai/components";
@@ -69,6 +75,9 @@ export function PlaygroundTool({
     JSON.stringify(tool.definition, null, 2)
   );
 
+  // track the current value of the editor, even when it is invalid
+  const currentValueRef = useRef(initialEditorValue);
+
   const [lastValidDefinition, setLastValidDefinition] = useState(
     tool.definition
   );
@@ -86,6 +95,8 @@ export function PlaygroundTool({
 
   const onChange = useCallback(
     (value: string) => {
+      // track the current value of the editor, even when it is invalid
+      currentValueRef.current = value;
       // note that we do not update initialEditorValue here, we only want to update it when
       // we are okay with the editor state resetting, which is basically only when the provider
       // changes
@@ -102,6 +113,8 @@ export function PlaygroundTool({
         return;
       }
 
+      // @todo: Reconsider this approach, as it may lead to a situation where the editor
+      // reflects one definition while what gets saved is another (the last valid one).
       setLastValidDefinition(definition);
 
       updateInstance({
@@ -153,7 +166,7 @@ export function PlaygroundTool({
       bodyStyle={{ padding: 0 }}
       extra={
         <Flex direction="row" gap="size-100">
-          <CopyToClipboardButton text={initialEditorValue} />
+          <CopyToClipboardButton text={currentValueRef} />
           <Button
             aria-label="Delete tool"
             leadingVisual={<Icon svg={<Icons.TrashOutline />} />}


### PR DESCRIPTION
Now that more codemirror editors treat their values as initial state, the copy paste button values were becoming stale.

We now track a live version of editor state onChange that the copy paste button can reference in its callback, without needing to re-render and receive new values every render.

Resolves #6329