### PR TITLE
fix: Add pre requisite build to `/app` develop docs

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -16,7 +16,13 @@ NB: The `--frozen-lockfile` flag forces `pnpm` to install the exact versions spe
 
 To develop the UI, you must run the `app` in conjunction with the backend server. You can start the application in development mode via the following:
 
+**Important:** Before running the development server for the first time, you need to build the app:
+
+```shell
+pnpm run build
 ```
+
+```shell
 pnpm run dev
 ```
 


### PR DESCRIPTION
In order to run `/app` UI in development mode  you must fist run `pnpm run build` otherwise `pnpm run dev` will not serve the UI correctly. Given the unconventional nature of this flow it needs to be added to the docs.

This may be because static assets don't exist and or GraphQL queries are not compiled.

This is unconventional as normally react/node applications dev commands normally handles the compilation steps automatically.