### PR TITLE
fix(annotations): Truncate long category names in annotation config table

### DIFF
--- a/app/src/pages/settings/AnnotationConfigTable.tsx
+++ b/app/src/pages/settings/AnnotationConfigTable.tsx
@@ -97,7 +97,9 @@ const columns = [
           }
           let tokens = row.values.map(
             (value: { label: string }, index: number) => (
-              <Token key={index}>{value.label}</Token>
+              <Token key={index} title={value.label}>
+                <Truncate maxWidth="40px">{value.label}</Truncate>
+              </Token>
             )
           );
           if (row.values.length > 5) {


### PR DESCRIPTION
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/dfc24609-b5d5-4b44-8065-8195017bc2f2" />

Resolves #7223