### PR TITLE
feat: separate TLS enabled flags for HTTP and gRPC

### DIFF
--- a/src/phoenix/server/grpc_server.py
+++ b/src/phoenix/server/grpc_server.py
@@ -18,6 +18,7 @@ from phoenix.config import (
     TLSConfigVerifyClient,
     get_env_grpc_port,
     get_env_tls_config,
+    get_env_tls_enabled_for_grpc,
 )
 from phoenix.server.bearer_auth import ApiKeyInterceptor
 from phoenix.trace.otel import decode_otlp_span
@@ -90,7 +91,8 @@ class GrpcServer:
             options=(("grpc.so_reuseport", 0),),
             interceptors=interceptors,
         )
-        if tls_config := get_env_tls_config():
+        if get_env_tls_enabled_for_grpc():
+            assert (tls_config := get_env_tls_config())
             private_key_certificate_chain_pairs = [(tls_config.key_data, tls_config.cert_data)]
             server_credentials = (
                 grpc.ssl_server_credentials(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -474,93 +474,17 @@ class TestGetEnvTlsEnabled:
                 },
                 True,
                 False,
-                id="http_overrides_global_disabled",
-            ),
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "true",
-                    "PHOENIX_TLS_ENABLED_FOR_HTTP": "false",
-                },
-                False,
-                True,
-                id="http_overrides_global_enabled",
+                id="http_overrides_global",
             ),
             # gRPC-specific variable tests - should override global
             pytest.param(
                 {
-                    "PHOENIX_TLS_ENABLED": "false",
-                    "PHOENIX_TLS_ENABLED_FOR_GRPC": "true",
-                },
-                False,
-                True,
-                id="grpc_overrides_global_disabled",
-            ),
-            pytest.param(
-                {
                     "PHOENIX_TLS_ENABLED": "true",
                     "PHOENIX_TLS_ENABLED_FOR_GRPC": "false",
                 },
                 True,
                 False,
-                id="grpc_overrides_global_enabled",
-            ),
-            # Both specific variables set - should override global
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "false",
-                    "PHOENIX_TLS_ENABLED_FOR_HTTP": "true",
-                    "PHOENIX_TLS_ENABLED_FOR_GRPC": "true",
-                },
-                True,
-                True,
-                id="both_specific_override_global_disabled",
-            ),
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "true",
-                    "PHOENIX_TLS_ENABLED_FOR_HTTP": "false",
-                    "PHOENIX_TLS_ENABLED_FOR_GRPC": "false",
-                },
-                False,
-                False,
-                id="both_specific_override_global_enabled",
-            ),
-            # Mixed cases - one specific, one falls back to global
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "true",
-                    "PHOENIX_TLS_ENABLED_FOR_HTTP": "false",
-                },
-                False,
-                True,
-                id="http_specific_grpc_falls_back",
-            ),
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "true",
-                    "PHOENIX_TLS_ENABLED_FOR_GRPC": "false",
-                },
-                True,
-                False,
-                id="grpc_specific_http_falls_back",
-            ),
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "false",
-                    "PHOENIX_TLS_ENABLED_FOR_HTTP": "true",
-                },
-                True,
-                False,
-                id="http_specific_grpc_falls_back_disabled",
-            ),
-            pytest.param(
-                {
-                    "PHOENIX_TLS_ENABLED": "false",
-                    "PHOENIX_TLS_ENABLED_FOR_GRPC": "true",
-                },
-                False,
-                True,
-                id="grpc_specific_http_falls_back_disabled",
+                id="grpc_overrides_global",
             ),
         ],
     )


### PR DESCRIPTION
resolves #7362 

# Add Independent Flags for Whether TLS is Enabled for HTTP and gRPC Servers

## Changes
This PR introduces separate controls for enabling TLS on HTTP and gRPC servers while maintaining a single TLS configuration. Previously, TLS was controlled by a single environment variable (`PHOENIX_TLS_ENABLED`), which enabled TLS for both servers simultaneously. Now, you can use the same TLS certificates and configuration but choose which servers to enable it for.

### Key Changes:
- Added new environment variables to control TLS enablement:
  - `PHOENIX_TLS_ENABLED_FOR_HTTP`: Enables TLS for HTTP server
  - `PHOENIX_TLS_ENABLED_FOR_GRPC`: Enables TLS for gRPC server
- Both new variables take precedence over the existing `PHOENIX_TLS_ENABLED` when set
- The underlying TLS configuration (certificates, keys, etc.) remains unified and shared
- Updated server configuration logic to handle independent TLS enablement
- Modified welcome message to show TLS status separately for HTTP and gRPC
- Updated URL generation to use the appropriate scheme based on TLS enablement

### Technical Details:
- Refactored `get_env_tls_enabled()` into two separate functions:
  - `get_env_tls_enabled_for_http()`
  - `get_env_tls_enabled_for_grpc()`
- Updated TLS enablement checks in both HTTP and gRPC server initialization
- Modified URL generation to use HTTP-specific TLS enablement