### PR TITLE
fix: Mcp tutorial instrumentation and server file path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: ruff-format
       - id: ruff
-        args: [ --fix ]
+        args: [ --fix, --config, ruff.toml]
   - repo: local
     hooks:
       - id: clean-notebooks

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[per-file-ignores]
+"tutorials/**/*.py" = ["E402"]

--- a/tutorials/mcp/tracing_between_mcp_client_and_server/client.py
+++ b/tutorials/mcp/tracing_between_mcp_client_and_server/client.py
@@ -1,24 +1,40 @@
 import asyncio
 
-from agents import Agent, Runner
-from agents.mcp import MCPServer, MCPServerStdio
 from dotenv import load_dotenv
+
+# 1. Load environment variables
+load_dotenv()
 
 from phoenix.otel import register
 
-load_dotenv()
+# Connect to your Arize instance
+tracer_provider = register(project_name="test_mcp_project")
 
-tracer_provider = register(auto_instrument=True, endpoint="http://localhost:6006/v1/traces")
+# 2. Set up instrumentation BEFORE any imports that use MCP
+from openinference.instrumentation.mcp import MCPInstrumentor
+from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+# Apply instrumentation before any MCP imports
+MCPInstrumentor().instrument(tracer_provider=tracer_provider)
+OpenAIAgentsInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# 3. Only NOW import modules that use MCP
+from agents import Agent, Runner
+from agents.mcp import MCPServer, MCPServerStdio
 
 
 async def run(mcp_server: MCPServer):
     agent = Agent(
-        name="Assistant",
         instructions="Use the tools to answer the users question.",
+        name="Assistant",
         mcp_servers=[mcp_server],
     )
     while True:
-        message = input("\n\nEnter your question (or 'exit' to quit): ")
+        message = input(
+            "\n\nEnter your question (or 'exit' to quit or blank for default): "
+        )
+        if not message:
+            message = "What is the effect of tariffs on canada"
         if message.lower() == "exit" or message.lower() == "q":
             break
         print(f"\n\nRunning: {message}")
@@ -31,7 +47,7 @@ async def main():
         name="Financial Analysis Server",
         params={
             "command": "fastmcp",
-            "args": ["run", "./tutorials/mcp/tracing_between_mcp_client_and_server/server.py"],
+            "args": ["run", "./server.py"],
         },
         client_session_timeout_seconds=30,
     ) as server:


### PR DESCRIPTION
The current tutorial was not reproducible for due to incorrect server path and more notably the instrumentation flow. The instrumentation flow depends on the instrumentation hooks to be registered before the corresponding modules are imported.

(Also made the instrumentation more explicit, instead of `auto_instrument`, which is more reproducible)

Because of the unconventional import flow this depends on #7634 to pass CI checks

To ensure context propagation works as intended I have also PRed this fix to the existing MCP instrumentation https://github.com/Arize-ai/openinference/pull/1644
