### PR TITLE
fix(security): fix for code scanning alert no. 42: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clean_up_caches.yml
+++ b/.github/workflows/clean_up_caches.yml
@@ -1,5 +1,7 @@
 #  https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 name: Clean Up Caches by a Branch
+permissions:
+  contents: read
 on:
   pull_request:
     types:

--- a/.github/workflows/collect-customer-issues.yaml
+++ b/.github/workflows/collect-customer-issues.yaml
@@ -1,4 +1,6 @@
 name: Collect customer issues
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/openapi-schema.yaml
+++ b/.github/workflows/openapi-schema.yaml
@@ -1,12 +1,14 @@
 name: OpenAPI Schema Backward Compatibility
+permissions:
+  contents: read
 
 on:
   push:
     paths:
-      - 'schemas/openapi.json'
+      - "schemas/openapi.json"
   pull_request:
     paths:
-      - 'schemas/openapi.json'
+      - "schemas/openapi.json"
 
 jobs:
   openapi-schema-backward-compatibility:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/python-cron.yml
+++ b/.github/workflows/python-cron.yml
@@ -1,4 +1,6 @@
 name: Python Cron
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -1,4 +1,6 @@
 name: Typescript CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -1,4 +1,6 @@
 name: Typescript Packages CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -1,4 +1,6 @@
 name: Typescript Packages Publish
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Arize-ai/phoenix/security/code-scanning/42](https://github.com/Arize-ai/phoenix/security/code-scanning/42)

To fix the issue, we will add a `permissions` block at the root of the workflow to apply minimal permissions to all jobs. Since the workflow primarily involves running tests and does not require write access, we will set `contents: read` as the default permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to read repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
