### PR TITLE
refactor(ui): change the span aside to be a resizable panel

### DIFF
--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -45,15 +45,7 @@ export function SpanAside(props: { span: SpanAside_span$key }) {
   const annotations = data.spanAnnotations;
   const hasAnnotations = annotations.length > 0;
   return (
-    <View
-      padding="size-200"
-      borderColor="dark"
-      backgroundColor="dark"
-      borderLeftWidth="thin"
-      width="230px"
-      flex="none"
-      minHeight="100%"
-    >
+    <View padding="size-200" width="100%" flex="none" minHeight="100%">
       <Flex direction="column" gap="size-200">
         <LabeledValue label="Feedback">
           {hasAnnotations ? (

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -32,11 +32,6 @@ export interface PreferencesProps {
    */
   projectsAutoRefreshEnabled: boolean;
   /**
-   * Whether or not to show the span aside that contains details about timing, status, etc.
-   * @default true
-   */
-  showSpanAside: boolean;
-  /**
    * Whether or not the trace tree shows metrics
    */
   showMetricsInTraceTree: boolean;
@@ -71,11 +66,6 @@ export interface PreferencesState extends PreferencesProps {
    * @param projectsAutoRefreshEnabled
    */
   setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled: boolean) => void;
-  /**
-   * Setter for enabling/disabling the span aside
-   * @param showSpanAside
-   */
-  setShowSpanAside: (showSpanAside: boolean) => void;
   /**
    * Setter for enabling/disabling metrics in the trace tree
    * @param showMetricsInTraceTree
@@ -116,10 +106,6 @@ export const createPreferencesStore = (
     projectsAutoRefreshEnabled: true,
     setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled) => {
       set({ projectsAutoRefreshEnabled });
-    },
-    showSpanAside: true,
-    setShowSpanAside: (showSpanAside) => {
-      set({ showSpanAside });
     },
     showMetricsInTraceTree: true,
     setShowMetricsInTraceTree: (showMetricsInTraceTree) => {


### PR DESCRIPTION
This is a pre-cursor to a larger refactor of having annotations show up directly next to the content.
<img width="943" alt="Screenshot 2025-03-26 at 3 10 20 PM" src="https://github.com/user-attachments/assets/f9fcf336-cd9a-42cd-91b3-4add2867395a" />
