### PR TITLE
chore(ci): run Playwright tests on changes to src/ or app/ directories

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -5,8 +5,14 @@ permissions:
 on:
   push:
     branches: [main, feat/annotations]
+    paths:
+      - "src/**"
+      - "app/**"
   pull_request:
     branches: [main, feat/annotations]
+    paths:
+      - "src/**"
+      - "app/**"
 jobs:
   e2e-test:
     timeout-minutes: 60


### PR DESCRIPTION
fixes #7601 

This pull request updates the `.github/workflows/playwright.yaml` file to refine the triggers for the workflow. Specifically, it adds path filters to ensure the workflow only runs when changes are made to specific directories.

Workflow trigger updates:

* [`.github/workflows/playwright.yaml`](diffhunk://#diff-b710b539e104e4351f3e7598f94f434b8c7aaafdba88e57b3280582c718f7b4bR8-R15): Added `paths` filters under both `push` and `pull_request` triggers to limit the workflow execution to changes within the `src/` and `app/` directories.