### PR TITLE
fix: Ensure "load next" button works on projects page

### DIFF
--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -112,6 +112,7 @@ export function ProjectsPage() {
     `,
     {
       first: PAGE_SIZE,
+      filter: { value: "", col: "name" },
       ...queryParams,
     }
   );


### PR DESCRIPTION
When the initial query arguments are incomplete, the refetchable loadNext query does not work until a manual refetch is performed with new query arguments.

Updating the initial query to use the same default filter value as the refetchable fragment fixes the load more button.

Resolves #7896

## Summary by Sourcery

Bug Fixes:
- Initialize the initial query filter to { value: "", col: "name" } to match the refetchable fragment and restore the load next functionality.