### PR TITLE
fix: Prevent toggle button text from wrapping

### DIFF
--- a/app/src/components/toggleButtonGroup/ToggleButton.tsx
+++ b/app/src/components/toggleButtonGroup/ToggleButton.tsx
@@ -14,6 +14,7 @@ import { useSize } from "@phoenix/contexts";
 const baseToggleButtonCSS = css(
   buttonCSS,
   `
+    text-wrap: nowrap;
     &[data-selected="true"] {
       background-color: var(--ac-global-button-primary-background-color);
       --button-border-color: var(--ac-global-button-primary-border-color);


### PR DESCRIPTION
Before/After

![2025-03-25 10 24 03](https://github.com/user-attachments/assets/d94e725d-5115-420a-95c2-f1df96fd8d06)
