### PR TITLE
fix(prompts): load f-string / none template format in playground from template

### DIFF
--- a/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
+++ b/app/src/pages/playground/UpsertPromptFromTemplateDialog.tsx
@@ -10,7 +10,10 @@ import { usePlaygroundStore } from "@phoenix/contexts/PlaygroundContext";
 import { UpsertPromptFromTemplateDialogCreateMutation } from "@phoenix/pages/playground/__generated__/UpsertPromptFromTemplateDialogCreateMutation.graphql";
 import { UpsertPromptFromTemplateDialogUpdateMutation } from "@phoenix/pages/playground/__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql";
 import { instanceToPromptVersion } from "@phoenix/pages/playground/fetchPlaygroundPrompt";
-import { denormalizePlaygroundInstance } from "@phoenix/pages/playground/playgroundUtils";
+import {
+  convertTemplateLanguageToTemplateFormat,
+  denormalizePlaygroundInstance,
+} from "@phoenix/pages/playground/playgroundUtils";
 import {
   SavePromptForm,
   SavePromptSubmitHandler,
@@ -43,12 +46,9 @@ const getInstancePromptParamsFromStore = (
   if (!promptInput) {
     throw new Error(`Could not convert instance ${instanceId} to prompt`);
   }
-  const templateFormat: "FSTRING" | "MUSTACHE" | "NONE" =
-    state.templateLanguage === "F_STRING"
-      ? "FSTRING"
-      : state.templateLanguage === "MUSTACHE"
-        ? "MUSTACHE"
-        : "NONE";
+  const templateFormat = convertTemplateLanguageToTemplateFormat(
+    state.templateLanguage
+  );
   return {
     promptInput,
     templateFormat,

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1,5 +1,6 @@
 import { LLMProvider } from "@arizeai/openinference-semantic-conventions";
 
+import { TemplateLanguages } from "@phoenix/components/templateEditor/constants";
 import { getTemplateLanguageUtils } from "@phoenix/components/templateEditor/templateEditorUtils";
 import { TemplateLanguage } from "@phoenix/components/templateEditor/types";
 import {
@@ -40,8 +41,6 @@ import {
 } from "@phoenix/typeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
-import { TemplateLanguages } from "../../components/templateEditor/constants";
-
 import { ChatCompletionOverDatasetInput } from "./__generated__/PlaygroundDatasetExamplesTableSubscription.graphql";
 import {
   ChatCompletionInput,
@@ -49,6 +48,7 @@ import {
   ChatCompletionMessageRole,
   InvocationParameterInput,
 } from "./__generated__/PlaygroundOutputSubscription.graphql";
+import { PromptTemplateFormat } from "./__generated__/UpsertPromptFromTemplateDialogUpdateMutation.graphql";
 import {
   ChatRoleMap,
   INPUT_MESSAGES_PARSING_ERROR,
@@ -1260,4 +1260,40 @@ export function mergeInvocationParametersWithDefaults(
 
   // Return the new invocation parameter inputs as an array
   return Array.from(currentInvocationParametersMap.values());
+}
+
+/**
+ * Function that converts graphql template format to a template language
+ */
+export function convertTemplateFormatToTemplateLanguage(
+  templateFormat: PromptTemplateFormat
+): TemplateLanguage {
+  switch (templateFormat) {
+    case "MUSTACHE":
+      return TemplateLanguages.Mustache;
+    case "FSTRING":
+      return TemplateLanguages.FString;
+    case "NONE":
+      return TemplateLanguages.NONE;
+    default:
+      assertUnreachable(templateFormat);
+  }
+}
+
+/**
+ * Function that converts a template language to a graphql template format
+ */
+export function convertTemplateLanguageToTemplateFormat(
+  templateLanguage: TemplateLanguage
+): PromptTemplateFormat {
+  switch (templateLanguage) {
+    case TemplateLanguages.Mustache:
+      return "MUSTACHE";
+    case TemplateLanguages.FString:
+      return "FSTRING";
+    case TemplateLanguages.NONE:
+      return "NONE";
+    default:
+      assertUnreachable(templateLanguage);
+  }
 }

--- a/app/src/pages/prompt/PromptPlaygroundPage.tsx
+++ b/app/src/pages/prompt/PromptPlaygroundPage.tsx
@@ -8,9 +8,11 @@ import {
 } from "@phoenix/store";
 
 import { Playground } from "../playground/Playground";
+import { convertTemplateFormatToTemplateLanguage } from "../playground/playgroundUtils";
 
 export function PromptPlaygroundPage() {
-  const { instanceWithPrompt } = useLoaderData() as PromptPlaygroundLoaderData;
+  const { instanceWithPrompt, templateFormat } =
+    useLoaderData() as PromptPlaygroundLoaderData;
 
   // create a playground instance with the prompt details configured
   // When the playground component mounts and sees the prompt id in the instance,
@@ -24,9 +26,15 @@ export function PromptPlaygroundPage() {
       // we don't want default messages in the instance, just the prompt messages
       template: instanceWithPrompt.template,
     } satisfies PlaygroundInstance;
+    // If there is a template loaded, we default to that format
 
     return { instance };
   }, [instanceWithPrompt]);
 
-  return <Playground instances={[instance]} />;
+  return (
+    <Playground
+      instances={[instance]}
+      templateLanguage={convertTemplateFormatToTemplateLanguage(templateFormat)}
+    />
+  );
 }

--- a/app/src/pages/prompt/promptPlaygroundLoader.tsx
+++ b/app/src/pages/prompt/promptPlaygroundLoader.tsx
@@ -14,7 +14,10 @@ export const promptPlaygroundLoader = async ({
     throw new Error("Prompt not found");
   }
 
-  return { instanceWithPrompt: response.instance };
+  return {
+    instanceWithPrompt: response.instance,
+    templateFormat: response.promptVersion.templateFormat,
+  };
 };
 
 export type PromptPlaygroundLoaderData = Awaited<


### PR DESCRIPTION
resolves #6369

This makes it so that the template when loaded dictates the playground template language at launch.

This uncovered https://github.com/Arize-ai/phoenix/issues/6374 which will be addressed separately.
