### PR TITLE
fix: restore streaming

### DIFF
--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -254,7 +254,7 @@ export function SessionsTable(props: SessionsTableProps) {
           first: PAGE_SIZE,
           filterIoSubstring: filterIoSubstring,
         },
-        { fetchPolicy: "store-or-network" }
+        { fetchPolicy: "store-and-network" }
       );
     });
   }, [sorting, refetch, filterIoSubstring, fetchKey]);

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -488,7 +488,7 @@ export function SpansTable(props: SpansTableProps) {
             filterCondition,
             rootSpansOnly,
           },
-          { fetchPolicy: "store-or-network" }
+          { fetchPolicy: "store-and-network" }
         );
       });
     }

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -679,7 +679,7 @@ export function TracesTable(props: TracesTableProps) {
             filterCondition: filterCondition,
           },
           {
-            fetchPolicy: "store-or-network",
+            fetchPolicy: "store-and-network",
           }
         );
       });


### PR DESCRIPTION
resolves #7103

The caching was introduced to eliminate reloads on navigations but it actually makes the payload never re-load.