### PR TITLE
fix: apply constraints related to extended thinking on anthropic invocation parameters

### DIFF
--- a/app/src/pages/playground/AnthropicReasoningConfigField.tsx
+++ b/app/src/pages/playground/AnthropicReasoningConfigField.tsx
@@ -5,9 +5,11 @@ import { Switch } from "@arizeai/components";
 
 import { Input, Label, NumberField, Text } from "@phoenix/components";
 
+const MINIMUM_BUDGET_TOKENS = 1024;
+
 const thinkingSchema = z.object({
   type: z.literal("enabled"),
-  budget_tokens: z.number().optional(),
+  budget_tokens: z.number().min(MINIMUM_BUDGET_TOKENS),
 });
 
 type AnthropicReasoningConfigFieldProps = {
@@ -30,9 +32,7 @@ export const AnthropicReasoningConfigField = ({
     if (enabled) {
       onChange({
         type: "enabled",
-        ...(lastBudgetTokens.current != null
-          ? { budget_tokens: lastBudgetTokens.current }
-          : {}),
+        budget_tokens: lastBudgetTokens.current || MINIMUM_BUDGET_TOKENS,
       });
     } else {
       onChange(null);
@@ -41,10 +41,10 @@ export const AnthropicReasoningConfigField = ({
 
   const handleBudgetTokensChange = (value: number | undefined) => {
     const hasBudget = value != null && !isNaN(value);
-    lastBudgetTokens.current = hasBudget ? value : undefined;
+    lastBudgetTokens.current = hasBudget ? value : MINIMUM_BUDGET_TOKENS;
     onChange({
       type: "enabled",
-      ...(hasBudget ? { budget_tokens: value } : {}),
+      budget_tokens: lastBudgetTokens.current,
     });
     if (!hasBudget) {
       setThinkingBudgetVersion((v) => v + 1);
@@ -65,12 +65,15 @@ export const AnthropicReasoningConfigField = ({
           value={configuration?.budget_tokens}
           onChange={handleBudgetTokensChange}
           isDisabled={configuration?.type !== "enabled"}
+          isRequired={true}
+          defaultValue={MINIMUM_BUDGET_TOKENS}
+          minValue={MINIMUM_BUDGET_TOKENS}
         >
           <Label>Budget Tokens</Label>
           <Input />
           <Text slot="description">
-            (optional) The maximum number of tokens that can be used for
-            reasoning.
+            Determines how many tokens Claude can use for its internal reasoning
+            process. Must be ≥1024 and less than max_tokens.
           </Text>
         </NumberField>
       )}

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -11,6 +11,7 @@ import {
   TOOL_CHOICE_PARAM_NAME,
 } from "@phoenix/pages/playground/constants";
 import {
+  applyProviderInvocationParameterConstraints,
   areInvocationParamsEqual,
   getChatRole,
   toCamelCase,
@@ -367,24 +368,28 @@ export const instanceToPromptVersion = (instance: PlaygroundInstance) => {
         }))
         .at(0) || undefined,
     invocationParameters: invocationParametersToObject(
-      instance.model.invocationParameters
-        .filter(
-          (invocationParameter) =>
-            !HIDDEN_INVOCATION_PARAMETERS.some((hidden) =>
-              areInvocationParamsEqual(hidden, invocationParameter)
-            )
-        )
-        .concat(
-          instance.toolChoice
-            ? [
-                {
-                  invocationName: TOOL_CHOICE_PARAM_NAME,
-                  valueJson: instance.toolChoice,
-                  canonicalName: TOOL_CHOICE_PARAM_CANONICAL_NAME,
-                },
-              ]
-            : []
-        ),
+      applyProviderInvocationParameterConstraints(
+        instance.model.invocationParameters
+          .filter(
+            (invocationParameter) =>
+              !HIDDEN_INVOCATION_PARAMETERS.some((hidden) =>
+                areInvocationParamsEqual(hidden, invocationParameter)
+              )
+          )
+          .concat(
+            instance.toolChoice
+              ? [
+                  {
+                    invocationName: TOOL_CHOICE_PARAM_NAME,
+                    valueJson: instance.toolChoice,
+                    canonicalName: TOOL_CHOICE_PARAM_CANONICAL_NAME,
+                  },
+                ]
+              : []
+          ),
+        instance.model.provider,
+        instance.model.modelName
+      ),
       instance.model.supportedInvocationParameters
     ),
   } satisfies Partial<ChatPromptVersionInput>;

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -761,13 +761,6 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
         import anthropic.types as anthropic_types
 
         anthropic_messages, system_prompt = self._build_anthropic_messages(messages)
-        if (
-            "thinking" in invocation_parameters
-            and isinstance(invocation_parameters["thinking"], dict)
-            and "type" in invocation_parameters["thinking"]
-            and invocation_parameters["thinking"]["type"] == "enabled"
-        ):
-            invocation_parameters.pop("top_p", None)
         anthropic_params = {
             "messages": anthropic_messages,
             "model": self.model_name,


### PR DESCRIPTION
This only applies to outgoing requests containing invocation parameters, not to parameters saved in the playground store, as the latter process involves additional complications which we've decided to address at a later time.