### PR TITLE
feat(client): typedoc docs gen for phoenix-client

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -51,3 +51,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Release docs
+      # Run pnpm run docs in js/packages/phoenix-client
+      # Deploy the static files in js/packages/phoenix-client/docs to github pages

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ sdist
 # Server static files
 /src/phoenix/server/static/*
 
+# Docgen
+/js/**/docs
+
 # Data files
 *.csv
 !tests/**/fixtures/*.csv

--- a/js/package.json
+++ b/js/package.json
@@ -12,6 +12,7 @@
     "prettier:write": "prettier --write .",
     "type:check": "pnpm run -r type:check",
     "lint": "eslint . --ext .ts",
+    "build": "pnpm run -r build",
     "ci:version": "pnpm changeset version",
     "ci:publish": "pnpm run -r build && pnpm publish -r --access public --provenance"
   },

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -39,7 +39,10 @@
     "build": "tsc --build tsconfig.json tsconfig.esm.json && tsc-alias -p tsconfig.esm.json",
     "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json && rimraf dist/test dist/examples",
     "type:check": "tsc --noEmit",
-    "test": "vitest --typecheck"
+    "test": "vitest --typecheck",
+    "_predocs": "pnpm run build",
+    "docs": "typedoc",
+    "docs:preview": "pnpx http-server ./docs -p 8080 -o"
   },
   "keywords": [],
   "author": "",
@@ -52,6 +55,7 @@
     "openai": "^4.77.0",
     "openapi-typescript": "^7.4.1",
     "tsx": "^4.19.1",
+    "typedoc": "^0.27.7",
     "vitest": "^2.1.8"
   },
   "dependencies": {

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -40,7 +40,6 @@
     "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json && rimraf dist/test dist/examples",
     "type:check": "tsc --noEmit",
     "test": "vitest --typecheck",
-    "_predocs": "pnpm run build",
     "docs": "typedoc",
     "docs:preview": "pnpx http-server ./docs -p 8080 -o"
   },

--- a/js/packages/phoenix-client/src/client.ts
+++ b/js/packages/phoenix-client/src/client.ts
@@ -1,4 +1,4 @@
-import createOpenApiClient, { ClientOptions } from "openapi-fetch";
+import createOpenApiClient, { type ClientOptions } from "openapi-fetch";
 import type {
   paths as oapiPathsV1,
   components as oapiComponentsV1,
@@ -14,7 +14,7 @@ type componentsV1 = oapiComponentsV1;
 type operationsV1 = oapiOperationsV1;
 
 /**
- * Generated openapi types for the Phoenix client
+ * Generated openapi types for the Phoenix client, by API version.
  */
 export type Types = {
   V1: {
@@ -29,6 +29,9 @@ export type Types = {
  * defaults < environment < explicit options
  *
  * Headers are simply replaced, not merged.
+ *
+ * You can call this function before instantiating the client if you need to retain access
+ * to the options that were passed in to the client.
  */
 export const getMergedOptions = ({
   options = {},
@@ -49,10 +52,25 @@ export const getMergedOptions = ({
 /**
  * Create a Phoenix client.
  *
+ * The client is strongly typed and uses generated openapi types.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from "@arize/phoenix-client";
+ *
+ * const client = createClient();
+ *
+ * const response = await client.GET("/v1/traces");
+ * // ^ path string is strongly typed, and completion works with autocomplete
+ * // path parameters, query parameters, and request body are also strongly typed based on the openapi spec,
+ * // the path, and the method.
+ * ```
+ *
  * @param config - The configuration to use for the client.
- * @param config.options - The options to use for the client's OpenAPI Fetch wrapper.
- * @param config.getEnvironmentOptions - The function to use to get the environment options.
- * @returns The Phoenix client.
+ * @param config.options - The options to use for [openapi-fetch.createOpenApiClient](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch).
+ * @param config.getEnvironmentOptions - The function to use to get the environment options. By default, a function that
+ * returns `process.env` is used.
+ * @returns The Phoenix client as a strongly typed [openapi-fetch](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch) client.
  */
 export const createClient = (
   config: {
@@ -65,6 +83,6 @@ export const createClient = (
 };
 
 /**
- * The type of the Phoenix client
+ * Resolved type of the Phoenix client
  */
 export type PhoenixClient = ReturnType<typeof createClient>;

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -13,9 +13,15 @@ import { promisifyResult } from "../utils/promisifyResult";
 import invariant from "tiny-invariant";
 import { pluralize } from "../utils/pluralize";
 import { ClientFn } from "../types/core";
-import { getDatasetLike } from "../utils/getDatasetLike";
+import { getDatasetBySelector } from "../utils/getDatasetBySelector";
 import { type Logger } from "../types/logger";
 
+/**
+ * Parameters for running an experiment.
+ *
+ * @experimental This feature is not complete, and will change in the future.
+ * @deprecated This function will be un-marked as deprecated once the experimental feature flag is removed.
+ */
 export type RunExperimentParams = ClientFn & {
   /**
    * An optional name for the experiment.
@@ -70,7 +76,7 @@ export async function runExperiment({
   record = true,
 }: RunExperimentParams): Promise<RanExperiment> {
   const client = _client ?? createClient();
-  const dataset = await getDatasetLike({ dataset: _dataset, client });
+  const dataset = await getDatasetBySelector({ dataset: _dataset, client });
   invariant(dataset, `Dataset not found`);
   invariant(dataset.examples.length > 0, `Dataset has no examples`);
   const experimentName =
@@ -223,7 +229,7 @@ export async function evaluateExperiment({
   logger: Logger;
 }): Promise<RanExperiment> {
   const client = _client ?? createClient();
-  const dataset = await getDatasetLike({
+  const dataset = await getDatasetBySelector({
     dataset: experiment.datasetId,
     client,
   });

--- a/js/packages/phoenix-client/src/prompts/constants.ts
+++ b/js/packages/phoenix-client/src/prompts/constants.ts
@@ -1,7 +1,7 @@
 import type { PromptModelProvider } from "../types/prompts";
 
 /**
- * A mapping of ModelProvider to a human-readable string
+ * A mapping of PromptModelProvider to a human-readable string
  */
 export const PromptModelProviders: Record<PromptModelProvider, string> = {
   OPENAI: "OpenAI",

--- a/js/packages/phoenix-client/src/prompts/createPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/createPrompt.ts
@@ -13,11 +13,11 @@ import {
 import { assertUnreachable } from "../utils/assertUnreachable";
 
 /**
- * Parameters to crate a prompt
+ * Parameters to create a prompt
  */
 export interface CreatePromptParams extends ClientFn, PromptData {
   /**
-   * The name of the promt
+   * The name of the prompt
    */
   name: string;
   /**
@@ -31,8 +31,12 @@ export interface CreatePromptParams extends ClientFn, PromptData {
 }
 
 /**
- * Create a prompt and store it in Phoenix
- * If a prompt with the same name exists, a new version of the prompt will be appended to the history
+ * Create a prompt and store it in Phoenix.
+ *
+ * If a prompt with the same name exists, a new version of the prompt will be appended to the history.
+ *
+ * @param params - The parameters to create a prompt.
+ * @returns The created prompt version.
  */
 export async function createPrompt({
   client: _client,
@@ -54,7 +58,13 @@ export async function createPrompt({
 }
 
 interface PromptVersionInputBase {
+  /**
+   * The description of the prompt version.
+   */
   description?: string;
+  /**
+   * The name of the model to use for the prompt version.
+   */
   modelName: PromptVersionData["model_name"];
   /**
    * The template for the prompt version.
@@ -99,7 +109,12 @@ type PromptVersionInput =
   | GooglePromptVersionInput;
 
 /**
- * A helper function to construct a prompt version declaratively
+ * A helper function to construct a prompt version declaratively.
+ *
+ * The output of this function can be used to create a prompt version in Phoenix.
+ *
+ * @param params - The parameters to create a prompt version.
+ * @returns Structured prompt version data, not yet persisted to Phoenix.
  */
 export function promptVersion(params: PromptVersionInput): PromptVersionData {
   const {

--- a/js/packages/phoenix-client/src/prompts/getPrompt.ts
+++ b/js/packages/phoenix-client/src/prompts/getPrompt.ts
@@ -1,10 +1,10 @@
 import { createClient } from "../client";
 import { ClientFn } from "../types/core";
 import { PromptSelector, PromptVersion } from "../types/prompts";
-import { getPromptBySelector } from "../utils/getPromptVersionLike";
+import { getPromptBySelector } from "../utils/getPromptBySelector";
 
 /**
- * Parameters for the getPrompt function
+ * Parameters for getting a prompt from Phoenix.
  */
 export interface GetPromptParams extends ClientFn {
   /**
@@ -15,6 +15,9 @@ export interface GetPromptParams extends ClientFn {
 
 /**
  * Get a prompt from the Phoenix API.
+ *
+ * @param params - The parameters to get a prompt.
+ * @returns The prompt version, or null if it does not exist.
  */
 export async function getPrompt({
   client: _client,

--- a/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
+++ b/js/packages/phoenix-client/src/prompts/sdks/toSDK.ts
@@ -64,12 +64,23 @@ type ToSDKParams<T extends SupportedSDK, V extends Variables = Variables> = {
 /**
  * Convert a Phoenix prompt to a specific SDK's parameters
  *
- * @example
+ * @example quickstart
  * ```ts
+ * // Get a prompt from Phoenix, use it via openai sdk
  * const prompt = await getPrompt({ prompt: { name: "my-prompt" } });
  * const openaiParams = toSDK({ sdk: "openai", prompt });
  * const response = await openai.chat.completions.create(openaiParams);
  * ```
+ *
+ * @example type safety
+ * ```ts
+ * // Enforce variable types via Generic argument
+ * const prompt = await getPrompt({ prompt: { name: "my-prompt" } });
+ * const openaiParams = toSDK<"openai", { name: string }>({ sdk: "openai", prompt, variables: { name: "John" } });
+ * ```
+ *
+ * @param params - The parameters to convert a prompt to an SDK's parameters
+ * @returns The SDK's parameters
  */
 export const toSDK = <T extends SupportedSDK, V extends Variables = Variables>({
   sdk: _sdk,

--- a/js/packages/phoenix-client/src/utils/getDatasetBySelector.ts
+++ b/js/packages/phoenix-client/src/utils/getDatasetBySelector.ts
@@ -8,6 +8,9 @@ import { Dataset } from "../types/datasets";
  * Parameters for the getDatasetLike function
  */
 export type GetDatasetLikeParams = {
+  /**
+   * The dataset to get. Can be in the form of a dataset id, an array of examples, or a dataset object.
+   */
   dataset: Dataset | string | Example[];
   client: PhoenixClient;
 };
@@ -19,10 +22,10 @@ export type GetDatasetLikeParams = {
  * If the input is an array of examples, create a new dataset from the examples then return it.
  * If the input is a dataset, return it as is.
  *
- * @param dataset - The dataset to get.
+ * @param params - The parameters to get a dataset.
  * @returns The dataset.
  */
-export async function getDatasetLike({
+export async function getDatasetBySelector({
   dataset,
   client,
 }: GetDatasetLikeParams): Promise<Dataset | null> {

--- a/js/packages/phoenix-client/src/utils/getPromptBySelector.ts
+++ b/js/packages/phoenix-client/src/utils/getPromptBySelector.ts
@@ -7,6 +7,9 @@ import { createClient } from "../client";
  * Parameters for the getPromptBySelector function
  */
 export type GetPromptBySelectorParams = ClientFn & {
+  /**
+   * The prompt to get. Can be in the form of a prompt id, a prompt version id, a prompt name, or a prompt name + tag.
+   */
   prompt: PromptSelector;
 };
 
@@ -17,6 +20,9 @@ export type GetPromptBySelectorParams = ClientFn & {
  * if the input is a prompt version id, fetch that prompt version.
  * if the input is a prompt tag and name, fetch the prompt version that has that tag and name.
  * if the input is a prompt name, fetch the latest prompt version from the client.
+ *
+ * @param params - The parameters to get a prompt.
+ * @returns The nearest prompt version that matches the selector, or null if it does not exist.
  */
 export async function getPromptBySelector({
   client: _client,

--- a/js/packages/phoenix-client/typedoc.jsonc
+++ b/js/packages/phoenix-client/typedoc.jsonc
@@ -1,0 +1,34 @@
+{
+  "name": "ArizeAI Phoenix Client",
+  // We have to manually keep this in sync with the entry points in the package.json
+  // Other projects seem to use one large entry point, but we have a lot of small ones
+  // The jury is out on which is better
+  "entryPoints": ["src/**/index.ts", "src/utils/*.ts", "src/types/*.ts"],
+  // Default kind sort order, but with "Function" first
+  // https://typedoc.org/documents/Options.Organization.html#kindsortorder
+  "kindSortOrder": [
+    "Function",
+    "Reference",
+    "Project",
+    "Module",
+    "Namespace",
+    "Enum",
+    "EnumMember",
+    "Class",
+    "Interface",
+    "TypeAlias",
+    "Constructor",
+    "Property",
+    "Variable",
+    "Accessor",
+    "Method",
+    "Parameter",
+    "TypeParameter",
+    "TypeLiteral",
+    "CallSignature",
+    "ConstructorSignature",
+    "IndexSignature",
+    "GetSignature",
+    "SetSignature",
+  ],
+}

--- a/js/packages/phoenix-client/typedoc.jsonc
+++ b/js/packages/phoenix-client/typedoc.jsonc
@@ -1,5 +1,5 @@
 {
-  "name": "ArizeAI Phoenix Client",
+  "name": "@arizeai/phoenix-client",
   // We have to manually keep this in sync with the entry points in the package.json
   // Other projects seem to use one large entry point, but we have a lot of small ones
   // The jury is out on which is better

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       tsx:
         specifier: ^4.19.1
         version: 4.19.2
+      typedoc:
+        specifier: ^0.27.7
+        version: 0.27.7(typescript@5.7.2)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.17.9)
@@ -540,6 +543,9 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@gerrit0/mini-shiki@1.27.2':
+    resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -751,11 +757,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -774,6 +792,9 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@6.21.0':
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -1123,6 +1144,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
@@ -1460,6 +1485,9 @@ packages:
   linear-sum-assignment@1.0.7:
     resolution: {integrity: sha512-jfLoSGwZNyjfY8eK4ayhjfcIu3BfWvP6sWieYzYI3AWldwXVoWEz1gtrQL10v/8YltYLBunqNjeVFXPMUs+MJg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1484,8 +1512,18 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1745,6 +1783,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1994,10 +2036,20 @@ packages:
     resolution: {integrity: sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==}
     engines: {node: '>=16'}
 
+  typedoc@0.27.7:
+    resolution: {integrity: sha512-K/JaUPX18+61W3VXek1cWC5gwmuLvYTOXJzBvD9W7jFvbPnefRnCHQCEPw7MSNrP/Hj7JJrhZtDDLKdcYm6ucg==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
+
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -2573,6 +2625,12 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@gerrit0/mini-shiki@1.27.2':
+    dependencies:
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2792,10 +2850,26 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.3':
     optional: true
 
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@types/diff-match-patch@1.0.36':
     optional: true
 
   '@types/estree@1.0.6': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
@@ -2815,6 +2889,8 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/semver@7.5.8': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
@@ -3187,6 +3263,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   es-module-lexer@1.6.0: {}
 
@@ -3592,6 +3670,10 @@ snapshots:
       ml-matrix: 6.12.0
       ml-spectra-processing: 14.9.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -3610,9 +3692,22 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lunr@2.3.9: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -3883,6 +3978,8 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   query-registry@3.0.1:
@@ -4111,7 +4208,18 @@ snapshots:
 
   type-fest@4.30.0: {}
 
+  typedoc@0.27.7(typescript@5.7.2):
+    dependencies:
+      '@gerrit0/mini-shiki': 1.27.2
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.7.2
+      yaml: 2.6.1
+
   typescript@5.7.2: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
To use:
```shell
cd js/packages/phoenix-client
pnpm i
pnpm run docs # builds docs
pnpm run docs:preview # serves docs artifacts on local server
```

Includes some minor file reorganization, justifying the feat tag

- [ ] Fill out stub github action. Run typedoc command, ship artifacts to some static site host like github pages
- [ ] Figure out domains. Do we need to match some scheme with python sphinx docs?


https://github.com/user-attachments/assets/d5c89140-5139-49a9-9cf4-10aec014348d

