### PR TITLE
fix: Bump minimum version for phoenix-otel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "cachetools",
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=0.20.6",
-  "arize-phoenix-otel>=0.9.2",
+  "arize-phoenix-otel>=0.10.1",
   "fastapi",
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",


### PR DESCRIPTION
Bumps the minimum version past a buggy release of `phoenix.otel`