### PR TITLE
feat(annotations): Paginate between traces on spans table or traces table

### DIFF
--- a/app/src/components/FocusHotkey.tsx
+++ b/app/src/components/FocusHotkey.tsx
@@ -1,0 +1,20 @@
+import { useFocusManager } from "react-aria";
+import { useHotkeys } from "react-hotkeys-hook";
+
+/**
+ * Place this component inside of a FocusScope, give it a hotkey, and it will
+ * focus the first element in the FocusScope when the hotkey is pressed.
+ */
+export const FocusHotkey = ({ hotkey }: { hotkey: string }) => {
+  const focus = useFocusManager();
+
+  useHotkeys(
+    hotkey,
+    () => {
+      focus?.focusFirst();
+    },
+    { preventDefault: true }
+  );
+
+  return null;
+};

--- a/app/src/components/KeyboardToken.tsx
+++ b/app/src/components/KeyboardToken.tsx
@@ -1,0 +1,27 @@
+import React, { forwardRef, Ref } from "react";
+import { css } from "@emotion/react";
+
+import { Keyboard, KeyboardProps } from "./content/Keyboard";
+
+const keyboardTokenCSS = css`
+  background-color: var(--ac-global-color-primary-100);
+  color: var(--ac-global-color-primary-700);
+  padding: var(--ac-global-dimension-static-size-50)
+    var(--ac-global-dimension-static-size-100);
+  border-radius: var(--ac-global-dimension-static-size-100);
+`;
+
+/**
+ * Keyboard Token represents text that specifies a keyboard command,
+ * and is styled to look like a keyboard key.
+ */
+export const KeyboardToken = forwardRef(function KeyboardToken(
+  { children, ...props }: KeyboardProps,
+  ref: Ref<HTMLElement>
+) {
+  return (
+    <Keyboard ref={ref} css={keyboardTokenCSS} {...props}>
+      {children}
+    </Keyboard>
+  );
+});

--- a/app/src/components/content/Keyboard.tsx
+++ b/app/src/components/content/Keyboard.tsx
@@ -1,35 +1,30 @@
 import React, { forwardRef, PropsWithChildren, Ref } from "react";
 import { css } from "@emotion/react";
 
+import { classNames } from "@arizeai/components";
+
 export interface KeyboardProps extends PropsWithChildren {
-  variant?: "default" | "primary";
+  className?: string;
 }
 
 const keyboardCSS = css`
   font-family: -apple-system, "system-ui", "Segoe UI", "Noto Sans", Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-  &[data-variant="primary"] {
-    background-color: var(--ac-global-color-primary-100);
-    color: var(--ac-global-color-primary-700);
-    padding: var(--ac-global-dimension-static-size-50)
-      var(--ac-global-dimension-static-size-100);
-    border-radius: var(--ac-global-dimension-static-size-100);
-  }
 `;
 
 /**
  * Keyboard represents text that specifies a keyboard command.
  */
 export const Keyboard = forwardRef(function Keyboard(
-  { variant = "default", children }: KeyboardProps,
+  { children, className, ...props }: KeyboardProps,
   ref: Ref<HTMLElement>
 ) {
   return (
     <kbd
       ref={ref}
       css={keyboardCSS}
-      className="ac-keyboard"
-      data-variant={variant}
+      className={classNames("ac-keyboard", className)}
+      {...props}
     >
       {children}
     </kbd>

--- a/app/src/components/content/Keyboard.tsx
+++ b/app/src/components/content/Keyboard.tsx
@@ -1,21 +1,37 @@
 import React, { forwardRef, PropsWithChildren, Ref } from "react";
 import { css } from "@emotion/react";
-export interface KeyboardProps extends PropsWithChildren {}
+
+export interface KeyboardProps extends PropsWithChildren {
+  variant?: "default" | "primary";
+}
 
 const keyboardCSS = css`
   font-family: -apple-system, "system-ui", "Segoe UI", "Noto Sans", Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  &[data-variant="primary"] {
+    background-color: var(--ac-global-color-primary-100);
+    color: var(--ac-global-color-primary-700);
+    padding: var(--ac-global-dimension-static-size-50)
+      var(--ac-global-dimension-static-size-100);
+    border-radius: var(--ac-global-dimension-static-size-100);
+  }
 `;
+
 /**
  * Keyboard represents text that specifies a keyboard command.
  */
 export const Keyboard = forwardRef(function Keyboard(
-  props: KeyboardProps,
+  { variant = "default", children }: KeyboardProps,
   ref: Ref<HTMLElement>
 ) {
   return (
-    <kbd ref={ref} css={keyboardCSS} className="ac-keyboard">
-      {props.children}
+    <kbd
+      ref={ref}
+      css={keyboardCSS}
+      className="ac-keyboard"
+      data-variant={variant}
+    >
+      {children}
     </kbd>
   );
 });

--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -26,6 +26,7 @@ export * from "./CopyToClipboardButton";
 export * from "./SectionHeading";
 export * from "./Empty";
 export * from "./exception";
+export * from "./KeyboardToken";
 
 // design system based components
 export * from "./alert";

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -79,6 +79,9 @@ export const tableCSS = css`
         padding: var(--ac-global-dimension-size-100)
           var(--ac-global-dimension-size-200);
       }
+      &[data-selected="true"] {
+        background-color: var(--ac-global-color-primary-100);
+      }
     }
   }
 `;

--- a/app/src/components/trace/SpanAnnotationsEditor.tsx
+++ b/app/src/components/trace/SpanAnnotationsEditor.tsx
@@ -28,6 +28,7 @@ import {
 } from "@phoenix/components";
 import { Annotation, AnnotationConfig } from "@phoenix/components/annotation";
 import { Empty } from "@phoenix/components/Empty";
+import { FocusHotkey } from "@phoenix/components/FocusHotkey";
 import { SpanAnnotationsEditorCreateAnnotationMutation } from "@phoenix/components/trace/__generated__/SpanAnnotationsEditorCreateAnnotationMutation.graphql";
 import { SpanAnnotationsEditorDeleteAnnotationMutation } from "@phoenix/components/trace/__generated__/SpanAnnotationsEditorDeleteAnnotationMutation.graphql";
 import { SpanAnnotationsEditorSpanAnnotationsListQuery } from "@phoenix/components/trace/__generated__/SpanAnnotationsEditorSpanAnnotationsListQuery.graphql";
@@ -43,6 +44,8 @@ import { Mutable } from "@phoenix/typeUtils";
 import { SpanAnnotationsEditor_spanAnnotations$key } from "./__generated__/SpanAnnotationsEditor_spanAnnotations.graphql";
 import { SpanAnnotationsEditorEditAnnotationMutation } from "./__generated__/SpanAnnotationsEditorEditAnnotationMutation.graphql";
 import { AnnotationFormData, SpanAnnotationInput } from "./SpanAnnotationInput";
+
+export const EDIT_ANNOTATION_HOTKEY = "e";
 
 export type SpanAnnotationsEditorProps = {
   spanNodeId: string;
@@ -470,7 +473,8 @@ function SpanAnnotationsList(props: {
         />
       )}
       {!!annotationConfigsLength && (
-        <FocusScope autoFocus>
+        <FocusScope>
+          <FocusHotkey hotkey={EDIT_ANNOTATION_HOTKEY} />
           {annotationConfigs?.map((annotationConfig, idx) => {
             const annotation = annotations.find(
               (annotation) => annotation.name === annotationConfig.config.name

--- a/app/src/constants/searchParams.ts
+++ b/app/src/constants/searchParams.ts
@@ -1,0 +1,5 @@
+/**
+ * The search param that contains the span node id of the selected span.
+ * This is used to highlight the selected span in trace details views.
+ */
+export const SELECTED_SPAN_NODE_ID_PARAM = "selectedSpanNodeId";

--- a/app/src/pages/example/ExampleDetailsDialog.tsx
+++ b/app/src/pages/example/ExampleDetailsDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@phoenix/components";
 import { JSONBlock } from "@phoenix/components/code";
 import { resizeHandleCSS } from "@phoenix/components/resize";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useNotifySuccess } from "@phoenix/contexts";
 
 import type { ExampleDetailsDialogQuery } from "./__generated__/ExampleDetailsDialogQuery.graphql";
@@ -91,7 +92,7 @@ export function ExampleDetailsDialog({
             {sourceSpanInfo ? (
               <LinkButton
                 size="S"
-                to={`/projects/${sourceSpanInfo.projectId}/traces/${sourceSpanInfo.traceId}?selectedSpanNodeId=${sourceSpanInfo.id}`}
+                to={`/projects/${sourceSpanInfo.projectId}/traces/${sourceSpanInfo.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${sourceSpanInfo.id}`}
               >
                 View Source Span
               </LinkButton>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import {
   CellContext,
   ColumnDef,
@@ -133,6 +133,7 @@ const annotationTooltipExtraCSS = css`
 export function ExperimentCompareTable(props: ExampleCompareTableProps) {
   const { datasetId, experimentIds, displayFullText } = props;
   const [filterCondition, setFilterCondition] = useState("");
+  const [, setSearchParams] = useSearchParams();
 
   const data = useLazyLoadQuery<ExperimentCompareTableQuery>(
     graphql`
@@ -525,6 +526,10 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             type="slideOver"
             onDismiss={() => {
               setDialog(null);
+              setSearchParams((searchParams) => {
+                searchParams.delete("selectedSpanNodeId");
+                return searchParams;
+              });
             }}
           >
             {dialog}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -56,6 +56,7 @@ import {
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { ExampleDetailsDialog } from "@phoenix/pages/example/ExampleDetailsDialog";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
@@ -527,7 +528,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             onDismiss={() => {
               setDialog(null);
               setSearchParams((searchParams) => {
-                searchParams.delete("selectedSpanNodeId");
+                searchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
                 return searchParams;
               });
             }}

--- a/app/src/pages/playground/Playground.tsx
+++ b/app/src/pages/playground/Playground.tsx
@@ -69,22 +69,9 @@ export function Playground(props: Partial<PlaygroundProps>) {
   const playgroundStreamingEnabled = usePreferencesContext(
     (state) => state.playgroundStreamingEnabled
   );
-  const [, setSearchParams] = useSearchParams();
   const hasInstalledProvider = modelProviders.some(
     (provider) => provider.dependenciesInstalled
   );
-
-  useEffect(() => {
-    setSearchParams(
-      (searchParams) => {
-        // remove lingering selectedSpanNodeId param so as to not poison the trace details slideover
-        // with stale data from previous pages
-        searchParams.delete("selectedSpanNodeId");
-        return searchParams;
-      },
-      { replace: true }
-    );
-  }, [setSearchParams]);
 
   if (!hasInstalledProvider) {
     return <NoInstalledProvider availableProviders={modelProviders} />;

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -50,6 +50,7 @@ import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useNotifyError } from "@phoenix/contexts";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import {
@@ -958,7 +959,7 @@ export function PlaygroundDatasetExamplesTable({
         onDismiss={() => {
           setDialog(null);
           setSearchParams((searchParams) => {
-            searchParams.delete("selectedSpanNodeId");
+            searchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
             return searchParams;
           });
         }}

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -957,6 +957,10 @@ export function PlaygroundDatasetExamplesTable({
         type="slideOver"
         onDismiss={() => {
           setDialog(null);
+          setSearchParams((searchParams) => {
+            searchParams.delete("selectedSpanNodeId");
+            return searchParams;
+          });
         }}
       >
         {dialog}

--- a/app/src/pages/playground/RunMetadataFooter.tsx
+++ b/app/src/pages/playground/RunMetadataFooter.tsx
@@ -9,6 +9,7 @@ import { Button, Flex, Icon, Icons, View } from "@phoenix/components";
 import { EditSpanAnnotationsDialog } from "@phoenix/components/trace/EditSpanAnnotationsDialog";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 
 import { RunMetadataFooterQuery } from "./__generated__/RunMetadataFooterQuery.graphql";
 import { PlaygroundRunTraceDetailsDialog } from "./PlaygroundRunTraceDialog";
@@ -108,7 +109,7 @@ export function RunMetadataFooter({ spanId }: { spanId: string }) {
         onDismiss={() => {
           setDialog(null);
           setSearchParams((searchParams) => {
-            searchParams.delete("selectedSpanNodeId");
+            searchParams.delete(SELECTED_SPAN_NODE_ID_PARAM);
             return searchParams;
           });
         }}

--- a/app/src/pages/playground/RunMetadataFooter.tsx
+++ b/app/src/pages/playground/RunMetadataFooter.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, startTransition, Suspense, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
+import { useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 
 import { DialogContainer } from "@arizeai/components";
@@ -14,6 +15,7 @@ import { PlaygroundRunTraceDetailsDialog } from "./PlaygroundRunTraceDialog";
 
 export function RunMetadataFooter({ spanId }: { spanId: string }) {
   const [dialog, setDialog] = useState<ReactNode>(null);
+  const [, setSearchParams] = useSearchParams();
   const data = useLazyLoadQuery<RunMetadataFooterQuery>(
     graphql`
       query RunMetadataFooterQuery($spanId: GlobalID!) {
@@ -103,7 +105,13 @@ export function RunMetadataFooter({ spanId }: { spanId: string }) {
       <DialogContainer
         type="slideOver"
         isDismissable
-        onDismiss={() => setDialog(null)}
+        onDismiss={() => {
+          setDialog(null);
+          setSearchParams((searchParams) => {
+            searchParams.delete("selectedSpanNodeId");
+            return searchParams;
+          });
+        }}
       >
         {dialog}
       </DialogContainer>

--- a/app/src/pages/playground/SpanPlaygroundPage.tsx
+++ b/app/src/pages/playground/SpanPlaygroundPage.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useNavigate } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Alert, Button, Flex, Icon, Icons } from "@phoenix/components";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { spanPlaygroundPageLoaderQuery$data } from "@phoenix/pages/playground/__generated__/spanPlaygroundPageLoaderQuery.graphql";
 import { Playground } from "@phoenix/pages/playground/Playground";
 import { spanPlaygroundPageLoader } from "@phoenix/pages/playground/spanPlaygroundPageLoader";
@@ -76,7 +77,7 @@ function SpanPlaygroundBanners({
               leadingVisual={<Icon svg={<Icons.ArrowBack />} />}
               onPress={() => {
                 navigate(
-                  `/projects/${span.project.id}/traces/${span.trace.traceId}?selectedSpanNodeId=${span.id}`
+                  `/projects/${span.project.id}/traces/${span.trace.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${span.id}`
                 );
               }}
             >

--- a/app/src/pages/project/ProjectSpansPage.tsx
+++ b/app/src/pages/project/ProjectSpansPage.tsx
@@ -5,6 +5,7 @@ import { Outlet } from "react-router";
 import { Loading } from "@phoenix/components";
 import { SpanFilterConditionProvider } from "@phoenix/pages/project/SpanFilterConditionContext";
 import { SpansTable } from "@phoenix/pages/project/SpansTable";
+import { TracePaginationProvider } from "@phoenix/pages/trace/TracePaginationContext";
 import { TracingRoot } from "@phoenix/pages/TracingRoot";
 
 import { ProjectPageQueriesSpansQuery as ProjectPageSpansQueryType } from "./__generated__/ProjectPageQueriesSpansQuery.graphql";
@@ -29,14 +30,16 @@ export const ProjectSpansPage = () => {
   }
   return (
     <TracingRoot>
-      <SpanFilterConditionProvider>
-        <Suspense fallback={<Loading />}>
-          <SpansTabContent queryReference={spansQueryReference} />
+      <TracePaginationProvider>
+        <SpanFilterConditionProvider>
+          <Suspense fallback={<Loading />}>
+            <SpansTabContent queryReference={spansQueryReference} />
+          </Suspense>
+        </SpanFilterConditionProvider>
+        <Suspense>
+          <Outlet />
         </Suspense>
-      </SpanFilterConditionProvider>
-      <Suspense>
-        <Outlet />
-      </Suspense>
+      </TracePaginationProvider>
     </TracingRoot>
   );
 };

--- a/app/src/pages/project/ProjectTracesPage.tsx
+++ b/app/src/pages/project/ProjectTracesPage.tsx
@@ -5,6 +5,7 @@ import { Outlet } from "react-router";
 import { Loading } from "@phoenix/components/loading/Loading";
 import { SpanFilterConditionProvider } from "@phoenix/pages/project/SpanFilterConditionContext";
 import { TracesTable } from "@phoenix/pages/project/TracesTable";
+import { TracePaginationProvider } from "@phoenix/pages/trace/TracePaginationContext";
 import { TracingRoot } from "@phoenix/pages/TracingRoot";
 
 import { ProjectPageQueriesTracesQuery as ProjectPageTracesQueryType } from "./__generated__/ProjectPageQueriesTracesQuery.graphql";
@@ -35,14 +36,16 @@ export const ProjectTracesPage = () => {
 
   return (
     <TracingRoot>
-      <SpanFilterConditionProvider>
-        <Suspense fallback={<Loading />}>
-          <TracesTabContent tracesQueryReference={tracesQueryReference} />
+      <TracePaginationProvider>
+        <SpanFilterConditionProvider>
+          <Suspense fallback={<Loading />}>
+            <TracesTabContent tracesQueryReference={tracesQueryReference} />
+          </Suspense>
+        </SpanFilterConditionProvider>
+        <Suspense>
+          <Outlet />
         </Suspense>
-      </SpanFilterConditionProvider>
-      <Suspense>
-        <Outlet />
-      </Suspense>
+      </TracePaginationProvider>
     </TracingRoot>
   );
 };

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -113,11 +113,6 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
                 `${row.original.trace.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${row.original.id}`
               )
             }
-            css={css`
-              &[data-selected="true"] {
-                background-color: var(--ac-global-color-primary-100);
-              }
-            `}
           >
             {row.getVisibleCells().map((cell) => {
               const colSizeVar = `--col-${cell.column.id}-size`;

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 import {
   ColumnDef,
   flexRender,
@@ -94,17 +94,29 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
   tableWidth: number;
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { traceId } = useParams();
+  const selectedSpanNodeId = searchParams.get("selectedSpanNodeId");
   return (
     <tbody>
       {table.getRowModel().rows.map((row) => {
+        const isSelected =
+          selectedSpanNodeId === row.original.id ||
+          (!selectedSpanNodeId && row.original.trace.traceId === traceId);
         return (
           <tr
             key={row.id}
+            data-selected={isSelected}
             onClick={() =>
               navigate(
                 `${row.original.trace.traceId}?selectedSpanNodeId=${row.original.id}`
               )
             }
+            css={css`
+              &[data-selected="true"] {
+                background-color: var(--ac-global-color-primary-100);
+              }
+            `}
           >
             {row.getVisibleCells().map((cell) => {
               const colSizeVar = `--col-${cell.column.id}-size`;

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -47,6 +47,7 @@ import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
+import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
 
 import {
   SpansTable_spans$key,
@@ -240,6 +241,23 @@ export function SpansTable(props: SpansTableProps) {
       `,
       props.project
     );
+
+  const pagination = useTracePagination();
+  const setTraceSequence = pagination?.setTraceSequence;
+  useEffect(() => {
+    if (!setTraceSequence) {
+      return;
+    }
+    setTraceSequence(
+      data.spans.edges.map(({ span }) => ({
+        traceId: span.trace.traceId,
+        spanId: span.id,
+      }))
+    );
+    return () => {
+      setTraceSequence([]);
+    };
+  }, [data.spans.edges, setTraceSequence]);
 
   const annotationColumnVisibility = useTracingContext(
     (state) => state.annotationColumnVisibility

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -43,6 +43,7 @@ import { SpanKindToken } from "@phoenix/components/trace/SpanKindToken";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { Truncate } from "@phoenix/components/utility/Truncate";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
@@ -96,7 +97,7 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { traceId } = useParams();
-  const selectedSpanNodeId = searchParams.get("selectedSpanNodeId");
+  const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
   return (
     <tbody>
       {table.getRowModel().rows.map((row) => {
@@ -109,7 +110,7 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
             data-selected={isSelected}
             onClick={() =>
               navigate(
-                `${row.original.trace.traceId}?selectedSpanNodeId=${row.original.id}`
+                `${row.original.trace.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${row.original.id}`
               )
             }
             css={css`
@@ -439,7 +440,7 @@ export function SpansTable(props: SpansTableProps) {
         const span = row.original;
         const { traceId } = span.trace;
         return (
-          <Link to={`${traceId}?selectedSpanNodeId=${span.id}`}>
+          <Link to={`${traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${span.id}`}>
             {getValue() as string}
           </Link>
         );

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -112,14 +112,7 @@ const TableBody = <
             onClick={() => navigate(`${row.original.trace.traceId}`)}
             data-is-additional-row={row.original.__additionalRow}
             data-selected={isSelected}
-            css={css(
-              trCSS,
-              `
-              &[data-selected="true"] {
-                background-color: var(--ac-global-color-primary-100);
-              }
-            `
-            )}
+            css={css(trCSS)}
           >
             {row.getVisibleCells().map((cell) => {
               const colSizeVar = `--col-${cell.column.id}-size`;

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -42,6 +42,7 @@ import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { ISpanItem } from "@phoenix/components/trace/types";
 import { createSpanTree, SpanTreeNode } from "@phoenix/components/trace/utils";
 import { Truncate } from "@phoenix/components/utility/Truncate";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
@@ -594,7 +595,7 @@ export function TracesTable(props: TracesTableProps) {
             : row.original.id;
           return (
             <Link
-              to={`${traceId}${spanId ? `?selectedSpanNodeId=${spanId}` : ""}`}
+              to={`${traceId}${spanId ? `?${SELECTED_SPAN_NODE_ID_PARAM}=${spanId}` : ""}`}
             >
               {getValue() as string}
             </Link>

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
 } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { useNavigate } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import {
   CellContext,
   ColumnDef,
@@ -100,15 +100,25 @@ const TableBody = <
   table: Table<T>;
 }) => {
   const navigate = useNavigate();
+  const { traceId } = useParams();
   return (
     <tbody>
       {table.getRowModel().rows.map((row) => {
+        const isSelected = row.original.trace.traceId === traceId;
         return (
           <tr
             key={row.id}
             onClick={() => navigate(`${row.original.trace.traceId}`)}
             data-is-additional-row={row.original.__additionalRow}
-            css={trCSS}
+            data-selected={isSelected}
+            css={css(
+              trCSS,
+              `
+              &[data-selected="true"] {
+                background-color: var(--ac-global-color-primary-100);
+              }
+            `
+            )}
           >
             {row.getVisibleCells().map((cell) => {
               const colSizeVar = `--col-${cell.column.id}-size`;

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -46,6 +46,7 @@ import { useStreamState } from "@phoenix/contexts/StreamStateContext";
 import { useTracingContext } from "@phoenix/contexts/TracingContext";
 import { SummaryValueLabels } from "@phoenix/pages/project/AnnotationSummary";
 import { MetadataTableCell } from "@phoenix/pages/project/MetadataTableCell";
+import { useTracePagination } from "@phoenix/pages/trace/TracePaginationContext";
 
 import {
   SpanStatusCode,
@@ -700,6 +701,24 @@ export function TracesTable(props: TracesTableProps) {
     },
     [hasNext, isLoadingNext, loadNext]
   );
+
+  const pagination = useTracePagination();
+  const setTraceSequence = pagination?.setTraceSequence;
+  useEffect(() => {
+    if (!setTraceSequence) {
+      return;
+    }
+    setTraceSequence(
+      data.rootSpans.edges.map(({ rootSpan }) => ({
+        traceId: rootSpan.trace.traceId,
+        spanId: rootSpan.id,
+      }))
+    );
+    return () => {
+      setTraceSequence([]);
+    };
+  }, [data.rootSpans.edges, setTraceSequence]);
+
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const columnVisibility = useTracingContext((state) => state.columnVisibility);
   const setColumnSizing = useTracingContext((state) => state.setColumnSizing);

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -11,6 +11,7 @@ import { AnnotationSummaryGroupTokens } from "@phoenix/components/annotation/Ann
 import { JSONBlock } from "@phoenix/components/code";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useChatMessageStyles } from "@phoenix/hooks/useChatMessageStyles";
 import { isStringKeyedObject } from "@phoenix/typeUtils";
 import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
@@ -111,7 +112,7 @@ function RootSpanDetails({
           <Flex direction={"row"} justifyContent={"space-between"}>
             <Text>Trace #{index + 1}</Text>
             <Link
-              to={`/projects/${rootSpan.project.id}/traces/${traceId}?selectedSpanNodeId=${rootSpan.id}`}
+              to={`/projects/${rootSpan.project.id}/traces/${traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${rootSpan.id}`}
             >
               <Flex alignItems={"center"}>
                 View Trace

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -3,15 +3,22 @@ import { graphql, useFragment } from "react-relay";
 import { PanelGroup } from "react-resizable-panels";
 import { css } from "@emotion/react";
 
-import { View } from "@phoenix/components";
+import { Flex, Keyboard, View } from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
-import { SpanAnnotationsEditor } from "@phoenix/components/trace/SpanAnnotationsEditor";
+import {
+  EDIT_ANNOTATION_HOTKEY,
+  SpanAnnotationsEditor,
+} from "@phoenix/components/trace/SpanAnnotationsEditor";
 import { SpanAsideAnnotationList_span$key } from "@phoenix/pages/trace/__generated__/SpanAsideAnnotationList_span.graphql";
 import { deduplicateAnnotationsByName } from "@phoenix/pages/trace/utils";
 
 import { SpanAside_span$key } from "./__generated__/SpanAside_span.graphql";
-import { SpanNotesEditor, SpanNotesEditorSkeleton } from "./SpanNotesEditor";
+import {
+  NOTE_HOTKEY,
+  SpanNotesEditor,
+  SpanNotesEditorSkeleton,
+} from "./SpanNotesEditor";
 
 const annotationListCSS = css`
   display: flex;
@@ -88,7 +95,12 @@ export function SpanAside(props: SpanAsideProps) {
       </Suspense>
       <TitledPanel
         resizable
-        title="Edit annotations"
+        title={
+          <Flex direction={"row"} gap="size-100" alignItems={"center"}>
+            <span>Edit annotations</span>
+            <Keyboard variant="primary">{EDIT_ANNOTATION_HOTKEY}</Keyboard>
+          </Flex>
+        }
         panelProps={{ order: 2, minSize: 10 }}
       >
         <View height="100%" maxHeight="100%">
@@ -100,7 +112,12 @@ export function SpanAside(props: SpanAsideProps) {
       </TitledPanel>
       <TitledPanel
         resizable
-        title="Notes"
+        title={
+          <Flex direction={"row"} gap="size-100" alignItems={"center"}>
+            <span>Notes</span>
+            <Keyboard variant="primary">{NOTE_HOTKEY}</Keyboard>
+          </Flex>
+        }
         panelProps={{ order: 3, minSize: 10 }}
       >
         <View height="100%" maxHeight="100%">

--- a/app/src/pages/trace/SpanAside.tsx
+++ b/app/src/pages/trace/SpanAside.tsx
@@ -3,7 +3,7 @@ import { graphql, useFragment } from "react-relay";
 import { PanelGroup } from "react-resizable-panels";
 import { css } from "@emotion/react";
 
-import { Flex, Keyboard, View } from "@phoenix/components";
+import { Flex, KeyboardToken, View } from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 import {
@@ -98,7 +98,7 @@ export function SpanAside(props: SpanAsideProps) {
         title={
           <Flex direction={"row"} gap="size-100" alignItems={"center"}>
             <span>Edit annotations</span>
-            <Keyboard variant="primary">{EDIT_ANNOTATION_HOTKEY}</Keyboard>
+            <KeyboardToken>{EDIT_ANNOTATION_HOTKEY}</KeyboardToken>
           </Flex>
         }
         panelProps={{ order: 2, minSize: 10 }}
@@ -115,7 +115,7 @@ export function SpanAside(props: SpanAsideProps) {
         title={
           <Flex direction={"row"} gap="size-100" alignItems={"center"}>
             <span>Notes</span>
-            <Keyboard variant="primary">{NOTE_HOTKEY}</Keyboard>
+            <KeyboardToken>{NOTE_HOTKEY}</KeyboardToken>
           </Flex>
         }
         panelProps={{ order: 3, minSize: 10 }}

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -61,7 +61,7 @@ import {
   Heading,
   Icon,
   Icons,
-  Keyboard,
+  KeyboardToken,
   LazyTabPanel,
   LinkButton,
   Tab,
@@ -339,9 +339,7 @@ export function SpanDetails({
                   trailingVisual={
                     !isCondensedView &&
                     !isAnnotatingSpans && (
-                      <Keyboard variant="primary">
-                        {EDIT_ANNOTATION_HOTKEY}
-                      </Keyboard>
+                      <KeyboardToken>{EDIT_ANNOTATION_HOTKEY}</KeyboardToken>
                     )
                   }
                 >

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -182,10 +182,10 @@ export function SpanDetails({
   const asidePanelRef = useRef<ImperativePanelHandle>(null);
   const spanDetailsContainerRef = useRef<HTMLDivElement>(null);
   const spanDetailsContainerDimensions = useDimensions(spanDetailsContainerRef);
-  const isCondensedView =
-    spanDetailsContainerDimensions?.width &&
-    spanDetailsContainerDimensions.width <
-      CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD;
+  const isCondensedView = spanDetailsContainerDimensions?.width
+    ? spanDetailsContainerDimensions.width <
+      CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD
+    : true;
   const { viewer } = useViewer();
   const { span } = useLazyLoadQuery<SpanDetailsQuery>(
     graphql`

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import {
   type ImperativePanelHandle,
@@ -60,6 +61,7 @@ import {
   Heading,
   Icon,
   Icons,
+  Keyboard,
   LazyTabPanel,
   LinkButton,
   Tab,
@@ -163,6 +165,7 @@ const defaultCardProps: Partial<CardProps> = {
 
 const CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD = 900;
 const ASIDE_PANEL_DEFAULT_SIZE = 33;
+const EDIT_ANNOTATION_HOTKEY = "e";
 
 export function SpanDetails({
   spanNodeId,
@@ -262,6 +265,16 @@ export function SpanDetails({
     );
   }
 
+  useHotkeys(
+    EDIT_ANNOTATION_HOTKEY,
+    () => {
+      if (!isAnnotatingSpans) {
+        setIsAnnotatingSpans(true);
+      }
+    },
+    { preventDefault: true }
+  );
+
   const hasExceptions = useMemo<boolean>(() => {
     return spanHasException(span);
   }, [span]);
@@ -323,6 +336,14 @@ export function SpanDetails({
                     }
                   }}
                   leadingVisual={<Icon svg={<Icons.EditOutline />} />}
+                  trailingVisual={
+                    !isCondensedView &&
+                    !isAnnotatingSpans && (
+                      <Keyboard variant="primary">
+                        {EDIT_ANNOTATION_HOTKEY}
+                      </Keyboard>
+                    )
+                  }
                 >
                   {isCondensedView ? null : "Annotate"}
                 </ToggleButton>

--- a/app/src/pages/trace/SpanNotesEditor.tsx
+++ b/app/src/pages/trace/SpanNotesEditor.tsx
@@ -1,4 +1,5 @@
 import React, { startTransition, useEffect, useRef, useState } from "react";
+import { FocusScope } from "react-aria";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { css } from "@emotion/react";
 
@@ -8,6 +9,7 @@ import {
   MessageBubble,
   MessageBubbleSkeleton,
 } from "@phoenix/components/chat";
+import { FocusHotkey } from "@phoenix/components/FocusHotkey";
 
 import { SpanNotesEditorAddNoteMutation } from "./__generated__/SpanNotesEditorAddNoteMutation.graphql";
 import { SpanNotesEditorQuery } from "./__generated__/SpanNotesEditorQuery.graphql";
@@ -15,6 +17,8 @@ import { SpanNotesEditorQuery } from "./__generated__/SpanNotesEditorQuery.graph
 type SpanNotesEditorProps = {
   spanNodeId: string;
 };
+
+export const NOTE_HOTKEY = "n";
 
 const notesListCSS = css`
   width: 100%;
@@ -128,11 +132,14 @@ export function SpanNotesEditor(props: SpanNotesEditorProps) {
         ))}
         <div ref={notesEndRef} aria-hidden="true" />
       </ul>
-      <MessageBar
-        onSendMessage={onAddNote}
-        placeholder="Add a note"
-        isSending={isAddingNote}
-      />
+      <FocusScope restoreFocus>
+        <FocusHotkey hotkey={NOTE_HOTKEY} />
+        <MessageBar
+          onSendMessage={onAddNote}
+          placeholder="Add a note"
+          isSending={isAddingNote}
+        />
+      </FocusScope>
     </Flex>
   );
 }

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, Suspense, useEffect, useMemo } from "react";
+import React, { PropsWithChildren, Suspense, useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useParams, useSearchParams } from "react-router";
@@ -110,20 +110,6 @@ export function TraceDetails(props: TraceDetailsProps) {
   const selectedSpanNodeId = urlSpanNodeId ?? spansList[0].id;
   const rootSpan = useMemo(() => findRootSpan(spansList), [spansList]);
 
-  // Clear the selected span param when the component unmounts
-  useEffect(() => {
-    return () => {
-      setSearchParams(
-        (searchParams) => {
-          searchParams.delete(SELECTED_SPAN_NODE_ID_URL_PARAM);
-          return searchParams;
-        },
-        { replace: true }
-      );
-    };
-    // eslint-disable-next-line react-compiler/react-compiler
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   return (
     <main
       css={css`

--- a/app/src/pages/trace/TraceDetails.tsx
+++ b/app/src/pages/trace/TraceDetails.tsx
@@ -10,6 +10,7 @@ import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanStatusCodeIcon } from "@phoenix/components/trace/SpanStatusCodeIcon";
 import { TraceTree } from "@phoenix/components/trace/TraceTree";
 import { useSpanStatusCodeColor } from "@phoenix/components/trace/useSpanStatusCodeColor";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 
 import {
   TraceDetailsQuery,
@@ -17,8 +18,6 @@ import {
 } from "./__generated__/TraceDetailsQuery.graphql";
 import { SpanDetails } from "./SpanDetails";
 import { TraceHeaderRootSpanAnnotations } from "./TraceHeaderRootSpanAnnotations";
-
-export const SELECTED_SPAN_NODE_ID_URL_PARAM = "selectedSpanNodeId";
 
 type Span = NonNullable<
   TraceDetailsQuery$data["project"]["trace"]
@@ -106,7 +105,7 @@ export function TraceDetails(props: TraceDetailsProps) {
     const gqlSpans = data.project.trace?.spans.edges || [];
     return gqlSpans.map((node) => node.span);
   }, [data]);
-  const urlSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_URL_PARAM);
+  const urlSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
   const selectedSpanNodeId = urlSpanNodeId ?? spansList[0].id;
   const rootSpan = useMemo(() => findRootSpan(spansList), [spansList]);
 
@@ -140,7 +139,7 @@ export function TraceDetails(props: TraceDetailsProps) {
               onSpanClick={(span) => {
                 setSearchParams(
                   (searchParams) => {
-                    searchParams.set(SELECTED_SPAN_NODE_ID_URL_PARAM, span.id);
+                    searchParams.set(SELECTED_SPAN_NODE_ID_PARAM, span.id);
                     return searchParams;
                   },
                   { replace: true }

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 
 import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
 
-import { Button, Flex, Icon, Icons, Keyboard } from "@phoenix/components";
+import { Button, Flex, Icon, Icons, KeyboardToken } from "@phoenix/components";
 import {
   getNeighbors,
   useTracePagination,
@@ -68,7 +68,7 @@ export const TraceDetailsPaginator = ({
         <Tooltip>
           <Flex direction="row" gap="size-100" alignItems="center">
             <span>Next trace</span>
-            <Keyboard variant="primary">{NEXT_TRACE_HOTKEY}</Keyboard>
+            <KeyboardToken>{NEXT_TRACE_HOTKEY}</KeyboardToken>
           </Flex>
         </Tooltip>
       </TooltipTrigger>
@@ -85,7 +85,7 @@ export const TraceDetailsPaginator = ({
         <Tooltip>
           <Flex direction="row" gap="size-100" alignItems="center">
             <span>Previous trace</span>
-            <Keyboard variant="primary">{PREVIOUS_TRACE_HOTKEY}</Keyboard>
+            <KeyboardToken>{PREVIOUS_TRACE_HOTKEY}</KeyboardToken>
           </Flex>
         </Tooltip>
       </TooltipTrigger>

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { css } from "@emotion/react";
 
-import { Button, Flex, Icon, Icons } from "@phoenix/components";
+import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
+
+import { Button, Flex, Icon, Icons, Keyboard } from "@phoenix/components";
 import {
   getNeighbors,
   useTracePagination,
 } from "@phoenix/pages/trace/TracePaginationContext";
+
+export const NEXT_TRACE_HOTKEY = "j";
+export const PREVIOUS_TRACE_HOTKEY = "k";
 
 export const TraceDetailsPaginator = ({
   currentId,
@@ -14,13 +20,13 @@ export const TraceDetailsPaginator = ({
 }) => {
   const pagination = useTracePagination();
 
-  useHotkeys("right", () => {
+  useHotkeys(NEXT_TRACE_HOTKEY, () => {
     if (pagination) {
       pagination.next(currentId);
     }
   });
 
-  useHotkeys("left", () => {
+  useHotkeys(PREVIOUS_TRACE_HOTKEY, () => {
     if (pagination) {
       pagination.previous(currentId);
     }
@@ -39,17 +45,50 @@ export const TraceDetailsPaginator = ({
   const hasNext = !!nextTraceId;
 
   return (
-    <Flex gap="size-50">
-      <Button
-        size="S"
-        onPress={() => previous(currentId)}
-        isDisabled={!hasPrevious}
-      >
-        <Icon svg={<Icons.ArrowIosBackOutline />} />
-      </Button>
-      <Button size="S" onPress={() => next(currentId)} isDisabled={!hasNext}>
-        <Icon svg={<Icons.ArrowIosForwardOutline />} />
-      </Button>
+    <Flex
+      gap="size-50"
+      css={css`
+        button {
+          // either the icons or the trigger wrap are making the buttons slightly too small
+          // so just spot adjust the min height here
+          min-height: 31px;
+        }
+      `}
+    >
+      <TooltipTrigger>
+        <TriggerWrap>
+          <Button
+            size="S"
+            onPress={() => next(currentId)}
+            isDisabled={!hasNext}
+          >
+            <Icon svg={<Icons.ArrowIosDownwardOutline />} />
+          </Button>
+        </TriggerWrap>
+        <Tooltip>
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <span>Next trace</span>
+            <Keyboard variant="primary">{NEXT_TRACE_HOTKEY}</Keyboard>
+          </Flex>
+        </Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <TriggerWrap>
+          <Button
+            size="S"
+            onPress={() => previous(currentId)}
+            isDisabled={!hasPrevious}
+          >
+            <Icon svg={<Icons.ArrowIosUpwardOutline />} />
+          </Button>
+        </TriggerWrap>
+        <Tooltip>
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <span>Previous trace</span>
+            <Keyboard variant="primary">{PREVIOUS_TRACE_HOTKEY}</Keyboard>
+          </Flex>
+        </Tooltip>
+      </TooltipTrigger>
     </Flex>
   );
 };

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -1,10 +1,17 @@
 import React from "react";
+import { type Selection, Tooltip, TooltipTrigger } from "react-aria-components";
 import { useHotkeys } from "react-hotkeys-hook";
 import { css } from "@emotion/react";
 
-import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
-import { Button, Flex, Icon, Icons, KeyboardToken } from "@phoenix/components";
+import {
+  Flex,
+  Icon,
+  Icons,
+  KeyboardToken,
+  ToggleButton,
+  ToggleButtonGroup,
+  View,
+} from "@phoenix/components";
 import {
   getNeighbors,
   useTracePagination,
@@ -44,6 +51,16 @@ export const TraceDetailsPaginator = ({
   const hasPrevious = !!previousTraceId;
   const hasNext = !!nextTraceId;
 
+  const handleSelectionChange = (selection: Selection) => {
+    if (selection === "all") return;
+    const selectedKey = Array.from(selection)[0];
+    if (selectedKey === "next") {
+      next(currentId);
+    } else if (selectedKey === "previous") {
+      previous(currentId);
+    }
+  };
+
   return (
     <Flex
       gap="size-50"
@@ -55,40 +72,58 @@ export const TraceDetailsPaginator = ({
         }
       `}
     >
-      <TooltipTrigger>
-        <TriggerWrap>
-          <Button
-            size="S"
-            onPress={() => next(currentId)}
+      <ToggleButtonGroup
+        aria-label="Trace Paginator"
+        size="S"
+        selectionMode="single"
+        selectedKeys={[]}
+        onSelectionChange={handleSelectionChange}
+      >
+        <TooltipTrigger delay={100}>
+          <ToggleButton
+            id="next"
+            leadingVisual={<Icon svg={<Icons.ArrowIosDownwardOutline />} />}
+            aria-label="Next trace"
             isDisabled={!hasNext}
-          >
-            <Icon svg={<Icons.ArrowIosDownwardOutline />} />
-          </Button>
-        </TriggerWrap>
-        <Tooltip>
-          <Flex direction="row" gap="size-100" alignItems="center">
-            <span>Next trace</span>
-            <KeyboardToken>{NEXT_TRACE_HOTKEY}</KeyboardToken>
-          </Flex>
-        </Tooltip>
-      </TooltipTrigger>
-      <TooltipTrigger>
-        <TriggerWrap>
-          <Button
-            size="S"
-            onPress={() => previous(currentId)}
+          />
+          <Tooltip>
+            <View
+              backgroundColor="dark"
+              borderWidth="thin"
+              borderColor="dark"
+              borderRadius="medium"
+              padding="size-100"
+            >
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <span>Next trace</span>
+                <KeyboardToken>{NEXT_TRACE_HOTKEY}</KeyboardToken>
+              </Flex>
+            </View>
+          </Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger delay={100}>
+          <ToggleButton
+            id="previous"
+            leadingVisual={<Icon svg={<Icons.ArrowIosUpwardOutline />} />}
+            aria-label="Previous trace"
             isDisabled={!hasPrevious}
-          >
-            <Icon svg={<Icons.ArrowIosUpwardOutline />} />
-          </Button>
-        </TriggerWrap>
-        <Tooltip>
-          <Flex direction="row" gap="size-100" alignItems="center">
-            <span>Previous trace</span>
-            <KeyboardToken>{PREVIOUS_TRACE_HOTKEY}</KeyboardToken>
-          </Flex>
-        </Tooltip>
-      </TooltipTrigger>
+          />
+          <Tooltip>
+            <View
+              backgroundColor="dark"
+              borderWidth="thin"
+              borderColor="dark"
+              borderRadius="medium"
+              padding="size-100"
+            >
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <span>Previous trace</span>
+                <KeyboardToken>{PREVIOUS_TRACE_HOTKEY}</KeyboardToken>
+              </Flex>
+            </View>
+          </Tooltip>
+        </TooltipTrigger>
+      </ToggleButtonGroup>
     </Flex>
   );
 };

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+
+import { Button, Flex, Icon, Icons } from "@phoenix/components";
+import {
+  getNeighbors,
+  useTracePagination,
+} from "@phoenix/pages/trace/TracePaginationContext";
+
+export const TraceDetailsPaginator = ({
+  currentId,
+}: {
+  currentId?: string;
+}) => {
+  const pagination = useTracePagination();
+
+  useHotkeys("right", () => {
+    if (pagination) {
+      pagination.next(currentId);
+    }
+  });
+
+  useHotkeys("left", () => {
+    if (pagination) {
+      pagination.previous(currentId);
+    }
+  });
+
+  if (!pagination || !pagination.traceSequence.length) {
+    return null;
+  }
+
+  const { previous, next, traceSequence } = pagination;
+  const { nextTraceId, previousTraceId } = getNeighbors(
+    traceSequence,
+    currentId
+  );
+  const hasPrevious = !!previousTraceId;
+  const hasNext = !!nextTraceId;
+
+  return (
+    <Flex gap="size-50">
+      <Button
+        size="S"
+        onPress={() => previous(currentId)}
+        isDisabled={!hasPrevious}
+      >
+        <Icon svg={<Icons.ArrowIosBackOutline />} />
+      </Button>
+      <Button size="S" onPress={() => next(currentId)} isDisabled={!hasNext}>
+        <Icon svg={<Icons.ArrowIosForwardOutline />} />
+      </Button>
+    </Flex>
+  );
+};

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router";
 import { Dialog, DialogContainer } from "@arizeai/components";
 
 import { Loading } from "@phoenix/components";
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
 import { TraceDetailsPaginator } from "@phoenix/pages/trace/TraceDetailsPaginator";
 
@@ -17,7 +18,7 @@ export function TracePage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { rootPath, tab } = useProjectRootPath();
-  const selectedSpanNodeId = searchParams.get("selectedSpanNodeId");
+  const selectedSpanNodeId = searchParams.get(SELECTED_SPAN_NODE_ID_PARAM);
 
   // if we are focused on a particular span, use that as the subjectId
   // otherwise, use the traceId

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1,9 +1,11 @@
-import React from "react";
-import { useNavigate, useParams } from "react-router";
+import React, { Suspense } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import { Dialog, DialogContainer } from "@arizeai/components";
 
+import { Loading } from "@phoenix/components";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
+import { TraceDetailsPaginator } from "@phoenix/pages/trace/TraceDetailsPaginator";
 
 import { TraceDetails } from "./TraceDetails";
 
@@ -12,20 +14,37 @@ import { TraceDetails } from "./TraceDetails";
  */
 export function TracePage() {
   const { traceId, projectId } = useParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { rootPath, tab } = useProjectRootPath();
+  const selectedSpanNodeId = searchParams.get("selectedSpanNodeId");
+
+  // if we are focused on a particular span, use that as the subjectId
+  // otherwise, use the traceId
+  const paginationSubjectId = selectedSpanNodeId || traceId;
 
   return (
     <DialogContainer
       type="slideOver"
       isDismissable
-      onDismiss={() => navigate(`${rootPath}/${tab}`)}
+      onDismiss={() => {
+        navigate(`${rootPath}/${tab}`);
+      }}
     >
-      <Dialog size="fullscreen" title="Trace Details">
-        <TraceDetails
-          traceId={traceId as string}
-          projectId={projectId as string}
-        />
+      <Dialog
+        size="fullscreen"
+        title="Trace Details"
+        extra={<TraceDetailsPaginator currentId={paginationSubjectId} />}
+      >
+        <Suspense fallback={<Loading />}>
+          <TraceDetails
+            // blow out state when the paginationSubjectId changes
+            // some components are uncontrolled and will not update by themselves when the subjectId changes
+            key={paginationSubjectId}
+            traceId={traceId as string}
+            projectId={projectId as string}
+          />
+        </Suspense>
       </Dialog>
     </DialogContainer>
   );

--- a/app/src/pages/trace/TracePaginationContext.tsx
+++ b/app/src/pages/trace/TracePaginationContext.tsx
@@ -1,0 +1,147 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router";
+
+/**
+ * A sequence of traceId/spanId pairs that represent the trace sequence.
+ * The sequence is used to navigate between traces, or spans within a trace.
+ */
+type TraceSequence = { traceId: string; spanId: string }[];
+
+type TracePaginationContextType = {
+  traceSequence: TraceSequence;
+  next: (currentId?: string) => void;
+  previous: (currentId?: string) => void;
+  setTraceSequence: (traceSequence: TraceSequence) => void;
+};
+
+export const TracePaginationContext =
+  createContext<TracePaginationContextType | null>(null);
+
+export const useTracePagination = () => {
+  const context = useContext(TracePaginationContext);
+
+  return context;
+};
+
+/**
+ * Get the next and previous traceId/spanId pairs based on the current traceId/spanId
+ * @param traceSequence - The sequence of traceId/spanId pairs to paginate against, this could be from the spans table for example
+ * @param currentId - The current traceId or spanId, the first sequence with a matching traceId or spanId will be matched against
+ * @returns The next and previous traceId and spanId, if they exist in the sequence
+ */
+export const getNeighbors = (
+  traceSequence: { traceId: string; spanId: string }[],
+  /** May be a traceId or a spanId */
+  currentId?: string
+) => {
+  const currentIndex = traceSequence.findIndex(
+    ({ traceId, spanId }) =>
+      currentId && (traceId === currentId || spanId === currentId)
+  );
+  const previousIndex = currentIndex - 1;
+  const nextIndex = currentIndex + 1;
+  const previousSequenceMember = traceSequence[previousIndex];
+  const nextSequenceMember = traceSequence[nextIndex];
+  return {
+    nextTraceId: nextSequenceMember?.traceId,
+    nextSpanId: nextSequenceMember?.spanId,
+    previousTraceId: previousSequenceMember?.traceId,
+    previousSpanId: previousSequenceMember?.spanId,
+  };
+};
+
+/**
+ * Make the next and previous trace urls based on the current traceId, spanId, and url pathname
+ * @param location - The location object from useLocation
+ * @param traceSequence - The sequence of traceId/spanId pairs to paginate against, this could be from the spans table for example
+ * @param currentId - The current traceId or spanId, the first sequence with a matching traceId or spanId will be matched against
+ * @returns The next and previous trace urls, if they exist in the sequence
+ */
+export const makeTraceUrls = (
+  location: ReturnType<typeof useLocation>,
+  traceSequence: { traceId: string; spanId: string }[],
+  currentId?: string
+) => {
+  const { nextTraceId, previousTraceId, nextSpanId, previousSpanId } =
+    getNeighbors(traceSequence, currentId);
+  // split up the url pathname into its components
+  // e.g. /projects/my-project/traces/123/spans/456 -> ["projects", "my-project", "traces", "123", "spans", "456"]
+  // we only really care about the last two components, which are the projectId and the resource
+  // resource is either "traces" or "spans", which we need to keep track of so we can build the correct url
+  const [projects, projectId, resource] = location.pathname
+    .split("/")
+    .filter((part) => part !== "");
+  const makeUrl = (traceId: string, currentSpanId?: string) => {
+    // we always navigate directly to a traceId
+    let path = `/${projects}/${projectId}/${resource}/${traceId}`;
+    // we add a selected span node id if provided to makeUrl
+    if (currentSpanId) {
+      path += `?selectedSpanNodeId=${currentSpanId}`;
+    }
+    return path;
+  };
+  const hasNext = !!nextTraceId;
+  const hasPrevious = !!previousTraceId;
+  // we build the next and previous trace urls if the traceId is present for those directions
+  return {
+    nextTracePath: hasNext ? makeUrl(nextTraceId, nextSpanId) : null,
+    previousTracePath: hasPrevious
+      ? makeUrl(previousTraceId, previousSpanId)
+      : null,
+  };
+};
+
+export const TracePaginationProvider = ({ children }: PropsWithChildren) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [traceSequence, setTraceSequence] = useState<
+    { traceId: string; spanId: string }[]
+  >([]);
+
+  const next = useCallback(
+    (currentId?: string) => {
+      const { nextTracePath } = makeTraceUrls(
+        location,
+        traceSequence,
+        currentId
+      );
+      if (nextTracePath) {
+        navigate(nextTracePath);
+      }
+    },
+    [navigate, location, traceSequence]
+  );
+
+  const previous = useCallback(
+    (currentId?: string) => {
+      const { previousTracePath } = makeTraceUrls(
+        location,
+        traceSequence,
+        currentId
+      );
+      if (previousTracePath) {
+        navigate(previousTracePath);
+      }
+    },
+    [navigate, location, traceSequence]
+  );
+
+  return (
+    <TracePaginationContext.Provider
+      value={{
+        traceSequence,
+        next,
+        previous,
+        setTraceSequence,
+      }}
+    >
+      {children}
+    </TracePaginationContext.Provider>
+  );
+};

--- a/app/src/pages/trace/TracePaginationContext.tsx
+++ b/app/src/pages/trace/TracePaginationContext.tsx
@@ -7,6 +7,8 @@ import React, {
 } from "react";
 import { useLocation, useNavigate } from "react-router";
 
+import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
+
 /**
  * A sequence of traceId/spanId pairs that represent the trace sequence.
  * The sequence is used to navigate between traces, or spans within a trace.
@@ -82,7 +84,7 @@ export const makeTraceUrls = (
     let path = `/${projects}/${projectId}/${resource}/${traceId}`;
     // we add a selected span node id if provided to makeUrl
     if (currentSpanId) {
-      path += `?selectedSpanNodeId=${currentSpanId}`;
+      path += `?${SELECTED_SPAN_NODE_ID_PARAM}=${currentSpanId}`;
     }
     return path;
   };


### PR DESCRIPTION
https://github.com/user-attachments/assets/eb59405d-f684-46dd-b4d5-55850ade060f


Adds pagination to trace details, as well as a bunch of hotkeys for jumping around the details dialog:

- While no inputs are focused
  - `j` change the dialog / url to the next trace/span
  - `k` change the dialog / url to the previous trace/span
  - `e` jump to the first span annotations editor input
  - `n` jump to the span notes message bar
- While annotation span aside is closed
  - `e` open the span annotations aside

Resolves #6485