### PR TITLE
fix: Do not refetch tables when trace/span details closed

### DIFF
--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -140,6 +140,7 @@ export function SpansTable(props: SpansTableProps) {
   const { fetchKey } = useStreamState();
   // Determine if the table is active based on the current path
   const isTableActive = !!useMatch("/projects/:projectId/spans");
+  const isTableActiveRef = useRef(isTableActive);
   //we need a reference to the scrolling element for logic down below
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const isFirstRender = useRef<boolean>(true);
@@ -476,7 +477,7 @@ export function SpansTable(props: SpansTableProps) {
       isFirstRender.current = false;
       return;
     }
-    if (isTableActive) {
+    if (isTableActiveRef.current) {
       //if the sorting changes, we need to reset the pagination
       startTransition(() => {
         const sort = sorting[0];
@@ -492,14 +493,7 @@ export function SpansTable(props: SpansTableProps) {
         );
       });
     }
-  }, [
-    sorting,
-    refetch,
-    filterCondition,
-    fetchKey,
-    isTableActive,
-    rootSpansOnly,
-  ]);
+  }, [sorting, refetch, filterCondition, fetchKey, rootSpansOnly]);
   const fetchMoreOnBottomReached = useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -194,6 +194,7 @@ export function TracesTable(props: TracesTableProps) {
   const [filterCondition, setFilterCondition] = useState<string>("");
   // Determine if the table is active based on the current path
   const isTableActive = !!useMatch("/projects/:projectId/traces");
+  const isTableActiveRef = useRef(isTableActive);
   const { fetchKey } = useStreamState();
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<TracesTableQuery, TracesTable_spans$key>(
@@ -667,7 +668,7 @@ export function TracesTable(props: TracesTableProps) {
       isFirstRender.current = false;
       return;
     }
-    if (isTableActive) {
+    if (isTableActiveRef.current) {
       //if the sorting changes, we need to reset the pagination
       const sort = sorting[0];
       startTransition(() => {
@@ -684,7 +685,7 @@ export function TracesTable(props: TracesTableProps) {
         );
       });
     }
-  }, [sorting, refetch, filterCondition, fetchKey, isTableActive]);
+  }, [sorting, refetch, filterCondition, fetchKey]);
 
   const fetchMoreOnBottomReached = useCallback(
     (containerRefElement?: HTMLDivElement | null) => {


### PR DESCRIPTION
`isTableActive` flips from true to false when a span is clicked, and then from false to true when the span details are closed. Going from false to true triggers a refetch.

Now using a ref so that the useEffect isn't triggered by active state changing, it will just check whatever the value happens to be the next time it fires, like when the stream toggle refresh goes off.