### PR TITLE
fix: Do not return notes from GET /span_annotations

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2338,11 +2338,6 @@ export interface operations {
                 span_ids: string[];
                 /** @description Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list. */
                 include_annotation_names?: string[] | null;
-                /**
-                 * @deprecated
-                 * @description [DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.
-                 */
-                annotation_names?: string[] | null;
                 /** @description Optional list of annotation names to exclude from results. */
                 exclude_annotation_names?: string[] | null;
                 /** @description A cursor for pagination */

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2336,6 +2336,10 @@ export interface operations {
             query: {
                 /** @description One or more span id to fetch annotations for */
                 span_ids: string[];
+                /** @description Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list. */
+                annotation_names?: string[] | null;
+                /** @description Optional list of annotation names to exclude from results. */
+                exclude_annotation_names?: string[] | null;
                 /** @description A cursor for pagination */
                 cursor?: string | null;
                 /** @description The maximum number of annotations to return in a single request */

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2337,6 +2337,11 @@ export interface operations {
                 /** @description One or more span id to fetch annotations for */
                 span_ids: string[];
                 /** @description Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list. */
+                include_annotation_names?: string[] | null;
+                /**
+                 * @deprecated
+                 * @description [DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.
+                 */
                 annotation_names?: string[] | null;
                 /** @description Optional list of annotation names to exclude from results. */
                 exclude_annotation_names?: string[] | null;

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -140,8 +140,8 @@ class Spans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str = "default",
-        annotation_names: Optional[Iterable[str]] = None,
-        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
+        annotation_names: Optional[Sequence[str]] = None,
+        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -243,8 +243,8 @@ class Spans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[Iterable[str]] = None,
-        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
+        annotation_names: Optional[Sequence[str]] = None,
+        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -428,8 +428,8 @@ class AsyncSpans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str,
-        annotation_names: Optional[Iterable[str]] = None,
-        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
+        annotation_names: Optional[Sequence[str]] = None,
+        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -530,8 +530,8 @@ class AsyncSpans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[Iterable[str]] = None,
-        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
+        annotation_names: Optional[Sequence[str]] = None,
+        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -155,8 +155,8 @@ class Spans:
                 `context.span_id` or `span_id` column.
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only
-                annotations with these names will be returned.
+            include_annotation_names: Optional list of annotation names to include. If provided,
+                only annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
                 Defaults to ["note"] to exclude note annotations, which are reserved for notes
                 added via the UI.
@@ -257,8 +257,8 @@ class Spans:
         Args:
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only
-                annotations with these names will be returned.
+            include_annotation_names: Optional list of annotation names to include. If provided,
+                only annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
                 Defaults to ["note"] to exclude note annotations, which are reserved for notes
                 added via the UI.
@@ -449,8 +449,8 @@ class AsyncSpans:
                 `context.span_id` or `span_id` column.
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only
-                annotations with these names will be returned.
+            include_annotation_names: Optional list of annotation names to include. If provided,
+                only annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
                 Defaults to ["note"] to exclude note annotations, which are reserved for notes
                 added via the UI.
@@ -550,8 +550,8 @@ class AsyncSpans:
         Args:
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only
-                annotations with these names will be returned.
+            include_annotation_names: Optional list of annotation names to include. If provided,
+                only annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
                 Defaults to ["note"] to exclude note annotations, which are reserved for notes
                 added via the UI.

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -140,8 +140,8 @@ class Spans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str = "default",
-        annotation_names: Optional[list[str]] = None,
-        exclude_annotation_names: Optional[list[str]] = None,
+        annotation_names: Optional[Iterable[str]] = None,
+        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -155,11 +155,11 @@ class Spans:
                 `context.span_id` or `span_id` column.
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only 
-                annotations with these names will be returned. "note" annotations are excluded 
-                by default unless explicitly included in this list.
+            annotation_names: Optional list of annotation names to include. If provided, only
+                annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
-                "note" annotations are always excluded unless explicitly included in annotation_names.
+                Defaults to ["note"] to exclude note annotations, which are reserved for notes
+                added via the UI.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -198,11 +198,6 @@ class Spans:
         if not span_ids_list:
             return pd.DataFrame()
 
-        effective_exclude_names = (exclude_annotation_names or []).copy()
-        if annotation_names is None or "note" not in annotation_names:
-            if "note" not in effective_exclude_names:
-                effective_exclude_names.append("note")
-
         annotations: list[v1.SpanAnnotation] = []
         path = f"v1/projects/{project_identifier}/span_annotations"
 
@@ -215,7 +210,7 @@ class Spans:
                     "limit": limit,
                 }
                 if annotation_names is not None:
-                    params["annotation_names"] = annotation_names
+                    params["include_annotation_names"] = annotation_names
                 if effective_exclude_names:
                     params["exclude_annotation_names"] = effective_exclude_names
                 if cursor:
@@ -248,8 +243,8 @@ class Spans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[list[str]] = None,
-        exclude_annotation_names: Optional[list[str]] = None,
+        annotation_names: Optional[Iterable[str]] = None,
+        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -259,11 +254,11 @@ class Spans:
         Args:
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only 
-                annotations with these names will be returned. "note" annotations are excluded 
-                by default unless explicitly included in this list.
+            annotation_names: Optional list of annotation names to include. If provided, only
+                annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
-                "note" annotations are always excluded unless explicitly included in annotation_names.
+                Defaults to ["note"] to exclude note annotations, which are reserved for notes
+                added via the UI.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -278,11 +273,6 @@ class Spans:
         if not span_ids_list:
             return []
 
-        effective_exclude_names = (exclude_annotation_names or []).copy()
-        if annotation_names is None or "note" not in annotation_names:
-            if "note" not in effective_exclude_names:
-                effective_exclude_names.append("note")
-
         annotations: list[v1.SpanAnnotation] = []
         path = f"v1/projects/{project_identifier}/span_annotations"
 
@@ -295,7 +285,7 @@ class Spans:
                     "limit": limit,
                 }
                 if annotation_names is not None:
-                    params["annotation_names"] = annotation_names
+                    params["include_annotation_names"] = annotation_names
                 if effective_exclude_names:
                     params["exclude_annotation_names"] = effective_exclude_names
                 if cursor:
@@ -437,8 +427,8 @@ class AsyncSpans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str,
-        annotation_names: Optional[list[str]] = None,
-        exclude_annotation_names: Optional[list[str]] = None,
+        annotation_names: Optional[Iterable[str]] = None,
+        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -452,11 +442,11 @@ class AsyncSpans:
                 `context.span_id` or `span_id` column.
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only 
-                annotations with these names will be returned. "note" annotations are excluded 
-                by default unless explicitly included in this list.
+            annotation_names: Optional list of annotation names to include. If provided, only
+                annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
-                "note" annotations are always excluded unless explicitly included in annotation_names.
+                Defaults to ["note"] to exclude note annotations, which are reserved for notes
+                added via the UI.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -494,11 +484,6 @@ class AsyncSpans:
         if not span_ids_list:
             return pd.DataFrame()
 
-        effective_exclude_names = (exclude_annotation_names or []).copy()
-        if annotation_names is None or "note" not in annotation_names:
-            if "note" not in effective_exclude_names:
-                effective_exclude_names.append("note")
-
         annotations: list[v1.SpanAnnotation] = []
         path = f"v1/projects/{project_identifier}/span_annotations"
 
@@ -511,7 +496,7 @@ class AsyncSpans:
                     "limit": limit,
                 }
                 if annotation_names is not None:
-                    params["annotation_names"] = annotation_names
+                    params["include_annotation_names"] = annotation_names
                 if effective_exclude_names:
                     params["exclude_annotation_names"] = effective_exclude_names
                 if cursor:
@@ -544,8 +529,8 @@ class AsyncSpans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[list[str]] = None,
-        exclude_annotation_names: Optional[list[str]] = None,
+        annotation_names: Optional[Iterable[str]] = None,
+        exclude_annotation_names: Optional[Iterable[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -555,11 +540,11 @@ class AsyncSpans:
         Args:
             span_ids: An iterable of span IDs.
             project_identifier: The project identifier (name or ID) used in the API path.
-            annotation_names: Optional list of annotation names to include. If provided, only 
-                annotations with these names will be returned. "note" annotations are excluded 
-                by default unless explicitly included in this list.
+            annotation_names: Optional list of annotation names to include. If provided, only
+                annotations with these names will be returned.
             exclude_annotation_names: Optional list of annotation names to exclude from results.
-                "note" annotations are always excluded unless explicitly included in annotation_names.
+                Defaults to ["note"] to exclude note annotations, which are reserved for notes
+                added via the UI.
             limit: Maximum number of annotations returned per request page.
             timeout: Optional request timeout in seconds.
 
@@ -574,11 +559,6 @@ class AsyncSpans:
         if not span_ids_list:
             return []
 
-        effective_exclude_names = (exclude_annotation_names or []).copy()
-        if annotation_names is None or "note" not in annotation_names:
-            if "note" not in effective_exclude_names:
-                effective_exclude_names.append("note")
-
         annotations: list[v1.SpanAnnotation] = []
         path = f"v1/projects/{project_identifier}/span_annotations"
 
@@ -591,9 +571,9 @@ class AsyncSpans:
                     "limit": limit,
                 }
                 if annotation_names is not None:
-                    params["annotation_names"] = annotation_names
-                if effective_exclude_names:
-                    params["exclude_annotation_names"] = effective_exclude_names
+                    params["include_annotation_names"] = annotation_names
+                if exclude_annotation_names:
+                    params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
                     params["cursor"] = cursor
                 response = await self._client.get(

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -577,6 +577,7 @@ class AsyncSpans:
                     params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
                     params["cursor"] = cursor
+
                 response = await self._client.get(
                     url=path,
                     params=params,

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -141,7 +141,7 @@ class Spans:
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str = "default",
         include_annotation_names: Optional[Sequence[str]] = None,
-        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
+        exclude_annotation_names: Optional[Sequence[str]] = None,
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -172,6 +172,9 @@ class Spans:
             ImportError: If pandas is not installed.
             httpx.HTTPStatusError: If the API returns an error response.
         """
+        if exclude_annotation_names is None:
+            exclude_annotation_names = ["note"]
+
         try:
             import pandas as pd
         except ImportError:  # pragma: no cover
@@ -244,7 +247,7 @@ class Spans:
         span_ids: Iterable[str],
         project_identifier: str,
         include_annotation_names: Optional[Sequence[str]] = None,
-        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
+        exclude_annotation_names: Optional[Sequence[str]] = None,
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -268,6 +271,9 @@ class Spans:
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
         """
+        if exclude_annotation_names is None:
+            exclude_annotation_names = ["note"]
+
         span_ids_list = list({*span_ids})
 
         if not span_ids_list:
@@ -429,7 +435,7 @@ class AsyncSpans:
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str,
         include_annotation_names: Optional[Sequence[str]] = None,
-        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
+        exclude_annotation_names: Optional[Sequence[str]] = None,
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
@@ -460,6 +466,9 @@ class AsyncSpans:
             ImportError: If pandas is not installed.
             httpx.HTTPStatusError: If the API returns an error response.
         """
+        if exclude_annotation_names is None:
+            exclude_annotation_names = ["note"]
+
         try:
             import pandas as pd
         except ImportError:  # pragma: no cover
@@ -531,7 +540,7 @@ class AsyncSpans:
         span_ids: Iterable[str],
         project_identifier: str,
         include_annotation_names: Optional[Sequence[str]] = None,
-        exclude_annotation_names: Optional[Sequence[str]] = ["note"],
+        exclude_annotation_names: Optional[Sequence[str]] = None,
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
@@ -555,6 +564,9 @@ class AsyncSpans:
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
         """
+        if exclude_annotation_names is None:
+            exclude_annotation_names = ["note"]
+
         span_ids_list = list({*span_ids})
 
         if not span_ids_list:

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -140,7 +140,7 @@ class Spans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str = "default",
-        annotation_names: Optional[Sequence[str]] = None,
+        include_annotation_names: Optional[Sequence[str]] = None,
         exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
@@ -209,8 +209,8 @@ class Spans:
                     "span_ids": batch_ids,
                     "limit": limit,
                 }
-                if annotation_names is not None:
-                    params["include_annotation_names"] = annotation_names
+                if include_annotation_names is not None:
+                    params["include_annotation_names"] = include_annotation_names
                 if exclude_annotation_names:
                     params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
@@ -243,7 +243,7 @@ class Spans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[Sequence[str]] = None,
+        include_annotation_names: Optional[Sequence[str]] = None,
         exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
@@ -284,8 +284,8 @@ class Spans:
                     "span_ids": batch_ids,
                     "limit": limit,
                 }
-                if annotation_names is not None:
-                    params["include_annotation_names"] = annotation_names
+                if include_annotation_names is not None:
+                    params["include_annotation_names"] = include_annotation_names
                 if exclude_annotation_names:
                     params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
@@ -428,7 +428,7 @@ class AsyncSpans:
         spans_dataframe: Optional["pd.DataFrame"] = None,
         span_ids: Optional[Iterable[str]] = None,
         project_identifier: str,
-        annotation_names: Optional[Sequence[str]] = None,
+        include_annotation_names: Optional[Sequence[str]] = None,
         exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
@@ -496,8 +496,8 @@ class AsyncSpans:
                     "span_ids": batch_ids,
                     "limit": limit,
                 }
-                if annotation_names is not None:
-                    params["include_annotation_names"] = annotation_names
+                if include_annotation_names is not None:
+                    params["include_annotation_names"] = include_annotation_names
                 if exclude_annotation_names:
                     params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
@@ -530,7 +530,7 @@ class AsyncSpans:
         *,
         span_ids: Iterable[str],
         project_identifier: str,
-        annotation_names: Optional[Sequence[str]] = None,
+        include_annotation_names: Optional[Sequence[str]] = None,
         exclude_annotation_names: Optional[Sequence[str]] = ["note"],
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
@@ -571,8 +571,8 @@ class AsyncSpans:
                     "span_ids": batch_ids,
                     "limit": limit,
                 }
-                if annotation_names is not None:
-                    params["include_annotation_names"] = annotation_names
+                if include_annotation_names is not None:
+                    params["include_annotation_names"] = include_annotation_names
                 if exclude_annotation_names:
                     params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -211,8 +211,8 @@ class Spans:
                 }
                 if annotation_names is not None:
                     params["include_annotation_names"] = annotation_names
-                if effective_exclude_names:
-                    params["exclude_annotation_names"] = effective_exclude_names
+                if exclude_annotation_names:
+                    params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
                     params["cursor"] = cursor
 
@@ -286,10 +286,11 @@ class Spans:
                 }
                 if annotation_names is not None:
                     params["include_annotation_names"] = annotation_names
-                if effective_exclude_names:
-                    params["exclude_annotation_names"] = effective_exclude_names
+                if exclude_annotation_names:
+                    params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
                     params["cursor"] = cursor
+
                 response = self._client.get(
                     url=path,
                     params=params,
@@ -497,8 +498,8 @@ class AsyncSpans:
                 }
                 if annotation_names is not None:
                     params["include_annotation_names"] = annotation_names
-                if effective_exclude_names:
-                    params["exclude_annotation_names"] = effective_exclude_names
+                if exclude_annotation_names:
+                    params["exclude_annotation_names"] = exclude_annotation_names
                 if cursor:
                     params["cursor"] = cursor
 

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -335,6 +335,48 @@
             "description": "One or more span id to fetch annotations for"
           },
           {
+            "name": "annotation_names",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list.",
+              "title": "Annotation Names"
+            },
+            "description": "Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list."
+          },
+          {
+            "name": "exclude_annotation_names",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional list of annotation names to exclude from results.",
+              "title": "Exclude Annotation Names"
+            },
+            "description": "Optional list of annotation names to exclude from results."
+          },
+          {
             "name": "cursor",
             "in": "query",
             "required": false,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -356,29 +356,6 @@
             "description": "Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list."
           },
           {
-            "name": "annotation_names",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.",
-              "deprecated": true,
-              "title": "Annotation Names"
-            },
-            "description": "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.",
-            "deprecated": true
-          },
-          {
             "name": "exclude_annotation_names",
             "in": "query",
             "required": false,

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -335,7 +335,7 @@
             "description": "One or more span id to fetch annotations for"
           },
           {
-            "name": "annotation_names",
+            "name": "include_annotation_names",
             "in": "query",
             "required": false,
             "schema": {
@@ -351,9 +351,32 @@
                 }
               ],
               "description": "Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list.",
-              "title": "Annotation Names"
+              "title": "Include Annotation Names"
             },
             "description": "Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list."
+          },
+          {
+            "name": "annotation_names",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.",
+              "deprecated": true,
+              "title": "Annotation Names"
+            },
+            "description": "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names to include.",
+            "deprecated": true
           },
           {
             "name": "exclude_annotation_names",

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -62,8 +62,13 @@ async def list_span_annotations(
     span_ids: list[str] = Query(
         ..., min_length=1, description="One or more span id to fetch annotations for"
     ),
-    annotation_names: Optional[list[str]] = Query(
-        default=None, description="Optional list of annotation names to include. If provided, only annotations with these names will be returned."
+    include_annotation_names: Optional[list[str]] = Query(
+        default=None,
+        description=(
+            "Optional list of annotation names to include. If provided, only annotations with "
+            "these names will be returned. 'note' annotations are excluded by default unless "
+            "explicitly included in this list."
+        ),
     ),
     exclude_annotation_names: Optional[list[str]] = Query(
         default=None, description="Optional list of annotation names to exclude from results."
@@ -90,20 +95,20 @@ async def list_span_annotations(
                 status_code=HTTP_404_NOT_FOUND,
                 detail=f"Project with identifier {project_identifier} not found",
             )
-        
+
         # Build the base query
         where_conditions = [
             models.Project.id == project.id,
             models.Span.span_id.in_(span_ids),
         ]
-        
+
         # Add annotation name filtering
-        if annotation_names:
-            where_conditions.append(models.SpanAnnotation.name.in_(annotation_names))
-        
+        if include_annotation_names:
+            where_conditions.append(models.SpanAnnotation.name.in_(include_annotation_names))
+
         if exclude_annotation_names:
             where_conditions.append(models.SpanAnnotation.name.not_in(exclude_annotation_names))
-        
+
         stmt = (
             select(models.Span.span_id, models.SpanAnnotation)
             .join(models.Trace, models.Span.trace_rowid == models.Trace.id)

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -69,7 +69,14 @@ async def list_span_annotations(
             "these names will be returned. 'note' annotations are excluded by default unless "
             "explicitly included in this list."
         ),
-        alias="annotation_names",  # For backwards compatibility
+    ),
+    annotation_names: Optional[list[str]] = Query(
+        default=None,
+        description=(
+            "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names "
+            "to include."
+        ),
+        deprecated=True,
     ),
     exclude_annotation_names: Optional[list[str]] = Query(
         default=None, description="Optional list of annotation names to exclude from results."
@@ -82,6 +89,10 @@ async def list_span_annotations(
         description="The maximum number of annotations to return in a single request",
     ),
 ) -> SpanAnnotationsResponseBody:
+    # Handle backwards compatibility: use include_annotation_names if provided
+    # otherwise fall back to annotation_names
+    include_annotation_names = include_annotation_names or annotation_names
+
     span_ids = list({*span_ids})
     if len(span_ids) > MAX_SPAN_IDS:
         raise HTTPException(

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -62,6 +62,12 @@ async def list_span_annotations(
     span_ids: list[str] = Query(
         ..., min_length=1, description="One or more span id to fetch annotations for"
     ),
+    annotation_names: Optional[list[str]] = Query(
+        default=None, description="Optional list of annotation names to include. If provided, only annotations with these names will be returned."
+    ),
+    exclude_annotation_names: Optional[list[str]] = Query(
+        default=None, description="Optional list of annotation names to exclude from results."
+    ),
     cursor: Optional[str] = Query(default=None, description="A cursor for pagination"),
     limit: int = Query(
         default=10,
@@ -84,16 +90,26 @@ async def list_span_annotations(
                 status_code=HTTP_404_NOT_FOUND,
                 detail=f"Project with identifier {project_identifier} not found",
             )
+        
+        # Build the base query
+        where_conditions = [
+            models.Project.id == project.id,
+            models.Span.span_id.in_(span_ids),
+        ]
+        
+        # Add annotation name filtering
+        if annotation_names:
+            where_conditions.append(models.SpanAnnotation.name.in_(annotation_names))
+        
+        if exclude_annotation_names:
+            where_conditions.append(models.SpanAnnotation.name.not_in(exclude_annotation_names))
+        
         stmt = (
             select(models.Span.span_id, models.SpanAnnotation)
             .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
             .join(models.Project, models.Trace.project_rowid == models.Project.id)
             .join(models.SpanAnnotation, models.SpanAnnotation.span_rowid == models.Span.id)
-            .where(
-                models.Project.id == project.id,
-                models.Span.span_id.in_(span_ids),
-                models.SpanAnnotation.name != "note",
-            )
+            .where(*where_conditions)
             .order_by(models.SpanAnnotation.id.desc())
             .limit(limit + 1)
         )

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -92,6 +92,7 @@ async def list_span_annotations(
             .where(
                 models.Project.id == project.id,
                 models.Span.span_id.in_(span_ids),
+                models.SpanAnnotation.name != "note",
             )
             .order_by(models.SpanAnnotation.id.desc())
             .limit(limit + 1)

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -70,14 +70,6 @@ async def list_span_annotations(
             "explicitly included in this list."
         ),
     ),
-    annotation_names: Optional[list[str]] = Query(
-        default=None,
-        description=(
-            "[DEPRECATED] Use include_annotation_names instead. Optional list of annotation names "
-            "to include."
-        ),
-        deprecated=True,
-    ),
     exclude_annotation_names: Optional[list[str]] = Query(
         default=None, description="Optional list of annotation names to exclude from results."
     ),
@@ -89,10 +81,6 @@ async def list_span_annotations(
         description="The maximum number of annotations to return in a single request",
     ),
 ) -> SpanAnnotationsResponseBody:
-    # Handle backwards compatibility: use include_annotation_names if provided
-    # otherwise fall back to annotation_names
-    include_annotation_names = include_annotation_names or annotation_names
-
     span_ids = list({*span_ids})
     if len(span_ids) > MAX_SPAN_IDS:
         raise HTTPException(

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -69,6 +69,7 @@ async def list_span_annotations(
             "these names will be returned. 'note' annotations are excluded by default unless "
             "explicitly included in this list."
         ),
+        alias="annotation_names",  # For backwards compatibility
     ),
     exclude_annotation_names: Optional[list[str]] = Query(
         default=None, description="Optional list of annotation names to exclude from results."

--- a/tests/integration/client/test_spans.py
+++ b/tests/integration/client/test_spans.py
@@ -87,7 +87,7 @@ class TestClientForSpanAnnotationsRetrieval:
         assert {
             span_id1,
             span_id2,
-        }.issubset(set(df.index.astype(str))), "Expected span IDs missing from dataframe"  # type: ignore[unused-ignore]
+        }.issubset(set(df.index.astype(str))), "Expected span IDs missing from dataframe"  # pyright: ignore[reportUnknownArgumentType,reportUnknownMemberType]
 
         annotations = await _await_or_return(
             Client().spans.get_span_annotations(
@@ -132,13 +132,13 @@ class TestClientForSpanAnnotationsRetrieval:
             (span_id1, annotation_name_1, label1, score1, explanation1),
             (span_id2, annotation_name_2, label2, score2, explanation2),
         ):
-            subset = df_from_df[df_from_df.index.astype(str) == sid]  # type: ignore[unused-ignore]
-            subset = subset[subset["annotation_name"] == aname]  # type: ignore[unused-ignore]
-            assert not subset.empty  # type: ignore[unused-ignore]
-            row = subset.iloc[0]  # type: ignore[unused-ignore]
+            subset = df_from_df[df_from_df.index.astype(str) == sid]  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            subset = subset[subset["annotation_name"] == aname]  # pyright: ignore[reportUnknownVariableType]
+            assert not subset.empty  # pyright: ignore[reportUnknownMemberType]
+            row = subset.iloc[0]  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
             assert "result.label" in row
             assert row["result.label"] == label
-            assert abs(float(row["result.score"]) - scr) < 1e-6  # type: ignore[unused-ignore]
+            assert abs(float(row["result.score"]) - scr) < 1e-6  # pyright: ignore[reportUnknownArgumentType]
             assert row["result.explanation"] == expl
 
     @pytest.mark.parametrize("is_async", [True, False])
@@ -151,7 +151,7 @@ class TestClientForSpanAnnotationsRetrieval:
         _get_user: _GetUser,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        (span_id1, span_gid1), (span_id2, span_gid2) = _span_ids
+        (span_id1, _), (span_id2, _) = _span_ids
 
         user = _get_user(role_or_user).log_in()
         monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
@@ -188,7 +188,7 @@ class TestClientForSpanAnnotationsRetrieval:
 
         assert isinstance(df_default, pd.DataFrame)
         if not df_default.empty:
-            annotation_names_default = set(df_default["annotation_name"].tolist())
+            annotation_names_default = set(df_default["annotation_name"].tolist())  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             assert regular_annotation_name in annotation_names_default
 
         df_with_notes = await _await_or_return(
@@ -201,7 +201,7 @@ class TestClientForSpanAnnotationsRetrieval:
 
         assert isinstance(df_with_notes, pd.DataFrame)
         if not df_with_notes.empty:
-            annotation_names_with_notes = set(df_with_notes["annotation_name"].tolist())
+            annotation_names_with_notes = set(df_with_notes["annotation_name"].tolist())  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             assert regular_annotation_name in annotation_names_with_notes
 
         df_excluded = await _await_or_return(
@@ -214,7 +214,7 @@ class TestClientForSpanAnnotationsRetrieval:
 
         assert isinstance(df_excluded, pd.DataFrame)
         if not df_excluded.empty:
-            annotation_names_excluded = set(df_excluded["annotation_name"].tolist())
+            annotation_names_excluded = set(df_excluded["annotation_name"].tolist())  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             assert regular_annotation_name not in annotation_names_excluded
 
         annotations_default = await _await_or_return(

--- a/tests/integration/client/test_spans.py
+++ b/tests/integration/client/test_spans.py
@@ -195,7 +195,7 @@ class TestClientForSpanAnnotationsRetrieval:
             Client().spans.get_span_annotations_dataframe(
                 span_ids=[span_id1, span_id2],
                 project_identifier="default",
-                annotation_names=[regular_annotation_name, "note"],
+                include_annotation_names=[regular_annotation_name, "note"],
             )
         )
 
@@ -233,7 +233,7 @@ class TestClientForSpanAnnotationsRetrieval:
             Client().spans.get_span_annotations(
                 span_ids=[span_id1, span_id2],
                 project_identifier="default",
-                annotation_names=[regular_annotation_name, "note"],
+                include_annotation_names=[regular_annotation_name, "note"],
             )
         )
 

--- a/tests/unit/server/api/routers/v1/test_annotations.py
+++ b/tests/unit/server/api/routers/v1/test_annotations.py
@@ -132,8 +132,7 @@ async def test_list_span_annotations_default_behavior(
     project_with_spans_and_annotations: Any,
 ) -> None:
     response = await httpx_client.get(
-        "v1/projects/test-project/span_annotations", 
-        params={"span_ids": ["span1", "span2"]}
+        "v1/projects/test-project/span_annotations", params={"span_ids": ["span1", "span2"]}
     )
 
     assert response.status_code == 200
@@ -165,8 +164,11 @@ async def test_list_span_annotations_inclusion_filter(
     project_with_spans_and_annotations: Any,
 ) -> None:
     response = await httpx_client.get(
-        "v1/projects/test-project/span_annotations", 
-        params={"span_ids": ["span1", "span2"], "annotation_names": ["correctness", "note"]}
+        "v1/projects/test-project/span_annotations",
+        params={
+            "span_ids": ["span1", "span2"],
+            "include_annotation_names": ["correctness", "note"],
+        },
     )
 
     assert response.status_code == 200
@@ -184,8 +186,8 @@ async def test_list_span_annotations_exclusion_filter(
     project_with_spans_and_annotations: Any,
 ) -> None:
     response = await httpx_client.get(
-        "v1/projects/test-project/span_annotations", 
-        params={"span_ids": ["span1", "span2"], "exclude_annotation_names": ["note"]}
+        "v1/projects/test-project/span_annotations",
+        params={"span_ids": ["span1", "span2"], "exclude_annotation_names": ["note"]},
     )
 
     assert response.status_code == 200
@@ -203,12 +205,12 @@ async def test_list_span_annotations_combined_filters(
     project_with_spans_and_annotations: Any,
 ) -> None:
     response = await httpx_client.get(
-        "v1/projects/test-project/span_annotations", 
+        "v1/projects/test-project/span_annotations",
         params={
-            "span_ids": ["span1", "span2"], 
-            "annotation_names": ["correctness", "relevance", "note"],
-            "exclude_annotation_names": ["note"]
-        }
+            "span_ids": ["span1", "span2"],
+            "include_annotation_names": ["correctness", "relevance", "note"],
+            "exclude_annotation_names": ["note"],
+        },
     )
 
     assert response.status_code == 200
@@ -279,8 +281,8 @@ async def test_list_span_annotations_empty_result_when_all_excluded(
         await session.commit()
 
     response = await httpx_client.get(
-        "v1/projects/filtered-project/span_annotations", 
-        params={"span_ids": ["filtered-span"], "exclude_annotation_names": ["test-annotation"]}
+        "v1/projects/filtered-project/span_annotations",
+        params={"span_ids": ["filtered-span"], "exclude_annotation_names": ["test-annotation"]},
     )
 
     assert response.status_code == 200
@@ -365,7 +367,11 @@ async def test_list_span_annotations_pagination_with_filters(
 
     response = await httpx_client.get(
         "v1/projects/pagination-project/span_annotations",
-        params={"span_ids": ["pagination-span"], "limit": 3, "exclude_annotation_names": ["excluded-annotation"]},
+        params={
+            "span_ids": ["pagination-span"],
+            "limit": 3,
+            "exclude_annotation_names": ["excluded-annotation"],
+        },
     )
 
     assert response.status_code == 200

--- a/tests/unit/server/api/routers/v1/test_annotations.py
+++ b/tests/unit/server/api/routers/v1/test_annotations.py
@@ -1,0 +1,328 @@
+from datetime import datetime
+from typing import Any
+
+import httpx
+import pytest
+from sqlalchemy import insert
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+
+@pytest.fixture
+async def project_with_spans_and_annotations(db: DbSessionFactory) -> None:
+    """
+    Creates a project with traces, spans, and various annotations including 'note' annotations.
+    This fixture sets up test data with:
+    - A project named "test-project"
+    - A trace with ID "test-trace-id"
+    - Two spans with IDs "span1" and "span2"
+    - Regular annotations (should be returned)
+    - "note" annotations (should NOT be returned)
+    """
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="test-project").returning(models.Project.id)
+        )
+
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="test-trace-id",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
+        )
+
+        span1_id = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="span1",
+                parent_id=None,
+                name="test span 1",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+
+        span2_id = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="span2",
+                parent_id=None,
+                name="test span 2",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+
+        await session.execute(
+            insert(models.SpanAnnotation).values(
+                span_rowid=span1_id,
+                name="correctness",
+                label="correct",
+                score=0.9,
+                explanation="This is correct",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="API",
+                identifier="test-identifier-1",
+            )
+        )
+
+        await session.execute(
+            insert(models.SpanAnnotation).values(
+                span_rowid=span2_id,
+                name="relevance",
+                label="relevant",
+                score=0.8,
+                explanation="This is relevant",
+                metadata_={},
+                annotator_kind="LLM",
+                source="APP",
+                identifier="test-identifier-2",
+            )
+        )
+
+        await session.execute(
+            insert(models.SpanAnnotation).values(
+                span_rowid=span1_id,
+                name="note",
+                label=None,
+                score=None,
+                explanation="This is a user note",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+                identifier="note-identifier-1",
+            )
+        )
+
+        await session.execute(
+            insert(models.SpanAnnotation).values(
+                span_rowid=span2_id,
+                name="note",
+                label=None,
+                score=None,
+                explanation="Another user note",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+                identifier="note-identifier-2",
+            )
+        )
+        await session.commit()
+
+
+async def test_list_span_annotations_excludes_notes(
+    httpx_client: httpx.AsyncClient,
+    project_with_spans_and_annotations: Any,
+) -> None:
+    """Test that the list_span_annotations endpoint excludes annotations with name 'note'."""
+    response = await httpx_client.get(
+        "v1/projects/test-project/span_annotations", params={"span_ids": ["span1", "span2"]}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["data"]) == 2
+
+    annotation_names = {annotation["name"] for annotation in data["data"]}
+    assert annotation_names == {"correctness", "relevance"}
+
+    assert "note" not in annotation_names
+
+    for annotation in data["data"]:
+        assert "id" in annotation
+        assert "span_id" in annotation
+        assert "name" in annotation
+        assert "result" in annotation
+        assert "metadata" in annotation
+        assert "annotator_kind" in annotation
+        assert "created_at" in annotation
+        assert "updated_at" in annotation
+        assert "identifier" in annotation
+        assert "source" in annotation
+
+
+async def test_list_span_annotations_returns_empty_when_only_notes_exist(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Test that the endpoint returns empty data when only 'note' annotations exist."""
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="notes-only-project").returning(models.Project.id)
+        )
+
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="notes-trace-id",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
+        )
+
+        span_id = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="notes-span",
+                parent_id=None,
+                name="test span with notes only",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+
+        await session.execute(
+            insert(models.SpanAnnotation).values(
+                span_rowid=span_id,
+                name="note",
+                label=None,
+                score=None,
+                explanation="This is only a note",
+                metadata_={},
+                annotator_kind="HUMAN",
+                source="APP",
+                identifier="only-note-identifier",
+            )
+        )
+
+        await session.commit()
+
+    response = await httpx_client.get(
+        "v1/projects/notes-only-project/span_annotations", params={"span_ids": ["notes-span"]}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["data"]) == 0
+    assert data["next_cursor"] is None
+
+
+async def test_list_span_annotations_pagination_excludes_notes(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Test that pagination works correctly when excluding 'note' annotations."""
+    async with db() as session:
+        project_row_id = await session.scalar(
+            insert(models.Project).values(name="pagination-project").returning(models.Project.id)
+        )
+
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                trace_id="pagination-trace-id",
+                project_rowid=project_row_id,
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:01:00.000+00:00"),
+            )
+            .returning(models.Trace.id)
+        )
+
+        span_id = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="pagination-span",
+                parent_id=None,
+                name="test span for pagination",
+                span_kind="CHAIN",
+                start_time=datetime.fromisoformat("2021-01-01T00:00:00.000+00:00"),
+                end_time=datetime.fromisoformat("2021-01-01T00:00:30.000+00:00"),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+
+        for i in range(5):
+            await session.execute(
+                insert(models.SpanAnnotation).values(
+                    span_rowid=span_id,
+                    name=f"annotation-{i}",
+                    label=f"label-{i}",
+                    score=0.1 * i,
+                    explanation=f"Explanation {i}",
+                    metadata_={},
+                    annotator_kind="HUMAN",
+                    source="API",
+                    identifier=f"identifier-{i}",
+                )
+            )
+
+        for i in range(3):
+            await session.execute(
+                insert(models.SpanAnnotation).values(
+                    span_rowid=span_id,
+                    name="note",
+                    label=None,
+                    score=None,
+                    explanation=f"Note {i}",
+                    metadata_={},
+                    annotator_kind="HUMAN",
+                    source="APP",
+                    identifier=f"note-identifier-{i}",
+                )
+            )
+
+        await session.commit()
+
+    response = await httpx_client.get(
+        "v1/projects/pagination-project/span_annotations",
+        params={"span_ids": ["pagination-span"], "limit": 3},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["data"]) == 3
+
+    for annotation in data["data"]:
+        assert annotation["name"] != "note"
+        assert annotation["name"].startswith("annotation-")
+
+    assert data["next_cursor"] is not None


### PR DESCRIPTION
While notes are implemented as annotations, they should not be returned alongside "normal" span annotations.

This adds filter options to `get_span_annotations` and `get_span_annotations_dataframe`

where `include_annotation_names=` and `exclude_annotation_names=` parameters passed into the client methods will filter annotations by name before being returned.

`exclude_annotation_names=` defaults to `["notes"]` in order to automatically filter out notes.