### PR TITLE
fix(langgraph): don't aggregate status

### DIFF
--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -223,7 +223,7 @@ export function TracesTable(props: TracesTableProps) {
                 spanKind
                 name
                 metadata
-                statusCode: propagatedStatusCode
+                statusCode
                 startTime
                 latencyMs
                 cumulativeTokenCountTotal

--- a/app/src/pages/project/__generated__/ProjectPageQueriesTracesQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQueriesTracesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a69b8c7ee4317870d112ba05932fa3c0>>
+ * @generated SignedSource<<99b700c3667ef60205c3011eae418a97>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -103,34 +103,27 @@ v7 = {
   "storageKey": null
 },
 v8 = {
-  "alias": "statusCode",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "propagatedStatusCode",
-  "storageKey": null
-},
-v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v12 = [
+v11 = [
   {
     "alias": "value",
     "args": null,
@@ -139,41 +132,41 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v11/*: any*/),
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v12/*: any*/),
+  "selections": (v11/*: any*/),
   "storageKey": null
 },
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanId",
   "storageKey": null
 },
-v16 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "traceId",
   "storageKey": null
 },
-v17 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanAnnotation",
@@ -207,7 +200,7 @@ v17 = {
   ],
   "storageKey": null
 },
-v18 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -338,9 +331,15 @@ return {
                             "name": "metadata",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "statusCode",
+                            "storageKey": null
+                          },
                           (v8/*: any*/),
                           (v9/*: any*/),
-                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -362,10 +361,10 @@ return {
                             "name": "cumulativeTokenCountCompletion",
                             "storageKey": null
                           },
-                          (v11/*: any*/),
+                          (v10/*: any*/),
+                          (v12/*: any*/),
                           (v13/*: any*/),
                           (v14/*: any*/),
-                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -375,7 +374,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v16/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -386,8 +385,8 @@ return {
                             ],
                             "storageKey": null
                           },
+                          (v16/*: any*/),
                           (v17/*: any*/),
-                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -417,10 +416,16 @@ return {
                                       (v3/*: any*/),
                                       (v7/*: any*/),
                                       (v4/*: any*/),
+                                      {
+                                        "alias": "statusCode",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "propagatedStatusCode",
+                                        "storageKey": null
+                                      },
                                       (v8/*: any*/),
                                       (v9/*: any*/),
                                       (v10/*: any*/),
-                                      (v11/*: any*/),
                                       {
                                         "alias": "cumulativeTokenCountTotal",
                                         "args": null,
@@ -442,9 +447,9 @@ return {
                                         "name": "tokenCountCompletion",
                                         "storageKey": null
                                       },
+                                      (v12/*: any*/),
                                       (v13/*: any*/),
                                       (v14/*: any*/),
-                                      (v15/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -454,12 +459,12 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v3/*: any*/),
-                                          (v16/*: any*/)
+                                          (v15/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v17/*: any*/),
-                                      (v18/*: any*/)
+                                      (v16/*: any*/),
+                                      (v17/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -546,12 +551,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "efa78bce39bc2b4c09226b7d7b74038e",
+    "cacheID": "6996a7561889a2b24588e77de7391a15",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQueriesTracesQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQueriesTracesQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...TracesTable_spans\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment TracesTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: 50, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanId\n        trace {\n          id\n          traceId\n          numSpans\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants(first: 50) {\n          edges {\n            node {\n              id\n              spanKind\n              name\n              statusCode: propagatedStatusCode\n              startTime\n              latencyMs\n              parentId\n              cumulativeTokenCountTotal: tokenCountTotal\n              cumulativeTokenCountPrompt: tokenCountPrompt\n              cumulativeTokenCountCompletion: tokenCountCompletion\n              input {\n                value: truncatedValue\n              }\n              output {\n                value: truncatedValue\n              }\n              spanId\n              trace {\n                id\n                traceId\n              }\n              spanAnnotations {\n                id\n                name\n                label\n                score\n                annotatorKind\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n            }\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQueriesTracesQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...TracesTable_spans\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment TracesTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: 50, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanId\n        trace {\n          id\n          traceId\n          numSpans\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants(first: 50) {\n          edges {\n            node {\n              id\n              spanKind\n              name\n              statusCode: propagatedStatusCode\n              startTime\n              latencyMs\n              parentId\n              cumulativeTokenCountTotal: tokenCountTotal\n              cumulativeTokenCountPrompt: tokenCountPrompt\n              cumulativeTokenCountCompletion: tokenCountCompletion\n              input {\n                value: truncatedValue\n              }\n              output {\n                value: truncatedValue\n              }\n              spanId\n              trace {\n                id\n                traceId\n              }\n              spanAnnotations {\n                id\n                name\n                label\n                score\n                annotatorKind\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n            }\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/__generated__/TracesTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3439483696f26adff95698d55f2d517>>
+ * @generated SignedSource<<7913f33fb0a8499bbf0df506813d9ef4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -150,34 +150,27 @@ v15 = {
   "storageKey": null
 },
 v16 = {
-  "alias": "statusCode",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "propagatedStatusCode",
-  "storageKey": null
-},
-v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v18 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v19 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v20 = [
+v19 = [
   {
     "alias": "value",
     "args": null,
@@ -186,41 +179,41 @@ v20 = [
     "storageKey": null
   }
 ],
-v21 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v20/*: any*/),
+  "selections": (v19/*: any*/),
   "storageKey": null
 },
-v22 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v20/*: any*/),
+  "selections": (v19/*: any*/),
   "storageKey": null
 },
-v23 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanId",
   "storageKey": null
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "traceId",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanAnnotation",
@@ -254,7 +247,7 @@ v25 = {
   ],
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -404,9 +397,15 @@ return {
                             "name": "metadata",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "statusCode",
+                            "storageKey": null
+                          },
                           (v16/*: any*/),
                           (v17/*: any*/),
-                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -428,10 +427,10 @@ return {
                             "name": "cumulativeTokenCountCompletion",
                             "storageKey": null
                           },
-                          (v19/*: any*/),
+                          (v18/*: any*/),
+                          (v20/*: any*/),
                           (v21/*: any*/),
                           (v22/*: any*/),
-                          (v23/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -441,7 +440,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v12/*: any*/),
-                              (v24/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -452,8 +451,8 @@ return {
                             ],
                             "storageKey": null
                           },
+                          (v24/*: any*/),
                           (v25/*: any*/),
-                          (v26/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -487,10 +486,16 @@ return {
                                       (v12/*: any*/),
                                       (v15/*: any*/),
                                       (v13/*: any*/),
+                                      {
+                                        "alias": "statusCode",
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "propagatedStatusCode",
+                                        "storageKey": null
+                                      },
                                       (v16/*: any*/),
                                       (v17/*: any*/),
                                       (v18/*: any*/),
-                                      (v19/*: any*/),
                                       {
                                         "alias": "cumulativeTokenCountTotal",
                                         "args": null,
@@ -512,9 +517,9 @@ return {
                                         "name": "tokenCountCompletion",
                                         "storageKey": null
                                       },
+                                      (v20/*: any*/),
                                       (v21/*: any*/),
                                       (v22/*: any*/),
-                                      (v23/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -524,12 +529,12 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v12/*: any*/),
-                                          (v24/*: any*/)
+                                          (v23/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v25/*: any*/),
-                                      (v26/*: any*/)
+                                      (v24/*: any*/),
+                                      (v25/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -616,16 +621,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7e9054483242410f5567caddcc8924c0",
+    "cacheID": "b53bc919668f6208aa2590c51cda931b",
     "id": null,
     "metadata": {},
     "name": "TracesTableQuery",
     "operationKind": "query",
-    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 50\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...TracesTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment TracesTable_spans_1XEuU on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode: propagatedStatusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanId\n        trace {\n          id\n          traceId\n          numSpans\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants(first: 50) {\n          edges {\n            node {\n              id\n              spanKind\n              name\n              statusCode: propagatedStatusCode\n              startTime\n              latencyMs\n              parentId\n              cumulativeTokenCountTotal: tokenCountTotal\n              cumulativeTokenCountPrompt: tokenCountPrompt\n              cumulativeTokenCountCompletion: tokenCountCompletion\n              input {\n                value: truncatedValue\n              }\n              output {\n                value: truncatedValue\n              }\n              spanId\n              trace {\n                id\n                traceId\n              }\n              spanAnnotations {\n                id\n                name\n                label\n                score\n                annotatorKind\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n            }\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query TracesTableQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 50\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...TracesTable_spans_1XEuU\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment TracesTable_spans_1XEuU on Project {\n  name\n  ...SpanColumnSelector_annotations\n  rootSpans: spans(first: $first, after: $after, sort: $sort, rootSpansOnly: true, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      rootSpan: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        parentId\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanId\n        trace {\n          id\n          traceId\n          numSpans\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        descendants(first: 50) {\n          edges {\n            node {\n              id\n              spanKind\n              name\n              statusCode: propagatedStatusCode\n              startTime\n              latencyMs\n              parentId\n              cumulativeTokenCountTotal: tokenCountTotal\n              cumulativeTokenCountPrompt: tokenCountPrompt\n              cumulativeTokenCountCompletion: tokenCountCompletion\n              input {\n                value: truncatedValue\n              }\n              output {\n                value: truncatedValue\n              }\n              spanId\n              trace {\n                id\n                traceId\n              }\n              spanAnnotations {\n                id\n                name\n                label\n                score\n                annotatorKind\n              }\n              documentRetrievalMetrics {\n                evaluationName\n                ndcg\n                precision\n                hit\n              }\n            }\n          }\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6757deb68e4b09c39445840106c9a3dd";
+(node as any).hash = "d42d2e6ece4569a9920f88f134624597";
 
 export default node;

--- a/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7575316847ba1c459a0fcb9e60d28086>>
+ * @generated SignedSource<<d49a12dc1026c2ad89eed4d612714c49>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -134,34 +134,27 @@ v3 = {
   "storageKey": null
 },
 v4 = {
-  "alias": "statusCode",
-  "args": null,
-  "kind": "ScalarField",
-  "name": "propagatedStatusCode",
-  "storageKey": null
-},
-v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "latencyMs",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "parentId",
   "storageKey": null
 },
-v8 = [
+v7 = [
   {
     "alias": "value",
     "args": null,
@@ -170,41 +163,41 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "input",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v7/*: any*/),
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanIOValue",
   "kind": "LinkedField",
   "name": "output",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v7/*: any*/),
   "storageKey": null
 },
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "spanId",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "traceId",
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "SpanAnnotation",
@@ -238,7 +231,7 @@ v13 = {
   ],
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "concreteType": "DocumentRetrievalMetrics",
@@ -399,9 +392,15 @@ return {
                   "name": "metadata",
                   "storageKey": null
                 },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "statusCode",
+                  "storageKey": null
+                },
                 (v4/*: any*/),
                 (v5/*: any*/),
-                (v6/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -423,10 +422,10 @@ return {
                   "name": "cumulativeTokenCountCompletion",
                   "storageKey": null
                 },
-                (v7/*: any*/),
+                (v6/*: any*/),
+                (v8/*: any*/),
                 (v9/*: any*/),
                 (v10/*: any*/),
-                (v11/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -436,7 +435,7 @@ return {
                   "plural": false,
                   "selections": [
                     (v2/*: any*/),
-                    (v12/*: any*/),
+                    (v11/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -447,8 +446,8 @@ return {
                   ],
                   "storageKey": null
                 },
+                (v12/*: any*/),
                 (v13/*: any*/),
-                (v14/*: any*/),
                 {
                   "alias": null,
                   "args": [
@@ -482,10 +481,16 @@ return {
                             (v2/*: any*/),
                             (v3/*: any*/),
                             (v1/*: any*/),
+                            {
+                              "alias": "statusCode",
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "propagatedStatusCode",
+                              "storageKey": null
+                            },
                             (v4/*: any*/),
                             (v5/*: any*/),
                             (v6/*: any*/),
-                            (v7/*: any*/),
                             {
                               "alias": "cumulativeTokenCountTotal",
                               "args": null,
@@ -507,9 +512,9 @@ return {
                               "name": "tokenCountCompletion",
                               "storageKey": null
                             },
+                            (v8/*: any*/),
                             (v9/*: any*/),
                             (v10/*: any*/),
-                            (v11/*: any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -519,12 +524,12 @@ return {
                               "plural": false,
                               "selections": [
                                 (v2/*: any*/),
-                                (v12/*: any*/)
+                                (v11/*: any*/)
                               ],
                               "storageKey": null
                             },
-                            (v13/*: any*/),
-                            (v14/*: any*/)
+                            (v12/*: any*/),
+                            (v13/*: any*/)
                           ],
                           "storageKey": null
                         }
@@ -600,6 +605,6 @@ return {
 };
 })();
 
-(node as any).hash = "6757deb68e4b09c39445840106c9a3dd";
+(node as any).hash = "d42d2e6ece4569a9920f88f134624597";
 
 export default node;

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -67,7 +67,7 @@ export function TraceDetails(props: TraceDetailsProps) {
                     spanId
                     name
                     spanKind
-                    statusCode: propagatedStatusCode
+                    statusCode
                     startTime
                     parentId
                     latencyMs

--- a/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/TraceDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85bf73e07ab7a5ac32add19bc07c03e9>>
+ * @generated SignedSource<<df97ed52d30faec0fd773ea26b0c0bee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -154,10 +154,10 @@ v5 = {
                       "storageKey": null
                     },
                     {
-                      "alias": "statusCode",
+                      "alias": null,
                       "args": null,
                       "kind": "ScalarField",
-                      "name": "propagatedStatusCode",
+                      "name": "statusCode",
                       "storageKey": null
                     },
                     {
@@ -275,16 +275,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ac9147f8bf0ef8c809d19877e0ee5f2c",
+    "cacheID": "9434c8c6e07d5ca4dd3a19286644f369",
     "id": null,
     "metadata": {},
     "name": "TraceDetailsQuery",
     "operationKind": "query",
-    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        projectSessionId\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              spanId\n              name\n              spanKind\n              statusCode: propagatedStatusCode\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n            }\n          }\n        }\n        latencyMs\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
+    "text": "query TraceDetailsQuery(\n  $traceId: ID!\n  $id: GlobalID!\n) {\n  project: node(id: $id) {\n    __typename\n    ... on Project {\n      trace(traceId: $traceId) {\n        projectSessionId\n        spans(first: 1000) {\n          edges {\n            span: node {\n              id\n              spanId\n              name\n              spanKind\n              statusCode\n              startTime\n              parentId\n              latencyMs\n              tokenCountTotal\n              tokenCountPrompt\n              tokenCountCompletion\n            }\n          }\n        }\n        latencyMs\n      }\n    }\n    __isNode: __typename\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "aedd511ed255adab3a80dde8956a01c4";
+(node as any).hash = "e4165ac98e972c7c7491e1573a1aec1a";
 
 export default node;


### PR DESCRIPTION
related to #6794 

This ultimately doesn't solve the problem that agent workflows use errors to change control flow.

<img width="1923" alt="Screenshot 2025-03-17 at 7 30 37 PM" src="https://github.com/user-attachments/assets/e832c53e-4fa8-4185-9cd2-be13ef37c510" />


It only makes there be less red