### PR TITLE
fix(session): improve PostgreSQL error message in launch_app

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -560,6 +560,15 @@ def launch_app(
         database_url = f"sqlite:///{_session_working_dir.name}/phoenix.db"
     else:
         database_url = get_env_database_connection_str()
+        # Raise error for PostgreSQL usage with launch_app
+        if database_url.startswith("postgresql"):
+            raise ValueError(
+                "PostgreSQL backend detected in your environment configuration. "
+                "This could be from PHOENIX_SQL_DATABASE_URL or PHOENIX_POSTGRES_* variables. "
+                "launch_app() is designed to work with SQLite for notebook environments. "
+                "To use PostgreSQL, please use 'phoenix serve' from the command line instead. "
+                "Make sure you have the PostgreSQL extras installed: pip install 'arize-phoenix[pg]'"
+            )
 
     enable_websockets_env = get_env_enable_websockets() or False
     enable_websockets = (

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -567,7 +567,8 @@ def launch_app(
                 "This could be from PHOENIX_SQL_DATABASE_URL or PHOENIX_POSTGRES_* variables. "
                 "launch_app() is designed to work with SQLite for notebook environments. "
                 "To use PostgreSQL, please use 'phoenix serve' from the command line instead. "
-                "Make sure you have the PostgreSQL extras installed: pip install 'arize-phoenix[pg]'"
+                "Make sure you have the PostgreSQL extras installed: "
+                "pip install 'arize-phoenix[pg]'"
             )
 
     enable_websockets_env = get_env_enable_websockets() or False


### PR DESCRIPTION
Fixes #6192

## Description

This PR improves the error message when users attempt to use PostgreSQL with `launch_app()`. The new message:

1. Indicates that PostgreSQL was detected in the environment configuration
2. Specifies which environment variables might be causing this (PHOENIX_SQL_DATABASE_URL or PHOENIX_POSTGRES_*)
3. Explains that `launch_app()` is designed for SQLite in notebook environments
4. Suggests using `phoenix serve` as the correct alternative
5. Reminds users to install PostgreSQL extras

## Motivation

Users attempting to use PostgreSQL with `launch_app()` were receiving cryptic errors like "relation 'user_roles' does not exist" when using custom PostgreSQL schemas. This happens because `launch_app()` is not designed to work with PostgreSQL backends.

As noted by @mikeldking in the issue:
> px.launch_app() is really only an entrypoint for launching the phoenix instance in a JupyterNotebook and isn't really designed to be used when you are using a postgres backend.

This PR adds a clear error message that:
- Prevents users from encountering confusing database errors later
- Explains why PostgreSQL isn't supported in this context
- Directs users to the correct approach (`phoenix serve`)
- Reminds users about required PostgreSQL extras

## Testing

- Manually tested by setting PostgreSQL environment variables and verifying the error message
- All unit tests pass with `tox run -e unit_tests`
- Code formatting verified with `tox run -e ruff`