### PR TITLE
feat(traces): make trace tree more readable on smaller sizes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",
-    "@emotion/react": "^11.11.4",
+    "@emotion/react": "^11.14.0",
     "@lezer/generator": "^1.7.1",
     "@playwright/test": "^1.48.0",
     "@storybook/addon-essentials": "^8.4.6",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)(storybook@8.4.6(prettier@3.3.3))
       '@emotion/react':
-        specifier: ^11.11.4
-        version: 11.11.4(@types/react@18.3.10)(react@18.3.1)
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@18.3.10)(react@18.3.1)
       '@lezer/generator':
         specifier: ^1.7.1
         version: 1.7.1
@@ -572,20 +572,20 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@emotion/babel-plugin@11.11.0':
-    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
 
-  '@emotion/cache@11.11.0':
-    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
 
-  '@emotion/hash@0.9.1':
-    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
-  '@emotion/memoize@0.8.1':
-    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
-  '@emotion/react@11.11.4':
-    resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
     peerDependencies:
       '@types/react': '*'
       react: '>=16.8.0'
@@ -593,25 +593,25 @@ packages:
       '@types/react':
         optional: true
 
-  '@emotion/serialize@1.1.4':
-    resolution: {integrity: sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==}
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
 
-  '@emotion/sheet@1.2.2':
-    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
 
-  '@emotion/unitless@0.8.1':
-    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.0.1':
-    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
     peerDependencies:
       react: '>=16.8.0'
 
-  '@emotion/utils@1.2.1':
-    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
 
-  '@emotion/weak-memoize@0.3.1':
-    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -5129,7 +5129,7 @@ snapshots:
 
   '@arizeai/components@2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@emotion/react': 11.11.4(@types/react@18.3.10)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.10)(react@18.3.1)
       '@react-aria/breadcrumbs': 3.5.19(react@18.3.1)
       '@react-aria/button': 3.11.0(react@18.3.1)
       '@react-aria/dialog': 3.5.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5522,13 +5522,13 @@ snapshots:
       react: 18.3.1
       tslib: 2.6.3
 
-  '@emotion/babel-plugin@11.11.0':
+  '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.24.7
-      '@babel/runtime': 7.24.8
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/serialize': 1.1.4
+      '@babel/runtime': 7.26.9
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
       babel-plugin-macros: 3.1.0
       convert-source-map: 1.9.0
       escape-string-regexp: 4.0.0
@@ -5538,27 +5538,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/cache@11.11.0':
+  '@emotion/cache@11.14.0':
     dependencies:
-      '@emotion/memoize': 0.8.1
-      '@emotion/sheet': 1.2.2
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
       stylis: 4.2.0
 
-  '@emotion/hash@0.9.1': {}
+  '@emotion/hash@0.9.2': {}
 
-  '@emotion/memoize@0.8.1': {}
+  '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.11.4(@types/react@18.3.10)(react@18.3.1)':
+  '@emotion/react@11.14.0(@types/react@18.3.10)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.8
-      '@emotion/babel-plugin': 11.11.0
-      '@emotion/cache': 11.11.0
-      '@emotion/serialize': 1.1.4
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
+      '@babel/runtime': 7.26.9
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
     optionalDependencies:
@@ -5566,25 +5566,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/serialize@1.1.4':
+  '@emotion/serialize@1.3.3':
     dependencies:
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/unitless': 0.8.1
-      '@emotion/utils': 1.2.1
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
       csstype: 3.1.3
 
-  '@emotion/sheet@1.2.2': {}
+  '@emotion/sheet@1.4.0': {}
 
-  '@emotion/unitless@0.8.1': {}
+  '@emotion/unitless@0.10.0': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.3.1)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@emotion/utils@1.2.1': {}
+  '@emotion/utils@1.4.2': {}
 
-  '@emotion/weak-memoize@0.3.1': {}
+  '@emotion/weak-memoize@0.4.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -7943,7 +7943,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.24.8
+      '@babel/runtime': 7.26.9
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 

--- a/app/src/components/layout/Flex.tsx
+++ b/app/src/components/layout/Flex.tsx
@@ -2,6 +2,8 @@ import React, { forwardRef, ReactNode, Ref } from "react";
 import { filterDOMProps } from "@react-aria/utils";
 import { css } from "@emotion/react";
 
+import { classNames } from "@arizeai/components";
+
 import { DOMProps, FlexStyleProps } from "@phoenix/components/types";
 import {
   passthroughStyle,
@@ -28,7 +30,7 @@ const flexStyleProps: StyleHandlers = {
 };
 
 function Flex(props: FlexProps, ref: Ref<HTMLDivElement>) {
-  const { children, ...otherProps } = props;
+  const { children, className, ...otherProps } = props;
 
   const matchedBreakpoints = ["base"];
   const { styleProps } = useStyleProps(otherProps);
@@ -59,7 +61,7 @@ function Flex(props: FlexProps, ref: Ref<HTMLDivElement>) {
     <div
       css={flexCSS}
       {...filterDOMProps(otherProps)}
-      className="flex"
+      className={classNames("flex", className)}
       style={style}
       ref={ref}
     >

--- a/app/src/components/trace/LatencyText.tsx
+++ b/app/src/components/trace/LatencyText.tsx
@@ -39,6 +39,7 @@ export function LatencyText({
       alignItems="center"
       justifyContent="start"
       gap="size-50"
+      className="latency-text"
     >
       {showIcon ? (
         <Text color={color} size={size}>

--- a/app/src/components/trace/TokenCount.tsx
+++ b/app/src/components/trace/TokenCount.tsx
@@ -57,7 +57,12 @@ function TokenItem({
   size?: TextProps["size"];
 }) {
   return (
-    <Flex direction="row" gap="size-50" alignItems="center">
+    <Flex
+      direction="row"
+      gap="size-50"
+      alignItems="center"
+      className="token-count-item"
+    >
       <Icon
         svg={<Icons.TokensOutline />}
         css={css`

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -13,7 +13,7 @@ import {
   TriggerWrap,
 } from "@arizeai/components";
 
-import { Button, Flex, Icon, Icons, View } from "@phoenix/components";
+import { Button, Flex, Heading, Icon, Icons } from "@phoenix/components";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
 
@@ -35,6 +35,11 @@ type TraceTreeProps = {
  */
 const NESTING_INDENT = 30;
 
+/**
+ * The breakpoint at which the trace tree switches to compact mode.
+ */
+const COMPACT_BREAKPOINT = "200px";
+
 export function TraceTree(props: TraceTreeProps) {
   const { spans, onSpanClick, selectedSpanNodeId } = props;
   const spanTree = createSpanTree(spans);
@@ -47,6 +52,7 @@ export function TraceTree(props: TraceTreeProps) {
           overflow: hidden;
           height: 100%;
           align-items: stretch;
+          container-type: inline-size;
         `}
       >
         <TraceTreeToolbar />
@@ -57,6 +63,23 @@ export function TraceTree(props: TraceTreeProps) {
             flex-direction: column;
             width: 100%;
             overflow: auto;
+            --trace-tree-nesting-indent: ${NESTING_INDENT}px;
+            @container (width < ${COMPACT_BREAKPOINT}) {
+              --trace-tree-nesting-indent: 0;
+              // Hide the collapse button
+              .span-controls,
+              .latency-text,
+              .token-count-item,
+              .span-tree-edge-connector,
+              .span-tree-edge {
+                display: none;
+                visibility: hidden;
+                width: 0;
+              }
+              .span-node-wrap {
+                padding-left: var(--ac-global-dimension-static-size-200);
+              }
+            }
           `}
           data-testid="trace-tree"
         >
@@ -83,74 +106,97 @@ function TraceTreeToolbar() {
   );
   const { isCollapsed, setIsCollapsed } = useTraceTree();
   return (
-    <View
-      borderBottomWidth="thin"
-      borderColor="dark"
-      padding="size-100"
-      flex="none"
+    <div
+      className="trace-tree-toolbar"
+      css={css`
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        box-sizing: border-box;
+        width: 100%;
+        align-items: center;
+        padding: var(--ac-global-dimension-size-100);
+        border-bottom: 1px solid var(--ac-global-color-grey-300);
+        height: var(--ac-global-dimension-size-600);
+        @container (width < ${COMPACT_BREAKPOINT}) {
+          button {
+            display: none;
+          }
+        }
+      `}
     >
-      <Flex direction="row" justifyContent="end" flex="none" gap="size-100">
-        <TooltipTrigger offset={5}>
-          <TriggerWrap>
-            <Button
-              variant="default"
-              size="S"
-              aria-label={isCollapsed ? "Expand all" : "Collapse all"}
-              onPress={() => {
-                setIsCollapsed(!isCollapsed);
-              }}
-              leadingVisual={
-                <Icon
-                  svg={
-                    isCollapsed ? (
-                      <Icons.RowCollapseOutline />
-                    ) : (
-                      <Icons.RowExpandOutline />
-                    )
-                  }
-                />
-              }
-            />
-          </TriggerWrap>
-          <Tooltip>
-            {isCollapsed
-              ? "Expand all nested spans"
-              : "Collapse all nested spans"}
-          </Tooltip>
-        </TooltipTrigger>
-        <TooltipTrigger offset={5}>
-          <TriggerWrap>
-            <Button
-              size="S"
-              aria-label={
-                showMetricsInTraceTree
-                  ? "Hide metrics in trace tree"
-                  : "Show metrics in trace tree"
-              }
-              onPress={() => {
-                setShowMetricsInTraceTree(!showMetricsInTraceTree);
-              }}
-              leadingVisual={
-                <Icon
-                  svg={
-                    showMetricsInTraceTree ? (
-                      <Icons.TimerOutline />
-                    ) : (
-                      <Icons.TimerOffOutline />
-                    )
-                  }
-                />
-              }
-            />
-          </TriggerWrap>
-          <Tooltip>
-            {showMetricsInTraceTree
-              ? "Hide metrics in trace tree"
-              : "Show metrics in trace tree"}
-          </Tooltip>
-        </TooltipTrigger>
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        flex="none"
+        gap="size-100"
+        width="100%"
+      >
+        <Heading level={3}>Trace</Heading>
+        <Flex direction="row" gap="size-100" className="trace-tree-controls">
+          <TooltipTrigger offset={5}>
+            <TriggerWrap>
+              <Button
+                variant="default"
+                size="S"
+                aria-label={isCollapsed ? "Expand all" : "Collapse all"}
+                onPress={() => {
+                  setIsCollapsed(!isCollapsed);
+                }}
+                leadingVisual={
+                  <Icon
+                    svg={
+                      isCollapsed ? (
+                        <Icons.RowCollapseOutline />
+                      ) : (
+                        <Icons.RowExpandOutline />
+                      )
+                    }
+                  />
+                }
+              />
+            </TriggerWrap>
+            <Tooltip>
+              {isCollapsed
+                ? "Expand all nested spans"
+                : "Collapse all nested spans"}
+            </Tooltip>
+          </TooltipTrigger>
+          <TooltipTrigger offset={5}>
+            <TriggerWrap>
+              <Button
+                size="S"
+                aria-label={
+                  showMetricsInTraceTree
+                    ? "Hide metrics in trace tree"
+                    : "Show metrics in trace tree"
+                }
+                onPress={() => {
+                  setShowMetricsInTraceTree(!showMetricsInTraceTree);
+                }}
+                leadingVisual={
+                  <Icon
+                    svg={
+                      showMetricsInTraceTree ? (
+                        <Icons.TimerOutline />
+                      ) : (
+                        <Icons.TimerOffOutline />
+                      )
+                    }
+                  />
+                }
+              />
+            </TriggerWrap>
+            <Tooltip>
+              {showMetricsInTraceTree
+                ? "Hide metrics in trace tree"
+                : "Show metrics in trace tree"}
+            </Tooltip>
+          </TooltipTrigger>
+        </Flex>
       </Flex>
-    </View>
+    </div>
   );
 }
 
@@ -201,7 +247,7 @@ function SpanTreeItem<TSpan extends ISpanItem>(props: {
         className="button--reset"
         css={css`
           width: 100%;
-          min-width: 200px;
+          overflow: hidden;
           cursor: pointer;
         `}
         onClick={() => {
@@ -239,10 +285,14 @@ function SpanTreeItem<TSpan extends ISpanItem>(props: {
               />
             ) : null}
             {latencyMs != null && showMetricsInTraceTree ? (
-              <LatencyText latencyMs={latencyMs} showIcon={false} />
+              <LatencyText latencyMs={latencyMs} showIcon={false} size="XS" />
             ) : null}
           </Flex>
-          <div css={spanControlsCSS} data-testid="span-controls">
+          <div
+            css={spanControlsCSS}
+            data-testid="span-controls"
+            className="span-controls"
+          >
             {hasChildren ? (
               <CollapseToggleButton
                 isCollapsed={isCollapsed}
@@ -299,7 +349,9 @@ function SpanNodeWrap(
 ) {
   return (
     <div
-      className={props.isSelected ? "is-selected" : ""}
+      className={classNames("span-node-wrap", {
+        "is-selected": props.isSelected,
+      })}
       css={css`
         width: 100%;
         display: flex;
@@ -319,7 +371,9 @@ function SpanNodeWrap(
           border-color: var(--ac-global-color-primary);
         }
         & > *:first-child {
-          margin-left: ${props.nestingLevel * NESTING_INDENT + 16}px;
+          margin-left: calc(
+            (${props.nestingLevel} * var(--trace-tree-nesting-indent)) + 16px
+          );
         }
       `}
     >
@@ -342,6 +396,7 @@ function SpanTreeEdgeConnector({
     <div
       aria-hidden="true"
       data-testid="span-tree-edge-connector"
+      className="span-tree-edge-connector"
       css={css`
         position: absolute;
         border-left: 1px solid
@@ -372,6 +427,7 @@ function SpanTreeEdge({
   return (
     <div
       aria-hidden="true"
+      className="span-tree-edge"
       css={css`
         position: absolute;
         border-left: 1px solid ${color};
@@ -428,7 +484,7 @@ function CollapseToggleButton({
         e.preventDefault();
         onClick();
       }}
-      className={classNames("button--reset", {
+      className={classNames("button--reset collapse-toggle-button", {
         "is-collapsed": isCollapsed,
       })}
       css={collapseButtonCSS}

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -142,7 +142,7 @@ export function TraceDetails(props: TraceDetailsProps) {
           overflow: hidden;
         `}
       >
-        <Panel defaultSize={30} minSize={10} maxSize={70}>
+        <Panel defaultSize={30} minSize={5}>
           <ScrollingPanelContent>
             <TraceTree
               spans={spansList}


### PR DESCRIPTION
resolves #6593

Makes it easier to really compact the trace tree when you say are needing more screen real-estate for annotations



https://github.com/user-attachments/assets/9e6ade8b-7364-408a-8bc1-efe37dff828a


