### PR TITLE
fix: Remove unpredictable playground transformations

### DIFF
--- a/app/src/components/code/JSONEditor.tsx
+++ b/app/src/components/code/JSONEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { defaultKeymap } from "@codemirror/commands";
 import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
@@ -38,12 +38,6 @@ export function JSONEditor(props: JSONEditorProps) {
   const { theme } = useTheme();
   const { jsonSchema, optionalLint, basicSetup, ...restProps } = props;
   const codeMirrorTheme = theme === "light" ? githubLight : githubDark;
-  // Force a refresh of the editor when the jsonSchema changes
-  // Code mirror does not automatically refresh when the extensions change
-  const [schemaKey, setSchemaKey] = React.useState(0);
-  useEffect(() => {
-    setSchemaKey((prev) => prev + 1);
-  }, [jsonSchema]);
   const contentLength = props.value?.length;
   // When optionalLint is false, this value will always be true
   // If optionalLint is true, we only lint when there is content to allow for empty json values
@@ -77,7 +71,6 @@ export function JSONEditor(props: JSONEditorProps) {
 
   return (
     <CodeMirror
-      key={schemaKey}
       value={props.value}
       extensions={extensions}
       editable

--- a/app/src/pages/playground/ChatMessageToolCallsEditor.tsx
+++ b/app/src/pages/playground/ChatMessageToolCallsEditor.tsx
@@ -2,10 +2,12 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { JSONSchema7 } from "json-schema";
 
 import { JSONEditor } from "@phoenix/components/code";
-import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import {
+  usePlaygroundContext,
+  usePlaygroundStore,
+} from "@phoenix/contexts/PlaygroundContext";
 import {
   anthropicToolCallsJSONSchema,
-  llmProviderToolCallsSchema,
   openAIToolCallsJSONSchema,
 } from "@phoenix/schemas/toolCallSchemas";
 import {
@@ -32,6 +34,8 @@ export function ChatMessageToolCallsEditor({
   if (instance == null) {
     throw new Error(`Instance ${playgroundInstanceId} not found`);
   }
+  const instanceProvider = instance.model.provider;
+  const store = usePlaygroundStore();
   const messageSelector = useMemo(
     () => selectPlaygroundInstanceMessage(messageId),
     [messageId]
@@ -42,36 +46,33 @@ export function ChatMessageToolCallsEditor({
   }
   const toolCalls = message.toolCalls;
   const updateMessage = usePlaygroundContext((state) => state.updateMessage);
-  const [editorValue, setEditorValue] = useState(() =>
+  const [initialEditorValue, setInitialEditorValue] = useState(() =>
     JSON.stringify(toolCalls, null, 2)
   );
 
-  const [lastValidToolCalls, setLastValidToolCalls] = useState(toolCalls);
-
-  // Update editor when tool calls changes externally, this can happen when switching between providers
+  // when the instance provider changes, we need to update the editor value
+  // to reflect the new tool calls schema
   useEffect(() => {
-    if (JSON.stringify(toolCalls) !== JSON.stringify(lastValidToolCalls)) {
-      setEditorValue(JSON.stringify(toolCalls, null, 2));
-      setLastValidToolCalls(toolCalls);
+    const state = store.getState();
+    const instance = state.instances.find((i) => i.id === playgroundInstanceId);
+    if (instance == null) {
+      return;
     }
-  }, [lastValidToolCalls, toolCalls]);
+    const message = selectPlaygroundInstanceMessage(messageId)(state);
+    if (message == null) {
+      return;
+    }
+    const newToolCalls = message.toolCalls;
+    const newEditorValue = JSON.stringify(newToolCalls, null, 2);
+    if (newEditorValue != null && newEditorValue !== "null") {
+      setInitialEditorValue(newEditorValue);
+    }
+  }, [instanceProvider, store, playgroundInstanceId, messageId]);
 
   const onChange = useCallback(
     (value: string) => {
-      setEditorValue(value);
       const { json: toolCalls } = safelyParseJSON(value);
-      if (toolCalls == null) {
-        return;
-      }
-      // Don't use data here returned by safeParse, as we want to allow for extra keys,
-      // there is no "deepPassthrough" to allow for extra keys
-      // at all levels of the schema, so we just use the json parsed value here,
-      // knowing that it is valid with potentially extra keys
-      const { success } = llmProviderToolCallsSchema.safeParse(toolCalls);
-      if (!success) {
-        return;
-      }
-      setLastValidToolCalls(toolCalls);
+
       updateMessage({
         instanceId: playgroundInstanceId,
         messageId,
@@ -98,7 +99,7 @@ export function ChatMessageToolCallsEditor({
 
   return (
     <JSONEditor
-      value={editorValue}
+      value={initialEditorValue}
       jsonSchema={toolCallsJSONSchema}
       onChange={onChange}
     />

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -208,17 +208,24 @@ const DEFAULT_EXPANDED_PROMPTS = ["prompts"];
 const DEFAULT_EXPANDED_PARAMS = ["input", "output"];
 
 function PlaygroundContent() {
-  const instances = usePlaygroundContext((state) => state.instances);
   const templateFormat = usePlaygroundContext((state) => state.templateFormat);
   const [searchParams] = useSearchParams();
   const datasetId = searchParams.get("datasetId");
   const isDatasetMode = datasetId != null;
-  const numInstances = instances.length;
+  const numInstances = usePlaygroundContext((state) => state.instances.length);
   const isSingleInstance = numInstances === 1;
-  const isRunning = instances.some((instance) => instance.activeRunId != null);
-  const anyDirtyPromptInstances = instances
-    .filter((i) => i.prompt)
-    .some((instance) => instance.dirty);
+  const isRunning = usePlaygroundContext((state) =>
+    state.instances.some((instance) => instance.activeRunId != null)
+  );
+  const anyDirtyPromptInstances = usePlaygroundContext((state) =>
+    Object.values(state.dirtyInstances).some((dirty) => dirty)
+  );
+  const instanceIds = usePlaygroundContext(
+    (state) => state.instances.map((instance) => instance.id),
+    (left, right) =>
+      left.length === right.length &&
+      left.every((id, index) => id === right[index])
+  );
 
   // Soft block at the router level when a run is in progress or there are dirty instances
   // Handles blocking navigation when a run is in progress
@@ -278,14 +285,14 @@ function PlaygroundContent() {
                 <DisclosurePanel>
                   <div css={promptsWrapCSS}>
                     <Flex direction="row" gap="size-200" maxWidth="100%">
-                      {instances.map((instance) => (
+                      {instanceIds.map((instanceId) => (
                         <View
                           flex="1 1 0px"
-                          key={`${instance.id}-prompt`}
+                          key={`${instanceId}-prompt`}
                           minWidth={PLAYGROUND_PROMPT_PANEL_MIN_WIDTH}
                         >
                           <PlaygroundTemplate
-                            playgroundInstanceId={instance.id}
+                            playgroundInstanceId={instanceId}
                           />
                         </View>
                       ))}
@@ -324,10 +331,10 @@ function PlaygroundContent() {
                   <DisclosurePanel>
                     <View padding="size-200" height="100%">
                       <Flex direction="row" gap="size-200">
-                        {instances.map((instance) => (
-                          <View key={`${instance.id}-output`} flex="1 1 0px">
+                        {instanceIds.map((instanceId) => (
+                          <View key={`${instanceId}-output`} flex="1 1 0px">
                             <PlaygroundOutput
-                              playgroundInstanceId={instance.id}
+                              playgroundInstanceId={instanceId}
                             />
                           </View>
                         ))}

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -49,7 +49,7 @@ import {
   selectPlaygroundInstanceMessage,
 } from "@phoenix/store/playground/selectors";
 import { assertUnreachable } from "@phoenix/typeUtils";
-import { safelyParseJSON, safelyStringifyJSON } from "@phoenix/utils/jsonUtils";
+import { safelyStringifyJSON } from "@phoenix/utils/jsonUtils";
 
 import { ChatMessageToolCallsEditor } from "./ChatMessageToolCallsEditor";
 import {
@@ -251,17 +251,6 @@ function MessageEditor({
           aria-label="tool message content"
           height={"100%"}
           onChange={(val) => updateMessage({ content: val })}
-          onBlur={() => {
-            if (message.content == null) {
-              return;
-            }
-            if (typeof message.content === "string") {
-              const { json: parsedContent } = safelyParseJSON(message.content);
-              updateMessage({
-                content: JSON.stringify(parsedContent, null, 2),
-              });
-            }
-          }}
         />
       </Form>
     );

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { JSONSchema7 } from "json-schema";
 
 import { Card } from "@arizeai/components";
@@ -16,14 +16,17 @@ import {
 } from "@phoenix/components";
 import { JSONEditor } from "@phoenix/components/code";
 import { LazyEditorWrapper } from "@phoenix/components/code/LazyEditorWrapper";
-import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import {
+  usePlaygroundContext,
+  usePlaygroundStore,
+} from "@phoenix/contexts/PlaygroundContext";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
 
 import {
   RESPONSE_FORMAT_PARAM_CANONICAL_NAME,
   RESPONSE_FORMAT_PARAM_NAME,
 } from "./constants";
-import { jsonObjectSchema, openAIResponseFormatJSONSchema } from "./schemas";
+import { openAIResponseFormatJSONSchema } from "./schemas";
 import { PlaygroundInstanceProps } from "./types";
 
 /**
@@ -46,6 +49,7 @@ export function PlaygroundResponseFormat({
   const instance = usePlaygroundContext((state) =>
     state.instances.find((i) => i.id === playgroundInstanceId)
   );
+  const instanceProvider = instance?.model.provider;
   const upsertInvocationParameterInput = usePlaygroundContext(
     (state) => state.upsertInvocationParameterInput
   );
@@ -59,29 +63,43 @@ export function PlaygroundResponseFormat({
       p.invocationName === RESPONSE_FORMAT_PARAM_NAME ||
       p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME
   );
-
-  const [initialResponseFormatDefinition] = useState(
-    JSON.stringify(responseFormat?.valueJson ?? {}, null, 2)
-  );
-
+  const [initialResponseFormatDefinition, setInitialResponseFormatDefinition] =
+    useState(() => JSON.stringify(responseFormat?.valueJson ?? {}, null, 2));
   const currentValueRef = useRef(initialResponseFormatDefinition);
+  const store = usePlaygroundStore();
+
+  useEffect(() => {
+    const state = store.getState();
+    const instance = state.instances.find((i) => i.id === playgroundInstanceId);
+    if (instance == null) {
+      return;
+    }
+    const responseFormat = instance.model.invocationParameters.find(
+      (p) =>
+        p.invocationName === RESPONSE_FORMAT_PARAM_NAME ||
+        p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME
+    );
+    if (responseFormat == null) {
+      return;
+    }
+    const newResponseFormatDefinition = JSON.stringify(
+      responseFormat.valueJson,
+      null,
+      2
+    );
+    if (
+      newResponseFormatDefinition != null &&
+      newResponseFormatDefinition !== "null"
+    ) {
+      setInitialResponseFormatDefinition(newResponseFormatDefinition);
+    }
+  }, [instanceProvider, store, playgroundInstanceId]);
 
   const onChange = useCallback(
     (value: string) => {
       // track the current value of the editor, even when it is invalid
       currentValueRef.current = value;
       const { json: format } = safelyParseJSON(value);
-      if (format == null) {
-        return;
-      }
-      // Don't use data here returned by safeParse, as we want to allow for extra keys,
-      // there is no "deepPassthrough" to allow for extra keys
-      // at all levels of the schema, so we just use the json parsed value here,
-      // knowing that it is valid with potentially extra keys
-      const { success } = jsonObjectSchema.safeParse(format);
-      if (!success) {
-        return;
-      }
       upsertInvocationParameterInput({
         instanceId: playgroundInstanceId,
         invocationParameterInput: {

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -68,6 +68,8 @@ export function PlaygroundResponseFormat({
   const currentValueRef = useRef(initialResponseFormatDefinition);
   const store = usePlaygroundStore();
 
+  // when the instance provider changes, we need to update the editor value
+  // to reflect the new response format schema
   useEffect(() => {
     const state = store.getState();
     const instance = state.instances.find((i) => i.id === playgroundInstanceId);

--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -34,7 +34,9 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
   const index = instances.findIndex((instance) => instance.id === instanceId);
   const prompt = instance?.prompt;
   const promptId = prompt?.id;
-  const dirty = instance?.dirty;
+  const dirty = usePlaygroundContext(
+    (state) => state.dirtyInstances[instanceId]
+  );
 
   const onChangePrompt = useCallback(
     async (promptId: string | null) => {

--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -20,10 +20,12 @@ import {
 import { JSONEditor } from "@phoenix/components/code";
 import { LazyEditorWrapper } from "@phoenix/components/code/LazyEditorWrapper";
 import { SpanKindIcon } from "@phoenix/components/trace";
-import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import {
+  usePlaygroundContext,
+  usePlaygroundStore,
+} from "@phoenix/contexts/PlaygroundContext";
 import {
   anthropicToolDefinitionJSONSchema,
-  llmProviderToolDefinitionSchema,
   openAIToolDefinitionJSONSchema,
 } from "@phoenix/schemas";
 import { findToolChoiceName } from "@phoenix/schemas/toolChoiceSchemas";
@@ -52,9 +54,8 @@ export function PlaygroundTool({
 }: PlaygroundInstanceProps & {
   toolId: Tool["id"];
 }) {
-  const [version, setVersion] = useState(0);
+  const store = usePlaygroundStore();
   const updateInstance = usePlaygroundContext((state) => state.updateInstance);
-
   const instance = usePlaygroundContext((state) =>
     state.instances.find((instance) => instance.id === playgroundInstanceId)
   );
@@ -63,60 +64,41 @@ export function PlaygroundTool({
     throw new Error(`Playground instance ${playgroundInstanceId} not found`);
   }
 
+  const instanceProvider = instance.model.provider;
   const instanceTools = instance.tools;
-
   const tool = instanceTools.find((t) => t.id === toolId);
 
   if (tool == null) {
     throw new Error(`Tool ${toolId} not found`);
   }
 
-  const [initialEditorValue, setEditorValue] = useState(
+  const [initialEditorValue, setInitialEditorValue] = useState(() =>
     JSON.stringify(tool.definition, null, 2)
   );
+  const editorValueRef = useRef(initialEditorValue);
 
-  // track the current value of the editor, even when it is invalid
-  const currentValueRef = useRef(initialEditorValue);
-
-  const [lastValidDefinition, setLastValidDefinition] = useState(
-    tool.definition
-  );
-
-  // Update editor when tool definition changes externally this can happen when switching between providers
+  // when the instance provider changes, we need to update the editor value
+  // to reflect the new tool definition schema
   useEffect(() => {
-    if (
-      JSON.stringify(tool.definition) !== JSON.stringify(lastValidDefinition)
-    ) {
-      setLastValidDefinition(tool.definition);
-      setEditorValue(JSON.stringify(tool.definition, null, 2));
-      setVersion((prev) => prev + 1);
+    const state = store.getState();
+    const instance = state.instances.find((i) => i.id === playgroundInstanceId);
+    if (instance == null) {
+      return;
     }
-  }, [tool.definition, lastValidDefinition]);
+    const tool = instance.tools.find((t) => t.id === toolId);
+    if (tool == null) {
+      return;
+    }
+    const newDefinition = JSON.stringify(tool.definition, null, 2);
+    if (newDefinition != null && newDefinition !== "null") {
+      setInitialEditorValue(newDefinition);
+    }
+  }, [instanceProvider, store, playgroundInstanceId, toolId]);
 
   const onChange = useCallback(
     (value: string) => {
-      // track the current value of the editor, even when it is invalid
-      currentValueRef.current = value;
-      // note that we do not update initialEditorValue here, we only want to update it when
-      // we are okay with the editor state resetting, which is basically only when the provider
-      // changes
+      editorValueRef.current = value;
       const { json: definition } = safelyParseJSON(value);
-      if (definition == null) {
-        return;
-      }
-      // Don't use data here returned by safeParse, as we want to allow for extra keys,
-      // there is no "deepPassthrough" to allow for extra keys
-      // at all levels of the schema, so we just use the json parsed value here,
-      // knowing that it is valid with potentially extra keys
-      const { success } = llmProviderToolDefinitionSchema.safeParse(definition);
-      if (!success) {
-        return;
-      }
-
-      // @todo: Reconsider this approach, as it may lead to a situation where the editor
-      // reflects one definition while what gets saved is another (the last valid one).
-      setLastValidDefinition(definition);
-
       updateInstance({
         instanceId: playgroundInstanceId,
         patch: {
@@ -166,7 +148,7 @@ export function PlaygroundTool({
       bodyStyle={{ padding: 0 }}
       extra={
         <Flex direction="row" gap="size-100">
-          <CopyToClipboardButton text={currentValueRef} />
+          <CopyToClipboardButton text={editorValueRef} />
           <Button
             aria-label="Delete tool"
             leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
@@ -201,9 +183,6 @@ export function PlaygroundTool({
         preInitializationMinHeight={TOOL_EDITOR_PRE_INIT_HEIGHT}
       >
         <JSONEditor
-          // force remount of the editor when the tool definition changes externally
-          // usually when switching between providers
-          key={version}
           value={initialEditorValue}
           onChange={onChange}
           jsonSchema={toolDefinitionJSONSchema}

--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -70,7 +70,6 @@ const baseTestPlaygroundInstance: PlaygroundInstance = {
   tools: [],
   toolChoice: "auto",
   spanId: null,
-  dirty: false,
   template: {
     __type: "chat",
     messages: [],
@@ -89,7 +88,6 @@ const expectedPlaygroundInstanceWithIO: PlaygroundInstance = {
   tools: [],
   toolChoice: "auto",
   spanId: "fake-span-global-id",
-  dirty: false,
   template: {
     __type: "chat",
     // These id's are not 0, 1, 2, because we create a playground instance (including messages) at the top of the transformSpanAttributesToPlaygroundInstance function
@@ -1091,7 +1089,6 @@ describe("getVariablesMapFromInstances", () => {
     tools: [],
     toolChoice: "auto",
     spanId: null,
-    dirty: false,
     template: {
       __type: "chat",
       messages: [],

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -127,10 +127,6 @@ export interface PlaygroundInstance {
    * Details about the prompt hub prompt associated with the instance, if any
    */
   prompt?: PlaygroundInstancePrompt | null;
-  /**
-   * Whether the instance has been modified since the instance was created
-   */
-  dirty: boolean;
 }
 
 /**
@@ -211,6 +207,11 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
    * message ids must be globally unique across all instances
    */
   allInstanceMessages: Record<number, ChatMessage>;
+
+  /**
+   * A map of instance id to whether the instance is dirty
+   */
+  dirtyInstances: Record<number, boolean>;
 
   /**
    * Setter for the invocation mode


### PR DESCRIPTION
The playground had a handful of unpredictable transformations / validations implemented. While they prevented runtime errors, they led to confusing and unexplained behavior.

Now, when errors are present in any of the json fields, they will pass through to the LLM client instead of sending last known good values.

This isn't perfect, as some error messages are being swallowed on the backend, but that can be improved over time.

Additionally, performance has been improved by normalized instance dirty state. Previously, every keystroke would re-render the entire playground because we were updating the root of the instance state to flip the dirty boolean. Now that dirty state is normalized, re-renders are once again localized to the editor that is being manipulated.

resolves #6312 
resolves #6310