### PR TITLE
chore(ui): upgrade resizable panels

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,7 @@
     "react-hotkeys-hook": "^4.5.0",
     "react-markdown": "^9.0.1",
     "react-relay": "^18.2.0",
-    "react-resizable-panels": "^1.0.10",
+    "react-resizable-panels": "^2.1.7",
     "react-router": "^6.25.1",
     "react-router-dom": "^6.25.1",
     "recharts": "^2.12.7",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.3.1)
       react-resizable-panels:
-        specifier: ^1.0.10
-        version: 1.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.1.7
+        version: 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router:
         specifier: ^6.25.1
         version: 6.25.1(react@18.3.1)
@@ -4224,11 +4224,11 @@ packages:
     peerDependencies:
       react: ^16.9.0 || ^17 || ^18
 
-  react-resizable-panels@1.0.10:
-    resolution: {integrity: sha512-0+g0CNqregkuocr+Mi+e6wgWVARnKTYIX3U1QK7GlkLQKCmbymZakx80YGwcRO7HNnKJTQ5v38HlBos/cGxWvg==}
+  react-resizable-panels@2.1.7:
+    resolution: {integrity: sha512-JtT6gI+nURzhMYQYsx8DKkx6bSoOGFp7A3CwMrOb8y5jFHFyqwo9m68UhmXRw57fRVJksFn1TSlm3ywEQ9vMgA==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   react-router-dom@6.25.1:
     resolution: {integrity: sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==}
@@ -10123,7 +10123,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  react-resizable-panels@1.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-resizable-panels@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -13,7 +13,7 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { resizeHandleCSS } from "@phoenix/components/resize";
+import { compactResizeHandleCSS } from "@phoenix/components/resize";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { TraceTree } from "@phoenix/components/trace/TraceTree";
@@ -159,7 +159,7 @@ export function TraceDetails(props: TraceDetailsProps) {
             />
           </ScrollingPanelContent>
         </Panel>
-        <PanelResizeHandle css={resizeHandleCSS} />
+        <PanelResizeHandle css={compactResizeHandleCSS} />
         <Panel>
           <ScrollingTabsWrapper>
             {selectedSpanNodeId ? (


### PR DESCRIPTION
this introduces the idea of pixel based re-sizing, which might be necessary when we want to set a constraint on the trace details views. Still unsure but good to upgrade none the less.