### PR TITLE
feat(ui): show the date format in the explanation

### DIFF
--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -6,6 +6,7 @@ export {
   Dialog,
   DialogTrigger,
   Form,
+  I18nProvider,
 } from "react-aria-components";
 export type {
   InputProps,

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -1,0 +1,6 @@
+// Re-export react-aria hooks
+export { useLocale } from "react-aria-components";
+
+// Custom hooks
+export * from "./useInterval";
+export * from "./useWordColor";

--- a/app/src/pages/projects/RemoveProjectDataForm.tsx
+++ b/app/src/pages/projects/RemoveProjectDataForm.tsx
@@ -23,6 +23,8 @@ import {
   View,
 } from "@phoenix/components";
 import { ONE_MONTH_MS } from "@phoenix/constants/timeConstants";
+import { useLocale } from "@phoenix/hooks";
+import { getLocaleDateFormatPattern } from "@phoenix/utils/timeFormatUtils";
 
 import { RemoveProjectDataFormMutation } from "./__generated__/RemoveProjectDataFormMutation.graphql";
 
@@ -37,6 +39,8 @@ type RemoveProjectDataFormParams = {
 
 export function RemoveProjectDataForm(props: RemoveProjectDataFormProps) {
   const { projectId } = props;
+  const { locale } = useLocale();
+  const dateFormatPattern = getLocaleDateFormatPattern(locale);
   const formRef = useRef<HTMLFormElement>(null);
   const [commit, isCommitting] = useMutation<RemoveProjectDataFormMutation>(
     graphql`
@@ -127,7 +131,7 @@ export function RemoveProjectDataForm(props: RemoveProjectDataFormProps) {
                 <FieldError>{error.message}</FieldError>
               ) : (
                 <Text slot="description">
-                  The date up to which you want to remove data
+                  {`The date up to which you want to remove data. The format is ${dateFormatPattern}.`}
                 </Text>
               )}
             </DateField>

--- a/app/src/utils/timeFormatUtils.ts
+++ b/app/src/utils/timeFormatUtils.ts
@@ -23,3 +23,30 @@ export const timeRangeFormatter = (timeRange: OpenTimeRange) => {
     return "All Time";
   }
 };
+
+export function getLocaleDateFormatPattern(locale: string) {
+  const formatParts = new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).formatToParts(new Date());
+
+  const pattern = formatParts
+    .map((part) => {
+      switch (part.type) {
+        case "day":
+          return "DD";
+        case "month":
+          return "MM";
+        case "year":
+          return "YYYY";
+        case "literal":
+          return part.value;
+        default:
+          return "";
+      }
+    })
+    .join("");
+
+  return pattern;
+}

--- a/app/stories/DateField.stories.tsx
+++ b/app/stories/DateField.stories.tsx
@@ -7,6 +7,7 @@ import {
   DateInput,
   DateSegment,
   DateValue,
+  I18nProvider,
   Label,
 } from "@phoenix/components";
 
@@ -33,3 +34,21 @@ const Template: StoryFn<DateFieldProps<DateValue>> = (args) => (
 export const Default = Template.bind({});
 
 Default.args = {};
+
+export const InternationalizedIndia = () => (
+  <I18nProvider locale="hi-IN-u-ca-indian">
+    <DateField granularity="hour">
+      <Label>Birth date</Label>
+      <DateInput>{(segment) => <DateSegment segment={segment} />}</DateInput>
+    </DateField>
+  </I18nProvider>
+);
+
+export const InternationalizedEngliand = () => (
+  <I18nProvider locale="en-GB">
+    <DateField granularity="hour">
+      <Label>Birth date</Label>
+      <DateInput>{(segment) => <DateSegment segment={segment} />}</DateInput>
+    </DateField>
+  </I18nProvider>
+);


### PR DESCRIPTION
resolves #6843

<img width="1265" alt="Screenshot 2025-03-19 at 6 34 58 PM" src="https://github.com/user-attachments/assets/9cf6101c-290a-42ec-aefd-1b7f066119f8" />
<img width="1297" alt="Screenshot 2025-03-19 at 6 34 33 PM" src="https://github.com/user-attachments/assets/254b31b0-8464-4c70-af1b-cf000fabed00" />
