### PR TITLE
refactor: Migrate dimension picker

### DIFF
--- a/app/src/components/form/DimensionPicker.tsx
+++ b/app/src/components/form/DimensionPicker.tsx
@@ -1,6 +1,5 @@
 import { startTransition, useEffect, useState } from "react";
 import { fetchQuery, graphql } from "react-relay";
-import { css } from "@emotion/react";
 
 import { Content, ContextualHelp } from "@arizeai/components";
 
@@ -114,16 +113,10 @@ export function DimensionPicker(props: DimensionPickerProps) {
           <ListBox>
             {dimensions.map((dimension) => (
               <SelectItem key={dimension.name} id={dimension.name}>
-                <div
-                  css={css`
-                    .ac-Token {
-                      margin-right: var(--ac-global-dimension-static-size-100);
-                    }
-                  `}
-                >
+                <Flex direction="row" alignItems="center" gap="size-100">
                   <DimensionTypeToken type={dimension.type} />
                   {dimension.name}
-                </div>
+                </Flex>
               </SelectItem>
             ))}
           </ListBox>


### PR DESCRIPTION
#6956 

before:
<img width="180" alt="Screenshot 2025-05-30 at 3 25 56 PM" src="https://github.com/user-attachments/assets/57490ff3-0582-4786-822a-2d8493a3db09" />
<img width="194" alt="Screenshot 2025-05-30 at 3 26 04 PM" src="https://github.com/user-attachments/assets/3d4a857a-16ea-4286-bef9-2f1fdf75b514" />


after:
<img width="182" alt="Screenshot 2025-05-30 at 3 28 46 PM" src="https://github.com/user-attachments/assets/b26d1a9a-f1f2-48b5-baef-04620e774eb0" />
<img width="214" alt="Screenshot 2025-05-30 at 3 30 25 PM" src="https://github.com/user-attachments/assets/9686c0ed-0191-4ff7-bd90-b4d24976321b" />
