### PR TITLE
refactor: use leading visual for icons

### DIFF
--- a/app/src/pages/settings/AnnotationConfigDialog.tsx
+++ b/app/src/pages/settings/AnnotationConfigDialog.tsx
@@ -406,9 +406,12 @@ export const AnnotationConfigDialog = ({
                             </NumberField>
                           )}
                         />
-                        <Button type="button" onPress={() => remove(index)}>
-                          <Icon svg={<Icons.TrashOutline />} />
-                        </Button>
+                        <Button
+                          type="button"
+                          leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+                          aria-label="Remove category"
+                          onPress={() => remove(index)}
+                        />
                       </Flex>
                     ))}
                     <Flex justifyContent="end" width="100%">
@@ -417,8 +420,8 @@ export const AnnotationConfigDialog = ({
                         onPress={() => {
                           append({ label: "", score: null });
                         }}
+                        leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
                       >
-                        <Icon svg={<Icons.PlusOutline />} />
                         Add category
                       </Button>
                     </Flex>


### PR DESCRIPTION
This aligns the buttons to use the leadingVisual primitive rather than just using the icon as a child. Renders more consistently.
<img width="713" alt="Screenshot 2025-04-30 at 3 13 16 PM" src="https://github.com/user-attachments/assets/c3364f2f-7c3f-4f25-9f80-4ea3771a4600" />
