### PR TITLE
fix: ignore e402 and pre-commit uses ruff.toml config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff-format
       - id: ruff
-        args: [ --fix ]
+        args: [ --fix, --config, ruff.toml]
   - repo: local
     hooks:
       - id: clean-notebooks

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[per-file-ignores]
+"tutorials/**/*.py" = ["E402"]


### PR DESCRIPTION
Tutorial files like in the case of the #7636  the instrumentation wrappers need to be executed before corresponding modules are imported. In cases like these the ruff formatting rules like e402 prohibit this import flow.

I have created a `ruff.toml` file that ignores e402 for `tutorial/` files  and updated `.pre-commit.config.yaml` to use that config.