### PR TITLE
fix: set Uvicorn logger level with PHOENIX_LOGGING_LEVEL

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -452,6 +452,7 @@ def main() -> None:
         host=host,  # type: ignore[arg-type]
         port=port,
         root_path=host_root_path,
+        log_level=Settings.logging_level,
     )
 
     if tls_enabled_for_http:


### PR DESCRIPTION
User complained that there is no way to control Uvicorn logger. Using PHOENIX_LOGGING_LEVEL attribute to toggle the Uvicorn logger's level.

If PHOENIX_LOGGING_LEVEL=WARNING, both Phoenix application logger and Uvicorn loggers will be configured to WARNING logs and above.

## Summary by Sourcery

New Features:
- Expose PHOENIX_LOGGING_LEVEL to set Uvicorn’s log_level on server startup.