### PR TITLE
refactor(annotations): allow batch deletion of annotation configs

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -655,6 +655,15 @@ type DeleteAnnotationConfigPayload {
   annotationConfig: AnnotationConfig!
 }
 
+input DeleteAnnotationConfigsInput {
+  ids: [GlobalID!]!
+}
+
+type DeleteAnnotationConfigsPayload {
+  query: Query!
+  annotationConfigs: [AnnotationConfig!]!
+}
+
 input DeleteAnnotationsInput {
   annotationIds: [GlobalID!]!
 }
@@ -1385,6 +1394,7 @@ type Mutation {
   createAnnotationConfig(input: CreateAnnotationConfigInput!): CreateAnnotationConfigPayload!
   updateAnnotationConfig(input: UpdateAnnotationConfigInput!): UpdateAnnotationConfigPayload!
   deleteAnnotationConfig(input: DeleteAnnotationConfigInput!): DeleteAnnotationConfigPayload!
+  deleteAnnotationConfigs(input: DeleteAnnotationConfigsInput!): DeleteAnnotationConfigsPayload!
   addAnnotationConfigToProject(input: [AddAnnotationConfigToProjectInput!]!): AddAnnotationConfigToProjectPayload!
   removeAnnotationConfigFromProject(input: [RemoveAnnotationConfigFromProjectInput!]!): RemoveAnnotationConfigFromProjectPayload!
   createSystemApiKey(input: CreateApiKeyInput!): CreateSystemApiKeyMutationPayload!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -646,15 +646,6 @@ type DbTableStats {
   numBytes: Float!
 }
 
-input DeleteAnnotationConfigInput {
-  configId: GlobalID!
-}
-
-type DeleteAnnotationConfigPayload {
-  query: Query!
-  annotationConfig: AnnotationConfig!
-}
-
 input DeleteAnnotationConfigsInput {
   ids: [GlobalID!]!
 }
@@ -1393,7 +1384,6 @@ input ModelsInput {
 type Mutation {
   createAnnotationConfig(input: CreateAnnotationConfigInput!): CreateAnnotationConfigPayload!
   updateAnnotationConfig(input: UpdateAnnotationConfigInput!): UpdateAnnotationConfigPayload!
-  deleteAnnotationConfig(input: DeleteAnnotationConfigInput!): DeleteAnnotationConfigPayload!
   deleteAnnotationConfigs(input: DeleteAnnotationConfigsInput!): DeleteAnnotationConfigsPayload!
   addAnnotationConfigToProject(input: [AddAnnotationConfigToProjectInput!]!): AddAnnotationConfigToProjectPayload!
   removeAnnotationConfigFromProject(input: [RemoveAnnotationConfigFromProjectInput!]!): RemoveAnnotationConfigFromProjectPayload!

--- a/app/src/pages/settings/SettingsAnnotationsPage.tsx
+++ b/app/src/pages/settings/SettingsAnnotationsPage.tsx
@@ -33,12 +33,12 @@ const SettingsAnnotations = ({
     annotations
   );
 
-  const [deleteAnnotationConfig] = useMutation(graphql`
-    mutation SettingsAnnotationsPageDeleteAnnotationConfigMutation(
-      $input: DeleteAnnotationConfigInput!
+  const [deleteAnnotationConfigs] = useMutation(graphql`
+    mutation SettingsAnnotationsPageDeleteAnnotationConfigsMutation(
+      $input: DeleteAnnotationConfigsInput!
     ) {
-      deleteAnnotationConfig(input: $input) {
-        annotationConfig {
+      deleteAnnotationConfigs(input: $input) {
+        annotationConfigs {
           __typename
         }
       }
@@ -140,8 +140,8 @@ const SettingsAnnotations = ({
       onError,
     }: { onCompleted?: () => void; onError?: (error: string) => void } = {}
   ) => {
-    deleteAnnotationConfig({
-      variables: { input: { configId: id } },
+    deleteAnnotationConfigs({
+      variables: { input: { ids: [id] } },
       onCompleted,
       onError: parseError(onError),
     });

--- a/app/src/pages/settings/__generated__/SettingsAnnotationsPageDeleteAnnotationConfigsMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAnnotationsPageDeleteAnnotationConfigsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<acea4279b21f37d7d19c487bc950d7b0>>
+ * @generated SignedSource<<3422641644534afcfe75a4c6c9bedc32>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,22 +9,22 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type DeleteAnnotationConfigInput = {
-  configId: string;
+export type DeleteAnnotationConfigsInput = {
+  ids: ReadonlyArray<string>;
 };
-export type SettingsAnnotationsPageDeleteAnnotationConfigMutation$variables = {
-  input: DeleteAnnotationConfigInput;
+export type SettingsAnnotationsPageDeleteAnnotationConfigsMutation$variables = {
+  input: DeleteAnnotationConfigsInput;
 };
-export type SettingsAnnotationsPageDeleteAnnotationConfigMutation$data = {
-  readonly deleteAnnotationConfig: {
-    readonly annotationConfig: {
+export type SettingsAnnotationsPageDeleteAnnotationConfigsMutation$data = {
+  readonly deleteAnnotationConfigs: {
+    readonly annotationConfigs: ReadonlyArray<{
       readonly __typename: string;
-    };
+    }>;
   };
 };
-export type SettingsAnnotationsPageDeleteAnnotationConfigMutation = {
-  response: SettingsAnnotationsPageDeleteAnnotationConfigMutation$data;
-  variables: SettingsAnnotationsPageDeleteAnnotationConfigMutation$variables;
+export type SettingsAnnotationsPageDeleteAnnotationConfigsMutation = {
+  response: SettingsAnnotationsPageDeleteAnnotationConfigsMutation$data;
+  variables: SettingsAnnotationsPageDeleteAnnotationConfigsMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -54,14 +54,14 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SettingsAnnotationsPageDeleteAnnotationConfigMutation",
+    "name": "SettingsAnnotationsPageDeleteAnnotationConfigsMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DeleteAnnotationConfigPayload",
+        "concreteType": "DeleteAnnotationConfigsPayload",
         "kind": "LinkedField",
-        "name": "deleteAnnotationConfig",
+        "name": "deleteAnnotationConfigs",
         "plural": false,
         "selections": [
           {
@@ -69,8 +69,8 @@ return {
             "args": null,
             "concreteType": null,
             "kind": "LinkedField",
-            "name": "annotationConfig",
-            "plural": false,
+            "name": "annotationConfigs",
+            "plural": true,
             "selections": [
               (v2/*: any*/)
             ],
@@ -87,14 +87,14 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "SettingsAnnotationsPageDeleteAnnotationConfigMutation",
+    "name": "SettingsAnnotationsPageDeleteAnnotationConfigsMutation",
     "selections": [
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "DeleteAnnotationConfigPayload",
+        "concreteType": "DeleteAnnotationConfigsPayload",
         "kind": "LinkedField",
-        "name": "deleteAnnotationConfig",
+        "name": "deleteAnnotationConfigs",
         "plural": false,
         "selections": [
           {
@@ -102,8 +102,8 @@ return {
             "args": null,
             "concreteType": null,
             "kind": "LinkedField",
-            "name": "annotationConfig",
-            "plural": false,
+            "name": "annotationConfigs",
+            "plural": true,
             "selections": [
               (v2/*: any*/),
               {
@@ -129,16 +129,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b6b9260d58a6721c5dc81f7596766a39",
+    "cacheID": "26434e94a78f9d52aa61c8e885eb5ca3",
     "id": null,
     "metadata": {},
-    "name": "SettingsAnnotationsPageDeleteAnnotationConfigMutation",
+    "name": "SettingsAnnotationsPageDeleteAnnotationConfigsMutation",
     "operationKind": "mutation",
-    "text": "mutation SettingsAnnotationsPageDeleteAnnotationConfigMutation(\n  $input: DeleteAnnotationConfigInput!\n) {\n  deleteAnnotationConfig(input: $input) {\n    annotationConfig {\n      __typename\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n  }\n}\n"
+    "text": "mutation SettingsAnnotationsPageDeleteAnnotationConfigsMutation(\n  $input: DeleteAnnotationConfigsInput!\n) {\n  deleteAnnotationConfigs(input: $input) {\n    annotationConfigs {\n      __typename\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "705e44815f407f6f7403516604019253";
+(node as any).hash = "b9c71db625b896a55591c5d5e88a2929";
 
 export default node;

--- a/src/phoenix/server/api/mutations/annotation_config_mutations.py
+++ b/src/phoenix/server/api/mutations/annotation_config_mutations.py
@@ -282,10 +282,7 @@ class AnnotationConfigMutationMixin:
         for config_gid in input.ids:
             if (type_name := config_gid.type_name) not in ANNOTATION_TYPE_NAMES:
                 raise BadRequest(f"Unexpected type name in Relay ID: {type_name}")
-            config_id = int(config_gid.node_id)
-            if config_id in config_ids:
-                raise BadRequest("Duplicate annotation config IDs provided")
-            config_ids.add(config_id)
+            config_ids.add(int(config_gid.node_id))
 
         async with info.context.db() as session:
             result = await session.scalars(


### PR DESCRIPTION
Allow batch deletions of annotation configs from the GraphQL perspective.

resolves #7224
