### PR TITLE
fix: MCP tutorial extended timeout

### DIFF
--- a/tutorials/mcp/tracing_between_mcp_client_and_server/client.py
+++ b/tutorials/mcp/tracing_between_mcp_client_and_server/client.py
@@ -33,6 +33,7 @@ async def main():
             "command": "fastmcp",
             "args": ["run", "./tutorials/mcp/tracing_between_mcp_client_and_server/server.py"],
         },
+        client_session_timeout_seconds=30,
     ) as server:
         await run(server)
 


### PR DESCRIPTION
Most calls will exceed the default timeout of 5s therefore this PR extends it to 30s to avoid timeout errors.

@Jgilhuly 