### PR TITLE
feat: Display tool call and tool result Ids in span details

### DIFF
--- a/app/src/components/disclosure/Disclosure.tsx
+++ b/app/src/components/disclosure/Disclosure.tsx
@@ -101,7 +101,7 @@ export const DisclosureTrigger = ({
   width,
 }: DisclosureTriggerProps) => {
   return (
-    <Heading>
+    <Heading className="react-aria-Heading ac-disclosure-trigger">
       <Button
         slot="trigger"
         data-arrow-position={arrowPosition}

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -27,6 +27,7 @@ export type AttributeLLMTool = {
 };
 
 export type AttributeToolCall = {
+  id?: string;
   function?: {
     name?: string;
     arguments?: string;
@@ -44,6 +45,7 @@ export type AttributeMessage = {
   [MessageAttributePostfixes.name]?: string;
   [MessageAttributePostfixes.function_call_name]?: string;
   [MessageAttributePostfixes.function_call_arguments_json]?: string;
+  [MessageAttributePostfixes.tool_call_id]?: string;
   [MessageAttributePostfixes.tool_calls]?: {
     [SemanticAttributePrefixes.tool_call]?: AttributeToolCall;
   }[];


### PR DESCRIPTION
This PR displays tool Ids, both call and result, in span details.
They are placed within disclosure headers, and can by copy/pasted via a copy button that only appears on hover.


Supports multiple tool calls

![Multiple Tool Calls](https://github.com/user-attachments/assets/0dc56996-5657-4a60-965d-791c1024e6f4)

Supports tool results

![Tool results](https://github.com/user-attachments/assets/6dfef3c0-a3b9-4d97-8392-ec5199abe97a)

Resolves #6427 