### PR TITLE
fix(client): Remove runtime dependency on vercel ai

### DIFF
--- a/js/.changeset/plenty-camels-end.md
+++ b/js/.changeset/plenty-camels-end.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+fix: Remove runtime dependency on `ai` package

--- a/js/examples/notebooks/phoenix_prompts_cross_sdk_tutorial.ipynb
+++ b/js/examples/notebooks/phoenix_prompts_cross_sdk_tutorial.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as PhoenixClient from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502\"\n",
+    "import * as PhoenixClient from \"npm:@arizeai/phoenix-client\"\n",
     "import OpenAI from \"npm:openai\"\n",
     "import { Anthropic } from \"npm:@anthropic-ai/sdk\""
    ]
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as Prompts from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502/prompts\"\n",
+    "import * as Prompts from \"npm:@arizeai/phoenix-client/prompts\"\n",
     "\n",
     "const questionSearcherPrompt = await Prompts.getPrompt({ client: px, prompt: { name: \"question-searcher\" } })\n",
     "\n",

--- a/js/examples/notebooks/phoenix_prompts_openai_tutorial.ipynb
+++ b/js/examples/notebooks/phoenix_prompts_openai_tutorial.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as PhoenixClient from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502\"\n",
+    "import * as PhoenixClient from \"npm:@arizeai/phoenix-client\"\n",
     "import OpenAI from \"npm:openai\""
    ]
   },
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as Prompts from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502/prompts\"\n",
+    "import * as Prompts from \"npm:@arizeai/phoenix-client/prompts\"\n",
     "\n",
     "const questionAskerPrompt = await Prompts.getPrompt({ client: px, prompt: { name: \"question-asker\" } })\n",
     "\n",

--- a/js/examples/notebooks/phoenix_prompts_vercel_ai_sdk.ipynb
+++ b/js/examples/notebooks/phoenix_prompts_vercel_ai_sdk.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as PhoenixClient from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502\"\n",
+    "import * as PhoenixClient from \"npm:@arizeai/phoenix-client\"\n",
     "import ai from \"npm:ai\"\n",
     "import { createOpenAI } from 'npm:@ai-sdk/openai';\n",
     "import { createGoogleGenerativeAI } from 'npm:@ai-sdk/google';"
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import * as Prompts from \"https://esm.sh/pr/Arize-ai/phoenix/@arizeai/phoenix-client@97c8502/prompts\"\n",
+    "import * as Prompts from \"npm:@arizeai/phoenix-client/prompts\"\n",
     "\n",
     "const questionSearcherPrompt = await Prompts.getPrompt({ client: px, prompt: { name: \"question-searcher\" } })\n",
     "\n",

--- a/js/packages/phoenix-client/src/schemas/llm/constants.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/constants.ts
@@ -16,6 +16,7 @@ import {
   openAIToolChoiceToAnthropic,
   openAIToolChoiceToVercelAI,
   openAIToolDefinitionToAnthropic,
+  openAIToolDefinitionToVercelAI,
 } from "./openai/converters";
 import {
   phoenixResponseFormatToOpenAI,
@@ -150,7 +151,7 @@ export const SDKProviderConverterMap = {
     },
     toolDefinitions: {
       toOpenAI: openAIToolDefinitionSchema,
-      fromOpenAI: z.unknown(),
+      fromOpenAI: openAIToolDefinitionToVercelAI,
     },
   }),
 } satisfies Record<PromptProviderSDKs, unknown>;

--- a/js/packages/phoenix-client/src/schemas/llm/converters.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/converters.ts
@@ -378,7 +378,9 @@ export const toOpenAIToolDefinition = (
         validatedToolDefinition
       );
     case "VERCEL_AI":
-      return null;
+      return SDKProviderConverterMap.VERCEL_AI.toolDefinitions.toOpenAI.parse(
+        validatedToolDefinition
+      );
     case null:
       return null;
     default:
@@ -415,7 +417,9 @@ export const fromOpenAIToolDefinition = <
         toolDefinition
       );
     case "VERCEL_AI":
-      return null;
+      return SDKProviderConverterMap.VERCEL_AI.toolDefinitions.fromOpenAI.parse(
+        toolDefinition
+      );
     default:
       assertUnreachable(targetProvider);
   }

--- a/js/packages/phoenix-client/src/schemas/llm/openai/converters.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/openai/converters.ts
@@ -28,6 +28,7 @@ import { isObject } from "../../../utils/isObject";
 import { VercelAIToolChoice } from "../vercel/toolChoiceSchemas";
 import { openAIToolDefinitionSchema } from "./toolSchemas";
 import { AnthropicToolDefinition } from "../anthropic/toolSchemas";
+import { VercelAIToolDefinition } from "../vercel/toolSchemas";
 
 export const openAIChatPartToAnthropic = openaiChatPartSchema.transform(
   (openai) => {
@@ -379,5 +380,21 @@ export const openAIToolDefinitionToAnthropic =
       name: openai.function.name,
       description: openai.function.description ?? openai.function.name,
       input_schema: openai.function.parameters,
+    })
+  );
+
+/**
+ * Parse incoming object as an OpenAI tool definition and immediately convert to Vercel AI format
+ */
+export const openAIToolDefinitionToVercelAI =
+  openAIToolDefinitionSchema.transform(
+    (openai): VercelAIToolDefinition => ({
+      type: "function",
+      description: openai.function.description,
+      parameters: {
+        _type: undefined,
+        jsonSchema: openai.function.parameters,
+        validate: undefined,
+      },
     })
   );

--- a/js/packages/phoenix-client/src/schemas/llm/types.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/types.ts
@@ -22,6 +22,7 @@ import { OpenAIResponseFormat } from "./openai/responseFormatSchema";
 import { AnthropicToolDefinition } from "./anthropic/toolSchemas";
 import { PhoenixToolDefinition } from "./phoenixPrompt/toolSchemas";
 import { PhoenixContentPart } from "./phoenixPrompt/messagePartSchemas";
+import { VercelAIToolDefinition } from "./vercel/toolSchemas";
 
 export type PromptSDKFormat = PromptProviderSDKs | null;
 
@@ -118,7 +119,7 @@ export type ToolDefinitionWithProvider =
     }
   | {
       provider: Extract<PromptSDKFormat, "VERCEL_AI">;
-      validatedToolDefinition: null;
+      validatedToolDefinition: VercelAIToolDefinition;
     }
   | { provider: null; validatedToolDefinition: null };
 

--- a/js/packages/phoenix-client/src/schemas/llm/utils.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/utils.ts
@@ -26,6 +26,7 @@ import { phoenixToolCallSchema } from "./phoenixPrompt/toolCallSchemas";
 import { phoenixToolChoiceSchema } from "./phoenixPrompt/toolChoiceSchemas";
 import { phoenixToolDefinitionSchema } from "./phoenixPrompt/toolSchemas";
 import { phoenixContentPartSchema } from "./phoenixPrompt/messagePartSchemas";
+import { vercelAIToolDefinitionSchema } from "./vercel/toolSchemas";
 
 export const makeSDKConverters = <
   MessageSchema extends ZodTypeAny,
@@ -207,6 +208,11 @@ export const detectToolDefinitionProvider = (
     phoenixToolDefinitionSchema.safeParse(toolDefinition);
   if (phoenixSuccess) {
     return { provider: "PHOENIX", validatedToolDefinition: phoenixData };
+  }
+  const { success: vercelSuccess, data: vercelData } =
+    vercelAIToolDefinitionSchema.safeParse(toolDefinition);
+  if (vercelSuccess) {
+    return { provider: "VERCEL_AI", validatedToolDefinition: vercelData };
   }
   return { provider: null, validatedToolDefinition: null };
 };

--- a/js/packages/phoenix-client/src/schemas/llm/vercel/toolSchemas.ts
+++ b/js/packages/phoenix-client/src/schemas/llm/vercel/toolSchemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+/**
+ * Vercel AI Tool Definition Schema
+ *
+ * Produces the same result as if you called `import { jsonSchema } from "ai"`
+ * https://github.com/vercel/ai/blob/83976abfa99bf26f8227cf493386b8a6f0e71fdd/packages/ui-utils/src/schema.ts#L34
+ */
+export const vercelAIToolDefinitionSchema = z.object({
+  type: z.literal("function"),
+  description: z.string().optional(),
+  parameters: z.object({
+    _type: z.unknown().optional().default(undefined),
+    validate: z.unknown().optional().default(undefined),
+    jsonSchema: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export type VercelAIToolDefinition = z.infer<
+  typeof vercelAIToolDefinitionSchema
+>;


### PR DESCRIPTION
When updating the notebooks to use the npm import of phoenix-client, I discovered a bug where we were accidentally depending on the vercel ai package at runtime for a small util.

Pulled that out so that we don't depend on vercel at runtime. The old notebook imports must have installed all deps, not just normal dependencies