### PR TITLE
fix: Sets a lower pin on phoenix-otel to support latest Otel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "cachetools",
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=0.20.6",
-  "arize-phoenix-otel>=0.10.1",
+  "arize-phoenix-otel>=0.10.3",
   "fastapi",
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",


### PR DESCRIPTION
Bumps the minimum version of phoenix-otel to support latest otel changes

## Summary by Sourcery

Build:
- Bump minimum arize-phoenix-otel dependency version to 0.10.3