### PR TITLE
fix: Improve browser compatibility for Table sizing features

### DIFF
--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -3,6 +3,9 @@ import { Column } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
 export const tableCSS = css`
+  // fixes table row sizing issues with full height cell children
+  // this enables features like hovering anywhere on a cell to display controls
+  height: fit-content;
   font-size: var(--ac-global-font-size-s);
   width: 100%;
   border-collapse: separate;
@@ -62,6 +65,8 @@ export const tableCSS = css`
   }
   tbody:not(.is-empty) {
     tr {
+      // when paired with table.height:fit-content, allows table cells and their children to fill entire row height
+      height: 100%;
       &:not(:last-of-type) {
         & > td {
           border-bottom: 1px solid var(--ac-global-border-color-default);

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -546,7 +546,6 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
-                  height: 1,
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                   padding: 0,
                 }}

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -35,7 +35,15 @@ import { css } from "@emotion/react";
 
 import { DialogContainer, Tooltip, TooltipTrigger } from "@arizeai/components";
 
-import { Button, Flex, Icon, Icons, Loading, Text } from "@phoenix/components";
+import {
+  Button,
+  Flex,
+  Icon,
+  Icons,
+  Loading,
+  Text,
+  View,
+} from "@phoenix/components";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
 import { JSONText } from "@phoenix/components/code/JSONText";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
@@ -145,7 +153,6 @@ const cellWithControlsWrapCSS = css`
   justify-content: center;
   height: 100%;
   min-height: 75px;
-  padding: var(--ac-global-dimension-static-size-200);
   .controls {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;
@@ -312,20 +319,22 @@ function ExampleOutputContent({
 
   return (
     <CellWithControlsWrap controls={spanControls}>
-      <Flex direction={"column"} gap="size-200">
-        {errorMessage != null ? (
-          <PlaygroundErrorWrap>{errorMessage}</PlaygroundErrorWrap>
-        ) : null}
-        <Text>{content}</Text>
-        {toolCalls != null
-          ? Object.values(toolCalls).map((toolCall) =>
-              toolCall == null ? null : (
-                <PlaygroundToolCall key={toolCall.id} toolCall={toolCall} />
+      <View padding="size-200">
+        <Flex direction={"column"} gap="size-200">
+          {errorMessage != null ? (
+            <PlaygroundErrorWrap>{errorMessage}</PlaygroundErrorWrap>
+          ) : null}
+          <Text>{content}</Text>
+          {toolCalls != null
+            ? Object.values(toolCalls).map((toolCall) =>
+                toolCall == null ? null : (
+                  <PlaygroundToolCall key={toolCall.id} toolCall={toolCall} />
+                )
               )
-            )
-          : null}
-        {hasSpan ? <SpanMetadata span={span} /> : null}
-      </Flex>
+            : null}
+          {hasSpan ? <SpanMetadata span={span} /> : null}
+        </Flex>
+      </View>
     </CellWithControlsWrap>
   );
 }
@@ -384,10 +393,7 @@ function TableBody<T>({ table }: { table: Table<T> }) {
               <td
                 key={cell.id}
                 style={{
-                  // the cell still grows to fit, we just need some height declared
-                  // so that height: 100% works in children elements
                   padding: 0,
-                  height: 1,
                   width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                   // allow long text with no symbols or spaces to wrap
                   // otherwise, it will prevent the cell from shrinking

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -66,9 +66,6 @@ const TableBody = <T extends { id: string }>({
                 <td
                   key={cell.id}
                   style={{
-                    // the cell still grows to fit, we just need some height declared
-                    // so that height: 100% works in children elements
-                    height: 1,
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     // prevent all wrapping, just show an ellipsis and let users expand if necessary

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -116,9 +116,6 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                 <td
                   key={cell.id}
                   style={{
-                    // the cell still grows to fit, we just need some height declared
-                    // so that height: 100% works in children elements
-                    height: 1,
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     // prevent all wrapping, just show an ellipsis and let users expand if necessary

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -120,9 +120,6 @@ const TableBody = <
                 <td
                   key={cell.id}
                   style={{
-                    // the cell still grows to fit, we just need some height declared
-                    // so that height: 100% works in children elements
-                    height: 1,
                     width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${cell.column.id}-size) * 1px)`,
                     // prevent all wrapping, just show an ellipsis and let users expand if necessary


### PR DESCRIPTION
## Before

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/36a2d975-2c2c-4a7e-8f58-4906abbeb563" />


## After

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/0bc6ceba-f560-4506-b8c8-5f16ef1d63ab" />


I did a spot check on all tables that had the previous `height: 1` implementation, and they still look good on all 3 browsers.

Resolves #7306