### PR TITLE
fix: Stabilize label extraction

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -241,7 +241,7 @@ def llm_classify(
                 )
                 printif(
                     verbose and unrailed_label == NOT_PARSABLE,
-                    f"- Could not parse {repr(response)}",
+                    f"- Could not parse {repr(response)} while extracting label and explanation",
                 )
             else:
                 unrailed_label = response

--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -437,7 +437,7 @@ def _extract_label_and_explanation(
             )
             printif(
                 verbose and unrailed_label == NOT_PARSABLE,
-                f"- Could not parse {repr(unparsed_output)}",
+                f"- Could not parse {repr(unparsed_output)} while extracting label and explanation",
             )
         else:
             unrailed_label = unparsed_output

--- a/packages/phoenix-evals/src/phoenix/evals/templates.py
+++ b/packages/phoenix-evals/src/phoenix/evals/templates.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Unio
 import pandas as pd
 
 from phoenix.evals.exceptions import PhoenixException
-from phoenix.evals.utils import NOT_PARSABLE
 
 DEFAULT_START_DELIM = "{"
 DEFAULT_END_DELIM = "}"
@@ -192,7 +191,7 @@ def parse_label_from_chain_of_thought_response(raw_string: str) -> str:
     parts = re.split(label_delimiter, raw_string, maxsplit=1, flags=re.IGNORECASE)
     if len(parts) == 2:
         return parts[1]
-    return NOT_PARSABLE
+    return raw_string  # Fallback to the whole string if no label delimiter is found
 
 
 def normalize_classification_template(

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -1490,7 +1490,7 @@ def test_run_evals_produces_expected_output_when_llm_outputs_unexpected_data(
     assert_frame_equal(
         pd.DataFrame(
             {
-                "label": ["NOT_PARSABLE", "NOT_PARSABLE", "unrelated"],
+                "label": ["relevant", "NOT_PARSABLE", "unrelated"],
                 "score": [0.0, 0.0, 0.0],
                 "explanation": [
                     "relevant-explanation\nrelevant",

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -1491,7 +1491,7 @@ def test_run_evals_produces_expected_output_when_llm_outputs_unexpected_data(
         pd.DataFrame(
             {
                 "label": ["relevant", "NOT_PARSABLE", "unrelated"],
-                "score": [0.0, 0.0, 0.0],
+                "score": [1.0, 0.0, 0.0],
                 "explanation": [
                     "relevant-explanation\nrelevant",
                     "some-explanation\nLABEL: unparseable-label",


### PR DESCRIPTION
When setting `provide_explanation=True` in `llm_classify`, failing to provide a compatible label extraction function will sometimes lead to unexpected `NOT_PARSABLE` labels when trying to pull out the label from the LLM output.

This falls back to attempting to snap the entire LLM output to rails in case the default parsing function cannot split the label from the explanation (our internal convention is to delimit using `label:`