### PR TITLE
fix: remove WebSocket dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
+    "@apollo/client": "^3.13.7",
     "@arizeai/components": "2.0.0-0",
     "@arizeai/openinference-semantic-conventions": "^0.13.0",
     "@arizeai/point-cloud": "^3.0.6",
@@ -35,7 +36,6 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^3.6.0",
-    "fetch-multipart-graphql": "^3.2.2",
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "polished": "^4.3.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
+    "@apollo/client": "^3.13.7",
     "@arizeai/components": "2.0.0-0",
     "@arizeai/openinference-semantic-conventions": "^0.13.0",
     "@arizeai/point-cloud": "^3.0.6",
@@ -35,7 +36,6 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^3.6.0",
-    "graphql-ws": "^6.0.4",
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "polished": "^4.3.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,6 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.13.7",
     "@arizeai/components": "2.0.0-0",
     "@arizeai/openinference-semantic-conventions": "^0.13.0",
     "@arizeai/point-cloud": "^3.0.6",
@@ -36,6 +35,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^3.6.0",
+    "fetch-multipart-graphql": "^3.2.2",
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "polished": "^4.3.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.13.7
+        version: 3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@arizeai/components':
         specifier: 2.0.0-0
         version: 2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -102,9 +105,6 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
-      fetch-multipart-graphql:
-        specifier: ^3.2.2
-        version: 3.2.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -331,6 +331,24 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apollo/client@3.13.7':
+    resolution: {integrity: sha512-jOp8EctxOirgg5BSV0hgpcUSprrW7b9pf4r8ybUcY6Z+0T+ja5W82kI/rJeLUHxhT3YOKBm+72hWUHfsNIa+Fg==}
+    peerDependencies:
+      graphql: ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5 || ^6.0.3
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
 
   '@arizeai/components@2.0.0-0':
     resolution: {integrity: sha512-3MEEaV2bNzWxE/bFM80zIyP/ZV5k2GVMmcDA67E7Jc+fxUMxY+BdR2nSERgdHXSSRrbmDMiBTj/Kf8yJKwXd5w==}
@@ -832,6 +850,11 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -2563,6 +2586,22 @@ packages:
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
+  '@wry/caches@1.0.1':
+    resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
+    engines: {node: '>=8'}
+
+  '@wry/context@0.7.4':
+    resolution: {integrity: sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==}
+    engines: {node: '>=8'}
+
+  '@wry/equality@0.5.7':
+    resolution: {integrity: sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==}
+    engines: {node: '>=8'}
+
+  '@wry/trie@0.5.0':
+    resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
+    engines: {node: '>=8'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3305,9 +3344,6 @@ packages:
   fbjs@3.0.5:
     resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
 
-  fetch-multipart-graphql@3.2.2:
-    resolution: {integrity: sha512-DV5u+dPBmnkZ1qpeSr5Esz2SmbWVP84IAhUs5aQb2KE4acEmbexED5fXdYPwSWdd4zpHy9auN1AhOGWCvxprzg==}
-
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
 
@@ -3432,6 +3468,12 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql-tag@2.12.6:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   graphql@15.3.0:
     resolution: {integrity: sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==}
@@ -4133,6 +4175,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  optimism@0.18.1:
+    resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4451,6 +4496,17 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
+  rehackt@0.1.0:
+    resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   relay-compiler@18.2.0:
     resolution: {integrity: sha512-P3o5/Gv/oLC9hckUaz/a+KvDgbFERpjtz5lgsJSIQILg9paaF3k1yaX9qSxErGuU4icZvjoK5G82a/bfPgGZpA==}
     hasBin: true
@@ -4728,6 +4784,10 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  symbol-observable@4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4829,6 +4889,10 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
 
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
@@ -5200,6 +5264,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zen-observable-ts@1.2.5:
+    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
+
+  zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+
   zod-to-json-schema@3.23.3:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
     peerDependencies:
@@ -5249,6 +5319,28 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@apollo/client@3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.9.0
+      graphql-tag: 2.12.6(graphql@16.9.0)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.1
+      prop-types: 15.8.1
+      rehackt: 0.1.0(@types/react@18.3.10)(react@18.3.1)
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.3
+      zen-observable-ts: 1.2.5
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@arizeai/components@2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5888,6 +5980,10 @@ snapshots:
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
       tslib: 2.6.3
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -8438,6 +8534,22 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@wry/caches@1.0.1':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/context@0.7.4':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/equality@0.5.7':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/trie@0.5.0':
+    dependencies:
+      tslib: 2.6.3
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -9349,8 +9461,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  fetch-multipart-graphql@3.2.2: {}
-
   fflate@0.6.10: {}
 
   fflate@0.8.2: {}
@@ -9483,6 +9593,11 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql-tag@2.12.6(graphql@16.9.0):
+    dependencies:
+      graphql: 16.9.0
+      tslib: 2.6.3
 
   graphql@15.3.0: {}
 
@@ -10405,6 +10520,13 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  optimism@0.18.1:
+    dependencies:
+      '@wry/caches': 1.0.1
+      '@wry/context': 0.7.4
+      '@wry/trie': 0.5.0
+      tslib: 2.6.3
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10845,6 +10967,11 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  rehackt@0.1.0(@types/react@18.3.10)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.10
+      react: 18.3.1
+
   relay-compiler@18.2.0: {}
 
   relay-runtime@18.2.0:
@@ -11173,6 +11300,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  symbol-observable@4.0.0: {}
+
   symbol-tree@3.2.4: {}
 
   text-table@0.2.0: {}
@@ -11254,6 +11383,10 @@ snapshots:
       typescript: 5.4.5
 
   ts-dedent@2.2.0: {}
+
+  ts-invariant@0.10.3:
+    dependencies:
+      tslib: 2.6.3
 
   tsconfck@3.1.4(typescript@5.4.5):
     optionalDependencies:
@@ -11662,6 +11795,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zen-observable-ts@1.2.5:
+    dependencies:
+      zen-observable: 0.8.15
+
+  zen-observable@0.8.15: {}
 
   zod-to-json-schema@3.23.3(zod@3.23.8):
     dependencies:

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
 
   .:
     dependencies:
-      '@apollo/client':
-        specifier: ^3.13.7
-        version: 3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@arizeai/components':
         specifier: 2.0.0-0
         version: 2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -105,6 +102,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      fetch-multipart-graphql:
+        specifier: ^3.2.2
+        version: 3.2.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -331,24 +331,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@apollo/client@3.13.7':
-    resolution: {integrity: sha512-jOp8EctxOirgg5BSV0hgpcUSprrW7b9pf4r8ybUcY6Z+0T+ja5W82kI/rJeLUHxhT3YOKBm+72hWUHfsNIa+Fg==}
-    peerDependencies:
-      graphql: ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5 || ^6.0.3
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-    peerDependenciesMeta:
-      graphql-ws:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      subscriptions-transport-ws:
-        optional: true
 
   '@arizeai/components@2.0.0-0':
     resolution: {integrity: sha512-3MEEaV2bNzWxE/bFM80zIyP/ZV5k2GVMmcDA67E7Jc+fxUMxY+BdR2nSERgdHXSSRrbmDMiBTj/Kf8yJKwXd5w==}
@@ -850,11 +832,6 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
-
-  '@graphql-typed-document-node/core@3.2.0':
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -2586,22 +2563,6 @@ packages:
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
-  '@wry/caches@1.0.1':
-    resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
-    engines: {node: '>=8'}
-
-  '@wry/context@0.7.4':
-    resolution: {integrity: sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==}
-    engines: {node: '>=8'}
-
-  '@wry/equality@0.5.7':
-    resolution: {integrity: sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==}
-    engines: {node: '>=8'}
-
-  '@wry/trie@0.5.0':
-    resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
-    engines: {node: '>=8'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3344,6 +3305,9 @@ packages:
   fbjs@3.0.5:
     resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
 
+  fetch-multipart-graphql@3.2.2:
+    resolution: {integrity: sha512-DV5u+dPBmnkZ1qpeSr5Esz2SmbWVP84IAhUs5aQb2KE4acEmbexED5fXdYPwSWdd4zpHy9auN1AhOGWCvxprzg==}
+
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
 
@@ -3468,12 +3432,6 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  graphql-tag@2.12.6:
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   graphql@15.3.0:
     resolution: {integrity: sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==}
@@ -4175,9 +4133,6 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  optimism@0.18.1:
-    resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4496,17 +4451,6 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
-  rehackt@0.1.0:
-    resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: '*'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-
   relay-compiler@18.2.0:
     resolution: {integrity: sha512-P3o5/Gv/oLC9hckUaz/a+KvDgbFERpjtz5lgsJSIQILg9paaF3k1yaX9qSxErGuU4icZvjoK5G82a/bfPgGZpA==}
     hasBin: true
@@ -4784,10 +4728,6 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
-  symbol-observable@4.0.0:
-    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
-    engines: {node: '>=0.10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4889,10 +4829,6 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  ts-invariant@0.10.3:
-    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
-    engines: {node: '>=8'}
 
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
@@ -5264,12 +5200,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zen-observable-ts@1.2.5:
-    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
-
-  zen-observable@0.8.15:
-    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
-
   zod-to-json-schema@3.23.3:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
     peerDependencies:
@@ -5319,28 +5249,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-
-  '@apollo/client@3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
-      '@wry/caches': 1.0.1
-      '@wry/equality': 0.5.7
-      '@wry/trie': 0.5.0
-      graphql: 16.9.0
-      graphql-tag: 2.12.6(graphql@16.9.0)
-      hoist-non-react-statics: 3.3.2
-      optimism: 0.18.1
-      prop-types: 15.8.1
-      rehackt: 0.1.0(@types/react@18.3.10)(react@18.3.1)
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
-      tslib: 2.6.3
-      zen-observable-ts: 1.2.5
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@arizeai/components@2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5980,10 +5888,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
       tslib: 2.6.3
-
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
-    dependencies:
-      graphql: 16.9.0
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -8534,22 +8438,6 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@wry/caches@1.0.1':
-    dependencies:
-      tslib: 2.6.3
-
-  '@wry/context@0.7.4':
-    dependencies:
-      tslib: 2.6.3
-
-  '@wry/equality@0.5.7':
-    dependencies:
-      tslib: 2.6.3
-
-  '@wry/trie@0.5.0':
-    dependencies:
-      tslib: 2.6.3
-
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -9461,6 +9349,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  fetch-multipart-graphql@3.2.2: {}
+
   fflate@0.6.10: {}
 
   fflate@0.8.2: {}
@@ -9593,11 +9483,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
-
-  graphql-tag@2.12.6(graphql@16.9.0):
-    dependencies:
-      graphql: 16.9.0
-      tslib: 2.6.3
 
   graphql@15.3.0: {}
 
@@ -10520,13 +10405,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  optimism@0.18.1:
-    dependencies:
-      '@wry/caches': 1.0.1
-      '@wry/context': 0.7.4
-      '@wry/trie': 0.5.0
-      tslib: 2.6.3
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10967,11 +10845,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  rehackt@0.1.0(@types/react@18.3.10)(react@18.3.1):
-    optionalDependencies:
-      '@types/react': 18.3.10
-      react: 18.3.1
-
   relay-compiler@18.2.0: {}
 
   relay-runtime@18.2.0:
@@ -11300,8 +11173,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  symbol-observable@4.0.0: {}
-
   symbol-tree@3.2.4: {}
 
   text-table@0.2.0: {}
@@ -11383,10 +11254,6 @@ snapshots:
       typescript: 5.4.5
 
   ts-dedent@2.2.0: {}
-
-  ts-invariant@0.10.3:
-    dependencies:
-      tslib: 2.6.3
 
   tsconfck@3.1.4(typescript@5.4.5):
     optionalDependencies:
@@ -11795,12 +11662,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  zen-observable-ts@1.2.5:
-    dependencies:
-      zen-observable: 0.8.15
-
-  zen-observable@0.8.15: {}
 
   zod-to-json-schema@3.23.3(zod@3.23.8):
     dependencies:

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.13.7
+        version: 3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@arizeai/components':
         specifier: 2.0.0-0
         version: 2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -102,9 +105,6 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
-      graphql-ws:
-        specifier: ^6.0.4
-        version: 6.0.4(graphql@16.9.0)(ws@8.18.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -331,6 +331,24 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apollo/client@3.13.7':
+    resolution: {integrity: sha512-jOp8EctxOirgg5BSV0hgpcUSprrW7b9pf4r8ybUcY6Z+0T+ja5W82kI/rJeLUHxhT3YOKBm+72hWUHfsNIa+Fg==}
+    peerDependencies:
+      graphql: ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5 || ^6.0.3
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
 
   '@arizeai/components@2.0.0-0':
     resolution: {integrity: sha512-3MEEaV2bNzWxE/bFM80zIyP/ZV5k2GVMmcDA67E7Jc+fxUMxY+BdR2nSERgdHXSSRrbmDMiBTj/Kf8yJKwXd5w==}
@@ -832,6 +850,11 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -2563,6 +2586,22 @@ packages:
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
+  '@wry/caches@1.0.1':
+    resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
+    engines: {node: '>=8'}
+
+  '@wry/context@0.7.4':
+    resolution: {integrity: sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==}
+    engines: {node: '>=8'}
+
+  '@wry/equality@0.5.7':
+    resolution: {integrity: sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==}
+    engines: {node: '>=8'}
+
+  '@wry/trie@0.5.0':
+    resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
+    engines: {node: '>=8'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3430,21 +3469,11 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql-ws@6.0.4:
-    resolution: {integrity: sha512-8b4OZtNOvv8+NZva8HXamrc0y1jluYC0+13gdh7198FKjVzXyTvVc95DCwGzaKEfn3YuWZxUqjJlHe3qKM/F2g==}
-    engines: {node: '>=20'}
+  graphql-tag@2.12.6:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
     peerDependencies:
-      '@fastify/websocket': ^10 || ^11
-      graphql: ^15.10.1 || ^16
-      uWebSockets.js: ^20
-      ws: ^8
-    peerDependenciesMeta:
-      '@fastify/websocket':
-        optional: true
-      uWebSockets.js:
-        optional: true
-      ws:
-        optional: true
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   graphql@15.3.0:
     resolution: {integrity: sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==}
@@ -4146,6 +4175,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  optimism@0.18.1:
+    resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4464,6 +4496,17 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
+  rehackt@0.1.0:
+    resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   relay-compiler@18.2.0:
     resolution: {integrity: sha512-P3o5/Gv/oLC9hckUaz/a+KvDgbFERpjtz5lgsJSIQILg9paaF3k1yaX9qSxErGuU4icZvjoK5G82a/bfPgGZpA==}
     hasBin: true
@@ -4741,6 +4784,10 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  symbol-observable@4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4842,6 +4889,10 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
 
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
@@ -5213,6 +5264,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zen-observable-ts@1.2.5:
+    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
+
+  zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+
   zod-to-json-schema@3.23.3:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
     peerDependencies:
@@ -5262,6 +5319,28 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@apollo/client@3.13.7(@types/react@18.3.10)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.9.0
+      graphql-tag: 2.12.6(graphql@16.9.0)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.1
+      prop-types: 15.8.1
+      rehackt: 0.1.0(@types/react@18.3.10)(react@18.3.1)
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.3
+      zen-observable-ts: 1.2.5
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@arizeai/components@2.0.0-0(@types/react@18.3.10)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5901,6 +5980,10 @@ snapshots:
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
       tslib: 2.6.3
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -8451,6 +8534,22 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@wry/caches@1.0.1':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/context@0.7.4':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/equality@0.5.7':
+    dependencies:
+      tslib: 2.6.3
+
+  '@wry/trie@0.5.0':
+    dependencies:
+      tslib: 2.6.3
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -9495,11 +9594,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-ws@6.0.4(graphql@16.9.0)(ws@8.18.0):
+  graphql-tag@2.12.6(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
-    optionalDependencies:
-      ws: 8.18.0
+      tslib: 2.6.3
 
   graphql@15.3.0: {}
 
@@ -10422,6 +10520,13 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  optimism@0.18.1:
+    dependencies:
+      '@wry/caches': 1.0.1
+      '@wry/context': 0.7.4
+      '@wry/trie': 0.5.0
+      tslib: 2.6.3
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10862,6 +10967,11 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  rehackt@0.1.0(@types/react@18.3.10)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.10
+      react: 18.3.1
+
   relay-compiler@18.2.0: {}
 
   relay-runtime@18.2.0:
@@ -11190,6 +11300,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  symbol-observable@4.0.0: {}
+
   symbol-tree@3.2.4: {}
 
   text-table@0.2.0: {}
@@ -11271,6 +11383,10 @@ snapshots:
       typescript: 5.4.5
 
   ts-dedent@2.2.0: {}
+
+  ts-invariant@0.10.3:
+    dependencies:
+      tslib: 2.6.3
 
   tsconfck@3.1.4(typescript@5.4.5):
     optionalDependencies:
@@ -11679,6 +11795,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zen-observable-ts@1.2.5:
+    dependencies:
+      zen-observable: 0.8.15
+
+  zen-observable@0.8.15: {}
 
   zod-to-json-schema@3.23.3(zod@3.23.8):
     dependencies:

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -102,7 +102,7 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
   );
 
 const subscribe = createFetchMultipartSubscription("/graphql", {
-  fetch: authFetch,
+  fetch: graphQLFetch,
 });
 
 // Export a singleton instance of Relay Environment configured with our network layer:

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -8,8 +8,8 @@ import {
   Store,
 } from "relay-runtime";
 
-import { authFetch, refreshTokens } from "@phoenix/authFetch";
-import { BASE_URL, WS_BASE_URL } from "@phoenix/config";
+import { authFetch } from "@phoenix/authFetch";
+import { BASE_URL } from "@phoenix/config";
 
 import { isObject } from "./typeUtils";
 

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -1,15 +1,11 @@
-import fetchMultipart from "fetch-multipart-graphql";
+import { createFetchMultipartSubscription } from "@apollo/client/utilities/subscriptions/relay";
 import {
   Environment,
   FetchFunction,
-  GraphQLResponse,
   Network,
   Observable,
   RecordSource,
-  RequestParameters,
   Store,
-  SubscribeFunction,
-  Variables,
 } from "relay-runtime";
 
 import { authFetch } from "@phoenix/authFetch";
@@ -105,35 +101,7 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
     }
   );
 
-const subscribe: SubscribeFunction = (
-  operation: RequestParameters,
-  variables: Variables
-) => {
-  return Observable.create<GraphQLResponse>((sink) => {
-    fetchMultipart("/graphql", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept:
-          "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
-      },
-      body: JSON.stringify({
-        operationName: operation.name,
-        query: operation.text as string,
-        variables,
-      }),
-      credentials: "include",
-      onNext: (parts: Array<{ payload?: GraphQLResponse }>) => {
-        parts.forEach((part: { payload?: GraphQLResponse }) => {
-          part?.payload && sink.next(part.payload);
-        });
-      },
-      onError: (err: unknown) =>
-        sink.error(err instanceof Error ? err : new Error(String(err))),
-      onComplete: () => sink.complete(),
-    });
-  });
-};
+const subscribe = createFetchMultipartSubscription("/graphql");
 
 // Export a singleton instance of Relay Environment configured with our network layer:
 export default new Environment({

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -101,7 +101,9 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
     }
   );
 
-const subscribe = createFetchMultipartSubscription("/graphql");
+const subscribe = createFetchMultipartSubscription("/graphql", {
+  fetch: authFetch,
+});
 
 // Export a singleton instance of Relay Environment configured with our network layer:
 export default new Environment({

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -86,19 +86,13 @@ export function Playground(props: Partial<PlaygroundProps>) {
     );
   }, [setSearchParams]);
 
-  const streaming = window.Config.websocketsEnabled
-    ? playgroundStreamingEnabled
-    : false;
-
-  const showStreamingToggle = window.Config.websocketsEnabled;
-
   if (!hasInstalledProvider) {
     return <NoInstalledProvider availableProviders={modelProviders} />;
   }
   return (
     <PlaygroundProvider
       {...props}
-      streaming={streaming}
+      streaming={playgroundStreamingEnabled}
       modelConfigByProvider={modelConfigByProvider}
     >
       <div css={playgroundWrapCSS}>
@@ -115,7 +109,7 @@ export function Playground(props: Partial<PlaygroundProps>) {
           >
             <Heading level={1}>Playground</Heading>
             <Flex direction="row" gap="size-100" alignItems="center">
-              {showStreamingToggle ? <PlaygroundStreamToggle /> : null}
+              <PlaygroundStreamToggle />
               <PlaygroundDatasetPicker />
               <PlaygroundCredentialsDropdown />
               <PlaygroundRunButton />

--- a/app/src/pages/playground/PlaygroundStreamToggle.tsx
+++ b/app/src/pages/playground/PlaygroundStreamToggle.tsx
@@ -16,11 +16,6 @@ export function PlaygroundStreamToggle() {
     state.instances.some((instance) => instance.activeRunId != null)
   );
 
-  // This toggle should never be shown if websockets are disabled
-  if (window.Config.websocketsEnabled === false) {
-    return null;
-  }
-
   return (
     <Switch
       labelPlacement="start"

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -21,7 +21,6 @@ declare global {
       };
       authenticationEnabled: boolean;
       oAuth2Idps: OAuth2Idp[];
-      websocketsEnabled: boolean;
     };
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "fastapi",
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",
-  "websockets",
   "arize-phoenix-client",
   "email-validator",
 ]

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -119,10 +119,6 @@ ENV_LOG_MIGRATIONS = "PHOENIX_LOG_MIGRATIONS"
 """
 Whether or not to log migrations. Defaults to true.
 """
-ENV_PHOENIX_ENABLE_WEBSOCKETS = "PHOENIX_ENABLE_WEBSOCKETS"
-"""
-Whether or not to enable websockets. Defaults to None.
-"""
 
 ENV_PHOENIX_DANGEROUSLY_DISABLE_MIGRATIONS = "PHOENIX_DANGEROUSLY_DISABLE_MIGRATIONS"
 """
@@ -572,10 +568,6 @@ def get_env_smtp_port() -> int:
 
 def get_env_smtp_validate_certs() -> bool:
     return _bool_val(ENV_PHOENIX_SMTP_VALIDATE_CERTS, True)
-
-
-def get_env_enable_websockets() -> Optional[bool]:
-    return _bool_val(ENV_PHOENIX_ENABLE_WEBSOCKETS)
 
 
 @dataclass(frozen=True)
@@ -1144,6 +1136,13 @@ def verify_server_environment_variables() -> None:
     get_env_root_url()
     get_env_phoenix_secret()
     get_env_phoenix_admin_secret()
+
+    # Notify users about deprecated environment variables if they are being used.
+    if _bool_val("PHOENIX_ENABLE_WEBSOCKETS"):
+        logger.info(
+            "The environment variable PHOENIX_ENABLE_WEBSOCKETS is deprecated "
+            "because WebSocket is no longer necessary."
+        )
 
 
 SKLEARN_VERSION = cast(tuple[int, int], tuple(map(int, version("scikit-learn").split(".", 2)[:2])))

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1138,8 +1138,8 @@ def verify_server_environment_variables() -> None:
     get_env_phoenix_admin_secret()
 
     # Notify users about deprecated environment variables if they are being used.
-    if _bool_val("PHOENIX_ENABLE_WEBSOCKETS"):
-        logger.info(
+    if os.getenv("PHOENIX_ENABLE_WEBSOCKETS") is not None:
+        logger.warning(
             "The environment variable PHOENIX_ENABLE_WEBSOCKETS is deprecated "
             "because WebSocket is no longer necessary."
         )

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -25,7 +25,6 @@ from urllib.parse import urlparse
 import strawberry
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.utils import is_body_allowed_for_status_code
 from grpc.aio import ServerInterceptor
 from sqlalchemy import select
@@ -122,6 +121,7 @@ from phoenix.server.dml_event_handler import DmlEventHandler
 from phoenix.server.email.types import EmailSender
 from phoenix.server.grpc_server import GrpcServer
 from phoenix.server.jwt_store import JwtStore
+from phoenix.server.middleware.gzip import GZipMiddleware
 from phoenix.server.oauth2 import OAuth2Clients
 from phoenix.server.telemetry import initialize_opentelemetry_tracer_provider
 from phoenix.server.types import (

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -31,17 +31,16 @@ from grpc.aio import ServerInterceptor
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from starlette.datastructures import State as StarletteState
-from starlette.exceptions import HTTPException, WebSocketException
+from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.responses import PlainTextResponse, Response
 from starlette.staticfiles import StaticFiles
 from starlette.status import HTTP_401_UNAUTHORIZED
 from starlette.templating import Jinja2Templates
 from starlette.types import Scope, StatefulLifespan
-from starlette.websockets import WebSocket
 from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL
@@ -207,7 +206,6 @@ class AppConfig(NamedTuple):
     web_manifest_path: Path
     authentication_enabled: bool
     """ Whether authentication is enabled """
-    websockets_enabled: bool
     oauth2_idps: Sequence[OAuth2Idp]
 
 
@@ -258,7 +256,6 @@ class Static(StaticFiles):
                     "manifest": self._web_manifest,
                     "authentication_enabled": self._app_config.authentication_enabled,
                     "oauth2_idps": self._app_config.oauth2_idps,
-                    "websockets_enabled": self._app_config.websockets_enabled,
                 },
             )
         except Exception as e:
@@ -723,36 +720,12 @@ async def plain_text_http_exception_handler(request: Request, exc: HTTPException
     return PlainTextResponse(str(exc.detail), status_code=exc.status_code, headers=headers)
 
 
-async def websocket_denial_response_handler(websocket: WebSocket, exc: WebSocketException) -> None:
-    """
-    Overrides the default exception handler for WebSocketException to ensure
-    that the HTTP response returned when a WebSocket connection is denied has
-    the same status code as the raised exception. This is in keeping with the
-    WebSocket Denial Response Extension of the ASGI specificiation described
-    below.
-
-    "Websocket connections start with the client sending a HTTP request
-    containing the appropriate upgrade headers. On receipt of this request a
-    server can choose to either upgrade the connection or respond with an HTTP
-    response (denying the upgrade). The core ASGI specification does not allow
-    for any control over the denial response, instead specifying that the HTTP
-    status code 403 should be returned, whereas this extension allows an ASGI
-    framework to control the denial response."
-
-    For details, see:
-    - https://asgi.readthedocs.io/en/latest/extensions.html#websocket-denial-response
-    """
-    assert isinstance(exc, WebSocketException)
-    await websocket.send_denial_response(JSONResponse(status_code=exc.code, content=exc.reason))
-
-
 def create_app(
     db: DbSessionFactory,
     export_path: Path,
     model: Model,
     authentication_enabled: bool,
     umap_params: UMAPParameters,
-    enable_websockets: bool,
     corpus: Optional[Model] = None,
     debug: bool = False,
     dev: bool = False,
@@ -900,7 +873,6 @@ def create_app(
         middleware=middlewares,
         exception_handlers={
             HTTPException: plain_text_http_exception_handler,
-            WebSocketException: websocket_denial_response_handler,  # type: ignore[dict-item]
         },
         debug=debug,
         swagger_ui_parameters={
@@ -935,7 +907,6 @@ def create_app(
                     authentication_enabled=authentication_enabled,
                     web_manifest_path=web_manifest_path,
                     oauth2_idps=oauth2_idps,
-                    websockets_enabled=enable_websockets,
                 ),
             ),
             name="static",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -23,7 +23,6 @@ from phoenix.config import (
     get_env_db_logging_level,
     get_env_disable_migrations,
     get_env_enable_prometheus,
-    get_env_enable_websockets,
     get_env_grpc_port,
     get_env_host,
     get_env_host_root_path,
@@ -355,13 +354,6 @@ def main() -> None:
         None if corpus_inferences is None else create_model_from_inferences(corpus_inferences)
     )
 
-    # Get enable_websockets from environment variable or command line argument
-    enable_websockets = get_env_enable_websockets()
-    if args.enable_websockets is not None:
-        enable_websockets = args.enable_websockets.lower() == "true"
-    if enable_websockets is None:
-        enable_websockets = True
-
     allowed_origins = get_env_allowed_origins()
 
     # Print information about the server
@@ -374,7 +366,6 @@ def main() -> None:
         storage=get_printable_db_url(db_connection_str),
         schema=get_env_database_schema(),
         auth_enabled=authentication_enabled,
-        websockets_enabled=enable_websockets,
         allowed_origins=allowed_origins,
     )
     if sys.platform.startswith("win"):
@@ -405,7 +396,6 @@ def main() -> None:
         db=factory,
         export_path=export_path,
         model=model,
-        enable_websockets=enable_websockets,
         authentication_enabled=authentication_enabled,
         umap_params=umap_params,
         corpus=corpus_model,

--- a/src/phoenix/server/middleware/gzip.py
+++ b/src/phoenix/server/middleware/gzip.py
@@ -1,0 +1,22 @@
+from starlette.datastructures import Headers
+from starlette.middleware.gzip import GZipMiddleware as _GZipMiddleware
+from starlette.middleware.gzip import GZipResponder, IdentityResponder
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class GZipMiddleware(_GZipMiddleware):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        responder: ASGIApp
+        if "gzip" not in headers.get("Accept-Encoding", "") or "multipart/mixed" in headers.get(
+            "Accept", ""
+        ):
+            responder = IdentityResponder(self.app, self.minimum_size)
+        else:
+            responder = GZipResponder(self.app, self.minimum_size, compresslevel=self.compresslevel)
+
+        await responder(scope, receive, send)

--- a/src/phoenix/server/middleware/gzip.py
+++ b/src/phoenix/server/middleware/gzip.py
@@ -5,6 +5,17 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 class GZipMiddleware(_GZipMiddleware):
+    """
+    Subclass of Starlette's GZipMiddleware that excludes multipart/mixed responses from compression.
+
+    This middleware adds a check to exclude multipart/mixed content types from compression,
+    which is important for streaming responses where compression could interfere with delivery.
+
+    The middleware will use the IdentityResponder (no compression) when:
+    1. The client doesn't support gzip compression, or
+    2. The response is a multipart/mixed content type
+    """
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)

--- a/src/phoenix/services.py
+++ b/src/phoenix/services.py
@@ -118,7 +118,6 @@ class AppService(Service):
         reference_inferences_name: Optional[str],
         corpus_inferences_name: Optional[str],
         trace_dataset_name: Optional[str],
-        enable_websockets: bool,
     ):
         self.database_url = database_url
         self.export_path = export_path
@@ -130,7 +129,6 @@ class AppService(Service):
         self.__reference_inferences_name = reference_inferences_name
         self.__corpus_inferences_name = corpus_inferences_name
         self.__trace_dataset_name = trace_dataset_name
-        self.enable_websockets = enable_websockets
         super().__init__()
 
     @property
@@ -158,7 +156,5 @@ class AppService(Service):
             command.extend(["--corpus", str(self.__corpus_inferences_name)])
         if self.__trace_dataset_name is not None:
             command.extend(["--trace", str(self.__trace_dataset_name)])
-        if self.enable_websockets:
-            command.append("--enable-websockets")
         logger.info(f"command: {' '.join(command)}")
         return command

--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -24,7 +24,6 @@ from phoenix.config import (
     ENV_PHOENIX_PORT,
     ensure_working_dir_if_needed,
     get_env_database_connection_str,
-    get_env_enable_websockets,
     get_env_host,
     get_env_port,
     get_exported_files,
@@ -271,7 +270,6 @@ class ProcessSession(Session):
         self,
         database_url: str,
         primary_inferences: Inferences,
-        enable_websockets: bool,
         reference_inferences: Optional[Inferences] = None,
         corpus_inferences: Optional[Inferences] = None,
         trace_dataset: Optional[TraceDataset] = None,
@@ -322,7 +320,6 @@ class ProcessSession(Session):
             trace_dataset_name=(
                 self.trace_dataset.name if self.trace_dataset is not None else None
             ),
-            enable_websockets=enable_websockets,
         )
 
     @property
@@ -339,7 +336,6 @@ class ThreadSession(Session):
         self,
         database_url: str,
         primary_inferences: Inferences,
-        enable_websockets: bool,
         reference_inferences: Optional[Inferences] = None,
         corpus_inferences: Optional[Inferences] = None,
         trace_dataset: Optional[TraceDataset] = None,
@@ -380,7 +376,6 @@ class ThreadSession(Session):
             export_path=self.export_path,
             model=self.model,
             authentication_enabled=False,
-            enable_websockets=enable_websockets,
             corpus=self.corpus,
             umap_params=self.umap_parameters,
             initial_spans=trace_dataset.to_spans() if trace_dataset else None,
@@ -444,7 +439,6 @@ def launch_app(
     run_in_thread: bool = True,
     notebook_environment: Optional[Union[NotebookEnvironment, str]] = None,
     use_temp_dir: bool = True,
-    enable_websockets: Optional[bool] = None,
 ) -> Optional[Session]:
     """
     Launches the phoenix application and returns a session to interact with.
@@ -479,8 +473,6 @@ def launch_app(
     use_temp_dir: bool, optional, default=True
         Whether to use a temporary directory to store the data. If set to False, the data will be
         stored in the directory specified by PHOENIX_WORKING_DIR environment variable via SQLite.
-    enable_websockets: bool, optional, default=False
-        Whether to enable websockets.
 
     Returns
     -------
@@ -571,16 +563,10 @@ def launch_app(
                 "pip install 'arize-phoenix[pg]'"
             )
 
-    enable_websockets_env = get_env_enable_websockets() or False
-    enable_websockets = (
-        enable_websockets if enable_websockets is not None else enable_websockets_env
-    )
-
     if run_in_thread:
         _session = ThreadSession(
             database_url,
             primary,
-            enable_websockets,
             reference,
             corpus,
             trace,
@@ -594,7 +580,6 @@ def launch_app(
         _session = ProcessSession(
             database_url,
             primary,
-            enable_websockets,
             reference,
             corpus,
             trace,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -201,7 +201,6 @@ async def app(
             umap_params=get_umap_parameters(None),
             serve_ui=False,
             bulk_inserter_factory=TestBulkInserter,
-            enable_websockets=True,
         )
         manager = await stack.enter_async_context(LifespanManager(app))
         yield manager.app


### PR DESCRIPTION
# Remove WebSocket Support and Migrate to Multipart Subscriptions

## Overview
This PR removes the WebSocket-based GraphQL subscription implementation and replaces it with [multipart subscription](https://strawberry.rocks/docs/general/multipart-subscriptions).

## Key Changes
- Removed WebSocket-related code and configuration:
  - Removed `graphql-ws` dependency
  - Removed WebSocket server setup and handlers
  - Removed WebSocket configuration from environment variables
  - Removed WebSocket-related UI configuration
- Added Apollo Client for GraphQL operations:
  - Added `@apollo/client` dependency
  - Updated Relay environment to use Apollo's subscription transport
- Special GZip compression handling:
  - Prevented GZip compression for multipart/mixed content types

## Technical Details
- Replaced `graphql-ws` with Apollo Client's built-in subscription support
- Removed `PHOENIX_ENABLE_WEBSOCKETS` environment variable
- Updated Relay environment to use `createFetchMultipartSubscription`
- Enhanced GZip middleware to properly handle multipart responses

## Migration Notes
The `PHOENIX_ENABLE_WEBSOCKETS` environment variable is now deprecated as WebSocket support is no longer necessary. Users should remove this configuration from their environment.

## Note For Developers
The only thing differentiating a multipart request (for Strawberry) from a WebSocket request is the addition of the following HTTP header (e.g. if you're using cURL).
```console
-H "Accept: multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json"
```

## Browser Screenshot
<img width="479" alt="Screenshot 2025-04-16 at 11 39 24 AM" src="https://github.com/user-attachments/assets/f255582c-912b-499c-b6cf-7bafed43d642" />

## TODO
- Convert unit tests away from WebSocket
