### PR TITLE
feat: Specialized UI for thinking budget parameter

### DIFF
--- a/app/src/pages/playground/AnthropicReasoningConfigField.tsx
+++ b/app/src/pages/playground/AnthropicReasoningConfigField.tsx
@@ -1,0 +1,79 @@
+import React, { useRef, useState } from "react";
+import { z } from "zod";
+
+import { Switch } from "@arizeai/components";
+
+import { Input, Label, NumberField, Text } from "@phoenix/components";
+
+const thinkingSchema = z.object({
+  type: z.literal("enabled"),
+  budget_tokens: z.number().optional(),
+});
+
+type AnthropicReasoningConfigFieldProps = {
+  onChange: (value: unknown) => void;
+  value: unknown;
+};
+
+export const AnthropicReasoningConfigField = ({
+  onChange,
+  value,
+}: AnthropicReasoningConfigFieldProps) => {
+  const [thinkingBudgetVersion, setThinkingBudgetVersion] = useState(0);
+  const validation = thinkingSchema.safeParse(value);
+  const configuration = validation.data;
+  const lastBudgetTokens = useRef<number | undefined>(
+    configuration?.budget_tokens
+  );
+
+  const handleEnabledChange = (enabled: boolean) => {
+    if (enabled) {
+      onChange({
+        type: "enabled",
+        ...(lastBudgetTokens.current != null
+          ? { budget_tokens: lastBudgetTokens.current }
+          : {}),
+      });
+    } else {
+      onChange(null);
+    }
+  };
+
+  const handleBudgetTokensChange = (value: number | undefined) => {
+    const hasBudget = value != null && !isNaN(value);
+    lastBudgetTokens.current = hasBudget ? value : undefined;
+    onChange({
+      type: "enabled",
+      ...(hasBudget ? { budget_tokens: value } : {}),
+    });
+    if (!hasBudget) {
+      setThinkingBudgetVersion((v) => v + 1);
+    }
+  };
+
+  return (
+    <>
+      <Switch
+        onChange={handleEnabledChange}
+        isSelected={Boolean(configuration?.type === "enabled")}
+      >
+        Thinking Enabled
+      </Switch>
+      {configuration?.type === "enabled" && (
+        <NumberField
+          key={thinkingBudgetVersion}
+          value={configuration?.budget_tokens}
+          onChange={handleBudgetTokensChange}
+          isDisabled={configuration?.type !== "enabled"}
+        >
+          <Label>Budget Tokens</Label>
+          <Input />
+          <Text slot="description">
+            (optional) The maximum number of tokens that can be used for
+            reasoning.
+          </Text>
+        </NumberField>
+      )}
+    </>
+  );
+};

--- a/app/src/pages/playground/AnthropicReasoningConfigField.tsx
+++ b/app/src/pages/playground/AnthropicReasoningConfigField.tsx
@@ -55,7 +55,7 @@ export const AnthropicReasoningConfigField = ({
     <>
       <Switch
         onChange={handleEnabledChange}
-        isSelected={Boolean(configuration?.type === "enabled")}
+        isSelected={configuration?.type === "enabled"}
       >
         Thinking Enabled
       </Switch>

--- a/app/src/pages/playground/InvocationParametersFormFields.tsx
+++ b/app/src/pages/playground/InvocationParametersFormFields.tsx
@@ -15,6 +15,7 @@ import {
   TextField,
 } from "@phoenix/components";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import { AnthropicReasoningConfigField } from "@phoenix/pages/playground/AnthropicReasoningConfigField";
 import { Mutable } from "@phoenix/typeUtils";
 
 import { ModelSupportedParamsFetcherQuery$data } from "./__generated__/ModelSupportedParamsFetcherQuery.graphql";
@@ -64,6 +65,12 @@ const InvocationParameterFormField = ({
     field.maxValue != null
       ? `${field.label || invocationName} must be at most ${field.maxValue}`
       : undefined;
+
+  // special case for anthropic reasoning config
+  if (field.canonicalName === "ANTHROPIC_EXTENDED_THINKING") {
+    return <AnthropicReasoningConfigField onChange={onChange} value={value} />;
+  }
+
   const { __typename } = field;
   switch (__typename) {
     case "InvocationParameterBase":


### PR DESCRIPTION
Tested the following:
- Save and load from prompts
- Save and load from default model config
- Add/remove budget tokens value
- enable/disable thinking

Keep in mind that default model config is not applied over a saved prompt, so don't expect to see your default thinking config appear in a prompt unless you save it in that prompt

![2025-03-06 19 43 03](https://github.com/user-attachments/assets/d5b87400-5616-4e0d-ab4c-4a95d0bd0445)
