### PR TITLE
fix: Formatting of additionalModelRequestFields based on model

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -181,7 +181,7 @@ class BedrockModel(BaseModel):
         additional_model_request_fields: Dict[str, Union[int, Dict[str, Any]]] = {}
         # Only add top_k if specified and model supports it
         if self.top_k is not None and self._model_supports_top_k():
-            if "nova" in self.model_id:
+            if self.model_id.startswith(("amazon.nova", "us.amazon.nova")):
                 additional_model_request_fields["inferenceConfig"] = {"topK": self.top_k}
             else:
                 additional_model_request_fields["top_k"] = self.top_k

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -178,7 +178,7 @@ class BedrockModel(BaseModel):
         }
 
         # Add any extra parameters that aren't part of the Converse inferenceConfig parameter
-        additional_model_request_fields = {}
+        additional_model_request_fields: Dict[str, Union[int, Dict[str, Any]]] = {}
         # Meta Llama and Titan models do not support the topK parameter
         # Only add if different from default
         if self.top_k != 256 and "meta.llama" not in self.model_id and "titan" not in self.model_id:

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -179,8 +179,13 @@ class BedrockModel(BaseModel):
 
         # Add any extra parameters that aren't part of the Converse inferenceConfig parameter
         additional_model_request_fields = {}
-        if self.top_k != 256:  # Only add if different from default
-            additional_model_request_fields["inferenceConfig"] = {"topK": self.top_k}
+        # Meta Llama and Titan models do not support the topK parameter
+        # Only add if different from default
+        if self.top_k != 256 and "meta.llama" not in self.model_id and "titan" not in self.model_id:
+            if "nova" in self.model_id:
+                additional_model_request_fields["inferenceConfig"] = {"topK": self.top_k}
+            else:
+                additional_model_request_fields["top_k"] = self.top_k
 
         # Add any remaining extra parameters
         additional_model_request_fields.update(self.extra_parameters)

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -204,12 +204,12 @@ class BedrockModel(BaseModel):
 
     def _parse_output(self, response: Any) -> Any:
         return response.get("output").get("message").get("content")[0]["text"]
-    
+
     def _model_supports_top_k(self) -> bool:
         """
         Some models do not support the topK parameter.
         Meta Llama and Titan models do not support the topK parameter
-        
+
         """
         models_that_do_not_support_top_k = ["meta.llama", "titan"]
         return not any(model in self.model_id for model in models_that_do_not_support_top_k)


### PR DESCRIPTION
For `Nova` models, additionalModelRequestFields should be structured as the following:
```
additionalModelRequestFields = {
    "inferenceConfig": {
         "topK": 20
    }
}
```
But in other models, should be structured like so:
`additionalModelRequestFields= {"top_k": 20}`