### PR TITLE
fix: db migrate from JSONB to JSON

### DIFF
--- a/src/phoenix/db/migrations/versions/8a3764fe7f1a_change_jsonb_to_json_for_prompts.py
+++ b/src/phoenix/db/migrations/versions/8a3764fe7f1a_change_jsonb_to_json_for_prompts.py
@@ -1,7 +1,7 @@
 """change jsonb to json for prompts
 
 Revision ID: 8a3764fe7f1a
-Revises: 8c9ff7c78bce
+Revises: bb8139330879
 Create Date: 2025-04-25 07:04:26.102957
 
 """
@@ -15,7 +15,7 @@ from sqlalchemy.ext.compiler import compiles
 
 # revision identifiers, used by Alembic.
 revision: str = "8a3764fe7f1a"
-down_revision: Union[str, None] = "8c9ff7c78bce"
+down_revision: Union[str, None] = "bb8139330879"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/8a3764fe7f1a_change_jsonb_to_json_for_prompts.py
+++ b/src/phoenix/db/migrations/versions/8a3764fe7f1a_change_jsonb_to_json_for_prompts.py
@@ -1,0 +1,76 @@
+"""change jsonb to json for prompts
+
+Revision ID: 8a3764fe7f1a
+Revises: 8c9ff7c78bce
+Create Date: 2025-04-25 07:04:26.102957
+
+"""
+
+from typing import Any, Sequence, Union
+
+from alembic import op
+from sqlalchemy import JSON
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.compiler import compiles
+
+# revision identifiers, used by Alembic.
+revision: str = "8a3764fe7f1a"
+down_revision: Union[str, None] = "8c9ff7c78bce"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+class JSONB(JSON):
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    __visit_name__ = "JSONB"
+
+
+@compiles(JSONB, "sqlite")
+def _(*args: Any, **kwargs: Any) -> str:
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    return "JSONB"
+
+
+JSON_ = (
+    JSON()
+    .with_variant(
+        postgresql.JSONB(),
+        "postgresql",
+    )
+    .with_variant(
+        JSONB(),
+        "sqlite",
+    )
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("prompt_versions") as batch_op:
+        batch_op.alter_column(
+            "tools",
+            type_=JSON,
+            existing_type=JSON_,
+            postgresql_using="tools::json",
+        )
+        batch_op.alter_column(
+            "response_format",
+            type_=JSON,
+            existing_type=JSON_,
+            postgresql_using="response_format::json",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("prompt_versions") as batch_op:
+        batch_op.alter_column(
+            "tools",
+            type_=JSON_,
+            existing_type=JSON,
+            postgresql_using="tools::jsonb",
+        )
+        batch_op.alter_column(
+            "response_format",
+            type_=JSON_,
+            existing_type=JSON,
+            postgresql_using="response_format::jsonb",
+        )

--- a/src/phoenix/db/migrations/versions/bb8139330879_create_project_trace_retention_policies_table.py
+++ b/src/phoenix/db/migrations/versions/bb8139330879_create_project_trace_retention_policies_table.py
@@ -1,7 +1,7 @@
 """create project trace retention policies table
 
 Revision ID: bb8139330879
-Revises: 8c9ff7c78bce
+Revises: 8a3764fe7f1a
 Create Date: 2025-02-27 15:57:18.752472
 
 """
@@ -41,7 +41,7 @@ JSON_ = (
 
 # revision identifiers, used by Alembic.
 revision: str = "bb8139330879"
-down_revision: Union[str, None] = "8c9ff7c78bce"
+down_revision: Union[str, None] = "8a3764fe7f1a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/bb8139330879_create_project_trace_retention_policies_table.py
+++ b/src/phoenix/db/migrations/versions/bb8139330879_create_project_trace_retention_policies_table.py
@@ -1,7 +1,7 @@
 """create project trace retention policies table
 
 Revision ID: bb8139330879
-Revises: 8a3764fe7f1a
+Revises: 8c9ff7c78bce
 Create Date: 2025-02-27 15:57:18.752472
 
 """
@@ -41,7 +41,7 @@ JSON_ = (
 
 # revision identifiers, used by Alembic.
 revision: str = "bb8139330879"
-down_revision: Union[str, None] = "8a3764fe7f1a"
+down_revision: Union[str, None] = "8c9ff7c78bce"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -274,7 +274,7 @@ class _PromptTemplate(TypeDecorator[PromptTemplate]):
 class _Tools(TypeDecorator[PromptTools]):
     # See # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
     cache_ok = True
-    impl = JSON_
+    impl = JSON
 
     def process_bind_param(
         self, value: Optional[PromptTools], _: Dialect
@@ -290,7 +290,7 @@ class _Tools(TypeDecorator[PromptTools]):
 class _PromptResponseFormat(TypeDecorator[PromptResponseFormat]):
     # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
     cache_ok = True
-    impl = JSON_
+    impl = JSON
 
     def process_bind_param(
         self, value: Optional[PromptResponseFormat], _: Dialect

--- a/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
+++ b/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
@@ -1,0 +1,238 @@
+import json
+import re
+from typing import Literal
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Engine, text
+
+from . import _down, _up, _version_num
+
+
+def test_change_jsonb_to_json_for_prompts(
+    _engine: Engine,
+    _alembic_config: Config,
+    _db_backend: Literal["sqlite", "postgresql"],
+) -> None:
+    """
+    Test the migration that changes the column type from JSONB to JSON for the
+    'tools' and 'response_format' columns in the 'prompt_versions' table.
+
+    This test verifies:
+    1. The initial state with JSONB columns
+    2. The migration to JSON columns
+    3. The downgrade back to JSONB columns
+
+    It also ensures data integrity throughout the migration process.
+    """
+    # Verify we're starting from a clean state
+    with pytest.raises(BaseException, match="alembic_version"):
+        _version_num(_engine)
+
+    # Run the migration that creates the prompt_versions table
+    _up(_engine, _alembic_config, "bc8fea3c2bc8")
+
+    # Sample data for testing - intentionally using keys in non-alphabetical order
+    # to demonstrate the difference between JSONB and JSON in PostgreSQL
+    tools_data = {"ZZZ": 3, "Z": 1, "ZZ": 2}
+    response_format_data = {"ZZZ": 3, "Z": 1, "ZZ": 2}
+
+    # Insert test data with JSONB columns
+    with _engine.connect() as conn:
+        # Create a prompt to reference
+        prompt_id = conn.execute(
+            text(
+                """
+                INSERT INTO prompts (name, description, metadata)
+                VALUES ('test_prompt', 'Test prompt for migration', '{}')
+                RETURNING id
+                """
+            )
+        ).scalar()
+
+        # Insert prompt version with JSONB data
+        prompt_version_id = conn.execute(
+            text(
+                """
+                INSERT INTO prompt_versions (
+                    prompt_id, description, template_type, template_format,
+                    template, invocation_parameters, tools, response_format,
+                    model_provider, model_name, metadata
+                )
+                VALUES (
+                    :prompt_id, 'Test prompt version', 'CHAT', 'F_STRING',
+                    '{}', '{}', :tools, :response_format,
+                    'OPENAI', 'gpt-4', '{}'
+                )
+                RETURNING id
+                """  # noqa: E501
+            ),
+            {
+                "prompt_id": prompt_id,
+                "tools": json.dumps(tools_data),
+                "response_format": json.dumps(response_format_data),
+            },
+        ).scalar()
+        conn.commit()  # Commit to ensure data is visible to subsequent connections
+
+    # STEP 1: Verify initial state with JSONB columns
+    with _engine.connect() as conn:
+        # Check column types based on database backend
+        if _db_backend == "postgresql":
+            # PostgreSQL: Use pg_typeof to check column types
+            column_types = conn.execute(
+                text(
+                    """
+                    SELECT pg_typeof(tools)::text, pg_typeof(response_format)::text
+                    FROM prompt_versions
+                    WHERE id = :id
+                    """
+                ),
+                {"id": prompt_version_id},
+            ).first()
+            assert column_types is not None
+            assert column_types[0] == "jsonb"
+            assert column_types[1] == "jsonb"
+        else:
+            # SQLite: Check table definition from sqlite_master
+            table_def = conn.execute(
+                text(
+                    """
+                    SELECT sql FROM sqlite_master
+                    WHERE type='table' AND name='prompt_versions';
+                    """
+                )
+            ).scalar()
+            assert table_def is not None
+            # Verify columns are defined as JSONB
+            assert re.search(r"\btools\s+JSONB\b", table_def) is not None
+            assert re.search(r"\bresponse_format\s+JSONB\b", table_def) is not None
+
+        # Verify data was inserted correctly
+        if _db_backend == "sqlite":
+            # SQLite: JSON is stored as a string exactly as inserted
+            result = conn.execute(
+                text("SELECT tools, response_format FROM prompt_versions WHERE id = :id"),
+                {"id": prompt_version_id},
+            ).first()
+            assert result is not None
+            assert result[0] == json.dumps(tools_data)
+            assert result[1] == json.dumps(response_format_data)
+        else:
+            # PostgreSQL: JSONB doesn't preserve key order
+            result = conn.execute(
+                text(
+                    """
+                    SELECT tools::text, response_format::text
+                    FROM prompt_versions WHERE id = :id
+                    """
+                ),
+                {"id": prompt_version_id},
+            ).first()
+            assert result is not None
+            # Data is semantically equivalent when parsed
+            assert json.loads(result[0]) == tools_data
+            assert json.loads(result[1]) == response_format_data
+            # But serialized string differs due to key reordering in JSONB
+            # JSONB stores data in a binary format and reorders keys alphabetically
+            assert result[0] != json.dumps(tools_data)
+            assert result[1] != json.dumps(response_format_data)
+
+    # STEP 2: Run the migration to change JSONB to JSON
+    _up(_engine, _alembic_config, "8a3764fe7f1a")
+
+    # Verify the migration worked correctly
+    with _engine.connect() as conn:
+        # Check data is still accessible
+        result = conn.execute(
+            text("SELECT tools, response_format FROM prompt_versions WHERE id = :id"),
+            {"id": prompt_version_id},
+        ).first()
+
+        assert result is not None
+        if _db_backend == "sqlite":
+            assert result[0] == json.dumps(tools_data)
+            assert result[1] == json.dumps(response_format_data)
+        else:
+            assert result[0] == tools_data
+            assert result[1] == response_format_data
+
+        # Check column types after migration
+        if _db_backend == "postgresql":
+            # PostgreSQL: Verify columns are now JSON
+            column_types = conn.execute(
+                text(
+                    """
+                    SELECT pg_typeof(tools)::text, pg_typeof(response_format)::text
+                    FROM prompt_versions
+                    WHERE id = :id
+                    """
+                ),
+                {"id": prompt_version_id},
+            ).first()
+            assert column_types is not None
+            assert column_types[0] == "json"
+            assert column_types[1] == "json"
+        else:
+            # SQLite: Verify columns are now JSON
+            table_def = conn.execute(
+                text(
+                    """
+                    SELECT sql FROM sqlite_master
+                    WHERE type='table' AND name='prompt_versions';
+                    """
+                )
+            ).scalar()
+            assert table_def is not None
+            # Verify columns are defined as JSON and not JSONB
+            assert re.search(r"\btools\s+JSON\b", table_def) is not None
+            assert re.search(r"\bresponse_format\s+JSON\b", table_def) is not None
+
+    # STEP 3: Test downgrade back to JSONB
+    _down(_engine, _alembic_config, "bc8fea3c2bc8")
+
+    # Verify the downgrade worked correctly
+    with _engine.connect() as conn:
+        # Check data is still accessible
+        result = conn.execute(
+            text("SELECT tools, response_format FROM prompt_versions WHERE id = :id"),
+            {"id": prompt_version_id},
+        ).first()
+
+        assert result is not None
+        if _db_backend == "sqlite":
+            assert result[0] == json.dumps(tools_data)
+            assert result[1] == json.dumps(response_format_data)
+        else:
+            assert result[0] == tools_data
+            assert result[1] == response_format_data
+
+        # Check column types after downgrade
+        if _db_backend == "postgresql":
+            # PostgreSQL: Verify columns are back to JSONB
+            column_types = conn.execute(
+                text(
+                    """
+                    SELECT pg_typeof(tools)::text, pg_typeof(response_format)::text
+                    FROM prompt_versions
+                    WHERE id = :id
+                    """
+                ),
+                {"id": prompt_version_id},
+            ).first()
+            assert column_types is not None
+            assert column_types[0] == "jsonb"
+            assert column_types[1] == "jsonb"
+        else:
+            # SQLite: Verify columns are back to JSONB
+            table_def = conn.execute(
+                text(
+                    """
+                    SELECT sql FROM sqlite_master
+                    WHERE type='table' AND name='prompt_versions';
+                    """
+                )
+            ).scalar()
+            assert table_def is not None
+            assert re.search(r"\btools\s+JSONB\b", table_def) is not None
+            assert re.search(r"\bresponse_format\s+JSONB\b", table_def) is not None

--- a/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
+++ b/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
@@ -32,7 +32,7 @@ def test_change_jsonb_to_json_for_prompts(
     # Run the migration that creates the prompt_versions table
     _up(_engine, _alembic_config, "bc8fea3c2bc8")
 
-    # Sample data for testing - intentionally using keys in non-alphabetical order
+    # Sample data for testing - intentionally using keys in arbitrary order
     # to demonstrate the difference between JSONB and JSON in PostgreSQL
     tools_data = {"ZZZ": 3, "Z": 1, "ZZ": 2}
     response_format_data = {"ZZZ": 3, "Z": 1, "ZZ": 2}

--- a/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
+++ b/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
@@ -43,8 +43,8 @@ def test_change_jsonb_to_json_for_prompts(
         prompt_id = conn.execute(
             text(
                 """
-                INSERT INTO prompts (name, description, metadata)
-                VALUES ('test_prompt', 'Test prompt for migration', '{}')
+                INSERT INTO prompts (name, metadata)
+                VALUES ('test_prompt', '{}')
                 RETURNING id
                 """
             )
@@ -55,12 +55,12 @@ def test_change_jsonb_to_json_for_prompts(
             text(
                 """
                 INSERT INTO prompt_versions (
-                    prompt_id, description, template_type, template_format,
+                    prompt_id, template_type, template_format,
                     template, invocation_parameters, tools, response_format,
                     model_provider, model_name, metadata
                 )
                 VALUES (
-                    :prompt_id, 'Test prompt version', 'CHAT', 'F_STRING',
+                    :prompt_id, 'CHAT', 'F_STRING',
                     '{}', '{}', :tools, :response_format,
                     'OPENAI', 'gpt-4', '{}'
                 )

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -305,6 +305,11 @@ def test_up_and_down_migrations(
     _up(_engine, _alembic_config, "8c9ff7c78bce")
 
     for _ in range(2):
-        _up(_engine, _alembic_config, "bb8139330879")
+        _up(_engine, _alembic_config, "8a3764fe7f1a")
         _down(_engine, _alembic_config, "8c9ff7c78bce")
+    _up(_engine, _alembic_config, "8a3764fe7f1a")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "bb8139330879")
+        _down(_engine, _alembic_config, "8a3764fe7f1a")
     _up(_engine, _alembic_config, "bb8139330879")

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -305,11 +305,11 @@ def test_up_and_down_migrations(
     _up(_engine, _alembic_config, "8c9ff7c78bce")
 
     for _ in range(2):
-        _up(_engine, _alembic_config, "8a3764fe7f1a")
+        _up(_engine, _alembic_config, "bb8139330879")
         _down(_engine, _alembic_config, "8c9ff7c78bce")
-    _up(_engine, _alembic_config, "8a3764fe7f1a")
+    _up(_engine, _alembic_config, "bb8139330879")
 
     for _ in range(2):
-        _up(_engine, _alembic_config, "bb8139330879")
-        _down(_engine, _alembic_config, "8a3764fe7f1a")
-    _up(_engine, _alembic_config, "bb8139330879")
+        _up(_engine, _alembic_config, "8a3764fe7f1a")
+        _down(_engine, _alembic_config, "bb8139330879")
+    _up(_engine, _alembic_config, "8a3764fe7f1a")


### PR DESCRIPTION
resolves #7254 

# Change JSONB to JSON for Prompts

This PR changes the column type from JSONB to JSON for the `tools` and `response_format` columns in the `prompt_versions` table. This change addresses a core issue where JSONB was automatically reordering object keys alphabetically, which could cause problems when key order needs to be preserved.

The change:
- Adds a new migration to convert JSONB columns to JSON type
- Updates SQLAlchemy model definitions to use JSON instead of JSONB
- Includes comprehensive tests to verify the migration works correctly in both PostgreSQL and SQLite
- Maintains data integrity during both upgrade and downgrade operations

The switch to JSON type ensures that object key ordering is preserved exactly as specified, while maintaining full functionality across different database backends.