### PR TITLE
fix: content wrap in markdown block

### DIFF
--- a/app/src/components/markdown/styles.ts
+++ b/app/src/components/markdown/styles.ts
@@ -14,4 +14,7 @@ export const markdownCSS = css`
   p:last-child {
     margin-bottom: 0;
   }
+  code {
+    text-wrap: wrap;
+  }
 `;


### PR DESCRIPTION
fixes #7474 

This pull request introduces a small update to the `markdownCSS` styles in `app/src/components/markdown/styles.ts`. The change ensures that inline `code` elements will now wrap text appropriately.

* [`app/src/components/markdown/styles.ts`](diffhunk://#diff-26a9167d5917a9cfd3c5d54b7980b02d8164c5c3be5d3c036a781b6c5f40bec7R17-R19): Added a `text-wrap: wrap;` rule to the `code` selector within the `markdownCSS` styles.

![content-wrap](https://github.com/user-attachments/assets/b330e717-6787-41ea-9aad-1c6d9935577b)
