### PR TITLE
feat: predefined query for extracting tool calls

### DIFF
--- a/tests/unit/trace/dsl/conftest.py
+++ b/tests/unit/trace/dsl/conftest.py
@@ -12,7 +12,9 @@ from phoenix.server.types import DbSessionFactory
 async def default_project(db: DbSessionFactory) -> None:
     async with db() as session:
         project_row_id = await session.scalar(
-            insert(models.Project).values(name=DEFAULT_PROJECT_NAME).returning(models.Project.id)
+            insert(models.Project)
+            .values(name=DEFAULT_PROJECT_NAME)
+            .returning(models.Project.id)
         )
         trace_rowid = await session.scalar(
             insert(models.Trace)
@@ -111,7 +113,11 @@ async def default_project(db: DbSessionFactory) -> None:
                 attributes={
                     "input": {"value": "xyz"},
                     "retrieval": {
-                        "documents": [{}, {}, {"document": {"content": "C", "score": 3}}],
+                        "documents": [
+                            {},
+                            {},
+                            {"document": {"content": "C", "score": 3}},
+                        ],
                     },
                 },
                 events=[],
@@ -140,6 +146,111 @@ async def default_project(db: DbSessionFactory) -> None:
                 cumulative_error_count=0,
                 cumulative_llm_token_count_prompt=0,
                 cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_rowid,
+                span_id="89101",
+                parent_id="2345",
+                name="llm span",
+                span_kind="LLM",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
+                attributes={
+                    "llm": {
+                        "input_messages": {
+                            "message": {"role": "user", "content": "what is 2 times 3"}
+                        },
+                        "output_messages": {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "function_call_name": "multiply",
+                                "function_call_arguments_json": '{\n  "a": 2,\n  "b": 3\n}',
+                            }
+                        },
+                        "function_call": {
+                            "arguments": '{\n  "a": 2,\n  "b": 3\n}',
+                            "name": "multiply",
+                        },
+                    },
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=10,
+                cumulative_llm_token_count_completion=5,
+            )
+            .returning(models.Span.id)
+        )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_rowid,
+                span_id="91011",
+                parent_id="2345",
+                name="llm span",
+                span_kind="LLM",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:05.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:20.000+00:00"),
+                attributes={
+                    "llm": {
+                        "input_messages": {
+                            "message": {"role": "user", "content": "what is 5 plus 7"}
+                        },
+                        "output_messages": {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "function_call_name": "add",
+                                "function_call_arguments_json": '{\n  "a": 5,\n  "b": 7\n}',
+                            }
+                        },
+                        "function_call": {
+                            "arguments": '{\n  "a": 5,\n  "b": 7\n}',
+                            "name": "add",
+                        },
+                    },
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=8,
+                cumulative_llm_token_count_completion=4,
+            )
+            .returning(models.Span.id)
+        )
+        await session.execute(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_rowid,
+                span_id="111213",
+                parent_id="2345",
+                name="llm span",
+                span_kind="LLM",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:25.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:35.000+00:00"),
+                attributes={
+                    "llm": {
+                        "input_messages": {
+                            "message": {"role": "user", "content": "abc"}
+                        },
+                        "output_messages": {
+                            "message": {"role": "assistant", "content": "xyz"}
+                        },
+                    }
+                },
+                events=[],
+                status_code="OK",
+                status_message="okay",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=6,
+                cumulative_llm_token_count_completion=15,
             )
             .returning(models.Span.id)
         )

--- a/tests/unit/trace/dsl/test_helpers.py
+++ b/tests/unit/trace/dsl/test_helpers.py
@@ -5,7 +5,11 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 
 from phoenix import Client
-from phoenix.trace.dsl.helpers import get_qa_with_reference, get_retrieved_documents
+from phoenix.trace.dsl.helpers import (
+    get_qa_with_reference,
+    get_retrieved_documents,
+    get_called_tools,
+)
 
 
 async def test_get_retrieved_documents(
@@ -44,7 +48,56 @@ async def test_get_qa_with_reference(
         }
     ).set_index("context.span_id")
     assert (actual := get_qa_with_reference(legacy_px_client)) is not None
-    actual["reference"] = actual["reference"].map(lambda s: "\n\n".join(sorted(s.split("\n\n"))))
+    actual["reference"] = actual["reference"].map(
+        lambda s: "\n\n".join(sorted(s.split("\n\n")))
+    )
+    assert_frame_equal(
+        actual.sort_index().sort_index(axis=1),
+        expected.sort_index().sort_index(axis=1),
+    )
+
+
+async def test_get_called_tools(
+    legacy_px_client: Client,
+    default_project: Any,
+    abc_project: Any,
+) -> None:
+    expected = pd.DataFrame(
+        {
+            "context.span_id": ["89101", "91011", "111213"],
+            "context.trace_id": ["0123", "0123", "0123"],
+            "question": [
+                {"message": {"role": "user", "content": "what is 2 times 3"}},
+                {"message": {"role": "user", "content": "what is 5 plus 7"}},
+                {"message": {"role": "user", "content": "abc"}},
+            ],
+            "response": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "function_call_name": "multiply",
+                        "function_call_arguments_json": '{\n  "a": 2,\n  "b": 3\n}',
+                    }
+                },
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "function_call_name": "add",
+                        "function_call_arguments_json": '{\n  "a": 5,\n  "b": 7\n}',
+                    }
+                },
+                {"message": {"role": "assistant", "content": "xyz"}},
+            ],
+            "tool_call": [
+                {"arguments": '{\n  "a": 2,\n  "b": 3\n}', "name": "multiply"},
+                {"arguments": '{\n  "a": 5,\n  "b": 7\n}', "name": "add"},
+                None,
+            ],
+        }
+    ).set_index("context.span_id")
+    actual = get_called_tools(legacy_px_client)
     assert_frame_equal(
         actual.sort_index().sort_index(axis=1),
         expected.sort_index().sort_index(axis=1),


### PR DESCRIPTION
Issue: Fixes https://github.com/Arize-ai/phoenix/issues/7158

Description: 
This PR introduces a predefined query `get_called_tools`  for querying LLM tool calls and their associated input/output messages from span data.

p.s: currently  testing that it works with top llm provider and framework auto-instrumentations as noted in the issue