### PR TITLE
feat(onboarding): datasets empty

### DIFF
--- a/app/src/components/button/ExternalLinkButton.tsx
+++ b/app/src/components/button/ExternalLinkButton.tsx
@@ -1,0 +1,74 @@
+import React, { Ref } from "react";
+import { css } from "@emotion/react";
+
+import { buttonCSS } from "./styles";
+import { ButtonProps } from "./types";
+
+// Custom props for the button styling and visuals
+interface ExternalLinkButtonCustomProps
+  extends Pick<
+    ButtonProps,
+    | "size"
+    | "variant"
+    | "leadingVisual"
+    | "trailingVisual"
+    | "css"
+    | "isDisabled"
+  > {}
+
+// Main props type: all anchor props + custom button props
+export type ExternalLinkButtonProps =
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & ExternalLinkButtonCustomProps;
+
+const externalLinkButtonCSS = css`
+  text-decoration: none;
+  user-select: none;
+  &[data-disabled="true"] {
+    pointer-events: none;
+    cursor: default;
+    opacity: var(--ac-opacity-disabled);
+  }
+`;
+
+/**
+ * A button-styled external link that opens in a new tab
+ */
+function ExternalLinkButton(
+  props: ExternalLinkButtonProps,
+  ref: Ref<HTMLAnchorElement>
+) {
+  const {
+    size = "M",
+    variant = "default",
+    leadingVisual,
+    trailingVisual,
+    children,
+    css: propCSS,
+    isDisabled,
+    target = "_blank",
+    ...rest
+  } = props;
+
+  return (
+    <a
+      ref={ref}
+      target={target}
+      rel="noopener noreferrer"
+      data-size={size}
+      data-variant={variant}
+      data-childless={!children}
+      data-disabled={isDisabled}
+      css={css(buttonCSS, externalLinkButtonCSS, propCSS)}
+      tabIndex={isDisabled ? -1 : undefined}
+      aria-disabled={isDisabled}
+      {...rest}
+    >
+      {leadingVisual}
+      {children}
+      {trailingVisual}
+    </a>
+  );
+}
+
+const _ExternalLinkButton = React.forwardRef(ExternalLinkButton);
+export { _ExternalLinkButton as ExternalLinkButton };

--- a/app/src/components/button/index.tsx
+++ b/app/src/components/button/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Button";
 export * from "./LinkButton";
+export * from "./ExternalLinkButton";
 export type * from "./types";
 export * from "./styles";

--- a/app/src/components/icon/Icons.tsx
+++ b/app/src/components/icon/Icons.tsx
@@ -1870,6 +1870,32 @@ export const Refresh = () => (
   </svg>
 );
 
+// @src: lucide
+export const Rocket = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path
+      d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"
+      fill="none"
+    />
+    <path
+      d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"
+      fill="none"
+    />
+    <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" fill="none" />
+    <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" fill="none" />
+  </svg>
+);
+
 export const RowCollapseOutline = () => (
   <svg
     width="24"

--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -50,3 +50,4 @@ export * from "./tabs";
 export * from "./loading";
 export * from "./alert";
 export * from "./select";
+export * from "./media";

--- a/app/src/components/table/TableEmpty.tsx
+++ b/app/src/components/table/TableEmpty.tsx
@@ -1,22 +1,14 @@
 import React from "react";
-import { css } from "@emotion/react";
+
+import { Text } from "@phoenix/components";
+
+import { TableEmptyWrap } from "./TableEmptyWrap";
 
 export function TableEmpty(props: { message?: string }) {
   const { message = "No Data" } = props;
   return (
-    <tbody className="is-empty">
-      <tr>
-        <td
-          colSpan={100}
-          css={css`
-            text-align: center;
-            padding: var(--ac-global-dimension-size-300)
-              var(--ac-global-dimension-size-300) !important;
-          `}
-        >
-          {message}
-        </td>
-      </tr>
-    </tbody>
+    <TableEmptyWrap>
+      <Text>{message}</Text>
+    </TableEmptyWrap>
   );
 }

--- a/app/src/components/table/TableEmptyWrap.tsx
+++ b/app/src/components/table/TableEmptyWrap.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren } from "react";
+import { css } from "@emotion/react";
+
+export function TableEmptyWrap(props: PropsWithChildren) {
+  const { children } = props;
+  return (
+    <tbody className="is-empty">
+      <tr>
+        <td
+          colSpan={100}
+          css={css`
+            text-align: center;
+            padding: var(--ac-global-dimension-size-300)
+              var(--ac-global-dimension-size-300) !important;
+          `}
+        >
+          {children}
+        </td>
+      </tr>
+    </tbody>
+  );
+}

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -6,3 +6,5 @@ export * from "./TextCell";
 export * from "./CompactJSONCell";
 export * from "./CellWithControlsWrapper";
 export * from "./LoadMoreRow";
+export * from "./TableEmpty";
+export * from "./TableEmptyWrap";

--- a/app/src/pages/datasets/DatasetsEmpty.tsx
+++ b/app/src/pages/datasets/DatasetsEmpty.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+import {
+  ExternalLinkButton,
+  Flex,
+  Icon,
+  Icons,
+  Text,
+  Video,
+  View,
+} from "@phoenix/components";
+
+export function DatasetsEmpty() {
+  return (
+    <View width="100%" paddingY="size-400">
+      <Flex
+        direction="column"
+        width="100%"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <View width="780px">
+          <Flex direction="column" gap="size-400" alignItems="center">
+            <Text size="XL">
+              Create datasets for testing prompts, experimentation, and
+              fine-tuning.
+            </Text>
+            <Video
+              src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/datasets.mp4"
+              autoPlay
+              muted
+              loop
+            />
+            <Flex direction="row" gap="size-200">
+              <ExternalLinkButton
+                href="https://docs.arize.com/phoenix/datasets-and-experiments/overview-datasets"
+                target="_blank"
+                leadingVisual={<Icon svg={<Icons.BookOutline />} />}
+              >
+                Documentation
+              </ExternalLinkButton>
+              <ExternalLinkButton
+                href="https://colab.research.google.com/github/arize-ai/phoenix/blob/main/tutorials/experiments/datasets_and_experiments_quickstart.ipynb"
+                target="_blank"
+                leadingVisual={<Icon svg={<Icons.Rocket />} />}
+              >
+                Quckstart
+              </ExternalLinkButton>
+            </Flex>
+          </Flex>
+        </View>
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/pages/datasets/DatasetsEmpty.tsx
+++ b/app/src/pages/datasets/DatasetsEmpty.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { css } from "@emotion/react";
 
 import {
   ExternalLinkButton,

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -19,7 +19,7 @@ import { css } from "@emotion/react";
 import { Icon, Icons, Link } from "@phoenix/components";
 import { CompactJSONCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
-import { TableEmpty } from "@phoenix/components/table/TableEmpty";
+import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
@@ -30,7 +30,7 @@ import {
   DatasetsTableDatasetsQuery,
 } from "./__generated__/DatasetsTableDatasetsQuery.graphql";
 import { DatasetActionMenu } from "./DatasetActionMenu";
-
+import { DatasetsEmpty } from "./DatasetsEmpty";
 const PAGE_SIZE = 100;
 
 type DatasetsTableProps = {
@@ -279,7 +279,9 @@ export function DatasetsTable(props: DatasetsTableProps) {
           ))}
         </thead>
         {isEmpty ? (
-          <TableEmpty />
+          <TableEmptyWrap>
+            <DatasetsEmpty />
+          </TableEmptyWrap>
         ) : (
           <tbody>
             {rows.map((row) => {


### PR DESCRIPTION

<img width="2022" alt="Screenshot 2025-05-01 at 8 52 13 AM" src="https://github.com/user-attachments/assets/4e090e82-1957-4588-935b-254264b52dbf" />
adds a tutorial and docs link to the dataset empty page.