### PR TITLE
fix(prompts): Parse tool result json correctly

### DIFF
--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -225,8 +225,7 @@ function MessageEditor({
     );
   }
   if (message.role === "tool") {
-    let toolMessageContent = message.content || "";
-    toolMessageContent = normalizeMessageContent(toolMessageContent);
+    const toolMessageContent = normalizeMessageContent(message.content);
     return (
       <Form
         onSubmit={(e) => {

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -225,7 +225,8 @@ function MessageEditor({
     );
   }
   if (message.role === "tool") {
-    const toolMessageContent = message.content || "";
+    let toolMessageContent = message.content || "";
+    toolMessageContent = normalizeMessageContent(toolMessageContent);
     return (
       <Form
         onSubmit={(e) => {

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1534,24 +1534,36 @@ describe("mergeInvocationParametersWithDefaults", () => {
 });
 
 describe("normalizeMessageContent", () => {
-  it("should return the content as a string", () => {
+  it("should return unknown json content as a string", () => {
     const content = "Hello, world!";
-    expect(normalizeMessageContent(content)).toBe(content);
+    expect(normalizeMessageContent(content)).toBe('"Hello, world!"');
   });
 
-  it("should return the content as a stringified JSON with pretty printing", () => {
+  it("should return the content as a stringified JSON with pretty printing if it is an object", () => {
     const content = { foo: "bar" };
     expect(normalizeMessageContent(content)).toBe(
       JSON.stringify(content, null, 2)
     );
   });
 
-  it("should return the content as a string if it is not a string or object", () => {
+  it("should return the content as a string if it is a number", () => {
     const content = 123;
     expect(normalizeMessageContent(content)).toBe("123");
   });
 
-  it("should return arrays as a stringified JSON", () => {
+  it("should return the content as a string if it is a boolean", () => {
+    const content = true;
+    expect(normalizeMessageContent(content)).toBe("true");
+    const content2 = false;
+    expect(normalizeMessageContent(content2)).toBe("false");
+  });
+
+  it("should return the content as a string if it is null", () => {
+    const content = null;
+    expect(normalizeMessageContent(content)).toBe("null");
+  });
+
+  it("should return the content as a string if it is an array", () => {
     const content = [1, "2", 3, { foo: "bar" }];
     expect(normalizeMessageContent(content)).toBe(
       `[

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -1537,6 +1537,18 @@ describe("normalizeMessageContent", () => {
   it("should return unknown json content as a string", () => {
     const content = "Hello, world!";
     expect(normalizeMessageContent(content)).toBe('"Hello, world!"');
+    const content2 = ".123";
+    expect(normalizeMessageContent(content2)).toBe('".123"');
+    const content3 = "True";
+    expect(normalizeMessageContent(content3)).toBe('"True"');
+    const content4 = "False";
+    expect(normalizeMessageContent(content4)).toBe('"False"');
+    const content5 = "Null";
+    expect(normalizeMessageContent(content5)).toBe('"Null"');
+    const content6 = "a";
+    expect(normalizeMessageContent(content6)).toBe('"a"');
+    const content7 = "u";
+    expect(normalizeMessageContent(content7)).toBe('"u"');
   });
 
   it("should return the content as a stringified JSON with pretty printing if it is an object", () => {
@@ -1549,6 +1561,14 @@ describe("normalizeMessageContent", () => {
   it("should return the content as a string if it is a number", () => {
     const content = 123;
     expect(normalizeMessageContent(content)).toBe("123");
+    const content2 = 123.456;
+    expect(normalizeMessageContent(content2)).toBe("123.456");
+    const content3 = -123.456;
+    expect(normalizeMessageContent(content3)).toBe("-123.456");
+    const content4 = 0;
+    expect(normalizeMessageContent(content4)).toBe("0");
+    const content6 = 0.5;
+    expect(normalizeMessageContent(content6)).toBe("0.5");
   });
 
   it("should return the content as a string if it is a boolean", () => {

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1148,7 +1148,7 @@ export const getChatCompletionOverDatasetInput = ({
  * @returns a normalized json string
  */
 export function normalizeMessageContent(content?: unknown): string {
-  if (content == null || content === "") {
+  if (content === "") {
     return "{}";
   }
 
@@ -1168,16 +1168,23 @@ export function normalizeMessageContent(content?: unknown): string {
         // Stringify the result to ensure consistent formatting
         return JSON.stringify(secondParse, null, 2);
       }
-      // For regular strings, return as-is
-      return content;
-    } catch (e) {
-      // If parsing fails, return the original content
+    } catch {
+      // If parsing fails, fall through
+    }
+    // If the content is a valid non-string top level json value, return it as-is
+    // https://datatracker.ietf.org/doc/html/rfc7159#section-3
+    // 0-9 { [ null false true
+    // a regex that matches possible top level json values, besides strings
+    const nonStringStart = /^\s*[0-9{[\]false true null]/.test(content);
+    if (nonStringStart) {
       return content;
     }
   }
 
-  // For non-string content, stringify it with pretty printing
-  return JSON.stringify(content, null, 2);
+  // For any content that doesn't match the json spec for a top level value, stringify it with pretty printing
+  const out = JSON.stringify(content, null, 2);
+
+  return out;
 }
 
 export function areRequiredInvocationParametersConfigured(

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1175,7 +1175,7 @@ export function normalizeMessageContent(content?: unknown): string {
     // https://datatracker.ietf.org/doc/html/rfc7159#section-3
     // 0-9 { [ null false true
     // a regex that matches possible top level json values, besides strings
-    const nonStringStart = /^\s*[0-9{[\]false true null]/.test(content);
+    const nonStringStart = /^\s*[0-9{[]|true|false|null/.test(content);
     if (nonStringStart) {
       return content;
     }

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1182,9 +1182,7 @@ export function normalizeMessageContent(content?: unknown): string {
   }
 
   // For any content that doesn't match the json spec for a top level value, stringify it with pretty printing
-  const out = JSON.stringify(content, null, 2);
-
-  return out;
+  return JSON.stringify(content, null, 2);
 }
 
 export function areRequiredInvocationParametersConfigured(

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1148,7 +1148,7 @@ export const getChatCompletionOverDatasetInput = ({
  * @returns a normalized json string
  */
 export function normalizeMessageContent(content?: unknown): string {
-  if (content === "") {
+  if (content === "" || typeof content === "undefined") {
     return "{}";
   }
 


### PR DESCRIPTION
A span carrying tool results of every valid json type now parses all values correctly

<img width="912" alt="image" src="https://github.com/user-attachments/assets/ee8f872c-f989-4d64-aee1-d2d280d54191" />

Resolves #6429
