### PR TITLE
feat(api): add RBAC primitives for fastAPI / REST

### DIFF
--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -2,7 +2,9 @@
 Authorization dependencies for FastAPI routes.
 
 Usage:
-    Use the provided dependencies (e.g., require_admin) with FastAPI's Depends to restrict access to certain routes.
+    Use the provided dependencies (e.g., require_admin) with FastAPI's Depends to restrict access to
+    certain routes.
+
     These dependencies will raise HTTP 403 if the user is not authorized.
 
     Example:
@@ -17,7 +19,7 @@ Usage:
             ...
 
     The require_admin dependency allows only admin or system users to access the route.
-    It expects authentication to be enabled and the request.user to be set by the authentication backend.
+    It expects authentication to be enabled and the request.user to be set by the authentication.
 """
 
 from fastapi import HTTPException, Request
@@ -40,7 +42,7 @@ def require_admin(request: Request) -> None:
     Behavior:
         - Allows access if the authenticated user is an admin or a system user.
         - Raises HTTP 403 Forbidden if the user is not authorized.
-        - Expects authentication to be enabled and request.user to be set by the authentication backend.
+        - Expects authentication to be enabled and request.user to be set by the authentication.
     """
     user = getattr(request, "user", None)
     # System users have all privileges

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -46,7 +46,7 @@ def require_admin(request: Request) -> None:
     """
     user = getattr(request, "user", None)
     # System users have all privileges
-    if not (getattr(user, "is_admin", False) or isinstance(user, PhoenixSystemUser)):
+    if not (isinstance(user, PhoenixUser) and user.is_admin):
         raise HTTPException(
             status_code=fastapi_status.HTTP_403_FORBIDDEN,
             detail="Only admin or system users can perform this action.",

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -25,7 +25,7 @@ Usage:
 from fastapi import HTTPException, Request
 from fastapi import status as fastapi_status
 
-from phoenix.server.bearer_auth import PhoenixSystemUser
+from phoenix.server.bearer_auth import PhoenixUser
 
 
 def require_admin(request: Request) -> None:

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -1,0 +1,51 @@
+"""
+Authorization dependencies for FastAPI routes.
+
+Usage:
+    Use the provided dependencies (e.g., require_admin) with FastAPI's Depends to restrict access to certain routes.
+    These dependencies will raise HTTP 403 if the user is not authorized.
+
+    Example:
+
+        from fastapi import APIRouter, Depends
+        from phoenix.server.authorization import require_admin
+
+        router = APIRouter()
+
+        @router.post("/dangerous-thing", dependencies=[Depends(require_admin)])
+        async def dangerous_thing(...):
+            ...
+
+    The require_admin dependency allows only admin or system users to access the route.
+    It expects authentication to be enabled and the request.user to be set by the authentication backend.
+"""
+
+from fastapi import HTTPException, Request
+from fastapi import status as fastapi_status
+
+from phoenix.server.bearer_auth import PhoenixSystemUser
+
+
+def require_admin(request: Request) -> None:
+    """
+    FastAPI dependency to restrict access to admin or system users only.
+
+    Usage:
+        Add as a dependency to any route that should only be accessible by admin or system users:
+
+            @router.post("/dangerous-thing", dependencies=[Depends(require_admin)])
+            async def dangerous_thing(...):
+                ...
+
+    Behavior:
+        - Allows access if the authenticated user is an admin or a system user.
+        - Raises HTTP 403 Forbidden if the user is not authorized.
+        - Expects authentication to be enabled and request.user to be set by the authentication backend.
+    """
+    user = getattr(request, "user", None)
+    # System users have all privileges
+    if not (getattr(user, "is_admin", False) or isinstance(user, PhoenixSystemUser)):
+        raise HTTPException(
+            status_code=fastapi_status.HTTP_403_FORBIDDEN,
+            detail="Only admin or system users can perform this action.",
+        )

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -16,14 +16,14 @@ class DummyNonAdminUser:
     is_admin = False
 
 
-def test_require_admin_allows_admin():
+def test_require_admin_allows_admin() -> None:
     req = mock.Mock(spec=Request)
     req.user = DummyAdminUser()
     # Should not raise
     require_admin(req)
 
 
-def test_require_admin_allows_system_user():
+def test_require_admin_allows_system_user() -> None:
     req = mock.Mock(spec=Request)
     # Cast to UserId to satisfy type checker
     user_id = UserId.__new__(UserId, 1)
@@ -32,7 +32,7 @@ def test_require_admin_allows_system_user():
     require_admin(req)
 
 
-def test_require_admin_denies_non_admin():
+def test_require_admin_denies_non_admin() -> None:
     req = mock.Mock(spec=Request)
     req.user = DummyNonAdminUser()
     with pytest.raises(HTTPException) as exc_info:
@@ -41,7 +41,7 @@ def test_require_admin_denies_non_admin():
     assert "Only admin or system users" in str(exc_info.value.detail)
 
 
-def test_require_admin_denies_no_user():
+def test_require_admin_denies_no_user() -> None:
     req = mock.Mock(spec=Request)
     req.user = None
     with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -26,7 +26,7 @@ def test_require_admin_allows_admin() -> None:
 def test_require_admin_allows_system_user() -> None:
     req = mock.Mock(spec=Request)
     # Cast to UserId to satisfy type checker
-    user_id = UserId.__new__(UserId, 1)
+    user_id = UserId(1)
     req.user = PhoenixSystemUser(user_id)  # type: ignore[arg-type]
     # Should not raise
     require_admin(req)

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -1,0 +1,48 @@
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException, Request, status
+
+from phoenix.server.authorization import PhoenixSystemUser, require_admin
+from phoenix.server.types import UserId
+
+
+class DummyAdminUser:
+    is_admin = True
+
+
+class DummyNonAdminUser:
+    is_admin = False
+
+
+def test_require_admin_allows_admin():
+    req = mock.Mock(spec=Request)
+    req.user = DummyAdminUser()
+    # Should not raise
+    require_admin(req)
+
+
+def test_require_admin_allows_system_user():
+    req = mock.Mock(spec=Request)
+    # Cast to UserId to satisfy type checker
+    user_id = UserId.__new__(UserId, 1)
+    req.user = PhoenixSystemUser(user_id)  # type: ignore[arg-type]
+    # Should not raise
+    require_admin(req)
+
+
+def test_require_admin_denies_non_admin():
+    req = mock.Mock(spec=Request)
+    req.user = DummyNonAdminUser()
+    with pytest.raises(HTTPException) as exc_info:
+        require_admin(req)
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert "Only admin or system users" in str(exc_info.value.detail)
+
+
+def test_require_admin_denies_no_user():
+    req = mock.Mock(spec=Request)
+    req.user = None
+    with pytest.raises(HTTPException) as exc_info:
+        require_admin(req)
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -3,29 +3,27 @@ from unittest import mock
 import pytest
 from fastapi import HTTPException, Request, status
 
+from phoenix.db.enums import UserRole
 from phoenix.server.authorization import require_admin
-from phoenix.server.bearer_auth import PhoenixSystemUser
-from phoenix.server.types import UserId
-
-
-class DummyAdminUser:
-    is_admin = True
-
-
-class DummyNonAdminUser:
-    is_admin = False
+from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
+from phoenix.server.types import AccessTokenId, UserClaimSet, UserId, UserTokenAttributes
 
 
 def test_require_admin_allows_admin() -> None:
     req = mock.Mock(spec=Request)
-    req.user = DummyAdminUser()
+    user_id = UserId(1)
+    claims = UserClaimSet(
+        subject=user_id,  # type: ignore
+        token_id=AccessTokenId(1),
+        attributes=UserTokenAttributes(user_role=UserRole.ADMIN),
+    )
+    req.user = PhoenixUser(user_id, claims)
     # Should not raise
     require_admin(req)
 
 
 def test_require_admin_allows_system_user() -> None:
     req = mock.Mock(spec=Request)
-    # Cast to UserId to satisfy type checker
     user_id = UserId(1)
     req.user = PhoenixSystemUser(user_id)  # type: ignore[arg-type]
     # Should not raise
@@ -34,7 +32,13 @@ def test_require_admin_allows_system_user() -> None:
 
 def test_require_admin_denies_non_admin() -> None:
     req = mock.Mock(spec=Request)
-    req.user = DummyNonAdminUser()
+    user_id = UserId(1)
+    claims = UserClaimSet(
+        subject=user_id,  # type: ignore
+        token_id=AccessTokenId(1),
+        attributes=UserTokenAttributes(user_role=UserRole.MEMBER),
+    )
+    req.user = PhoenixUser(user_id, claims)  # type: ignore
     with pytest.raises(HTTPException) as exc_info:
         require_admin(req)
     assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -34,7 +34,7 @@ def test_require_admin_denies_non_admin() -> None:
     req = mock.Mock(spec=Request)
     user_id = UserId(1)
     claims = UserClaimSet(
-        subject=user_id,  # type: ignore
+        subject=user_id,
         token_id=AccessTokenId(1),
         attributes=UserTokenAttributes(user_role=UserRole.MEMBER),
     )

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -13,7 +13,7 @@ def test_require_admin_allows_admin() -> None:
     req = mock.Mock(spec=Request)
     user_id = UserId(1)
     claims = UserClaimSet(
-        subject=user_id,  # type: ignore
+        subject=user_id,
         token_id=AccessTokenId(1),
         attributes=UserTokenAttributes(user_role=UserRole.ADMIN),
     )
@@ -25,7 +25,7 @@ def test_require_admin_allows_admin() -> None:
 def test_require_admin_allows_system_user() -> None:
     req = mock.Mock(spec=Request)
     user_id = UserId(1)
-    req.user = PhoenixSystemUser(user_id)  # type: ignore[arg-type]
+    req.user = PhoenixSystemUser(user_id)
     # Should not raise
     require_admin(req)
 
@@ -38,7 +38,7 @@ def test_require_admin_denies_non_admin() -> None:
         token_id=AccessTokenId(1),
         attributes=UserTokenAttributes(user_role=UserRole.MEMBER),
     )
-    req.user = PhoenixUser(user_id, claims)  # type: ignore
+    req.user = PhoenixUser(user_id, claims)
     with pytest.raises(HTTPException) as exc_info:
         require_admin(req)
     assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -3,7 +3,8 @@ from unittest import mock
 import pytest
 from fastapi import HTTPException, Request, status
 
-from phoenix.server.authorization import PhoenixSystemUser, require_admin
+from phoenix.server.authorization import require_admin
+from phoenix.server.bearer_auth import PhoenixSystemUser
 from phoenix.server.types import UserId
 
 


### PR DESCRIPTION
adds fastapi authorization primatives

# How to Use
To restrict any route to admin/system users, add Depends(require_admin) to the route’s dependencies.
Example:
```python
  @router.post("/dangerous-thing", dependencies=[Depends(require_admin)])
  async def dangerous_thing(...):
      ...
```

