### PR TITLE
ci: enable ci on feature branches

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main, feat/annotations]
+    branches: [main, feat/bedrock, feat/cost]
   pull_request:
     paths:
       - "**/*.py"
@@ -519,7 +519,7 @@ jobs:
       fail-fast: false
       matrix:
         py: [3.9]
-        pkg: [openai, google_generativeai]  # NOTE: bypass Anthropic check while types are changing
+        pkg: [openai, google_generativeai] # NOTE: bypass Anthropic check while types are changing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main, feat/annotations]
+    branches: [main, feat/bedrock, feat/cost]
   pull_request:
     paths:
       - "app/**"

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [main, feat/annotations]
+    branches: [main, feat/bedrock, feat/cost]
   pull_request:
     paths:
       - "js/**"


### PR DESCRIPTION
## Summary by Sourcery

Enable continuous integration on new feature branches by updating branch filters across existing workflows

CI:
- Add feat/bedrock and feat/cost to push triggers in python-CI.yml
- Add feat/bedrock and feat/cost to push triggers in typescript-CI.yml
- Add feat/bedrock and feat/cost to push triggers in typescript-packages-CI.yml