### PR TITLE
fix: Add max_completion_tokens to openai param validation

### DIFF
--- a/js/.changeset/brown-months-shout.md
+++ b/js/.changeset/brown-months-shout.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Update type definitions to include max_completion_tokens openai parameter

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -594,6 +594,8 @@ export interface components {
             temperature?: number;
             /** Max Tokens */
             max_tokens?: number;
+            /** Max Completion Tokens */
+            max_completion_tokens?: number;
             /** Frequency Penalty */
             frequency_penalty?: number;
             /** Presence Penalty */
@@ -677,6 +679,8 @@ export interface components {
             temperature?: number;
             /** Max Tokens */
             max_tokens?: number;
+            /** Max Completion Tokens */
+            max_completion_tokens?: number;
             /** Frequency Penalty */
             frequency_penalty?: number;
             /** Presence Penalty */

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -116,6 +116,7 @@ class PromptAnthropicInvocationParametersContent(TypedDict):
 class PromptAzureOpenAIInvocationParametersContent(TypedDict):
     temperature: NotRequired[float]
     max_tokens: NotRequired[int]
+    max_completion_tokens: NotRequired[int]
     frequency_penalty: NotRequired[float]
     presence_penalty: NotRequired[float]
     top_p: NotRequired[float]
@@ -136,6 +137,7 @@ class PromptGoogleInvocationParametersContent(TypedDict):
 class PromptOpenAIInvocationParametersContent(TypedDict):
     temperature: NotRequired[float]
     max_tokens: NotRequired[int]
+    max_completion_tokens: NotRequired[int]
     frequency_penalty: NotRequired[float]
     presence_penalty: NotRequired[float]
     top_p: NotRequired[float]

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
@@ -305,6 +305,8 @@ class _InvocationParametersConversion:
             assert_never(model_provider)
         if "max_completion_tokens" in obj and obj["max_completion_tokens"] is not None:
             content["max_tokens"] = obj["max_completion_tokens"]
+        if "max_tokens" in obj and obj["max_tokens"] is not None:
+            content["max_tokens"] = obj["max_tokens"]
         if "temperature" in obj and obj["temperature"] is not None:
             content["temperature"] = obj["temperature"]
         if "top_p" in obj and obj["top_p"] is not None:

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
@@ -69,6 +69,7 @@ class _ToolKwargs(TypedDict, total=False):
 class _InvocationParameters(TypedDict, total=False):
     frequency_penalty: float
     max_completion_tokens: int
+    max_tokens: int
     presence_penalty: float
     reasoning_effort: ChatCompletionReasoningEffort
     seed: int
@@ -197,8 +198,10 @@ class _InvocationParametersConversion:
         if obj["type"] == "openai":
             openai_params: v1.PromptOpenAIInvocationParametersContent
             openai_params = obj["openai"]
+            if "max_completion_tokens" in openai_params:
+                ans["max_completion_tokens"] = openai_params["max_completion_tokens"]
             if "max_tokens" in openai_params:
-                ans["max_completion_tokens"] = openai_params["max_tokens"]
+                ans["max_tokens"] = openai_params["max_tokens"]
             if "temperature" in openai_params:
                 ans["temperature"] = openai_params["temperature"]
             if "top_p" in openai_params:
@@ -214,8 +217,10 @@ class _InvocationParametersConversion:
         elif obj["type"] == "azure_openai":
             azure_params: v1.PromptAzureOpenAIInvocationParametersContent
             azure_params = obj["azure_openai"]
+            if "max_completion_tokens" in azure_params:
+                ans["max_completion_tokens"] = azure_params["max_completion_tokens"]
             if "max_tokens" in azure_params:
-                ans["max_completion_tokens"] = azure_params["max_tokens"]
+                ans["max_tokens"] = azure_params["max_tokens"]
             if "temperature" in azure_params:
                 ans["temperature"] = azure_params["temperature"]
             if "top_p" in azure_params:

--- a/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/sdk/openai/chat.py
@@ -304,7 +304,7 @@ class _InvocationParametersConversion:
         else:
             assert_never(model_provider)
         if "max_completion_tokens" in obj and obj["max_completion_tokens"] is not None:
-            content["max_tokens"] = obj["max_completion_tokens"]
+            content["max_completion_tokens"] = obj["max_completion_tokens"]
         if "max_tokens" in obj and obj["max_tokens"] is not None:
             content["max_tokens"] = obj["max_tokens"]
         if "temperature" in obj and obj["temperature"] is not None:

--- a/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
+++ b/packages/phoenix-client/tests/canary/sdk/openai/test_chat.py
@@ -424,6 +424,42 @@ class TestCompletionCreateParamsBase:
                 "max_completion_tokens": randint(1, 256),
                 "top_p": random(),
             },
+            {
+                "model": token_hex(8),
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a UI generator. Convert the user input into a UI.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Make a form for {{ feature }}.",
+                    },
+                ],
+                "response_format": cast(
+                    "ResponseFormat",
+                    type_to_response_format_param(
+                        create_model("Response", ui=(_UI, ...)),
+                    ),
+                ),
+                "temperature": random(),
+                "max_tokens": randint(1, 256),
+                "top_p": random(),
+            },
+            {
+                "model": token_hex(8),
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "What is the latest population estimate for {{ location }}?",
+                    }
+                ],
+                "tools": _TOOLS,
+                "tool_choice": "required",
+                "temperature": random(),
+                "max_tokens": randint(1, 256),
+                "top_p": random(),
+            },
         ],
     )
     def test_round_trip(self, obj: CompletionCreateParamsBase) -> None:

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2309,6 +2309,10 @@
             "type": "integer",
             "title": "Max Tokens"
           },
+          "max_completion_tokens": {
+            "type": "integer",
+            "title": "Max Completion Tokens"
+          },
           "frequency_penalty": {
             "type": "number",
             "title": "Frequency Penalty"
@@ -2538,6 +2542,10 @@
           "max_tokens": {
             "type": "integer",
             "title": "Max Tokens"
+          },
+          "max_completion_tokens": {
+            "type": "integer",
+            "title": "Max Completion Tokens"
           },
           "frequency_penalty": {
             "type": "number",

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -348,6 +348,7 @@ class AnthropicToolDefinition(PromptModel):
 class PromptOpenAIInvocationParametersContent(PromptModel):
     temperature: float = UNDEFINED
     max_tokens: int = UNDEFINED
+    max_completion_tokens: int = UNDEFINED
     frequency_penalty: float = UNDEFINED
     presence_penalty: float = UNDEFINED
     top_p: float = UNDEFINED

--- a/tests/integration/prompts/test_prompts.py
+++ b/tests/integration/prompts/test_prompts.py
@@ -386,6 +386,7 @@ class TestClient:
                     top_p=random(),
                     presence_penalty=random(),
                     frequency_penalty=random(),
+                    max_tokens=randint(1, 256),
                     seed=randint(24, 42),
                     messages=[
                         {"role": "system", "content": "You are {role}."},
@@ -403,6 +404,7 @@ class TestClient:
                     top_p=random(),
                     presence_penalty=random(),
                     frequency_penalty=random(),
+                    max_completion_tokens=randint(1, 256),
                     seed=randint(24, 42),
                     messages=[
                         {


### PR DESCRIPTION
Pydantic was not allowing o1 models to be saved as prompts, due to max_completion_params not being defined in invocation param validation

Resolves #6366