### PR TITLE
feat: gracefully handle ctrl-c

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -423,7 +423,7 @@ def main() -> None:
     try:
         server.run()
     except KeyboardInterrupt:
-        pass # don't bother the user with a stack trace on Ctrl-C
+        pass  # don't bother the user with a stack trace on Ctrl-C
 
 
 def initialize_settings() -> None:

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -420,8 +420,10 @@ def main() -> None:
     server = Server(config=Config(app, host=host, port=port, root_path=host_root_path))  # type: ignore
     Thread(target=_write_pid_file_when_ready, args=(server,), daemon=True).start()
 
-    # Start the server
-    server.run()
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        pass # don't bother the user with a stack trace on Ctrl-C
 
 
 def initialize_settings() -> None:


### PR DESCRIPTION
Right now, if you run phoenix in a terminal and stop it (via ctrl-c) you get a scary message and non-zero exit status (130) like this:

```
Traceback (most recent call last):
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/phoenix/env/phoenix/server/main.py", line 436, in <module>
    main()
  File "/phoenix/env/phoenix/server/main.py", line 424, in main
    server.run()
  File "/phoenix/env/uvicorn/server.py", line 66, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 123, in run
    raise KeyboardInterrupt()
KeyboardInterrupt
```

This swallows a `KeyboardInterrupt` so that the server output doesn't look like a failure occurred.

The "jury is out" on the right exit code, many just returning 0 not for a documented reason. I chose default 0 because the user is unlikely to want the server to run forever. OTOH, if we want to exit with 130 I can change it.