### PR TITLE
refactor: migrate both metric and inferenceTime selector as both are in same tab

### DIFF
--- a/app/src/components/filter/PrimaryInferencesTimeRange.tsx
+++ b/app/src/components/filter/PrimaryInferencesTimeRange.tsx
@@ -40,6 +40,18 @@ const primaryInferencesSelectCSS = css`
   }
 `;
 
+const triggerWrapCSS = css`
+  /* Target the button element specifically */
+  button[aria-haspopup="listbox"] {
+    border: 1.1px solid var(--ac-global-color-designation-turquoise) !important;
+    border-radius: var(--ac-global-rounding-small) !important;
+
+    &:hover {
+      border-color: white !important;
+    }
+  }
+`;
+
 export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
   const {
     timeRange,
@@ -51,100 +63,105 @@ export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
   } = useInferences();
   const nameAbbr = name.slice(0, 10);
   return (
-    <FieldColorDesignation color={"designationTurquoise"}>
-      <TooltipTrigger delay={0}>
-        <TriggerWrap>
-          <Select
-            selectedKey={selectedTimePreset}
-            data-testid="inferences-time-range"
-            aria-label={`Time range for the primary inferences`}
-            onSelectionChange={(key) => {
-              if (key !== selectedTimePreset) {
-                setTimePreset(key as TimePreset);
-              }
-            }}
-            css={primaryInferencesSelectCSS}
-          >
-            <Label>{nameAbbr} inferences</Label>
-            <Button>
-              <SelectValue />
-              <SelectChevronUpDownIcon />
-            </Button>
-            <Text slot="description">{""}</Text>
-            <Popover>
-              <ListBox>
-                <SelectItem key={TimePreset.all} id={TimePreset.all}>
-                  All
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.last_hour}
-                  id={TimePreset.last_hour}
-                >
-                  Last Hour
-                </SelectItem>
-                <SelectItem key={TimePreset.last_day} id={TimePreset.last_day}>
-                  Last Day
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.last_week}
-                  id={TimePreset.last_week}
-                >
-                  Last Week
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.last_month}
-                  id={TimePreset.last_month}
-                >
-                  Last Month
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.last_3_months}
-                  id={TimePreset.last_3_months}
-                >
-                  Last 3 Months
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.first_hour}
-                  id={TimePreset.first_hour}
-                >
-                  First Hour
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.first_day}
-                  id={TimePreset.first_day}
-                >
-                  First Day
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.first_week}
-                  id={TimePreset.first_week}
-                >
-                  First Week
-                </SelectItem>
-                <SelectItem
-                  key={TimePreset.first_month}
-                  id={TimePreset.first_month}
-                >
-                  First Month
-                </SelectItem>
-              </ListBox>
-            </Popover>
-          </Select>
-        </TriggerWrap>
-        <HelpTooltip>
-          <section
-            css={css`
-              h4 {
-                margin-bottom: 0.5rem;
-              }
-            `}
-          >
-            <Heading level={4}>primary inferences time range</Heading>
-            <div>start: {fullTimeFormatter(timeRange.start)}</div>
-            <div>end: {fullTimeFormatter(timeRange.end)}</div>
-          </section>
-        </HelpTooltip>
-      </TooltipTrigger>
-    </FieldColorDesignation>
+    <div css={triggerWrapCSS}>
+      <FieldColorDesignation color={"designationTurquoise"}>
+        <TooltipTrigger>
+          <TriggerWrap>
+            <Select
+              selectedKey={selectedTimePreset}
+              data-testid="inferences-time-range"
+              aria-label={`Time range for the primary inferences`}
+              onSelectionChange={(key) => {
+                if (key !== selectedTimePreset) {
+                  setTimePreset(key as TimePreset);
+                }
+              }}
+              css={primaryInferencesSelectCSS}
+            >
+              <Label>{nameAbbr} inferences</Label>
+              <Button>
+                <SelectValue />
+                <SelectChevronUpDownIcon />
+              </Button>
+              <Text slot="description">{""}</Text>
+              <Popover>
+                <ListBox>
+                  <SelectItem key={TimePreset.all} id={TimePreset.all}>
+                    All
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.last_hour}
+                    id={TimePreset.last_hour}
+                  >
+                    Last Hour
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.last_day}
+                    id={TimePreset.last_day}
+                  >
+                    Last Day
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.last_week}
+                    id={TimePreset.last_week}
+                  >
+                    Last Week
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.last_month}
+                    id={TimePreset.last_month}
+                  >
+                    Last Month
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.last_3_months}
+                    id={TimePreset.last_3_months}
+                  >
+                    Last 3 Months
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.first_hour}
+                    id={TimePreset.first_hour}
+                  >
+                    First Hour
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.first_day}
+                    id={TimePreset.first_day}
+                  >
+                    First Day
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.first_week}
+                    id={TimePreset.first_week}
+                  >
+                    First Week
+                  </SelectItem>
+                  <SelectItem
+                    key={TimePreset.first_month}
+                    id={TimePreset.first_month}
+                  >
+                    First Month
+                  </SelectItem>
+                </ListBox>
+              </Popover>
+            </Select>
+          </TriggerWrap>
+          <HelpTooltip>
+            <section
+              css={css`
+                h4 {
+                  margin-bottom: 0.5rem;
+                }
+              `}
+            >
+              <Heading level={4}>primary inferences time range</Heading>
+              <div>start: {fullTimeFormatter(timeRange.start)}</div>
+              <div>end: {fullTimeFormatter(timeRange.end)}</div>
+            </section>
+          </HelpTooltip>
+        </TooltipTrigger>
+      </FieldColorDesignation>
+    </div>
   );
 }

--- a/app/src/components/filter/PrimaryInferencesTimeRange.tsx
+++ b/app/src/components/filter/PrimaryInferencesTimeRange.tsx
@@ -2,19 +2,43 @@ import { css } from "@emotion/react";
 
 import {
   FieldColorDesignation,
-  Item,
-  Picker,
-  Tooltip,
+  HelpTooltip,
   TooltipTrigger,
   TriggerWrap,
 } from "@arizeai/components";
 
-import { Heading } from "@phoenix/components";
+import {
+  Button,
+  Heading,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Text,
+} from "@phoenix/components";
 import { useInferences } from "@phoenix/contexts";
 import { TimePreset, useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 import { fullTimeFormatter } from "@phoenix/utils/timeFormatUtils";
 
 type PrimaryInferencesTimeRangeProps = object;
+
+const primaryInferencesSelectCSS = css`
+  /* Align with other toolbar components */
+  .react-aria-Button {
+    height: 30px;
+    min-height: 30px;
+  }
+
+  .react-aria-Label {
+    padding: 5px 0;
+    display: inline-block;
+    font-size: var(--ac-global-dimension-static-font-size-75);
+    font-weight: var(--px-font-weight-heavy);
+  }
+`;
 
 export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
   const {
@@ -28,33 +52,86 @@ export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
   const nameAbbr = name.slice(0, 10);
   return (
     <FieldColorDesignation color={"designationTurquoise"}>
-      <TooltipTrigger delay={0} placement="bottom right">
+      <TooltipTrigger delay={0}>
         <TriggerWrap>
-          <Picker
-            label="primary inferences"
-            defaultSelectedKey={selectedTimePreset}
+          <Select
+            selectedKey={selectedTimePreset}
             data-testid="inferences-time-range"
             aria-label={`Time range for the primary inferences`}
-            addonBefore={nameAbbr}
             onSelectionChange={(key) => {
               if (key !== selectedTimePreset) {
                 setTimePreset(key as TimePreset);
               }
             }}
+            css={primaryInferencesSelectCSS}
           >
-            <Item key={TimePreset.all}>All</Item>
-            <Item key={TimePreset.last_hour}>Last Hour</Item>
-            <Item key={TimePreset.last_day}>Last Day</Item>
-            <Item key={TimePreset.last_week}>Last Week</Item>
-            <Item key={TimePreset.last_month}>Last Month</Item>
-            <Item key={TimePreset.last_3_months}>Last 3 Months</Item>
-            <Item key={TimePreset.first_hour}>First Hour</Item>
-            <Item key={TimePreset.first_day}>First Day</Item>
-            <Item key={TimePreset.first_week}>First Week</Item>
-            <Item key={TimePreset.first_month}>First Month</Item>
-          </Picker>
+            <Label>{nameAbbr} inferences</Label>
+            <Button>
+              <SelectValue />
+              <SelectChevronUpDownIcon />
+            </Button>
+            <Text slot="description">{""}</Text>
+            <Popover>
+              <ListBox>
+                <SelectItem key={TimePreset.all} id={TimePreset.all}>
+                  All
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_hour}
+                  id={TimePreset.last_hour}
+                >
+                  Last Hour
+                </SelectItem>
+                <SelectItem key={TimePreset.last_day} id={TimePreset.last_day}>
+                  Last Day
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_week}
+                  id={TimePreset.last_week}
+                >
+                  Last Week
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_month}
+                  id={TimePreset.last_month}
+                >
+                  Last Month
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_3_months}
+                  id={TimePreset.last_3_months}
+                >
+                  Last 3 Months
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_hour}
+                  id={TimePreset.first_hour}
+                >
+                  First Hour
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_day}
+                  id={TimePreset.first_day}
+                >
+                  First Day
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_week}
+                  id={TimePreset.first_week}
+                >
+                  First Week
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_month}
+                  id={TimePreset.first_month}
+                >
+                  First Month
+                </SelectItem>
+              </ListBox>
+            </Popover>
+          </Select>
         </TriggerWrap>
-        <Tooltip>
+        <HelpTooltip>
           <section
             css={css`
               h4 {
@@ -66,7 +143,7 @@ export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
             <div>start: {fullTimeFormatter(timeRange.start)}</div>
             <div>end: {fullTimeFormatter(timeRange.end)}</div>
           </section>
-        </Tooltip>
+        </HelpTooltip>
       </TooltipTrigger>
     </FieldColorDesignation>
   );

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -2,7 +2,7 @@ import { Key, useCallback, useTransition } from "react";
 import { graphql, useFragment } from "react-relay";
 import { css } from "@emotion/react";
 
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
+import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
 
 import {
   Button,
@@ -235,7 +235,6 @@ export function MetricSelector({
             <SelectValue />
             <SelectChevronUpDownIcon />
           </Button>
-          <Text slot="description">{""}</Text>
           <Popover>
             <ListBox>
               {allMetrics.map((metric) => (
@@ -247,7 +246,7 @@ export function MetricSelector({
           </Popover>
         </Select>
       </TriggerWrap>
-      <HelpTooltip>
+      <Tooltip>
         <section
           css={css`
             h4 {
@@ -256,18 +255,18 @@ export function MetricSelector({
           `}
         >
           <Heading level={4}>Analysis Metric</Heading>
-          <div>Select a metric to drive the analysis of your embeddings.</div>
-          <div>
+          <Text>Select a metric to drive the analysis of your embeddings.</Text>
+          <Text>
             To analyze the the drift between your two inferences, select a drift
             metric and the UI will highlight areas of high drift.
-          </div>
-          <div>
+          </Text>
+          <Text>
             To analyze the quality of your embeddings, select a dimension data
             quality metric by which to analyze the point cloud. The UI will
             highlight areas where the data quality is degrading.
-          </div>
+          </Text>
         </section>
-      </HelpTooltip>
+      </Tooltip>
     </TooltipTrigger>
   );
 }

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -1,16 +1,21 @@
 import { Key, useCallback, useTransition } from "react";
 import { graphql, useFragment } from "react-relay";
+import { css } from "@emotion/react";
+
+import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
 
 import {
-  CollectionElement,
-  Content,
-  ContextualHelp,
-  Item,
-  Picker,
-  Section,
-} from "@arizeai/components";
-
-import { Heading } from "@phoenix/components";
+  Button,
+  Heading,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Text,
+} from "@phoenix/components";
 import { useInferences, usePointCloudContext } from "@phoenix/contexts";
 import {
   DriftMetricDefinition,
@@ -110,25 +115,21 @@ function parseMetricKey({
   }
 }
 
-const contextualHelp = (
-  <ContextualHelp variant="info">
-    <Heading level={4} weight="heavy">
-      Analysis Metric
-    </Heading>
-    <Content>
-      <p>Select a metric to drive the analysis of your embeddings.</p>
-      <p>
-        To analyze the the drift between your two inferences, select a drift
-        metric and the UI will highlight areas of high drift.
-      </p>
-      <p>
-        To analyze the quality of your embeddings, select a dimension data
-        quality metric by which to analyze the point cloud. The UI will
-        highlight areas where the data quality is degrading.
-      </p>
-    </Content>
-  </ContextualHelp>
-);
+const metricSelectorCSS = css`
+  /* Align with other toolbar components */
+  .react-aria-Button {
+    height: 30px;
+    min-height: 30px;
+  }
+
+  .react-aria-Label {
+    padding: 5px 0;
+    display: inline-block;
+    font-size: var(--ac-global-dimension-static-font-size-75);
+    font-weight: var(--px-font-weight-heavy);
+  }
+`;
+
 export function MetricSelector({
   model,
 }: {
@@ -173,70 +174,100 @@ export function MetricSelector({
     },
     [setMetric, numericDimensions, startTransition]
   );
+
+  // Create a flat list of all available metrics
+  const allMetrics = [];
+
+  if (hasReferenceInferences) {
+    allMetrics.push({
+      key: getMetricKey({
+        type: "drift",
+        metric: "euclideanDistance",
+      }),
+      label: "Euclidean Distance",
+    });
+  }
+
+  if (hasCorpusInferences) {
+    allMetrics.push({
+      key: getMetricKey({
+        type: "retrieval",
+        metric: "queryDistance",
+      }),
+      label: "Query Distance",
+    });
+  }
+
+  allMetrics.push({
+    key: getMetricKey({
+      type: "performance",
+      metric: "accuracyScore",
+    }),
+    label: "Accuracy Score",
+  });
+
+  if (hasNumericDimensions) {
+    numericDimensions.forEach((dimension) => {
+      allMetrics.push({
+        key: getMetricKey({
+          type: "dataQuality",
+          metric: "average",
+          dimension,
+        }),
+        label: `${dimension.name} avg`,
+      });
+    });
+  }
+
   return (
-    <Picker
-      label="metric"
-      labelExtra={contextualHelp}
-      selectedKey={metric ? getMetricKey(metric) : undefined}
-      onSelectionChange={onSelectionChange}
-      placeholder="Select a metric..."
-      isDisabled={loading}
-    >
-      {hasReferenceInferences ? (
-        <Section title="Drift">
-          <Item
-            key={getMetricKey({
-              type: "drift",
-              metric: "euclideanDistance",
-            })}
-          >
-            Euclidean Distance
-          </Item>
-        </Section>
-      ) : (
-        (null as unknown as CollectionElement<unknown>)
-      )}
-      {hasCorpusInferences ? (
-        <Section title="Retrieval">
-          <Item
-            key={getMetricKey({
-              type: "retrieval",
-              metric: "queryDistance",
-            })}
-          >
-            Query Distance
-          </Item>
-        </Section>
-      ) : (
-        (null as unknown as CollectionElement<unknown>)
-      )}
-      <Section title="Performance">
-        <Item
-          key={getMetricKey({
-            type: "performance",
-            metric: "accuracyScore",
-          })}
+    <TooltipTrigger delay={0}>
+      <TriggerWrap>
+        <Select
+          selectedKey={metric ? getMetricKey(metric) : undefined}
+          onSelectionChange={onSelectionChange}
+          placeholder="Select a metric..."
+          isDisabled={loading}
+          aria-label="Analysis metric"
+          css={metricSelectorCSS}
         >
-          Accuracy Score
-        </Item>
-      </Section>
-      {hasNumericDimensions ? (
-        <Section title="Data Quality">
-          {numericDimensions.map((dimension) => {
-            return (
-              <Item
-                key={getMetricKey({
-                  type: "dataQuality",
-                  metric: "average",
-                  dimension,
-                })}
-              >{`${dimension.name} avg`}</Item>
-            );
-          })}
-        </Section>
-      ) : (
-        (null as unknown as CollectionElement<unknown>)
-      )}
-    </Picker>
+          <Label>Metric</Label>
+          <Button>
+            <SelectValue />
+            <SelectChevronUpDownIcon />
+          </Button>
+          <Text slot="description">{""}</Text>
+          <Popover>
+            <ListBox>
+              {allMetrics.map((metric) => (
+                <SelectItem key={metric.key} id={metric.key}>
+                  {metric.label}
+                </SelectItem>
+              ))}
+            </ListBox>
+          </Popover>
+        </Select>
+      </TriggerWrap>
+      <HelpTooltip>
+        <section
+          css={css`
+            h4 {
+              margin-bottom: 0.5rem;
+            }
+          `}
+        >
+          <Heading level={4}>Analysis Metric</Heading>
+          <div>Select a metric to drive the analysis of your embeddings.</div>
+          <div>
+            To analyze the the drift between your two inferences, select a drift
+            metric and the UI will highlight areas of high drift.
+          </div>
+          <div>
+            To analyze the quality of your embeddings, select a dimension data
+            quality metric by which to analyze the point cloud. The UI will
+            highlight areas where the data quality is degrading.
+          </div>
+        </section>
+      </HelpTooltip>
+    </TooltipTrigger>
   );
 }


### PR DESCRIPTION
#6956 

before:
<img width="664" alt="Screenshot 2025-05-30 at 3 04 12 PM" src="https://github.com/user-attachments/assets/99751129-8b8e-4c03-b2fe-813f049625c8" />
<img width="240" alt="Screenshot 2025-05-30 at 3 04 29 PM" src="https://github.com/user-attachments/assets/1ee5c0ac-34fb-4ee8-8f57-a527069dfee6" />
<img width="216" alt="Screenshot 2025-05-30 at 3 04 24 PM" src="https://github.com/user-attachments/assets/2a8c1144-b92f-4831-9796-f753a0a45292" />

after:
<img width="805" alt="Screenshot 2025-05-30 at 3 18 56 PM" src="https://github.com/user-attachments/assets/94e3435f-8ec1-4f20-bb69-c0b3df6506a1" />
<img width="222" alt="Screenshot 2025-05-30 at 2 46 03 PM" src="https://github.com/user-attachments/assets/544eefe2-fcc2-46f5-bdaf-bdad2c00863f" />
<img width="171" alt="Screenshot 2025-05-30 at 3 01 33 PM" src="https://github.com/user-attachments/assets/19742974-64b9-4b49-8463-154a255d19a8" />
