### PR TITLE
feat: Toggling Uvicorn logger level with PHOENIX_LOGGING_LEVEL param

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -452,6 +452,7 @@ def main() -> None:
         host=host,  # type: ignore[arg-type]
         port=port,
         root_path=host_root_path,
+        log_level=Settings.logging_level,
     )
 
     if tls_enabled_for_http:


### PR DESCRIPTION
Uvicorn logs can be excessive and expensive: https://arize-ai.slack.com/archives/C04R3GXC8HK/p1748899514617569

Applying PHOENIX_LOGGING_LEVEL env variable to the Uvicorn loggers. 

If PHOENIX_LOGGING_LEVEL=WARNING, Uvicorn loggers will only log WARNING and higher logs. 