### PR TITLE
fix: simplify homeLoaderQuery

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1016,9 +1016,6 @@ type FunctionCallChunk implements ChatCompletionSubscriptionPayload {
 type Functionality {
   """Model inferences are available for analysis"""
   modelInferences: Boolean!
-
-  """Generative tracing records are available for analysis"""
-  tracing: Boolean!
 }
 
 type GenerativeModel {

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -427,11 +427,8 @@ class Query:
     @strawberry.field
     async def functionality(self, info: Info[Context, None]) -> "Functionality":
         has_model_inferences = not info.context.model.is_empty
-        async with info.context.db() as session:
-            has_traces = (await session.scalar(select(models.Trace).limit(1))) is not None
         return Functionality(
             model_inferences=has_model_inferences,
-            tracing=has_traces,
         )
 
     @strawberry.field

--- a/src/phoenix/server/api/types/Functionality.py
+++ b/src/phoenix/server/api/types/Functionality.py
@@ -10,6 +10,3 @@ class Functionality:
     model_inferences: bool = strawberry.field(
         description="Model inferences are available for analysis"
     )
-    tracing: bool = strawberry.field(
-        description="Generative tracing records are available for analysis"
-    )


### PR DESCRIPTION
This query seems to be causing occasional issues when the home page is left idle. Not sure of the root cause, but either way, the part that actually hits the DB is legacy and no longer in use.

resolves #7337