### PR TITLE
fix(perf): add a toggle to treat orphans as root

### DIFF
--- a/app/src/pages/project/ProjectFilterConfigButton.tsx
+++ b/app/src/pages/project/ProjectFilterConfigButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { css } from "@emotion/react";
 
 import { Switch } from "@arizeai/components";
 
@@ -16,11 +15,6 @@ import {
 } from "@phoenix/components";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 
-const buttonCSS = css`
-  padding: var(--ac-global-dimension-static-size-100);
-  border-radius: var(--ac-global-rounding-small);
-`;
-
 /**
  * A button that opens a configuration popover for project filters.
  * Currently allows configuring how orphan spans are treated in the trace view.
@@ -36,7 +30,6 @@ export function ProjectFilterConfigButton() {
     <DialogTrigger>
       <Button
         size="M"
-        css={buttonCSS}
         aria-label="Filter Configuration"
         leadingVisual={<Icon svg={<Icons.OptionsOutline />} />}
       />

--- a/app/src/pages/project/ProjectFilterConfigButton.tsx
+++ b/app/src/pages/project/ProjectFilterConfigButton.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+import { Switch } from "@arizeai/components";
+
+import {
+  Button,
+  Dialog,
+  DialogTrigger,
+  Flex,
+  Icon,
+  Icons,
+  Popover,
+  PopoverArrow,
+  View,
+} from "@phoenix/components";
+import { useProjectContext } from "@phoenix/contexts/ProjectContext";
+
+const buttonCSS = css`
+  padding: var(--ac-global-dimension-static-size-100);
+  border-radius: var(--ac-global-rounding-small);
+`;
+
+/**
+ * A button that opens a configuration popover for project filters.
+ * Currently allows configuring how orphan spans are treated in the trace view.
+ */
+export function ProjectFilterConfigButton() {
+  const treatOrphansAsRoots = useProjectContext(
+    (state) => state.treatOrphansAsRoots
+  );
+  const setTreatOrphansAsRoots = useProjectContext(
+    (state) => state.setTreatOrphansAsRoots
+  );
+  return (
+    <DialogTrigger>
+      <Button
+        size="M"
+        css={buttonCSS}
+        aria-label="Filter Configuration"
+        leadingVisual={<Icon svg={<Icons.OptionsOutline />} />}
+      />
+      <Popover>
+        <PopoverArrow />
+        <Dialog>
+          <View padding="size-100">
+            <Flex direction="column" gap="size-100">
+              <Switch
+                isSelected={treatOrphansAsRoots}
+                onChange={(isSelected) => {
+                  setTreatOrphansAsRoots(isSelected);
+                }}
+              >
+                Treat Orphan Spans as Roots
+              </Switch>
+            </Flex>
+          </View>
+        </Dialog>
+      </Popover>
+    </DialogTrigger>
+  );
+}

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -21,6 +21,7 @@ import {
   ConnectedLastNTimeRangePicker,
   useTimeRange,
 } from "@phoenix/components/datetime";
+import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 
@@ -103,6 +104,9 @@ export function ProjectPageContent({
   projectId: string;
   timeRange: OpenTimeRange;
 }) {
+  const treatOrphansAsRoots = useProjectContext(
+    (state) => state.treatOrphansAsRoots
+  );
   const timeRangeVariable = useMemo(() => {
     return {
       start: timeRange?.start?.toISOString(),
@@ -150,6 +154,7 @@ export function ProjectPageContent({
       loadSpansQuery({
         id: projectId as string,
         timeRange: timeRangeVariable,
+        orphanSpanAsRootSpan: treatOrphansAsRoots,
       });
     } else if (tabIndex === 1) {
       loadTracesQuery({
@@ -185,6 +190,7 @@ export function ProjectPageContent({
     loadSessionsQuery,
     loadProjectConfigQuery,
     disposeProjectConfigQuery,
+    treatOrphansAsRoots,
   ]);
 
   const onTabChange = useCallback(

--- a/app/src/pages/project/ProjectPageQueries.tsx
+++ b/app/src/pages/project/ProjectPageQueries.tsx
@@ -14,7 +14,11 @@ export const ProjectPageQueriesTracesQuery = graphql`
 `;
 
 export const ProjectPageQueriesSpansQuery = graphql`
-  query ProjectPageQueriesSpansQuery($id: GlobalID!, $timeRange: TimeRange!) {
+  query ProjectPageQueriesSpansQuery(
+    $id: GlobalID!
+    $timeRange: TimeRange!
+    $orphanSpanAsRootSpan: Boolean!
+  ) {
     project: node(id: $id) {
       ...SpansTable_spans
     }

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -54,6 +54,7 @@ import {
 import { SpansTableSpansQuery } from "./__generated__/SpansTableSpansQuery.graphql";
 import { AnnotationTooltipFilterActions } from "./AnnotationTooltipFilterActions";
 import { DEFAULT_PAGE_SIZE } from "./constants";
+import { ProjectFilterConfigButton } from "./ProjectFilterConfigButton";
 import { ProjectTableEmpty } from "./ProjectTableEmpty";
 import { RetrievalEvaluationLabel } from "./RetrievalEvaluationLabel";
 import { SpanColumnSelector } from "./SpanColumnSelector";
@@ -170,6 +171,7 @@ export function SpansTable(props: SpansTableProps) {
             sort: $sort
             rootSpansOnly: $rootSpansOnly
             filterCondition: $filterCondition
+            orphanSpanAsRootSpan: $orphanSpanAsRootSpan
             timeRange: $timeRange
           ) @connection(key: "SpansTable_spans") {
             edges {
@@ -588,6 +590,7 @@ export function SpansTable(props: SpansTableProps) {
       >
         <Flex direction="row" gap="size-100" width="100%" alignItems="center">
           <SpanFilterConditionField onValidCondition={setFilterCondition} />
+
           <ToggleButtonGroup
             aria-label="Toggle between root and all spans"
             selectionMode="single"
@@ -613,6 +616,7 @@ export function SpansTable(props: SpansTableProps) {
               All
             </ToggleButton>
           </ToggleButtonGroup>
+          <ProjectFilterConfigButton />
           <SpanColumnSelector columns={computedColumns} query={data} />
         </Flex>
       </View>

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -616,8 +616,8 @@ export function SpansTable(props: SpansTableProps) {
               All
             </ToggleButton>
           </ToggleButtonGroup>
-          <ProjectFilterConfigButton />
           <SpanColumnSelector columns={computedColumns} query={data} />
+          <ProjectFilterConfigButton />
         </Flex>
       </View>
       <div

--- a/app/src/pages/project/__generated__/ProjectPageQueriesSpansQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQueriesSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4c773ba1ba88ba5cfaba3f4cf8760b04>>
+ * @generated SignedSource<<53d6af2dbb8876539b9018fb27d405c8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type TimeRange = {
 };
 export type ProjectPageQueriesSpansQuery$variables = {
   id: string;
+  orphanSpanAsRootSpan: boolean;
   timeRange: TimeRange;
 };
 export type ProjectPageQueriesSpansQuery$data = {
@@ -29,51 +30,59 @@ export type ProjectPageQueriesSpansQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "id"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "timeRange"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orphanSpanAsRootSpan"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "timeRange"
+},
+v3 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v2 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
+  },
+  {
+    "kind": "Variable",
+    "name": "orphanSpanAsRootSpan",
+    "variableName": "orphanSpanAsRootSpan"
   },
   {
     "kind": "Literal",
@@ -94,7 +103,7 @@ v5 = [
     "variableName": "timeRange"
   }
 ],
-v6 = [
+v8 = [
   {
     "alias": "value",
     "args": null,
@@ -105,14 +114,18 @@ v6 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "ProjectPageQueriesSpansQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v1/*: any*/),
+        "args": (v3/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -132,28 +145,32 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Operation",
     "name": "ProjectPageQueriesSpansQuery",
     "selections": [
       {
         "alias": "project",
-        "args": (v1/*: any*/),
+        "args": (v3/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          (v3/*: any*/),
+          (v5/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v4/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -163,7 +180,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -185,7 +202,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -193,7 +210,7 @@ return {
                             "name": "spanKind",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -279,7 +296,7 @@ return {
                             "name": "trace",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
+                              (v5/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -297,7 +314,7 @@ return {
                             "kind": "LinkedField",
                             "name": "input",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -307,7 +324,7 @@ return {
                             "kind": "LinkedField",
                             "name": "output",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -318,7 +335,7 @@ return {
                             "name": "spanAnnotations",
                             "plural": true,
                             "selections": [
-                              (v4/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -400,7 +417,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -437,11 +454,12 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v7/*: any*/),
                 "filters": [
                   "sort",
                   "rootSpansOnly",
                   "filterCondition",
+                  "orphanSpanAsRootSpan",
                   "timeRange"
                 ],
                 "handle": "connection",
@@ -459,16 +477,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b51a4db184716ccec6d1929466116e1c",
+    "cacheID": "05f5f4fe0a7acdcdf65c5f56c7eb693a",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQueriesSpansQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQueriesSpansQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQueriesSpansQuery(\n  $id: GlobalID!\n  $timeRange: TimeRange!\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e542eba73c6dca4efa0c889866e493d8";
+(node as any).hash = "a5fa32795ad28b109d44f7d21b18afa0";
 
 export default node;

--- a/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2a113ab235ad2fa2c488f9f44ca1288>>
+ * @generated SignedSource<<e871157f5267446298ce1bd395799b9b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type SpansTableSpansQuery$variables = {
   filterCondition?: string | null;
   first?: number | null;
   id: string;
+  orphanSpanAsRootSpan?: boolean | null;
   rootSpansOnly?: boolean | null;
   sort?: SpanSort | null;
   timeRange?: TimeRange | null;
@@ -67,11 +68,16 @@ v3 = {
   "name": "id"
 },
 v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orphanSpanAsRootSpan"
+},
+v5 = {
   "defaultValue": true,
   "kind": "LocalArgument",
   "name": "rootSpansOnly"
 },
-v5 = {
+v6 = {
   "defaultValue": {
     "col": "startTime",
     "dir": "desc"
@@ -79,77 +85,82 @@ v5 = {
   "kind": "LocalArgument",
   "name": "sort"
 },
-v6 = {
+v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
   "name": "timeRange"
 },
-v7 = [
+v8 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "after",
   "variableName": "after"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "filterCondition",
   "variableName": "filterCondition"
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v11 = {
+v12 = {
   "kind": "Variable",
   "name": "rootSpansOnly",
   "variableName": "rootSpansOnly"
 },
-v12 = {
+v13 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v16 = [
-  (v8/*: any*/),
+v17 = [
   (v9/*: any*/),
   (v10/*: any*/),
   (v11/*: any*/),
+  {
+    "kind": "Variable",
+    "name": "orphanSpanAsRootSpan",
+    "variableName": "orphanSpanAsRootSpan"
+  },
   (v12/*: any*/),
+  (v13/*: any*/),
   {
     "kind": "Variable",
     "name": "timeRange",
     "variableName": "timeRange"
   }
 ],
-v17 = [
+v18 = [
   {
     "alias": "value",
     "args": null,
@@ -167,7 +178,8 @@ return {
       (v3/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
-      (v6/*: any*/)
+      (v6/*: any*/),
+      (v7/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -175,7 +187,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v8/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -183,11 +195,11 @@ return {
         "selections": [
           {
             "args": [
-              (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
-              (v12/*: any*/)
+              (v12/*: any*/),
+              (v13/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "SpansTable_spans"
@@ -208,6 +220,7 @@ return {
       (v4/*: any*/),
       (v5/*: any*/),
       (v6/*: any*/),
+      (v7/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -215,22 +228,22 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v8/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isNode"
           },
-          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v15/*: any*/),
+              (v16/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -240,7 +253,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "concreteType": "SpanConnection",
                 "kind": "LinkedField",
                 "name": "spans",
@@ -262,7 +275,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -270,7 +283,7 @@ return {
                             "name": "spanKind",
                             "storageKey": null
                           },
-                          (v15/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -356,7 +369,7 @@ return {
                             "name": "trace",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -374,7 +387,7 @@ return {
                             "kind": "LinkedField",
                             "name": "input",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -384,7 +397,7 @@ return {
                             "kind": "LinkedField",
                             "name": "output",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -395,7 +408,7 @@ return {
                             "name": "spanAnnotations",
                             "plural": true,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -477,7 +490,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -514,11 +527,12 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "filters": [
                   "sort",
                   "rootSpansOnly",
                   "filterCondition",
+                  "orphanSpanAsRootSpan",
                   "timeRange"
                 ],
                 "handle": "connection",
@@ -536,16 +550,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dd7db515b7947a1a1481324515eb9785",
+    "cacheID": "724a34c18ec17312b01be5ccae4d7159",
     "id": null,
     "metadata": {},
     "name": "SpansTableSpansQuery",
     "operationKind": "query",
-    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 30\n  $rootSpansOnly: Boolean = true\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_xYL0c\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans_xYL0c on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: $first, after: $after, sort: $sort, rootSpansOnly: $rootSpansOnly, filterCondition: $filterCondition, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 30\n  $orphanSpanAsRootSpan: Boolean\n  $rootSpansOnly: Boolean = true\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: GlobalID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_xYL0c\n    __isNode: __typename\n    id\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans_xYL0c on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: $first, after: $after, sort: $sort, rootSpansOnly: $rootSpansOnly, filterCondition: $filterCondition, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        tokenCountPrompt\n        tokenCountCompletion\n        cumulativeTokenCountTotal\n        cumulativeTokenCountPrompt\n        cumulativeTokenCountCompletion\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          name\n          label\n          score\n          annotatorKind\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n      }\n      cursor\n      node {\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8f991e4edeea0af9ef62e623be424c50";
+(node as any).hash = "3abfb2f2fae91e346221687ee5213714";
 
 export default node;

--- a/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<78d153705911957b05cb83181bea563a>>
+ * @generated SignedSource<<15d6b44453b1e7aa781b5edd07316779>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -113,6 +113,10 @@ return {
       "name": "first"
     },
     {
+      "kind": "RootArgument",
+      "name": "orphanSpanAsRootSpan"
+    },
+    {
       "defaultValue": true,
       "kind": "LocalArgument",
       "name": "rootSpansOnly"
@@ -174,6 +178,11 @@ return {
           "kind": "Variable",
           "name": "filterCondition",
           "variableName": "filterCondition"
+        },
+        {
+          "kind": "Variable",
+          "name": "orphanSpanAsRootSpan",
+          "variableName": "orphanSpanAsRootSpan"
         },
         {
           "kind": "Variable",
@@ -475,6 +484,6 @@ return {
 };
 })();
 
-(node as any).hash = "8f991e4edeea0af9ef62e623be424c50";
+(node as any).hash = "3abfb2f2fae91e346221687ee5213714";
 
 export default node;

--- a/app/src/store/projectStore.ts
+++ b/app/src/store/projectStore.ts
@@ -6,6 +6,15 @@ import { ProjectTab } from "@phoenix/pages/project/constants";
 export interface ProjectState {
   defaultTab: ProjectTab;
   setDefaultTab: (tab: ProjectTab) => void;
+  /**
+   * Whether to treat orphan spans as roots.
+   * @default false
+   */
+  treatOrphansAsRoots: boolean;
+  /**
+   * Set whether to treat orphan spans as roots.
+   */
+  setTreatOrphansAsRoots: (treatOrphansAsRoots: boolean) => void;
 }
 
 export interface ProjectStore {
@@ -28,6 +37,10 @@ export function createProjectStore({
         defaultTab: "spans",
         setDefaultTab: (tab: ProjectTab) => {
           set({ defaultTab: tab });
+        },
+        treatOrphansAsRoots: false,
+        setTreatOrphansAsRoots: (treatOrphansAsRoots: boolean) => {
+          set({ treatOrphansAsRoots });
         },
       }),
       {


### PR DESCRIPTION
resolve #6915 

Adds a toggle to enable treating orphan spans as root.
<img width="362" alt="Screenshot 2025-03-25 at 4 32 52 PM" src="https://github.com/user-attachments/assets/48ca40e3-bfe5-46ff-aac7-eb29e5a4939e" />
