### PR TITLE
fix: redirect GET v1/* to home

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -84,11 +84,11 @@ const router = createBrowserRouter(
     <Route path="/" errorElement={<ErrorElement />}>
       {/* 
         Redirect /v1/traces to root path (/)
-        This route is commonly used by OpenTelemetry trace collectors, but users sometimes
-        accidentally try to access Phoenix through this URL in their browser, leading to confusion.
+        This route is for OpenTelemetry trace collectors, but users sometimes accidentally
+        try to access Phoenix through this URL in their browser, leading to confusion.
         This redirect helps prevent those issues by sending them to the main application.
       */}
-      <Route path="/v1/traces" element={<Navigate to="/" replace />} />
+      <Route path="/v1/*" element={<Navigate to="/" replace />} />
       <Route path="/login" element={<LoginPage />} />
       <Route
         path="/reset-password"

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -83,10 +83,11 @@ const router = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/" errorElement={<ErrorElement />}>
       {/* 
-        Redirect /v1/traces to root path (/)
-        This route is for OpenTelemetry trace collectors, but users sometimes accidentally
-        try to access Phoenix through this URL in their browser, leading to confusion.
-        This redirect helps prevent those issues by sending them to the main application.
+        Using /v1/* below redirects all /v1/* routes that don't have a GET method to the root path.
+        In particular, this redirects /v1/traces to the root path (/). This route is for the
+        OpenTelemetry trace collector, but users sometimes accidentally try to access Phoenix
+        through this URL in their browser, leading to confusion. This redirect helps prevent
+        those issues by sending them to the main application.
       */}
       <Route path="/v1/*" element={<Navigate to="/" replace />} />
       <Route path="/login" element={<LoginPage />} />

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   createBrowserRouter,
   createRoutesFromElements,
+  Navigate,
   Route,
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -81,6 +82,13 @@ import {
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/" errorElement={<ErrorElement />}>
+      {/* 
+        Redirect /v1/traces to root path (/)
+        This route is commonly used by OpenTelemetry trace collectors, but users sometimes
+        accidentally try to access Phoenix through this URL in their browser, leading to confusion.
+        This redirect helps prevent those issues by sending them to the main application.
+      */}
+      <Route path="/v1/traces" element={<Navigate to="/" replace />} />
       <Route path="/login" element={<LoginPage />} />
       <Route
         path="/reset-password"


### PR DESCRIPTION
# Redirect /v1/traces to root path

Users frequently try to access Phoenix through `/v1/traces` in their browser (which is the OpenTelemetry trace collector endpoint) and submit GitHub issues when they see a blank page or error. This PR redirects such requests to the root path to prevent confusion.

The OpenTelemetry collector still works since it uses POST requests, while this redirect only affects GET requests.