### PR TITLE
fix: add aiohttp to container for azure-identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ container = [
   "prometheus-client",
   "openai>=1.0.0",
   "azure-identity",
+  "aiohttp",  # used by azure-identity via azure.core.pipeline.transport
   "opentelemetry-sdk",
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-exporter-otlp",


### PR DESCRIPTION
error stack trace when aiohttp is not present

```shell
phoenix-1  | GraphQL request:4:3
phoenix-1  | 3 | ) {
phoenix-1  | 4 |   chatCompletion(input: $input) {
phoenix-1  |   |   ^
phoenix-1  | 5 |     __typename
phoenix-1  | Traceback (most recent call last):
phoenix-1  |   File "/phoenix/env/azure/core/pipeline/transport/__init__.py", line 90, in __getattr__
phoenix-1  |     from ._aiohttp import AioHttpTransport
phoenix-1  |   File "/phoenix/env/azure/core/pipeline/transport/_aiohttp.py", line 45, in <module>
phoenix-1  |     import aiohttp
phoenix-1  | ModuleNotFoundError: No module named 'aiohttp'
phoenix-1  |
phoenix-1  | The above exception was the direct cause of the following exception:
phoenix-1  |
phoenix-1  | Traceback (most recent call last):
phoenix-1  |   File "/phoenix/env/phoenix/server/api/mutations/chat_mutations.py", line 284, in chat_completion
phoenix-1  |     llm_client = llm_client_class(
phoenix-1  |                  ^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/phoenix/server/api/helpers/playground_clients.py", line 683, in __init__
phoenix-1  |     DefaultAzureCredential(),
phoenix-1  |     ^^^^^^^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/azure/identity/aio/_credentials/default.py", line 154, in __init__
phoenix-1  |     ManagedIdentityCredential(
phoenix-1  |   File "/phoenix/env/azure/identity/aio/_credentials/managed_identity.py", line 111, in __init__
phoenix-1  |     self._credential = ImdsCredential(client_id=client_id, identity_config=identity_config, **kwargs)
phoenix-1  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/azure/identity/aio/_credentials/imds.py", line 23, in __init__
phoenix-1  |     self._client = AsyncManagedIdentityClient(_get_request, **dict(PIPELINE_SETTINGS, **kwargs))
phoenix-1  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/azure/identity/_internal/managed_identity_client.py", line 39, in __init__
phoenix-1  |     self._pipeline = self._build_pipeline(**kwargs)
phoenix-1  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/azure/identity/aio/_internal/managed_identity_client.py", line 39, in _build_pipeline
phoenix-1  |     return build_async_pipeline(**kwargs)
phoenix-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/azure/identity/_internal/pipeline.py", line 88, in build_async_pipeline
phoenix-1  |     from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import, no-name-in-module
phoenix-1  |   File "/phoenix/env/azure/core/pipeline/transport/__init__.py", line 94, in __getattr__
phoenix-1  |     raise ImportError("aiohttp package is not installed") from err
phoenix-1  | ImportError: aiohttp package is not installed
phoenix-1  |
phoenix-1  | During handling of the above exception, another exception occurred:
phoenix-1  |
phoenix-1  | Traceback (most recent call last):
phoenix-1  |   File "/phoenix/env/graphql/execution/execute.py", line 530, in await_result
phoenix-1  |     return_type, field_nodes, info, path, await result
phoenix-1  |                                           ^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/strawberry/schema/schema_converter.py", line 752, in _async_resolver
phoenix-1  |     return await await_maybe(
phoenix-1  |            ^^^^^^^^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/strawberry/utils/await_maybe.py", line 13, in await_maybe
phoenix-1  |     return await value
phoenix-1  |            ^^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/strawberry/permission.py", line 215, in resolve_async
phoenix-1  |     return await next
phoenix-1  |            ^^^^^^^^^^
phoenix-1  |   File "/phoenix/env/phoenix/server/api/mutations/chat_mutations.py", line 291, in chat_completion
phoenix-1  |     raise BadRequest(
phoenix-1  | phoenix.server.api.exceptions.BadRequest: Failed to connect to LLM API for Azure OpenAI gpt-4o-mini: aiohttp package is not installed
```
