### PR TITLE
feat: style keyboard tokens to look more like keys

### DIFF
--- a/app/src/components/KeyboardToken.tsx
+++ b/app/src/components/KeyboardToken.tsx
@@ -8,7 +8,13 @@ const keyboardTokenCSS = css`
   color: var(--ac-global-color-primary-700);
   padding: var(--ac-global-dimension-static-size-50)
     var(--ac-global-dimension-static-size-100);
+  font-size: var(--ac-global-dimension-static-font-size-50);
   border-radius: var(--ac-global-dimension-static-size-100);
+  border: 1px solid var(--ac-global-color-primary-700);
+  box-shadow: 0 2px 0 0 var(--ac-global-color-primary-200);
+  // Offset the shadow to make it look like it's on the key
+  margin-top: -1px;
+  text-transform: uppercase;
 `;
 
 /**

--- a/app/src/components/KeyboardToken.tsx
+++ b/app/src/components/KeyboardToken.tsx
@@ -10,7 +10,7 @@ const keyboardTokenCSS = css`
     var(--ac-global-dimension-static-size-100);
   font-size: var(--ac-global-dimension-static-font-size-50);
   border-radius: var(--ac-global-dimension-static-size-100);
-  border: 1px solid var(--ac-global-color-primary-700);
+  border: 1px solid var(--ac-global-color-primary-200);
   box-shadow: 0 2px 0 0 var(--ac-global-color-primary-200);
   // Offset the shadow to make it look like it's on the key
   margin-top: -1px;

--- a/app/stories/KeyboardToken.stories.tsx
+++ b/app/stories/KeyboardToken.stories.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { KeyboardToken } from "../src/components/KeyboardToken";
+
+/**
+ * KeyboardToken visually represents a keyboard key or shortcut, styled to look like a keyboard key.
+ * Useful for documentation, tooltips, or UI hints where you want to show keyboard commands.
+ *
+ * ## Usage
+ * ```tsx
+ * <KeyboardToken>⌘</KeyboardToken>
+ * <KeyboardToken>Ctrl</KeyboardToken>
+ * <KeyboardToken>Shift + Enter</KeyboardToken>
+ * ```
+ *
+ * ## Features
+ * - Styled with design tokens for consistency
+ * - Supports custom children (text or symbols)
+ * - Can be used inline with text
+ */
+const meta: Meta<typeof KeyboardToken> = {
+  title: "Content/KeyboardToken",
+  component: KeyboardToken,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A component for displaying keyboard keys or shortcuts in a visually distinct way.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      control: "text",
+      description: "The key or shortcut to display",
+      table: {
+        type: { summary: "ReactNode" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof KeyboardToken>;
+
+/**
+ * Default usage with a single key.
+ */
+export const Default: Story = {
+  args: {
+    children: "⌘",
+  },
+};
+
+/**
+ * Shows a common keyboard shortcut.
+ */
+export const Shortcut: Story = {
+  args: {
+    children: "Ctrl + S",
+  },
+};
+
+/**
+ * Shows a multi-key combination.
+ */
+export const MultiKey: Story = {
+  args: {
+    children: "Shift + Enter",
+  },
+};
+
+/**
+ * Shows the component inline with text.
+ */
+export const InlineWithText: Story = {
+  render: (args) => (
+    <span>
+      Press <KeyboardToken {...args} /> to save your work.
+    </span>
+  ),
+  args: {
+    children: "Ctrl + S",
+  },
+};


### PR DESCRIPTION
This styles keyboard hotkeys to look a bit more skeuomorphic like https://dribbble.com/shots/14161157-Shortcuts
<img width="2422" alt="Screenshot 2025-05-06 at 10 28 08 AM" src="https://github.com/user-attachments/assets/1acb5d66-4cbf-47ed-a919-27e0e909dce8" />


It also uppercases the character to be consistent with other hotkeys.