### PR TITLE
feat: Update spans dsl to search for annotation existence

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -33,7 +33,7 @@ EVAL_EXPRESSION_PATTERN = re.compile(
 )
 
 EVAL_NAME_PATTERN = re.compile(
-    r"""\b((annotations|evals)\[(".*?"|'.*?')\])\b"""
+    r"""((annotations|evals)\[(".*?"|'.*?')\])"""
 )
 
 

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -32,7 +32,9 @@ EVAL_EXPRESSION_PATTERN = re.compile(
     r"""\b((annotations|evals)\[(".*?"|'.*?')\][.](label|score))\b"""
 )
 
-EVAL_NAME_PATTERN = re.compile(r"""((annotations|evals)\[(".*?"|'.*?')\])""")
+EVAL_NAME_PATTERN = re.compile(
+    r"""(?<!\w)((annotations|evals)\[(".*?"|'.*?')\])(?!\w)"""
+)
 
 
 @dataclass(frozen=True)

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -9,11 +9,11 @@ from types import MappingProxyType
 from uuid import uuid4
 
 import sqlalchemy
+from sqlalchemy import case, literal
 from sqlalchemy.orm import Mapped, aliased
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.expression import Select
 from typing_extensions import TypeAlias, TypeGuard, assert_never
-from sqlalchemy import case, literal
 
 import phoenix.trace.v1 as pb
 from phoenix.db import models
@@ -32,9 +32,7 @@ EVAL_EXPRESSION_PATTERN = re.compile(
     r"""\b((annotations|evals)\[(".*?"|'.*?')\][.](label|score))\b"""
 )
 
-EVAL_NAME_PATTERN = re.compile(
-    r"""((annotations|evals)\[(".*?"|'.*?')\])"""
-)
+EVAL_NAME_PATTERN = re.compile(r"""((annotations|evals)\[(".*?"|'.*?')\])""")
 
 
 @dataclass(frozen=True)
@@ -74,8 +72,9 @@ class AliasedAnnotationRelation:
         """
         yield self._label_attribute_alias, self.table.label
         yield self._score_attribute_alias, self.table.score
-        yield self._exists_attribute_alias, case(
-            (self.table.id.is_not(None), literal(True)), else_=literal(False)
+        yield (
+            self._exists_attribute_alias,
+            case((self.table.id.is_not(None), literal(True)), else_=literal(False)),
         )
 
     def attribute_alias(self, attribute: AnnotationAttribute) -> str:

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -33,7 +33,7 @@ EVAL_EXPRESSION_PATTERN = re.compile(
 )
 
 EVAL_NAME_PATTERN = re.compile(
-    r"""\b((annotations|evals)\[(\".*?\"|'.*?')\])\b"""
+    r"""\b((annotations|evals)\[(".*?"|'.*?')\])\b"""
 )
 
 
@@ -75,7 +75,7 @@ class AliasedAnnotationRelation:
         yield self._label_attribute_alias, self.table.label
         yield self._score_attribute_alias, self.table.score
         yield self._exists_attribute_alias, case(
-            (self.table.id.is_not(None), literal(True))
+            (self.table.id.is_not(None), literal(True)), else_=literal(False)
         )
 
     def attribute_alias(self, attribute: AnnotationAttribute) -> str:

--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -32,9 +32,7 @@ EVAL_EXPRESSION_PATTERN = re.compile(
     r"""\b((annotations|evals)\[(".*?"|'.*?')\][.](label|score))\b"""
 )
 
-EVAL_NAME_PATTERN = re.compile(
-    r"""(?<!\w)((annotations|evals)\[(".*?"|'.*?')\])(?!\w)"""
-)
+EVAL_NAME_PATTERN = re.compile(r"""(?<!\w)((annotations|evals)\[(".*?"|'.*?')\])(?![\w\.])""")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -232,6 +232,17 @@ async def test_filter_translated(
             "span_annotation_0_label_00000000000000000000000000000000 is not None",
             id="double-quoted-annotation-name",
         ),
+        # Existence checks (bare annotation reference)
+        pytest.param(
+            """evals['Hallucination']""",
+            "span_annotation_0_exists_00000000000000000000000000000000",
+            id="bare-evals-exists",
+        ),
+        pytest.param(
+            """annotations['Hallucination']""",
+            "span_annotation_0_exists_00000000000000000000000000000000",
+            id="bare-annotations-exists",
+        ),
     ],
 )
 def test_apply_eval_aliasing(filter_condition: str, expected: str) -> None:

--- a/tests/unit/trace/dsl/test_query.py
+++ b/tests/unit/trace/dsl/test_query.py
@@ -914,10 +914,22 @@ async def test_filter_on_trace_id_multiple(
         ["evals['0'].score is None or evals['1'].label is not None", ["234", "456", "567"]],
         ["evals['0'].score == 0 or evals['1'].label != '1'", ["345", "567"]],
         ["evals['0'].score != 0 or evals['1'].label == '1'", ["456"]],
-        ["evals['0']", ["345", "456"],],
-        ["annotations['0']", ["345", "456"],],
-        ["evals['1']", ["456", "567"],],
-        ["annotations['1']", ["456", "567"],],
+        [
+            "evals['0']",
+            ["345", "456"],
+        ],
+        [
+            "annotations['0']",
+            ["345", "456"],
+        ],
+        [
+            "evals['1']",
+            ["456", "567"],
+        ],
+        [
+            "annotations['1']",
+            ["456", "567"],
+        ],
     ],
 )
 async def test_filter_on_span_annotation(

--- a/tests/unit/trace/dsl/test_query.py
+++ b/tests/unit/trace/dsl/test_query.py
@@ -914,6 +914,10 @@ async def test_filter_on_trace_id_multiple(
         ["evals['0'].score is None or evals['1'].label is not None", ["234", "456", "567"]],
         ["evals['0'].score == 0 or evals['1'].label != '1'", ["345", "567"]],
         ["evals['0'].score != 0 or evals['1'].label == '1'", ["456"]],
+        ["evals['0']", ["345", "456"],],
+        ["annotations['0']", ["345", "456"],],
+        ["evals['1']", ["456", "567"],],
+        ["annotations['1']", ["456", "567"],],
     ],
 )
 async def test_filter_on_span_annotation(


### PR DESCRIPTION
Enables querying for annotation/eval existence:

```
query = SpanQuery().where("annotations['user_feedback']")
spans = client.spans.get_spans_dataframe(query=query, project_identifier="default")
```

