### PR TITLE
fix: formatting issues incase of escaped characters

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/utils/template_formatters.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/template_formatters.py
@@ -121,11 +121,9 @@ class MustacheBaseTemplateFormatter(BaseTemplateFormatter):
         variables: Mapping[str, str] = MappingProxyType({}),
     ) -> str:
         for variable_name in variable_names:
-            template = re.sub(
-                pattern=rf"(?<!\\){{{{\s*{variable_name}\s*}}}}",
-                repl=variables[variable_name],
-                string=template,
-            )
+            pattern = rf"(?<!\\){{{{\s*{re.escape(variable_name)}\s*}}}}"
+            replacement = variables[variable_name]
+            template = re.sub(pattern, lambda _: replacement, template)
         return template
 
 

--- a/packages/phoenix-client/src/phoenix/client/utils/template_formatters.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/template_formatters.py
@@ -123,7 +123,11 @@ class MustacheBaseTemplateFormatter(BaseTemplateFormatter):
         for variable_name in variable_names:
             pattern = rf"(?<!\\){{{{\s*{re.escape(variable_name)}\s*}}}}"
             replacement = variables[variable_name]
-            template = re.sub(pattern, lambda _: replacement, template)
+            template = re.sub(
+                pattern=pattern,
+                repl=lambda _: replacement,
+                string=template,
+            )
         return template
 
 

--- a/packages/phoenix-client/tests/utils/test_template_formatters.py
+++ b/packages/phoenix-client/tests/utils/test_template_formatters.py
@@ -1,0 +1,116 @@
+import pytest
+
+from phoenix.client.utils.template_formatters import (
+    FStringBaseTemplateFormatter,
+    MustacheBaseTemplateFormatter,
+    NoOpFormatterBase,
+)
+
+@pytest.mark.parametrize(
+    "formatter_cls, template, variables, expected_output",
+    [
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{ user_id }}",
+            {"user_id": "2025\l6300"},
+            "2025\l6300",
+            id="mustache-escaped-sequence",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{ hello }}",
+            {"hello": "world"},
+            "world",
+            id="mustache-whitespace-both-sides",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{hello}}",
+            {"hello": "world"},
+            "world",
+            id="mustache-no-whitespace",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{  hello}}",
+            {"hello": "world"},
+            "world",
+            id="mustache-whitespace-left",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{hello }}",
+            {"hello": "world"},
+            "world",
+            id="mustache-whitespace-right",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            r"\{{ hello }}",
+            {"hello": "world"},
+            r"\{{ hello }}",
+            id="mustache-escaped-sequence-is-not-replaced",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{ hello }}, {{ world }}",
+            {"hello": "1", "world": "2"},
+            "1, 2",
+            id="mustache-multiple-variables",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{ hello }} + {{hello}} = {{ world }}",
+            {"hello": "1", "world": "2"},
+            "1 + 1 = 2",
+            id="mustache-duplicate-variables",
+        ),
+        pytest.param(
+            MustacheBaseTemplateFormatter,
+            "{{ hello }}, {{ world }}",
+            {"hello": "world", "world": "hello"},
+            "world, hello",
+            id="mustache-value-is-variable-name",
+        ),
+        pytest.param(
+            FStringBaseTemplateFormatter,
+            "{hello}",
+            {"hello": "world"},
+            "world",
+            id="fstring-single-variable",
+        ),
+        pytest.param(
+            FStringBaseTemplateFormatter,
+            "{hello}, {world}",
+            {"hello": "1", "world": "2"},
+            "1, 2",
+            id="fstring-multiple-variables",
+        ),
+        pytest.param(
+            FStringBaseTemplateFormatter,
+            "{hello} + {hello} = {world}",
+            {"hello": "1", "world": "2"},
+            "1 + 1 = 2",
+            id="fstring-duplicate-variables",
+        ),
+        pytest.param(
+            FStringBaseTemplateFormatter,
+            "{hello}, {world}",
+            {"hello": "world", "world": "hello"},
+            "world, hello",
+            id="fstring-value-is-variable-name",
+        ),
+        pytest.param(
+            NoOpFormatterBase,
+            "Hello, world!",
+            {},
+            "Hello, world!",
+            id="noop-formatter-no-change",
+        ),
+    ]
+)
+def test_formatters_produce_expected_output(formatter_cls, template, variables, expected_output):
+    formatter = formatter_cls()
+    output = formatter.format(template, variables=variables)
+    assert output == expected_output
+

--- a/packages/phoenix-client/tests/utils/test_template_formatters.py
+++ b/packages/phoenix-client/tests/utils/test_template_formatters.py
@@ -6,8 +6,9 @@ from phoenix.client.utils.template_formatters import (
     FStringBaseTemplateFormatter,
     MustacheBaseTemplateFormatter,
     NoOpFormatterBase,
-    TemplateFormatter
+    TemplateFormatter,
 )
+
 
 @pytest.mark.parametrize(
     "formatter_cls, template, variables, expected_output",
@@ -110,7 +111,7 @@ from phoenix.client.utils.template_formatters import (
             "Hello, world!",
             id="noop-formatter-no-change",
         ),
-    ]
+    ],
 )
 def test_formatters_produce_expected_output(
     formatter_cls: type[TemplateFormatter],
@@ -121,4 +122,3 @@ def test_formatters_produce_expected_output(
     formatter = formatter_cls()
     output = formatter.format(template, variables=variables)
     assert output == expected_output
-

--- a/packages/phoenix-client/tests/utils/test_template_formatters.py
+++ b/packages/phoenix-client/tests/utils/test_template_formatters.py
@@ -1,9 +1,12 @@
+from typing import Any
+
 import pytest
 
 from phoenix.client.utils.template_formatters import (
     FStringBaseTemplateFormatter,
     MustacheBaseTemplateFormatter,
     NoOpFormatterBase,
+    TemplateFormatter
 )
 
 @pytest.mark.parametrize(
@@ -12,8 +15,8 @@ from phoenix.client.utils.template_formatters import (
         pytest.param(
             MustacheBaseTemplateFormatter,
             "{{ user_id }}",
-            {"user_id": "2025\l6300"},
-            "2025\l6300",
+            {"user_id": r"2025\l6300"},
+            r"2025\l6300",
             id="mustache-escaped-sequence",
         ),
         pytest.param(
@@ -109,7 +112,12 @@ from phoenix.client.utils.template_formatters import (
         ),
     ]
 )
-def test_formatters_produce_expected_output(formatter_cls, template, variables, expected_output):
+def test_formatters_produce_expected_output(
+    formatter_cls: type[TemplateFormatter],
+    template: str,
+    variables: dict[str, Any],
+    expected_output: str,
+) -> None:
     formatter = formatter_cls()
     output = formatter.format(template, variables=variables)
     assert output == expected_output


### PR DESCRIPTION
fixes #7405 

This pull request refactors the `_format` function in `template_formatters.py` to improve code readability and maintainability by simplifying the usage of the `re.sub` function.

Code readability and maintainability improvements:

* [`packages/phoenix-client/src/phoenix/client/utils/template_formatters.py`](diffhunk://#diff-a81d308fcb723dd36d645305ed1500d95a095570509fe95705faacbe0355d9e5L124-R126): Refactored the `_format` function by separating the regex pattern and replacement logic into distinct variables (`pattern` and `replacement`). Additionally, replaced the `repl` parameter with a lambda function to enhance clarity and flexibility.