### PR TITLE
feat(prompts): client prompt creation

### DIFF
--- a/js/.changeset/tasty-maps-remember.md
+++ b/js/.changeset/tasty-maps-remember.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Add the ability to push prompts via the typescript client sdk

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -1,8 +1,6 @@
 # @arizeai/phoenix-client
 
-This package provides a client for the Phoenix API. It is still under active development and is subject to change.
-
-It utilizes [openapi-ts](https://openapi-ts.pages.dev/) to generate the types from the Phoenix OpenAPI spec.
+This package provides a client for the [Arize Phoenix](https://github.com/Arize-ai/phoenix) API. It is still under active development and is subject to change.
 
 ## Installation
 
@@ -45,11 +43,40 @@ const phoenix = createClient({
 
 ## Prompts
 
-`@arizeai/phoenix-client` provides a `prompts` export that exposes various utilities for working with prompts.
+`@arizeai/phoenix-client` provides a `prompts` export that exposes utilities for working with prompts for LLMs.
+
+### Creating a Prompt and push it to Phoenix
+
+The `createPrompt` function can be used to create a prompt in Phoenix for version control and reuse.
+
+```ts
+import { createPrompt, promptVersion } from "@arizeai/phoenix-client/prompts";
+
+const version = createPrompt({
+  name: "my-prompt",
+  description: "test-description",
+  version: promptVersion({
+    description: "version description here",
+    modelProvider: "OPENAI",
+    modelName: "gpt-3.5-turbo",
+    template: [
+      {
+        role: "user",
+        content: "{{ question }}",
+      },
+    ],
+    invocationParameters: {
+      temperature: 0.8,
+    },
+  }),
+});
+```
+
+Prompts that are pushed to Phoenix are versioned and can be tagged.
 
 ### Pulling a Prompt from Phoenix
 
-The `getPrompt` helper function can be used to pull a prompt from Phoenix based on some Prompt Identifier and returns it in the Phoenix SDK Prompt type.
+The `getPrompt` function can be used to pull a prompt from Phoenix based on some Prompt Identifier and returns it in the Phoenix SDK Prompt type.
 
 ```ts
 import { getPrompt } from "@arizeai/phoenix-client/prompts";
@@ -141,3 +168,15 @@ pnpm install
 pnpx tsx examples/list_datasets.ts
 # change the file name to run other examples
 ```
+
+## Compatibility
+
+This package utilizes [openapi-ts](https://openapi-ts.pages.dev/) to generate the types from the Phoenix OpenAPI spec.
+
+Because of this, this package only works with the `arize-phonix` server 8.0.0 and above.
+
+Compatibility Table:
+
+| Phoenix Client Version | Phoenix Server Version |
+| ---------------------- | ---------------------- |
+| ^1.0.0                 | ^8.0.0                 |

--- a/js/packages/phoenix-client/README.md
+++ b/js/packages/phoenix-client/README.md
@@ -179,4 +179,4 @@ Compatibility Table:
 
 | Phoenix Client Version | Phoenix Server Version |
 | ---------------------- | ---------------------- |
-| ^1.0.0                 | ^8.0.0                 |
+| ^0.0.0                 | ^8.0.0                 |

--- a/js/packages/phoenix-client/examples/create_prompt_openai.ts
+++ b/js/packages/phoenix-client/examples/create_prompt_openai.ts
@@ -1,0 +1,20 @@
+import { createPrompt, promptVersion } from "../src/prompts";
+
+const version = createPrompt({
+  name: "test-prompt",
+  description: "test-description",
+  version: promptVersion({
+    description: "version description here",
+    model_provider: "OPENAI",
+    model_name: "gpt-3.5-turbo",
+    template: [
+      {
+        role: "user",
+        content: "{{ question }}",
+      },
+    ],
+    invocation_parameters: {
+      temperature: 0.8,
+    },
+  }),
+});

--- a/js/packages/phoenix-client/examples/create_prompt_openai.ts
+++ b/js/packages/phoenix-client/examples/create_prompt_openai.ts
@@ -13,15 +13,15 @@ const main = async () => {
     description: "test-description",
     version: promptVersion({
       description: "version description here",
-      model_provider: "OPENAI",
-      model_name: "gpt-4o",
+      modelProvider: "OPENAI",
+      modelName: "gpt-4o",
       template: [
         {
           role: "user",
           content: "{{question}}",
         },
       ],
-      invocation_parameters: {
+      invocationParameters: {
         temperature: 0.8,
       },
     }),

--- a/js/packages/phoenix-client/examples/create_prompt_openai.ts
+++ b/js/packages/phoenix-client/examples/create_prompt_openai.ts
@@ -1,20 +1,56 @@
+/* eslint-disable no-console */
 import { createPrompt, promptVersion } from "../src/prompts";
+import { toSDK } from "../src/prompts";
+import OpenAI from "openai";
 
-const version = createPrompt({
-  name: "test-prompt",
-  description: "test-description",
-  version: promptVersion({
-    description: "version description here",
-    model_provider: "OPENAI",
-    model_name: "gpt-3.5-turbo",
-    template: [
-      {
-        role: "user",
-        content: "{{ question }}",
-      },
-    ],
-    invocation_parameters: {
-      temperature: 0.8,
-    },
-  }),
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
 });
+
+const main = async () => {
+  const prompt = await createPrompt({
+    name: "test-prompt",
+    description: "test-description",
+    version: promptVersion({
+      description: "version description here",
+      model_provider: "OPENAI",
+      model_name: "gpt-4o",
+      template: [
+        {
+          role: "user",
+          content: "{{question}}",
+        },
+      ],
+      invocation_parameters: {
+        temperature: 0.8,
+      },
+    }),
+  });
+  console.log("Prompt Verion:");
+  console.dir(prompt, { depth: null });
+
+  const openAIParams = toSDK({
+    prompt,
+    sdk: "openai",
+    variables: {
+      question: "What is the capital of France?",
+    },
+  })!;
+
+  console.log("OpenAI Params:");
+  console.dir(openAIParams);
+
+  const response = await openai.chat.completions.create({
+    ...openAIParams,
+    model: "gpt-4o",
+    stream: false,
+  });
+
+  console.dir(
+    response.choices[0]?.message.content ??
+      response.choices[0]?.message.tool_calls,
+    { depth: null }
+  );
+};
+
+main();

--- a/js/packages/phoenix-client/examples/create_prompt_openai.ts
+++ b/js/packages/phoenix-client/examples/create_prompt_openai.ts
@@ -20,6 +20,7 @@ const openai = new OpenAI({
 
 const main = async () => {
   const prompt = await createPrompt({
+    client,
     name: "test-prompt",
     description: "test-description",
     version: promptVersion({

--- a/js/packages/phoenix-client/examples/create_prompt_openai.ts
+++ b/js/packages/phoenix-client/examples/create_prompt_openai.ts
@@ -1,7 +1,18 @@
 /* eslint-disable no-console */
+import { createClient } from "../src";
 import { createPrompt, promptVersion } from "../src/prompts";
 import { toSDK } from "../src/prompts";
 import OpenAI from "openai";
+
+// Optional: create a phoenix client to explicitly set the credentials
+const client = createClient({
+  options: {
+    baseUrl: "http://localhost:6006",
+    // headers: {
+    //   Authorization: `Bearer ${process.env.PHOENIX_API_KEY}`,
+    // },
+  },
+});
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY!,

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -55,7 +55,7 @@ export async function createPrompt({
 
 interface PromptVersionInputBase {
   description?: string;
-  model_name: PromptVersionData["model_name"];
+  modelName: PromptVersionData["model_name"];
   /**
    * The template for the prompt version.
    * Currently only chat is supported.
@@ -63,33 +63,33 @@ interface PromptVersionInputBase {
   template: PromptChatMessage[];
   /**
    * The format of the template.
-   * Currently only MUSTACHE is supported.
+   * @default "MUSTACHE"
    */
-  template_format?: PromptVersionData["template_format"];
+  templateFormat?: PromptVersionData["template_format"];
 }
 
 interface OpenAIPromptVersionInput extends PromptVersionInputBase {
-  model_provider: "OPENAI";
-  invocation_parameters?: OpenAIInvocationParameters;
+  modelProvider: "OPENAI";
+  invocationParameters?: OpenAIInvocationParameters;
 }
 
 interface AzureOpenAIPromptVersionInput extends PromptVersionInputBase {
-  model_provider: "AZURE_OPENAI";
-  invocation_parameters?: AzureOpenAIInvocationParameters;
+  modelProvider: "AZURE_OPENAI";
+  invocationParameters?: AzureOpenAIInvocationParameters;
 }
 
 interface AnthropicPromptVersionInput extends PromptVersionInputBase {
-  model_provider: "ANTHROPIC";
+  modelProvider: "ANTHROPIC";
   /**
    * The invocation parameters for the prompt version.
    * For Anthropic, the invocation parameters are required since max_tokens is required.
    */
-  invocation_parameters: AnthropicInvocationParameters;
+  invocationParameters: AnthropicInvocationParameters;
 }
 
 interface GeminiPromptVersionInput extends PromptVersionInputBase {
-  model_provider: "GEMINI";
-  invocation_parameters?: GeminiInvocationParameters;
+  modelProvider: "GEMINI";
+  invocationParameters?: GeminiInvocationParameters;
 }
 
 type PromptVersionInput =
@@ -104,11 +104,11 @@ type PromptVersionInput =
 export function promptVersion(params: PromptVersionInput): PromptVersionData {
   const {
     description = "",
-    model_provider,
-    model_name,
+    modelProvider: model_provider,
+    modelName: model_name,
     template: templateMessages,
-    template_format = "MUSTACHE",
-    invocation_parameters,
+    templateFormat: template_format = "MUSTACHE",
+    invocationParameters: invocation_parameters,
   } = params;
   switch (model_provider) {
     case "OPENAI":

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -1,0 +1,35 @@
+import { createClient } from "../client";
+import { ClientFn } from "../types/core";
+import { PromptVersion } from "../types/prompts";
+
+/**
+ * Parameters to crate a prompt
+ */
+export interface CreatePromptParams extends ClientFn {
+  /**
+   * The name of the promt
+   */
+  name: string;
+  /**
+   * The description of the prompt
+   */
+  description?: string;
+  /**
+   * The prompt version to push onto the history of the promt
+   */
+  version: PromptVersion;
+}
+
+/**
+ * Create a prompt and store it in Phoenix
+ * If a prompt with the same name exists, a new version of the prompt will be appended to the history
+ */
+export async function createPrompt({
+  client: _client,
+  version,
+  ...promptParams
+}: CreatePromptParams): Promise<PromptVersion> {
+  const client = _client ?? createClient();
+  const prompt = await createPrompt({ client, prompt: _prompt });
+  return prompt;
+}

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -1,6 +1,16 @@
 import { createClient } from "../client";
 import { ClientFn } from "../types/core";
-import { PromptData, PromptVersionData, PromptVersion } from "../types/prompts";
+import {
+  PromptData,
+  PromptVersionData,
+  PromptVersion,
+  OpenAIInvocationParameters,
+  AzureOpenAIInvocationParameters,
+  AnthropicInvocationParameters,
+  GeminiInvocationParameters,
+  PromptChatMessage,
+} from "../types/prompts";
+import { assertUnreachable } from "../utils/assertUnreachable";
 
 /**
  * Parameters to crate a prompt
@@ -41,4 +51,131 @@ export async function createPrompt({
     throw new Error("Failed to create prompt");
   }
   return createdPromptVersion;
+}
+
+interface PromptVersionInputBase {
+  description?: string;
+  model_name: PromptVersionData["model_name"];
+  /**
+   * The template for the prompt version.
+   * Currently only chat is supported.
+   */
+  template: PromptChatMessage[];
+  /**
+   * The format of the template.
+   * Currently only MUSTACHE is supported.
+   */
+  template_format?: PromptVersionData["template_format"];
+}
+
+interface OpenAIPromptVersionInput extends PromptVersionInputBase {
+  model_provider: "OPENAI";
+  invocation_parameters?: OpenAIInvocationParameters;
+}
+
+interface AzureOpenAIPromptVersionInput extends PromptVersionInputBase {
+  model_provider: "AZURE_OPENAI";
+  invocation_parameters?: AzureOpenAIInvocationParameters;
+}
+
+interface AnthropicPromptVersionInput extends PromptVersionInputBase {
+  model_provider: "ANTHROPIC";
+  /**
+   * The invocation parameters for the prompt version.
+   * For Anthropic, the invocation parameters are required since max_tokens is required.
+   */
+  invocation_parameters: AnthropicInvocationParameters;
+}
+
+interface GeminiPromptVersionInput extends PromptVersionInputBase {
+  model_provider: "GEMINI";
+  invocation_parameters?: GeminiInvocationParameters;
+}
+
+type PromptVersionInput =
+  | OpenAIPromptVersionInput
+  | AzureOpenAIPromptVersionInput
+  | AnthropicPromptVersionInput
+  | GeminiPromptVersionInput;
+
+/**
+ * A helper function to construct a prompt version declaratively
+ */
+export function promptVersion(params: PromptVersionInput): PromptVersionData {
+  const {
+    description = "",
+    model_provider,
+    model_name,
+    template: templateMessages,
+    template_format = "MUSTACHE",
+    invocation_parameters,
+  } = params;
+  switch (model_provider) {
+    case "OPENAI":
+      return {
+        description,
+        model_provider,
+        model_name,
+        template_type: "CHAT",
+        template_format,
+        template: {
+          type: "chat",
+          messages: templateMessages,
+        },
+        invocation_parameters: {
+          type: "openai",
+          openai: invocation_parameters ?? {},
+        },
+      };
+    case "AZURE_OPENAI":
+      return {
+        description,
+        model_provider,
+        model_name,
+        template_type: "CHAT",
+        template_format,
+        template: {
+          type: "chat",
+          messages: templateMessages,
+        },
+        invocation_parameters: {
+          type: "azure_openai",
+          azure_openai: invocation_parameters ?? {},
+        },
+      };
+    case "ANTHROPIC":
+      return {
+        description,
+        model_provider,
+        model_name,
+        template_type: "CHAT",
+        template_format,
+        template: {
+          type: "chat",
+          messages: templateMessages,
+        },
+        invocation_parameters: {
+          type: "anthropic",
+          anthropic: invocation_parameters,
+        },
+      };
+    case "GEMINI":
+      return {
+        description,
+        model_provider,
+        model_name,
+        template_type: "CHAT",
+        template_format,
+        template: {
+          type: "chat",
+          messages: templateMessages,
+        },
+        invocation_parameters: {
+          type: "gemini",
+          gemini: invocation_parameters ?? {},
+        },
+      };
+    default:
+      assertUnreachable(model_provider);
+  }
 }

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -1,11 +1,11 @@
 import { createClient } from "../client";
 import { ClientFn } from "../types/core";
-import { PromptVersion } from "../types/prompts";
+import { PromptData, PromptVersionData, PromptVersion } from "../types/prompts";
 
 /**
  * Parameters to crate a prompt
  */
-export interface CreatePromptParams extends ClientFn {
+export interface CreatePromptParams extends ClientFn, PromptData {
   /**
    * The name of the promt
    */
@@ -15,9 +15,9 @@ export interface CreatePromptParams extends ClientFn {
    */
   description?: string;
   /**
-   * The prompt version to push onto the history of the promt
+   * The prompt version to push onto the history of the prompt
    */
-  version: PromptVersion;
+  version: PromptVersionData;
 }
 
 /**
@@ -30,6 +30,15 @@ export async function createPrompt({
   ...promptParams
 }: CreatePromptParams): Promise<PromptVersion> {
   const client = _client ?? createClient();
-  const prompt = await createPrompt({ client, prompt: _prompt });
-  return prompt;
+  const response = await client.POST("/v1/prompts", {
+    body: {
+      prompt: promptParams,
+      version: version,
+    },
+  });
+  const createdPromptVersion = response.data?.data;
+  if (!createdPromptVersion) {
+    throw new Error("Failed to create prompt");
+  }
+  return createdPromptVersion;
 }

--- a/js/packages/phoenix-client/src/prompts/index.ts
+++ b/js/packages/phoenix-client/src/prompts/index.ts
@@ -1,2 +1,3 @@
 export * from "./getPrompt";
+export * from "./createPrompt";
 export * from "./sdks";

--- a/js/packages/phoenix-client/src/types/prompts.ts
+++ b/js/packages/phoenix-client/src/types/prompts.ts
@@ -67,11 +67,21 @@ export type PromptSelector =
   | GetPromptByTagSelector;
 
 /**
+ * The prompt data needed to create a prompt.
+ */
+export type PromptData = components["schemas"]["PromptData"];
+
+/**
  * The prompt version type from the API.
  *
  * aka the prompt at a specific point in time
  */
 export type PromptVersion = components["schemas"]["PromptVersion"];
+
+/**
+ * The prompt version data needed to create a prompt version.
+ */
+export type PromptVersionData = components["schemas"]["PromptVersionData"];
 
 /**
  * The format of the prompt template message(s).

--- a/js/packages/phoenix-client/src/types/prompts.ts
+++ b/js/packages/phoenix-client/src/types/prompts.ts
@@ -84,6 +84,30 @@ export type PromptVersion = components["schemas"]["PromptVersion"];
 export type PromptVersionData = components["schemas"]["PromptVersionData"];
 
 /**
+ * The invocation parameters for a prompt version for OpenAI.
+ */
+export type OpenAIInvocationParameters =
+  components["schemas"]["PromptOpenAIInvocationParametersContent"];
+
+/**
+ * The invocation parameters for a prompt version for Azure OpenAI.
+ */
+export type AzureOpenAIInvocationParameters =
+  components["schemas"]["PromptAzureOpenAIInvocationParametersContent"];
+
+/**
+ * The invocation parameters for a prompt version for Anthropic.
+ */
+export type AnthropicInvocationParameters =
+  components["schemas"]["PromptAnthropicInvocationParametersContent"];
+
+/**
+ * The invocation parameters for a prompt version for Gemini.
+ */
+export type GeminiInvocationParameters =
+  components["schemas"]["PromptGeminiInvocationParametersContent"];
+
+/**
  * The format of the prompt template message(s).
  */
 export type PromptTemplateFormat = PromptVersion["template_format"];

--- a/js/packages/phoenix-client/src/utils/formatPromptMessages.ts
+++ b/js/packages/phoenix-client/src/utils/formatPromptMessages.ts
@@ -47,22 +47,33 @@ export function formatPromptMessages(
     ...message,
     content:
       typeof message.content == "string"
-        ? message.content // TODO: Fix this string substitution
+        ? applyReplacements(message.content, replacements)
         : message.content.map((content) => {
             const textPart = asTextPart(content);
             if (textPart) {
-              let newText = textPart.text;
-              const toReplace = [...replacements];
-              while (toReplace.length > 0) {
-                const [key, value] = toReplace.shift()!;
-                newText = newText.replaceAll(key, value);
-              }
               return {
                 ...textPart,
-                text: newText,
+                text: applyReplacements(textPart.text, replacements),
               } satisfies TextPart;
             }
             return content;
           }),
   }));
+}
+
+/**
+ * Apply a list of replacements to a string
+ * @param text - The text to apply the replacements to
+ * @param replacements - The replacements to apply
+ * @returns The text with the replacements applied
+ */
+function applyReplacements(
+  text: string,
+  replacements: [RegExp, string][]
+): string {
+  let newText = text;
+  for (const [key, value] of replacements) {
+    newText = newText.replaceAll(key, value);
+  }
+  return newText;
 }

--- a/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
@@ -77,15 +77,15 @@ describe("createPrompt", () => {
       name: "test-prompt",
       description: "test-description",
       version: promptVersion({
-        model_provider: "OPENAI",
-        model_name: "gpt-3.5-turbo",
+        modelProvider: "OPENAI",
+        modelName: "gpt-3.5-turbo",
         template: [
           {
             role: "user",
             content: "{{ question }}",
           },
         ],
-        invocation_parameters: {
+        invocationParameters: {
           temperature: 0.5,
         },
       }),

--- a/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
@@ -8,7 +8,6 @@ vi.mock("openapi-fetch", () => ({
       data: {
         data: {
           id: "mocked-prompt-id",
-          // Add other expected prompt properties here
           description: "test-description",
           model_provider: "OPENAI",
           model_name: "gpt-3.5-turbo",

--- a/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createPrompt } from "../../src/prompts";
+import { createPrompt, promptVersion } from "../../src/prompts";
 
 // Mock the fetch module
 vi.mock("openapi-fetch", () => ({
@@ -70,6 +70,27 @@ describe("createPrompt", () => {
       },
     });
 
+    expect(prompt).toBeDefined();
+    expect(prompt.id).toBe("mocked-prompt-id");
+  });
+  it("should let you craate a prompt usering promptVersion", async () => {
+    const prompt = await createPrompt({
+      name: "test-prompt",
+      description: "test-description",
+      version: promptVersion({
+        model_provider: "OPENAI",
+        model_name: "gpt-3.5-turbo",
+        template: [
+          {
+            role: "user",
+            content: "{{ question }}",
+          },
+        ],
+        invocation_parameters: {
+          temperature: 0.5,
+        },
+      }),
+    });
     expect(prompt).toBeDefined();
     expect(prompt.id).toBe("mocked-prompt-id");
   });

--- a/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
+++ b/js/packages/phoenix-client/test/prompts/createPrompt.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createPrompt } from "../../src/prompts";
+
+// Mock the fetch module
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    POST: vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          id: "mocked-prompt-id",
+          // Add other expected prompt properties here
+          description: "test-description",
+          model_provider: "OPENAI",
+          model_name: "gpt-3.5-turbo",
+          template_type: "CHAT",
+          template_format: "MUSTACHE",
+          invocation_parameters: {
+            type: "openai",
+            openai: {
+              temperature: 0.5,
+            },
+          },
+          template: {
+            type: "chat",
+            messages: [
+              {
+                role: "user",
+                content: "{{ question }}",
+              },
+            ],
+          },
+        },
+      },
+      error: null,
+    }),
+  }),
+}));
+
+describe("createPrompt", () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  it("should create a prompt", async () => {
+    const prompt = await createPrompt({
+      name: "test-prompt",
+      description: "test-description",
+      version: {
+        description: "test-description",
+        model_provider: "OPENAI",
+        model_name: "gpt-3.5-turbo",
+        template_type: "CHAT",
+        template_format: "MUSTACHE",
+        invocation_parameters: {
+          type: "openai",
+          openai: {
+            temperature: 0.5,
+          },
+        },
+        template: {
+          type: "chat",
+          messages: [
+            {
+              role: "user",
+              content: "{{ question }}",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(prompt).toBeDefined();
+    expect(prompt.id).toBe("mocked-prompt-id");
+  });
+});

--- a/js/packages/phoenix-client/test/utils/formatPromptMessages.test.ts
+++ b/js/packages/phoenix-client/test/utils/formatPromptMessages.test.ts
@@ -62,6 +62,21 @@ describe("formatPromptMessages", () => {
       });
     });
 
+    it("should support string content", () => {
+      const messages: PromptChatMessage[] = [
+        {
+          role: "user",
+          content: "Hello {{firstName}} {{lastName}}",
+        },
+      ];
+
+      const formatted = formatPromptMessages("MUSTACHE", messages, {
+        firstName: "John",
+        lastName: "Doe",
+      });
+      expect(formatted?.[0]?.content).toEqual("Hello John Doe");
+    });
+
     it("should replace multiple instances of same variable", () => {
       const messages: PromptChatMessage[] = [
         {
@@ -136,6 +151,21 @@ describe("formatPromptMessages", () => {
         type: "text",
         text: "Hello there, World!",
       });
+    });
+
+    it("should support string content", () => {
+      const messages: PromptChatMessage[] = [
+        {
+          role: "user",
+          content: "Hello {firstName} {lastName}",
+        },
+      ];
+
+      const formatted = formatPromptMessages("F_STRING", messages, {
+        firstName: "John",
+        lastName: "Doe",
+      });
+      expect(formatted?.[0]?.content).toEqual("Hello John Doe");
     });
 
     it("should replace multiple instances of same variable", () => {


### PR DESCRIPTION
Adds support for prompt version creation from the typescript client

```typescript
import { createPrompt, promptVersion } from "@arizeai/phoenix-client";

const version = createPrompt({
  name: "test-prompt",
  description: "test-description",
  version: promptVersion({
    description: "version description here",
    modelProvider: "OPENAI",
    modelName: "gpt-3.5-turbo",
    template: [
      {
        role: "user",
        content: "{{ question }}",
      },
    ],
    invocationParameters: {
      temperature: 0.8,
    },
  }),
});

```