### PR TITLE
fix: Re-enable project stream toggle

### DIFF
--- a/app/src/pages/project/StreamToggle.tsx
+++ b/app/src/pages/project/StreamToggle.tsx
@@ -17,7 +17,7 @@ const REFRESH_INTERVAL_MS = 2000;
 /**
  * Routes where streaming is enabled
  */
-const STREAMING_ENABLED_ROUTE_TAILS = ["/spans", "/traces", "/sessions"];
+const STREAMING_ENABLED_ROUTE_TAILS = ["spans", "traces", "sessions"];
 
 export function StreamToggle(props: { project: StreamToggle_data$key }) {
   const {
@@ -78,7 +78,6 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
       onChange={() => {
         setIsStreaming(!isStreamingState);
       }}
-      isDisabled={!isStreamingEnabled}
     >
       Stream
     </Switch>


### PR DESCRIPTION
- route tails had slash while tail check logic did not so streaming could never enable
- switch was disabled completely whenever streaming was turned off so you could not turn it back on