### PR TITLE
feat: Simple support for message_contents span content in playground

### DIFF
--- a/app/src/pages/playground/__tests__/playgroundUtils.test.ts
+++ b/app/src/pages/playground/__tests__/playgroundUtils.test.ts
@@ -643,6 +643,52 @@ describe("transformSpanAttributesToPlaygroundInstance", () => {
       parsingErrors: [MODEL_CONFIG_WITH_RESPONSE_FORMAT_PARSING_ERROR],
     });
   });
+
+  it("should parse multi-part message contents", () => {
+    const span = {
+      ...basePlaygroundSpan,
+      attributes: JSON.stringify({
+        ...spanAttributesWithInputMessages,
+        llm: {
+          ...spanAttributesWithInputMessages.llm,
+          input_messages: [
+            {
+              message: {
+                content: "You are a chatbot",
+                role: "system",
+              },
+            },
+            {
+              message: {
+                role: "user",
+                contents: [
+                  {
+                    message_content: {
+                      type: "image",
+                      image_url: "https://example.com/image.png",
+                    },
+                  },
+                  { message_content: { type: "text", text: "hello?" } },
+                  {
+                    message_content: {
+                      type: "text",
+                      text: "I won't be parsed!",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    };
+    expect(transformSpanAttributesToPlaygroundInstance(span)).toEqual({
+      playgroundInstance: {
+        ...expectedPlaygroundInstanceWithIO,
+      },
+      parsingErrors: [],
+    });
+  });
 });
 
 describe("getChatRole", () => {

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -206,8 +206,15 @@ function processAttributeMessagesToChatMessage({
         message.tool_call_id != null
           ? getChatRole("tool")
           : getChatRole(message.role),
-      content:
-        typeof message.content === "string" ? message.content : undefined,
+      // TODO: truly support multi-part message contents
+      // for now, just take the first text based message if it exists
+      content: Array.isArray(message.contents)
+        ? (message.contents.find(
+            (content) => content.message_content.type === "text"
+          )?.message_content?.text ?? undefined)
+        : typeof message.content === "string"
+          ? message.content
+          : undefined,
       toolCalls: processAttributeToolCalls({
         provider,
         toolCalls: message.tool_calls,

--- a/app/src/pages/playground/schemas.ts
+++ b/app/src/pages/playground/schemas.ts
@@ -54,6 +54,9 @@ const messageSchema = z.object({
     [MessageAttributePostfixes.content]: z
       .union([z.string(), z.array(z.record(z.string(), z.unknown()))])
       .default(""),
+    [MessageAttributePostfixes.contents]: z
+      .array(z.object({ message_content: z.record(z.string()) }))
+      .optional(),
     [MessageAttributePostfixes.tool_calls]: z.array(toolCallSchema).optional(),
     [MessageAttributePostfixes.tool_call_id]: z.string().optional(),
   }),


### PR DESCRIPTION
This prevents scenarios where multi-part instrumented messages can't be replayed in the playground despite just having text contents as multi-part.

This is just the first small step towards supporting multi-part content that adds a little bit more value to playground

Resolves #7400 