### PR TITLE
fix(onboarding): add space between link and text in new project guide

### DIFF
--- a/app/src/components/project/PythonProjectGuide.tsx
+++ b/app/src/components/project/PythonProjectGuide.tsx
@@ -121,7 +121,7 @@ export function PythonProjectGuide(props: PythonProjectGuideProps) {
       <View paddingBottom="size-100">
         <Text>
           <b>arize-phoenix-otel</b> automatically picks up your configuration
-          from
+          from{" "}
           <ExternalLink href={PHOENIX_ENVIRONMENT_VARIABLES_LINK}>
             environment variables
           </ExternalLink>


### PR DESCRIPTION
![Screenshot 2025-03-14 at 4 56 44 PM](https://github.com/user-attachments/assets/7de0be72-6576-4364-b301-6a6b18bb6b41)
