### PR TITLE
perf: Cache project table results when toggling details slide over

### DIFF
--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -254,7 +254,7 @@ export function SessionsTable(props: SessionsTableProps) {
           first: PAGE_SIZE,
           filterIoSubstring: filterIoSubstring,
         },
-        { fetchPolicy: "store-and-network" }
+        { fetchPolicy: "store-or-network" }
       );
     });
   }, [sorting, refetch, filterIoSubstring, fetchKey]);

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -488,7 +488,7 @@ export function SpansTable(props: SpansTableProps) {
             filterCondition,
             rootSpansOnly,
           },
-          { fetchPolicy: "store-and-network" }
+          { fetchPolicy: "store-or-network" }
         );
       });
     }

--- a/app/src/pages/project/StreamToggle.tsx
+++ b/app/src/pages/project/StreamToggle.tsx
@@ -17,7 +17,7 @@ const REFRESH_INTERVAL_MS = 2000;
 /**
  * Routes where streaming is enabled
  */
-const STREAMING_ENABLED_ROUTE_TAILS = ["/spans", "/traces", "/sessions"];
+const STREAMING_ENABLED_ROUTE_TAILS = ["spans", "traces", "sessions"];
 
 export function StreamToggle(props: { project: StreamToggle_data$key }) {
   const {
@@ -78,7 +78,6 @@ export function StreamToggle(props: { project: StreamToggle_data$key }) {
       onChange={() => {
         setIsStreaming(!isStreamingState);
       }}
-      isDisabled={!isStreamingEnabled}
     >
       Stream
     </Switch>

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -679,7 +679,7 @@ export function TracesTable(props: TracesTableProps) {
             filterCondition: filterCondition,
           },
           {
-            fetchPolicy: "store-and-network",
+            fetchPolicy: "store-or-network",
           }
         );
       });


### PR DESCRIPTION
Turns out the loaders were not responsible for this performance hit, we just needed to let relay fall back to the store for table results if the data is fresh enough. Streaming will still load in new results as expected.

In the video note that when I open and close the slide over, no additional SpanTableQuery is made. It will be made if relay decides that the data is stale.

https://github.com/user-attachments/assets/27363cda-4c1d-4e6b-b9b5-ed5ab257f0e9

Additionally backports a fix from #6969 that should have targeted main

Resolves #6907