### PR TITLE
refactor(prompts): move prompt models into db types

### DIFF
--- a/src/phoenix/db/types/db_models.py
+++ b/src/phoenix/db/types/db_models.py
@@ -3,7 +3,11 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 
-class PromptModel(BaseModel):
+class DBBaseModel(BaseModel):
+    """
+    A base Pydantic model suitable for use with JSON columns in the database.
+    """
+
     model_config = ConfigDict(
         extra="forbid",  # disallow extra attributes
         use_enum_values=True,

--- a/src/phoenix/db/types/db_models.py
+++ b/src/phoenix/db/types/db_models.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PromptModel(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",  # disallow extra attributes
+        use_enum_values=True,
+        validate_assignment=True,
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs = {k: v for k, v in kwargs.items() if v is not UNDEFINED}
+        super().__init__(*args, **kwargs)
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return super().model_dump(*args, exclude_unset=True, by_alias=True, **kwargs)
+
+
+class Undefined:
+    """
+    A singleton class that represents an unset or undefined value. Needed since Pydantic
+    can't natively distinguish between an undefined value and a value that is set to
+    None.
+    """
+
+    def __new__(cls) -> Any:
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNDEFINED: Any = Undefined()

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -3,33 +3,15 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Literal, Mapping, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
+from pydantic import Field, RootModel, model_validator
 from typing_extensions import Annotated, Self, TypeAlias, TypeGuard, assert_never
 
+from phoenix.db.types.db_models import UNDEFINED, PromptModel
 from phoenix.db.types.model_provider import ModelProvider
 from phoenix.server.api.helpers.prompts.conversions.anthropic import AnthropicToolChoiceConversion
 from phoenix.server.api.helpers.prompts.conversions.openai import OpenAIToolChoiceConversion
 
 JSONSerializable = Union[None, bool, int, float, str, dict[str, Any], list[Any]]
-
-
-class Undefined:
-    """
-    A singleton class that represents an unset or undefined value. Needed since Pydantic
-    can't natively distinguish between an undefined value and a value that is set to
-    None.
-    """
-
-    def __new__(cls) -> Any:
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __bool__(self) -> bool:
-        return False
-
-
-UNDEFINED: Any = Undefined()
 
 
 class PromptTemplateType(str, Enum):
@@ -48,21 +30,6 @@ class PromptTemplateFormat(str, Enum):
     MUSTACHE = "MUSTACHE"
     F_STRING = "F_STRING"
     NONE = "NONE"
-
-
-class PromptModel(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",  # disallow extra attributes
-        use_enum_values=True,
-        validate_assignment=True,
-    )
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs = {k: v for k, v in kwargs.items() if v is not UNDEFINED}
-        super().__init__(*args, **kwargs)
-
-    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        return super().model_dump(*args, exclude_unset=True, by_alias=True, **kwargs)
 
 
 class TextContentPart(PromptModel):


### PR DESCRIPTION
This makes the base DB model type accessible for other uses, in particular, for annotation configs.
