### PR TITLE
docs(prompts): add prompt create to deno notebook

### DIFF
--- a/js/examples/notebooks/phoenix_prompts_openai_tutorial.ipynb
+++ b/js/examples/notebooks/phoenix_prompts_openai_tutorial.ipynb
@@ -95,9 +95,7 @@
     "\n",
     "Let's set up the prompt to use `OpenAI` as the LLM provider, and lets also add a \"variable\" to one of the prompt messages, named `question`.\n",
     "\n",
-    "This will allow us to pass in a question to the prompt when we invoke it.\n",
-    "\n",
-    "[Follow the steps outlined in the documentation](https://docs.arize.com/phoenix/prompt-engineering/how-to-prompts/create-a-prompt) to build your prompt in the UI.\n",
+    "This will allow us to pass in a question to the prompt when we invoke it\n",
     "\n",
     "Once you have a prompt, you can pull it into the notebook using the Phoenix client."
    ]
@@ -109,7 +107,42 @@
    "outputs": [],
    "source": [
     "import * as Prompts from \"npm:@arizeai/phoenix-client/prompts\"\n",
+    "import { promptVersion } from \"npm:@arizeai/phoenix-client/prompts\"\n",
     "\n",
+    "const questionAskerPrompt = await Prompts.createPrompt({\n",
+    " name: \"question-asker\",\n",
+    " description: \"Asks a question\",\n",
+    " version: promptVersion({\n",
+    "  description: \"Initial version\",\n",
+    "  templateFormat: \"MUSTACHE\",\n",
+    "  modelProvider: \"OPENAI\",\n",
+    "  modelName: \"gpt-3.5-turbo\",\n",
+    "  template: [\n",
+    "   {\n",
+    "     role: \"user\",\n",
+    "     content: \"{{question}}\"\n",
+    "   },\n",
+    "  ],\n",
+    " })\n",
+    "})\n",
+    "\n",
+    "await Deno.jupyter.md`\n",
+    "  ### question-asker prompt\n",
+    "\n",
+    "  \\`\\`\\`json\n",
+    "  ${JSON.stringify(questionAskerPrompt, null, 2)}\n",
+    "  \\`\\`\\`\n",
+    "  `\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// We already have the prompt, but this just proves that we can fetch it from the server as well\n",
     "const questionAskerPrompt = await Prompts.getPrompt({ client: px, prompt: { name: \"question-asker\" } })\n",
     "\n",
     "await Deno.jupyter.md`\n",
@@ -197,8 +230,19 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
   "language_info": {
-   "name": "typescript"
+   "codemirror_mode": "typescript",
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nbconvert_exporter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
partially related to #6500

Adds prompt creation to the notebook for a fully encapsulated example.