### PR TITLE
fix: Allow scrolling the entire experiment compare table

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -456,82 +456,82 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
 
   const isEmpty = rows.length === 0;
 
-  // Make sure the table is at least 1280px wide
-
   return (
-    <Flex direction="column" height="100%">
-      <View
-        paddingTop="size-100"
-        paddingBottom="size-100"
-        paddingStart="size-200"
-        paddingEnd="size-200"
-        borderBottomColor="grey-300"
-        borderBottomWidth="thin"
-        flex="none"
-      >
-        <ExperimentRunFilterConditionField
-          onValidCondition={setFilterCondition}
-        />
-      </View>
-      <div css={tableWrapCSS}>
-        <table
-          css={css(tableCSS, borderedTableCSS)}
-          style={{
-            ...columnSizeVars,
-            width: table.getTotalSize(),
-            minWidth: "100%",
-          }}
+    <View overflow="auto">
+      <Flex direction="column" height="100%">
+        <View
+          paddingTop="size-100"
+          paddingBottom="size-100"
+          paddingStart="size-200"
+          paddingEnd="size-200"
+          borderBottomColor="grey-300"
+          borderBottomWidth="thin"
+          flex="none"
         >
-          <thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <th
-                    key={header.id}
-                    style={{
-                      width: `calc(var(--header-${header?.id}-size) * 1px)`,
-                    }}
-                  >
-                    <div>
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                    </div>
-                    <div
-                      {...{
-                        onMouseDown: header.getResizeHandler(),
-                        onTouchStart: header.getResizeHandler(),
-                        className: `resizer ${
-                          header.column.getIsResizing() ? "isResizing" : ""
-                        }`,
+          <ExperimentRunFilterConditionField
+            onValidCondition={setFilterCondition}
+          />
+        </View>
+        <div css={tableWrapCSS}>
+          <table
+            css={css(tableCSS, borderedTableCSS)}
+            style={{
+              ...columnSizeVars,
+              width: table.getTotalSize(),
+              minWidth: "100%",
+            }}
+          >
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th
+                      key={header.id}
+                      style={{
+                        width: `calc(var(--header-${header?.id}-size) * 1px)`,
                       }}
-                    />
-                  </th>
-                ))}
-              </tr>
-            ))}
-          </thead>
-          {isEmpty ? (
-            <TableEmpty />
-          ) : /* When resizing any column we will render this special memoized version of our table body */
-          table.getState().columnSizingInfo.isResizingColumn ? (
-            <MemoizedTableBody table={table} />
-          ) : (
-            <TableBody table={table} />
-          )}
-        </table>
-        <DialogContainer
-          isDismissable
-          type="slideOver"
-          onDismiss={() => {
-            setDialog(null);
-          }}
-        >
-          {dialog}
-        </DialogContainer>
-      </div>
-    </Flex>
+                    >
+                      <div>
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                      </div>
+                      <div
+                        {...{
+                          onMouseDown: header.getResizeHandler(),
+                          onTouchStart: header.getResizeHandler(),
+                          className: `resizer ${
+                            header.column.getIsResizing() ? "isResizing" : ""
+                          }`,
+                        }}
+                      />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            {isEmpty ? (
+              <TableEmpty />
+            ) : table.getState().columnSizingInfo.isResizingColumn ? (
+              /* When resizing any column we will render this special memoized version of our table body */
+              <MemoizedTableBody table={table} />
+            ) : (
+              <TableBody table={table} />
+            )}
+          </table>
+          <DialogContainer
+            isDismissable
+            type="slideOver"
+            onDismiss={() => {
+              setDialog(null);
+            }}
+          >
+            {dialog}
+          </DialogContainer>
+        </div>
+      </Flex>
+    </View>
   );
 }
 


### PR DESCRIPTION
Just needed a container around the table segment of the page

### Before

https://github.com/user-attachments/assets/91da0352-9b4e-4d6c-9b35-2ec65ae3fb48

### After

https://github.com/user-attachments/assets/34200be6-0313-4f26-8116-4ad4933af0ed

Resolves #6986