### PR TITLE
feat: Allow configuration of postgres username/password/db/host using standard env vars

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -624,7 +624,7 @@ def get_env_project_name() -> str:
 
 
 def get_env_database_connection_str() -> str:
-    phoenix_url = os.getenv("ENV_PHOENIX_SQL_DATABASE_URL")
+    phoenix_url = os.getenv(ENV_PHOENIX_SQL_DATABASE_URL)
 
     if phoenix_url:
         parsed = urlparse(phoenix_url)

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -627,30 +627,6 @@ def get_env_database_connection_str() -> str:
     phoenix_url = os.getenv(ENV_PHOENIX_SQL_DATABASE_URL)
 
     if phoenix_url:
-        parsed = urlparse(phoenix_url)
-        # If a postgres connection string is provided without credentials,
-        # attempt to insert them from the PostgreSQL environment variables
-        # https://hub.docker.com/_/postgres
-        if phoenix_url.startswith("postgres") and not parsed.username:
-            pg_user = os.getenv("POSTGRES_USER")
-            pg_password = os.getenv("POSTGRES_PASS")
-            pg_db = os.getenv("POSTGRES_DB") or (
-                parsed.path.lstrip("/") if parsed.path.lstrip("/") else None
-            )
-            pg_port = os.getenv("POSTGRES_PORT") or parsed.port
-
-            if pg_user and pg_password:
-                encoded_password = quote_plus(pg_password)
-
-                netloc = f"{pg_user}:{encoded_password}@{parsed.hostname}"
-                if pg_port:
-                    netloc += f":{pg_port}"
-                new_parsed = parsed._replace(netloc=netloc)
-
-                if pg_db:
-                    new_parsed = new_parsed._replace(path=f"/{pg_db}")
-
-                return urlunparse(new_parsed)
         return phoenix_url
 
     # try to build the connection string entirely from PostgreSQL environment variables.
@@ -663,9 +639,6 @@ def get_env_database_connection_str() -> str:
     if pg_host and ":" in pg_host:
         pg_host, parsed_port = pg_host.split(":")
         pg_port = pg_port or parsed_port  # use the explicitly set port if provided
-
-    if pg_host == "localhost" and not pg_port:
-        pg_port = "5432"
 
     if pg_host and pg_user and pg_password:
         encoded_password = quote_plus(pg_password)

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -8,7 +8,7 @@ from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
 from typing import Optional, cast, overload
-from urllib.parse import quote_plus, urlparse, urlunparse
+from urllib.parse import quote_plus, urlparse
 
 from phoenix.utilities.logging import log_a_list
 
@@ -624,12 +624,17 @@ def get_env_project_name() -> str:
 
 
 def get_env_database_connection_str() -> str:
-    phoenix_url = os.getenv(ENV_PHOENIX_SQL_DATABASE_URL)
-
-    if phoenix_url:
+    if phoenix_url := os.getenv(ENV_PHOENIX_SQL_DATABASE_URL):
         return phoenix_url
 
-    # try to build the connection string entirely from PostgreSQL environment variables.
+    if postgres_url := get_env_postgres_connection_str():
+        return postgres_url
+
+    working_dir = get_working_dir()
+    return f"sqlite:///{working_dir}/phoenix.db"
+
+
+def get_env_postgres_connection_str() -> Optional[str]:
     pg_user = os.getenv("PHOENIX_POSTGRES_USER")
     pg_password = os.getenv("PHOENIX_POSTGRES_PASSWORD")
     pg_host = os.getenv("PHOENIX_POSTGRES_HOST")
@@ -649,9 +654,7 @@ def get_env_database_connection_str() -> str:
             connection_str = f"{connection_str}/{pg_db}"
 
         return connection_str
-
-    working_dir = get_working_dir()
-    return f"sqlite:///{working_dir}/phoenix.db"
+    return None
 
 
 def get_env_database_schema() -> Optional[str]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -653,6 +653,26 @@ def get_env_database_connection_str() -> str:
                 return urlunparse(new_parsed)
         return phoenix_url
 
+    # try to build the connection string entirely from PostgreSQL environment variables.
+    pg_user = os.getenv("POSTGRES_USER")
+    pg_password = os.getenv("POSTGRES_PASS")
+    pg_host = os.getenv("POSTGRES_HOST", "localhost")
+    pg_port = os.getenv("POSTGRES_PORT")
+    pg_db = os.getenv("POSTGRES_DB")
+
+    if ":" in pg_host:
+        pg_host, pg_port = pg_host.split(":")
+
+    if pg_host == "localhost" and not pg_port:
+        pg_port = "5432"
+
+    if pg_user and pg_password and pg_db:
+        encoded_password = quote_plus(pg_password)
+        if pg_port:
+            return f"postgresql://{pg_user}:{encoded_password}@{pg_host}:{pg_port}/{pg_db}"
+        else:
+            return f"postgresql://{pg_user}:{encoded_password}@{pg_host}/{pg_db}"
+
     working_dir = get_working_dir()
     return f"sqlite:///{working_dir}/phoenix.db"
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -630,11 +630,11 @@ def get_env_database_connection_str() -> str:
         return phoenix_url
 
     # try to build the connection string entirely from PostgreSQL environment variables.
-    pg_user = os.getenv("POSTGRES_USER")
-    pg_password = os.getenv("POSTGRES_PASS")
-    pg_host = os.getenv("POSTGRES_HOST")
-    pg_port = os.getenv("POSTGRES_PORT")
-    pg_db = os.getenv("POSTGRES_DB")
+    pg_user = os.getenv("PHOENIX_POSTGRES_USER")
+    pg_password = os.getenv("PHOENIX_POSTGRES_PASSWORD")
+    pg_host = os.getenv("PHOENIX_POSTGRES_HOST")
+    pg_port = os.getenv("PHOENIX_POSTGRES_PORT")
+    pg_db = os.getenv("PHOENIX_POSTGRES_DB")
 
     if pg_host and ":" in pg_host:
         pg_host, parsed_port = pg_host.split(":")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,9 +1,10 @@
+import pytest
 from urllib.parse import quote_plus
 
 from phoenix.config import get_env_postgres_connection_str
 
 
-def test_missing_required_vars(monkeypatch):
+def test_missing_required_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PHOENIX_POSTGRES_USER", raising=False)
     monkeypatch.delenv("PHOENIX_POSTGRES_PASSWORD", raising=False)
     monkeypatch.delenv("PHOENIX_POSTGRES_HOST", raising=False)
@@ -16,7 +17,7 @@ def test_missing_required_vars(monkeypatch):
     assert get_env_postgres_connection_str() is None
 
 
-def test_basic_connection_string(monkeypatch):
+def test_basic_connection_string(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
     monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
@@ -27,7 +28,7 @@ def test_basic_connection_string(monkeypatch):
     assert get_env_postgres_connection_str() == expected
 
 
-def test_with_port_from_env(monkeypatch):
+def test_with_port_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
     monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
@@ -38,7 +39,7 @@ def test_with_port_from_env(monkeypatch):
     assert get_env_postgres_connection_str() == expected
 
 
-def test_with_port_in_host(monkeypatch):
+def test_with_port_in_host(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
     # Host includes a port, and no explicit port is set.
@@ -50,7 +51,7 @@ def test_with_port_in_host(monkeypatch):
     assert get_env_postgres_connection_str() == expected
 
 
-def test_overrides_port_in_host(monkeypatch):
+def test_overrides_port_in_host(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
     monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:5432")
@@ -61,7 +62,7 @@ def test_overrides_port_in_host(monkeypatch):
     assert get_env_postgres_connection_str() == expected
 
 
-def test_with_db(monkeypatch):
+def test_with_db(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
     monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
@@ -72,7 +73,7 @@ def test_with_db(monkeypatch):
     assert get_env_postgres_connection_str() == expected
 
 
-def test_with_all_params_and_special_chars(monkeypatch):
+def test_with_all_params_and_special_chars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
     monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pa ss")
     monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:5432")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,83 @@
+from urllib.parse import quote_plus
+
+from phoenix.config import get_env_postgres_connection_str
+
+
+def test_missing_required_vars(monkeypatch):
+    monkeypatch.delenv("PHOENIX_POSTGRES_USER", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_PASSWORD", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_HOST", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_PORT", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    assert get_env_postgres_connection_str() is None
+
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
+    assert get_env_postgres_connection_str() is None
+
+
+def test_basic_connection_string(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
+    monkeypatch.delenv("PHOENIX_POSTGRES_PORT", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_with_port_from_env(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "5555")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost:5555"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_with_port_in_host(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # Host includes a port, and no explicit port is set.
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:6666")
+    monkeypatch.delenv("PHOENIX_POSTGRES_PORT", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost:6666"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_overrides_port_in_host(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:5432")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "9999")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost:9999"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_with_db(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("PHOENIX_POSTGRES_DB", "mydb")
+    monkeypatch.delenv("PHOENIX_POSTGRES_PORT", raising=False)
+
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost/mydb"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_with_all_params_and_special_chars(monkeypatch):
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pa ss")
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:5432")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "1234")
+    monkeypatch.setenv("PHOENIX_POSTGRES_DB", "mydb")
+
+    expected = f"postgresql://user:{quote_plus('pa ss')}@localhost:1234/mydb"
+    assert get_env_postgres_connection_str() == expected

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,6 @@
-import pytest
 from urllib.parse import quote_plus
+
+import pytest
 
 from phoenix.config import get_env_postgres_connection_str
 


### PR DESCRIPTION
resolves #5307 

The db_connection string for postgres databases can now be configured with the following env vars

PHOENIX_POSTGRES_USER
PHOENIX_POSTGRES_PASSWORD
PHOENIX_POSTGRES_DB
PHOENIX_POSTGRES_PORT
PHOENIX_POSTGRES_HOST