### PR TITLE
Eval parsing

### DIFF
--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -88,17 +88,17 @@ def test_parse_label_from_chain_of_thought_response_avoids_false_positives_from_
     # Should NOT extract "relevant" from explanation text
     assert parse_label_from_chain_of_thought_response(
         "EXPLANATION: The text is relevant to the question", rails
-    ) == NOT_PARSABLE
+    ) == "EXPLANATION: The text is relevant to the question"
     
     # Should NOT extract "incorrect" from middle of explanation  
     assert parse_label_from_chain_of_thought_response(
         "The answer seems incorrect based on the context", rails
-    ) == NOT_PARSABLE
+    ) == "The answer seems incorrect based on the context"
 
 
 def test_parse_label_from_chain_of_thought_response_handles_label_keyword_positioning():
     """Test that the function handles LABEL keyword in different positions and incomplete explanations."""
-    rails = ["relevant", "unrelated", "correct", "incorrect"]
+    rails = [ "correct", "incorrect"]
     
     # LABEL at beginning with incomplete explanation
     assert parse_label_from_chain_of_thought_response(
@@ -112,8 +112,8 @@ def test_parse_label_from_chain_of_thought_response_handles_label_keyword_positi
     
     # LABEL with just the label word and no explanation
     assert parse_label_from_chain_of_thought_response(
-        "LABEL: relevant", rails
-    ) == "relevant"
+        "LABEL: correct", rails
+    ) == "correct"
     
     # Multiple LABEL keywords - should use first one
     assert parse_label_from_chain_of_thought_response(
@@ -126,8 +126,8 @@ def test_parse_label_from_chain_of_thought_response_handles_edge_cases():
     rails = ["relevant", "irrelevant"]
     
     # Empty/whitespace input (return path 1)
-    assert parse_label_from_chain_of_thought_response("", rails) == NOT_PARSABLE
-    assert parse_label_from_chain_of_thought_response("   ", rails) == NOT_PARSABLE
+    assert parse_label_from_chain_of_thought_response("", rails) == ""
+    assert parse_label_from_chain_of_thought_response("   ", rails) == "   "
     
     # LABEL keyword with first word matching rail when rail not found in label part (return path 3)
     assert parse_label_from_chain_of_thought_response(

--- a/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/templates/test_template.py
@@ -7,7 +7,10 @@ from phoenix.evals.templates import (
     InvalidClassificationTemplateError,
     PromptOptions,
     PromptTemplate,
+    parse_label_from_chain_of_thought_response
 )
+
+from phoenix.evals.utils import NOT_PARSABLE
 
 
 def test_classification_template_raises_error_when_initialized_with_mismatched_labels_and_scores():
@@ -64,3 +67,77 @@ def test_template_with_alternate_delimiters():
         str(template.format(variable_values={"name": "world"}))
         == 'Hello, world! Look at this JSON {"hello": "world"}'
     )
+def test_parse_label_from_chain_of_thought_response_extracts_first_word_when_matching_rail():
+    """Test that the function extracts labels from the first word when it matches a rail."""
+    rails = ["relevant", "unrelated", "correct", "incorrect"]
+    
+    # First word matches rail - this is the key new functionality
+    assert parse_label_from_chain_of_thought_response(
+        "incorrect EXPLANATION: The user input is wrong", rails
+    ) == "incorrect"
+    
+    assert parse_label_from_chain_of_thought_response(
+        "relevant EXPLANATION because it answers the question", rails
+    ) == "relevant"
+
+
+def test_parse_label_from_chain_of_thought_response_avoids_false_positives_from_explanations():
+    """Test that the function doesn't extract labels from explanations (only first word)."""
+    rails = ["relevant", "unrelated", "correct", "incorrect"]
+    
+    # Should NOT extract "relevant" from explanation text
+    assert parse_label_from_chain_of_thought_response(
+        "EXPLANATION: The text is relevant to the question", rails
+    ) == NOT_PARSABLE
+    
+    # Should NOT extract "incorrect" from middle of explanation  
+    assert parse_label_from_chain_of_thought_response(
+        "The answer seems incorrect based on the context", rails
+    ) == NOT_PARSABLE
+
+
+def test_parse_label_from_chain_of_thought_response_handles_label_keyword_positioning():
+    """Test that the function handles LABEL keyword in different positions and incomplete explanations."""
+    rails = ["relevant", "unrelated", "correct", "incorrect"]
+    
+    # LABEL at beginning with incomplete explanation
+    assert parse_label_from_chain_of_thought_response(
+        "LABEL: incorrect EXPLANATION: The user is asking about the availability of", rails
+    ) == "incorrect"
+    
+    # EXPLANATION first, then LABEL (should extract from LABEL section)
+    assert parse_label_from_chain_of_thought_response(
+        "EXPLANATION: The user is asking about the availability of\nLABEL: correct", rails
+    ) == "correct"
+    
+    # LABEL with just the label word and no explanation
+    assert parse_label_from_chain_of_thought_response(
+        "LABEL: relevant", rails
+    ) == "relevant"
+    
+    # Multiple LABEL keywords - should use first one
+    assert parse_label_from_chain_of_thought_response(
+        "LABEL: incorrect EXPLANATION: something LABEL: correct", rails
+    ) == "incorrect"
+
+
+def test_parse_label_from_chain_of_thought_response_handles_edge_cases():
+    """Test edge cases to ensure complete coverage of all return paths."""
+    rails = ["relevant", "irrelevant"]
+    
+    # Empty/whitespace input (return path 1)
+    assert parse_label_from_chain_of_thought_response("", rails) == NOT_PARSABLE
+    assert parse_label_from_chain_of_thought_response("   ", rails) == NOT_PARSABLE
+    
+    # LABEL keyword with first word matching rail when rail not found in label part (return path 3)
+    assert parse_label_from_chain_of_thought_response(
+        "LABEL: relevant but contains other text", ["relevant"]
+    ) == "relevant"
+    
+    # LABEL keyword with no rails provided (return path 4)
+    assert parse_label_from_chain_of_thought_response(
+        "LABEL: someword explanation", None
+    ) == "someword"
+    
+    # No rails provided, single word response (return path 6)
+    assert parse_label_from_chain_of_thought_response("singleword", None) == "singleword"


### PR DESCRIPTION
Fixed Eval parsing issue and added tests:

The following are common parsing needs that failed in the old approach. Hitting these a lot.

1) LABEL before explanation 
LABEL: incorrect EXPLANATION: The user is asking about the availability of 

2) Missing the label but just having the "rail" this is common customer experience 
incorrect EXPLANATION: The user is asking about the availability of 