### PR TITLE
fix(annotations): Write to annotation explanation instead of label for freeform annotations

### DIFF
--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -79,6 +79,9 @@ const useAnnotationSummaryGroup = (span: AnnotationSummaryGroup$key) => {
     () =>
       spanAnnotations.reduce(
         (acc, annotation) => {
+          if (annotation.label == null && annotation.score == null) {
+            return acc;
+          }
           if (!acc[annotation.name]) {
             acc[annotation.name] = [annotation];
           } else {
@@ -147,7 +150,7 @@ export const AnnotationSummaryGroupTokens = ({
   return (
     <Flex direction="row" gap="size-50" wrap="wrap">
       {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name][0];
+        const latestAnnotation = annotationsByName[summary.name]?.[0];
         const meanScore = summary?.meanScore;
         if (!latestAnnotation) {
           return null;
@@ -199,12 +202,10 @@ export const AnnotationSummaryGroupStacks = ({
   if (sortedSummariesByName.length === 0 && renderEmptyState) {
     return renderEmptyState();
   }
-  // TODO: how do we want to render annotations that don't have a score?
-  // We can display a count per name, display nothing, display all labels of the annotation on hover, etc
   return (
     <Flex direction="row" gap="size-400">
       {sortedSummariesByName.map((summary) => {
-        const latestAnnotation = annotationsByName[summary.name][0];
+        const latestAnnotation = annotationsByName[summary.name]?.[0];
         if (!latestAnnotation) {
           return null;
         }

--- a/app/src/components/annotation/FreeformAnnotationInput.tsx
+++ b/app/src/components/annotation/FreeformAnnotationInput.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from "react";
 import { TextArea } from "react-aria-components";
 
 import { Flex, Text, TextField, TextFieldProps } from "@phoenix/components";
-import { AnnotationInputExplanation } from "@phoenix/components/annotation/AnnotationInputExplanation";
 import { AnnotationInputLabel } from "@phoenix/components/annotation/AnnotationInputLabel";
 
 import type {
@@ -16,41 +15,25 @@ type FreeformAnnotationInputProps =
 export const FreeformAnnotationInput = forwardRef<
   HTMLDivElement,
   FreeformAnnotationInputProps
->(
-  (
-    {
-      annotationConfig,
-      containerRef,
-      annotation,
-      onSubmitExplanation,
-      ...props
-    },
-    ref
-  ) => {
-    return (
-      <Flex gap="size-50" alignItems="center" position="relative">
-        <AnnotationInputExplanation
-          annotation={annotation}
-          onSubmit={onSubmitExplanation}
-          containerRef={containerRef}
-        />
-        <TextField
-          id={annotationConfig.id}
-          name={annotationConfig.name}
-          defaultValue={annotation?.label ?? undefined}
-          {...props}
-          ref={ref}
-          css={{
-            width: "100%",
-          }}
-        >
-          <AnnotationInputLabel>{annotationConfig.name}</AnnotationInputLabel>
-          <TextArea />
-          <Text slot="description">{annotationConfig.description}</Text>
-        </TextField>
-      </Flex>
-    );
-  }
-);
+>(({ annotationConfig, annotation, ...props }, ref) => {
+  return (
+    <Flex gap="size-50" alignItems="center" position="relative">
+      <TextField
+        id={annotationConfig.id}
+        name={annotationConfig.name}
+        defaultValue={annotation?.explanation ?? undefined}
+        {...props}
+        ref={ref}
+        css={{
+          width: "100%",
+        }}
+      >
+        <AnnotationInputLabel>{annotationConfig.name}</AnnotationInputLabel>
+        <TextArea />
+        <Text slot="description">{annotationConfig.description}</Text>
+      </TextField>
+    </Flex>
+  );
+});
 
 FreeformAnnotationInput.displayName = "FreeformAnnotationInput";

--- a/app/src/components/trace/SpanAnnotationInput.tsx
+++ b/app/src/components/trace/SpanAnnotationInput.tsx
@@ -127,25 +127,15 @@ export function SpanAnnotationInput(props: SpanAnnotationInputProps) {
             render={({ field: { value: _value, ...field } }) => (
               <FreeformAnnotationInput
                 annotationConfig={annotationConfig}
-                containerRef={containerRef ?? undefined}
                 annotation={annotation}
                 {...field}
-                onSubmitExplanation={(explanation) => {
-                  if (annotation?.id) {
-                    field.onChange({
-                      ...annotation,
-                      name: annotationConfig.name,
-                      explanation,
-                    });
-                  }
-                }}
-                value={_value?.label ?? ""}
+                value={_value?.explanation ?? ""}
                 onChange={(value) => {
                   field.onChange({
                     ...annotation,
                     id: annotation?.id,
                     name: annotationConfig.name,
-                    label: value,
+                    explanation: value,
                   });
                 }}
               />


### PR DESCRIPTION
<img width="1922" alt="image" src="https://github.com/user-attachments/assets/d65c4c1a-8e87-431f-b810-9dcaf96bcee5" />

One minor thing is that freeform annotations still appear in the top level project annotations summaries but they do not appear in the table rows

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/0ddf3590-7068-408d-9ede-2e29cd6785b8" />
