### PR TITLE
feat(performance): don't fetch new traces when the traces slideover is visible

### DIFF
--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate } from "react-router";
+import { useMatch, useNavigate } from "react-router";
 import {
   ColumnDef,
   flexRender,
@@ -62,6 +62,8 @@ const PAGE_SIZE = 50;
 
 export function SpansTable(props: SpansTableProps) {
   const { fetchKey } = useStreamState();
+  // Determine if the table is active based on the current path
+  const isTableActive = !!useMatch("/projects/:projectId");
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [rowSelection, setRowSelection] = useState({});
@@ -370,17 +372,19 @@ export function SpansTable(props: SpansTableProps) {
     const sort = sorting[0];
 
     startTransition(() => {
-      refetch(
-        {
-          sort: sort ? getGqlSort(sort) : DEFAULT_SORT,
-          after: null,
-          first: PAGE_SIZE,
-          filterCondition,
-        },
-        { fetchPolicy: "store-and-network" }
-      );
+      if (isTableActive) {
+        refetch(
+          {
+            sort: sort ? getGqlSort(sort) : DEFAULT_SORT,
+            after: null,
+            first: PAGE_SIZE,
+            filterCondition,
+          },
+          { fetchPolicy: "store-and-network" }
+        );
+      }
     });
-  }, [sorting, refetch, filterCondition, fetchKey]);
+  }, [sorting, refetch, filterCondition, fetchKey, isTableActive]);
   const fetchMoreOnBottomReached = useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate } from "react-router";
+import { useMatch, useNavigate } from "react-router";
 import {
   ColumnDef,
   ExpandedState,
@@ -100,6 +100,8 @@ export function TracesTable(props: TracesTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [filterCondition, setFilterCondition] = useState<string>("");
   const navigate = useNavigate();
+  // Determine if the table is active based on the current path
+  const isTableActive = !!useMatch("/projects/:projectId");
   const { fetchKey } = useStreamState();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<TracesTableQuery, TracesTable_spans$key>(
@@ -480,22 +482,24 @@ export function TracesTable(props: TracesTableProps) {
   ];
 
   useEffect(() => {
-    //if the sorting changes, we need to reset the pagination
-    const sort = sorting[0];
-    startTransition(() => {
-      refetch(
-        {
-          sort: sort ? getGqlSort(sort) : DEFAULT_SORT,
-          after: null,
-          first: PAGE_SIZE,
-          filterCondition: filterCondition,
-        },
-        {
-          fetchPolicy: "store-and-network",
-        }
-      );
-    });
-  }, [sorting, refetch, filterCondition, fetchKey]);
+    if (isTableActive) {
+      //if the sorting changes, we need to reset the pagination
+      const sort = sorting[0];
+      startTransition(() => {
+        refetch(
+          {
+            sort: sort ? getGqlSort(sort) : DEFAULT_SORT,
+            after: null,
+            first: PAGE_SIZE,
+            filterCondition: filterCondition,
+          },
+          {
+            fetchPolicy: "store-and-network",
+          }
+        );
+      });
+    }
+  }, [sorting, refetch, filterCondition, fetchKey, isTableActive]);
   const fetchMoreOnBottomReached = React.useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {


### PR DESCRIPTION
resolves #6480 

When streaming is enabled, the table in the background can keep refetching and causing cache invalidation issues. This PR pauses the streaming state when the tables are no longer active in view.