### PR TITLE
feat: server side playground credentials

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1209,11 +1209,16 @@ type GenerativeProvider {
   dependencies: [String!]!
   dependenciesInstalled: Boolean!
 
-  """The API key for the provider"""
-  apiKeyEnvVar: String!
+  """The credential requirements for the provider"""
+  credentialRequirements: [GenerativeProviderCredentialConfig!]!
 
   """Whether the credentials are set on the server for the provider"""
-  apiKeySet: Boolean!
+  credentialsSet: Boolean!
+}
+
+type GenerativeProviderCredentialConfig {
+  envVarName: String!
+  isRequired: Boolean!
 }
 
 enum GenerativeProviderKey {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -242,7 +242,7 @@ input ChatCompletionOverDatasetInput {
   model: GenerativeModelInput!
   invocationParameters: [InvocationParameterInput!]! = []
   tools: [JSON!]
-  apiKey: String = null
+  credentials: [GenerativeCredentialInput!]
   templateFormat: PromptTemplateFormat! = MUSTACHE
   datasetId: ID!
   datasetVersionId: ID = null

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -197,7 +197,7 @@ input ChatCompletionInput {
   model: GenerativeModelInput!
   invocationParameters: [InvocationParameterInput!]! = []
   tools: [JSON!]
-  apiKey: String = null
+  credentials: [GenerativeCredentialInput!]
   template: PromptTemplateOptions
   promptName: Identifier = null
 }
@@ -1183,6 +1183,11 @@ type FunctionCallChunk implements ChatCompletionSubscriptionPayload {
 type Functionality {
   """Model inferences are available for analysis"""
   modelInferences: Boolean!
+}
+
+input GenerativeCredentialInput {
+  envVarName: String!
+  value: String!
 }
 
 type GenerativeModel {

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8697c065b8c8c2089352084dfcb92352>>
+ * @generated SignedSource<<05e9fa98eec391918dc355624b41abd9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OPENAI" | "XAI";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionOverDatasetInput = {
-  apiKey?: string | null;
+  credentials?: ReadonlyArray<GenerativeCredentialInput> | null;
   datasetId: string;
   datasetVersionId?: string | null;
   experimentDescription?: string | null;
@@ -50,6 +50,10 @@ export type InvocationParameterInput = {
   valueJson?: any | null;
   valueString?: string | null;
   valueStringList?: ReadonlyArray<string> | null;
+};
+export type GenerativeCredentialInput = {
+  envVarName: string;
+  value: string;
 };
 export type PlaygroundDatasetExamplesTableMutation$variables = {
   input: ChatCompletionOverDatasetInput;

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<73cdc1d552bb8b4b36cfd46255485f67>>
+ * @generated SignedSource<<38af7d6a23b5eecf0bfe8107a6f39d4f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OPENAI" | "XAI";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionOverDatasetInput = {
-  apiKey?: string | null;
+  credentials?: ReadonlyArray<GenerativeCredentialInput> | null;
   datasetId: string;
   datasetVersionId?: string | null;
   experimentDescription?: string | null;
@@ -50,6 +50,10 @@ export type InvocationParameterInput = {
   valueJson?: any | null;
   valueString?: string | null;
   valueStringList?: ReadonlyArray<string> | null;
+};
+export type GenerativeCredentialInput = {
+  envVarName: string;
+  value: string;
 };
 export type PlaygroundDatasetExamplesTableSubscription$variables = {
   input: ChatCompletionOverDatasetInput;

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76523ab935b72f0441cbe08231cc6c3c>>
+ * @generated SignedSource<<7bd261c0a3e8ee890101d85d6f0c8421>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OPENAI" | "XAI";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionInput = {
-  apiKey?: string | null;
+  credentials?: ReadonlyArray<GenerativeCredentialInput> | null;
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
@@ -45,6 +45,10 @@ export type InvocationParameterInput = {
   valueJson?: any | null;
   valueString?: string | null;
   valueStringList?: ReadonlyArray<string> | null;
+};
+export type GenerativeCredentialInput = {
+  envVarName: string;
+  value: string;
 };
 export type PromptTemplateOptions = {
   format: PromptTemplateFormat;

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fa63bc1806e273a9beb9ee2a31f18644>>
+ * @generated SignedSource<<a0f72b5356ed7716698dbb3a5218d6f6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OPENAI" | "XAI";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionInput = {
-  apiKey?: string | null;
+  credentials?: ReadonlyArray<GenerativeCredentialInput> | null;
   invocationParameters?: ReadonlyArray<InvocationParameterInput>;
   messages: ReadonlyArray<ChatCompletionMessageInput>;
   model: GenerativeModelInput;
@@ -45,6 +45,10 @@ export type InvocationParameterInput = {
   valueJson?: any | null;
   valueString?: string | null;
   valueStringList?: ReadonlyArray<string> | null;
+};
+export type GenerativeCredentialInput = {
+  envVarName: string;
+  value: string;
 };
 export type PromptTemplateOptions = {
   format: PromptTemplateFormat;

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -49,8 +49,11 @@ export function GenerativeProvidersCard({
           key
           dependenciesInstalled
           dependencies
-          apiKeyEnvVar
-          apiKeySet
+          credentialRequirements {
+            envVarName
+            isRequired
+          }
+          credentialsSet
         }
       }
     `,
@@ -81,7 +84,10 @@ export function GenerativeProvidersCard({
             ProviderToCredentialsConfigMap[row.original.key];
           const envVars =
             credentialsConfig?.map((config) => config.envVarName).join(", ") ||
-            row.original.apiKeyEnvVar;
+            row.original.credentialRequirements
+              .map((config) => config.envVarName)
+              .join(", ") ||
+            "--";
           return <Text>{envVars}</Text>;
         },
       },
@@ -102,7 +108,7 @@ export function GenerativeProvidersCard({
           if (hasLocalCredentials) {
             return <Text color="success">local</Text>;
           }
-          if (row.original.apiKeySet) {
+          if (row.original.credentialsSet) {
             return <Text color="success">configured on the server</Text>;
           }
           return <Text color="text-700">not configured</Text>;

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -93,17 +93,21 @@ export function GenerativeProvidersCard({
       },
       {
         header: "configuration",
-        accessorKey: "apiKeySet",
+        accessorKey: "credentialsSet",
         cell: ({ row }) => {
           if (!row.original.dependenciesInstalled) {
             return <Text color="warning">missing dependencies</Text>;
           }
 
           // Check if any credentials are set locally
+          const credentialRequirements = row.original.credentialRequirements;
           const providerCredentials = credentials[row.original.key];
-          const hasLocalCredentials =
-            providerCredentials &&
-            Object.values(providerCredentials).some((value) => value);
+          const hasLocalCredentials = credentialRequirements.every(
+            ({ envVarName, isRequired }) => {
+              const envVarSet = providerCredentials?.[envVarName] !== undefined;
+              return envVarSet || !isRequired;
+            }
+          );
 
           if (hasLocalCredentials) {
             return <Text color="success">local</Text>;

--- a/app/src/pages/settings/__generated__/GenerativeProvidersCard_data.graphql.ts
+++ b/app/src/pages/settings/__generated__/GenerativeProvidersCard_data.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ba84fcb231e8cb4b0a84ee06a2b3b0a>>
+ * @generated SignedSource<<0643d31a743bcd2315989d9b2946f7cc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,8 +13,11 @@ export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | 
 import { FragmentRefs } from "relay-runtime";
 export type GenerativeProvidersCard_data$data = {
   readonly modelProviders: ReadonlyArray<{
-    readonly apiKeyEnvVar: string;
-    readonly apiKeySet: boolean;
+    readonly credentialRequirements: ReadonlyArray<{
+      readonly envVarName: string;
+      readonly isRequired: boolean;
+    }>;
+    readonly credentialsSet: boolean;
     readonly dependencies: ReadonlyArray<string>;
     readonly dependenciesInstalled: boolean;
     readonly key: GenerativeProviderKey;
@@ -72,15 +75,33 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "apiKeyEnvVar",
+          "concreteType": "GenerativeProviderCredentialConfig",
+          "kind": "LinkedField",
+          "name": "credentialRequirements",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "envVarName",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isRequired",
+              "storageKey": null
+            }
+          ],
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "apiKeySet",
+          "name": "credentialsSet",
           "storageKey": null
         }
       ],
@@ -91,6 +112,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "0168d590171b96e7a2e41449a41754be";
+(node as any).hash = "4062531cfa3f77e541172a44101f5331";
 
 export default node;

--- a/app/src/pages/settings/__generated__/settingsAIProvidersPageLoaderQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/settingsAIProvidersPageLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c8b2423e06fab062b5127b3ee540e643>>
+ * @generated SignedSource<<c8606f200b49db7fc42c3fa2b4d713f0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,15 +80,33 @@ const node: ConcreteRequest = {
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "apiKeyEnvVar",
+            "concreteType": "GenerativeProviderCredentialConfig",
+            "kind": "LinkedField",
+            "name": "credentialRequirements",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "envVarName",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isRequired",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "apiKeySet",
+            "name": "credentialsSet",
             "storageKey": null
           }
         ],
@@ -97,12 +115,12 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "cc6e19e54ea894e905970362ee382e43",
+    "cacheID": "1238ea27e05b70fd2c203ab4be6a1209",
     "id": null,
     "metadata": {},
     "name": "settingsAIProvidersPageLoaderQuery",
     "operationKind": "query",
-    "text": "query settingsAIProvidersPageLoaderQuery {\n  ...GenerativeProvidersCard_data\n}\n\nfragment GenerativeProvidersCard_data on Query {\n  modelProviders {\n    name\n    key\n    dependenciesInstalled\n    dependencies\n    apiKeyEnvVar\n    apiKeySet\n  }\n}\n"
+    "text": "query settingsAIProvidersPageLoaderQuery {\n  ...GenerativeProvidersCard_data\n}\n\nfragment GenerativeProvidersCard_data on Query {\n  modelProviders {\n    name\n    key\n    dependenciesInstalled\n    dependencies\n    credentialRequirements {\n      envVarName\n      isRequired\n    }\n    credentialsSet\n  }\n}\n"
   }
 };
 

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -472,11 +472,7 @@ def _get_credential_value(
     if not credentials:
         return None
     return next(
-        (
-            credential.value
-            for credential in credentials
-            if credential.env_var_name == env_var_name
-        ),
+        (credential.value for credential in credentials if credential.env_var_name == env_var_name),
         None,
     )
 

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -7,6 +7,7 @@ import json
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable, Iterator
+from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Hashable, Mapping, MutableMapping, Optional, Union
 
@@ -64,6 +65,16 @@ if TYPE_CHECKING:
 
 SetSpanAttributesFn: TypeAlias = Callable[[Mapping[str, Any]], None]
 ChatCompletionChunk: TypeAlias = Union[TextChunk, ToolCallChunk]
+
+
+@dataclass
+class PlaygroundClientCredential:
+    """
+    Represents a credential for LLM providers.
+    """
+
+    env_var_name: str
+    value: str
 
 
 class Dependency:
@@ -172,9 +183,10 @@ class PlaygroundStreamingClient(ABC):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         self._attributes: dict[str, AttributeValue] = dict()
+        self._credentials = credentials or []
 
     @classmethod
     @abstractmethod
@@ -243,11 +255,11 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient):
         *,
         client: Union["AsyncOpenAI", "AsyncAzureOpenAI"],
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         from openai import RateLimitError as OpenAIRateLimitError
 
-        super().__init__(model=model, api_key=api_key)
+        super().__init__(model=model, credentials=credentials)
         self.client = client
         self.model_name = model.name
         self.rate_limiter = PlaygroundRateLimiter(model.provider_key, OpenAIRateLimitError)
@@ -453,6 +465,28 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient):
         yield LLM_TOKEN_COUNT_TOTAL, usage.total_tokens
 
 
+def _get_credential_value(
+    credentials: Optional[list[PlaygroundClientCredential]], env_var_name: str
+) -> Optional[str]:
+    """Helper function to extract credential value from credentials list."""
+    if not credentials:
+        return None
+    for credential in credentials:
+        if credential.env_var_name == env_var_name:
+            return credential.value
+    return None
+
+
+def _require_credential(
+    credentials: Optional[list[PlaygroundClientCredential]], env_var_name: str, provider_name: str
+) -> str:
+    """Helper function to require a credential value, raising an exception if not found."""
+    value = _get_credential_value(credentials, env_var_name)
+    if value is None:
+        raise BadRequest(f"Missing required credential '{env_var_name}' for {provider_name}")
+    return value
+
+
 @register_llm_client(
     provider_key=GenerativeProviderKey.DEEPSEEK,
     model_names=[
@@ -465,17 +499,24 @@ class DeepSeekStreamingClient(OpenAIBaseStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         from openai import AsyncOpenAI
 
         base_url = model.base_url or getenv("DEEPSEEK_BASE_URL")
-        if not (api_key := api_key or getenv("DEEPSEEK_API_KEY")):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = _get_credential_value(credentials, "DEEPSEEK_API_KEY") or getenv(
+            "DEEPSEEK_API_KEY"
+        )
+
+        if not api_key:
             if not base_url:
                 raise BadRequest("An API key is required for DeepSeek models")
             api_key = "sk-fake-api-key"
+
         client = AsyncOpenAI(api_key=api_key, base_url=base_url or "https://api.deepseek.com")
-        super().__init__(client=client, model=model, api_key=api_key)
+        super().__init__(client=client, model=model, credentials=credentials)
         # DeepSeek uses OpenAI-compatible API but we'll track it as a separate provider
         # Adding a custom "deepseek" provider value to make it distinguishable in traces
         self._attributes[LLM_PROVIDER] = "deepseek"
@@ -498,17 +539,22 @@ class XAIStreamingClient(OpenAIBaseStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         from openai import AsyncOpenAI
 
         base_url = model.base_url or getenv("XAI_BASE_URL")
-        if not (api_key := api_key or getenv("XAI_API_KEY")):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = _get_credential_value(credentials, "XAI_API_KEY") or getenv("XAI_API_KEY")
+
+        if not api_key:
             if not base_url:
                 raise BadRequest("An API key is required for xAI models")
             api_key = "sk-fake-api-key"
+
         client = AsyncOpenAI(api_key=api_key, base_url=base_url or "https://api.x.ai/v1")
-        super().__init__(client=client, model=model, api_key=api_key)
+        super().__init__(client=client, model=model, credentials=credentials)
         # xAI uses OpenAI-compatible API but we'll track it as a separate provider
         # Adding a custom "xai" provider value to make it distinguishable in traces
         self._attributes[LLM_PROVIDER] = "xai"
@@ -550,17 +596,22 @@ class OpenAIStreamingClient(OpenAIBaseStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         from openai import AsyncOpenAI
 
         base_url = model.base_url or getenv("OPENAI_BASE_URL")
-        if not (api_key := api_key or getenv("OPENAI_API_KEY")):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = _get_credential_value(credentials, "OPENAI_API_KEY") or getenv("OPENAI_API_KEY")
+
+        if not api_key:
             if not base_url:
                 raise BadRequest("An API key is required for OpenAI models")
             api_key = "sk-fake-api-key"
+
         client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        super().__init__(client=client, model=model, api_key=api_key)
+        super().__init__(client=client, model=model, credentials=credentials)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.OPENAI.value
         self._attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.OPENAI.value
 
@@ -723,7 +774,7 @@ class AzureOpenAIStreamingClient(OpenAIBaseStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ):
         from openai import AsyncAzureOpenAI
 
@@ -731,7 +782,13 @@ class AzureOpenAIStreamingClient(OpenAIBaseStreamingClient):
             raise BadRequest("An Azure endpoint is required for Azure OpenAI models")
         if not (api_version := model.api_version or getenv("OPENAI_API_VERSION")):
             raise BadRequest("An OpenAI API version is required for Azure OpenAI models")
-        if api_key := api_key or getenv("AZURE_OPENAI_API_KEY"):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = _get_credential_value(credentials, "AZURE_OPENAI_API_KEY") or getenv(
+            "AZURE_OPENAI_API_KEY"
+        )
+
+        if api_key:
             client = AsyncAzureOpenAI(
                 api_key=api_key,
                 azure_endpoint=endpoint,
@@ -754,7 +811,7 @@ class AzureOpenAIStreamingClient(OpenAIBaseStreamingClient):
                 azure_endpoint=endpoint,
                 api_version=api_version,
             )
-        super().__init__(client=client, model=model, api_key=api_key)
+        super().__init__(client=client, model=model, credentials=credentials)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.AZURE.value
         self._attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.OPENAI.value
 
@@ -783,15 +840,22 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         import anthropic
 
-        super().__init__(model=model, api_key=api_key)
+        super().__init__(model=model, credentials=credentials)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.ANTHROPIC.value
         self._attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.ANTHROPIC.value
-        if not (api_key := api_key or getenv("ANTHROPIC_API_KEY")):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = _get_credential_value(credentials, "ANTHROPIC_API_KEY") or getenv(
+            "ANTHROPIC_API_KEY"
+        )
+
+        if not api_key:
             raise BadRequest("An API key is required for Anthropic models")
+
         self.client = anthropic.AsyncAnthropic(api_key=api_key)
         self.model_name = model.name
         self.rate_limiter = PlaygroundRateLimiter(model.provider_key, anthropic.RateLimitError)
@@ -991,15 +1055,25 @@ class GoogleStreamingClient(PlaygroundStreamingClient):
     def __init__(
         self,
         model: GenerativeModelInput,
-        api_key: Optional[str] = None,
+        credentials: Optional[list[PlaygroundClientCredential]] = None,
     ) -> None:
         import google.generativeai as google_genai
 
-        super().__init__(model=model, api_key=api_key)
+        super().__init__(model=model, credentials=credentials)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.GOOGLE.value
         self._attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.VERTEXAI.value
-        if not (api_key := api_key or getenv("GEMINI_API_KEY") or getenv("GOOGLE_API_KEY")):
+
+        # Try to get API key from credentials first, then fallback to env
+        api_key = (
+            _get_credential_value(credentials, "GEMINI_API_KEY")
+            or _get_credential_value(credentials, "GOOGLE_API_KEY")
+            or getenv("GEMINI_API_KEY")
+            or getenv("GOOGLE_API_KEY")
+        )
+
+        if not api_key:
             raise BadRequest("An API key is required for Gemini models")
+
         google_genai.configure(api_key=api_key)
         self.model_name = model.name
 

--- a/src/phoenix/server/api/helpers/playground_spans.py
+++ b/src/phoenix/server/api/helpers/playground_spans.py
@@ -263,10 +263,13 @@ def llm_tools(tools: list[JSONScalarType]) -> Iterator[tuple[str, Any]]:
 def input_value_and_mime_type(
     input: Union[ChatCompletionInput, ChatCompletionOverDatasetInput],
 ) -> Iterator[tuple[str, Any]]:
-    assert (api_key := "api_key") in (input_data := jsonify(input))
-    disallowed_keys = {"api_key", "invocation_parameters"}
+    input_data = jsonify(input)
+    # Filter out sensitive credential information and invocation parameters
+    disallowed_keys = {"api_key", "credentials", "invocation_parameters"}
     input_data = {k: v for k, v in input_data.items() if k not in disallowed_keys}
-    assert api_key not in input_data
+    # Ensure sensitive data is not included in trace data
+    assert "api_key" not in input_data
+    assert "credentials" not in input_data
     yield INPUT_MIME_TYPE, JSON
     yield INPUT_VALUE, safe_json_dumps(input_data)
 

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -34,7 +34,7 @@ class ChatCompletionOverDatasetInput:
     model: GenerativeModelInput
     invocation_parameters: list[InvocationParameterInput] = strawberry.field(default_factory=list)
     tools: Optional[list[JSON]] = UNSET
-    api_key: Optional[str] = strawberry.field(default=None)
+    credentials: Optional[list[GenerativeCredentialInput]] = UNSET
     template_format: PromptTemplateFormat = PromptTemplateFormat.MUSTACHE
     dataset_id: GlobalID
     dataset_version_id: Optional[GlobalID] = None

--- a/src/phoenix/server/api/input_types/ChatCompletionInput.py
+++ b/src/phoenix/server/api/input_types/ChatCompletionInput.py
@@ -8,6 +8,7 @@ from strawberry.scalars import JSON
 from phoenix.server.api.helpers.prompts.models import (
     PromptTemplateFormat,
 )
+from phoenix.server.api.input_types.GenerativeCredentialInput import GenerativeCredentialInput
 from phoenix.server.api.types.Identifier import Identifier
 
 from .ChatCompletionMessageInput import ChatCompletionMessageInput
@@ -22,7 +23,7 @@ class ChatCompletionInput:
     model: GenerativeModelInput
     invocation_parameters: list[InvocationParameterInput] = strawberry.field(default_factory=list)
     tools: Optional[list[JSON]] = UNSET
-    api_key: Optional[str] = strawberry.field(default=None)
+    credentials: Optional[list[GenerativeCredentialInput]] = UNSET
     template: Optional[PromptTemplateOptions] = UNSET
     prompt_name: Optional[Identifier] = None
 

--- a/src/phoenix/server/api/input_types/GenerativeCredentialInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeCredentialInput.py
@@ -1,0 +1,9 @@
+import strawberry
+
+
+@strawberry.input
+class GenerativeCredentialInput:
+    env_var_name: str
+    """The name of the environment variable to set."""
+    value: str
+    """The value of the environment variable to set."""

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -134,16 +134,16 @@ class ChatCompletionMutationMixin:
             raise BadRequest(f"Unknown LLM provider: '{provider_key.value}'")
         try:
             # Convert GraphQL credentials to PlaygroundCredential objects
-            playground_credentials = None
-            if hasattr(input, "credentials") and input.credentials:
-                playground_credentials = [
+            credentials = None
+            if input.credentials:
+                credentials = [
                     PlaygroundClientCredential(env_var_name=cred.env_var_name, value=cred.value)
                     for cred in input.credentials
                 ]
 
             llm_client = llm_client_class(
                 model=input.model,
-                credentials=playground_credentials,
+                credentials=credentials,
             )
         except CustomGraphQLError:
             raise

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -31,6 +31,7 @@ from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
 from phoenix.server.api.helpers.playground_clients import (
     PlaygroundStreamingClient,
+    PlaygroundClientCredential,
     initialize_playground_clients,
 )
 from phoenix.server.api.helpers.playground_registry import (
@@ -98,9 +99,17 @@ class Subscription:
         if llm_client_class is None:
             raise BadRequest(f"Unknown LLM provider: '{provider_key.value}'")
         try:
+            # Convert GraphQL credentials to PlaygroundCredential objects
+            playground_credentials = None
+            if input.credentials:
+                playground_credentials = [
+                    PlaygroundClientCredential(env_var_name=cred.env_var_name, value=cred.value)
+                    for cred in input.credentials
+                ]
+
             llm_client = llm_client_class(
                 model=input.model,
-                api_key=input.api_key,
+                credentials=playground_credentials,
             )
         except CustomGraphQLError:
             raise
@@ -176,9 +185,17 @@ class Subscription:
         if llm_client_class is None:
             raise BadRequest(f"Unknown LLM provider: '{provider_key.value}'")
         try:
+            # Convert GraphQL credentials to PlaygroundCredential objects
+            playground_credentials = None
+            if input.credentials:
+                playground_credentials = [
+                    PlaygroundClientCredential(env_var_name=cred.env_var_name, value=cred.value)
+                    for cred in input.credentials
+                ]
+
             llm_client = llm_client_class(
                 model=input.model,
-                api_key=input.api_key,
+                credentials=playground_credentials,
             )
         except CustomGraphQLError:
             raise

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -30,8 +30,8 @@ from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
 from phoenix.server.api.helpers.playground_clients import (
-    PlaygroundStreamingClient,
     PlaygroundClientCredential,
+    PlaygroundStreamingClient,
     initialize_playground_clients,
 )
 from phoenix.server.api.helpers.playground_registry import (

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -102,17 +102,14 @@ class GenerativeProvider:
 
     @strawberry.field(description="The credential requirements for the provider")  # type: ignore
     async def credential_requirements(self) -> list[GenerativeProviderCredentialConfig]:
-        return [
-            credential_config
-            for credential_config in self.model_provider_to_credential_requirements_map.values()
-        ]
+        return [self.model_provider_to_credential_requirements_map[self.key]]
 
     @strawberry.field(description="Whether the credentials are set on the server for the provider")  # type: ignore
     async def credentials_set(self) -> bool:
         # Check if every required credential is set
         return all(
             getenv(credential_config.env_var_name) is not None or not credential_config.is_required
-            for credential_config in self.model_provider_to_credential_requirements_map.values()
+            for credential_config in await self.credential_requirements()
         )
 
     @classmethod

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from turtle import st
 from typing import Any, ClassVar, Optional, Union
 
 import strawberry
@@ -16,6 +17,12 @@ class GenerativeProviderKey(Enum):
     GOOGLE = "Google AI Studio"
     DEEPSEEK = "DeepSeek"
     XAI = "xAI"
+
+
+@strawberry.type
+class GenerativeProviderCredentialConfig:
+    env_var_name: str
+    is_required: bool
 
 
 @strawberry.type
@@ -43,13 +50,31 @@ class GenerativeProvider:
         # The provider will be determined through model name prefix matching instead
     }
 
-    model_provider_to_api_key_env_var_map: ClassVar[dict[GenerativeProviderKey, str]] = {
-        GenerativeProviderKey.AZURE_OPENAI: "AZURE_OPENAI_API_KEY",
-        GenerativeProviderKey.ANTHROPIC: "ANTHROPIC_API_KEY",
-        GenerativeProviderKey.OPENAI: "OPENAI_API_KEY",
-        GenerativeProviderKey.GOOGLE: "GEMINI_API_KEY",
-        GenerativeProviderKey.DEEPSEEK: "DEEPSEEK_API_KEY",
-        GenerativeProviderKey.XAI: "XAI_API_KEY",
+    """
+    A map of model provider keys to their credential requirements.
+    E.x. OpenAI requires a single API key
+    """
+    model_provider_to_credential_requirements_map: ClassVar[
+        dict[GenerativeProviderKey, GenerativeProviderCredentialConfig]
+    ] = {
+        GenerativeProviderKey.AZURE_OPENAI: GenerativeProviderCredentialConfig(
+            env_var_name="AZURE_OPENAI_API_KEY", is_required=True
+        ),
+        GenerativeProviderKey.ANTHROPIC: GenerativeProviderCredentialConfig(
+            env_var_name="ANTHROPIC_API_KEY", is_required=True
+        ),
+        GenerativeProviderKey.OPENAI: GenerativeProviderCredentialConfig(
+            env_var_name="OPENAI_API_KEY", is_required=True
+        ),
+        GenerativeProviderKey.GOOGLE: GenerativeProviderCredentialConfig(
+            env_var_name="GEMINI_API_KEY", is_required=True
+        ),
+        GenerativeProviderKey.DEEPSEEK: GenerativeProviderCredentialConfig(
+            env_var_name="DEEPSEEK_API_KEY", is_required=True
+        ),
+        GenerativeProviderKey.XAI: GenerativeProviderCredentialConfig(
+            env_var_name="XAI_API_KEY", is_required=True
+        ),
     }
 
     @strawberry.field
@@ -76,13 +101,20 @@ class GenerativeProvider:
             return default_client.dependencies_are_installed()
         return False
 
-    @strawberry.field(description="The API key for the provider")  # type: ignore
-    async def api_key_env_var(self) -> str:
-        return self.model_provider_to_api_key_env_var_map[self.key]
+    @strawberry.field(description="The credential requirements for the provider")  # type: ignore
+    async def credential_requirements(self) -> list[GenerativeProviderCredentialConfig]:
+        return [
+            credential_config
+            for credential_config in self.model_provider_to_credential_requirements_map.values()
+        ]
 
     @strawberry.field(description="Whether the credentials are set on the server for the provider")  # type: ignore
-    async def api_key_set(self) -> bool:
-        return getenv(self.model_provider_to_api_key_env_var_map[self.key]) is not None
+    async def credentials_set(self) -> bool:
+        # Check if every required credential is set
+        return all(
+            getenv(credential_config.env_var_name) is not None or not credential_config.is_required
+            for credential_config in self.model_provider_to_credential_requirements_map.values()
+        )
 
     @classmethod
     def _infer_model_provider_from_model_name(

--- a/src/phoenix/server/api/types/GenerativeProvider.py
+++ b/src/phoenix/server/api/types/GenerativeProvider.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from turtle import st
 from typing import Any, ClassVar, Optional, Union
 
 import strawberry

--- a/tests/unit/server/api/mutations/test_chat_mutations.py
+++ b/tests/unit/server/api/mutations/test_chat_mutations.py
@@ -65,7 +65,7 @@ class TestChatCompletionMutationMixin:
                     }
                 ],
                 "templateFormat": "F_STRING",
-                "apiKey": "sk-",
+                "credentials": [{"envVarName": "OPENAI_API_KEY", "value": "sk-"}],
             }
         }
         custom_vcr.register_matcher(


### PR DESCRIPTION
This makes a client have 0 to many pieces of credentials be declarative on the server.

## Summary by Sourcery

Replace the single apiKey approach with a credentials array for generative providers, updating the Playground utility, GraphQL schema, and server input types accordingly.

New Features:
- Support passing multiple credentials to generative providers as a list of envVarName/value pairs.

Enhancements:
- Rename getApiKey to getCredentials and adapt it to return an array of credentials.
- Replace the apiKey field with credentials in ChatCompletionInput across frontend schema and backend Python input types.
- Add GenerativeCredentialInput type to both the GraphQL schema and Python server inputs.

## Summary by Sourcery

Implement credential list support across server and client for playground LLM integration, replacing single apiKey parameters with structured credential inputs

New Features:
- Introduce server-side credential management for playground LLM clients with a new PlaygroundClientCredential type
- Upgrade GraphQL schema to accept a list of credentials instead of a single apiKey for chat operations

Enhancements:
- Replace api_key parameters with credentials in all PlaygroundStreamingClient implementations and resolve keys via helper functions
- Add utility functions _get_credential_value and _require_credential to centralize credential extraction and validation
- Update generative provider metadata to expose credential requirements and configuration status
- Mask sensitive credential data in spans by filtering out api_key and credentials fields

Documentation:
- Extend schema and type definitions with GenerativeCredentialInput and GenerativeProviderCredentialConfig

Tests:
- Adjust unit tests for chat mutations to use credentials lists instead of apiKey