### PR TITLE
feat(ui): Group component with refactored pagination buttons

### DIFF
--- a/app/src/components/icon/Icons.tsx
+++ b/app/src/components/icon/Icons.tsx
@@ -126,6 +126,33 @@ export const ArrowIosDownwardOutline = () => (
   </svg>
 );
 
+export const ArrowUpwardOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="arrow-upward">
+        <rect
+          width="24"
+          height="24"
+          transform="rotate(180 12 12)"
+          opacity="0"
+        />
+        <path d="M5.23 10.64a1 1 0 0 0 1.41.13L11 7.14V19a1 1 0 0 0 2 0V7.14l4.36 3.63a1 1 0 1 0 1.28-1.54l-6-5-.15-.09-.13-.07a1 1 0 0 0-.72 0l-.13.07-.15.09-6 5a1 1 0 0 0-.13 1.41z" />
+      </g>
+    </g>
+  </svg>
+);
+
+export const ArrowDownwardOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="arrow-downward">
+        <rect width="24" height="24" opacity="0" />
+        <path d="M18.77 13.36a1 1 0 0 0-1.41-.13L13 16.86V5a1 1 0 0 0-2 0v11.86l-4.36-3.63a1 1 0 1 0-1.28 1.54l6 5 .15.09.13.07a1 1 0 0 0 .72 0l.13-.07.15-.09 6-5a1 1 0 0 0 .13-1.41z" />
+      </g>
+    </g>
+  </svg>
+);
+
 export const ArrowDownWithStem = () => (
   <svg
     width="20"

--- a/app/src/components/layout/Group.tsx
+++ b/app/src/components/layout/Group.tsx
@@ -1,0 +1,52 @@
+import React, { forwardRef } from "react";
+import {
+  Group as AriaGroup,
+  GroupProps as AriaGroupProps,
+} from "react-aria-components";
+import { css } from "@emotion/react";
+
+import { ComponentSize } from "@phoenix/components/types";
+import { SizeProvider } from "@phoenix/contexts";
+
+/**
+ * A forwardRef wrapper around react-aria-components Group.
+ *
+ * Usage:
+ * ```tsx
+ * <Group ref={myRef} ...props />
+ * ```
+ */
+
+const groupCSS = css`
+  display: flex;
+  align-items: center;
+  gap: 0;
+
+  & > button:not(:first-of-type):not(:last-of-type) {
+    border-radius: 0;
+    border-right: none;
+  }
+  & > button:first-of-type {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+  }
+  & > button:last-of-type {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`;
+
+type GroupProps = AriaGroupProps & {
+  size?: ComponentSize;
+};
+
+export const Group = forwardRef<HTMLDivElement, GroupProps>(
+  ({ size, ...props }, ref) => (
+    <SizeProvider size={size}>
+      <AriaGroup {...props} ref={ref} css={groupCSS} />
+    </SizeProvider>
+  )
+);
+
+Group.displayName = "Group";

--- a/app/src/components/layout/index.tsx
+++ b/app/src/components/layout/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Flex";
+export * from "./Group";

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { type Selection, Tooltip, TooltipTrigger } from "react-aria-components";
+import { Tooltip, TooltipTrigger } from "react-aria-components";
 import { useHotkeys } from "react-hotkeys-hook";
 import { css } from "@emotion/react";
 
 import {
+  Button,
   Flex,
+  Group,
   Icon,
   Icons,
   KeyboardToken,
-  ToggleButton,
-  ToggleButtonGroup,
   View,
 } from "@phoenix/components";
 import {
@@ -51,16 +51,6 @@ export const TraceDetailsPaginator = ({
   const hasPrevious = !!previousTraceId;
   const hasNext = !!nextTraceId;
 
-  const handleSelectionChange = (selection: Selection) => {
-    if (selection === "all") return;
-    const selectedKey = Array.from(selection)[0];
-    if (selectedKey === "next") {
-      next(currentId);
-    } else if (selectedKey === "previous") {
-      previous(currentId);
-    }
-  };
-
   return (
     <Flex
       gap="size-50"
@@ -72,19 +62,14 @@ export const TraceDetailsPaginator = ({
         }
       `}
     >
-      <ToggleButtonGroup
-        aria-label="Trace Paginator"
-        size="S"
-        selectionMode="single"
-        selectedKeys={[]}
-        onSelectionChange={handleSelectionChange}
-      >
+      <Group aria-label="Trace Paginator" size="S">
         <TooltipTrigger delay={100}>
-          <ToggleButton
+          <Button
             id="next"
-            leadingVisual={<Icon svg={<Icons.ArrowIosDownwardOutline />} />}
+            leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
             aria-label="Next trace"
             isDisabled={!hasNext}
+            onPress={() => next(currentId)}
           />
           <Tooltip>
             <View
@@ -102,11 +87,12 @@ export const TraceDetailsPaginator = ({
           </Tooltip>
         </TooltipTrigger>
         <TooltipTrigger delay={100}>
-          <ToggleButton
+          <Button
             id="previous"
-            leadingVisual={<Icon svg={<Icons.ArrowIosUpwardOutline />} />}
+            leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
             aria-label="Previous trace"
             isDisabled={!hasPrevious}
+            onPress={() => previous(currentId)}
           />
           <Tooltip>
             <View
@@ -123,7 +109,7 @@ export const TraceDetailsPaginator = ({
             </View>
           </Tooltip>
         </TooltipTrigger>
-      </ToggleButtonGroup>
+      </Group>
     </Flex>
   );
 };

--- a/app/stories/Group.stories.tsx
+++ b/app/stories/Group.stories.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "../src/components/button/Button";
+import { Group } from "../src/components/layout/Group";
+
+/**
+ * Group visually connects a set of buttons or controls, making them appear as a single component.
+ *
+ * ## Usage
+ * ```tsx
+ * <Group>
+ *   <Button>Left</Button>
+ *   <Button>Middle</Button>
+ *   <Button>Right</Button>
+ * </Group>
+ * ```
+ *
+ * The `size` prop can be used to control the sizing of the group and its children.
+ */
+const meta: Meta<typeof Group> = {
+  title: "Layout/Group",
+  component: Group,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["S", "M", "L"],
+      description: "Size of the group and its children",
+      table: {
+        type: { summary: "ComponentSize" },
+        defaultValue: { summary: "M" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Group>;
+
+export const Default: Story = {
+  args: {
+    size: "M",
+    children: (
+      <>
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A group of three buttons visually connected as a single component.",
+      },
+    },
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "S",
+    children: (
+      <>
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Small size group.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
Uses the `Group` component to display buttons as a group rather than using toggle button.
<img width="180" alt="Screenshot 2025-05-06 at 11 05 01 AM" src="https://github.com/user-attachments/assets/aed431e9-0ac2-41cc-909e-37ebf0997a27" />
