### PR TITLE
fix: upgrade lower version pin on openinference-instrumentation and openinference-instrumentation-semantic-conventions

### DIFF
--- a/packages/phoenix-otel/pyproject.toml
+++ b/packages/phoenix-otel/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
   "opentelemetry-exporter-otlp",
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-sdk",
-  "openinference-semantic-conventions>=0.1.9",
-  "openinference-instrumentation>=0.1.21",
+  "openinference-semantic-conventions>=0.1.17",
+  "openinference-instrumentation>=0.1.32",
   "typing-extensions>=4.5, <5",
 ]
 


### PR DESCRIPTION
resolves #7895
