### PR TITLE
feat: empty state for prompts and experiments

### DIFF
--- a/app/src/components/icon/Icons.tsx
+++ b/app/src/components/icon/Icons.tsx
@@ -483,6 +483,27 @@ export const BrowserOutline = () => (
   </svg>
 );
 
+export const BulbOutline = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g data-name="Layer 2">
+      <g data-name="bulb">
+        <rect
+          width="24"
+          height="24"
+          transform="rotate(180 12 12)"
+          opacity="0"
+        />
+        <path d="M12 7a5 5 0 0 0-3 9v4a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2v-4a5 5 0 0 0-3-9zm1.5 7.59a1 1 0 0 0-.5.87V20h-2v-4.54a1 1 0 0 0-.5-.87A3 3 0 0 1 9 12a3 3 0 0 1 6 0 3 3 0 0 1-1.5 2.59z" />
+        <path d="M12 6a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1z" />
+        <path d="M21 11h-2a1 1 0 0 0 0 2h2a1 1 0 0 0 0-2z" />
+        <path d="M5 11H3a1 1 0 0 0 0 2h2a1 1 0 0 0 0-2z" />
+        <path d="M7.66 6.42L6.22 5a1 1 0 0 0-1.39 1.47l1.44 1.39a1 1 0 0 0 .73.28 1 1 0 0 0 .72-.31 1 1 0 0 0-.06-1.41z" />
+        <path d="M19.19 5.05a1 1 0 0 0-1.41 0l-1.44 1.37a1 1 0 0 0 0 1.41 1 1 0 0 0 .72.31 1 1 0 0 0 .69-.28l1.44-1.39a1 1 0 0 0 0-1.42z" />
+      </g>
+    </g>
+  </svg>
+);
+
 //C
 export const CalendarOutline = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/app/src/pages/dataset/RunExperimentButton.tsx
+++ b/app/src/pages/dataset/RunExperimentButton.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useCallback, useMemo, useState } from "react";
 
-import { Dialog, DialogContainer } from "@arizeai/components";
+import { ButtonProps, Dialog, DialogContainer } from "@arizeai/components";
 
 import {
   Button,
@@ -216,7 +216,11 @@ function RunExperimentExampleSwitcher() {
   );
 }
 
-export function RunExperimentButton() {
+export function RunExperimentButton({
+  variant = "default",
+}: {
+  variant?: ButtonProps["variant"];
+}) {
   const [dialog, setDialog] = useState<ReactNode>(null);
   const onRunExample = useCallback(() => {
     setDialog(<RunExperimentExampleSwitcher />);
@@ -225,6 +229,7 @@ export function RunExperimentButton() {
     <>
       <Button
         size="S"
+        variant={variant}
         leadingVisual={<Icon svg={<Icons.ExperimentOutline />} />}
         onPress={onRunExample}
       >

--- a/app/src/pages/datasets/DatasetsEmpty.tsx
+++ b/app/src/pages/datasets/DatasetsEmpty.tsx
@@ -17,7 +17,7 @@ export function DatasetsEmpty() {
         alignItems="center"
         justifyContent="center"
       >
-        <View width="780px">
+        <View width="100%" maxWidth="780px">
           <Flex direction="column" gap="size-400" alignItems="center">
             <Text size="XL">
               Create datasets for testing prompts, experimentation, and
@@ -42,7 +42,7 @@ export function DatasetsEmpty() {
                 target="_blank"
                 leadingVisual={<Icon svg={<Icons.Rocket />} />}
               >
-                Quckstart
+                Quickstart
               </ExternalLinkButton>
             </Flex>
           </Flex>

--- a/app/src/pages/experiments/ExperimentsEmpty.tsx
+++ b/app/src/pages/experiments/ExperimentsEmpty.tsx
@@ -19,7 +19,7 @@ export function ExperimentsEmpty() {
         alignItems="center"
         justifyContent="center"
       >
-        <View width="780px">
+        <View width="100%" maxWidth="780px">
           <Flex direction="column" gap="size-400" alignItems="center">
             <Text size="XL">
               Run experiments to evaluate and improve your AI applications.

--- a/app/src/pages/experiments/ExperimentsEmpty.tsx
+++ b/app/src/pages/experiments/ExperimentsEmpty.tsx
@@ -1,0 +1,55 @@
+import {
+  ExternalLinkButton,
+  Flex,
+  Icon,
+  Icons,
+  Text,
+  Video,
+  View,
+} from "@phoenix/components";
+
+import { RunExperimentButton } from "../dataset/RunExperimentButton";
+
+export function ExperimentsEmpty() {
+  return (
+    <View width="100%" paddingY="size-400">
+      <Flex
+        direction="column"
+        width="100%"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <View width="780px">
+          <Flex direction="column" gap="size-400" alignItems="center">
+            <Text size="XL">
+              Run experiments to evaluate and improve your AI applications.
+            </Text>
+            <Video
+              src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/experiments.mp4"
+              autoPlay
+              muted
+              loop
+            />
+            <Flex direction="row" gap="size-200">
+              <ExternalLinkButton
+                href="https://docs.arize.com/phoenix/datasets-and-experiments/how-to-experiments/run-experiments"
+                target="_blank"
+                leadingVisual={<Icon svg={<Icons.BookOutline />} />}
+              >
+                Documentation
+              </ExternalLinkButton>
+              <ExternalLinkButton
+                href="https://docs.arize.com/phoenix/cookbook/datasets-and-experiments/summarization"
+                target="_blank"
+                leadingVisual={<Icon svg={<Icons.BulbOutline />} />}
+              >
+                Example
+              </ExternalLinkButton>
+              <RunExperimentButton variant="primary" />
+            </Flex>
+          </Flex>
+        </View>
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -32,41 +32,15 @@ import {
   formatPercent,
 } from "@phoenix/utils/numberFormatUtils";
 
-import { RunExperimentButton } from "../dataset/RunExperimentButton";
-
 import { experimentsLoaderQuery$data } from "./__generated__/experimentsLoaderQuery.graphql";
 import type { ExperimentsTableFragment$key } from "./__generated__/ExperimentsTableFragment.graphql";
 import { ExperimentsTableQuery } from "./__generated__/ExperimentsTableQuery.graphql";
 import { DownloadExperimentActionMenu } from "./DownloadExperimentActionMenu";
 import { ErrorRateCell } from "./ErrorRateCell";
 import { ExperimentSelectionToolbar } from "./ExperimentSelectionToolbar";
+import { ExperimentsEmpty } from "./ExperimentsEmpty";
 
 const PAGE_SIZE = 100;
-
-export function ExperimentsTableEmpty() {
-  return (
-    <tbody className="is-empty">
-      <tr>
-        <td
-          colSpan={100}
-          css={css`
-            text-align: center;
-            padding: var(--ac-global-dimension-size-400) !important;
-            button {
-              margin-top: var(--ac-global-dimension-size-200);
-              margin-left: auto;
-              margin-right: auto;
-            }
-          `}
-        >
-          No experiments for this dataset. To see how to run experiments on a
-          dataset, check out the documentation.
-          <RunExperimentButton />
-        </td>
-      </tr>
-    </tbody>
-  );
-}
 
 export function ExperimentsTable({
   dataset,
@@ -331,6 +305,11 @@ export function ExperimentsTable({
     [hasNext, isLoadingNext, loadNext]
   );
   const navigate = useNavigate();
+
+  if (isEmpty) {
+    return <ExperimentsEmpty />;
+  }
+
   return (
     <div
       css={css`
@@ -361,33 +340,26 @@ export function ExperimentsTable({
             </tr>
           ))}
         </thead>
-        {isEmpty ? (
-          <ExperimentsTableEmpty />
-        ) : (
-          <tbody>
-            {rows.map((row) => (
-              <tr
-                key={row.id}
-                onClick={() => {
-                  navigate(
-                    `/datasets/${dataset.id}/compare?experimentId=${row.original.id}`
-                  );
-                }}
-              >
-                {row.getVisibleCells().map((cell) => {
-                  return (
-                    <td key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        )}
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              onClick={() => {
+                navigate(
+                  `/datasets/${dataset.id}/compare?experimentId=${row.original.id}`
+                );
+              }}
+            >
+              {row.getVisibleCells().map((cell) => {
+                return (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
       </table>
       {selectedRows.length ? (
         <ExperimentSelectionToolbar

--- a/app/src/pages/prompts/PromptsEmpty.tsx
+++ b/app/src/pages/prompts/PromptsEmpty.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from "react-router";
+
+import {
+  Button,
+  ExternalLinkButton,
+  Flex,
+  Icon,
+  Icons,
+  Text,
+  Video,
+  View,
+} from "@phoenix/components";
+
+export function PromptsEmpty() {
+  const navigate = useNavigate();
+
+  return (
+    <View width="100%" paddingY="size-400">
+      <Flex
+        direction="column"
+        width="100%"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <View width="780px">
+          <Flex direction="column" gap="size-400" alignItems="center">
+            <Text size="XL">
+              Create and manage prompt templates for your AI applications.
+            </Text>
+            <Video
+              src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/prompts.mp4"
+              autoPlay
+              muted
+              loop
+            />
+            <Flex direction="row" gap="size-200">
+              <ExternalLinkButton
+                href="https://arize.com/docs/phoenix/prompt-engineering/quickstart-prompts/quickstart-prompts-ui"
+                target="_blank"
+                leadingVisual={<Icon svg={<Icons.BookOutline />} />}
+              >
+                Documentation
+              </ExternalLinkButton>
+              <Button
+                variant="primary"
+                leadingVisual={<Icon svg={<Icons.PlayCircleOutline />} />}
+                onPress={() => navigate("/playground")}
+              >
+                Playground
+              </Button>
+            </Flex>
+          </Flex>
+        </View>
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/pages/prompts/PromptsEmpty.tsx
+++ b/app/src/pages/prompts/PromptsEmpty.tsx
@@ -22,7 +22,7 @@ export function PromptsEmpty() {
         alignItems="center"
         justifyContent="center"
       >
-        <View width="780px">
+        <View width="100%" maxWidth="780px">
           <Flex direction="column" gap="size-400" alignItems="center">
             <Text size="XL">
               Create and manage prompt templates for your AI applications.

--- a/app/src/pages/prompts/PromptsPage.tsx
+++ b/app/src/pages/prompts/PromptsPage.tsx
@@ -16,6 +16,7 @@ import { PromptsTable } from "./PromptsTable";
 export function PromptsPage() {
   const loaderData = useLoaderData<typeof promptsLoader>();
   invariant(loaderData, "loaderData is required");
+
   return (
     <Flex direction="column" height="100%">
       <View

--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -14,12 +14,12 @@ import { Flex, Icon, Icons, Link, LinkButton } from "@phoenix/components";
 import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { TextCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
-import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 
 import { PromptsTable_prompts$key } from "./__generated__/PromptsTable_prompts.graphql";
 import { PromptsTablePromptsQuery } from "./__generated__/PromptsTablePromptsQuery.graphql";
 import { PromptActionMenu } from "./PromptActionMenu";
+import { PromptsEmpty } from "./PromptsEmpty";
 
 const PAGE_SIZE = 100;
 
@@ -156,6 +156,11 @@ export function PromptsTable(props: PromptsTableProps) {
 
   const rows = table.getRowModel().rows;
   const isEmpty = rows.length === 0;
+
+  if (isEmpty) {
+    return <PromptsEmpty />;
+  }
+
   return (
     <div
       css={css`
@@ -209,34 +214,27 @@ export function PromptsTable(props: PromptsTableProps) {
             </tr>
           ))}
         </thead>
-        {isEmpty ? (
-          <TableEmpty />
-        ) : (
-          <tbody>
-            {rows.map((row) => {
-              return (
-                <tr
-                  key={row.id}
-                  onClick={() => {
-                    navigate(`${row.original.id}`);
-                  }}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <td
-                      key={cell.id}
-                      align={cell.column.columnDef.meta?.textAlign}
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              );
-            })}
-          </tbody>
-        )}
+        <tbody>
+          {rows.map((row) => {
+            return (
+              <tr
+                key={row.id}
+                onClick={() => {
+                  navigate(`${row.original.id}`);
+                }}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    align={cell.column.columnDef.meta?.textAlign}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
       </table>
     </div>
   );


### PR DESCRIPTION
## Summary by Sourcery

Provide rich, reusable empty states for prompts and experiments tables, streamline table rendering, and enhance button customization and iconography.

New Features:
- Add dedicated empty-state components (ExperimentsEmpty, PromptsEmpty) featuring videos, documentation links, and action buttons for rich UI when no items are present
- Allow RunExperimentButton to accept a variant prop for customizable styling
- Introduce BulbOutline SVG icon

Enhancements:
- Replace inline empty-table fallbacks in ExperimentsTable and PromptsTable with early-return of the new empty-state components