### PR TITLE
fix: Pad message content lists in span details

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1765,6 +1765,7 @@ function MessageContentsList({
  */
 const messageContentTextListItemCSS = css`
   flex: 1 1 100%;
+  padding: var(--ac-global-dimension-static-size-200);
 `;
 /**
  * Displays multi-modal message content. Typically an image or text.


### PR DESCRIPTION
## Before

![image (5)](https://github.com/user-attachments/assets/ec18a3ba-05ab-4b08-b0da-6684aaaffa24)

## After


![image (6)](https://github.com/user-attachments/assets/d225c067-3152-4382-9b92-570ac9cab9d1)
