### PR TITLE
fix(annotations): Safeguard against null spanAnnotationSummaries

### DIFF
--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -373,7 +373,7 @@ export function TracesTable(props: TracesTableProps) {
                 const annotation = (
                   row.original
                     .spanAnnotationSummaries as TracesTable_spans$data["rootSpans"]["edges"][number]["rootSpan"]["spanAnnotationSummaries"]
-                ).find((annotation) => annotation.name === name);
+                )?.find((annotation) => annotation.name === name);
                 if (!annotation) {
                   return null;
                 }
@@ -392,7 +392,7 @@ export function TracesTable(props: TracesTableProps) {
                 const annotation = (
                   row.original
                     .spanAnnotationSummaries as TracesTable_spans$data["rootSpans"]["edges"][number]["rootSpan"]["spanAnnotationSummaries"]
-                ).find((annotation) => annotation.name === name);
+                )?.find((annotation) => annotation.name === name);
                 if (!annotation) {
                   return null;
                 }


### PR DESCRIPTION
When viewing broken traces, with parentage not in phoenix yet, this would cause the page to crash.

This doesn't happen anymore. Not sure what conditions in the db exactly trigger this, but my current local environment has a mess of traces with weird parentage so might as well fix it just in case