### PR TITLE
fix(prompts): Make tool schema properties field optional

### DIFF
--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -30,14 +30,18 @@ const jsonSchemaPropertiesSchema = z
 export const jsonSchemaZodSchema = z
   .object({
     type: z.literal("object"),
-    properties: z.record(
-      z.union([
-        jsonSchemaPropertiesSchema,
-        z
-          .object({ anyOf: z.array(jsonSchemaPropertiesSchema) })
-          .describe("A list of possible parameter names to their definitions"),
-      ])
-    ),
+    properties: z
+      .record(
+        z.union([
+          jsonSchemaPropertiesSchema,
+          z
+            .object({ anyOf: z.array(jsonSchemaPropertiesSchema) })
+            .describe(
+              "A list of possible parameter names to their definitions"
+            ),
+        ])
+      )
+      .optional(),
     required: z
       .array(z.string())
       .optional()


### PR DESCRIPTION
This formerly invalid tool schema, is now valid and selectable in the tool choice list.

<img width="922" alt="image" src="https://github.com/user-attachments/assets/87aac5de-4710-4106-8dd2-bbff9aa6d189" />

Resolves #6413