### PR TITLE
feat(playground): add support for multiple credential kv pairs - frontend only

### DIFF
--- a/app/src/@types/generative.d.ts
+++ b/app/src/@types/generative.d.ts
@@ -22,3 +22,12 @@ declare type ToolChoice =
   | "required"
   | "none"
   | { type: "function"; function: { name: string } };
+
+/**
+ * A credential for a model provider
+ * E.x. { envVarName: "OPENAI_API_KEY", isRequired: true }
+ */
+type ModelProviderCredentialConfig = {
+  envVarName: string;
+  isRequired: boolean;
+};

--- a/app/src/constants/__tests__/generativeConstants.test.ts
+++ b/app/src/constants/__tests__/generativeConstants.test.ts
@@ -1,0 +1,67 @@
+import {
+  ModelProviders,
+  ProviderToCredentialsConfigMap,
+} from "../generativeConstants";
+
+describe("generativeConstants", () => {
+  describe("ProviderToCredentialsMap", () => {
+    it("should have credentials defined for every provider", () => {
+      const providers = Object.keys(ModelProviders) as ModelProvider[];
+      const credentialProviders = Object.keys(
+        ProviderToCredentialsConfigMap
+      ) as ModelProvider[];
+
+      // Check that every provider has credentials defined
+      providers.forEach((provider) => {
+        expect(ProviderToCredentialsConfigMap).toHaveProperty(provider);
+        expect(ProviderToCredentialsConfigMap[provider]).toBeDefined();
+        expect(Array.isArray(ProviderToCredentialsConfigMap[provider])).toBe(
+          true
+        );
+        expect(ProviderToCredentialsConfigMap[provider].length).toBeGreaterThan(
+          0
+        );
+      });
+
+      // Check that every credential entry has required fields
+      credentialProviders.forEach((provider) => {
+        const credentials = ProviderToCredentialsConfigMap[provider];
+        credentials.forEach((credential) => {
+          expect(credential).toHaveProperty("envVarName");
+          expect(credential).toHaveProperty("isRequired");
+          expect(typeof credential.envVarName).toBe("string");
+          expect(credential.envVarName.length).toBeGreaterThan(0);
+          expect(typeof credential.isRequired).toBe("boolean");
+        });
+      });
+
+      // Ensure no extra providers in credentials map
+      expect(credentialProviders.sort()).toEqual(providers.sort());
+    });
+
+    it("should have at least one required credential per provider", () => {
+      const providers = Object.keys(ModelProviders) as ModelProvider[];
+
+      providers.forEach((provider) => {
+        const credentials = ProviderToCredentialsConfigMap[provider];
+        const hasRequiredCredential = credentials.some(
+          (credential) => credential.isRequired
+        );
+        expect(hasRequiredCredential).toBe(true);
+      });
+    });
+
+    it("should have unique environment variable names per provider", () => {
+      const providers = Object.keys(ModelProviders) as ModelProvider[];
+
+      providers.forEach((provider) => {
+        const credentials = ProviderToCredentialsConfigMap[provider];
+        const envVarNames = credentials.map(
+          (credential) => credential.envVarName
+        );
+        const uniqueEnvVarNames = new Set(envVarNames);
+        expect(uniqueEnvVarNames.size).toBe(envVarNames.length);
+      });
+    });
+  });
+});

--- a/app/src/constants/generativeConstants.ts
+++ b/app/src/constants/generativeConstants.ts
@@ -62,3 +62,19 @@ export const ChatRoleMap: Record<ChatMessageRole, string[]> = {
   system: ["system", "developer"],
   tool: ["tool"],
 };
+
+/**
+ * A mapping of model providers to the credentials configs that are required for secure access.
+ * In most cases, there is only one credential name per provider, but some providers require multiple credentials.
+ */
+export const ProviderToCredentialsConfigMap: Record<
+  ModelProvider,
+  ModelProviderCredentialConfig[]
+> = {
+  OPENAI: [{ envVarName: "OPENAI_API_KEY", isRequired: true }],
+  AZURE_OPENAI: [{ envVarName: "AZURE_OPENAI_API_KEY", isRequired: true }],
+  ANTHROPIC: [{ envVarName: "ANTHROPIC_API_KEY", isRequired: true }],
+  GOOGLE: [{ envVarName: "GEMINI_API_KEY", isRequired: true }],
+  DEEPSEEK: [{ envVarName: "DEEPSEEK_API_KEY", isRequired: true }],
+  XAI: [{ envVarName: "XAI_API_KEY", isRequired: true }],
+} as const;

--- a/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
+++ b/app/src/pages/playground/PlaygroundCredentialsDropdown.tsx
@@ -18,16 +18,11 @@ import {
   Text,
   View,
 } from "@phoenix/components";
+import { GenerativeProviderIcon } from "@phoenix/components/generative/GenerativeProviderIcon";
+import { ProviderToCredentialsConfigMap } from "@phoenix/constants/generativeConstants";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
-export const ProviderToCredentialNameMap: Record<ModelProvider, string> = {
-  OPENAI: "OPENAI_API_KEY",
-  ANTHROPIC: "ANTHROPIC_API_KEY",
-  AZURE_OPENAI: "AZURE_OPENAI_API_KEY",
-  GOOGLE: "GEMINI_API_KEY",
-  DEEPSEEK: "DEEPSEEK_API_KEY",
-  XAI: "XAI_API_KEY",
-};
+import { getProviderName } from "@phoenix/utils/generativeUtils";
 
 export function PlaygroundCredentialsDropdown() {
   const currentProviders = usePlaygroundContext((state) =>
@@ -38,8 +33,6 @@ export function PlaygroundCredentialsDropdown() {
   const isRunning = usePlaygroundContext((state) =>
     state.instances.some((instance) => instance.activeRunId != null)
   );
-  const setCredential = useCredentialsContext((state) => state.setCredential);
-  const credentials = useCredentialsContext((state) => state);
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div
@@ -78,23 +71,18 @@ export function PlaygroundCredentialsDropdown() {
               </View>
               <Flex direction="column" gap="size-100">
                 {currentProviders.map((provider) => {
-                  const credentialName = ProviderToCredentialNameMap[provider];
                   return (
-                    <CredentialField
-                      size="S"
-                      key={provider}
-                      isRequired
-                      onChange={(value) => {
-                        setCredential({ provider, value });
-                      }}
-                      value={credentials[provider]}
-                    >
-                      <Label>{credentialName}</Label>
-                      <CredentialInput />
-                      <Text slot="description">
-                        {`Alternatively, you can set the "${credentialName}" environment variable on the phoenix server.`}
-                      </Text>
-                    </CredentialField>
+                    <View key={provider} paddingY="size-50">
+                      <Flex direction="row" gap="size-100" alignItems="center">
+                        <GenerativeProviderIcon provider={provider} />
+                        <Heading level={3} weight="heavy">
+                          {getProviderName(provider)}
+                        </Heading>
+                      </Flex>
+                      <View paddingBottom="size-100" paddingTop="size-100">
+                        <ProviderCredentials provider={provider} />
+                      </View>
+                    </View>
                   );
                 })}
               </Flex>
@@ -115,5 +103,40 @@ export function PlaygroundCredentialsDropdown() {
         </DropdownMenu>
       </DropdownTrigger>
     </div>
+  );
+}
+
+function ProviderCredentials({ provider }: { provider: ModelProvider }) {
+  const setCredential = useCredentialsContext((state) => state.setCredential);
+  const credentialsConfig = ProviderToCredentialsConfigMap[provider];
+  const credentials = useCredentialsContext((state) => state[provider]);
+  const isRunning = usePlaygroundContext((state) =>
+    state.instances.some((instance) => instance.activeRunId != null)
+  );
+  return (
+    <View>
+      {credentialsConfig.map((credentialConfig) => (
+        <CredentialField
+          size="S"
+          key={credentialConfig.envVarName}
+          isRequired={credentialConfig.isRequired}
+          onChange={(value) => {
+            setCredential({
+              provider,
+              envVarName: credentialConfig.envVarName,
+              value,
+            });
+          }}
+          value={credentials?.[credentialConfig.envVarName] ?? ""}
+          isDisabled={isRunning}
+        >
+          <Label>{credentialConfig.envVarName}</Label>
+          <CredentialInput />
+          <Text slot="description">
+            {`Alternatively, you can set the "${credentialConfig.envVarName}" environment variable on the server.`}
+          </Text>
+        </CredentialField>
+      ))}
+    </View>
   );
 }

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -12,17 +12,19 @@ import { Card, Dialog, DialogContainer } from "@arizeai/components";
 
 import {
   Button,
+  CredentialField,
+  CredentialInput,
   Flex,
+  Form,
   Icon,
   Icons,
-  Input,
   Label,
   Text,
-  TextField,
   View,
 } from "@phoenix/components";
 import { GenerativeProviderIcon } from "@phoenix/components/generative";
 import { tableCSS } from "@phoenix/components/table/styles";
+import { ProviderToCredentialsConfigMap } from "@phoenix/constants/generativeConstants";
 import { useCredentialsContext } from "@phoenix/contexts/CredentialsContext";
 
 import {
@@ -39,7 +41,6 @@ export function GenerativeProvidersCard({
     GenerativeProvidersCard_data$data["modelProviders"][number] | null
   >(null);
   const credentials = useCredentialsContext((state) => state);
-  const setCredential = useCredentialsContext((state) => state.setCredential);
   const data = useFragment<GenerativeProvidersCard_data$key>(
     graphql`
       fragment GenerativeProvidersCard_data on Query {
@@ -73,10 +74,15 @@ export function GenerativeProvidersCard({
         },
       },
       {
-        header: "Environment Variable",
+        header: "Environment Variables",
         accessorKey: "apiKeyEnvVar",
         cell: ({ row }) => {
-          return <Text>{row.original.apiKeyEnvVar}</Text>;
+          const credentialsConfig =
+            ProviderToCredentialsConfigMap[row.original.key];
+          const envVars =
+            credentialsConfig?.map((config) => config.envVarName).join(", ") ||
+            row.original.apiKeyEnvVar;
+          return <Text>{envVars}</Text>;
         },
       },
       {
@@ -86,7 +92,14 @@ export function GenerativeProvidersCard({
           if (!row.original.dependenciesInstalled) {
             return <Text color="warning">missing dependencies</Text>;
           }
-          if (credentials[row.original.key]) {
+
+          // Check if any credentials are set locally
+          const providerCredentials = credentials[row.original.key];
+          const hasLocalCredentials =
+            providerCredentials &&
+            Object.values(providerCredentials).some((value) => value);
+
+          if (hasLocalCredentials) {
             return <Text color="success">local</Text>;
           }
           if (row.original.apiKeySet) {
@@ -175,7 +188,10 @@ export function GenerativeProvidersCard({
         onDismiss={() => setSelectedProvider(null)}
       >
         {selectedProvider && (
-          <Dialog title={`Set ${selectedProvider.name} API Key`} size="S">
+          <Dialog
+            title={`Configure ${selectedProvider.name} Credentials`}
+            size="S"
+          >
             <View padding="size-200">
               <View paddingBottom="size-100">
                 <Text size="XS">
@@ -184,45 +200,68 @@ export function GenerativeProvidersCard({
                   only be sent to the server during API requests.
                 </Text>
               </View>
-              <TextField
-                onChange={(value) => {
-                  setCredential({
-                    provider: selectedProvider.key,
-                    value,
-                  });
+              <Form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  setSelectedProvider(null);
                 }}
-                value={credentials[selectedProvider.key]}
-                type="password"
               >
-                <Label>{`${selectedProvider.name} API Key`}</Label>
-                <Input placeholder={`e.g. ${selectedProvider.apiKeyEnvVar}`} />
-
-                <Text slot="description">
-                  The API key will be stored locally in your browser
-                </Text>
-              </TextField>
-            </View>
-            <View
-              paddingX="size-200"
-              paddingY="size-100"
-              borderTopWidth="thin"
-              borderColor="light"
-            >
-              <Flex direction="row" justifyContent="end" gap="size-100">
-                <Button
-                  variant="primary"
-                  size="S"
-                  onPress={() => {
-                    setSelectedProvider(null);
-                  }}
-                >
-                  Set API Key
-                </Button>
-              </Flex>
+                <ProviderCredentials provider={selectedProvider.key} />
+                <View paddingTop="size-200">
+                  <Flex direction="row" justifyContent="end" gap="size-100">
+                    <Button
+                      variant="default"
+                      size="S"
+                      onPress={() => {
+                        setSelectedProvider(null);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="S"
+                      onPress={() => {
+                        setSelectedProvider(null);
+                      }}
+                    >
+                      Save Credentials
+                    </Button>
+                  </Flex>
+                </View>
+              </Form>
             </View>
           </Dialog>
         )}
       </DialogContainer>
     </Card>
+  );
+}
+
+function ProviderCredentials({ provider }: { provider: ModelProvider }) {
+  const setCredential = useCredentialsContext((state) => state.setCredential);
+  const credentialsConfig = ProviderToCredentialsConfigMap[provider];
+  const credentials = useCredentialsContext((state) => state[provider]);
+
+  return (
+    <Flex direction="column" gap="size-100">
+      {credentialsConfig.map((credentialConfig) => (
+        <CredentialField
+          key={credentialConfig.envVarName}
+          isRequired={credentialConfig.isRequired}
+          onChange={(value) => {
+            setCredential({
+              provider,
+              envVarName: credentialConfig.envVarName,
+              value,
+            });
+          }}
+          value={credentials?.[credentialConfig.envVarName] ?? undefined}
+        >
+          <Label>{credentialConfig.envVarName}</Label>
+          <CredentialInput />
+        </CredentialField>
+      ))}
+    </Flex>
   );
 }

--- a/app/src/store/credentialsStore.tsx
+++ b/app/src/store/credentialsStore.tsx
@@ -1,7 +1,59 @@
 import { create, StateCreator } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-export type CredentialsProps = Partial<Record<ModelProvider, string>>;
+import { ProviderToCredentialsConfigMap } from "@phoenix/constants/generativeConstants";
+import { isModelProvider } from "@phoenix/utils/generativeUtils";
+
+/**
+ * A type representing the v0 credentials props. This is the legacy format of credentials where each provider had a single credential.
+ * @deprecated
+ */
+type V0CredentialsProps = Record<ModelProvider, string>;
+
+/**
+ * Check if the given props are a valid v0 credentials object
+ * @param props the props to check
+ * @returns true if the props are a valid v0 credentials object, false otherwise
+ */
+function isV0CredentialsProps(props: unknown): props is V0CredentialsProps {
+  return (
+    typeof props === "object" &&
+    props !== null &&
+    Object.keys(props).length > 0 &&
+    Object.keys(props).every((key) => key in ProviderToCredentialsConfigMap) &&
+    Object.values(props).every((value) => typeof value === "string")
+  );
+}
+
+function migrateV0CredentialsProps(
+  props: V0CredentialsProps
+): CredentialsProps {
+  const newProps: CredentialsProps = {};
+  for (const provider of Object.keys(props)) {
+    if (!isModelProvider(provider)) {
+      continue;
+    }
+    // Only migrate credentials if the provider has 1 credential
+    if (ProviderToCredentialsConfigMap[provider].length === 1) {
+      newProps[provider] = {
+        [ProviderToCredentialsConfigMap[provider][0].envVarName]:
+          props[provider],
+      };
+    }
+  }
+  return newProps;
+}
+
+type CredentialEnvVarName = string;
+type CredentialValue = string;
+/**
+ * A simple string to string map of environment variables to values
+ */
+type ProviderCredentialsMap = Record<CredentialEnvVarName, CredentialValue>;
+
+export type CredentialsProps = Partial<
+  Record<ModelProvider, ProviderCredentialsMap>
+>;
 
 export interface CredentialsState extends CredentialsProps {
   /**
@@ -9,21 +61,38 @@ export interface CredentialsState extends CredentialsProps {
    * @param credential the name of the credential to set
    * @param value the value of the credential
    */
-  setCredential: (params: { provider: ModelProvider; value: string }) => void;
+  setCredential: (params: {
+    provider: ModelProvider;
+    envVarName: string;
+    value: string;
+  }) => void;
 }
 
 export const createCredentialsStore = (
   initialProps: Partial<CredentialsProps>
 ) => {
   const credentialsStore: StateCreator<CredentialsState> = (set) => ({
-    setCredential: ({ provider, value }) => {
-      set({ [provider]: value });
+    setCredential: ({ provider, envVarName, value }) => {
+      set((state) => ({
+        [provider]: {
+          ...state[provider],
+          [envVarName]: value,
+        },
+      }));
     },
     ...initialProps,
   });
   return create<CredentialsState>()(
     persist(devtools(credentialsStore), {
+      version: 1,
       name: "arize-phoenix-credentials",
+      // Migrate from legacy credentials to new credentials
+      migrate: (state: unknown) => {
+        // Only provide a migration if the state is a valid legacy credentials object
+        if (isV0CredentialsProps(state)) {
+          return migrateV0CredentialsProps(state);
+        }
+      },
     })
   );
 };

--- a/app/src/store/credentialsStore.tsx
+++ b/app/src/store/credentialsStore.tsx
@@ -45,7 +45,7 @@ function migrateV0CredentialsProps(
 }
 
 type CredentialEnvVarName = string;
-type CredentialValue = string;
+type CredentialValue = string | null;
 /**
  * A simple string to string map of environment variables to values
  */
@@ -64,7 +64,7 @@ export interface CredentialsState extends CredentialsProps {
   setCredential: (params: {
     provider: ModelProvider;
     envVarName: string;
-    value: string;
+    value: string | null;
   }) => void;
 }
 

--- a/app/src/utils/generativeUtils.ts
+++ b/app/src/utils/generativeUtils.ts
@@ -1,3 +1,5 @@
+import { assertUnreachable } from "@phoenix/typeUtils";
+
 /**
  * A TypeGuard to ensure that a string is a valid ModelProvider
  */
@@ -10,4 +12,23 @@ export function isModelProvider(provider: string): provider is ModelProvider {
     provider === "DEEPSEEK" ||
     provider === "XAI"
   );
+}
+
+export function getProviderName(provider: ModelProvider): string {
+  switch (provider) {
+    case "OPENAI":
+      return "OpenAI";
+    case "AZURE_OPENAI":
+      return "Azure OpenAI";
+    case "ANTHROPIC":
+      return "Anthropic";
+    case "GOOGLE":
+      return "Google";
+    case "DEEPSEEK":
+      return "DeepSeek";
+    case "XAI":
+      return "XAI";
+    default:
+      assertUnreachable(provider);
+  }
 }


### PR DESCRIPTION
This migrates the frontend to be able to support multiple credentials in anticipation of bedrock. I think we should probably refactor the backend to also work in this paradigm so that we can add bedrock more seamlessly.

## Summary by Sourcery

Support multiple credential key-value pairs per model provider by updating the state shape and persistence layer with a migration path, and enhance the playground credentials UI to render fields dynamically based on provider configurations.

New Features:
- Store multiple credential key-value pairs per provider in the credentials store.
- Automatically migrate legacy single-string credentials to the new structured format on persistence rehydration.
- Render dynamic credential input fields for each required environment variable in the playground UI based on provider configuration.

Enhancements:
- Extend the credentials store API to accept an environment variable name when setting credentials and bump persistence version.
- Introduce ProviderToCredentialsConfigMap constant and ModelProviderCredentialConfig type to centralize credential requirements.
- Add getProviderName utility and display provider icons and friendly names in the credentials dropdown UI.

Tests:
- Add unit tests for generativeConstants credential configuration mapping.