### PR TITLE
docs: mention symlink step (tox run -e add_symlinks) in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@
 
 We recommend using a virtual environment to isolate your Python dependencies. This guide will use `uv`, but you can use a different virtual environment management tool such as `conda` if you want.
 
-First, ensure that your virtual environment manager is installed. For macOS users, we recommend installing `uv` via `brew` with
+**First**, ensure that your virtual environment manager is installed. For macOS users, we recommend installing `uv` via `brew` with
 
 ```
 brew install uv
@@ -47,8 +47,16 @@ From the root of the reposistory, install the `arize-phoenix` package in editabl
 ```bash
 uv pip install -e ".[dev]"
 ```
+Some parts of Phoenix—such as `phoenix.evals`, `phoenix.otel`, and `phoenix.client` developed as local packages located under the packages/ directory. These modules are excluded from the standard build process and are not installed automatically.
 
-Second, install the web build dependencies.
+To make these modules available when working from source, run:
+
+```bash
+tox run -e add_symlinks
+```
+This command will create symbolic links inside src/phoenix/ pointing to the relevant submodules.
+
+**Second**, install the web build dependencies.
 
 We recommend installing [nodejs via nvm](https://github.com/nvm-sh/nvm) and then
 installing `pnpm` globally to manage the web frontend dependencies.


### PR DESCRIPTION
### Title

docs: mention symlink step (tox run -e add_symlinks) in DEVELOPMENT.md

### Description

This PR updates `DEVELOPMENT.md` to include a missing but important step for contributors working from source: linking local submodules via `tox run -e add_symlinks`.

Without this step, contributors may encounter import errors such as:
`ModuleNotFoundError: No module named 'phoenix.evals'`

This is because several parts of Phoenix—like `phoenix.evals`, `phoenix.otel`, and `phoenix.client`—live in the `packages/` directory and are excluded from the standard build and install process.

Running:

```bash
tox run -e add_symlinks
```
creates symbolic links to make these modules available for import in the local development environment. This behavior is defined in the tox.ini file but not documented, which may confuse new contributors.

The use of this command was suggested by Dustin Ngo on [Slack](https://arize-ai.slack.com/archives/C04R3GXC8HK/p1743639671633009?thread_ts=1743639291.403459&cid=C04R3GXC8HK):
“When you install Phoenix locally you’ll need to run our symlink script to get our submodules installed locally”

No issue was created since this is a minor documentation update, though I understand that issues are generally required per CONTRIBUTING.md. Happy to adjust or close the PR if preferred.