### PR TITLE
feat: Add span comment mutation

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -426,9 +426,9 @@ input CreateSpanAnnotationInput {
   source: AnnotationSource!
 }
 
-input CreateSpanCommentInput {
+input CreateSpanNoteInput {
   spanId: GlobalID!
-  comment: String!
+  note: String!
 }
 
 type CreateSystemApiKeyMutationPayload {
@@ -1434,7 +1434,7 @@ type Mutation {
   setPromptLabel(input: SetPromptLabelInput!): PromptLabelMutationPayload!
   unsetPromptLabel(input: UnsetPromptLabelInput!): PromptLabelMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
-  createSpanComment(annotationInput: CreateSpanCommentInput!): SpanAnnotationMutationPayload!
+  createSpanNote(annotationInput: CreateSpanNoteInput!): SpanAnnotationMutationPayload!
   patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
   createTraceAnnotations(input: [CreateTraceAnnotationInput!]!): TraceAnnotationMutationPayload!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -426,6 +426,11 @@ input CreateSpanAnnotationInput {
   source: AnnotationSource!
 }
 
+input CreateSpanCommentInput {
+  spanId: GlobalID!
+  comment: String!
+}
+
 type CreateSystemApiKeyMutationPayload {
   jwt: String!
   apiKey: SystemApiKey!
@@ -1429,6 +1434,7 @@ type Mutation {
   setPromptLabel(input: SetPromptLabelInput!): PromptLabelMutationPayload!
   unsetPromptLabel(input: UnsetPromptLabelInput!): PromptLabelMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
+  createSpanComment(annotationInput: CreateSpanCommentInput!): SpanAnnotationMutationPayload!
   patchSpanAnnotations(input: [PatchAnnotationInput!]!): SpanAnnotationMutationPayload!
   deleteSpanAnnotations(input: DeleteAnnotationsInput!): SpanAnnotationMutationPayload!
   createTraceAnnotations(input: [CreateTraceAnnotationInput!]!): TraceAnnotationMutationPayload!

--- a/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
@@ -22,6 +22,6 @@ class CreateSpanAnnotationInput:
 
 
 @strawberry.input
-class CreateSpanCommentInput:
+class CreateSpanNoteInput:
     span_id: GlobalID
-    comment: str
+    note: str

--- a/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
+++ b/src/phoenix/server/api/input_types/CreateSpanAnnotationInput.py
@@ -19,3 +19,9 @@ class CreateSpanAnnotationInput:
     metadata: JSON = strawberry.field(default_factory=dict)
     identifier: Optional[str] = None
     source: AnnotationSource
+
+
+@strawberry.input
+class CreateSpanCommentInput:
+    span_id: GlobalID
+    comment: str

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 import strawberry
@@ -9,11 +10,15 @@ from phoenix.db import models
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound, Unauthorized
-from phoenix.server.api.input_types.CreateSpanAnnotationInput import CreateSpanAnnotationInput
+from phoenix.server.api.input_types.CreateSpanAnnotationInput import (
+    CreateSpanAnnotationInput,
+    CreateSpanCommentInput,
+)
 from phoenix.server.api.input_types.DeleteAnnotationsInput import DeleteAnnotationsInput
 from phoenix.server.api.input_types.PatchAnnotationInput import PatchAnnotationInput
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.AnnotationSource import AnnotationSource
+from phoenix.server.api.types.AnnotatorKind import AnnotatorKind
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.SpanAnnotation import SpanAnnotation, to_gql_span_annotation
 from phoenix.server.bearer_auth import PhoenixUser
@@ -121,6 +126,49 @@ class SpanAnnotationMutationMixin:
             await session.commit()
         return SpanAnnotationMutationPayload(
             span_annotations=returned_annotations,
+            query=Query(),
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsLocked])  # type: ignore
+    async def create_span_comment(
+        self, info: Info[Context, None], annotation_input: CreateSpanCommentInput
+    ) -> SpanAnnotationMutationPayload:
+        assert isinstance(request := info.context.request, Request)
+        user_id: Optional[int] = None
+        if "user" in request.scope and isinstance((user := info.context.user), PhoenixUser):
+            user_id = int(user.identity)
+
+        try:
+            span_rowid = from_global_id_with_expected_type(input.span_id, "Span")
+        except ValueError:
+            raise BadRequest(f"Invalid span ID: {input.span_id}")
+
+        async with info.context.db() as session:
+            timestamp = datetime.now().isoformat()
+            comment_identifier = f"px-span-comment:{timestamp}"
+            values = {
+                "span_rowid": span_rowid,
+                "name": "px-span-comment",
+                "label": None,
+                "score": None,
+                "explanation": annotation_input.comment,
+                "annotator_kind": AnnotatorKind.HUMAN.value,
+                "metadata_": dict(),
+                "identifier": comment_identifier,
+                "source": AnnotationSource.APP.value,
+                "user_id": user_id,
+            }
+
+            stmt = insert(models.SpanAnnotation).values(**values)
+            stmt = stmt.returning(models.SpanAnnotation)
+            result = await session.scalars(stmt)
+            processed_annotation = result.one()
+
+            info.context.event_queue.put(SpanAnnotationInsertEvent(processed_annotation.id))
+            returned_annotation = to_gql_span_annotation(processed_annotation)
+            await session.commit()
+        return SpanAnnotationMutationPayload(
+            span_annotations=[returned_annotation],
             query=Query(),
         )
 

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -12,7 +12,7 @@ from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound, Unauthorized
 from phoenix.server.api.input_types.CreateSpanAnnotationInput import (
     CreateSpanAnnotationInput,
-    CreateSpanCommentInput,
+    CreateSpanNoteInput,
 )
 from phoenix.server.api.input_types.DeleteAnnotationsInput import DeleteAnnotationsInput
 from phoenix.server.api.input_types.PatchAnnotationInput import PatchAnnotationInput
@@ -130,8 +130,8 @@ class SpanAnnotationMutationMixin:
         )
 
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsLocked])  # type: ignore
-    async def create_span_comment(
-        self, info: Info[Context, None], annotation_input: CreateSpanCommentInput
+    async def create_span_note(
+        self, info: Info[Context, None], annotation_input: CreateSpanNoteInput
     ) -> SpanAnnotationMutationPayload:
         assert isinstance(request := info.context.request, Request)
         user_id: Optional[int] = None
@@ -145,16 +145,16 @@ class SpanAnnotationMutationMixin:
 
         async with info.context.db() as session:
             timestamp = datetime.now().isoformat()
-            comment_identifier = f"px-span-comment:{timestamp}"
+            note_identifier = f"px-span-note:{timestamp}"
             values = {
                 "span_rowid": span_rowid,
-                "name": "px-span-comment",
+                "name": "note",
                 "label": None,
                 "score": None,
-                "explanation": annotation_input.comment,
+                "explanation": annotation_input.note,
                 "annotator_kind": AnnotatorKind.HUMAN.value,
                 "metadata_": dict(),
-                "identifier": comment_identifier,
+                "identifier": note_identifier,
                 "source": AnnotationSource.APP.value,
                 "user_id": user_id,
             }

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -139,9 +139,9 @@ class SpanAnnotationMutationMixin:
             user_id = int(user.identity)
 
         try:
-            span_rowid = from_global_id_with_expected_type(input.span_id, "Span")
+            span_rowid = from_global_id_with_expected_type(annotation_input.span_id, "Span")
         except ValueError:
-            raise BadRequest(f"Invalid span ID: {input.span_id}")
+            raise BadRequest(f"Invalid span ID: {annotation_input.span_id}")
 
         async with info.context.db() as session:
             timestamp = datetime.now().isoformat()

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -164,7 +164,7 @@ class SpanAnnotationMutationMixin:
             result = await session.scalars(stmt)
             processed_annotation = result.one()
 
-            info.context.event_queue.put(SpanAnnotationInsertEvent(processed_annotation.id))
+            info.context.event_queue.put(SpanAnnotationInsertEvent((processed_annotation.id,)))
             returned_annotation = to_gql_span_annotation(processed_annotation)
             await session.commit()
         return SpanAnnotationMutationPayload(


### PR DESCRIPTION
Adds a mutation for creating span comments (with unique identifier) that only requires the span id and comment as an input payload

resolves #7261