### PR TITLE
fix: Allow hover anywhere on experiment cell

### DIFF
--- a/app/src/components/table/CellWithControlsWrapper.tsx
+++ b/app/src/components/table/CellWithControlsWrapper.tsx
@@ -3,7 +3,8 @@ import { css } from "@emotion/react";
 
 const cellWithControlsWrapCSS = css`
   position: relative;
-  min-height: 75px;
+  height: 100%;
+  min-height: 100%;
   .controls {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -278,13 +278,15 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                 </TooltipTrigger>
               }
             >
-              <LargeTextWrap>
-                <JSONText
-                  json={row.original.input}
-                  disableTitle
-                  space={displayFullText ? 2 : 0}
-                />
-              </LargeTextWrap>
+              <PaddedCell>
+                <LargeTextWrap>
+                  <JSONText
+                    json={row.original.input}
+                    disableTitle
+                    space={displayFullText ? 2 : 0}
+                  />
+                </LargeTextWrap>
+              </PaddedCell>
             </CellWithControlsWrap>
           );
         },
@@ -293,7 +295,11 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
         header: "reference output",
         accessorKey: "referenceOutput",
         minWidth: 500,
-        cell: displayFullText ? JSONCell : CompactJSONCell,
+        cell: (props) => (
+          <PaddedCell>
+            {displayFullText ? JSONCell(props) : CompactJSONCell(props)}
+          </PaddedCell>
+        ),
       },
     ];
   }, [displayFullText]);
@@ -399,14 +405,18 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
 
         return run ? (
           <CellWithControlsWrap controls={runControls}>
-            <ExperimentRunOutput
-              {...run}
-              displayFullText={displayFullText}
-              setDialog={setDialog}
-            />
+            <PaddedCell>
+              <ExperimentRunOutput
+                {...run}
+                displayFullText={displayFullText}
+                setDialog={setDialog}
+              />
+            </PaddedCell>
           </CellWithControlsWrap>
         ) : (
-          <NotRunText />
+          <PaddedCell>
+            <NotRunText />
+          </PaddedCell>
         );
       },
     }));
@@ -536,8 +546,9 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
+                  height: 1,
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
-                  wordBreak: "break-all",
+                  padding: 0,
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -959,5 +970,13 @@ function TraceDetailsDialog({
     >
       <TraceDetails traceId={traceId} projectId={projectId} />
     </Dialog>
+  );
+}
+
+function PaddedCell({ children }: { children: ReactNode }) {
+  return (
+    <View paddingX="size-200" paddingY="size-100">
+      {children}
+    </View>
   );
 }


### PR DESCRIPTION
similarly to the playground table, the experiment table should let you hover the entire cell.

This is done by removing padding from the td, adding height 100% to cell contents and a height to td, then adding padding back to the cell children.

![2025-03-21 10 43 55](https://github.com/user-attachments/assets/d97d6b80-9d46-4d16-b8c6-b8f347f09798)

Resolves #6818 