### PR TITLE
feat: allow project name as identifier in REST path

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -406,18 +406,18 @@ export interface paths {
         };
         /**
          * Get project by ID or name
-         * @description Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
+         * @description Retrieve a specific project using its unique identifier: either project ID or hex-encoded project name.
          */
         get: operations["getProject"];
         /**
          * Update a project by ID or name
-         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
+         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or hex-encoded project name.
          */
         put: operations["updateProject"];
         post?: never;
         /**
          * Delete a project by ID or name
-         * @description Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. The default project cannot be deleted.
+         * @description Delete an existing project and all its associated data. The project identifier is either project ID or hex-encoded project name. The default project cannot be deleted.
          */
         delete: operations["deleteProject"];
         options?: never;
@@ -2518,7 +2518,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
+                /** @description The project identifier: either project ID or hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2568,7 +2568,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
+                /** @description The project identifier: either project ID or hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2622,7 +2622,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
+                /** @description The project identifier: either project ID or hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2435,6 +2435,8 @@ export interface operations {
                 cursor?: string | null;
                 /** @description The max number of projects to return at a time. */
                 limit?: number;
+                /** @description Include experiment projects in the response. Experiment projects are created from running experiments. */
+                include_experiment_projects?: boolean;
             };
             header?: never;
             path?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -406,18 +406,18 @@ export interface paths {
         };
         /**
          * Get project by ID or name
-         * @description Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.
+         * @description Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
          */
         get: operations["getProject"];
         /**
          * Update a project by ID or name
-         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.
+         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
          */
         put: operations["updateProject"];
         post?: never;
         /**
          * Delete a project by ID or name
-         * @description Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. The default project cannot be deleted.
+         * @description Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. The default project cannot be deleted.
          */
         delete: operations["deleteProject"];
         options?: never;
@@ -2431,7 +2431,7 @@ export interface operations {
     getProjects: {
         parameters: {
             query?: {
-                /** @description Cursor for pagination (base64-encoded project ID) */
+                /** @description Cursor for pagination (project ID) */
                 cursor?: string | null;
                 /** @description The max number of projects to return at a time. */
                 limit?: number;
@@ -2518,7 +2518,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2568,7 +2568,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2622,7 +2622,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. */
                 project_identifier: string;
             };
             cookie?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -397,7 +397,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/projects/{project_id}": {
+    "/v1/projects/{project_identifier}": {
         parameters: {
             query?: never;
             header?: never;
@@ -405,19 +405,19 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get project by ID
-         * @description Retrieve a specific project using its unique identifier.
+         * Get project by ID or name
+         * @description Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.
          */
         get: operations["getProject"];
         /**
-         * Update a project
-         * @description Update an existing project with new configuration. Project names cannot be changed.
+         * Update a project by ID or name
+         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.
          */
         put: operations["updateProject"];
         post?: never;
         /**
-         * Delete a project
-         * @description Delete an existing project and all its associated data.
+         * Delete a project by ID or name
+         * @description Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. The default project cannot be deleted.
          */
         delete: operations["deleteProject"];
         options?: never;
@@ -479,7 +479,10 @@ export interface components {
         };
         /** CreateProjectRequestBody */
         CreateProjectRequestBody: {
-            project: components["schemas"]["ProjectData"];
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
         };
         /** CreateProjectResponseBody */
         CreateProjectResponseBody: {
@@ -731,13 +734,6 @@ export interface components {
             description?: string | null;
             /** Id */
             id: string;
-        };
-        /** ProjectData */
-        ProjectData: {
-            /** Name */
-            name: string;
-            /** Description */
-            description?: string | null;
         };
         /** Prompt */
         Prompt: {
@@ -1163,7 +1159,8 @@ export interface components {
         };
         /** UpdateProjectRequestBody */
         UpdateProjectRequestBody: {
-            project: components["schemas"]["ProjectData"];
+            /** Description */
+            description?: string | null;
         };
         /** UpdateProjectResponseBody */
         UpdateProjectResponseBody: {
@@ -2521,8 +2518,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The ID of the project. */
-                project_id: string;
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                project_identifier: string;
             };
             cookie?: never;
         };
@@ -2571,8 +2568,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The ID of the project to update. */
-                project_id: string;
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                project_identifier: string;
             };
             cookie?: never;
         };
@@ -2625,8 +2622,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The ID of the project to delete. */
-                project_id: string;
+                /** @description The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. */
+                project_identifier: string;
             };
             cookie?: never;
         };

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -406,18 +406,18 @@ export interface paths {
         };
         /**
          * Get project by ID or name
-         * @description Retrieve a specific project using its unique identifier: either project ID or hex-encoded project name.
+         * @description Retrieve a specific project using its unique identifier: either project ID or project name. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.
          */
         get: operations["getProject"];
         /**
          * Update a project by ID or name
-         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or hex-encoded project name.
+         * @description Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or project name. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.
          */
         put: operations["updateProject"];
         post?: never;
         /**
          * Delete a project by ID or name
-         * @description Delete an existing project and all its associated data. The project identifier is either project ID or hex-encoded project name. The default project cannot be deleted.
+         * @description Delete an existing project and all its associated data. The project identifier is either project ID or project name. The default project cannot be deleted. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.
          */
         delete: operations["deleteProject"];
         options?: never;
@@ -2520,7 +2520,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier: either project ID or hex-encoded project name. */
+                /** @description The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2570,7 +2570,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier: either project ID or hex-encoded project name. */
+                /** @description The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters. */
                 project_identifier: string;
             };
             cookie?: never;
@@ -2624,7 +2624,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The project identifier: either project ID or hex-encoded project name. */
+                /** @description The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters. */
                 project_identifier: string;
             };
             cookie?: never;

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -15,6 +15,11 @@ class CreateExperimentRequestBody(TypedDict):
     repetitions: NotRequired[int]
 
 
+class CreateProjectRequestBody(TypedDict):
+    name: str
+    description: NotRequired[str]
+
+
 class Dataset(TypedDict):
     id: str
     name: str
@@ -99,11 +104,6 @@ class ListExperimentsResponseBody(TypedDict):
 class Project(TypedDict):
     name: str
     id: str
-    description: NotRequired[str]
-
-
-class ProjectData(TypedDict):
-    name: str
     description: NotRequired[str]
 
 
@@ -229,7 +229,7 @@ class ToolResultContentPart(TypedDict):
 
 
 class UpdateProjectRequestBody(TypedDict):
-    project: ProjectData
+    description: NotRequired[str]
 
 
 class UpdateProjectResponseBody(TypedDict):
@@ -256,10 +256,6 @@ class AnnotateSpansResponseBody(TypedDict):
 
 class CreateExperimentResponseBody(TypedDict):
     data: Experiment
-
-
-class CreateProjectRequestBody(TypedDict):
-    project: ProjectData
 
 
 class CreateProjectResponseBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 from typing import Optional, cast
-from urllib.parse import quote_plus
 
 import httpx
 
 from phoenix.client.__generated__ import v1
+from phoenix.client.utils.encode_path_param import encode_path_param
 
 logger = logging.getLogger(__name__)
 
@@ -70,11 +70,11 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         response = self._client.get(url)
         response.raise_for_status()
         return cast(v1.GetProjectResponseBody, response.json())["data"]
@@ -200,11 +200,11 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         if description is None:
             raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
@@ -244,11 +244,11 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         response = self._client.delete(url)
         response.raise_for_status()
 
@@ -309,11 +309,11 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         response = await self._client.get(url)
         response.raise_for_status()
         return cast(v1.GetProjectResponseBody, response.json())["data"]
@@ -439,11 +439,11 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         if description is None:
             raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
@@ -483,11 +483,11 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = _encode_project_name(project_name)
+            project_identifier = project_name
         else:
             assert project_id
             project_identifier = project_id
-        url = f"v1/projects/{quote_plus(project_identifier)}"
+        url = f"v1/projects/{encode_path_param(project_identifier)}"
         response = await self._client.delete(url)
         response.raise_for_status()
 

--- a/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import logging
 from typing import Optional, cast
 from urllib.parse import quote_plus
@@ -71,7 +70,7 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
@@ -201,7 +200,7 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
@@ -245,7 +244,7 @@ class Projects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
@@ -310,7 +309,7 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
@@ -440,7 +439,7 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
@@ -484,10 +483,23 @@ class AsyncProjects:
         if project_id and project_name:
             raise ValueError("Only one of project_id or project_name can be provided.")
         if project_name:
-            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+            project_identifier = _encode_project_name(project_name)
         else:
             assert project_id
             project_identifier = project_id
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await self._client.delete(url)
         response.raise_for_status()
+
+
+def _encode_project_name(name: str) -> str:
+    """
+    Encode a project name using URL-safe hex encoding.
+
+    Args:
+        name: The project name to encode
+
+    Returns:
+        The hex-encoded project name
+    """
+    return name.encode().hex()

--- a/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
@@ -206,7 +206,7 @@ class Projects:
             assert project_id
             project_identifier = project_id
         url = f"v1/projects/{quote_plus(project_identifier)}"
-        if not description:
+        if description is None:
             raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
         response = self._client.put(url=url, json=json_)
@@ -445,7 +445,7 @@ class AsyncProjects:
             assert project_id
             project_identifier = project_id
         url = f"v1/projects/{quote_plus(project_identifier)}"
-        if not description:
+        if description is None:
             raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
         response = await self._client.put(url=url, json=json_)
@@ -455,24 +455,39 @@ class AsyncProjects:
     async def delete(
         self,
         *,
-        project_id: str,
+        project_id: Optional[str] = None,
+        project_name: Optional[str] = None,
     ) -> None:
-        """Delete a project by ID.
+        """Delete a project by ID or name.
 
         Args:
             project_id: The ID of the project to delete.
+            project_name: The name of the project to delete.
 
         Raises:
             httpx.HTTPError: If the request fails.
+            ValueError: If neither project_id nor project_name is provided.
 
         Example:
             ```python
             from phoenix.client import AsyncClient
 
             async_client = AsyncClient()
+            # Delete by ID
             await async_client.projects.delete(project_id="UHJvamVjdDoy")
+            # Delete by name
+            await async_client.projects.delete(project_name="My Project")
             ```
         """  # noqa: E501
-        url = f"v1/projects/{quote_plus(project_id)}"
+        if not project_id and not project_name:
+            raise ValueError("Either project_id or project_name must be provided.")
+        if project_id and project_name:
+            raise ValueError("Only one of project_id or project_name can be provided.")
+        if project_name:
+            project_identifier = base64.urlsafe_b64encode(project_name.encode()).decode()
+        else:
+            assert project_id
+            project_identifier = project_id
+        url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await self._client.delete(url)
         response.raise_for_status()

--- a/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/projects/__init__.py
@@ -147,7 +147,9 @@ class Projects:
             ```
         """  # noqa: E501
         url = "v1/projects"
-        json_ = v1.CreateProjectRequestBody(name=name, description=description)
+        json_ = v1.CreateProjectRequestBody(name=name)
+        if description:
+            json_["description"] = description
         response = self._client.post(url=url, json=json_)
         response.raise_for_status()
         return cast(v1.CreateProjectResponseBody, response.json())["data"]
@@ -204,7 +206,8 @@ class Projects:
             assert project_id
             project_identifier = project_id
         url = f"v1/projects/{quote_plus(project_identifier)}"
-
+        if not description:
+            raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
         response = self._client.put(url=url, json=json_)
         response.raise_for_status()
@@ -383,7 +386,9 @@ class AsyncProjects:
             ```
         """  # noqa: E501
         url = "v1/projects"
-        json_ = v1.CreateProjectRequestBody(name=name, description=description)
+        json_ = v1.CreateProjectRequestBody(name=name)
+        if description:
+            json_["description"] = description
         response = await self._client.post(url=url, json=json_)
         response.raise_for_status()
         return cast(v1.CreateProjectResponseBody, response.json())["data"]
@@ -440,7 +445,8 @@ class AsyncProjects:
             assert project_id
             project_identifier = project_id
         url = f"v1/projects/{quote_plus(project_identifier)}"
-
+        if not description:
+            raise ValueError("description must be provided.")
         json_ = v1.UpdateProjectRequestBody(description=description)
         response = await self._client.put(url=url, json=json_)
         response.raise_for_status()

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 from typing import Optional, cast
-from urllib.parse import quote_plus
 
 import httpx
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.types.prompts import PromptVersion
+from phoenix.client.utils.encode_path_param import encode_path_param
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class PromptVersionTags:
             ...     description="Ready for staging environment"
             ... )
         """
-        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags"
+        url = f"v1/prompt_versions/{encode_path_param(prompt_version_id)}/tags"
         data = v1.PromptVersionTagData(name=name)
         if description:
             data["description"] = description
@@ -171,7 +171,7 @@ class PromptVersionTags:
             >>> for tag in tags:
             ...     print(f"Tag: {tag.name}, Description: {tag.description}")
         """
-        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags"
+        url = f"v1/prompt_versions/{encode_path_param(prompt_version_id)}/tags"
         response = self._client.get(url)
         response.raise_for_status()
         return list(cast(v1.GetPromptVersionTagsResponseBody, response.json())["data"])
@@ -304,7 +304,7 @@ class AsyncPromptVersionTags:
             ...     description="Ready for staging environment"
             ... )
         """
-        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags"
+        url = f"v1/prompt_versions/{encode_path_param(prompt_version_id)}/tags"
         data = v1.PromptVersionTagData(name=name)
         if description:
             data["description"] = description
@@ -336,7 +336,7 @@ class AsyncPromptVersionTags:
             >>> for tag in tags:
             ...     print(f"Tag: {tag.name}, Description: {tag.description}")
         """
-        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags"
+        url = f"v1/prompt_versions/{encode_path_param(prompt_version_id)}/tags"
         response = await self._client.get(url)
         response.raise_for_status()
         return list(cast(v1.GetPromptVersionTagsResponseBody, response.json())["data"])
@@ -378,12 +378,12 @@ def _url(
     """
     if prompt_version_id is not None:
         assert isinstance(prompt_version_id, str)
-        return f"v1/prompt_versions/{quote_plus(prompt_version_id)}"
+        return f"v1/prompt_versions/{encode_path_param(prompt_version_id)}"
     assert (
         prompt_identifier is not None
     ), "Must specify either `prompt_version_id` or `prompt_identifier`"
     assert isinstance(prompt_identifier, str)
     if tag is not None:
         assert isinstance(tag, str)
-        return f"v1/prompts/{quote_plus(prompt_identifier)}/tags/{quote_plus(tag)}"
-    return f"v1/prompts/{quote_plus(prompt_identifier)}/latest"
+        return f"v1/prompts/{encode_path_param(prompt_identifier)}/tags/{encode_path_param(tag)}"
+    return f"v1/prompts/{encode_path_param(prompt_identifier)}/latest"

--- a/packages/phoenix-client/src/phoenix/client/utils/encode_path_param.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/encode_path_param.py
@@ -1,0 +1,23 @@
+from urllib.parse import quote
+
+
+def encode_path_param(s: str) -> str:
+    """
+    Quoting function for FastAPI path parameters.
+
+    Encodes a string for use in URL paths, raising ValueError if it
+    contains characters that would cause routing issues (/, ?, #).
+
+    Args:
+        s (str): The string to encode
+
+    Returns:
+        str: The encoded string safe for path parameters
+
+    Raises:
+        ValueError: If the string contains /, ?, or # characters
+    """
+    for char in "/?#":
+        if char in s:
+            raise ValueError(f"Cannot encode string containing '{char}' for URL path: {s}")
+    return quote(s, safe="")

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -1921,10 +1921,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Cursor for pagination (base64-encoded project ID)",
+              "description": "Cursor for pagination (project ID)",
               "title": "Cursor"
             },
-            "description": "Cursor for pagination (base64-encoded project ID)"
+            "description": "Cursor for pagination (project ID)"
           },
           {
             "name": "limit",
@@ -2030,7 +2030,7 @@
           "projects"
         ],
         "summary": "Get project by ID or name",
-        "description": "Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+        "description": "Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
         "operationId": "getProject",
         "parameters": [
           {
@@ -2039,10 +2039,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
           }
         ],
         "responses": {
@@ -2093,7 +2093,7 @@
           "projects"
         ],
         "summary": "Update a project by ID or name",
-        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
         "operationId": "updateProject",
         "parameters": [
           {
@@ -2102,10 +2102,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
           }
         ],
         "requestBody": {
@@ -2166,7 +2166,7 @@
           "projects"
         ],
         "summary": "Delete a project by ID or name",
-        "description": "Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. The default project cannot be deleted.",
+        "description": "Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. The default project cannot be deleted.",
         "operationId": "deleteProject",
         "parameters": [
           {
@@ -2175,10 +2175,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
           }
         ],
         "responses": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -1938,6 +1938,18 @@
               "title": "Limit"
             },
             "description": "The max number of projects to return at a time."
+          },
+          {
+            "name": "include_experiment_projects",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include experiment projects in the response. Experiment projects are created from running experiments.",
+              "default": false,
+              "title": "Include Experiment Projects"
+            },
+            "description": "Include experiment projects in the response. Experiment projects are created from running experiments."
           }
         ],
         "responses": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2024,25 +2024,25 @@
         }
       }
     },
-    "/v1/projects/{project_id}": {
+    "/v1/projects/{project_identifier}": {
       "get": {
         "tags": [
           "projects"
         ],
-        "summary": "Get project by ID",
-        "description": "Retrieve a specific project using its unique identifier.",
+        "summary": "Get project by ID or name",
+        "description": "Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
         "operationId": "getProject",
         "parameters": [
           {
-            "name": "project_id",
+            "name": "project_identifier",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The ID of the project.",
-              "title": "Project Id"
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "title": "Project Identifier"
             },
-            "description": "The ID of the project."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
           }
         ],
         "responses": {
@@ -2092,20 +2092,20 @@
         "tags": [
           "projects"
         ],
-        "summary": "Update a project",
-        "description": "Update an existing project with new configuration. Project names cannot be changed.",
+        "summary": "Update a project by ID or name",
+        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
         "operationId": "updateProject",
         "parameters": [
           {
-            "name": "project_id",
+            "name": "project_identifier",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The ID of the project to update.",
-              "title": "Project Id"
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "title": "Project Identifier"
             },
-            "description": "The ID of the project to update."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
           }
         ],
         "requestBody": {
@@ -2165,20 +2165,20 @@
         "tags": [
           "projects"
         ],
-        "summary": "Delete a project",
-        "description": "Delete an existing project and all its associated data.",
+        "summary": "Delete a project by ID or name",
+        "description": "Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name. The default project cannot be deleted.",
         "operationId": "deleteProject",
         "parameters": [
           {
-            "name": "project_id",
+            "name": "project_identifier",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The ID of the project to delete.",
-              "title": "Project Id"
+              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name.",
+              "title": "Project Identifier"
             },
-            "description": "The ID of the project to delete."
+            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a base64-encoded project name."
           }
         ],
         "responses": {
@@ -2329,13 +2329,25 @@
       },
       "CreateProjectRequestBody": {
         "properties": {
-          "project": {
-            "$ref": "#/components/schemas/ProjectData"
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
           }
         },
         "type": "object",
         "required": [
-          "project"
+          "name"
         ],
         "title": "CreateProjectRequestBody"
       },
@@ -2960,30 +2972,6 @@
           "id"
         ],
         "title": "Project"
-      },
-      "ProjectData": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "ProjectData"
       },
       "Prompt": {
         "properties": {
@@ -4190,14 +4178,19 @@
       },
       "UpdateProjectRequestBody": {
         "properties": {
-          "project": {
-            "$ref": "#/components/schemas/ProjectData"
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
           }
         },
         "type": "object",
-        "required": [
-          "project"
-        ],
         "title": "UpdateProjectRequestBody"
       },
       "UpdateProjectResponseBody": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2030,7 +2030,7 @@
           "projects"
         ],
         "summary": "Get project by ID or name",
-        "description": "Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
+        "description": "Retrieve a specific project using its unique identifier: either project ID or hex-encoded project name.",
         "operationId": "getProject",
         "parameters": [
           {
@@ -2039,10 +2039,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
+              "description": "The project identifier: either project ID or hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
+            "description": "The project identifier: either project ID or hex-encoded project name."
           }
         ],
         "responses": {
@@ -2093,7 +2093,7 @@
           "projects"
         ],
         "summary": "Update a project by ID or name",
-        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
+        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or hex-encoded project name.",
         "operationId": "updateProject",
         "parameters": [
           {
@@ -2102,10 +2102,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
+              "description": "The project identifier: either project ID or hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
+            "description": "The project identifier: either project ID or hex-encoded project name."
           }
         ],
         "requestBody": {
@@ -2166,7 +2166,7 @@
           "projects"
         ],
         "summary": "Delete a project by ID or name",
-        "description": "Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. The default project cannot be deleted.",
+        "description": "Delete an existing project and all its associated data. The project identifier is either project ID or hex-encoded project name. The default project cannot be deleted.",
         "operationId": "deleteProject",
         "parameters": [
           {
@@ -2175,10 +2175,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",
+              "description": "The project identifier: either project ID or hex-encoded project name.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name."
+            "description": "The project identifier: either project ID or hex-encoded project name."
           }
         ],
         "responses": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2331,7 +2331,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "ge": 1
           },
           "description": {
             "anyOf": [
@@ -2948,7 +2949,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "ge": 1
           },
           "description": {
             "anyOf": [

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2331,8 +2331,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name",
-            "ge": 1
+            "minLength": 1,
+            "title": "Name"
           },
           "description": {
             "anyOf": [
@@ -2949,8 +2949,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name",
-            "ge": 1
+            "minLength": 1,
+            "title": "Name"
           },
           "description": {
             "anyOf": [

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2042,7 +2042,7 @@
           "projects"
         ],
         "summary": "Get project by ID or name",
-        "description": "Retrieve a specific project using its unique identifier: either project ID or hex-encoded project name.",
+        "description": "Retrieve a specific project using its unique identifier: either project ID or project name. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
         "operationId": "getProject",
         "parameters": [
           {
@@ -2051,10 +2051,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier: either project ID or hex-encoded project name.",
+              "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier: either project ID or hex-encoded project name."
+            "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters."
           }
         ],
         "responses": {
@@ -2105,7 +2105,7 @@
           "projects"
         ],
         "summary": "Update a project by ID or name",
-        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or hex-encoded project name.",
+        "description": "Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or project name. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
         "operationId": "updateProject",
         "parameters": [
           {
@@ -2114,10 +2114,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier: either project ID or hex-encoded project name.",
+              "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier: either project ID or hex-encoded project name."
+            "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters."
           }
         ],
         "requestBody": {
@@ -2178,7 +2178,7 @@
           "projects"
         ],
         "summary": "Delete a project by ID or name",
-        "description": "Delete an existing project and all its associated data. The project identifier is either project ID or hex-encoded project name. The default project cannot be deleted.",
+        "description": "Delete an existing project and all its associated data. The project identifier is either project ID or project name. The default project cannot be deleted. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
         "operationId": "deleteProject",
         "parameters": [
           {
@@ -2187,10 +2187,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "description": "The project identifier: either project ID or hex-encoded project name.",
+              "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",
               "title": "Project Identifier"
             },
-            "description": "The project identifier: either project ID or hex-encoded project name."
+            "description": "The project identifier: either project ID or project name. If using a project name, it cannot contain slash (/), question mark (?), or pound sign (#) characters."
           }
         ],
         "responses": {

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1066,3 +1066,4 @@ def get_env_allowed_origins() -> Optional[list[str]]:
 
 
 SKLEARN_VERSION = cast(tuple[int, int], tuple(map(int, version("scikit-learn").split(".", 2)[:2])))
+PLAYGROUND_PROJECT_NAME = "playground"

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 )
 from typing_extensions import assert_never
 
+from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.db import models
 
 
@@ -157,3 +158,18 @@ def get_dataset_example_revisions(
             ),
         )
     )
+
+
+_AnyTuple = TypeVar("_AnyTuple", bound=tuple[Any, ...])
+
+
+def exclude_experiment_projects(
+    stmt: Select[_AnyTuple],
+) -> Select[_AnyTuple]:
+    return stmt.outerjoin(
+        models.Experiment,
+        and_(
+            models.Project.name == models.Experiment.project_name,
+            models.Experiment.project_name != PLAYGROUND_PROJECT_NAME,
+        ),
+    ).where(models.Experiment.project_name.is_(None))

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -131,7 +131,7 @@ async def get_projects(
     "/projects/{project_identifier}",
     operation_id="getProject",
     summary="Get project by ID or name",  # noqa: E501
-    description="Retrieve a specific project using its unique identifier. The identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",  # noqa: E501
+    description="Retrieve a specific project using its unique identifier: either project ID or hex-encoded project name.",  # noqa: E501
     response_description="The requested project",  # noqa: E501
     responses=add_errors_to_responses(
         [
@@ -143,7 +143,7 @@ async def get_projects(
 async def get_project(
     request: Request,
     project_identifier: str = Path(
-        description="The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",  # noqa: E501
+        description="The project identifier: either project ID or hex-encoded project name.",  # noqa: E501
     ),
 ) -> GetProjectResponseBody:
     """
@@ -151,7 +151,7 @@ async def get_project(
 
     Args:
         request (Request): The FastAPI request object.
-        project_identifier (str): The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
+        project_identifier (str): The project identifier: either project ID or hex-encoded project name.
 
     Returns:
         GetProjectResponseBody: Response containing the requested project.
@@ -209,7 +209,7 @@ async def create_project(
     "/projects/{project_identifier}",
     operation_id="updateProject",
     summary="Update a project by ID or name",  # noqa: E501
-    description="Update an existing project with new configuration. Project names cannot be changed. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",  # noqa: E501
+    description="Update an existing project with new configuration. Project names cannot be changed. The project identifier is either project ID or hex-encoded project name.",  # noqa: E501
     response_description="The updated project",  # noqa: E501
     responses=add_errors_to_responses(
         [
@@ -223,7 +223,7 @@ async def update_project(
     request: Request,
     request_body: UpdateProjectRequestBody,
     project_identifier: str = Path(
-        description="The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",  # noqa: E501
+        description="The project identifier: either project ID or hex-encoded project name.",  # noqa: E501
     ),
 ) -> UpdateProjectResponseBody:
     """
@@ -232,7 +232,7 @@ async def update_project(
     Args:
         request (Request): The FastAPI request object.
         request_body (UpdateProjectRequestBody): The request body containing the new description.
-        project_identifier (str): The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
+        project_identifier (str): The project identifier: either project ID or hex-encoded project name.
 
     Returns:
         UpdateProjectResponseBody: Response containing the updated project.
@@ -269,7 +269,7 @@ async def update_project(
     "/projects/{project_identifier}",
     operation_id="deleteProject",
     summary="Delete a project by ID or name",  # noqa: E501
-    description="Delete an existing project and all its associated data. The project identifier is first interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name. The default project cannot be deleted.",  # noqa: E501
+    description="Delete an existing project and all its associated data. The project identifier is either project ID or hex-encoded project name. The default project cannot be deleted.",  # noqa: E501
     response_description="No content returned on successful deletion",  # noqa: E501
     status_code=HTTP_204_NO_CONTENT,
     responses=add_errors_to_responses(
@@ -283,7 +283,7 @@ async def update_project(
 async def delete_project(
     request: Request,
     project_identifier: str = Path(
-        description="The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.",  # noqa: E501
+        description="The project identifier: either project ID or hex-encoded project name.",  # noqa: E501
     ),
 ) -> None:
     """
@@ -291,7 +291,7 @@ async def delete_project(
 
     Args:
         request (Request): The FastAPI request object.
-        project_identifier (str): The project identifier. First interpreted as a project ID. If the ID format is invalid, it is then treated as a hex-encoded project name.
+        project_identifier (str): The project identifier: either project ID or hex-encoded project name.
 
     Returns:
         None: Returns a 204 No Content response on success.

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -2,6 +2,7 @@ import base64
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Path, Query
+from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
@@ -29,7 +30,7 @@ router = APIRouter(tags=["projects"])
 
 
 class ProjectData(V1RoutesBaseModel):
-    name: str
+    name: str = Field(..., ge=1)
     description: Optional[str] = None
 
 

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -119,20 +119,19 @@ async def get_projects(
                 )
 
         stmt = stmt.limit(limit + 1)
-        result = await session.execute(stmt)
-        orm_projects = result.scalars().all()
+        projects = (await session.scalars(stmt)).all()
 
-        if not orm_projects:
+        if not projects:
             return GetProjectsResponseBody(next_cursor=None, data=[])
 
         next_cursor = None
-        if len(orm_projects) == limit + 1:
-            last_project = orm_projects[-1]
+        if len(projects) == limit + 1:
+            last_project = projects[-1]
             next_cursor = str(GlobalID(ProjectNodeType.__name__, str(last_project.id)))
-            orm_projects = orm_projects[:-1]
+            projects = projects[:-1]
 
-        projects = [_to_project_response(orm_project) for orm_project in orm_projects]
-    return GetProjectsResponseBody(next_cursor=next_cursor, data=projects)
+        project_responses = [_to_project_response(project) for project in projects]
+    return GetProjectsResponseBody(next_cursor=next_cursor, data=project_responses)
 
 
 @router.get(

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -30,7 +30,7 @@ router = APIRouter(tags=["projects"])
 
 
 class ProjectData(V1RoutesBaseModel):
-    name: str = Field(..., ge=1)
+    name: str = Field(..., min_length=1)
     description: Optional[str] = None
 
 

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -23,6 +23,7 @@ from strawberry.relay.types import GlobalID
 from strawberry.types import Info
 from typing_extensions import TypeAlias, assert_never
 
+from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
@@ -84,7 +85,6 @@ ChatCompletionResult: TypeAlias = tuple[
     DatasetExampleID, Optional[models.Span], models.ExperimentRun
 ]
 ChatStream: TypeAlias = AsyncGenerator[ChatCompletionSubscriptionPayload, None]
-PLAYGROUND_PROJECT_NAME = "playground"
 
 
 @strawberry.type

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -14,11 +14,6 @@ class TestClientForProjectsAPI:
 
     name_and_description_test_cases = [
         pytest.param(
-            token_hex(16),
-            token_hex(16),
-            id="regular_chars",
-        ),
-        pytest.param(
             f"Punctuations {string.punctuation.translate(str.maketrans('', '', '/?#'))}",
             "Punctuation characters excluding /, ?, # (not safe for URL)",
             id="punctuation_chars_with_exclusion",
@@ -51,7 +46,7 @@ class TestClientForProjectsAPI:
         4. Projects can be updated (description only, not name) (admin only)
         5. Projects can be deleted (admin only)
         6. Project names must be unique (both admin and member)
-        7. Special characters in names and descriptions are handled correctly
+        7. Special characters in project names are handled correctly
         """  # noqa: E501
         # Set up test environment with logged-in user
         u = _get_user(role_or_user).log_in()
@@ -62,7 +57,7 @@ class TestClientForProjectsAPI:
 
         Client = AsyncClient if is_async else SyncClient
 
-        # Create a project with special characters and ensure uniqueness
+        # Create a project with name suffix to ensure uniqueness
         name = f"{project_name}_{token_hex(16)}"
         description = f"A project with {project_description}"
 

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -160,6 +160,7 @@ class TestClientForProjectsAPI:
 
         # Delete the project (admin only) (DELETE operation)
         if role_or_user == _ADMIN:
+            # Test deleting by ID
             await _await_or_return(
                 Client().projects.delete(
                     project_id=project["id"],
@@ -171,6 +172,29 @@ class TestClientForProjectsAPI:
                 await _await_or_return(
                     Client().projects.get(
                         project_id=project["id"],
+                    )
+                )
+
+            # Create another project to test deleting by name
+            another_project = await _await_or_return(
+                Client().projects.create(
+                    name=f"Another_{project_name}_{token_hex(8)}",
+                    description=f"Another project with {project_description}",
+                )
+            )
+
+            # Test deleting by name
+            await _await_or_return(
+                Client().projects.delete(
+                    project_name=another_project["name"],
+                )
+            )
+
+            # Verify project was deleted by name
+            with pytest.raises(Exception):
+                await _await_or_return(
+                    Client().projects.get(
+                        project_id=another_project["id"],
                     )
                 )
 

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -19,19 +19,14 @@ class TestClientForProjectsAPI:
             id="regular_chars",
         ),
         pytest.param(
-            f"Punctuations {string.punctuation}",
-            "Punctuation characters",
-            id="punctuation_chars",
+            f"Punctuations {string.punctuation.translate(str.maketrans('', '', '/?#'))}",
+            "Punctuation characters excluding /, ?, # (not safe for URL)",
+            id="punctuation_chars_with_exclusion",
         ),
         pytest.param(
             "项目名称",
             "Unicode characters (Chinese)",
             id="unicode_chars",
-        ),
-        pytest.param(
-            "Project Name/With Spaces/And Slashes",
-            "Spaces and slashes",
-            id="spaces_and_slashes",
         ),
     ]
 

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -68,21 +68,19 @@ class TestClientForProjectsAPI:
         Client = AsyncClient if is_async else SyncClient
 
         # Create a project with special characters and ensure uniqueness
-        unique_project_name = f"{project_name}_{token_hex(8)}"
+        name = f"{project_name}_{token_hex(16)}"
         description = f"A project with {project_description}"
 
         project = await _await_or_return(
             Client().projects.create(
-                name=unique_project_name,
+                name=name,
                 description=description,
             )
         )
 
         # Verify project was created with correct attributes (CREATE operation)
         assert project["id"], "Project ID should be present after creation"  # noqa: E501
-        assert (
-            project["name"] == unique_project_name
-        ), "Project name should match input after creation"  # noqa: E501
+        assert project["name"] == name, "Project name should match input after creation"  # noqa: E501
         assert "description" in project, "Project should have a description field"  # noqa: E501
         assert (
             project["description"] == description
@@ -92,7 +90,7 @@ class TestClientForProjectsAPI:
         with pytest.raises(Exception):
             await _await_or_return(
                 Client().projects.create(
-                    name=unique_project_name,
+                    name=name,
                 )
             )
 
@@ -108,7 +106,7 @@ class TestClientForProjectsAPI:
             retrieved_project["id"] == project["id"]
         ), "Retrieved project ID should match created project"  # noqa: E501
         assert (
-            retrieved_project["name"] == unique_project_name
+            retrieved_project["name"] == name
         ), "Retrieved project name should match created project"  # noqa: E501
         assert (
             "description" in retrieved_project
@@ -139,9 +137,7 @@ class TestClientForProjectsAPI:
             assert (
                 updated_project["id"] == project["id"]
             ), "Updated project ID should match original project"  # noqa: E501
-            assert (
-                updated_project["name"] == unique_project_name
-            ), "Project name should not change after update"  # noqa: E501
+            assert updated_project["name"] == name, "Project name should not change after update"  # noqa: E501
             assert (
                 "description" in updated_project
             ), "Updated project should have a description field"  # noqa: E501

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 from __future__ import annotations
 
+import string
 from secrets import token_hex
 
 import pytest
@@ -11,16 +12,42 @@ from .._helpers import _ADMIN, _MEMBER, _await_or_return, _GetUser, _RoleOrUser
 class TestClientForProjectsAPI:
     """Integration tests for the Projects client REST endpoints."""  # noqa: E501
 
+    name_and_description_test_cases = [
+        pytest.param(
+            token_hex(16),
+            token_hex(16),
+            id="regular_chars",
+        ),
+        pytest.param(
+            f"Punctuations {string.punctuation}",
+            "Punctuation characters",
+            id="punctuation_chars",
+        ),
+        pytest.param(
+            "项目名称",
+            "Unicode characters (Chinese)",
+            id="unicode_chars",
+        ),
+        pytest.param(
+            "Project Name/With Spaces/And Slashes",
+            "Spaces and slashes",
+            id="spaces_and_slashes",
+        ),
+    ]
+
     @pytest.mark.parametrize("is_async", [True, False])
     @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    @pytest.mark.parametrize("project_name,project_description", name_and_description_test_cases)
     async def test_crud_operations(
         self,
         is_async: bool,
         role_or_user: _RoleOrUser,
+        project_name: str,
+        project_description: str,
         _get_user: _GetUser,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Test basic CRUD operations for projects.
+        """Test CRUD operations for projects.
 
         This test verifies that:
         1. Projects can be created with a name and optional description (both admin and member)
@@ -29,6 +56,7 @@ class TestClientForProjectsAPI:
         4. Projects can be updated (description only, not name) (admin only)
         5. Projects can be deleted (admin only)
         6. Project names must be unique (both admin and member)
+        7. Special characters in names and descriptions are handled correctly
         """  # noqa: E501
         # Set up test environment with logged-in user
         u = _get_user(role_or_user).log_in()
@@ -39,30 +67,32 @@ class TestClientForProjectsAPI:
 
         Client = AsyncClient if is_async else SyncClient
 
-        # Create a project with a random name and description
-        project_name = f"test-project-{token_hex(8)}"
-        project_description = f"Test project description {token_hex(8)}"
+        # Create a project with special characters and ensure uniqueness
+        unique_project_name = f"{project_name}_{token_hex(8)}"
+        description = f"A project with {project_description}"
 
         project = await _await_or_return(
             Client().projects.create(
-                name=project_name,
-                description=project_description,
+                name=unique_project_name,
+                description=description,
             )
         )
 
         # Verify project was created with correct attributes (CREATE operation)
         assert project["id"], "Project ID should be present after creation"  # noqa: E501
-        assert project["name"] == project_name, "Project name should match input after creation"  # noqa: E501
+        assert (
+            project["name"] == unique_project_name
+        ), "Project name should match input after creation"  # noqa: E501
         assert "description" in project, "Project should have a description field"  # noqa: E501
         assert (
-            project["description"] == project_description
+            project["description"] == description
         ), "Project description should match input after creation"  # noqa: E501
 
         # Test project name uniqueness (CREATE operation)
         with pytest.raises(Exception):
             await _await_or_return(
                 Client().projects.create(
-                    name=project_name,
+                    name=unique_project_name,
                 )
             )
 
@@ -78,13 +108,13 @@ class TestClientForProjectsAPI:
             retrieved_project["id"] == project["id"]
         ), "Retrieved project ID should match created project"  # noqa: E501
         assert (
-            retrieved_project["name"] == project_name
+            retrieved_project["name"] == unique_project_name
         ), "Retrieved project name should match created project"  # noqa: E501
         assert (
             "description" in retrieved_project
         ), "Retrieved project should have a description field"  # noqa: E501
         assert (
-            retrieved_project["description"] == project_description
+            retrieved_project["description"] == description
         ), "Retrieved project description should match created project"  # noqa: E501
 
         # List all projects (READ operation)
@@ -96,7 +126,7 @@ class TestClientForProjectsAPI:
         ), "Created project should be present in list of all projects"  # noqa: E501
 
         # Update the project description (admin only) (UPDATE operation)
-        new_description = f"Updated description {token_hex(8)}"
+        new_description = f"Updated description with {project_description}"
         if role_or_user == _ADMIN:
             updated_project = await _await_or_return(
                 Client().projects.update(
@@ -110,7 +140,7 @@ class TestClientForProjectsAPI:
                 updated_project["id"] == project["id"]
             ), "Updated project ID should match original project"  # noqa: E501
             assert (
-                updated_project["name"] == project_name
+                updated_project["name"] == unique_project_name
             ), "Project name should not change after update"  # noqa: E501
             assert (
                 "description" in updated_project

--- a/tests/unit/server/api/routers/v1/test_projects.py
+++ b/tests/unit/server/api/routers/v1/test_projects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import string
 from secrets import token_hex
 from typing import Any
@@ -13,6 +12,7 @@ from strawberry.relay import GlobalID
 
 from phoenix.config import DEFAULT_PROJECT_NAME
 from phoenix.db import models
+from phoenix.server.api.routers.v1.projects import _encode_project_name
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project
 from phoenix.server.types import DbSessionFactory
@@ -142,7 +142,7 @@ class TestProjects:
             await session.flush()
 
         # Test retrieving the project by name
-        project_identifier = base64.urlsafe_b64encode(project.name.encode()).decode()
+        project_identifier = _encode_project_name(project.name)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.get(url)
         assert response.is_success, f"GET /projects/{project_identifier} failed with status code {response.status_code}: {response.text}"  # noqa: E501
@@ -229,7 +229,7 @@ class TestProjects:
         updated_project_data = {
             "description": updated_description,
         }
-        project_identifier = base64.urlsafe_b64encode(project.name.encode()).decode()
+        project_identifier = _encode_project_name(project.name)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.put(url, json=updated_project_data)
         assert response.is_success, f"PUT /projects/{project_identifier} failed with status code {response.status_code}: {response.text}"  # noqa: E501
@@ -273,7 +273,7 @@ class TestProjects:
             await session.flush()
 
         # Delete the project by name
-        project_identifier = base64.urlsafe_b64encode(project.name.encode()).decode()
+        project_identifier = _encode_project_name(project.name)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.delete(url)
         assert (
@@ -337,7 +337,7 @@ class TestProjects:
             ), f"Default project {default_project.id} should still exist in database"  # noqa: E501
 
         # Try to delete the default project by name
-        project_identifier = base64.urlsafe_b64encode(DEFAULT_PROJECT_NAME.encode()).decode()
+        project_identifier = _encode_project_name(DEFAULT_PROJECT_NAME)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.delete(url)
 
@@ -369,7 +369,7 @@ class TestProjects:
 
         # Test with a nonexistent project name
         name = token_hex(16)
-        project_identifier = base64.urlsafe_b64encode(name.encode()).decode()
+        project_identifier = _encode_project_name(name)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.get(url)
         assert (
@@ -402,7 +402,7 @@ class TestProjects:
 
         # Test with a nonexistent project name
         name = token_hex(16)
-        project_identifier = base64.urlsafe_b64encode(name.encode()).decode()
+        project_identifier = _encode_project_name(name)
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.put(url, json=updated_project_data)
         assert (
@@ -428,7 +428,7 @@ class TestProjects:
         ), f"DELETE /projects/{project_identifier} should return a 404 status code, got {response.status_code}: {response.text}"  # noqa: E501
 
         # Test with a nonexistent project name
-        project_identifier = base64.urlsafe_b64encode(token_hex(16).encode()).decode()
+        project_identifier = _encode_project_name(token_hex(16))
         url = f"v1/projects/{quote_plus(project_identifier)}"
         response = await httpx_client.delete(url)
         assert (

--- a/tests/unit/server/api/routers/v1/test_projects.py
+++ b/tests/unit/server/api/routers/v1/test_projects.py
@@ -20,11 +20,6 @@ from phoenix.server.types import DbSessionFactory
 class TestProjects:
     name_and_description_test_cases = [
         pytest.param(
-            token_hex(16),
-            token_hex(16),
-            id="regular_chars",
-        ),
-        pytest.param(
             f"Punctuations {string.punctuation.translate(str.maketrans('', '', '/?#'))}",
             "Punctuation characters excluding /, ?, # (not safe for URL)",
             id="punctuation_chars_with_exclusion",
@@ -126,7 +121,6 @@ class TestProjects:
         3. The project ID, name, and description match the expected values
         4. Projects with special characters in their names can be retrieved correctly
         """  # noqa: E501
-        # Test with special characters
         project = models.Project(
             name=project_name,
             description=f"A project with {project_description}",
@@ -143,10 +137,6 @@ class TestProjects:
         data = response.json()["data"]
         assert isinstance(data, dict), f"Response data should be a dictionary, got {type(data)}"  # noqa: E501
         self._compare_project(data, project, f"Project with name {project.name}")
-
-        # Clean up
-        async with db() as session:
-            await session.delete(project)
 
     @pytest.mark.parametrize("project_name,project_description", name_and_description_test_cases)
     async def test_create_project(
@@ -209,7 +199,6 @@ class TestProjects:
         4. The response contains the updated project data
         5. Projects with special characters in their names can be updated correctly
         """  # noqa: E501
-        # Test with special characters
         project = models.Project(
             name=special_chars_name,
             description=f"A project with {description}",
@@ -236,10 +225,6 @@ class TestProjects:
             data["description"] == updated_description
         ), f"Updated project description should be '{updated_description}', got '{data['description']}'"  # noqa: E501
 
-        # Clean up
-        async with db() as session:
-            await session.delete(project)
-
     @pytest.mark.parametrize("special_chars_name,description", name_and_description_test_cases)
     async def test_delete_project_by_name(
         self,
@@ -257,7 +242,6 @@ class TestProjects:
         3. Subsequent attempts to retrieve the deleted project return a 404 error
         4. Projects with special characters in their names can be deleted correctly
         """  # noqa: E501
-        # Test with special characters
         project = models.Project(
             name=special_chars_name,
             description=f"A project with {description}",


### PR DESCRIPTION
resolves #7084

This PR enhances the project management API by introducing support for identifying projects through both IDs and names, making the API more flexible and user-friendly. The changes include simplifying the project creation request body structure, restricting project updates to description changes only, and adding validation for project names. The codebase has been improved with better error handling for invalid identifiers and special characters, while maintaining backward compatibility. Comprehensive test coverage has been added to ensure reliability, including tests for special characters, Unicode support, and both ID and name-based operations.

## Enhanced project identification
- Added support for identifying projects by both ID and hex-encoded name
- Introduced a new `_get_project_by_identifier` helper function to handle both identification methods

## Improved project management
- Simplified project creation by removing nested "project" object in request body
- Updated project update endpoint to only accept description changes
- Added validation for project names with min_length=1
- Added query parameter for including or excluding experiment projects