### PR TITLE
feat: Add URL logging for experiments in TypeScript client

### DIFF
--- a/js/.changeset/chatty-memes-look.md
+++ b/js/.changeset/chatty-memes-look.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+feat(phoenix-client): Log the experiement/dataset link when calling runExperiment

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -32,6 +32,11 @@ import {
 import { ensureString } from "../utils/ensureString";
 import type { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { objectAsAttributes } from "../utils/objectAsAttributes";
+import {
+  getDatasetUrl,
+  getDatasetExperimentsUrl,
+  getExperimentUrl,
+} from "../utils/urls";
 
 /**
  * Parameters for running an experiment.
@@ -197,6 +202,26 @@ export async function runExperiment({
     );
   }
 
+  if (!isDryRun && client.config.baseUrl) {
+    const datasetUrl = getDatasetUrl({
+      baseUrl: client.config.baseUrl,
+      datasetId: dataset.id,
+    });
+    const datasetExperimentsUrl = getDatasetExperimentsUrl({
+      baseUrl: client.config.baseUrl,
+      datasetId: dataset.id,
+    });
+    const experimentUrl = getExperimentUrl({
+      baseUrl: client.config.baseUrl,
+      datasetId: dataset.id,
+      experimentId: experiment.id,
+    });
+    
+    logger.info(`📊 View dataset: ${datasetUrl}`);
+    logger.info(`📺 View dataset experiments: ${datasetExperimentsUrl}`);
+    logger.info(`🔗 View this experiment: ${experimentUrl}`);
+  }
+
   logger.info(
     `🧪 Starting experiment "${experimentName || `<unnamed>`}" on dataset "${dataset.id}" with task "${task.name}" and ${evaluators?.length ?? 0} ${pluralize(
       "evaluator",
@@ -242,6 +267,15 @@ export async function runExperiment({
   ranExperiment.evaluationRuns = evaluationRuns;
 
   logger.info(`✅ Experiment ${experiment.id} completed`);
+  
+  if (!isDryRun && client.config.baseUrl) {
+    const experimentUrl = getExperimentUrl({
+      baseUrl: client.config.baseUrl,
+      datasetId: dataset.id,
+      experimentId: experiment.id,
+    });
+    logger.info(`🔍 View results: ${experimentUrl}`);
+  }
 
   return ranExperiment;
 }
@@ -444,6 +478,15 @@ export async function evaluateExperiment({
       evaluators?.length ?? 0
     )}`
   );
+
+  if (!isDryRun && client.config.baseUrl) {
+    const experimentUrl = getExperimentUrl({
+      baseUrl: client.config.baseUrl,
+      datasetId: experiment.datasetId,
+      experimentId: experiment.id,
+    });
+    logger.info(`🔗 View experiment evaluation: ${experimentUrl}`);
+  }
   type EvaluationId = string;
   const evaluationRuns: Record<EvaluationId, ExperimentEvaluationRun> = {};
 

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -36,7 +36,7 @@ import {
   getDatasetUrl,
   getDatasetExperimentsUrl,
   getExperimentUrl,
-} from "../utils/urls";
+} from "../utils/urlUtils";
 
 /**
  * Parameters for running an experiment.

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -216,7 +216,7 @@ export async function runExperiment({
       datasetId: dataset.id,
       experimentId: experiment.id,
     });
-    
+
     logger.info(`📊 View dataset: ${datasetUrl}`);
     logger.info(`📺 View dataset experiments: ${datasetExperimentsUrl}`);
     logger.info(`🔗 View this experiment: ${experimentUrl}`);
@@ -267,7 +267,7 @@ export async function runExperiment({
   ranExperiment.evaluationRuns = evaluationRuns;
 
   logger.info(`✅ Experiment ${experiment.id} completed`);
-  
+
   if (!isDryRun && client.config.baseUrl) {
     const experimentUrl = getExperimentUrl({
       baseUrl: client.config.baseUrl,

--- a/js/packages/phoenix-client/src/utils/urlUtils.ts
+++ b/js/packages/phoenix-client/src/utils/urlUtils.ts
@@ -7,8 +7,8 @@
  * @param baseUrl The base URL of the Phoenix API
  * @returns The base URL for the Phoenix web UI
  */
-export function getWebBaseUrl(baseUrl: string): string {
-  return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+function getWebBaseUrl(baseUrl: string): string {
+  return new URL(baseUrl).toString();
 }
 
 /**

--- a/js/packages/phoenix-client/src/utils/urls.ts
+++ b/js/packages/phoenix-client/src/utils/urls.ts
@@ -1,4 +1,4 @@
- /**
+/**
  * Utility functions for constructing URLs to Phoenix resources
  */
 
@@ -8,56 +8,56 @@
  * @returns The base URL for the Phoenix web UI
  */
 export function getWebBaseUrl(baseUrl: string): string {
-    return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-  }
-  
-  /**
-   * Get the URL to view a specific experiment in the Phoenix web UI
-   * @param baseUrl The base URL of the Phoenix API
-   * @param datasetId The ID of the dataset
-   * @param experimentId The ID of the experiment
-   * @returns The URL to view the experiment
-   */
-  export function getExperimentUrl({
-    baseUrl,
-    datasetId,
-    experimentId,
-  }: {
-    baseUrl: string;
-    datasetId: string;
-    experimentId: string;
-  }): string {
-    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/compare?experimentId=${experimentId}`;
-  }
-  
-  /**
-   * Get the URL to view experiments for a dataset in the Phoenix web UI
-   * @param baseUrl The base URL of the Phoenix API
-   * @param datasetId The ID of the dataset
-   * @returns The URL to view dataset experiments
-   */
-  export function getDatasetExperimentsUrl({
-    baseUrl,
-    datasetId,
-  }: {
-    baseUrl: string;
-    datasetId: string;
-  }): string {
-    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/experiments`;
-  }
-  
-  /**
-   * Get the URL to view a dataset in the Phoenix web UI
-   * @param baseUrl The base URL of the Phoenix API
-   * @param datasetId The ID of the dataset
-   * @returns The URL to view the dataset
-   */
-  export function getDatasetUrl({
-    baseUrl,
-    datasetId,
-  }: {
-    baseUrl: string;
-    datasetId: string;
-  }): string {
-    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/examples`;
-  } 
+  return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+}
+
+/**
+ * Get the URL to view a specific experiment in the Phoenix web UI
+ * @param baseUrl The base URL of the Phoenix API
+ * @param datasetId The ID of the dataset
+ * @param experimentId The ID of the experiment
+ * @returns The URL to view the experiment
+ */
+export function getExperimentUrl({
+  baseUrl,
+  datasetId,
+  experimentId,
+}: {
+  baseUrl: string;
+  datasetId: string;
+  experimentId: string;
+}): string {
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/compare?experimentId=${experimentId}`;
+}
+
+/**
+ * Get the URL to view experiments for a dataset in the Phoenix web UI
+ * @param baseUrl The base URL of the Phoenix API
+ * @param datasetId The ID of the dataset
+ * @returns The URL to view dataset experiments
+ */
+export function getDatasetExperimentsUrl({
+  baseUrl,
+  datasetId,
+}: {
+  baseUrl: string;
+  datasetId: string;
+}): string {
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/experiments`;
+}
+
+/**
+ * Get the URL to view a dataset in the Phoenix web UI
+ * @param baseUrl The base URL of the Phoenix API
+ * @param datasetId The ID of the dataset
+ * @returns The URL to view the dataset
+ */
+export function getDatasetUrl({
+  baseUrl,
+  datasetId,
+}: {
+  baseUrl: string;
+  datasetId: string;
+}): string {
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/examples`;
+}

--- a/js/packages/phoenix-client/src/utils/urls.ts
+++ b/js/packages/phoenix-client/src/utils/urls.ts
@@ -1,0 +1,63 @@
+ /**
+ * Utility functions for constructing URLs to Phoenix resources
+ */
+
+/**
+ * Get the base URL for Phoenix web UI
+ * @param baseUrl The base URL of the Phoenix API
+ * @returns The base URL for the Phoenix web UI
+ */
+export function getWebBaseUrl(baseUrl: string): string {
+    return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+  }
+  
+  /**
+   * Get the URL to view a specific experiment in the Phoenix web UI
+   * @param baseUrl The base URL of the Phoenix API
+   * @param datasetId The ID of the dataset
+   * @param experimentId The ID of the experiment
+   * @returns The URL to view the experiment
+   */
+  export function getExperimentUrl({
+    baseUrl,
+    datasetId,
+    experimentId,
+  }: {
+    baseUrl: string;
+    datasetId: string;
+    experimentId: string;
+  }): string {
+    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/compare?experimentId=${experimentId}`;
+  }
+  
+  /**
+   * Get the URL to view experiments for a dataset in the Phoenix web UI
+   * @param baseUrl The base URL of the Phoenix API
+   * @param datasetId The ID of the dataset
+   * @returns The URL to view dataset experiments
+   */
+  export function getDatasetExperimentsUrl({
+    baseUrl,
+    datasetId,
+  }: {
+    baseUrl: string;
+    datasetId: string;
+  }): string {
+    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/experiments`;
+  }
+  
+  /**
+   * Get the URL to view a dataset in the Phoenix web UI
+   * @param baseUrl The base URL of the Phoenix API
+   * @param datasetId The ID of the dataset
+   * @returns The URL to view the dataset
+   */
+  export function getDatasetUrl({
+    baseUrl,
+    datasetId,
+  }: {
+    baseUrl: string;
+    datasetId: string;
+  }): string {
+    return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/examples`;
+  } 


### PR DESCRIPTION
similar to python client, log the link back to Phoenix UI on the created Dataset/Experiment #7629

test outputs(tested locally):
```
npx tsx js/packages/phoenix-client/examples/evaluate_experiment.ts
📊 View dataset: http://localhost:6006/datasets/RGF0YXNldDoxNQ==/examples
📺 View dataset experiments: http://localhost:6006/datasets/RGF0YXNldDoxNQ==/experiments
🔗 View this experiment: http://localhost:6006/datasets/RGF0YXNldDoxNQ==/compare?experimentId=RXhwZXJpbWVudDoxNg==
```