### PR TITLE
fix: forbid deletion of default policy

### DIFF
--- a/src/phoenix/server/api/mutations/project_trace_retention_policy_mutations.py
+++ b/src/phoenix/server/api/mutations/project_trace_retention_policy_mutations.py
@@ -208,7 +208,7 @@ class ProjectTraceRetentionPolicyMutationMixin:
     ) -> ProjectTraceRetentionPolicyMutationPayload:
         id_ = from_global_id_with_expected_type(input.id, ProjectTraceRetentionPolicy.__name__)
         if id_ == DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID:
-            raise BadRequest("Cannot delete the default project trace retention policy. ")
+            raise BadRequest("Cannot delete the default project trace retention policy.")
         stmt = (
             sa.delete(models.ProjectTraceRetentionPolicy)
             .where(models.ProjectTraceRetentionPolicy.id == id_)

--- a/src/phoenix/server/api/mutations/project_trace_retention_policy_mutations.py
+++ b/src/phoenix/server/api/mutations/project_trace_retention_policy_mutations.py
@@ -8,6 +8,7 @@ from strawberry import UNSET, Info
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
 from phoenix.db.types.trace_retention import (
     MaxCountRule,
     MaxDaysOrCountRule,
@@ -206,6 +207,8 @@ class ProjectTraceRetentionPolicyMutationMixin:
         input: DeleteProjectTraceRetentionPolicyInput,
     ) -> ProjectTraceRetentionPolicyMutationPayload:
         id_ = from_global_id_with_expected_type(input.id, ProjectTraceRetentionPolicy.__name__)
+        if id_ == DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID:
+            raise BadRequest("Cannot delete the default project trace retention policy. ")
         stmt = (
             sa.delete(models.ProjectTraceRetentionPolicy)
             .where(models.ProjectTraceRetentionPolicy.id == id_)

--- a/tests/unit/server/api/mutations/test_project_trace_retention_policy_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_trace_retention_policy_mutations.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.ProjectTraceRetentionPolicy import ProjectTraceRetentionPolicy
@@ -310,13 +311,12 @@ class TestProjectTraceRetentionPolicyMutations:
 
         This test verifies that attempting to delete the default policy results in a BadRequest error.
         """  # noqa: E501
-        from phoenix.db.constants import DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID
-        from phoenix.server.api.types.ProjectTraceRetentionPolicy import ProjectTraceRetentionPolicy
 
         # Create a GlobalID for the default policy
         default_policy_gid = str(
             GlobalID(
-                ProjectTraceRetentionPolicy.__name__, str(DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID)
+                ProjectTraceRetentionPolicy.__name__,
+                str(DEFAULT_PROJECT_TRACE_RETENTION_POLICY_ID),
             )
         )
 


### PR DESCRIPTION
Add validation to prevent deletion of default trace retention policy

This PR adds validation to prevent deletion of the default project trace retention policy (ID 0) and includes a test to verify this behavior. The changes:

1. Add a check in the `delete_project_trace_retention_policy` mutation to raise a BadRequest error if attempting to delete the default policy
2. Add a new test method `test_cannot_delete_default_policy` that verifies the validation works correctly

This ensures the default policy remains available as a fallback for projects that don't have a specific retention policy assigned.