### PR TITLE
fix(annotations): validate values for categorical annotation config

### DIFF
--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Annotated, Literal, Optional, Union
 
-from pydantic import Field, RootModel
+from pydantic import AfterValidator, Field, RootModel
 from typing_extensions import TypeAlias
 
 from .db_models import DBBaseModel
@@ -27,10 +27,30 @@ class CategoricalAnnotationValue(DBBaseModel):
     score: Optional[float] = None
 
 
+def is_non_empty(values: list[CategoricalAnnotationValue]) -> list[CategoricalAnnotationValue]:
+    if not values:
+        raise ValueError("Values must be non-empty")
+    return values
+
+
+def has_unique_labels(values: list[CategoricalAnnotationValue]) -> list[CategoricalAnnotationValue]:
+    labels = set()
+    for value in values:
+        label = value.label
+        if label in labels:
+            raise ValueError("Values for categorical annotation config must have unique labels")
+        labels.add(label)
+    return values
+
+
 class CategoricalAnnotationConfig(_BaseAnnotationConfig):
     type: Literal[AnnotationType.CATEGORICAL.value]  # type: ignore[name-defined]
     optimization_direction: OptimizationDirection
-    values: list[CategoricalAnnotationValue]
+    values: Annotated[
+        list[CategoricalAnnotationValue],
+        AfterValidator(is_non_empty),
+        AfterValidator(has_unique_labels),
+    ]
 
 
 class ContinuousAnnotationConfig(_BaseAnnotationConfig):

--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -39,7 +39,7 @@ def has_unique_labels(values: list[CategoricalAnnotationValue]) -> list[Categori
         label = value.label
         if label in labels:
             raise ValueError(
-                f'Values for categorical annotation config have duplicate label: "{label}"'
+                f'Values for categorical annotation config has duplicate label: "{label}"'
             )
         labels.add(label)
     return values

--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -38,7 +38,9 @@ def has_unique_labels(values: list[CategoricalAnnotationValue]) -> list[Categori
     for value in values:
         label = value.label
         if label in labels:
-            raise ValueError("Values for categorical annotation config must have unique labels")
+            raise ValueError(
+                f'Values for categorical annotation config have duplicate label: "{label}"'
+            )
         labels.add(label)
     return values
 

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -77,17 +77,16 @@ class SpanAnnotationMutationMixin:
                     "user_id": user_id,
                 }
 
-                identifier = annotation_input.identifier
                 processed_annotation: Optional[models.SpanAnnotation] = None
 
                 q = select(models.SpanAnnotation).where(
                     models.SpanAnnotation.span_rowid == span_rowid,
                     models.SpanAnnotation.name == annotation_input.name,
                 )
-                if identifier is None:
+                if resolved_identifier is None:
                     q = q.where(models.SpanAnnotation.identifier.is_(None))
                 else:
-                    q = q.where(models.SpanAnnotation.identifier == identifier)
+                    q = q.where(models.SpanAnnotation.identifier == resolved_identifier)
 
                 existing_annotation = await session.scalar(q)
 

--- a/src/phoenix/server/api/mutations/trace_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_annotations_mutations.py
@@ -78,7 +78,6 @@ class TraceAnnotationMutationMixin:
                     "user_id": user_id,
                 }
 
-                identifier = annotation_input.identifier
                 processed_annotation: Optional[models.TraceAnnotation] = None
 
                 # Check if an annotation with this trace_rowid, name, and identifier already exists
@@ -86,10 +85,10 @@ class TraceAnnotationMutationMixin:
                     models.TraceAnnotation.trace_rowid == trace_rowid,
                     models.TraceAnnotation.name == annotation_input.name,
                 )
-                if identifier is None:
+                if resolved_identifier is None:
                     q = q.where(models.TraceAnnotation.identifier.is_(None))
                 else:
-                    q = q.where(models.TraceAnnotation.identifier == identifier)
+                    q = q.where(models.TraceAnnotation.identifier == resolved_identifier)
 
                 existing_annotation = await session.scalar(q)
 

--- a/tests/unit/db/types/test_annotation_configs.py
+++ b/tests/unit/db/types/test_annotation_configs.py
@@ -1,0 +1,51 @@
+from contextlib import nullcontext
+from typing import Any, ContextManager
+
+import pytest
+
+from phoenix.db.types.annotation_configs import (
+    AnnotationType,
+    CategoricalAnnotationConfig,
+    CategoricalAnnotationValue,
+    OptimizationDirection,
+)
+
+
+@pytest.mark.parametrize(
+    "values, expectation",
+    (
+        pytest.param(
+            [
+                CategoricalAnnotationValue(label="A", score=1.0),
+            ],
+            nullcontext(),
+            id="valid-values-pass-validation",
+        ),
+        pytest.param(
+            [],
+            pytest.raises(ValueError, match="Values must be non-empty"),
+            id="empty-values-raise-validation-error",
+        ),
+        pytest.param(
+            [
+                CategoricalAnnotationValue(label="A", score=1.0),
+                CategoricalAnnotationValue(label="A", score=2.0),
+            ],
+            pytest.raises(
+                ValueError,
+                match="Values for categorical annotation config must have unique labels",
+            ),
+            id="duplicate-labels-raise-validation-error",
+        ),
+    ),
+)
+def test_categorical_annotation_config_correctly_validates_values(
+    values: list[CategoricalAnnotationValue],
+    expectation: ContextManager[Any],
+) -> None:
+    with expectation:
+        CategoricalAnnotationConfig(
+            type=AnnotationType.CATEGORICAL.value,
+            values=values,
+            optimization_direction=OptimizationDirection.MAXIMIZE,
+        )

--- a/tests/unit/db/types/test_annotation_configs.py
+++ b/tests/unit/db/types/test_annotation_configs.py
@@ -33,7 +33,7 @@ from phoenix.db.types.annotation_configs import (
             ],
             pytest.raises(
                 ValueError,
-                match="Values for categorical annotation config must have unique labels",
+                match='Values for categorical annotation config has duplicate label: "A"',
             ),
             id="duplicate-labels-raise-validation-error",
         ),

--- a/tests/unit/server/api/mutations/test_span_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_span_annotation_mutations.py
@@ -96,7 +96,7 @@ class TestSpanAnnotationMutations:
                             "annotatorKind": AnnotatorKind.HUMAN.name,
                             "metadata": {},
                             "identifier": None,
-                            "source": AnnotationSource.APP.name,
+                            "source": AnnotationSource.API.name,
                         }
                     ]
                 },

--- a/tests/unit/server/api/types/test_SpanAnnotation.py
+++ b/tests/unit/server/api/types/test_SpanAnnotation.py
@@ -159,7 +159,7 @@ async def test_annotating_a_span(
     assert orm_annotation.explanation == "Updated explanation"
     assert orm_annotation.metadata_ == {"updated": True}
     assert orm_annotation.identifier == "updated-identifier"
-    assert orm_annotation.source == "APP"
+    assert orm_annotation.source == "API"
     assert orm_annotation.user_id is None
 
     response = await gql_client.execute(

--- a/tests/unit/server/api/types/test_TraceAnnotation.py
+++ b/tests/unit/server/api/types/test_TraceAnnotation.py
@@ -161,7 +161,7 @@ async def test_annotating_a_trace(
     assert orm_annotation.explanation == "Updated explanation"
     assert orm_annotation.metadata_ == {"updated": True}
     assert orm_annotation.identifier == "updated-identifier"
-    assert orm_annotation.source == "APP"
+    assert orm_annotation.source == "API"
     assert orm_annotation.user_id is None
 
     response = await gql_client.execute(


### PR DESCRIPTION
Ensures that categorical annotation config values are non-empty and have unique labels. This is enforced at the level of DB types, so will protect both the REST and GraphQL APIs.

resolves #7234
