### PR TITLE
chore(ui): remove codemirror deps

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,6 @@
     "@codemirror/lang-python": "6.1.3",
     "@codemirror/language": "^6.10.3",
     "@codemirror/lint": "^6.8.1",
-    "@codemirror/view": "^6.28.5",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@codemirror/lint':
         specifier: ^6.8.1
         version: 6.8.1
-      '@codemirror/view':
-        specifier: ^6.28.5
-        version: 6.29.0
       '@dnd-kit/core':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/app/src/components/code/JSONBlock.tsx
+++ b/app/src/components/code/JSONBlock.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
-import { EditorView } from "@codemirror/view";
 import { nord } from "@uiw/codemirror-theme-nord";
-import CodeMirror, { ReactCodeMirrorProps } from "@uiw/react-codemirror";
+import CodeMirror, {
+  EditorView,
+  ReactCodeMirrorProps,
+} from "@uiw/react-codemirror";
 
 import { useTheme } from "@phoenix/contexts";
 

--- a/app/src/components/code/JSONEditor.tsx
+++ b/app/src/components/code/JSONEditor.tsx
@@ -2,10 +2,14 @@ import React, { useEffect, useMemo } from "react";
 import { defaultKeymap } from "@codemirror/commands";
 import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
-import { EditorView, hoverTooltip, keymap } from "@codemirror/view";
 import { githubLight } from "@uiw/codemirror-theme-github";
 import { nord } from "@uiw/codemirror-theme-nord";
-import CodeMirror, { ReactCodeMirrorProps } from "@uiw/react-codemirror";
+import CodeMirror, {
+  EditorView,
+  hoverTooltip,
+  keymap,
+  ReactCodeMirrorProps,
+} from "@uiw/react-codemirror";
 import {
   handleRefresh,
   jsonCompletion,


### PR DESCRIPTION
There seems to be times where we load two versions of codemirror. This reduces the number of codemirror dependancies to try to unify. I don't think this is the only cause of issues with codemirror dependancies but it solves a part of it.