### PR TITLE
fix: make azure api key optional for playground

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ container = [
   "google-generativeai",
   "prometheus-client",
   "openai>=1.0.0",
+  "azure-identity",
   "opentelemetry-sdk",
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-exporter-otlp",

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,3 +8,4 @@ pyright[nodejs]==1.1.394
 deepdiff==8.2.0
 anthropic==0.49.0
 openai==1.62.0
+azure-identity


### PR DESCRIPTION
resolves #6063

see e.g. 
- https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints#microsoft-entra-id-authentication
- https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential?view=azure-python