### PR TITLE
fix: use CTE for orphan span query

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -236,21 +236,6 @@ class Project(Node):
                 stmt = stmt.where(time_range.start <= models.Span.start_time)
             if time_range.end:
                 stmt = stmt.where(models.Span.start_time < time_range.end)
-        if root_spans_only:
-            # A root span is either a span with no parent_id or an orphan span
-            # (a span whose parent_id references a span that doesn't exist in the database)
-            if orphan_span_as_root_span:
-                # Include both types of root spans
-                parent_spans = select(models.Span.span_id).alias("parent_spans")
-                stmt = stmt.where(
-                    ~select(1).where(models.Span.parent_id == parent_spans.c.span_id).exists()
-                    # Note: We avoid using an OR clause with Span.parent_id.is_(None) here
-                    # because it significantly degraded PostgreSQL performance (>10x worse)
-                    # during testing.
-                )
-            else:
-                # Only include explicit root spans (spans with parent_id = NULL)
-                stmt = stmt.where(models.Span.parent_id.is_(None))
         if filter_condition:
             span_filter = SpanFilter(condition=filter_condition)
             stmt = span_filter(stmt)
@@ -274,11 +259,29 @@ class Project(Node):
                 )
             else:
                 stmt = stmt.where(models.Span.id > cursor.rowid)
+        stmt = stmt.order_by(cursor_rowid_column)
+        if root_spans_only:
+            # A root span is either a span with no parent_id or an orphan span
+            # (a span whose parent_id references a span that doesn't exist in the database)
+            if orphan_span_as_root_span:
+                # Include both types of root spans
+                parent_spans = select(models.Span.span_id).alias("parent_spans")
+                candidate_spans = stmt.add_columns(models.Span.parent_id).cte("candidate_spans")
+                stmt = select(candidate_spans).where(
+                    or_(
+                        candidate_spans.c.parent_id.is_(None),
+                        ~select(1)
+                        .where(candidate_spans.c.parent_id == parent_spans.c.span_id)
+                        .exists(),
+                    )
+                )
+            else:
+                # Only include explicit root spans (spans with parent_id = NULL)
+                stmt = stmt.where(models.Span.parent_id.is_(None))
         if first:
             stmt = stmt.limit(
                 first + 1  # overfetch by one to determine whether there's a next page
             )
-        stmt = stmt.order_by(cursor_rowid_column)
         cursors_and_nodes = []
         async with info.context.db() as session:
             span_records = await session.stream(stmt)

--- a/tests/unit/server/api/types/test_Project.py
+++ b/tests/unit/server/api/types/test_Project.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E501
 import base64
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from secrets import token_hex
 from typing import Any
 
@@ -1222,60 +1222,75 @@ class TestProject:
         self,
         db: DbSessionFactory,
     ) -> _Data:
-        # Creates spans with missing parent references to test orphan span handling
-        projects, traces, spans = [], [], []
+        """Creates spans with missing parent references to test orphan span handling.
+
+        This fixture creates a test dataset with spans that have various parent-child relationships:
+        - Some spans have no parent (parent_id=None) - these are true root spans
+        - Some spans have parent_ids that don't exist - these are orphan spans
+        - Some spans have valid parent references
+
+        The fixture is used to test how the API handles orphan spans in different configurations.
+        """
+        projects, traces = [], []
+        spans: list[models.Span] = []
         async with db() as session:
+            # Create a test project
             projects.append(models.Project(name=token_hex(8)))
             session.add(projects[-1])
             await session.flush()
-            traces.append(
-                models.Trace(
-                    trace_id=token_hex(16),
-                    project_rowid=projects[-1].id,
-                    start_time=datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
-                    end_time=datetime.fromisoformat("2024-01-01T00:00:01+00:00"),
+
+            start_time = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+            for i in range(2):
+                # Create two traces with different start times
+                trace_start_time = start_time + timedelta(seconds=i)
+                traces.append(
+                    models.Trace(
+                        trace_id=token_hex(16),
+                        project_rowid=projects[-1].id,
+                        start_time=trace_start_time,
+                        end_time=trace_start_time + timedelta(seconds=1),
+                    )
                 )
-            )
-            session.add(traces[-1])
-            await session.flush()
-            spans.append(
-                models.Span(
-                    trace_rowid=traces[-1].id,
-                    span_id=token_hex(8),
-                    parent_id=None,
-                    name="root",
-                    span_kind="CHAIN",
-                    start_time=datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
-                    end_time=datetime.fromisoformat("2024-01-01T00:00:01+00:00"),
-                    attributes={},
-                    events=[],
-                    status_code="OK",
-                    status_message="",
-                    cumulative_error_count=0,
-                    cumulative_llm_token_count_prompt=0,
-                    cumulative_llm_token_count_completion=0,
-                )
-            )
-            spans.append(
-                models.Span(
-                    trace_rowid=traces[-1].id,
-                    span_id=token_hex(8),
-                    parent_id=token_hex(8),
-                    name="orphan",
-                    span_kind="LLM",
-                    start_time=datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
-                    end_time=datetime.fromisoformat("2024-01-01T00:00:01+00:00"),
-                    attributes={},
-                    events=[],
-                    status_code="OK",
-                    status_message="",
-                    cumulative_error_count=0,
-                    cumulative_llm_token_count_prompt=0,
-                    cumulative_llm_token_count_completion=0,
-                )
-            )
+                session.add(traces[-1])
+                await session.flush()
+
+                n = 7
+                for j in range(n):
+                    # Create spans with different parent relationships:
+                    if j % 2:
+                        # Odd-indexed spans have non-existent parent IDs (orphan spans)
+                        parent_id = token_hex(8)
+                    elif j and j == n - 1:
+                        # The last span (when j is even and non-zero) references the previous span
+                        parent_id = spans[-1].span_id
+                    else:
+                        # Even-indexed spans (except the last) have no parent (root spans)
+                        parent_id = None
+
+                    span_start_time = trace_start_time + timedelta(seconds=j)
+                    spans.append(
+                        models.Span(
+                            trace_rowid=traces[-1].id,
+                            span_id=token_hex(8),
+                            parent_id=parent_id,
+                            name=token_hex(8),
+                            span_kind="CHAIN",
+                            start_time=span_start_time,
+                            end_time=span_start_time + timedelta(seconds=1),
+                            # Input value contains sequential digits (0, 01, 012, etc.)
+                            # This is used for filtering in tests
+                            attributes={"input": {"value": "".join(map(str, range(j)))}},
+                            events=[],
+                            status_code="OK",
+                            status_message="",
+                            cumulative_error_count=0,
+                            cumulative_llm_token_count_prompt=0,
+                            cumulative_llm_token_count_completion=0,
+                        )
+                    )
             session.add_all(spans)
             await session.flush()
+
         return _Data(
             spans=spans,
             traces=traces,
@@ -1481,31 +1496,58 @@ class TestProject:
         res = await self._node(field, project, httpx_client)
         assert {e["node"]["id"] for e in res["edges"]} == set()
 
-    async def test_root_spans_only_without_orphan_spans(
-        self,
-        _orphan_spans: _Data,
-        httpx_client: httpx.AsyncClient,
-    ) -> None:
-        project = _orphan_spans.projects[0]
-        field = "spans(rootSpansOnly: true, orphanSpanAsRootSpan: false){edges{node{id}}}"
-        res = await self._node(field, project, httpx_client)
-        # Only spans with parent_id = NULL should be included
-        root_spans = {e["node"]["id"] for e in res["edges"]}
-        assert root_spans == {
-            _gid(_orphan_spans.spans[0]),
-        }
-
+    @pytest.mark.parametrize("orphan_span_as_root_span", [False, True])
     async def test_root_spans_only_with_orphan_spans(
         self,
         _orphan_spans: _Data,
         httpx_client: httpx.AsyncClient,
+        orphan_span_as_root_span: bool,
     ) -> None:
+        """Test pagination of root spans with orphan span handling.
+
+        This test verifies that:
+        1. Root spans are correctly identified based on orphan_span_as_root_span setting
+        2. Pagination works correctly when fetching spans in chunks
+        3. Spans are properly filtered and sorted
+        """
         project = _orphan_spans.projects[0]
-        field = "spans(rootSpansOnly: true){edges{node{id}}}"
-        res = await self._node(field, project, httpx_client)
-        # Both root spans and orphan spans should be included
-        root_spans = {e["node"]["id"] for e in res["edges"]}
-        assert root_spans == {
-            _gid(_orphan_spans.spans[0]),
-            _gid(_orphan_spans.spans[1]),
-        }
+
+        # Filter spans containing "2" in their input value
+        filtered_spans = [s for s in _orphan_spans.spans if "2" in s.attributes["input"]["value"]]
+
+        # Determine root spans based on configuration
+        if orphan_span_as_root_span:
+            existing_span_ids = {s.span_id for s in _orphan_spans.spans}
+            root_spans = [s for s in filtered_spans if s.parent_id not in existing_span_ids]
+        else:
+            root_spans = [s for s in filtered_spans if s.parent_id is None]
+
+        # Sort spans by start time and ID
+        sorted_spans = sorted(root_spans, key=lambda t: (t.start_time, t.id), reverse=True)
+
+        # Convert to global IDs for comparison
+        gids = list(map(_gid, sorted_spans))
+        n = len(gids)
+        first = n // 2 + 1  # Request half the spans plus one
+
+        # Test pagination
+        cursor = ""
+        for i in range(n):
+            expected = gids[i : i + first]
+
+            # Construct GraphQL query
+            field = (
+                "spans("
+                f"rootSpansOnly:true,"
+                f"orphanSpanAsRootSpan:{str(orphan_span_as_root_span).lower()},"
+                "sort:{col:startTime,dir:desc},"
+                "filterCondition:\"'2' in input.value\","
+                f"first:{str(first)},"
+                f'after:"{cursor}"'
+                "){edges{node{id}cursor}}"
+            )
+
+            # Execute query and verify results
+            res = await self._node(field, project, httpx_client)
+            assert [e["node"]["id"] for e in res["edges"]] == expected
+            cursor = res["edges"][0]["cursor"]


### PR DESCRIPTION
## Query Performance Comparison

| Query #    | Median (ms)  | Ratio    | P90 (ms)   | N Runs   | Rows Returned |
|------------|-------------:|---------:|-----------:|---------:|--------------:|
| Query 1    |       1115.3 |      1.6 |     1162.3 |       20 |          1000 |
| Query 2    |        684.5 |      1.0 |      789.5 |       20 |          1000 |

### Data Stats
traces: 76,551
spans: 4,457,957
disk: 80 GiB

### Queries

```sql
-- Query 1
SELECT spans.id, spans.start_time AS "startTime_span_sort_column"
FROM spans
         JOIN traces ON traces.id = spans.trace_rowid
WHERE traces.project_rowid = 1
  AND spans.start_time >= (NOW() - INTERVAL '2400 hours')
  AND NOT (EXISTS (SELECT 1
                   FROM (SELECT spans.span_id AS span_id
                         FROM spans) AS parent_spans
                   WHERE spans.parent_id = parent_spans.span_id))
ORDER BY "startTime_span_sort_column" DESC NULLS LAST, spans.id DESC
LIMIT 1000;

-- Query 2
WITH candidate_spans AS
         (SELECT spans.id         AS id,
                 spans.start_time AS "startTime_span_sort_column",
                 spans.parent_id  AS parent_id
          FROM spans
                   JOIN traces ON traces.id = spans.trace_rowid
          WHERE traces.project_rowid = 1
            AND spans.start_time >= (NOW() - INTERVAL '2400 hours')
          ORDER BY "startTime_span_sort_column" DESC NULLS LAST, spans.id DESC)
SELECT candidate_spans.id,
       candidate_spans."startTime_span_sort_column",
       candidate_spans.parent_id
FROM candidate_spans
WHERE candidate_spans.parent_id IS NULL
   OR NOT (EXISTS (SELECT 1
                   FROM (SELECT spans.span_id AS span_id
                         FROM spans) AS parent_spans
                   WHERE candidate_spans.parent_id = parent_spans.span_id))
LIMIT 1000;
```

## Query Plans (PostgreSQL 12.22)
Query 1
```
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                            |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=408178.36..408295.04 rows=1000 width=12) (actual time=1230.083..1271.330 rows=1000 loops=1)                                                              |
|  ->  Gather Merge  (cost=408178.36..408497.59 rows=2736 width=12) (actual time=1220.296..1261.504 rows=1000 loops=1)                                                 |
|        Workers Planned: 2                                                                                                                                            |
|        Workers Launched: 2                                                                                                                                           |
|        ->  Sort  (cost=407178.34..407181.76 rows=1368 width=12) (actual time=1209.305..1209.343 rows=765 loops=3)                                                    |
|              Sort Key: spans.start_time DESC NULLS LAST, spans.id DESC                                                                                               |
|              Sort Method: top-N heapsort  Memory: 139kB                                                                                                              |
|              Worker 0:  Sort Method: top-N heapsort  Memory: 142kB                                                                                                   |
|              Worker 1:  Sort Method: top-N heapsort  Memory: 142kB                                                                                                   |
|              ->  Nested Loop  (cost=189305.90..407107.08 rows=1368 width=12) (actual time=814.070..1193.453 rows=258182 loops=3)                                     |
|                    ->  Parallel Hash Anti Join  (cost=189305.48..406505.39 rows=1368 width=16) (actual time=814.027..975.277 rows=258182 loops=3)                    |
|                          Hash Cond: ((spans.parent_id)::text = (spans_1.span_id)::text)                                                                              |
|                          ->  Parallel Seq Scan on spans  (cost=0.00..169925.93 rows=1784510 width=33) (actual time=0.038..214.670 rows=1485986 loops=3)              |
|                                Filter: (start_time >= (now() - '2400:00:00'::interval))                                                                              |
|                          ->  Parallel Hash  (cost=156542.10..156542.10 rows=1784510 width=17) (actual time=327.627..327.627 rows=1485986 loops=3)                    |
|                                Buckets: 65536  Batches: 128  Memory Usage: 2496kB                                                                                    |
|                                ->  Parallel Seq Scan on spans spans_1  (cost=0.00..156542.10 rows=1784510 width=17) (actual time=3.155..152.610 rows=1485986 loops=3)|
|                    ->  Index Scan using pk_traces on traces  (cost=0.42..0.44 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=774547)                         |
|                          Index Cond: (id = spans.trace_rowid)                                                                                                        |
|                          Filter: (project_rowid = 1)                                                                                                                 |
|Planning Time: 0.953 ms                                                                                                                                               |
|JIT:                                                                                                                                                                  |
|  Functions: 52                                                                                                                                                       |
|  Options: Inlining false, Optimization false, Expressions true, Deforming true                                                                                       |
|  Timing: Generation 1.762 ms, Inlining 0.000 ms, Optimization 0.924 ms, Emission 18.364 ms, Total 21.050 ms                                                          |
|Execution Time: 1272.420 ms                                                                                                                                           |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Query 2
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                              |
+--------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=449177.76..466317.97 rows=1000 width=29) (actual time=1234.638..1251.062 rows=1000 loops=1)                                                |
|  ->  Subquery Scan on candidate_spans  (cost=449177.76..31059501.70 rows=1785878 width=29) (actual time=1223.753..1240.142 rows=1000 loops=1)          |
|        Filter: ((candidate_spans.parent_id IS NULL) OR (NOT (SubPlan 1)))                                                                              |
|        Rows Removed by Filter: 2336                                                                                                                    |
|        ->  Gather Merge  (cost=449177.76..865592.50 rows=3569020 width=29) (actual time=1220.785..1228.090 rows=3336 loops=1)                          |
|              Workers Planned: 2                                                                                                                        |
|              Workers Launched: 2                                                                                                                       |
|              ->  Sort  (cost=448177.73..452639.01 rows=1784510 width=29) (actual time=1175.885..1175.974 rows=1598 loops=3)                            |
|                    Sort Key: spans.start_time DESC NULLS LAST, spans.id DESC                                                                           |
|                    Sort Method: external merge  Disk: 63616kB                                                                                          |
|                    Worker 0:  Sort Method: external merge  Disk: 61984kB                                                                               |
|                    Worker 1:  Sort Method: external merge  Disk: 62080kB                                                                               |
|                    ->  Parallel Hash Join  (cost=2878.75..177489.28 rows=1784510 width=29) (actual time=17.389..682.119 rows=1485986 loops=3)          |
|                          Hash Cond: (spans.trace_rowid = traces.id)                                                                                    |
|                          ->  Parallel Seq Scan on spans  (cost=0.00..169925.93 rows=1784510 width=33) (actual time=4.317..500.170 rows=1485986 loops=3)|
|                                Filter: (start_time >= (now() - '2400:00:00'::interval))                                                                |
|                          ->  Parallel Hash  (cost=2315.88..2315.88 rows=45030 width=4) (actual time=12.239..12.239 rows=25517 loops=3)                 |
|                                Buckets: 131072  Batches: 1  Memory Usage: 4032kB                                                                       |
|                                ->  Parallel Seq Scan on traces  (cost=0.00..2315.88 rows=45030 width=4) (actual time=0.053..22.329 rows=76551 loops=1) |
|                                      Filter: (project_rowid = 1)                                                                                       |
|        SubPlan 1                                                                                                                                       |
|          ->  Index Only Scan using uq_spans_span_id on spans spans_1  (cost=0.43..8.45 rows=1 width=0) (actual time=0.003..0.003 rows=1 loops=3336)    |
|                Index Cond: (span_id = (candidate_spans.parent_id)::text)                                                                               |
|                Heap Fetches: 2336                                                                                                                      |
|Planning Time: 2.073 ms                                                                                                                                 |
|JIT:                                                                                                                                                    |
|  Functions: 48                                                                                                                                         |
|  Options: Inlining false, Optimization false, Expressions true, Deforming true                                                                         |
|  Timing: Generation 4.975 ms, Inlining 0.000 ms, Optimization 2.244 ms, Emission 21.511 ms, Total 28.729 ms                                            |
|Execution Time: 1257.530 ms                                                                                                                             |
+--------------------------------------------------------------------------------------------------------------------------------------------------------+
```