### PR TITLE
feat(retention): Add capability based access to retention policy

### DIFF
--- a/app/src/components/auth/AuthGuard.tsx
+++ b/app/src/components/auth/AuthGuard.tsx
@@ -23,3 +23,19 @@ export function IsAdmin(props: PropsWithChildren<AuthGuardProps>) {
   }
   return children;
 }
+
+/**
+ * Users can access retention policy settings if:
+ * - Authentication is disabled
+ * - Authentication is enabled and the user is an admin
+ */
+export function CanManageRetentionPolicy(
+  props: PropsWithChildren<AuthGuardProps>
+) {
+  const { fallback = null, children } = props;
+  const { viewer } = useViewer();
+  if (viewer && viewer.role.name !== "ADMIN") {
+    return <>{fallback}</>;
+  }
+  return children;
+}

--- a/app/src/pages/settings/SettingsGeneralPage.tsx
+++ b/app/src/pages/settings/SettingsGeneralPage.tsx
@@ -14,7 +14,7 @@ import {
   TextField,
   View,
 } from "@phoenix/components";
-import { IsAdmin } from "@phoenix/components/auth";
+import { CanManageRetentionPolicy, IsAdmin } from "@phoenix/components/auth";
 import { BASE_URL, VERSION } from "@phoenix/config";
 import { APIKeysCard } from "@phoenix/pages/settings/APIKeysCard";
 import { DBUsagePieChart } from "@phoenix/pages/settings/DBUsagePieChart";
@@ -84,8 +84,10 @@ export function SettingsGeneralPage() {
       <IsAdmin>
         <APIKeysCard />
         <UsersCard />
-        <GlobalRetentionPolicyCard />
       </IsAdmin>
+      <CanManageRetentionPolicy>
+        <GlobalRetentionPolicyCard />
+      </CanManageRetentionPolicy>
     </Flex>
   );
 }


### PR DESCRIPTION
Tested under the following conditions:

- Auth enabled, user is admin: visible
- Auth enabled, user is _not_ admin: invisible
- Auth disabled: visible

We should expand this to the backend as well if it does not already check for admin membership or auth disabled.

Resolves #6959