### PR TITLE
fix(annotations): Show 0 scores in summary labels

### DIFF
--- a/app/src/components/annotation/AnnotationSummaryPopover.tsx
+++ b/app/src/components/annotation/AnnotationSummaryPopover.tsx
@@ -158,7 +158,7 @@ export function AnnotationSummaryPopover({
                             </td>
                             <td>
                               <Text size="M" weight="heavy">
-                                {annotation.score
+                                {annotation.score != null
                                   ? formatFloat(annotation.score)
                                   : null}
                               </Text>

--- a/app/src/components/trace/SpanAnnotationInput.tsx
+++ b/app/src/components/trace/SpanAnnotationInput.tsx
@@ -62,7 +62,7 @@ export function SpanAnnotationInput(props: SpanAnnotationInputProps) {
                   if (selectedKey === _value?.label) {
                     selectedKey = null;
                   }
-                  if (typeof selectedKey === "string" && selectedKey) {
+                  if (typeof selectedKey === "string" && selectedKey != null) {
                     const newAnnotation: Annotation = {
                       ...annotation,
                       id: annotation?.id,


### PR DESCRIPTION
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/adcad188-2dd6-4855-a123-6e37a80744cb" />

Resolves #7367