### PR TITLE
feat: Persistent custom time range

### DIFF
--- a/app/src/components/datetime/TimeRangeContext.tsx
+++ b/app/src/components/datetime/TimeRangeContext.tsx
@@ -53,17 +53,13 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [timeRange, _setTimeRange] = useState<OpenTimeRangeWithKey>(() => {
     // Handle different kinds of stored time range keys with fallback
     if (storedCustomTimeRange) {
-      try {
-        // Parse the stored custom range
-        const { start, end } = storedCustomTimeRange;
-        return {
-          timeRangeKey: "custom",
-          start: start ? new Date(start) : undefined,
-          end: end ? new Date(end) : undefined,
-        };
-      } catch (e) {
-        console.error("Failed to parse custom time range", e);
-      }
+      // Parse the stored custom range
+      const { start, end } = storedCustomTimeRange;
+      return {
+        timeRangeKey: "custom",
+        start: start ? new Date(start) : undefined,
+        end: end ? new Date(end) : undefined,
+      };
     } else if (isLastNTimeRangeKey(storedLastNTimeRangeKey)) {
       return {
         timeRangeKey: storedLastNTimeRangeKey,

--- a/app/src/store/preferencesStore.tsx
+++ b/app/src/store/preferencesStore.tsx
@@ -27,6 +27,10 @@ export interface PreferencesProps {
    */
   lastNTimeRangeKey: LastNTimeRangeKey;
   /**
+   * The custom time range to load data for
+   */
+  customTimeRange: OpenTimeRange | null;
+  /**
    * Whether or not to automatically refresh projects
    * @default true
    */
@@ -66,6 +70,10 @@ export interface PreferencesState extends PreferencesProps {
    * Setter for the last N time range to load data for
    */
   setLastNTimeRangeKey: (lastNTimeRangeKey: LastNTimeRangeKey) => void;
+  /**
+   * Setter for the custom time range
+   */
+  setCustomTimeRange: (customTimeRange: OpenTimeRange | null) => void;
   /**
    * Setter for enabling/disabling project auto refresh
    * @param projectsAutoRefreshEnabled
@@ -111,6 +119,10 @@ export const createPreferencesStore = (
     lastNTimeRangeKey: "7d",
     setLastNTimeRangeKey: (lastNTimeRangeKey) => {
       set({ lastNTimeRangeKey });
+    },
+    customTimeRange: null,
+    setCustomTimeRange: (customTimeRange) => {
+      set({ customTimeRange });
     },
     projectsAutoRefreshEnabled: true,
     setProjectAutoRefreshEnabled: (projectsAutoRefreshEnabled) => {


### PR DESCRIPTION
#7520 
Custom time range is cached so that on page update the custom time range configuration will persist.

Currently the range dates do not persist if you cange the time range setting, resetting it.
(For example: if you set `custom` time range from X to Y -> switch to `7d` -> switch back to `custom` then it will not return to X to Y)
Created #7529 to track that.