### PR TITLE
fix: quick metadata filters for nested fields

### DIFF
--- a/app/src/pages/project/MetadataTooltip.tsx
+++ b/app/src/pages/project/MetadataTooltip.tsx
@@ -16,7 +16,13 @@ export const makeMetadataTooltipFilterCondition = (
    */
   value: string | number | boolean
 ) => {
-  return `metadata['${key}'] == ${toPythonPrimitiveStr(value)}`;
+  const pathSegments = key.split(".");
+  const bracketNotation = pathSegments
+    .map((segment) => {
+      return /^\d+$/.test(segment) ? `[${segment}]` : `['${segment}']`;
+    })
+    .join("");
+  return `metadata${bracketNotation} == ${toPythonPrimitiveStr(value)}`;
 };
 
 type MetadataTooltipProps = {


### PR DESCRIPTION
fixes #7345 

This pull request updates the `makeMetadataTooltipFilterCondition` function in `MetadataTooltip.tsx` to enhance its handling of nested keys in metadata. The change ensures that keys with dot notation are correctly converted to bracket notation for Python compatibility.

### Key Change:
* Updated the `makeMetadataTooltipFilterCondition` function to split keys by dots and convert them into bracket notation, enabling support for nested metadata keys. Numeric segments are wrapped in square brackets, while other segments are wrapped in single quotes.