### PR TITLE
feat: Improve client semantics

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -217,6 +217,8 @@ class Spans:
                     break  # finished paginating this batch
 
         df = pd.DataFrame(annotations)
+        df = _flatten_nested_column(df, "result")
+        df.rename(columns={"name": "annotation_name"}, inplace=True)
         df.set_index("span_id", inplace=True)
         return df
 
@@ -474,6 +476,8 @@ class AsyncSpans:
                     break
 
         df = pd.DataFrame(annotations)
+        df = _flatten_nested_column(df, "result")
+        df.rename(columns={"name": "annotation_name"}, inplace=True)
         df.set_index("span_id", inplace=True)
         return df
 
@@ -593,6 +597,19 @@ def _process_span_dataframe(response: httpx.Response) -> "pd.DataFrame":
         return dfs[0]  # we only expect one dataframe
     else:
         return pd.DataFrame()
+
+
+def _flatten_nested_column(df: "pd.DataFrame", column_name: str) -> "pd.DataFrame":
+    import pandas as pd
+
+    if column_name in df.columns:
+        # Flatten the nested dictionary column and prefix each resulting column with
+        # the original column name (e.g., "result.label").
+        nested_df = pd.json_normalize(df[column_name]).rename(
+            columns=lambda col: f"{column_name}.{col}"
+        )
+        df = pd.concat([df.drop(columns=[column_name]), nested_df], axis=1)
+    return df
 
 
 class TimeoutError(Exception): ...

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -622,7 +622,7 @@ def _flatten_nested_column(df: "pd.DataFrame", column_name: str) -> "pd.DataFram
     if column_name in df.columns:
         # Flatten the nested dictionary column and prefix each resulting column with
         # the original column name (e.g., "result.label").
-        nested_df = pd.json_normalize(df[column_name]).rename(  # type: ignore[unused-ignore]
+        nested_df = pd.json_normalize(df[column_name]).rename(  # type: ignore[arg-type]
             columns=lambda col: f"{column_name}.{col}"
         )
         df = pd.concat([df.drop(columns=[column_name]), nested_df], axis=1)

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -46,6 +46,7 @@ class Spans:
         end_time: Optional[datetime] = None,
         limit: int = 1000,
         root_spans_only: Optional[bool] = None,
+        project_identifier: Optional[str] = None,
         project_name: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -58,7 +59,9 @@ class Spans:
             end_time: Optional end time for filtering.
             limit: Maximum number of spans to return.
             root_spans_only: Whether to return only root spans.
-            project_name: Optional project name to filter by.
+            project_name: Optional project name to filter by. Deprecated, use `project_identifier`
+                to also specify by the project id.
+            project_identifier: Optional project identifier (name or id) to filter by.
             timeout: Optional request timeout in seconds.
 
         Returns:
@@ -85,6 +88,18 @@ class Spans:
             import pandas as pd
 
             _ = pd  # Prevent unused symbol error
+
+            if project_identifier and project_name:
+                raise ValueError("Provide only one of 'project_identifier' or 'project_name'.")
+            elif project_identifier and not project_name:
+                project_response = self._client.get(
+                    url=f"v1/projects/{project_identifier}",
+                    headers={"accept": "application/json"},
+                    timeout=timeout,
+                )
+                project_response.raise_for_status()
+                project = project_response.json()
+                project_name = project["data"]["name"]
 
             response = self._client.post(
                 url="v1/spans",
@@ -120,7 +135,7 @@ class Spans:
         *,
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
-        project: str = "default",
+        project_identifier: str = "default",
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -133,7 +148,7 @@ class Spans:
             spans_dataframe: A DataFrame (typically returned by `get_spans_dataframe`) with a
                 `context.span_id` or `span_id` column.
             span_ids: An iterable of span IDs.
-            project: The project identifier (name or ID) used in the API path.
+            project_identifier: The project identifier (name or ID) used in the API path.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -173,7 +188,7 @@ class Spans:
             return pd.DataFrame()
 
         annotations: list[v1.SpanAnnotation] = []
-        path = f"v1/projects/{project}/span_annotations"
+        path = f"v1/projects/{project_identifier}/span_annotations"
 
         for i in range(0, len(span_ids_list), _MAX_SPAN_IDS_PER_REQUEST):
             batch_ids = span_ids_list[i : i + _MAX_SPAN_IDS_PER_REQUEST]
@@ -209,7 +224,7 @@ class Spans:
         self,
         *,
         span_ids: Iterable[str],
-        project: str,
+        project_identifier: str,
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -218,7 +233,7 @@ class Spans:
 
         Args:
             span_ids: An iterable of span IDs.
-            project: The project identifier (name or ID) used in the API path.
+            project_identifier: The project identifier (name or ID) used in the API path.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -234,7 +249,7 @@ class Spans:
             return []
 
         annotations: list[v1.SpanAnnotation] = []
-        path = f"v1/projects/{project}/span_annotations"
+        path = f"v1/projects/{project_identifier}/span_annotations"
 
         for i in range(0, len(span_ids_list), _MAX_SPAN_IDS_PER_REQUEST):
             batch_ids = span_ids_list[i : i + _MAX_SPAN_IDS_PER_REQUEST]
@@ -290,6 +305,7 @@ class AsyncSpans:
         limit: int = 1000,
         root_spans_only: Optional[bool] = None,
         project_name: Optional[str] = None,
+        project_identifier: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
         """
@@ -301,7 +317,9 @@ class AsyncSpans:
             end_time: Optional end time for filtering.
             limit: Maximum number of spans to return.
             root_spans_only: Whether to return only root spans.
-            project_name: Optional project name to filter by.
+            project_name: Optional project name to filter by. Deprecated, use `project_identifier`
+                to also specify by the project id.
+            project_identifier: Optional project identifier (name or id) to filter by.
             timeout: Optional request timeout in seconds.
 
         Returns:
@@ -328,6 +346,18 @@ class AsyncSpans:
             import pandas as pd
 
             _ = pd  # Prevent unused symbol error
+
+            if project_identifier and project_name:
+                raise ValueError("Provide only one of 'project_identifier' or 'project_name'.")
+            elif project_identifier and not project_name:
+                project_response = await self._client.get(
+                    url=f"v1/projects/{project_identifier}",
+                    headers={"accept": "application/json"},
+                    timeout=timeout,
+                )
+                project_response.raise_for_status()
+                project = project_response.json()
+                project_name = project["name"]
 
             response = await self._client.post(
                 url="v1/spans",

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -223,7 +223,7 @@ class Spans:
         df = pd.DataFrame(annotations)
         df = _flatten_nested_column(df, "result")
         df.rename(columns={"name": "annotation_name"}, inplace=True)
-        df.set_index("span_id", inplace=True)
+        df.set_index("span_id", inplace=True)  # type: ignore[unused-ignore]
         return df
 
     def get_span_annotations(
@@ -485,7 +485,7 @@ class AsyncSpans:
         df = pd.DataFrame(annotations)
         df = _flatten_nested_column(df, "result")
         df.rename(columns={"name": "annotation_name"}, inplace=True)
-        df.set_index("span_id", inplace=True)
+        df.set_index("span_id", inplace=True)  # type: ignore[unused-ignore]
         return df
 
     async def get_span_annotations(
@@ -622,7 +622,7 @@ def _flatten_nested_column(df: "pd.DataFrame", column_name: str) -> "pd.DataFram
     if column_name in df.columns:
         # Flatten the nested dictionary column and prefix each resulting column with
         # the original column name (e.g., "result.label").
-        nested_df = pd.json_normalize(df[column_name]).rename(
+        nested_df = pd.json_normalize(df[column_name]).rename(  # type: ignore[unused-ignore]
             columns=lambda col: f"{column_name}.{col}"
         )
         df = pd.concat([df.drop(columns=[column_name]), nested_df], axis=1)

--- a/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
+++ b/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
@@ -252,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "annotations_df.join(spans_df, how=\"inner\", lsuffix=\"_annotation\", rsuffix=\"_span\")"
+    "annotations_df.join(spans_df, how=\"inner\")"
    ]
   },
   {

--- a/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
+++ b/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
@@ -240,9 +240,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spans_df = client.spans.get_spans_dataframe(project_name=\"default\")\n",
+    "spans_df = client.spans.get_spans_dataframe(project_identifier=\"default\")\n",
     "annotations_df = client.spans.get_span_annotations_dataframe(\n",
-    "    spans_dataframe=spans_df, project=\"default\"\n",
+    "    spans_dataframe=spans_df, project_identifier=\"default\"\n",
     ")"
    ]
   },
@@ -253,6 +253,17 @@
    "outputs": [],
    "source": [
     "annotations_df.join(spans_df, how=\"inner\", lsuffix=\"_annotation\", rsuffix=\"_span\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.spans.get_span_annotations(\n",
+    "    span_ids=spans_df.index, project_identifier=\"default\"\n",
+    ")"
    ]
   }
  ],

--- a/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
+++ b/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,22 +266,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "dev",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
+++ b/tutorials/human_feedback/chatbot_with_human_feedback.ipynb
@@ -261,9 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.spans.get_span_annotations(\n",
-    "    span_ids=spans_df.index, project_identifier=\"default\"\n",
-    ")"
+    "client.spans.get_span_annotations(span_ids=spans_df.index, project_identifier=\"default\")"
    ]
   }
  ],


### PR DESCRIPTION
- Adds `project_identifier` argument to `get_spans_dataframe`
- Breaks out `result` into `result.score` `result.label` and `result.explanation` columns
- Renames the `name` column in the annotations dataframe to `annotation_name` for easier joining