### PR TITLE
fix(UI): close time selector on duplicate selection

### DIFF
--- a/app/src/components/datetime/TimeRangeSelector.tsx
+++ b/app/src/components/datetime/TimeRangeSelector.tsx
@@ -100,6 +100,7 @@ export function TimeRangeSelector(props: TimeRangeSelectorProps) {
               css={listBoxCSS}
               onSelectionChange={(selection) => {
                 if (selection === "all" || selection.size === 0) {
+                  setOpen(false);
                   return;
                 }
                 const timeRangeKey = selection.keys().next().value;


### PR DESCRIPTION
resolves #6861 

Closes the time range selector when you click the same value.