### PR TITLE
Bugfix no local storage should skip creating dirs

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1177,7 +1177,7 @@ def ensure_working_dir_if_needed() -> None:
     This is bypassed if a postgres database is configured and a working directory is not set.
     """
     if _no_local_storage():
-        pass
+        return
 
     logger.info(f"📋 Ensuring phoenix working directory: {WORKING_DIR}")
     try:


### PR DESCRIPTION
## Title
fix(config): return early when local storage is disabled to skip working-dir creation

## Issue
I haven't created one, but I can if you want!

## Description
Short summary – Prevents ensure_working_dir_if_needed() from attempting to create /.phoenix when Phoenix is configured for external Postgres and no PHOENIX_WORKING_DIR is defined.

## Details & rationale
When only Postgres env-vars are present (`PHOENIX_POSTGRES_*`) and `PHOENIX_WORKING_DIR` is not set, helper `_no_local_storage()` correctly evaluates to `True`, but the function previously executed a bare `pass`, allowing the subsequent code path to continue and call `ath.mkdir(...)`, which raises `PermissionError: [Errno 13] Permission denied: '/.phoenix'.`

Swapping pass for an explicit return exits early, honoring the intent of the guard clause and keeping deployments stateless when a remote RDS postgres is configured.

```
 if _no_local_storage():
-    pass
+    return
```

## Test coverage
Added `tests/unit/test_config.py::test_ensure_working_dir_if_needed_skips_when_no_local_storage` to assert that `path.mkdir` is not invoked whenever `_no_local_storage()` is `True`.

## Impact / backwards-compatibility
No behavioral change for deployments that use local storage. The only difference is the removal of an erroneous side effect; no API surface or config keys are affected.

## Known limitations
n/a

## Root Cause Analysis
Today we tried deploying phoenix to our Kubernetes cluster. We've got it setup to use a Postgres RDS instance, and when the pod came up, it failed to start. The stack trace was:

```
PermissionError: [Errno 13] Permission denied: '/.phoenix'
os.mkdir(self, mode)
File ""/usr/lib/python3.11/pathlib.py"", line 1117, in mkdir
^^^^^^^^^^^^^^^^^^^^^
result = attr(*args, **kwargs)
File ""/phoenix/env/phoenix/config.py"", line 729, in wrapped_attr
path.mkdir(parents=True, exist_ok=True)
File ""/phoenix/env/phoenix/config.py"", line 803, in ensure_working_dir_if_needed
ensure_working_dir_if_needed()
File ""/phoenix/env/phoenix/config.py"", line 814, in <module>
from phoenix.config import INFERENCES_DIR
File ""/phoenix/env/phoenix/inferences/fixtures.py"", line 13, in <module>
from .inferences.fixtures import ExampleInferences, load_example
File ""/phoenix/env/phoenix/__init__.py"", line 7, in <module>
File ""<frozen runpy>"", line 112, in _get_module_details
File ""<frozen runpy>"", line 189, in _run_module_as_main
Traceback (most recent call last):
💥 Failed to initialize the working directory at /.phoenix due to an error: [Errno 13] Permission denied: '/.phoenix'.Phoenix requires a working directory to persist data
```

We have these envvars set:

```
PHOENIX_POSTGRES_USER
PHOENIX_POSTGRES_PASSWORD
PHOENIX_POSTGRES_HOST
PHOENIX_POSTGRES_PORT
PHOENIX_POSTGRES_DB
```
and we do NOT have this set:

```
PHOENIX_WORKING_DIR
```