### PR TITLE
fix(helm): respect `postgres.enabled` value

### DIFF
--- a/helm/templates/database/deployment.yaml
+++ b/helm/templates/database/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - name: POSTGRES_PASSWORD
           value: "{{ .Values.database.postgres.password }}"
         resources: {{ toYaml .Values.postgres.resources | nindent 10 }}
+    {{- if .Values.postgres.persistence.enabled }}
         volumeMounts:
         - name: postgres-data
           mountPath: /var/lib/postgresql/data
@@ -38,4 +39,5 @@ spec:
       - name: postgres-data
         persistentVolumeClaim:
           claimName: {{ template "phoenix.postgres-pvc" . }}
+    {{- end }}
 {{- end }}

--- a/helm/templates/database/deployment.yaml
+++ b/helm/templates/database/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,3 +38,4 @@ spec:
       - name: postgres-data
         persistentVolumeClaim:
           claimName: {{ template "phoenix.postgres-pvc" . }}
+{{- end }}

--- a/helm/templates/database/pvc.yaml
+++ b/helm/templates/database/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgres.persistence.enabled }}
+{{- if and .Values.postgres.enabled .Values.postgres.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/templates/database/service.yaml
+++ b/helm/templates/database/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,7 +9,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - name: postgres 
+    - name: postgres
       port: 5432
   selector:
     app: postgres
+{{- end }}


### PR DESCRIPTION
This pull request adds missing conditional logic to the Helm templates for the PostgreSQL resources, ensuring that these resources are only deployed when PostgreSQL is enabled in the Helm chart values and are omitted if not.

I stumbled across this, while trying to install the provided helm chart with a dedicated managed PostgreSQL instance.

## Summary by Sourcery

Add missing conditional logic to Helm chart templates to ensure PostgreSQL resources are only deployed when enabled

Bug Fixes:
- Conditionally render the PostgreSQL Service and Deployment only when .Values.postgres.enabled is true
- Include .Values.postgres.enabled in the PVC persistence condition to prevent PVC creation when PostgreSQL is disabled