### PR TITLE
feat: graphql query to get byte size of each db table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -511,6 +511,11 @@ input DatasetVersionSort {
 """Date with time (isoformat)"""
 scalar DateTime
 
+type DbTableStats {
+  tableName: String!
+  bytes: Int!
+}
+
 input DeleteAnnotationsInput {
   annotationIds: [GlobalID!]!
 }
@@ -1683,6 +1688,7 @@ type Query {
     """HDBSCAN cluster selection epsilon"""
     clusterSelectionEpsilon: Float! = 0
   ): [Cluster!]!
+  dbTableStats: [DbTableStats!]!
 }
 
 type ResponseFormat {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -513,7 +513,7 @@ scalar DateTime
 
 type DbTableStats {
   tableName: String!
-  bytes: Int!
+  numBytes: Int!
 }
 
 input DeleteAnnotationsInput {

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -821,7 +821,7 @@ def _consolidate_sqlite_db_table_stats(
     """
     Consolidate SQLite database stats by combining indexes with their respective tables.
     """
-    aggregate: dict[str, int] = defaultdict(int)
+    aggregate: dict[str, int] = {}
     for name, bytes_ in stats:
         # Skip internal SQLite tables and indexes.
         if name.startswith("ix_") or name.startswith("sqlite_"):

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1,19 +1,21 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional, Union
+from typing import Iterable, Optional, Union, cast
 
 import numpy as np
 import numpy.typing as npt
 import strawberry
-from sqlalchemy import and_, distinct, func, select
+from sqlalchemy import and_, distinct, func, select, text
 from sqlalchemy.orm import joinedload
 from starlette.authentication import UnauthenticatedUser
 from strawberry import ID, UNSET
 from strawberry.relay import Connection, GlobalID, Node
 from strawberry.types import Info
-from typing_extensions import Annotated, TypeAlias
+from typing_extensions import Annotated, TypeAlias, assert_never
 
+from phoenix.config import ENV_PHOENIX_SQL_DATABASE_SCHEMA, getenv
 from phoenix.db import enums, models
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.models import DatasetExample as OrmExample
 from phoenix.db.models import DatasetExampleRevision as OrmRevision
 from phoenix.db.models import DatasetVersion as OrmVersion
@@ -79,6 +81,12 @@ initialize_playground_clients()
 class ModelsInput:
     provider_key: Optional[GenerativeProviderKey]
     model_name: Optional[str] = None
+
+
+@strawberry.type
+class DbTableStats:
+    table_name: str
+    bytes: int
 
 
 @strawberry.type
@@ -780,3 +788,66 @@ class Query:
         return to_gql_clusters(
             clustered_events=clustered_events,
         )
+
+    @strawberry.field
+    async def db_table_stats(
+        self,
+        info: Info[Context, None],
+    ) -> list[DbTableStats]:
+        if info.context.db.dialect == SupportedSQLDialect.SQLITE:
+            stmt = text("SELECT name, sum(pgsize) FROM dbstat group by name;")
+            async with info.context.db() as session:
+                stats = cast(Iterable[tuple[str, int]], await session.execute(stmt))
+                return _consolidate_sqlite_db_stats(stats)
+        if info.context.db.dialect == SupportedSQLDialect.POSTGRESQL:
+            stmt = text(f"""\
+                SELECT c.relname, pg_total_relation_size(c.oid)
+                FROM pg_class as c
+                INNER JOIN pg_namespace as n ON n.oid = c.relnamespace
+                WHERE c.relkind = 'r'
+                AND n.nspname = '{getenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA) or "public"}';
+            """)
+            async with info.context.db() as session:
+                stats = cast(Iterable[tuple[str, int]], await session.execute(stmt))
+                return [
+                    DbTableStats(table_name=table_name, bytes=bytes_)
+                    for table_name, bytes_ in stats
+                ]
+        assert_never(info.context.db.dialect)
+
+
+def _consolidate_sqlite_db_stats(
+    stats: Iterable[tuple[str, int]],
+) -> list[DbTableStats]:
+    """
+    Consolidate SQLite database stats by combining indexes with their respective tables.
+    """
+    aggregate: dict[str, int] = defaultdict(int)
+    for name, bytes_ in stats:
+        # Skip internal SQLite tables and indexes.
+        if name.startswith("ix_") or name.startswith("sqlite_"):
+            continue
+        aggregate[name] = bytes_
+    for name, bytes_ in stats:
+        # Combine indexes with their respective tables.
+        for flag in ["sqlite_autoindex_", "ix_"]:
+            if not name.startswith(flag):
+                continue
+            if parent := _longest_matching_prefix(name[len(flag) :], aggregate.keys()):
+                aggregate[parent] += bytes_
+            break
+    return [
+        DbTableStats(table_name=table_name, bytes=bytes_)
+        for table_name, bytes_ in aggregate.items()
+    ]
+
+
+def _longest_matching_prefix(s: str, prefixes: Iterable[str]):
+    """
+    Return the longest prefix of s that matches any of the given prefixes.
+    """
+    longest = ""
+    for prefix in prefixes:
+        if s.startswith(prefix) and len(prefix) > len(longest):
+            longest = prefix
+    return longest

--- a/tests/__generated__/graphql/__init__.py
+++ b/tests/__generated__/graphql/__init__.py
@@ -310,6 +310,12 @@ class DatasetVersionEdge(BaseModel):
     node: DatasetVersion = Field(...)
 
 
+class DbTableStats(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    numBytes: int
+    tableName: str
+
+
 class DeleteApiKeyMutationPayload(BaseModel):
     model_config = ConfigDict(frozen=True)
     apiKeyId: str

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -180,9 +180,7 @@ async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
     response = await gql_client.execute(query=query)
     assert not response.errors
     assert (data := response.data) is not None
-    assert set(s["tableName"] for s in data["dbTableStats"]) == set(
-        models.Base.metadata.tables.keys()
-    )
+    assert set(s["tableName"] for s in data["dbTableStats"]) == set(models.Base.metadata.tables)
 
 
 @pytest.fixture

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -7,7 +7,6 @@ from sqlalchemy import insert
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
-from phoenix.db.models import Base
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -181,7 +180,9 @@ async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
     response = await gql_client.execute(query=query)
     assert not response.errors
     assert (data := response.data) is not None
-    assert set(s["tableName"] for s in data["dbTableStats"]) == set(Base.metadata.tables.keys())
+    assert set(s["tableName"] for s in data["dbTableStats"]) == set(
+        models.Base.metadata.tables.keys()
+    )
 
 
 @pytest.fixture

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -7,6 +7,7 @@ from sqlalchemy import insert
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.models import Base
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -166,6 +167,21 @@ async def test_compare_experiments_returns_expected_comparisons(
             },
         ]
     }
+
+
+async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
+    query = """
+      query {
+        dbTableStats {
+          tableName
+          bytes
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert set(s["tableName"] for s in data["dbTableStats"]) == set(Base.metadata.tables.keys())
 
 
 @pytest.fixture

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -173,7 +173,7 @@ async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
       query {
         dbTableStats {
           tableName
-          bytes
+          numBytes
         }
       }
     """


### PR DESCRIPTION
Notes:
- SQLite freelist pages are excluded. So the total is not the size on disk, but the sum of existing pages. The size on disk includes pages that are deleted and can be re-used later. See [here](https://www.sqlite.org/dbstat.html) for more info.

screenshot below is using postgres v12

<img width="600" src="https://github.com/user-attachments/assets/81507f26-e920-4c24-91d5-ebafd2ae0654" />
