### PR TITLE
feat: Add dataset methods to phoenix client

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/client.py
+++ b/packages/phoenix-client/src/phoenix/client/client.py
@@ -5,6 +5,7 @@ from typing import Mapping, Optional
 import httpx
 
 from phoenix.client.resources.annotations import Annotations, AsyncAnnotations
+from phoenix.client.resources.datasets import AsyncDatasets, Datasets
 from phoenix.client.resources.projects import AsyncProjects, Projects
 from phoenix.client.resources.prompts import AsyncPrompts, Prompts
 from phoenix.client.resources.spans import AsyncSpans, Spans
@@ -55,6 +56,7 @@ class Client:
         self._projects = Projects(value)
         self._spans = Spans(value)
         self._annotations = Annotations(value)
+        self._datasets = Datasets(value)
 
     @property
     def prompts(self) -> Prompts:
@@ -97,6 +99,14 @@ class Client:
             Annotations: An instance of the Annotations class.
         """  # noqa: E501
         return self._annotations
+
+    @property
+    def datasets(self) -> Datasets:
+        """
+        Returns an instance of the Datasets class for interacting with dataset-related
+        API endpoints.
+        """
+        return self._datasets
 
 
 class AsyncClient:
@@ -142,6 +152,7 @@ class AsyncClient:
         self._projects = AsyncProjects(value)
         self._spans = AsyncSpans(value)
         self._annotations = AsyncAnnotations(value)
+        self._datasets = AsyncDatasets(value)
 
     @property
     def prompts(self) -> AsyncPrompts:
@@ -186,6 +197,14 @@ class AsyncClient:
             AsyncAnnotations: An instance of the Annotations class.
         """  # noqa: E501
         return self._annotations
+
+    @property
+    def datasets(self) -> AsyncDatasets:
+        """
+        Returns an instance of the Asynchronous Datasets class for interacting with dataset-related
+        API endpoints.
+        """
+        return self._datasets
 
 
 def _update_headers(

--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -1,0 +1,630 @@
+import csv
+import gzip
+import logging
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, Optional, Union
+from urllib.parse import quote, urljoin
+
+import httpx
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+from phoenix.client.__generated__ import v1
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_IN_SECONDS = 5
+
+
+# Stub classes for client interface compatibility
+class DatasetKeys:
+    """
+    Stub for dataset key validation logic.
+
+    TRICKY: This replicates the DatasetKeys functionality from phoenix.db.insertion.dataset
+    without importing from the main phoenix package.
+    """
+
+    def __init__(
+        self, input_keys: frozenset[str], output_keys: frozenset[str], metadata_keys: frozenset[str]
+    ):
+        self.input = input_keys
+        self.output = output_keys
+        self.metadata = metadata_keys
+
+    def check_differences(self, available_keys: frozenset[str]) -> None:
+        """Check that all specified keys exist in available keys."""
+        # TODO: Implement validation logic
+        raise NotImplementedError("DatasetKeys validation needs to be implemented")
+
+    def __iter__(self):
+        """Allow iteration over all keys."""
+        return iter(self.input | self.output | self.metadata)
+
+
+def _parse_datetime(datetime_str: str) -> datetime:
+    """Convert ISO datetime string to datetime object."""
+    return datetime.fromisoformat(datetime_str)
+
+
+class Datasets:
+    """
+    Provides methods for interacting with dataset resources.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client import Client
+            >>> client = Client()
+            >>> dataset = client.datasets.get_dataset(dataset_name="my-dataset")
+            >>> versions_df = client.datasets.get_dataset_versions_dataframe(dataset_id="123")
+    """
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+
+    def get_dataset(
+        self,
+        *,
+        dataset_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        version_id: Optional[str] = None,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Gets the dataset for a specific version, or gets the latest version of
+        the dataset if no version is specified.
+
+        Args:
+            dataset_id: An ID for the dataset.
+            dataset_name: The name for the dataset. If provided, the ID
+                is ignored and the dataset is retrieved by name.
+            version_id: An ID for the version of the dataset, or None.
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            A tuple of (dataset_info, examples_data) containing the dataset metadata
+            and examples with version information.
+
+        Raises:
+            ValueError: If neither dataset_id nor dataset_name is provided.
+            httpx.HTTPStatusError: If the API returns an error response.
+        """
+        # TODO: Implement - needs to handle name->id lookup and version resolution
+        raise NotImplementedError("Method needs to be implemented")
+
+    def get_dataset_versions_dataframe(
+        self,
+        *,
+        dataset_id: str,
+        limit: Optional[int] = 100,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> "pd.DataFrame":
+        """
+        Get dataset versions as pandas DataFrame.
+
+        Args:
+            dataset_id: Dataset ID
+            limit: Maximum number of versions to return, starting from the most recent version
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            pandas DataFrame with version information
+
+        Raises:
+            ImportError: If pandas is not installed
+            httpx.HTTPStatusError: If the API returns an error response.
+        """
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError(
+                "pandas is required to use get_dataset_versions_dataframe. "
+                "Install it with 'pip install pandas'"
+            )
+        # TODO: Implement - straightforward API call returning DataFrame
+        raise NotImplementedError("Method needs to be implemented")
+
+    def create_dataset(
+        self,
+        *,
+        dataset_name: str,
+        dataframe: Optional["pd.DataFrame"] = None,
+        csv_file_path: Optional[Union[str, Path]] = None,
+        input_keys: Iterable[str] = (),
+        output_keys: Iterable[str] = (),
+        metadata_keys: Iterable[str] = (),
+        inputs: Iterable[Mapping[str, Any]] = (),
+        outputs: Iterable[Mapping[str, Any]] = (),
+        metadata: Iterable[Mapping[str, Any]] = (),
+        dataset_description: Optional[str] = None,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Create a new dataset by uploading examples to the Phoenix server.
+
+        Args:
+            dataset_name: Name of the dataset.
+            dataframe: pandas DataFrame (requires pandas to be installed).
+            csv_file_path: Location of a CSV text file
+            input_keys: List of column names used as input keys.
+            output_keys: List of column names used as output keys.
+            metadata_keys: List of column names used as metadata keys.
+            inputs: List of dictionaries each corresponding to an example.
+            outputs: List of dictionaries each corresponding to an example.
+            metadata: List of dictionaries each corresponding to an example.
+            dataset_description: Description of the dataset.
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            A tuple of (dataset_info, examples_data) containing the uploaded dataset
+            metadata and examples with version information.
+
+        Raises:
+            ValueError: If invalid parameter combinations are provided.
+            ImportError: If pandas is required but not installed.
+            httpx.HTTPStatusError: If the API returns an error response.
+        """
+        # TODO: Implement - complex method with multiple upload formats
+        # TRICKY: Need to handle CSV/DataFrame vs JSON inputs, file uploads,
+        # key validation, gzip compression. Pandas usage must be lazy-imported.
+        raise NotImplementedError("Method needs to be implemented")
+
+    def add_examples_to_dataset(
+        self,
+        *,
+        dataset_name: str,
+        dataframe: Optional["pd.DataFrame"] = None,
+        csv_file_path: Optional[Union[str, Path]] = None,
+        input_keys: Iterable[str] = (),
+        output_keys: Iterable[str] = (),
+        metadata_keys: Iterable[str] = (),
+        inputs: Iterable[Mapping[str, Any]] = (),
+        outputs: Iterable[Mapping[str, Any]] = (),
+        metadata: Iterable[Mapping[str, Any]] = (),
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Append examples to an existing dataset on the Phoenix server.
+
+        Args:
+            dataset_name: Name of the dataset.
+            dataframe: pandas DataFrame (requires pandas to be installed).
+            csv_file_path: Location of a CSV text file
+            input_keys: List of column names used as input keys.
+            output_keys: List of column names used as output keys.
+            metadata_keys: List of column names used as metadata keys.
+            inputs: List of dictionaries each corresponding to an example.
+            outputs: List of dictionaries each corresponding to an example.
+            metadata: List of dictionaries each corresponding to an example.
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            A tuple of (dataset_info, examples_data) containing the dataset
+            metadata and examples with version information.
+
+        Raises:
+            ValueError: If invalid parameter combinations are provided.
+            ImportError: If pandas is required but not installed.
+            httpx.HTTPStatusError: If the API returns an error response.
+        """
+        # TODO: Implement - similar to create_dataset but with append action
+        # TRICKY: Same complexity as create_dataset
+        raise NotImplementedError("Method needs to be implemented")
+
+    def _get_dataset_id_by_name(
+        self,
+        *,
+        dataset_name: str,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> str:
+        """
+        Gets a dataset ID by name.
+
+        Args:
+            dataset_name: The name of the dataset.
+            timeout: Optional request timeout in seconds.
+
+        Returns:
+            The dataset ID.
+
+        Raises:
+            ValueError: If dataset not found or multiple datasets found.
+            httpx.HTTPStatusError: If the API returns an error response.
+        """
+        # TODO: Implement - straightforward API call with error handling
+        raise NotImplementedError("Method needs to be implemented")
+
+    def _upload_tabular_dataset(
+        self,
+        table: Union[str, Path, "pd.DataFrame"],
+        *,
+        dataset_name: str,
+        input_keys: Iterable[str],
+        output_keys: Iterable[str] = (),
+        metadata_keys: Iterable[str] = (),
+        dataset_description: Optional[str] = None,
+        action: Literal["create", "append"] = "create",
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Upload tabular data (CSV or DataFrame) as dataset.
+
+        TRICKY IMPLEMENTATION NOTES:
+        - Need to handle both CSV files and pandas DataFrames
+        - Requires DatasetKeys validation and key inference logic
+        - CSV files need column header validation for duplicates
+        - DataFrame conversion to JSON with gzip compression (avoid heavy PyArrow dependency)
+        - CSV files need gzip compression
+        - File upload handling with proper MIME types and headers
+        - Complex error handling for various file/data issues
+        - All pandas usage must be lazy-imported with proper ImportError handling
+        """
+        # TODO: Implement - very complex method
+        raise NotImplementedError("Method needs to be implemented")
+
+    def _upload_json_dataset(
+        self,
+        *,
+        dataset_name: str,
+        inputs: Iterable[Mapping[str, Any]],
+        outputs: Iterable[Mapping[str, Any]] = (),
+        metadata: Iterable[Mapping[str, Any]] = (),
+        dataset_description: Optional[str] = None,
+        action: Literal["create", "append"] = "create",
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Upload JSON data as dataset.
+
+        TRICKY IMPLEMENTATION NOTES:
+        - Need to validate that inputs/outputs/metadata are all dictionaries
+        - Sequence length validation between inputs/outputs/metadata
+        - Gzip compression for JSON payload
+        - Convert pandas Series to lists to avoid serialization issues
+        """
+        # TODO: Implement - moderately complex validation and upload
+        raise NotImplementedError("Method needs to be implemented")
+
+    def _process_dataset_upload_response(
+        self,
+        response: httpx.Response,
+        *,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """
+        Process the response from dataset upload operations.
+
+        TRICKY IMPLEMENTATION NOTES:
+        - Need to handle HTTP errors with custom DatasetUploadError
+        - Extract dataset_id from response and make follow-up API call
+        - Build complete response tuple with dataset info and examples
+        - Print user-friendly URLs and version information
+        - Convert datetime strings to datetime objects
+        """
+        # TODO: Implement - response processing with follow-up calls
+        raise NotImplementedError("Method needs to be implemented")
+
+
+class AsyncDatasets:
+    """
+    Provides async methods for interacting with dataset resources.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
+            >>> dataset_info, examples_data = await client.datasets.get_dataset(dataset_name="my-dataset")
+    """
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    async def get_dataset(
+        self,
+        *,
+        dataset_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        version_id: Optional[str] = None,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """Async version of get_dataset."""
+        # TODO: Implement async version
+        raise NotImplementedError("Method needs to be implemented")
+
+    async def get_dataset_versions_dataframe(
+        self,
+        *,
+        dataset_id: str,
+        limit: Optional[int] = 100,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> "pd.DataFrame":
+        """Async version of get_dataset_versions_dataframe."""
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError(
+                "pandas is required to use get_dataset_versions_dataframe. "
+                "Install it with 'pip install pandas'"
+            )
+        # TODO: Implement async version
+        raise NotImplementedError("Method needs to be implemented")
+
+    async def create_dataset(
+        self,
+        *,
+        dataset_name: str,
+        dataframe: Optional["pd.DataFrame"] = None,
+        csv_file_path: Optional[Union[str, Path]] = None,
+        input_keys: Iterable[str] = (),
+        output_keys: Iterable[str] = (),
+        metadata_keys: Iterable[str] = (),
+        inputs: Iterable[Mapping[str, Any]] = (),
+        outputs: Iterable[Mapping[str, Any]] = (),
+        metadata: Iterable[Mapping[str, Any]] = (),
+        dataset_description: Optional[str] = None,
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """Async version of create_dataset."""
+        # TODO: Implement async version
+        raise NotImplementedError("Method needs to be implemented")
+
+    async def add_examples_to_dataset(
+        self,
+        *,
+        dataset_name: str,
+        dataframe: Optional["pd.DataFrame"] = None,
+        csv_file_path: Optional[Union[str, Path]] = None,
+        input_keys: Iterable[str] = (),
+        output_keys: Iterable[str] = (),
+        metadata_keys: Iterable[str] = (),
+        inputs: Iterable[Mapping[str, Any]] = (),
+        outputs: Iterable[Mapping[str, Any]] = (),
+        metadata: Iterable[Mapping[str, Any]] = (),
+        timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    ) -> tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]:
+        """Async version of add_examples_to_dataset."""
+        # TODO: Implement async version
+        raise NotImplementedError("Method needs to be implemented")
+
+    # TODO: Add async versions of private helper methods as needed
+
+
+# Helper functions that will need to be implemented
+# These are currently in session/client.py and need to be moved/adapted
+
+
+def _get_csv_column_headers(path: Path) -> tuple[str, ...]:
+    """
+    Extract column headers from CSV file.
+
+    TRICKY: Need proper error handling for missing files, empty files, etc.
+    """
+    # TODO: Implement using only built-in csv module
+    raise NotImplementedError("Helper function needs to be implemented")
+
+
+def _prepare_csv(path: Path, keys: DatasetKeys) -> tuple[str, BinaryIO, str, dict[str, str]]:
+    """
+    Prepare CSV file for upload with validation and compression.
+
+    TRICKY:
+    - Column header validation for duplicates using built-in csv module
+    - DatasetKeys validation against CSV columns
+    - Gzip compression of file contents
+    - Return proper file tuple for httpx file upload
+    """
+    # TODO: Implement using only built-ins (csv, gzip)
+    raise NotImplementedError("Helper function needs to be implemented")
+
+
+def _prepare_dataframe_as_json(
+    df: "pd.DataFrame", keys: DatasetKeys
+) -> tuple[str, BinaryIO, str, dict[str, str]]:
+    """
+    Prepare pandas DataFrame for upload as compressed JSON.
+
+    TRICKY:
+    - Convert DataFrame to JSON format using pandas.to_dict()
+    - Gzip compression for upload
+    - Proper column validation
+    - Return file tuple for httpx upload
+    - Must lazy-import pandas with proper error handling
+    """
+    # TODO: Implement using JSON serialization instead of PyArrow to avoid heavy dependency
+    raise NotImplementedError("Helper function needs to be implemented")
+
+
+def _infer_keys(
+    table: Union[str, Path, "pd.DataFrame"],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """
+    Infer input/output/metadata keys from table structure.
+
+    TRICKY: Pattern matching to detect response/output columns automatically
+    """
+    # TODO: Implement using regex and built-in csv for file inspection
+    raise NotImplementedError("Helper function needs to be implemented")
+
+
+def _is_all_dict(seq: Iterable[Any]) -> bool:
+    """Check if all items in sequence are dictionaries."""
+    return all(isinstance(item, dict) for item in seq)
+
+
+class DatasetUploadError(Exception):
+    """Custom exception for dataset upload errors."""
+
+    ...
+
+
+# MIGRATION NOTES:
+#
+# DEPENDENCY MINIMIZATION APPROACH:
+#
+# 1. Core Dependencies (Always Available):
+#    - httpx: Already required by the client
+#    - All Python built-ins: csv, gzip, json, pathlib, datetime, etc.
+#    - Generated types from phoenix.client.__generated__.v1
+#
+# 2. Optional Dependencies (Lazy Import):
+#    - pandas: Only imported when DataFrame methods are actually called
+#    - Graceful ImportError handling with helpful error messages
+#    - All DataFrame functionality behind try/except ImportError blocks
+#
+# 3. Removed Heavy Dependencies:
+#    - PyArrow: Replaced with JSON serialization approach for DataFrames
+#    - No direct phoenix package imports
+#    - No SQLAlchemy, starlette, or other server dependencies
+#
+# CLIENT INTERFACE DESIGN:
+#
+# We return tuples of generated v1 types directly instead of wrapper classes:
+# - get_dataset() → tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]
+# - create_dataset() → tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]
+# - add_examples_to_dataset() → tuple[Union[v1.Dataset, v1.DatasetWithExampleCount], v1.ListDatasetExamplesData]
+#
+# BENEFITS OF USING GENERATED TYPES DIRECTLY:
+# ✅ Lightweight: No wrapper classes, fewer dependencies
+# ✅ Type Safety: TypedDict provides static type checking
+# ✅ API Consistency: Same types used across client and server
+# ✅ Maintainability: One source of truth for type definitions
+# ✅ Simplicity: Users work with familiar dict-like structures
+#
+# DATASET METHODS BEING MIGRATED FROM SESSION CLIENT:
+#
+# 📦 SESSION CLIENT → NEW CLIENT METHOD MAPPING:
+# - get_dataset() → get_dataset() (returns tuple instead of wrapper class)
+# - get_dataset_versions() → get_dataset_versions_dataframe()
+# - upload_dataset() → create_dataset() (returns tuple instead of wrapper class)
+# - append_to_dataset() → add_examples_to_dataset() (returns tuple instead of wrapper class)
+# - _get_dataset_id_by_name() → _get_dataset_id_by_name()
+# - _upload_tabular_dataset() → _upload_tabular_dataset() (returns tuple)
+# - _upload_json_dataset() → _upload_json_dataset() (returns tuple)
+# - _process_dataset_upload_response() → _process_dataset_upload_response() (returns tuple)
+#
+# DATETIME HANDLING:
+# - Generated types use ISO datetime strings (v1.DatasetExample["updated_at"]: str)
+# - Users can convert to datetime objects using _parse_datetime() utility if needed
+# - Example: _parse_datetime(example["updated_at"]) → datetime object
+#
+# TUPLE RESPONSE FORMAT:
+# All dataset methods return (dataset_info, examples_data) where:
+# - dataset_info: v1.Dataset or v1.DatasetWithExampleCount (basic info + metadata)
+# - examples_data: v1.ListDatasetExamplesData (dataset_id, version_id, examples list)
+#
+# This gives users access to:
+# - dataset_info["id"], dataset_info["name"], dataset_info["description"], etc.
+# - examples_data["version_id"] for the specific version
+# - examples_data["examples"] for the list of v1.DatasetExample dicts
+# - Individual examples: examples_data["examples"][0]["input"], ["output"], ["metadata"], etc.
+#
+# 📉 COMPRESSION STRATEGY FOR DATASET UPLOADS - QUESTIONS STILL UNRESOLVED:
+#
+# Current session client compression analysis for dataset methods:
+# - _upload_json_dataset (Line 745): Sets "Content-Encoding: gzip" header but doesn't compress payload! 🤔
+# - _prepare_csv (Line 824): Manual gzip.compress(f.read()) for CSV files 🤔
+#
+# COMPRESSION QUESTIONS TO RESOLVE:
+# 1. JSON Dataset Upload: Session client sets gzip header but doesn't compress payload
+#    - Suggests server may not require compression for JSON dataset uploads
+#    - Or httpx handles compression automatically
+#    - Or it's a bug/inconsistency
+#
+# 2. CSV Dataset Upload: Manual compression might be server requirement or optimization
+#    - Need to test if server accepts uncompressed CSV for dataset uploads
+#    - Compression may not provide significant benefit for typical dataset sizes
+#
+# RECOMMENDED IMPLEMENTATION PHASES:
+#
+# Phase 1 - Minimal Working Version (START HERE):
+# ```python
+# def create_dataset(self, *, dataset_name: str, inputs: list[dict], ...):
+#     response = self._client.post(
+#         url="v1/datasets/upload",
+#         json={"name": dataset_name, "inputs": inputs, ...}
+#         # NO compression headers - test if server accepts this
+#     )
+# ```
+#
+# Phase 2 - Add Compression Only If Required:
+# ```python
+# import gzip
+# import json
+# payload = json.dumps({...}).encode('utf-8')
+# compressed = gzip.compress(payload)
+# response = self._client.post(
+#     url="v1/datasets/upload",
+#     content=compressed,
+#     headers={"Content-Encoding": "gzip", "Content-Type": "application/json"}
+# )
+# ```
+#
+# TESTING STRATEGY FOR DATASET UPLOADS:
+# 1. Test dataset upload server requirements:
+#    - Try dataset uploads without compression first
+#    - Check if server returns errors or accepts uncompressed data
+#    - Measure performance difference with/without compression for dataset uploads
+# 2. Gradual enhancement:
+#    - Start with simplest approach that works
+#    - Add compression only if server requires it or significant performance benefit
+#    - Prioritize correctness over premature optimization
+#
+# BENEFITS OF MINIMAL COMPRESSION APPROACH:
+# - ✅ Simpler code: No gzip import, no manual compression logic
+# - ✅ Fewer edge cases: No compression errors or encoding issues
+# - ✅ Faster development: Focus on core dataset functionality first
+# - ✅ Easier debugging: Raw dataset payloads are human-readable
+# - ✅ Modern HTTP: Most servers/proxies handle compression automatically
+#
+# MOST TRICKY IMPLEMENTATIONS STILL TO CONSIDER:
+#
+# 1. Dataset File Upload Handling:
+#    - Need to handle CSV files and JSON data with only built-ins
+#    - DataFrame support via lazy pandas import + JSON serialization
+#    - Gzip compression using built-in gzip module (ONLY IF REQUIRED BY SERVER)
+#    - Proper MIME types and headers for different upload formats
+#    - httpx file upload syntax for dataset uploads
+#
+# 2. DatasetKeys Integration:
+#    - Created stub DatasetKeys class to avoid importing from phoenix.db
+#    - Key validation logic using frozensets and difference checking
+#    - Key inference logic with regex pattern matching for dataset columns
+#
+# 3. Lightweight DataFrame Handling for Datasets:
+#    - JSON serialization instead of PyArrow to avoid heavy dependency
+#    - Pandas usage behind lazy imports with ImportError handling
+#    - CSV handling using built-in csv module for dataset uploads
+#
+# 4. Dataset Response Processing:
+#    - Upload response parsing using v1.UploadDatasetResponseBody
+#    - Follow-up API calls to get complete dataset info using v1.ListDatasetExamplesResponseBody
+#    - Return tuples of generated types instead of wrapper classes
+#    - URL construction for user feedback
+#
+# 5. Dataset Parameter Validation:
+#    - Complex validation between mutually exclusive parameter groups (dataframe vs csv vs inputs)
+#    - Length validation between related sequences (inputs/outputs/metadata)
+#    - Type checking for dictionary sequences using built-in isinstance
+#
+# 6. Dataset Error Handling:
+#    - Custom DatasetUploadError with proper error message extraction
+#    - File system errors for CSV files
+#    - HTTP error handling with informative messages
+#    - ImportError handling for optional pandas dependency
+#
+# 7. Async Dataset Versions:
+#    - All dataset file operations and HTTP calls need async equivalents
+#    - Proper async context managers for file handling
+#    - Same lazy import approach for pandas in async methods
+#
+# 8. Generated Type Integration for Datasets:
+#    - Use v1.Dataset, v1.DatasetExample, v1.DatasetVersion for API data
+#    - Use v1.ListDatasetExamplesResponseBody, v1.UploadDatasetResponseBody for responses
+#    - Return tuples of generated types directly (no wrapper classes needed)
+#    - DatasetKeys stub class still needed to replicate validation logic without phoenix.db dependency

--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -139,18 +139,18 @@ class Dataset:
     def to_dataframe(self) -> "pd.DataFrame":
         """
         Convert the dataset examples to a pandas DataFrame.
-        
+
         Returns:
             A pandas DataFrame with the following columns:
             - input: Dictionary containing the input data
-            - output: Dictionary containing the output data  
+            - output: Dictionary containing the output data
             - metadata: Dictionary containing the metadata
-            
+
             The DataFrame is indexed by example_id.
-            
+
         Raises:
             ImportError: If pandas is not installed.
-            
+
         Example:
             >>> dataset = client.datasets.get_dataset(dataset_name="my-dataset")
             >>> df = dataset.to_dataframe()
@@ -163,29 +163,28 @@ class Dataset:
             import pandas as pd
         except ImportError:
             raise ImportError(
-                "pandas is required to use to_dataframe(). "
-                "Install it with 'pip install pandas'"
+                "pandas is required to use to_dataframe(). " "Install it with 'pip install pandas'"
             )
-        
+
         from copy import deepcopy
-        
+
         if not self.examples:
             # Return empty DataFrame with expected structure
-            return pd.DataFrame(columns=['input', 'output', 'metadata']).set_index(
-                pd.Index([], name='example_id')
+            return pd.DataFrame(columns=["input", "output", "metadata"]).set_index(
+                pd.Index([], name="example_id")
             )
-        
+
         # Convert examples to records for DataFrame
         records = [
             {
-                "example_id": example['id'],
-                "input": deepcopy(example['input']),
-                "output": deepcopy(example['output']),
-                "metadata": deepcopy(example['metadata']),
+                "example_id": example["id"],
+                "input": deepcopy(example["input"]),
+                "output": deepcopy(example["output"]),
+                "metadata": deepcopy(example["metadata"]),
             }
             for example in self.examples
         ]
-        
+
         return pd.DataFrame.from_records(records).set_index("example_id")
 
 
@@ -283,7 +282,7 @@ class Datasets:
             >>> df = dataset.to_dataframe()
             >>> print(df.head())
             >>> # DataFrame has 'input', 'output', 'metadata' columns containing dictionaries
-            
+
         Using DataFrame with add_examples_to_dataset:
             >>> # Get dataset and convert to DataFrame
             >>> source = client.datasets.get_dataset(dataset_name="source")
@@ -890,7 +889,7 @@ class AsyncDatasets:
             ...     dataset_name="target",
             ...     examples=source_dataset[0]  # Pass a single example!
             ... )
-            
+
         Using DataFrame with add_examples_to_dataset:
             >>> # Get dataset and convert to DataFrame
             >>> source = await client.datasets.get_dataset(dataset_name="source")

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -1,4 +1,3 @@
-import base64
 import logging
 from datetime import datetime, timezone, tzinfo
 from io import StringIO
@@ -11,6 +10,7 @@ if TYPE_CHECKING:
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.types.spans import SpanQuery
+from phoenix.client.utils.id_handling import is_node_id
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ class Spans:
             if project_identifier and project_name:
                 raise ValueError("Provide only one of 'project_identifier' or 'project_name'.")
             elif project_identifier and not project_name:
-                if _is_node_id(project_identifier, node_type="Project"):
+                if is_node_id(project_identifier, node_type="Project"):
                     project_response = self._client.get(
                         url=f"v1/projects/{project_identifier}",
                         headers={"accept": "application/json"},
@@ -866,16 +866,6 @@ def _process_span_dataframe(response: httpx.Response) -> "pd.DataFrame":
         return dfs[0]  # only passing in one query
     else:
         return pd.DataFrame()
-
-
-def _is_node_id(s: str, node_type: str) -> bool:
-    try:
-        decoded = base64.b64decode(s, validate=True)
-        if not decoded.startswith(f"{node_type}:".encode("utf-8")):
-            return False
-        return True
-    except Exception:
-        return False
 
 
 def _flatten_nested_column(df: "pd.DataFrame", column_name: str) -> "pd.DataFrame":

--- a/packages/phoenix-client/src/phoenix/client/utils/id_handling.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/id_handling.py
@@ -1,0 +1,17 @@
+import base64
+
+def is_node_id(s: str, node_type: str) -> bool:
+    """
+    Check if a string is a valid node ID.
+
+    Args:
+        s (str): The string to check.
+        node_type (str): The type of node.
+    """
+    try:
+        decoded = base64.b64decode(s, validate=True)
+        if not decoded.startswith(f"{node_type}:".encode("utf-8")):
+            return False
+        return True
+    except Exception:
+        return False

--- a/packages/phoenix-client/src/phoenix/client/utils/id_handling.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/id_handling.py
@@ -1,5 +1,6 @@
 import base64
 
+
 def is_node_id(s: str, node_type: str) -> bool:
     """
     Check if a string is a valid node ID.

--- a/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
+++ b/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
@@ -1,24 +1,23 @@
 import gzip
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import httpx
 import pandas as pd
 import pytest
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.datasets import (
-    AsyncDatasets,
     Dataset,
     DatasetKeys,
-    Datasets,
     DatasetUploadError,
     _get_csv_column_headers,
     _infer_keys,
     _is_all_dict,
+    _is_valid_dataset_example,
     _parse_datetime,
     _prepare_csv,
+    _prepare_dataframe_as_json,
 )
 
 
@@ -58,11 +57,6 @@ class TestDataset:
             ],
         )
 
-    def test_init(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
-        assert dataset._dataset_info == dataset_info
-        assert dataset._examples_data == examples_data
-
     def test_properties(self, dataset_info, examples_data):
         dataset = Dataset(dataset_info, examples_data)
 
@@ -73,63 +67,36 @@ class TestDataset:
         assert len(dataset.examples) == 2
         assert dataset.metadata == {"key": "value"}
         assert dataset.example_count == 2
-
-    def test_datetime_properties(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
-
         assert isinstance(dataset.created_at, datetime)
-        assert dataset.created_at.year == 2024
-        assert dataset.created_at.month == 1
-        assert dataset.created_at.day == 15
-        assert dataset.created_at.hour == 10
-
         assert isinstance(dataset.updated_at, datetime)
-        assert dataset.updated_at.hour == 11
 
-    def test_properties_missing_fields(self, examples_data):
-        minimal_info = v1.Dataset(
-            id="dataset123",
-            name="Test Dataset",
-            description=None,
-            metadata={},
-            created_at="2024-01-15T10:00:00",
-            updated_at="2024-01-15T10:00:00",
-        )
-        dataset = Dataset(minimal_info, examples_data)
-
-        assert dataset.description is None
-        assert dataset.created_at is not None
-        assert dataset.updated_at is not None
-        assert dataset.metadata == {}
-
-    def test_example_count_fallback(self, dataset_info, examples_data):
-        dataset_info_no_count = v1.Dataset(
-            id=dataset_info["id"],
-            name=dataset_info["name"],
-            description=dataset_info["description"],
-            metadata=dataset_info["metadata"],
-            created_at=dataset_info["created_at"],
-            updated_at=dataset_info["updated_at"],
-        )
-        dataset = Dataset(dataset_info_no_count, examples_data)
-
-        assert dataset.example_count == 2
-
-    def test_len(self, dataset_info, examples_data):
+    def test_sequence_operations(self, dataset_info, examples_data):
         dataset = Dataset(dataset_info, examples_data)
+        
         assert len(dataset) == 2
-
-    def test_iter(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
-        examples = list(dataset)
-        assert len(examples) == 2
-        assert examples[0]["id"] == "ex1"
-        assert examples[1]["id"] == "ex2"
-
-    def test_getitem(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
         assert dataset[0]["id"] == "ex1"
         assert dataset[1]["id"] == "ex2"
+        
+        examples = list(dataset)
+        assert len(examples) == 2
+        assert all(isinstance(ex, dict) for ex in examples)
+
+    def test_to_dataframe(self, dataset_info, examples_data):
+        dataset = Dataset(dataset_info, examples_data)
+        df = dataset.to_dataframe()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert list(df.columns) == ["input", "output", "metadata"]
+        assert df.index.name == "example_id"
+        assert list(df.index) == ["ex1", "ex2"]
+
+    def test_to_dataframe_no_pandas(self, dataset_info, examples_data):
+        dataset = Dataset(dataset_info, examples_data)
+
+        with patch("builtins.__import__", side_effect=ImportError("No pandas")):
+            with pytest.raises(ImportError, match="pandas is required"):
+                dataset.to_dataframe()
 
     def test_repr(self, dataset_info, examples_data):
         dataset = Dataset(dataset_info, examples_data)
@@ -137,99 +104,10 @@ class TestDataset:
         assert "Dataset(" in repr_str
         assert "id='dataset123'" in repr_str
         assert "name='Test Dataset'" in repr_str
-        assert "version_id='version456'" in repr_str
-        assert "examples=2" in repr_str
-
-    def test_to_dataframe(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
-
-        import pandas as pd
-
-        df = dataset.to_dataframe()
-
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 2
-
-        assert list(df.columns) == ["input", "output", "metadata"]
-
-        assert df.index.name == "example_id"
-        assert list(df.index) == ["ex1", "ex2"]
-
-        assert df.loc["ex1", "input"] == {"text": "hello"}
-        assert df.loc["ex1", "output"] == {"response": "hi"}
-        assert df.loc["ex1", "metadata"] == {"source": "test"}
-
-        assert df.loc["ex2", "input"] == {"text": "world"}
-        assert df.loc["ex2", "output"] == {"response": "earth"}
-        assert df.loc["ex2", "metadata"] == {"source": "test"}
-
-    def test_to_dataframe_empty(self, dataset_info):
-        empty_examples_data = v1.ListDatasetExamplesData(
-            dataset_id="dataset123", version_id="version456", examples=[]
-        )
-        dataset = Dataset(dataset_info, empty_examples_data)
-
-        import pandas as pd
-
-        df = dataset.to_dataframe()
-
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 0
-        assert list(df.columns) == ["input", "output", "metadata"]
-        assert df.index.name == "example_id"
-
-    def test_to_dataframe_no_pandas(self, dataset_info, examples_data):
-        dataset = Dataset(dataset_info, examples_data)
-
-        def mock_import(name, *args, **kwargs):
-            if name == "pandas":
-                raise ImportError("No module named 'pandas'")
-            return __import__(name, *args, **kwargs)
-
-        with patch("builtins.__import__", side_effect=mock_import):
-            with pytest.raises(ImportError, match="pandas is required to use to_dataframe"):
-                dataset.to_dataframe()
-
-    def test_to_dataframe_varied_keys(self, dataset_info):
-        varied_examples_data = v1.ListDatasetExamplesData(
-            dataset_id="dataset123",
-            version_id="version456",
-            examples=[
-                v1.DatasetExample(
-                    id="ex1",
-                    input={"question": "What is 2+2?", "context": "math"},
-                    output={"answer": "4", "confidence": 0.9},
-                    metadata={"category": "arithmetic"},
-                    updated_at="2024-01-15T10:00:00",
-                ),
-                v1.DatasetExample(
-                    id="ex2",
-                    input={"question": "What is the capital of France?"},
-                    output={"answer": "Paris"},
-                    metadata={"category": "geography", "difficulty": "easy"},
-                    updated_at="2024-01-15T11:00:00",
-                ),
-            ],
-        )
-        dataset = Dataset(dataset_info, varied_examples_data)
-
-
-        df = dataset.to_dataframe()
-
-        assert list(df.columns) == ["input", "output", "metadata"]
-        assert df.index.name == "example_id"
-
-        assert df.loc["ex1", "input"] == {"question": "What is 2+2?", "context": "math"}
-        assert df.loc["ex1", "output"] == {"answer": "4", "confidence": 0.9}
-        assert df.loc["ex1", "metadata"] == {"category": "arithmetic"}
-
-        assert df.loc["ex2", "input"] == {"question": "What is the capital of France?"}
-        assert df.loc["ex2", "output"] == {"answer": "Paris"}
-        assert df.loc["ex2", "metadata"] == {"category": "geography", "difficulty": "easy"}
 
 
 class TestDatasetKeys:
-    def test_init_valid_keys(self):
+    def test_valid_keys(self):
         keys = DatasetKeys(
             input_keys=frozenset(["a", "b"]),
             output_keys=frozenset(["c"]),
@@ -238,8 +116,9 @@ class TestDatasetKeys:
         assert keys.input == frozenset(["a", "b"])
         assert keys.output == frozenset(["c"])
         assert keys.metadata == frozenset(["d", "e"])
+        assert set(keys) == {"a", "b", "c", "d", "e"}
 
-    def test_init_overlapping_input_output(self):
+    def test_overlapping_keys_validation(self):
         with pytest.raises(ValueError, match="Input and output keys overlap"):
             DatasetKeys(
                 input_keys=frozenset(["a", "b"]),
@@ -247,1252 +126,157 @@ class TestDatasetKeys:
                 metadata_keys=frozenset(["d"]),
             )
 
-    def test_init_overlapping_input_metadata(self):
-        with pytest.raises(ValueError, match="Input and metadata keys overlap"):
-            DatasetKeys(
-                input_keys=frozenset(["a", "b"]),
-                output_keys=frozenset(["c"]),
-                metadata_keys=frozenset(["a", "d"]),
-            )
-
-    def test_init_overlapping_output_metadata(self):
-        with pytest.raises(ValueError, match="Output and metadata keys overlap"):
-            DatasetKeys(
-                input_keys=frozenset(["a"]),
-                output_keys=frozenset(["b", "c"]),
-                metadata_keys=frozenset(["c", "d"]),
-            )
-
-    def test_check_differences_all_present(self):
+    def test_check_differences(self):
         keys = DatasetKeys(
-            input_keys=frozenset(["a", "b"]),
-            output_keys=frozenset(["c"]),
-            metadata_keys=frozenset(["d"]),
+            input_keys=frozenset(["a"]),
+            output_keys=frozenset(["b"]),
+            metadata_keys=frozenset(["c"]),
         )
-        keys.check_differences(frozenset(["a", "b", "c", "d", "e"]))
-
-    def test_check_differences_missing_keys(self):
-        keys = DatasetKeys(
-            input_keys=frozenset(["a", "b"]),
-            output_keys=frozenset(["c"]),
-            metadata_keys=frozenset(["d"]),
-        )
-        with pytest.raises(ValueError, match="Keys not found in available columns"):
-            keys.check_differences(frozenset(["a", "c"]))
-
-    def test_iter(self):
-        keys = DatasetKeys(
-            input_keys=frozenset(["a", "b"]),
-            output_keys=frozenset(["c"]),
-            metadata_keys=frozenset(["d"]),
-        )
-        assert set(keys) == {"a", "b", "c", "d"}
+        
+        keys.check_differences(frozenset(["a", "b", "c", "d"]))
+        
+        with pytest.raises(ValueError, match="Keys not found"):
+            keys.check_differences(frozenset(["a", "b"]))
 
 
 class TestHelperFunctions:
     def test_parse_datetime(self):
-        dt_str = "2024-01-15T10:30:00"
-        dt = _parse_datetime(dt_str)
+        dt = _parse_datetime("2024-01-15T10:30:00")
         assert dt.year == 2024
         assert dt.month == 1
         assert dt.day == 15
         assert dt.hour == 10
         assert dt.minute == 30
 
-    def test_is_all_dict_true(self):
-        assert _is_all_dict([{"a": 1}, {"b": 2}, {}])
-
-    def test_is_all_dict_false(self):
-        assert not _is_all_dict([{"a": 1}, "not a dict", {"b": 2}])
-        assert not _is_all_dict([{"a": 1}, None, {"b": 2}])
-        assert not _is_all_dict([{"a": 1}, 123, {"b": 2}])
-
-    def test_is_all_dict_empty(self):
+    def test_is_all_dict(self):
+        assert _is_all_dict([{"a": 1}, {"b": 2}])
+        assert not _is_all_dict([{"a": 1}, "not a dict"])
         assert _is_all_dict([])
 
-    def test_get_csv_column_headers_valid(self, tmp_path):
+    def test_is_valid_dataset_example(self):
+        valid_example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+        assert _is_valid_dataset_example(valid_example)
+        assert not _is_valid_dataset_example({"incomplete": "dict"})
+        assert not _is_valid_dataset_example("not a dict")
+
+    def test_get_csv_column_headers(self, tmp_path):
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
-
+        
         headers = _get_csv_column_headers(csv_file)
         assert headers == ("col1", "col2", "col3")
 
-    def test_get_csv_column_headers_empty_file(self, tmp_path):
-        csv_file = tmp_path / "empty.csv"
-        csv_file.write_text("")
-
+    def test_get_csv_column_headers_errors(self, tmp_path):
+        empty_file = tmp_path / "empty.csv"
+        empty_file.write_text("")
+        
         with pytest.raises(ValueError, match="CSV file has no data rows"):
-            _get_csv_column_headers(csv_file)
-
-    def test_get_csv_column_headers_only_headers(self, tmp_path):
-        csv_file = tmp_path / "headers_only.csv"
-        csv_file.write_text("col1,col2,col3\n")
-
-        with pytest.raises(ValueError, match="CSV file has no data rows"):
-            _get_csv_column_headers(csv_file)
-
-    def test_get_csv_column_headers_file_not_found(self):
-        with pytest.raises(FileNotFoundError, match="File does not exist"):
+            _get_csv_column_headers(empty_file)
+        
+        with pytest.raises(FileNotFoundError):
             _get_csv_column_headers(Path("/non/existent/file.csv"))
 
-    def test_infer_keys_with_response_column(self):
-        df = pd.DataFrame(
-            {"input1": [1, 2], "input2": [3, 4], "response": [5, 6], "metadata1": [7, 8]}
-        )
-
+    def test_infer_keys(self, tmp_path):
+        df = pd.DataFrame({
+            "input1": [1, 2],
+            "input2": [3, 4],
+            "response": [5, 6],
+            "metadata1": [7, 8]
+        })
+        
         input_keys, output_keys, metadata_keys = _infer_keys(df)
-
+        
         assert input_keys == ("input1", "input2")
         assert output_keys == ("response",)
         assert metadata_keys == ("metadata1",)
 
-    def test_infer_keys_with_output_column(self, tmp_path):
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("feature1,feature2,output,extra\nval1,val2,val3,val4\n")
-
+        
         input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
-
+        
         assert input_keys == ("feature1", "feature2")
         assert output_keys == ("output",)
         assert metadata_keys == ("extra",)
 
-    def test_infer_keys_with_answer_column(self, tmp_path):
+    def test_prepare_csv(self, tmp_path):
         csv_file = tmp_path / "test.csv"
-        csv_file.write_text("q1,q2,answer\nval1,val2,val3\n")
-
-        input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
-
-        assert input_keys == ("q1", "q2")
-        assert output_keys == ("answer",)
-        assert metadata_keys == ()
-
-    def test_infer_keys_no_output_column(self, tmp_path):
-        csv_file = tmp_path / "test.csv"
-        csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
-
-        input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
-
-        assert input_keys == ("col1", "col2", "col3")
-        assert output_keys == ()
-        assert metadata_keys == ()
-
-    def test_prepare_csv_valid(self, tmp_path):
-        csv_file = tmp_path / "test.csv"
-        csv_content = "input1,input2,output,metadata1\nval1,val2,val3,val4\n"
+        csv_content = "input1,input2,output\nval1,val2,val3\n"
         csv_file.write_text(csv_content)
-
+        
         keys = DatasetKeys(
             input_keys=frozenset(["input1", "input2"]),
             output_keys=frozenset(["output"]),
-            metadata_keys=frozenset(["metadata1"]),
+            metadata_keys=frozenset(),
         )
-
+        
         name, file_obj, content_type, headers = _prepare_csv(csv_file, keys)
-
+        
         assert name == "test.csv"
         assert content_type == "text/csv"
         assert headers == {"Content-Encoding": "gzip"}
-
+        
         file_obj.seek(0)
         decompressed = gzip.decompress(file_obj.read()).decode()
         assert decompressed == csv_content
 
-    def test_prepare_csv_duplicate_headers(self, tmp_path):
+    def test_prepare_csv_validation(self, tmp_path):
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col1,col2\nval1,val2,val3\n")
-
+        
         keys = DatasetKeys(
-            input_keys=frozenset(["col1", "col2"]),
+            input_keys=frozenset(["col1"]),
             output_keys=frozenset(),
             metadata_keys=frozenset(),
         )
-
-        with pytest.raises(ValueError, match="Duplicate column headers in CSV"):
+        
+        with pytest.raises(ValueError, match="Duplicate column headers"):
             _prepare_csv(csv_file, keys)
 
-    def test_prepare_csv_missing_keys(self, tmp_path):
-        csv_file = tmp_path / "test.csv"
-        csv_file.write_text("col1,col2\nval1,val2\n")
-
-        keys = DatasetKeys(
-            input_keys=frozenset(["col1", "col3"]),  # col3 doesn't exist
-            output_keys=frozenset(),
-            metadata_keys=frozenset(),
-        )
-
-        with pytest.raises(ValueError, match="Keys not found in available columns"):
-            _prepare_csv(csv_file, keys)
-
-    @pytest.mark.skipif(True, reason="Requires pandas - would be tested in integration tests")
     def test_prepare_dataframe_as_json(self):
-        pass
-
-
-class TestDatasets:
-    @pytest.fixture
-    def mock_client(self):
-        return Mock(spec=httpx.Client)
-
-    @pytest.fixture
-    def datasets(self, mock_client):
-        return Datasets(mock_client)
-
-    def test_get_dataset_by_id(self, datasets, mock_client):
-        dataset_info = {
-            "id": "dataset123",
-            "name": "Test Dataset",
-            "description": "A test dataset",
-            "metadata": {"key": "value"},
-            "created_at": "2024-01-15T10:00:00",
-            "updated_at": "2024-01-15T10:00:00",
-            "example_count": 5,
-        }
-
-        examples_data = {
-            "dataset_id": "dataset123",
-            "version_id": "version456",
-            "examples": [
-                {
-                    "id": "ex1",
-                    "input": {"text": "hello"},
-                    "output": {"response": "hi"},
-                    "metadata": {"source": "test"},
-                    "updated_at": "2024-01-15T10:00:00",
-                }
-            ],
-        }
-
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        dataset = datasets.get_dataset(dataset_id="dataset123")
-
-        assert mock_client.get.call_count == 2
-        mock_client.get.assert_any_call(
-            url="v1/datasets/dataset123", headers={"accept": "application/json"}, timeout=5
+        df = pd.DataFrame({
+            "input": ["a", "b"],
+            "output": ["x", "y"],
+            "metadata": ["m1", "m2"]
+        })
+        
+        keys = DatasetKeys(
+            input_keys=frozenset(["input"]),
+            output_keys=frozenset(["output"]),
+            metadata_keys=frozenset(["metadata"]),
         )
-        mock_client.get.assert_any_call(
-            url="v1/datasets/dataset123/examples",
-            params=None,
-            headers={"accept": "application/json"},
-            timeout=5,
+        
+        name, file_obj, content_type, headers = _prepare_dataframe_as_json(df, keys)
+        
+        assert name == "dataframe.csv"
+        assert content_type == "text/csv"
+        assert headers == {"Content-Encoding": "gzip"}
+        
+        file_obj.seek(0)
+        decompressed = gzip.decompress(file_obj.read()).decode()
+        assert "input,output,metadata" in decompressed  # CSV header
+        assert "a,x,m1" in decompressed
+        assert "b,y,m2" in decompressed
+
+    def test_prepare_dataframe_validation(self):
+        df = pd.DataFrame()
+        keys = DatasetKeys(
+            input_keys=frozenset(),
+            output_keys=frozenset(),
+            metadata_keys=frozenset(),
         )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
-        assert dataset.name == "Test Dataset"
-        assert dataset.version_id == "version456"
-        assert len(dataset.examples) == 1
-
-    def test_get_dataset_by_name(self, datasets, mock_client):
-        name_lookup_response = Mock()
-        name_lookup_response.json.return_value = {
-            "data": [{"id": "dataset123", "name": "Test Dataset"}]
-        }
-        name_lookup_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
-
-        mock_client.get.side_effect = [
-            name_lookup_response,
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        dataset = datasets.get_dataset(dataset_name="Test Dataset")
-
-        mock_client.get.assert_any_call(
-            url="v1/datasets",
-            params={"name": "Test Dataset"},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.name == "Test Dataset"
-
-    def test_get_dataset_with_dataset_object(self, datasets, mock_client):
-        existing_dataset = Mock(spec=Dataset)
-        existing_dataset.id = "dataset123"
-        existing_dataset.name = "Test Dataset"
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
-
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        datasets.get_dataset(dataset=existing_dataset)
-
-        mock_client.get.assert_any_call(
-            url="v1/datasets/dataset123", headers={"accept": "application/json"}, timeout=5
-        )
-
-    def test_get_dataset_no_identifier(self, datasets):
-        with pytest.raises(
-            ValueError, match="Dataset id, name, or dataset object must be provided"
-        ):
-            datasets.get_dataset()
-
-    def test_get_dataset_versions_with_dataset_object(self, datasets, mock_client):
-        dataset_obj = Mock(spec=Dataset)
-        dataset_obj.id = "dataset123"
-        dataset_obj.name = "Test Dataset"
-
-        versions_data = [
-            {
-                "version_id": "v1",
-                "description": "Version 1",
-                "metadata": {},
-                "created_at": "2024-01-15T10:00:00",
-            }
-        ]
-
-        mock_response = Mock()
-        mock_response.json.return_value = {"data": versions_data}
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        result = datasets.get_dataset_versions(dataset=dataset_obj)
-
-        mock_client.get.assert_called_once_with(
-            url="v1/datasets/dataset123/versions",
-            params={"limit": 100},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0]["version_id"] == "v1"
-        assert isinstance(result[0]["created_at"], datetime)
-
-    def test_get_dataset_versions_with_name(self, datasets, mock_client):
-        name_lookup_response = Mock()
-        name_lookup_response.json.return_value = {
-            "data": [{"id": "dataset123", "name": "Test Dataset"}]
-        }
-        name_lookup_response.raise_for_status.return_value = None
-
-        versions_data = [{"version_id": "v1", "created_at": "2024-01-15T10:00:00"}]
-        versions_response = Mock()
-        versions_response.json.return_value = {"data": versions_data}
-        versions_response.raise_for_status.return_value = None
-
-        mock_client.get.side_effect = [name_lookup_response, versions_response]
-
-        result = datasets.get_dataset_versions(dataset_name="Test Dataset")
-
-        assert mock_client.get.call_count == 2
-        mock_client.get.assert_any_call(
-            url="v1/datasets",
-            params={"name": "Test Dataset"},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-        assert isinstance(result, list)
-        assert len(result) == 1
-
-    def test_get_dataset_versions(self, datasets, mock_client):
-        versions_data = [
-            {
-                "version_id": "v1",
-                "description": "Version 1",
-                "metadata": {},
-                "created_at": "2024-01-15T10:00:00",
-            },
-            {
-                "version_id": "v2",
-                "description": "Version 2",
-                "metadata": {},
-                "created_at": "2024-01-16T10:00:00",
-            },
-        ]
-
-        mock_response = Mock()
-        mock_response.json.return_value = {"data": versions_data}
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        result = datasets.get_dataset_versions(dataset_id="dataset123")
-
-        mock_client.get.assert_called_once_with(
-            url="v1/datasets/dataset123/versions",
-            params={"limit": 100},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-        assert isinstance(result, list)
-        assert len(result) == 2
-        assert result[0]["version_id"] == "v1"
-        assert result[1]["version_id"] == "v2"
-        assert all(isinstance(v["created_at"], datetime) for v in result)
-
-    def test_get_dataset_versions_empty(self, datasets, mock_client):
-        mock_response = Mock()
-        mock_response.json.return_value = {"data": []}
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        result = datasets.get_dataset_versions(dataset_id="dataset123")
-
-        assert result == []
-
-    def test_create_dataset_json(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        inputs = [{"text": "hello"}, {"text": "world"}]
-        outputs = [{"response": "hi"}, {"response": "earth"}]
-
-        dataset = datasets.create_dataset(
-            dataset_name="Test Dataset",
-            inputs=inputs,
-            outputs=outputs,
-            dataset_description="Test description",
-        )
-
-        mock_client.post.assert_called_once_with(
-            url="v1/datasets/upload",
-            json={
-                "action": "create",
-                "name": "Test Dataset",
-                "inputs": inputs,
-                "outputs": outputs,
-                "metadata": [{}, {}],
-                "description": "Test description",
-            },
-            params={"sync": True},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
-        assert dataset.name == "Test Dataset"
-
-    def test_create_dataset_csv(self, datasets, mock_client, tmp_path):
-        csv_file = tmp_path / "test.csv"
-        csv_file.write_text("input_col,output_col\nval1,result1\nval2,result2\n")
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        dataset = datasets.create_dataset(
-            dataset_name="Test Dataset",
-            csv_file_path=csv_file,
-            input_keys=["input_col"],
-            output_keys=["output_col"],
-        )
-
-        assert mock_client.post.call_count == 1
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["url"] == "v1/datasets/upload"
-        assert call_kwargs["params"] == {"sync": True}
-        assert "file" in call_kwargs["files"]
-        assert call_kwargs["data"]["name"] == "Test Dataset"
-        assert set(call_kwargs["data"]["input_keys[]"]) == {"input_col"}
-        assert set(call_kwargs["data"]["output_keys[]"]) == {"output_col"}
-
-        assert isinstance(dataset, Dataset)
-
-    def test_create_dataset_invalid_params(self, datasets):
-        with pytest.raises(ValueError, match="Please provide either dataframe or csv_file_path"):
-            datasets.create_dataset(dataset_name="Test", dataframe=Mock(), csv_file_path="test.csv")
-
-        with pytest.raises(ValueError, match="Please provide only one of"):
-            datasets.create_dataset(
-                dataset_name="Test", csv_file_path="test.csv", inputs=[{"a": 1}]
-            )
-
-    def test_add_examples_to_dataset_with_name(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        inputs = [{"text": "new"}]
-
-        dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", inputs=inputs)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["name"] == "Test Dataset"
-
-        assert isinstance(dataset, Dataset)
-
-    def test_add_examples_to_dataset_with_object(self, datasets, mock_client):
-        existing_dataset = Mock(spec=Dataset)
-        existing_dataset.id = "dataset123"
-        existing_dataset.name = "Test Dataset"
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        inputs = [{"text": "new"}]
-
-        dataset = datasets.add_examples_to_dataset(dataset=existing_dataset, inputs=inputs)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["name"] == "Test Dataset"
-
-        assert isinstance(dataset, Dataset)
-
-    def test_method_chaining_workflow(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        versions_data = [{"version_id": "v1", "created_at": "2024-01-15T10:00:00"}]
-        versions_response = Mock()
-        versions_response.json.return_value = {"data": versions_data}
-        versions_response.raise_for_status.return_value = None
-
-        upload_response2 = Mock()
-        upload_response2.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response2.raise_for_status.return_value = None
-
-        updated_examples_data = {
-            "dataset_id": "dataset123",
-            "version_id": "version789",
-            "examples": [],
-        }
-
-        mock_client.post.side_effect = [upload_response, upload_response2]
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-            versions_response,
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": updated_examples_data}, raise_for_status=lambda: None),
-        ]
-
-        dataset = datasets.create_dataset(
-            dataset_name="Test Dataset", inputs=[{"text": "hello"}], outputs=[{"response": "hi"}]
-        )
-
-        versions = datasets.get_dataset_versions(dataset=dataset)
-
-        updated_dataset = datasets.add_examples_to_dataset(
-            dataset=dataset, inputs=[{"text": "world"}], outputs=[{"response": "earth"}]
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert isinstance(versions, list)
-        assert len(versions) == 1
-        assert isinstance(updated_dataset, Dataset)
-
-        assert mock_client.get.call_count == 5
-
-    def test_get_dataset_id_by_name_found(self, datasets, mock_client):
-        mock_response = Mock()
-        mock_response.json.return_value = {"data": [{"id": "dataset123", "name": "Test Dataset"}]}
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        dataset_id = datasets._get_dataset_id_by_name(dataset_name="Test Dataset")
-
-        assert dataset_id == "dataset123"
-        mock_client.get.assert_called_once_with(
-            url="v1/datasets",
-            params={"name": "Test Dataset"},
-            headers={"accept": "application/json"},
-            timeout=5,
-        )
-
-    def test_get_dataset_id_by_name_not_found(self, datasets, mock_client):
-        mock_response = Mock()
-        mock_response.json.return_value = {"data": []}
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        with pytest.raises(ValueError, match="Dataset not found"):
-            datasets._get_dataset_id_by_name(dataset_name="Nonexistent")
-
-    def test_get_dataset_id_by_name_multiple_found(self, datasets, mock_client):
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": [{"id": "dataset1", "name": "Test"}, {"id": "dataset2", "name": "Test"}]
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_client.get.return_value = mock_response
-
-        with pytest.raises(ValueError, match="Multiple datasets found"):
-            datasets._get_dataset_id_by_name(dataset_name="Test")
-
-    def test_upload_json_dataset_validation(self, datasets, mock_client):
-        with pytest.raises(ValueError, match="inputs must be non-empty"):
-            datasets._upload_json_dataset(dataset_name="Test", inputs=[])
-
-        with pytest.raises(ValueError, match="inputs must contain only dictionaries"):
-            datasets._upload_json_dataset(dataset_name="Test", inputs=["not", "dicts"])
-
-        with pytest.raises(ValueError, match="outputs must have same length as inputs"):
-            datasets._upload_json_dataset(
-                dataset_name="Test",
-                inputs=[{"a": 1}, {"b": 2}],
-                outputs=[{"c": 3}],
-            )
-
-        with pytest.raises(ValueError, match="outputs must contain only dictionaries"):
-            datasets._upload_json_dataset(
-                dataset_name="Test", inputs=[{"a": 1}], outputs=["not dict"]
-            )
-
-    def test_process_dataset_upload_response_error(self, datasets, mock_client):
-        error_response = Mock(spec=httpx.Response)
-        error_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "Bad Request", request=Mock(), response=error_response
-        )
-        error_response.json.return_value = {"detail": "Invalid dataset name"}
-
-        with pytest.raises(DatasetUploadError, match="Dataset upload failed: Invalid dataset name"):
-            datasets._process_dataset_upload_response(error_response)
-
-    def test_add_examples_to_dataset_with_single_example(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-
-        dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", examples=example)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}]
-        assert call_kwargs["json"]["metadata"] == [{"source": "test"}]
-        assert isinstance(dataset, Dataset)
-
-    def test_add_examples_to_dataset_with_multiple_examples(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        examples = [
-            v1.DatasetExample(
-                id="ex1",
-                input={"text": "hello"},
-                output={"response": "hi"},
-                metadata={"source": "test1"},
-                updated_at="2024-01-15T10:00:00",
-            ),
-            v1.DatasetExample(
-                id="ex2",
-                input={"text": "world"},
-                output={"response": "earth"},
-                metadata={"source": "test2"},
-                updated_at="2024-01-15T10:00:00",
-            ),
-        ]
-
-        dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", examples=examples)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}, {"text": "world"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}, {"response": "earth"}]
-        assert call_kwargs["json"]["metadata"] == [{"source": "test1"}, {"source": "test2"}]
-        assert isinstance(dataset, Dataset)
-
-    def test_create_dataset_with_single_example(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-
-        dataset = datasets.create_dataset(dataset_name="Test Dataset", examples=example)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "create"
-        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}]
-        assert call_kwargs["json"]["metadata"] == [{"source": "test"}]
-        assert isinstance(dataset, Dataset)
-
-    def test_create_dataset_with_multiple_examples(self, datasets, mock_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-        ]
-
-        examples = [
-            v1.DatasetExample(
-                id="ex1",
-                input={"text": "hello"},
-                output={"response": "hi"},
-                metadata={"source": "test1"},
-                updated_at="2024-01-15T10:00:00",
-            ),
-            v1.DatasetExample(
-                id="ex2",
-                input={"text": "world"},
-                output={"response": "earth"},
-                metadata={"source": "test2"},
-                updated_at="2024-01-15T10:00:00",
-            ),
-        ]
-
-        dataset = datasets.create_dataset(dataset_name="Test Dataset", examples=examples)
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "create"
-        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}, {"text": "world"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}, {"response": "earth"}]
-        assert call_kwargs["json"]["metadata"] == [{"source": "test1"}, {"source": "test2"}]
-        assert isinstance(dataset, Dataset)
-
-    def test_add_examples_to_dataset_validation_multiple_sources(self, datasets):
-        example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-
-        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
-            datasets.add_examples_to_dataset(
-                dataset_name="Test", examples=example, inputs=[{"text": "hello"}]
-            )
-
-        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
-            datasets.add_examples_to_dataset(
-                dataset_name="Test", examples=example, csv_file_path="test.csv"
-            )
-
-    def test_create_dataset_validation_multiple_sources(self, datasets):
-        example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-
-        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
-            datasets.create_dataset(
-                dataset_name="Test", examples=example, inputs=[{"text": "hello"}]
-            )
-
-        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
-            datasets.create_dataset(dataset_name="Test", examples=example, csv_file_path="test.csv")
-
-    def test_chaining_examples_from_dataset_to_dataset(self, datasets, mock_client):
-        source_dataset_info = {
-            "id": "source123",
-            "name": "Source Dataset",
-            "description": "Source dataset",
-            "metadata": {},
-            "created_at": "2024-01-15T10:00:00",
-            "updated_at": "2024-01-15T10:00:00",
-            "example_count": 2,
-        }
-
-        source_examples_data = {
-            "dataset_id": "source123",
-            "version_id": "source_v1",
-            "examples": [
-                {
-                    "id": "ex1",
-                    "input": {"text": "hello world"},
-                    "output": {"response": "greetings"},
-                    "metadata": {"category": "greeting"},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-                {
-                    "id": "ex2",
-                    "input": {"text": "goodbye"},
-                    "output": {"response": "farewell"},
-                    "metadata": {"category": "farewell"},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-            ],
-        }
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "target456", "version_id": "target_v1"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        target_dataset_info = {"id": "target456", "name": "Target Dataset"}
-        target_examples_data = {
-            "dataset_id": "target456",
-            "version_id": "target_v1",
-            "examples": [],
-        }
-
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": source_dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": source_examples_data}, raise_for_status=lambda: None),
-        ]
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect.extend(
-            [
-                Mock(json=lambda: {"data": target_dataset_info}, raise_for_status=lambda: None),
-                Mock(json=lambda: {"data": target_examples_data}, raise_for_status=lambda: None),
-            ]
-        )
-
-        source_dataset = datasets.get_dataset(dataset_name="Source Dataset")
-
-        first_example = source_dataset[0]
-
-        target_dataset = datasets.add_examples_to_dataset(
-            dataset_name="Target Dataset", examples=first_example
-        )
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["name"] == "Target Dataset"
-        assert call_kwargs["json"]["inputs"] == [{"text": "hello world"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "greetings"}]
-        assert call_kwargs["json"]["metadata"] == [{"category": "greeting"}]
-
-        assert isinstance(source_dataset, Dataset)
-        assert isinstance(target_dataset, Dataset)
-        assert len(source_dataset) == 2
-        assert source_dataset[0]["input"]["text"] == "hello world"
-
-    def test_chaining_multiple_examples_from_dataset_to_dataset(self, datasets, mock_client):
-        source_dataset_info = {
-            "id": "source123",
-            "name": "Source Dataset",
-            "description": "Source dataset",
-            "metadata": {},
-            "created_at": "2024-01-15T10:00:00",
-            "updated_at": "2024-01-15T10:00:00",
-            "example_count": 3,
-        }
-
-        source_examples_data = {
-            "dataset_id": "source123",
-            "version_id": "source_v1",
-            "examples": [
-                {
-                    "id": "ex1",
-                    "input": {"text": "first"},
-                    "output": {"response": "1st"},
-                    "metadata": {"order": 1},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-                {
-                    "id": "ex2",
-                    "input": {"text": "second"},
-                    "output": {"response": "2nd"},
-                    "metadata": {"order": 2},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-                {
-                    "id": "ex3",
-                    "input": {"text": "third"},
-                    "output": {"response": "3rd"},
-                    "metadata": {"order": 3},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-            ],
-        }
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "target456", "version_id": "target_v1"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        target_dataset_info = {"id": "target456", "name": "Target Dataset"}
-        target_examples_data = {
-            "dataset_id": "target456",
-            "version_id": "target_v1",
-            "examples": [],
-        }
-
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": source_dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": source_examples_data}, raise_for_status=lambda: None),
-        ]
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect.extend(
-            [
-                Mock(json=lambda: {"data": target_dataset_info}, raise_for_status=lambda: None),
-                Mock(json=lambda: {"data": target_examples_data}, raise_for_status=lambda: None),
-            ]
-        )
-
-        source_dataset = datasets.get_dataset(dataset_name="Source Dataset")
-
-        first_two_examples = source_dataset.examples[:2]
-
-        target_dataset = datasets.add_examples_to_dataset(
-            dataset_name="Target Dataset", examples=first_two_examples
-        )
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["inputs"] == [{"text": "first"}, {"text": "second"}]
-        assert call_kwargs["json"]["outputs"] == [{"response": "1st"}, {"response": "2nd"}]
-        assert call_kwargs["json"]["metadata"] == [{"order": 1}, {"order": 2}]
-
-        assert isinstance(source_dataset, Dataset)
-        assert isinstance(target_dataset, Dataset)
-        assert len(source_dataset) == 3
-
-    def test_add_examples_from_dataframe_dictionaries(self, datasets, mock_client):
-        source_dataset_info = {
-            "id": "source123",
-            "name": "Source Dataset",
-            "example_count": 2,
-        }
-
-        source_examples_data = {
-            "dataset_id": "source123",
-            "version_id": "source_v1",
-            "examples": [
-                {
-                    "id": "ex1",
-                    "input": {"question": "What is 2+2?", "context": "math"},
-                    "output": {"answer": "4", "confidence": 0.9},
-                    "metadata": {"category": "arithmetic"},
-                    "updated_at": "2024-01-15T10:00:00",
-                },
-                {
-                    "id": "ex2",
-                    "input": {"question": "Capital of France?"},
-                    "output": {"answer": "Paris"},
-                    "metadata": {"category": "geography"},
-                    "updated_at": "2024-01-15T10:30:00",
-                },
-            ],
-        }
-
-        name_lookup_response = Mock()
-        name_lookup_response.json.return_value = {
-            "data": [{"id": "source123", "name": "Source Dataset"}]
-        }
-        name_lookup_response.raise_for_status.return_value = None
-
-        mock_client.get.side_effect = [
-            name_lookup_response,
-            Mock(json=lambda: {"data": source_dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": source_examples_data}, raise_for_status=lambda: None),
-        ]
-
-        source_dataset = datasets.get_dataset(dataset_name="Source Dataset")
-
-        df = source_dataset.to_dataframe()
-
-        inputs = df["input"].tolist()
-        outputs = df["output"].tolist()
-        metadata = df["metadata"].tolist()
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "target456", "version_id": "target_v1"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        target_dataset_info = {"id": "target456", "name": "Target Dataset"}
-        target_examples_data = {
-            "dataset_id": "target456",
-            "version_id": "target_v1",
-            "examples": [],
-        }
-
-        mock_client.post.return_value = upload_response
-        mock_client.get.side_effect = [
-            Mock(json=lambda: {"data": target_dataset_info}, raise_for_status=lambda: None),
-            Mock(json=lambda: {"data": target_examples_data}, raise_for_status=lambda: None),
-        ]
-
-        target_dataset = datasets.add_examples_to_dataset(
-            dataset_name="Target Dataset", inputs=inputs, outputs=outputs, metadata=metadata
-        )
-
-        call_kwargs = mock_client.post.call_args.kwargs
-        assert call_kwargs["url"] == "v1/datasets/upload"
-        assert call_kwargs["json"]["action"] == "append"
-        assert call_kwargs["json"]["name"] == "Target Dataset"
-        assert call_kwargs["json"]["inputs"] == inputs
-        assert call_kwargs["json"]["outputs"] == outputs
-        assert call_kwargs["json"]["metadata"] == metadata
-
-        assert isinstance(target_dataset, Dataset)
-
-
-class TestAsyncDatasets:
-    @pytest.fixture
-    def mock_async_client(self):
-        return Mock(spec=httpx.AsyncClient)
-
-    @pytest.fixture
-    def async_datasets(self, mock_async_client):
-        return AsyncDatasets(mock_async_client)
-
-    @pytest.mark.asyncio
-    async def test_get_dataset_async(self, async_datasets, mock_async_client):
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
-
-        dataset_response = Mock()
-        dataset_response.json.return_value = {"data": dataset_info}
-        dataset_response.raise_for_status.return_value = None
-
-        examples_response = Mock()
-        examples_response.json.return_value = {"data": examples_data}
-        examples_response.raise_for_status.return_value = None
-
-        async def async_get(*args, **kwargs):
-            if "examples" in kwargs.get("url", ""):
-                return examples_response
-            return dataset_response
-
-        mock_async_client.get.side_effect = async_get
-
-        dataset = await async_datasets.get_dataset(dataset_id="dataset123")
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
-        assert dataset.name == "Test Dataset"
-
-    @pytest.mark.asyncio
-    async def test_create_dataset_async(self, async_datasets, mock_async_client):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version456"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
-
-        async def async_post(*args, **kwargs):
-            return upload_response
-
-        async def async_get(*args, **kwargs):
-            if "examples" in kwargs.get("url", ""):
-                response = Mock()
-                response.json.return_value = {"data": examples_data}
-                response.raise_for_status.return_value = None
-                return response
-            response = Mock()
-            response.json.return_value = {"data": dataset_info}
-            response.raise_for_status.return_value = None
-            return response
-
-        mock_async_client.post.side_effect = async_post
-        mock_async_client.get.side_effect = async_get
-
-        dataset = await async_datasets.create_dataset(
-            dataset_name="Test Dataset", inputs=[{"text": "hello"}]
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
-        assert dataset.name == "Test Dataset"
-
-    @pytest.mark.asyncio
-    async def test_add_examples_with_dataset_object_async(self, async_datasets, mock_async_client):
-        existing_dataset = Mock(spec=Dataset)
-        existing_dataset.id = "dataset123"
-        existing_dataset.name = "Test Dataset"
-
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        async def async_post(*args, **kwargs):
-            return upload_response
-
-        async def async_get(*args, **kwargs):
-            if "examples" in kwargs.get("url", ""):
-                response = Mock()
-                response.json.return_value = {"data": examples_data}
-                response.raise_for_status.return_value = None
-                return response
-            response = Mock()
-            response.json.return_value = {"data": dataset_info}
-            response.raise_for_status.return_value = None
-            return response
-
-        mock_async_client.post.side_effect = async_post
-        mock_async_client.get.side_effect = async_get
-
-        dataset = await async_datasets.add_examples_to_dataset(
-            dataset=existing_dataset, inputs=[{"text": "new data"}]
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
-
-    @pytest.mark.asyncio
-    async def test_add_examples_with_examples_parameter_async(
-        self, async_datasets, mock_async_client
-    ):
-        upload_response = Mock()
-        upload_response.json.return_value = {
-            "data": {"dataset_id": "dataset123", "version_id": "version789"}
-        }
-        upload_response.raise_for_status.return_value = None
-
-        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
-        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
-
-        async def async_post(*args, **kwargs):
-            return upload_response
-
-        async def async_get(*args, **kwargs):
-            if "examples" in kwargs.get("url", ""):
-                response = Mock()
-                response.json.return_value = {"data": examples_data}
-                response.raise_for_status.return_value = None
-                return response
-            response = Mock()
-            response.json.return_value = {"data": dataset_info}
-            response.raise_for_status.return_value = None
-            return response
-
-        mock_async_client.post.side_effect = async_post
-        mock_async_client.get.side_effect = async_get
-
-        example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-
-        dataset = await async_datasets.add_examples_to_dataset(
-            dataset_name="Test Dataset", examples=example
-        )
-
-        assert isinstance(dataset, Dataset)
-        assert dataset.id == "dataset123"
+        
+        with pytest.raises(ValueError, match="DataFrame has no data"):
+            _prepare_dataframe_as_json(df, keys)
 
 
 class TestDatasetUploadError:
-    def test_exception_message(self):
+    def test_error_message(self):
         error = DatasetUploadError("Upload failed")
         assert str(error) == "Upload failed"

--- a/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
+++ b/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
@@ -1,0 +1,701 @@
+"""Unit tests for phoenix.client.resources.datasets module."""
+
+import gzip
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import httpx
+import pandas as pd
+import pytest
+
+from phoenix.client.resources.datasets import (
+    AsyncDatasets,
+    DatasetKeys,
+    Datasets,
+    DatasetUploadError,
+    _get_csv_column_headers,
+    _infer_keys,
+    _is_all_dict,
+    _parse_datetime,
+    _prepare_csv,
+)
+
+
+class TestDatasetKeys:
+    """Test DatasetKeys validation class."""
+
+    def test_init_valid_keys(self):
+        """Test creating DatasetKeys with valid non-overlapping keys."""
+        keys = DatasetKeys(
+            input_keys=frozenset(["a", "b"]),
+            output_keys=frozenset(["c"]),
+            metadata_keys=frozenset(["d", "e"]),
+        )
+        assert keys.input == frozenset(["a", "b"])
+        assert keys.output == frozenset(["c"])
+        assert keys.metadata == frozenset(["d", "e"])
+
+    def test_init_overlapping_input_output(self):
+        """Test that overlapping input/output keys raise ValueError."""
+        with pytest.raises(ValueError, match="Input and output keys overlap"):
+            DatasetKeys(
+                input_keys=frozenset(["a", "b"]),
+                output_keys=frozenset(["b", "c"]),
+                metadata_keys=frozenset(["d"]),
+            )
+
+    def test_init_overlapping_input_metadata(self):
+        """Test that overlapping input/metadata keys raise ValueError."""
+        with pytest.raises(ValueError, match="Input and metadata keys overlap"):
+            DatasetKeys(
+                input_keys=frozenset(["a", "b"]),
+                output_keys=frozenset(["c"]),
+                metadata_keys=frozenset(["a", "d"]),
+            )
+
+    def test_init_overlapping_output_metadata(self):
+        """Test that overlapping output/metadata keys raise ValueError."""
+        with pytest.raises(ValueError, match="Output and metadata keys overlap"):
+            DatasetKeys(
+                input_keys=frozenset(["a"]),
+                output_keys=frozenset(["b", "c"]),
+                metadata_keys=frozenset(["c", "d"]),
+            )
+
+    def test_check_differences_all_present(self):
+        """Test check_differences when all keys are present."""
+        keys = DatasetKeys(
+            input_keys=frozenset(["a", "b"]),
+            output_keys=frozenset(["c"]),
+            metadata_keys=frozenset(["d"]),
+        )
+        # Should not raise
+        keys.check_differences(frozenset(["a", "b", "c", "d", "e"]))
+
+    def test_check_differences_missing_keys(self):
+        """Test check_differences when keys are missing."""
+        keys = DatasetKeys(
+            input_keys=frozenset(["a", "b"]),
+            output_keys=frozenset(["c"]),
+            metadata_keys=frozenset(["d"]),
+        )
+        with pytest.raises(ValueError, match="Keys not found in available columns"):
+            keys.check_differences(frozenset(["a", "c"]))
+
+    def test_iter(self):
+        """Test iterating over all keys."""
+        keys = DatasetKeys(
+            input_keys=frozenset(["a", "b"]),
+            output_keys=frozenset(["c"]),
+            metadata_keys=frozenset(["d"]),
+        )
+        assert set(keys) == {"a", "b", "c", "d"}
+
+
+class TestHelperFunctions:
+    """Test helper functions."""
+
+    def test_parse_datetime(self):
+        """Test ISO datetime parsing."""
+        dt_str = "2024-01-15T10:30:00"
+        dt = _parse_datetime(dt_str)
+        assert dt.year == 2024
+        assert dt.month == 1
+        assert dt.day == 15
+        assert dt.hour == 10
+        assert dt.minute == 30
+
+    def test_is_all_dict_true(self):
+        """Test _is_all_dict with all dictionaries."""
+        assert _is_all_dict([{"a": 1}, {"b": 2}, {}])
+
+    def test_is_all_dict_false(self):
+        """Test _is_all_dict with non-dictionaries."""
+        assert not _is_all_dict([{"a": 1}, "not a dict", {"b": 2}])
+        assert not _is_all_dict([{"a": 1}, None, {"b": 2}])
+        assert not _is_all_dict([{"a": 1}, 123, {"b": 2}])
+
+    def test_is_all_dict_empty(self):
+        """Test _is_all_dict with empty list."""
+        assert _is_all_dict([])
+
+    def test_get_csv_column_headers_valid(self, tmp_path):
+        """Test extracting headers from valid CSV."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
+
+        headers = _get_csv_column_headers(csv_file)
+        assert headers == ("col1", "col2", "col3")
+
+    def test_get_csv_column_headers_empty_file(self, tmp_path):
+        """Test extracting headers from empty CSV."""
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text("")
+
+        with pytest.raises(ValueError, match="CSV file has no data rows"):
+            _get_csv_column_headers(csv_file)
+
+    def test_get_csv_column_headers_only_headers(self, tmp_path):
+        """Test extracting headers from CSV with only headers."""
+        csv_file = tmp_path / "headers_only.csv"
+        csv_file.write_text("col1,col2,col3\n")
+
+        with pytest.raises(ValueError, match="CSV file has no data rows"):
+            _get_csv_column_headers(csv_file)
+
+    def test_get_csv_column_headers_file_not_found(self):
+        """Test extracting headers from non-existent file."""
+        with pytest.raises(FileNotFoundError, match="File does not exist"):
+            _get_csv_column_headers(Path("/non/existent/file.csv"))
+
+    def test_infer_keys_with_response_column(self):
+        """Test key inference with response column."""
+        # Test with DataFrame - use real pandas since it's available in test environment
+        df = pd.DataFrame(
+            {"input1": [1, 2], "input2": [3, 4], "response": [5, 6], "metadata1": [7, 8]}
+        )
+
+        input_keys, output_keys, metadata_keys = _infer_keys(df)
+
+        assert input_keys == ("input1", "input2")
+        assert output_keys == ("response",)
+        assert metadata_keys == ("metadata1",)
+
+    def test_infer_keys_with_output_column(self, tmp_path):
+        """Test key inference with output column."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("feature1,feature2,output,extra\nval1,val2,val3,val4\n")
+
+        input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
+
+        assert input_keys == ("feature1", "feature2")
+        assert output_keys == ("output",)
+        assert metadata_keys == ("extra",)
+
+    def test_infer_keys_with_answer_column(self, tmp_path):
+        """Test key inference with answer column."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("q1,q2,answer\nval1,val2,val3\n")
+
+        input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
+
+        assert input_keys == ("q1", "q2")
+        assert output_keys == ("answer",)
+        assert metadata_keys == ()
+
+    def test_infer_keys_no_output_column(self, tmp_path):
+        """Test key inference without output column."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
+
+        input_keys, output_keys, metadata_keys = _infer_keys(csv_file)
+
+        assert input_keys == ("col1", "col2", "col3")
+        assert output_keys == ()
+        assert metadata_keys == ()
+
+    def test_prepare_csv_valid(self, tmp_path):
+        """Test preparing CSV file for upload."""
+        csv_file = tmp_path / "test.csv"
+        csv_content = "input1,input2,output,metadata1\nval1,val2,val3,val4\n"
+        csv_file.write_text(csv_content)
+
+        keys = DatasetKeys(
+            input_keys=frozenset(["input1", "input2"]),
+            output_keys=frozenset(["output"]),
+            metadata_keys=frozenset(["metadata1"]),
+        )
+
+        name, file_obj, content_type, headers = _prepare_csv(csv_file, keys)
+
+        assert name == "test.csv"
+        assert content_type == "text/csv"
+        assert headers == {"Content-Encoding": "gzip"}
+
+        # Verify content is gzipped
+        file_obj.seek(0)
+        decompressed = gzip.decompress(file_obj.read()).decode()
+        assert decompressed == csv_content
+
+    def test_prepare_csv_duplicate_headers(self, tmp_path):
+        """Test preparing CSV with duplicate headers."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("col1,col1,col2\nval1,val2,val3\n")
+
+        keys = DatasetKeys(
+            input_keys=frozenset(["col1", "col2"]),
+            output_keys=frozenset(),
+            metadata_keys=frozenset(),
+        )
+
+        with pytest.raises(ValueError, match="Duplicate column headers in CSV"):
+            _prepare_csv(csv_file, keys)
+
+    def test_prepare_csv_missing_keys(self, tmp_path):
+        """Test preparing CSV with missing keys."""
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("col1,col2\nval1,val2\n")
+
+        keys = DatasetKeys(
+            input_keys=frozenset(["col1", "col3"]),  # col3 doesn't exist
+            output_keys=frozenset(),
+            metadata_keys=frozenset(),
+        )
+
+        with pytest.raises(ValueError, match="Keys not found in available columns"):
+            _prepare_csv(csv_file, keys)
+
+    @pytest.mark.skipif(True, reason="Requires pandas - would be tested in integration tests")
+    def test_prepare_dataframe_as_json(self):
+        """Test preparing DataFrame for upload as JSON."""
+        # This would require pandas, so we skip in unit tests
+        pass
+
+
+class TestDatasets:
+    """Test Datasets client class."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock httpx client."""
+        return Mock(spec=httpx.Client)
+
+    @pytest.fixture
+    def datasets(self, mock_client):
+        """Create Datasets instance with mock client."""
+        return Datasets(mock_client)
+
+    def test_get_dataset_by_id(self, datasets, mock_client):
+        """Test getting dataset by ID."""
+        # Mock responses
+        dataset_info = {
+            "id": "dataset123",
+            "name": "Test Dataset",
+            "description": "A test dataset",
+            "metadata": {"key": "value"},
+            "created_at": "2024-01-15T10:00:00",
+            "updated_at": "2024-01-15T10:00:00",
+            "example_count": 5,
+        }
+
+        examples_data = {
+            "dataset_id": "dataset123",
+            "version_id": "version456",
+            "examples": [
+                {
+                    "id": "ex1",
+                    "input": {"text": "hello"},
+                    "output": {"response": "hi"},
+                    "metadata": {"source": "test"},
+                    "updated_at": "2024-01-15T10:00:00",
+                }
+            ],
+        }
+
+        # Setup mock responses
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        # Call method
+        dataset, examples = datasets.get_dataset(dataset_id="dataset123")
+
+        # Verify calls
+        assert mock_client.get.call_count == 2
+        mock_client.get.assert_any_call(
+            url="v1/datasets/dataset123", headers={"accept": "application/json"}, timeout=5
+        )
+        mock_client.get.assert_any_call(
+            url="v1/datasets/dataset123/examples",
+            params=None,
+            headers={"accept": "application/json"},
+            timeout=5,
+        )
+
+        # Verify response
+        assert dataset == dataset_info
+        assert examples == examples_data
+
+    def test_get_dataset_by_name(self, datasets, mock_client):
+        """Test getting dataset by name."""
+        # Mock name lookup response
+        name_lookup_response = Mock()
+        name_lookup_response.json.return_value = {
+            "data": [{"id": "dataset123", "name": "Test Dataset"}]
+        }
+        name_lookup_response.raise_for_status.return_value = None
+
+        # Mock dataset responses
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        mock_client.get.side_effect = [
+            name_lookup_response,
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        # Call method
+        dataset, examples = datasets.get_dataset(dataset_name="Test Dataset")
+
+        # Verify name lookup was called
+        mock_client.get.assert_any_call(
+            url="v1/datasets",
+            params={"name": "Test Dataset"},
+            headers={"accept": "application/json"},
+            timeout=5,
+        )
+
+    def test_get_dataset_no_id_or_name(self, datasets):
+        """Test get_dataset raises when neither ID nor name provided."""
+        with pytest.raises(ValueError, match="Dataset id or name must be provided"):
+            datasets.get_dataset()
+
+    def test_get_dataset_versions_dataframe(self, datasets, mock_client):
+        """Test getting dataset versions as DataFrame."""
+        # Mock response
+        versions_data = [
+            {
+                "version_id": "v1",
+                "description": "Version 1",
+                "metadata": {},
+                "created_at": "2024-01-15T10:00:00",
+            },
+            {
+                "version_id": "v2",
+                "description": "Version 2",
+                "metadata": {},
+                "created_at": "2024-01-16T10:00:00",
+            },
+        ]
+
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": versions_data}
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+
+        # Call method - pandas is available in test environment
+        result = datasets.get_dataset_versions_dataframe(dataset_id="dataset123")
+
+        # Verify call
+        mock_client.get.assert_called_once_with(
+            url="v1/datasets/dataset123/versions",
+            params={"limit": 100},
+            headers={"accept": "application/json"},
+            timeout=5,
+        )
+
+        # Verify we got a DataFrame back
+        assert hasattr(result, "index")  # Basic DataFrame check
+        assert len(result) == 2  # Should have 2 records
+
+    def test_get_dataset_versions_dataframe_no_pandas(self, datasets, mock_client):
+        """Test get_dataset_versions_dataframe raises when pandas not installed."""
+
+        # Mock the import to raise ImportError
+        def mock_import(name, *args, **kwargs):
+            if name == "pandas":
+                raise ImportError("No module named 'pandas'")
+            # Fall back to the real import for other modules
+            return __import__(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with pytest.raises(ImportError, match="pandas is required"):
+                datasets.get_dataset_versions_dataframe(dataset_id="dataset123")
+
+    def test_create_dataset_json(self, datasets, mock_client):
+        """Test creating dataset with JSON data."""
+        # Mock upload response
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version456"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        # Mock get dataset response
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        # Call method
+        inputs = [{"text": "hello"}, {"text": "world"}]
+        outputs = [{"response": "hi"}, {"response": "earth"}]
+
+        dataset, examples = datasets.create_dataset(
+            dataset_name="Test Dataset",
+            inputs=inputs,
+            outputs=outputs,
+            dataset_description="Test description",
+        )
+
+        # Verify upload call
+        mock_client.post.assert_called_once_with(
+            url="v1/datasets/upload",
+            json={
+                "action": "create",
+                "name": "Test Dataset",
+                "inputs": inputs,
+                "outputs": outputs,
+                "metadata": [{}, {}],
+                "description": "Test description",
+            },
+            params={"sync": True},
+            headers={"accept": "application/json"},
+            timeout=5,
+        )
+
+    def test_create_dataset_csv(self, datasets, mock_client, tmp_path):
+        """Test creating dataset with CSV file."""
+        # Create test CSV
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("input_col,output_col\nval1,result1\nval2,result2\n")
+
+        # Mock responses
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version456"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        # Call method
+        dataset, examples = datasets.create_dataset(
+            dataset_name="Test Dataset",
+            csv_file_path=csv_file,
+            input_keys=["input_col"],
+            output_keys=["output_col"],
+        )
+
+        # Verify upload call
+        assert mock_client.post.call_count == 1
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["url"] == "v1/datasets/upload"
+        assert call_kwargs["params"] == {"sync": True}
+        assert "file" in call_kwargs["files"]
+        assert call_kwargs["data"]["name"] == "Test Dataset"
+        assert set(call_kwargs["data"]["input_keys[]"]) == {"input_col"}
+        assert set(call_kwargs["data"]["output_keys[]"]) == {"output_col"}
+
+    def test_create_dataset_invalid_params(self, datasets):
+        """Test create_dataset with invalid parameter combinations."""
+        # Both dataframe and csv_file_path
+        with pytest.raises(ValueError, match="Please provide either dataframe or csv_file_path"):
+            datasets.create_dataset(dataset_name="Test", dataframe=Mock(), csv_file_path="test.csv")
+
+        # Both tabular and JSON data
+        with pytest.raises(ValueError, match="Please provide either tabular data"):
+            datasets.create_dataset(
+                dataset_name="Test", csv_file_path="test.csv", inputs=[{"a": 1}]
+            )
+
+    def test_add_examples_to_dataset(self, datasets, mock_client):
+        """Test adding examples to existing dataset."""
+        # Mock responses
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version789"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        # Call method
+        inputs = [{"text": "new"}]
+
+        dataset, examples = datasets.add_examples_to_dataset(
+            dataset_name="Test Dataset", inputs=inputs
+        )
+
+        # Verify append action
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "append"
+        assert call_kwargs["json"]["name"] == "Test Dataset"
+
+    def test_get_dataset_id_by_name_found(self, datasets, mock_client):
+        """Test _get_dataset_id_by_name when dataset is found."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": [{"id": "dataset123", "name": "Test Dataset"}]}
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+
+        dataset_id = datasets._get_dataset_id_by_name(dataset_name="Test Dataset")
+
+        assert dataset_id == "dataset123"
+        mock_client.get.assert_called_once_with(
+            url="v1/datasets",
+            params={"name": "Test Dataset"},
+            headers={"accept": "application/json"},
+            timeout=5,
+        )
+
+    def test_get_dataset_id_by_name_not_found(self, datasets, mock_client):
+        """Test _get_dataset_id_by_name when dataset not found."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": []}
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="Dataset not found"):
+            datasets._get_dataset_id_by_name(dataset_name="Nonexistent")
+
+    def test_get_dataset_id_by_name_multiple_found(self, datasets, mock_client):
+        """Test _get_dataset_id_by_name when multiple datasets found."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [{"id": "dataset1", "name": "Test"}, {"id": "dataset2", "name": "Test"}]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="Multiple datasets found"):
+            datasets._get_dataset_id_by_name(dataset_name="Test")
+
+    def test_upload_json_dataset_validation(self, datasets, mock_client):
+        """Test _upload_json_dataset validation."""
+        # Empty inputs
+        with pytest.raises(ValueError, match="inputs must be non-empty"):
+            datasets._upload_json_dataset(dataset_name="Test", inputs=[])
+
+        # Non-dict inputs
+        with pytest.raises(ValueError, match="inputs must contain only dictionaries"):
+            datasets._upload_json_dataset(dataset_name="Test", inputs=["not", "dicts"])
+
+        # Length mismatch
+        with pytest.raises(ValueError, match="outputs must have same length as inputs"):
+            datasets._upload_json_dataset(
+                dataset_name="Test",
+                inputs=[{"a": 1}, {"b": 2}],
+                outputs=[{"c": 3}],  # Only 1 output for 2 inputs
+            )
+
+        # Non-dict outputs
+        with pytest.raises(ValueError, match="outputs must contain only dictionaries"):
+            datasets._upload_json_dataset(
+                dataset_name="Test", inputs=[{"a": 1}], outputs=["not dict"]
+            )
+
+    def test_process_dataset_upload_response_error(self, datasets, mock_client):
+        """Test _process_dataset_upload_response with error response."""
+        error_response = Mock(spec=httpx.Response)
+        error_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Bad Request", request=Mock(), response=error_response
+        )
+        error_response.json.return_value = {"detail": "Invalid dataset name"}
+
+        with pytest.raises(DatasetUploadError, match="Dataset upload failed: Invalid dataset name"):
+            datasets._process_dataset_upload_response(error_response)
+
+
+class TestAsyncDatasets:
+    """Test AsyncDatasets client class."""
+
+    @pytest.fixture
+    def mock_async_client(self):
+        """Create a mock async httpx client."""
+        return Mock(spec=httpx.AsyncClient)
+
+    @pytest.fixture
+    def async_datasets(self, mock_async_client):
+        """Create AsyncDatasets instance with mock client."""
+        return AsyncDatasets(mock_async_client)
+
+    @pytest.mark.asyncio
+    async def test_get_dataset_async(self, async_datasets, mock_async_client):
+        """Test async get_dataset."""
+        # Mock responses
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        # Create async mock responses
+        dataset_response = Mock()
+        dataset_response.json.return_value = {"data": dataset_info}
+        dataset_response.raise_for_status.return_value = None
+
+        examples_response = Mock()
+        examples_response.json.return_value = {"data": examples_data}
+        examples_response.raise_for_status.return_value = None
+
+        # Configure async mock
+        async def async_get(*args, **kwargs):
+            if "examples" in kwargs.get("url", ""):
+                return examples_response
+            return dataset_response
+
+        mock_async_client.get.side_effect = async_get
+
+        # Call method
+        dataset, examples = await async_datasets.get_dataset(dataset_id="dataset123")
+
+        # Verify response
+        assert dataset == dataset_info
+        assert examples == examples_data
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_async(self, async_datasets, mock_async_client):
+        """Test async create_dataset."""
+        # Mock upload response
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version456"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        # Mock get responses
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "examples": []}
+
+        async def async_post(*args, **kwargs):
+            return upload_response
+
+        async def async_get(*args, **kwargs):
+            if "examples" in kwargs.get("url", ""):
+                response = Mock()
+                response.json.return_value = {"data": examples_data}
+                response.raise_for_status.return_value = None
+                return response
+            response = Mock()
+            response.json.return_value = {"data": dataset_info}
+            response.raise_for_status.return_value = None
+            return response
+
+        mock_async_client.post.side_effect = async_post
+        mock_async_client.get.side_effect = async_get
+
+        # Call method
+        dataset, examples = await async_datasets.create_dataset(
+            dataset_name="Test Dataset", inputs=[{"text": "hello"}]
+        )
+
+        # Verify response
+        assert dataset == dataset_info
+        assert examples == examples_data
+
+
+class TestDatasetUploadError:
+    """Test custom exception class."""
+
+    def test_exception_message(self):
+        """Test DatasetUploadError with message."""
+        error = DatasetUploadError("Upload failed")
+        assert str(error) == "Upload failed"

--- a/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
+++ b/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
@@ -1,5 +1,3 @@
-"""Unit tests for phoenix.client.resources.datasets module."""
-
 import gzip
 from datetime import datetime
 from pathlib import Path
@@ -25,11 +23,9 @@ from phoenix.client.resources.datasets import (
 
 
 class TestDataset:
-    """Test Dataset class."""
 
     @pytest.fixture
     def dataset_info(self):
-        """Sample dataset info data."""
         return v1.DatasetWithExampleCount(
             id="dataset123",
             name="Test Dataset",
@@ -42,7 +38,6 @@ class TestDataset:
 
     @pytest.fixture
     def examples_data(self):
-        """Sample examples data."""
         return v1.ListDatasetExamplesData(
             dataset_id="dataset123",
             version_id="version456",
@@ -65,13 +60,11 @@ class TestDataset:
         )
 
     def test_init(self, dataset_info, examples_data):
-        """Test Dataset initialization."""
         dataset = Dataset(dataset_info, examples_data)
         assert dataset._dataset_info == dataset_info
         assert dataset._examples_data == examples_data
 
     def test_properties(self, dataset_info, examples_data):
-        """Test Dataset properties."""
         dataset = Dataset(dataset_info, examples_data)
 
         assert dataset.id == "dataset123"
@@ -80,10 +73,9 @@ class TestDataset:
         assert dataset.version_id == "version456"
         assert len(dataset.examples) == 2
         assert dataset.metadata == {"key": "value"}
-        assert dataset.example_count == 2  # From dataset_info
+        assert dataset.example_count == 2
 
     def test_datetime_properties(self, dataset_info, examples_data):
-        """Test Dataset datetime properties."""
         dataset = Dataset(dataset_info, examples_data)
 
         assert isinstance(dataset.created_at, datetime)
@@ -96,7 +88,6 @@ class TestDataset:
         assert dataset.updated_at.hour == 11
 
     def test_properties_missing_fields(self, examples_data):
-        """Test Dataset properties when optional fields are missing."""
         minimal_info = v1.Dataset(
             id="dataset123",
             name="Test Dataset",
@@ -108,12 +99,11 @@ class TestDataset:
         dataset = Dataset(minimal_info, examples_data)
 
         assert dataset.description is None
-        assert dataset.created_at is not None  # Should have created_at since we provided it
-        assert dataset.updated_at is not None  # Should have updated_at since we provided it
+        assert dataset.created_at is not None
+        assert dataset.updated_at is not None
         assert dataset.metadata == {}
 
     def test_example_count_fallback(self, dataset_info, examples_data):
-        """Test example_count falls back to counting examples."""
         # Create a Dataset without example_count
         dataset_info_no_count = v1.Dataset(
             id=dataset_info["id"],
@@ -125,15 +115,13 @@ class TestDataset:
         )
         dataset = Dataset(dataset_info_no_count, examples_data)
 
-        assert dataset.example_count == 2  # Counts from examples list
+        assert dataset.example_count == 2
 
     def test_len(self, dataset_info, examples_data):
-        """Test Dataset __len__ method."""
         dataset = Dataset(dataset_info, examples_data)
         assert len(dataset) == 2
 
     def test_iter(self, dataset_info, examples_data):
-        """Test Dataset __iter__ method."""
         dataset = Dataset(dataset_info, examples_data)
         examples = list(dataset)
         assert len(examples) == 2
@@ -141,13 +129,11 @@ class TestDataset:
         assert examples[1]["id"] == "ex2"
 
     def test_getitem(self, dataset_info, examples_data):
-        """Test Dataset __getitem__ method."""
         dataset = Dataset(dataset_info, examples_data)
         assert dataset[0]["id"] == "ex1"
         assert dataset[1]["id"] == "ex2"
 
     def test_repr(self, dataset_info, examples_data):
-        """Test Dataset __repr__ method."""
         dataset = Dataset(dataset_info, examples_data)
         repr_str = repr(dataset)
         assert "Dataset(" in repr_str
@@ -158,10 +144,8 @@ class TestDataset:
 
 
 class TestDatasetKeys:
-    """Test DatasetKeys validation class."""
 
     def test_init_valid_keys(self):
-        """Test creating DatasetKeys with valid non-overlapping keys."""
         keys = DatasetKeys(
             input_keys=frozenset(["a", "b"]),
             output_keys=frozenset(["c"]),
@@ -172,7 +156,6 @@ class TestDatasetKeys:
         assert keys.metadata == frozenset(["d", "e"])
 
     def test_init_overlapping_input_output(self):
-        """Test that overlapping input/output keys raise ValueError."""
         with pytest.raises(ValueError, match="Input and output keys overlap"):
             DatasetKeys(
                 input_keys=frozenset(["a", "b"]),
@@ -181,7 +164,6 @@ class TestDatasetKeys:
             )
 
     def test_init_overlapping_input_metadata(self):
-        """Test that overlapping input/metadata keys raise ValueError."""
         with pytest.raises(ValueError, match="Input and metadata keys overlap"):
             DatasetKeys(
                 input_keys=frozenset(["a", "b"]),
@@ -190,7 +172,6 @@ class TestDatasetKeys:
             )
 
     def test_init_overlapping_output_metadata(self):
-        """Test that overlapping output/metadata keys raise ValueError."""
         with pytest.raises(ValueError, match="Output and metadata keys overlap"):
             DatasetKeys(
                 input_keys=frozenset(["a"]),
@@ -199,17 +180,14 @@ class TestDatasetKeys:
             )
 
     def test_check_differences_all_present(self):
-        """Test check_differences when all keys are present."""
         keys = DatasetKeys(
             input_keys=frozenset(["a", "b"]),
             output_keys=frozenset(["c"]),
             metadata_keys=frozenset(["d"]),
         )
-        # Should not raise
         keys.check_differences(frozenset(["a", "b", "c", "d", "e"]))
 
     def test_check_differences_missing_keys(self):
-        """Test check_differences when keys are missing."""
         keys = DatasetKeys(
             input_keys=frozenset(["a", "b"]),
             output_keys=frozenset(["c"]),
@@ -219,7 +197,6 @@ class TestDatasetKeys:
             keys.check_differences(frozenset(["a", "c"]))
 
     def test_iter(self):
-        """Test iterating over all keys."""
         keys = DatasetKeys(
             input_keys=frozenset(["a", "b"]),
             output_keys=frozenset(["c"]),
@@ -229,10 +206,8 @@ class TestDatasetKeys:
 
 
 class TestHelperFunctions:
-    """Test helper functions."""
 
     def test_parse_datetime(self):
-        """Test ISO datetime parsing."""
         dt_str = "2024-01-15T10:30:00"
         dt = _parse_datetime(dt_str)
         assert dt.year == 2024
@@ -242,21 +217,17 @@ class TestHelperFunctions:
         assert dt.minute == 30
 
     def test_is_all_dict_true(self):
-        """Test _is_all_dict with all dictionaries."""
         assert _is_all_dict([{"a": 1}, {"b": 2}, {}])
 
     def test_is_all_dict_false(self):
-        """Test _is_all_dict with non-dictionaries."""
         assert not _is_all_dict([{"a": 1}, "not a dict", {"b": 2}])
         assert not _is_all_dict([{"a": 1}, None, {"b": 2}])
         assert not _is_all_dict([{"a": 1}, 123, {"b": 2}])
 
     def test_is_all_dict_empty(self):
-        """Test _is_all_dict with empty list."""
         assert _is_all_dict([])
 
     def test_get_csv_column_headers_valid(self, tmp_path):
-        """Test extracting headers from valid CSV."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
 
@@ -264,7 +235,6 @@ class TestHelperFunctions:
         assert headers == ("col1", "col2", "col3")
 
     def test_get_csv_column_headers_empty_file(self, tmp_path):
-        """Test extracting headers from empty CSV."""
         csv_file = tmp_path / "empty.csv"
         csv_file.write_text("")
 
@@ -272,7 +242,6 @@ class TestHelperFunctions:
             _get_csv_column_headers(csv_file)
 
     def test_get_csv_column_headers_only_headers(self, tmp_path):
-        """Test extracting headers from CSV with only headers."""
         csv_file = tmp_path / "headers_only.csv"
         csv_file.write_text("col1,col2,col3\n")
 
@@ -280,13 +249,10 @@ class TestHelperFunctions:
             _get_csv_column_headers(csv_file)
 
     def test_get_csv_column_headers_file_not_found(self):
-        """Test extracting headers from non-existent file."""
         with pytest.raises(FileNotFoundError, match="File does not exist"):
             _get_csv_column_headers(Path("/non/existent/file.csv"))
 
     def test_infer_keys_with_response_column(self):
-        """Test key inference with response column."""
-        # Test with DataFrame - use real pandas since it's available in test environment
         df = pd.DataFrame(
             {"input1": [1, 2], "input2": [3, 4], "response": [5, 6], "metadata1": [7, 8]}
         )
@@ -298,7 +264,6 @@ class TestHelperFunctions:
         assert metadata_keys == ("metadata1",)
 
     def test_infer_keys_with_output_column(self, tmp_path):
-        """Test key inference with output column."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("feature1,feature2,output,extra\nval1,val2,val3,val4\n")
 
@@ -309,7 +274,6 @@ class TestHelperFunctions:
         assert metadata_keys == ("extra",)
 
     def test_infer_keys_with_answer_column(self, tmp_path):
-        """Test key inference with answer column."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("q1,q2,answer\nval1,val2,val3\n")
 
@@ -320,7 +284,6 @@ class TestHelperFunctions:
         assert metadata_keys == ()
 
     def test_infer_keys_no_output_column(self, tmp_path):
-        """Test key inference without output column."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col2,col3\nval1,val2,val3\n")
 
@@ -331,7 +294,6 @@ class TestHelperFunctions:
         assert metadata_keys == ()
 
     def test_prepare_csv_valid(self, tmp_path):
-        """Test preparing CSV file for upload."""
         csv_file = tmp_path / "test.csv"
         csv_content = "input1,input2,output,metadata1\nval1,val2,val3,val4\n"
         csv_file.write_text(csv_content)
@@ -348,13 +310,11 @@ class TestHelperFunctions:
         assert content_type == "text/csv"
         assert headers == {"Content-Encoding": "gzip"}
 
-        # Verify content is gzipped
         file_obj.seek(0)
         decompressed = gzip.decompress(file_obj.read()).decode()
         assert decompressed == csv_content
 
     def test_prepare_csv_duplicate_headers(self, tmp_path):
-        """Test preparing CSV with duplicate headers."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col1,col2\nval1,val2,val3\n")
 
@@ -368,7 +328,6 @@ class TestHelperFunctions:
             _prepare_csv(csv_file, keys)
 
     def test_prepare_csv_missing_keys(self, tmp_path):
-        """Test preparing CSV with missing keys."""
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("col1,col2\nval1,val2\n")
 
@@ -383,27 +342,20 @@ class TestHelperFunctions:
 
     @pytest.mark.skipif(True, reason="Requires pandas - would be tested in integration tests")
     def test_prepare_dataframe_as_json(self):
-        """Test preparing DataFrame for upload as JSON."""
-        # This would require pandas, so we skip in unit tests
         pass
 
 
 class TestDatasets:
-    """Test Datasets client class."""
 
     @pytest.fixture
     def mock_client(self):
-        """Create a mock httpx client."""
         return Mock(spec=httpx.Client)
 
     @pytest.fixture
     def datasets(self, mock_client):
-        """Create Datasets instance with mock client."""
         return Datasets(mock_client)
 
     def test_get_dataset_by_id(self, datasets, mock_client):
-        """Test getting dataset by ID."""
-        # Mock responses
         dataset_info = {
             "id": "dataset123",
             "name": "Test Dataset",
@@ -428,16 +380,13 @@ class TestDatasets:
             ],
         }
 
-        # Setup mock responses
         mock_client.get.side_effect = [
             Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method
         dataset = datasets.get_dataset(dataset_id="dataset123")
 
-        # Verify calls
         assert mock_client.get.call_count == 2
         mock_client.get.assert_any_call(
             url="v1/datasets/dataset123", headers={"accept": "application/json"}, timeout=5
@@ -449,7 +398,6 @@ class TestDatasets:
             timeout=5,
         )
 
-        # Verify response - now returns Dataset object
         assert isinstance(dataset, Dataset)
         assert dataset.id == "dataset123"
         assert dataset.name == "Test Dataset"
@@ -457,15 +405,12 @@ class TestDatasets:
         assert len(dataset.examples) == 1
 
     def test_get_dataset_by_name(self, datasets, mock_client):
-        """Test getting dataset by name."""
-        # Mock name lookup response
         name_lookup_response = Mock()
         name_lookup_response.json.return_value = {
             "data": [{"id": "dataset123", "name": "Test Dataset"}]
         }
         name_lookup_response.raise_for_status.return_value = None
 
-        # Mock dataset responses
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
 
@@ -475,10 +420,8 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method
         dataset = datasets.get_dataset(dataset_name="Test Dataset")
 
-        # Verify name lookup was called
         mock_client.get.assert_any_call(
             url="v1/datasets",
             params={"name": "Test Dataset"},
@@ -486,18 +429,14 @@ class TestDatasets:
             timeout=5,
         )
 
-        # Verify response
         assert isinstance(dataset, Dataset)
         assert dataset.name == "Test Dataset"
 
     def test_get_dataset_with_dataset_object(self, datasets, mock_client):
-        """Test getting dataset using a Dataset object as input."""
-        # Create a mock Dataset object
         existing_dataset = Mock(spec=Dataset)
         existing_dataset.id = "dataset123"
         existing_dataset.name = "Test Dataset"
 
-        # Mock responses
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
 
@@ -506,29 +445,23 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method with dataset object
         datasets.get_dataset(dataset=existing_dataset)
 
-        # Verify it used the ID from the dataset object
         mock_client.get.assert_any_call(
             url="v1/datasets/dataset123", headers={"accept": "application/json"}, timeout=5
         )
 
     def test_get_dataset_no_identifier(self, datasets):
-        """Test get_dataset raises when no identifier provided."""
         with pytest.raises(
             ValueError, match="Dataset id, name, or dataset object must be provided"
         ):
             datasets.get_dataset()
 
     def test_get_dataset_versions_dataframe_with_dataset_object(self, datasets, mock_client):
-        """Test getting dataset versions using Dataset object."""
-        # Create a mock Dataset object
         dataset_obj = Mock(spec=Dataset)
         dataset_obj.id = "dataset123"
         dataset_obj.name = "Test Dataset"
 
-        # Mock response
         versions_data = [
             {
                 "version_id": "v1",
@@ -543,10 +476,8 @@ class TestDatasets:
         mock_response.raise_for_status.return_value = None
         mock_client.get.return_value = mock_response
 
-        # Call method with dataset object
         datasets.get_dataset_versions_dataframe(dataset=dataset_obj)
 
-        # Verify call used the dataset ID
         mock_client.get.assert_called_once_with(
             url="v1/datasets/dataset123/versions",
             params={"limit": 100},
@@ -555,15 +486,12 @@ class TestDatasets:
         )
 
     def test_get_dataset_versions_dataframe_with_name(self, datasets, mock_client):
-        """Test getting dataset versions using dataset name."""
-        # Mock name lookup
         name_lookup_response = Mock()
         name_lookup_response.json.return_value = {
             "data": [{"id": "dataset123", "name": "Test Dataset"}]
         }
         name_lookup_response.raise_for_status.return_value = None
 
-        # Mock versions response
         versions_data = [{"version_id": "v1", "created_at": "2024-01-15T10:00:00"}]
         versions_response = Mock()
         versions_response.json.return_value = {"data": versions_data}
@@ -571,10 +499,8 @@ class TestDatasets:
 
         mock_client.get.side_effect = [name_lookup_response, versions_response]
 
-        # Call method with dataset name
         datasets.get_dataset_versions_dataframe(dataset_name="Test Dataset")
 
-        # Verify name lookup was called
         assert mock_client.get.call_count == 2
         mock_client.get.assert_any_call(
             url="v1/datasets",
@@ -584,8 +510,6 @@ class TestDatasets:
         )
 
     def test_get_dataset_versions_dataframe(self, datasets, mock_client):
-        """Test getting dataset versions as DataFrame."""
-        # Mock response
         versions_data = [
             {
                 "version_id": "v1",
@@ -606,10 +530,8 @@ class TestDatasets:
         mock_response.raise_for_status.return_value = None
         mock_client.get.return_value = mock_response
 
-        # Call method - pandas is available in test environment
         result = datasets.get_dataset_versions_dataframe(dataset_id="dataset123")
 
-        # Verify call
         mock_client.get.assert_called_once_with(
             url="v1/datasets/dataset123/versions",
             params={"limit": 100},
@@ -617,18 +539,13 @@ class TestDatasets:
             timeout=5,
         )
 
-        # Verify we got a DataFrame back
-        assert hasattr(result, "index")  # Basic DataFrame check
-        assert len(result) == 2  # Should have 2 records
+        assert hasattr(result, "index")
+        assert len(result) == 2
 
     def test_get_dataset_versions_dataframe_no_pandas(self, datasets, mock_client):
-        """Test get_dataset_versions_dataframe raises when pandas not installed."""
-
-        # Mock the import to raise ImportError
         def mock_import(name, *args, **kwargs):
             if name == "pandas":
                 raise ImportError("No module named 'pandas'")
-            # Fall back to the real import for other modules
             return __import__(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=mock_import):
@@ -636,15 +553,12 @@ class TestDatasets:
                 datasets.get_dataset_versions_dataframe(dataset_id="dataset123")
 
     def test_create_dataset_json(self, datasets, mock_client):
-        """Test creating dataset with JSON data."""
-        # Mock upload response
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version456"}
         }
         upload_response.raise_for_status.return_value = None
 
-        # Mock get dataset response
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
 
@@ -654,7 +568,6 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method
         inputs = [{"text": "hello"}, {"text": "world"}]
         outputs = [{"response": "hi"}, {"response": "earth"}]
 
@@ -665,7 +578,6 @@ class TestDatasets:
             dataset_description="Test description",
         )
 
-        # Verify upload call
         mock_client.post.assert_called_once_with(
             url="v1/datasets/upload",
             json={
@@ -681,18 +593,14 @@ class TestDatasets:
             timeout=5,
         )
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
         assert dataset.id == "dataset123"
         assert dataset.name == "Test Dataset"
 
     def test_create_dataset_csv(self, datasets, mock_client, tmp_path):
-        """Test creating dataset with CSV file."""
-        # Create test CSV
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("input_col,output_col\nval1,result1\nval2,result2\n")
 
-        # Mock responses
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version456"}
@@ -708,7 +616,6 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method
         dataset = datasets.create_dataset(
             dataset_name="Test Dataset",
             csv_file_path=csv_file,
@@ -716,7 +623,6 @@ class TestDatasets:
             output_keys=["output_col"],
         )
 
-        # Verify upload call
         assert mock_client.post.call_count == 1
         call_kwargs = mock_client.post.call_args.kwargs
         assert call_kwargs["url"] == "v1/datasets/upload"
@@ -726,24 +632,18 @@ class TestDatasets:
         assert set(call_kwargs["data"]["input_keys[]"]) == {"input_col"}
         assert set(call_kwargs["data"]["output_keys[]"]) == {"output_col"}
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
 
     def test_create_dataset_invalid_params(self, datasets):
-        """Test create_dataset with invalid parameter combinations."""
-        # Both dataframe and csv_file_path
         with pytest.raises(ValueError, match="Please provide either dataframe or csv_file_path"):
             datasets.create_dataset(dataset_name="Test", dataframe=Mock(), csv_file_path="test.csv")
 
-        # Both tabular and JSON data
         with pytest.raises(ValueError, match="Please provide either tabular data"):
             datasets.create_dataset(
                 dataset_name="Test", csv_file_path="test.csv", inputs=[{"a": 1}]
             )
 
     def test_add_examples_to_dataset_with_name(self, datasets, mock_client):
-        """Test adding examples to existing dataset using dataset name."""
-        # Mock responses
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version789"}
@@ -759,27 +659,21 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method
         inputs = [{"text": "new"}]
 
         dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", inputs=inputs)
 
-        # Verify append action
         call_kwargs = mock_client.post.call_args.kwargs
         assert call_kwargs["json"]["action"] == "append"
         assert call_kwargs["json"]["name"] == "Test Dataset"
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
 
     def test_add_examples_to_dataset_with_object(self, datasets, mock_client):
-        """Test adding examples using a Dataset object."""
-        # Create a mock Dataset object
         existing_dataset = Mock(spec=Dataset)
         existing_dataset.id = "dataset123"
         existing_dataset.name = "Test Dataset"
 
-        # Mock responses
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version789"}
@@ -795,21 +689,16 @@ class TestDatasets:
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Call method with dataset object
         inputs = [{"text": "new"}]
 
         dataset = datasets.add_examples_to_dataset(dataset=existing_dataset, inputs=inputs)
 
-        # Verify it used the name from the dataset object
         call_kwargs = mock_client.post.call_args.kwargs
         assert call_kwargs["json"]["name"] == "Test Dataset"
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
 
     def test_method_chaining_workflow(self, datasets, mock_client):
-        """Test natural method chaining workflow."""
-        # Mock responses for create_dataset
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version456"}
@@ -819,13 +708,11 @@ class TestDatasets:
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
 
-        # Mock responses for get_dataset_versions_dataframe
         versions_data = [{"version_id": "v1", "created_at": "2024-01-15T10:00:00"}]
         versions_response = Mock()
         versions_response.json.return_value = {"data": versions_data}
         versions_response.raise_for_status.return_value = None
 
-        # Mock responses for add_examples_to_dataset
         upload_response2 = Mock()
         upload_response2.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version789"}
@@ -838,43 +725,32 @@ class TestDatasets:
             "examples": [],
         }
 
-        # Configure mock client responses in order
         mock_client.post.side_effect = [upload_response, upload_response2]
         mock_client.get.side_effect = [
-            # First get_dataset call after create
             Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
             Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
-            # get_dataset_versions_dataframe call
             versions_response,
-            # Second get_dataset call after add_examples
             Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
             Mock(json=lambda: {"data": updated_examples_data}, raise_for_status=lambda: None),
         ]
 
-        # Simulate the natural workflow
-        # 1. Create dataset
         dataset = datasets.create_dataset(
             dataset_name="Test Dataset", inputs=[{"text": "hello"}], outputs=[{"response": "hi"}]
         )
 
-        # 2. Get versions using the dataset object
         versions = datasets.get_dataset_versions_dataframe(dataset=dataset)
 
-        # 3. Add more examples using the dataset object
         updated_dataset = datasets.add_examples_to_dataset(
             dataset=dataset, inputs=[{"text": "world"}], outputs=[{"response": "earth"}]
         )
 
-        # Verify all operations worked with Dataset objects
         assert isinstance(dataset, Dataset)
-        assert hasattr(versions, "index")  # DataFrame
+        assert hasattr(versions, "index")
         assert isinstance(updated_dataset, Dataset)
 
-        # Verify the dataset object was used properly for method chaining
-        assert mock_client.get.call_count == 5  # 2 for create, 1 for versions, 2 for add
+        assert mock_client.get.call_count == 5
 
     def test_get_dataset_id_by_name_found(self, datasets, mock_client):
-        """Test _get_dataset_id_by_name when dataset is found."""
         mock_response = Mock()
         mock_response.json.return_value = {"data": [{"id": "dataset123", "name": "Test Dataset"}]}
         mock_response.raise_for_status.return_value = None
@@ -891,7 +767,6 @@ class TestDatasets:
         )
 
     def test_get_dataset_id_by_name_not_found(self, datasets, mock_client):
-        """Test _get_dataset_id_by_name when dataset not found."""
         mock_response = Mock()
         mock_response.json.return_value = {"data": []}
         mock_response.raise_for_status.return_value = None
@@ -901,7 +776,6 @@ class TestDatasets:
             datasets._get_dataset_id_by_name(dataset_name="Nonexistent")
 
     def test_get_dataset_id_by_name_multiple_found(self, datasets, mock_client):
-        """Test _get_dataset_id_by_name when multiple datasets found."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": [{"id": "dataset1", "name": "Test"}, {"id": "dataset2", "name": "Test"}]
@@ -913,31 +787,25 @@ class TestDatasets:
             datasets._get_dataset_id_by_name(dataset_name="Test")
 
     def test_upload_json_dataset_validation(self, datasets, mock_client):
-        """Test _upload_json_dataset validation."""
-        # Empty inputs
         with pytest.raises(ValueError, match="inputs must be non-empty"):
             datasets._upload_json_dataset(dataset_name="Test", inputs=[])
 
-        # Non-dict inputs
         with pytest.raises(ValueError, match="inputs must contain only dictionaries"):
             datasets._upload_json_dataset(dataset_name="Test", inputs=["not", "dicts"])
 
-        # Length mismatch
         with pytest.raises(ValueError, match="outputs must have same length as inputs"):
             datasets._upload_json_dataset(
                 dataset_name="Test",
                 inputs=[{"a": 1}, {"b": 2}],
-                outputs=[{"c": 3}],  # Only 1 output for 2 inputs
+                outputs=[{"c": 3}],
             )
 
-        # Non-dict outputs
         with pytest.raises(ValueError, match="outputs must contain only dictionaries"):
             datasets._upload_json_dataset(
                 dataset_name="Test", inputs=[{"a": 1}], outputs=["not dict"]
             )
 
     def test_process_dataset_upload_response_error(self, datasets, mock_client):
-        """Test _process_dataset_upload_response with error response."""
         error_response = Mock(spec=httpx.Response)
         error_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "Bad Request", request=Mock(), response=error_response
@@ -947,28 +815,355 @@ class TestDatasets:
         with pytest.raises(DatasetUploadError, match="Dataset upload failed: Invalid dataset name"):
             datasets._process_dataset_upload_response(error_response)
 
+    def test_add_examples_to_dataset_with_single_example(self, datasets, mock_client):
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version789"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+
+        dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", examples=example)
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "append"
+        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}]
+        assert call_kwargs["json"]["metadata"] == [{"source": "test"}]
+        assert isinstance(dataset, Dataset)
+
+    def test_add_examples_to_dataset_with_multiple_examples(self, datasets, mock_client):
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version789"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        examples = [
+            v1.DatasetExample(
+                id="ex1",
+                input={"text": "hello"},
+                output={"response": "hi"},
+                metadata={"source": "test1"},
+                updated_at="2024-01-15T10:00:00",
+            ),
+            v1.DatasetExample(
+                id="ex2",
+                input={"text": "world"},
+                output={"response": "earth"},
+                metadata={"source": "test2"},
+                updated_at="2024-01-15T10:00:00",
+            ),
+        ]
+
+        dataset = datasets.add_examples_to_dataset(dataset_name="Test Dataset", examples=examples)
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "append"
+        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}, {"text": "world"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}, {"response": "earth"}]
+        assert call_kwargs["json"]["metadata"] == [{"source": "test1"}, {"source": "test2"}]
+        assert isinstance(dataset, Dataset)
+
+    def test_create_dataset_with_single_example(self, datasets, mock_client):
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version456"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+
+        dataset = datasets.create_dataset(dataset_name="Test Dataset", examples=example)
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "create"
+        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}]
+        assert call_kwargs["json"]["metadata"] == [{"source": "test"}]
+        assert isinstance(dataset, Dataset)
+
+    def test_create_dataset_with_multiple_examples(self, datasets, mock_client):
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version456"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
+
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": examples_data}, raise_for_status=lambda: None),
+        ]
+
+        examples = [
+            v1.DatasetExample(
+                id="ex1",
+                input={"text": "hello"},
+                output={"response": "hi"},
+                metadata={"source": "test1"},
+                updated_at="2024-01-15T10:00:00",
+            ),
+            v1.DatasetExample(
+                id="ex2",
+                input={"text": "world"},
+                output={"response": "earth"},
+                metadata={"source": "test2"},
+                updated_at="2024-01-15T10:00:00",
+            ),
+        ]
+
+        dataset = datasets.create_dataset(dataset_name="Test Dataset", examples=examples)
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "create"
+        assert call_kwargs["json"]["inputs"] == [{"text": "hello"}, {"text": "world"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "hi"}, {"response": "earth"}]
+        assert call_kwargs["json"]["metadata"] == [{"source": "test1"}, {"source": "test2"}]
+        assert isinstance(dataset, Dataset)
+
+    def test_add_examples_to_dataset_validation_multiple_sources(self, datasets):
+        example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+
+        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
+            datasets.add_examples_to_dataset(
+                dataset_name="Test", examples=example, inputs=[{"text": "hello"}]
+            )
+
+        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
+            datasets.add_examples_to_dataset(
+                dataset_name="Test", examples=example, csv_file_path="test.csv"
+            )
+
+    def test_create_dataset_validation_multiple_sources(self, datasets):
+        example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+
+        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
+            datasets.create_dataset(dataset_name="Test", examples=example, inputs=[{"text": "hello"}])
+
+        with pytest.raises(ValueError, match="Please provide only one of: examples, tabular data"):
+            datasets.create_dataset(dataset_name="Test", examples=example, csv_file_path="test.csv")
+
+    def test_chaining_examples_from_dataset_to_dataset(self, datasets, mock_client):
+        source_dataset_info = {
+            "id": "source123",
+            "name": "Source Dataset",
+            "description": "Source dataset",
+            "metadata": {},
+            "created_at": "2024-01-15T10:00:00",
+            "updated_at": "2024-01-15T10:00:00",
+            "example_count": 2,
+        }
+
+        source_examples_data = {
+            "dataset_id": "source123",
+            "version_id": "source_v1",
+            "examples": [
+                {
+                    "id": "ex1",
+                    "input": {"text": "hello world"},
+                    "output": {"response": "greetings"},
+                    "metadata": {"category": "greeting"},
+                    "updated_at": "2024-01-15T10:00:00",
+                },
+                {
+                    "id": "ex2",
+                    "input": {"text": "goodbye"},
+                    "output": {"response": "farewell"},
+                    "metadata": {"category": "farewell"},
+                    "updated_at": "2024-01-15T10:00:00",
+                },
+            ],
+        }
+
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "target456", "version_id": "target_v1"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        target_dataset_info = {"id": "target456", "name": "Target Dataset"}
+        target_examples_data = {"dataset_id": "target456", "version_id": "target_v1", "examples": []}
+
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": source_dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": source_examples_data}, raise_for_status=lambda: None),
+        ]
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect.extend([
+            Mock(json=lambda: {"data": target_dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": target_examples_data}, raise_for_status=lambda: None),
+        ])
+
+        source_dataset = datasets.get_dataset(dataset_name="Source Dataset")
+        
+        first_example = source_dataset[0]
+        
+        target_dataset = datasets.add_examples_to_dataset(
+            dataset_name="Target Dataset", 
+            examples=first_example
+        )
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "append"
+        assert call_kwargs["json"]["name"] == "Target Dataset"
+        assert call_kwargs["json"]["inputs"] == [{"text": "hello world"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "greetings"}]
+        assert call_kwargs["json"]["metadata"] == [{"category": "greeting"}]
+        
+        assert isinstance(source_dataset, Dataset)
+        assert isinstance(target_dataset, Dataset)
+        assert len(source_dataset) == 2
+        assert source_dataset[0]["input"]["text"] == "hello world"
+
+    def test_chaining_multiple_examples_from_dataset_to_dataset(self, datasets, mock_client):
+        source_dataset_info = {
+            "id": "source123",
+            "name": "Source Dataset", 
+            "description": "Source dataset",
+            "metadata": {},
+            "created_at": "2024-01-15T10:00:00",
+            "updated_at": "2024-01-15T10:00:00",
+            "example_count": 3,
+        }
+
+        source_examples_data = {
+            "dataset_id": "source123",
+            "version_id": "source_v1",
+            "examples": [
+                {
+                    "id": "ex1",
+                    "input": {"text": "first"},
+                    "output": {"response": "1st"},
+                    "metadata": {"order": 1},
+                    "updated_at": "2024-01-15T10:00:00",
+                },
+                {
+                    "id": "ex2", 
+                    "input": {"text": "second"},
+                    "output": {"response": "2nd"},
+                    "metadata": {"order": 2},
+                    "updated_at": "2024-01-15T10:00:00",
+                },
+                {
+                    "id": "ex3",
+                    "input": {"text": "third"},
+                    "output": {"response": "3rd"}, 
+                    "metadata": {"order": 3},
+                    "updated_at": "2024-01-15T10:00:00",
+                },
+            ],
+        }
+
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "target456", "version_id": "target_v1"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        target_dataset_info = {"id": "target456", "name": "Target Dataset"}
+        target_examples_data = {"dataset_id": "target456", "version_id": "target_v1", "examples": []}
+
+        mock_client.get.side_effect = [
+            Mock(json=lambda: {"data": source_dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": source_examples_data}, raise_for_status=lambda: None),
+        ]
+        mock_client.post.return_value = upload_response
+        mock_client.get.side_effect.extend([
+            Mock(json=lambda: {"data": target_dataset_info}, raise_for_status=lambda: None),
+            Mock(json=lambda: {"data": target_examples_data}, raise_for_status=lambda: None),
+        ])
+
+        source_dataset = datasets.get_dataset(dataset_name="Source Dataset")
+        
+        first_two_examples = source_dataset.examples[:2]
+        
+        target_dataset = datasets.add_examples_to_dataset(
+            dataset_name="Target Dataset",
+            examples=first_two_examples
+        )
+
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"]["action"] == "append"
+        assert call_kwargs["json"]["inputs"] == [{"text": "first"}, {"text": "second"}]
+        assert call_kwargs["json"]["outputs"] == [{"response": "1st"}, {"response": "2nd"}]
+        assert call_kwargs["json"]["metadata"] == [{"order": 1}, {"order": 2}]
+        
+        assert isinstance(source_dataset, Dataset)
+        assert isinstance(target_dataset, Dataset)
+        assert len(source_dataset) == 3
+
 
 class TestAsyncDatasets:
-    """Test AsyncDatasets client class."""
 
     @pytest.fixture
     def mock_async_client(self):
-        """Create a mock async httpx client."""
         return Mock(spec=httpx.AsyncClient)
 
     @pytest.fixture
     def async_datasets(self, mock_async_client):
-        """Create AsyncDatasets instance with mock client."""
         return AsyncDatasets(mock_async_client)
 
     @pytest.mark.asyncio
     async def test_get_dataset_async(self, async_datasets, mock_async_client):
-        """Test async get_dataset."""
-        # Mock responses
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "v1", "examples": []}
 
-        # Create async mock responses
         dataset_response = Mock()
         dataset_response.json.return_value = {"data": dataset_info}
         dataset_response.raise_for_status.return_value = None
@@ -977,7 +1172,6 @@ class TestAsyncDatasets:
         examples_response.json.return_value = {"data": examples_data}
         examples_response.raise_for_status.return_value = None
 
-        # Configure async mock
         async def async_get(*args, **kwargs):
             if "examples" in kwargs.get("url", ""):
                 return examples_response
@@ -985,25 +1179,20 @@ class TestAsyncDatasets:
 
         mock_async_client.get.side_effect = async_get
 
-        # Call method
         dataset = await async_datasets.get_dataset(dataset_id="dataset123")
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
         assert dataset.id == "dataset123"
         assert dataset.name == "Test Dataset"
 
     @pytest.mark.asyncio
     async def test_create_dataset_async(self, async_datasets, mock_async_client):
-        """Test async create_dataset."""
-        # Mock upload response
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version456"}
         }
         upload_response.raise_for_status.return_value = None
 
-        # Mock get responses
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "version456", "examples": []}
 
@@ -1024,32 +1213,26 @@ class TestAsyncDatasets:
         mock_async_client.post.side_effect = async_post
         mock_async_client.get.side_effect = async_get
 
-        # Call method
         dataset = await async_datasets.create_dataset(
             dataset_name="Test Dataset", inputs=[{"text": "hello"}]
         )
 
-        # Verify response is Dataset object
         assert isinstance(dataset, Dataset)
         assert dataset.id == "dataset123"
         assert dataset.name == "Test Dataset"
 
     @pytest.mark.asyncio
     async def test_add_examples_with_dataset_object_async(self, async_datasets, mock_async_client):
-        """Test async add_examples_to_dataset with Dataset object."""
-        # Create a mock Dataset object
         existing_dataset = Mock(spec=Dataset)
         existing_dataset.id = "dataset123"
         existing_dataset.name = "Test Dataset"
 
-        # Mock upload response
         upload_response = Mock()
         upload_response.json.return_value = {
             "data": {"dataset_id": "dataset123", "version_id": "version789"}
         }
         upload_response.raise_for_status.return_value = None
 
-        # Mock get responses
         dataset_info = {"id": "dataset123", "name": "Test Dataset"}
         examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
 
@@ -1070,20 +1253,59 @@ class TestAsyncDatasets:
         mock_async_client.post.side_effect = async_post
         mock_async_client.get.side_effect = async_get
 
-        # Call method with dataset object
         dataset = await async_datasets.add_examples_to_dataset(
             dataset=existing_dataset, inputs=[{"text": "new data"}]
         )
 
-        # Verify response is Dataset object
+        assert isinstance(dataset, Dataset)
+        assert dataset.id == "dataset123"
+
+    @pytest.mark.asyncio
+    async def test_add_examples_with_examples_parameter_async(self, async_datasets, mock_async_client):
+        upload_response = Mock()
+        upload_response.json.return_value = {
+            "data": {"dataset_id": "dataset123", "version_id": "version789"}
+        }
+        upload_response.raise_for_status.return_value = None
+
+        dataset_info = {"id": "dataset123", "name": "Test Dataset"}
+        examples_data = {"dataset_id": "dataset123", "version_id": "version789", "examples": []}
+
+        async def async_post(*args, **kwargs):
+            return upload_response
+
+        async def async_get(*args, **kwargs):
+            if "examples" in kwargs.get("url", ""):
+                response = Mock()
+                response.json.return_value = {"data": examples_data}
+                response.raise_for_status.return_value = None
+                return response
+            response = Mock()
+            response.json.return_value = {"data": dataset_info}
+            response.raise_for_status.return_value = None
+            return response
+
+        mock_async_client.post.side_effect = async_post
+        mock_async_client.get.side_effect = async_get
+
+        example = v1.DatasetExample(
+            id="ex1",
+            input={"text": "hello"},
+            output={"response": "hi"},
+            metadata={"source": "test"},
+            updated_at="2024-01-15T10:00:00",
+        )
+
+        dataset = await async_datasets.add_examples_to_dataset(
+            dataset_name="Test Dataset", examples=example
+        )
+
         assert isinstance(dataset, Dataset)
         assert dataset.id == "dataset123"
 
 
 class TestDatasetUploadError:
-    """Test custom exception class."""
 
     def test_exception_message(self):
-        """Test DatasetUploadError with message."""
         error = DatasetUploadError("Upload failed")
         assert str(error) == "Upload failed"

--- a/tests/integration/client/test_datasets.py
+++ b/tests/integration/client/test_datasets.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from phoenix.client.__generated__ import v1
+
+from .._helpers import _ADMIN, _MEMBER, _await_or_return, _GetUser, _RoleOrUser
+
+
+class TestDatasetIntegration:
+    """Integration tests for dataset operations against a real Phoenix server."""
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    async def test_create_and_get_dataset(
+        self,
+        is_async: bool,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(role_or_user).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_dataset_{uuid.uuid4().hex[:8]}"
+
+        # Create dataset with JSON data
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                inputs=[{"text": "What is 2+2?"}, {"text": "What is the capital of France?"}],
+                outputs=[{"answer": "4"}, {"answer": "Paris"}],
+                metadata=[{"category": "math"}, {"category": "geography"}],
+                dataset_description="A test dataset for integration testing",
+            )
+        )
+
+        assert dataset.name == unique_name
+        assert dataset.description == "A test dataset for integration testing"
+        assert len(dataset) == 2
+        assert dataset[0]["input"]["text"] == "What is 2+2?"
+        assert dataset[0]["output"]["answer"] == "4"
+
+        # Get the same dataset
+        retrieved = await _await_or_return(Client().datasets.get_dataset(dataset=unique_name))
+
+        assert retrieved.id == dataset.id
+        assert retrieved.version_id == dataset.version_id
+        assert len(retrieved) == 2
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    async def test_add_examples_to_dataset(
+        self,
+        is_async: bool,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(role_or_user).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_dataset_{uuid.uuid4().hex[:8]}"
+
+        # Create initial dataset
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                inputs=[{"text": "Hello"}],
+                outputs=[{"response": "Hi"}],
+            )
+        )
+
+        assert len(dataset) == 1
+
+        # Add more examples
+        updated = await _await_or_return(
+            Client().datasets.add_examples_to_dataset(
+                dataset=dataset,  # Pass the dataset object
+                inputs=[{"text": "Goodbye"}, {"text": "Thanks"}],
+                outputs=[{"response": "Bye"}, {"response": "You're welcome"}],
+            )
+        )
+
+        assert len(updated) == 3
+        assert updated.id == dataset.id
+        assert updated.version_id != dataset.version_id  # New version
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    async def test_dataset_versions(
+        self,
+        is_async: bool,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(role_or_user).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_dataset_{uuid.uuid4().hex[:8]}"
+
+        # Create dataset
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                inputs=[{"text": "v1"}],
+                outputs=[{"response": "version 1"}],
+            )
+        )
+
+        # Add examples to create new version
+        await _await_or_return(
+            Client().datasets.add_examples_to_dataset(
+                dataset=dataset,
+                inputs=[{"text": "v2"}],
+                outputs=[{"response": "version 2"}],
+            )
+        )
+
+        # Get versions
+        versions = await _await_or_return(Client().datasets.get_dataset_versions(dataset=dataset))
+
+        assert len(versions) >= 2
+        assert all("version_id" in v for v in versions)
+        assert all("created_at" in v for v in versions)
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_create_dataset_from_csv(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        # Create CSV file
+        csv_file = tmp_path / "test_data.csv"
+        csv_content = """question,answer,category
+What is 2+2?,4,math
+Capital of France?,Paris,geography
+Who wrote Hamlet?,Shakespeare,literature
+"""
+        csv_file.write_text(csv_content)
+
+        unique_name = f"test_csv_{uuid.uuid4().hex[:8]}"
+
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                csv_file_path=csv_file,
+                input_keys=["question"],
+                output_keys=["answer"],
+                metadata_keys=["category"],
+            )
+        )
+
+        assert len(dataset) == 3
+        assert dataset[0]["input"]["question"] == "What is 2+2?"
+        assert dataset[0]["output"]["answer"] == "4"
+        assert dataset[0]["metadata"]["category"] == "math"
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_create_dataset_from_dataframe(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        df = pd.DataFrame(
+            {
+                "prompt": ["Write a poem", "Tell a joke", "Explain gravity"],
+                "response": ["Roses are red...", "Why did the chicken...", "Gravity is a force..."],
+                "rating": [5, 4, 5],
+            }
+        )
+
+        unique_name = f"test_df_{uuid.uuid4().hex[:8]}"
+
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                dataframe=df,
+                input_keys=["prompt"],
+                output_keys=["response"],
+                metadata_keys=["rating"],
+            )
+        )
+
+        assert len(dataset) == 3
+        assert dataset[0]["input"]["prompt"] == "Write a poem"
+        assert dataset[1]["output"]["response"] == "Why did the chicken..."
+        assert dataset[2]["metadata"]["rating"] == "5"
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_dataset_to_dataframe_round_trip(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_roundtrip_{uuid.uuid4().hex[:8]}"
+
+        # Create dataset
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                inputs=[
+                    {"question": "What is AI?", "context": "technology"},
+                    {"question": "Define ML", "context": "tech"},
+                ],
+                outputs=[
+                    {"answer": "Artificial Intelligence", "confidence": 0.9},
+                    {"answer": "Machine Learning", "confidence": 0.95},
+                ],
+                metadata=[
+                    {"source": "wiki", "verified": True},
+                    {"source": "textbook", "verified": True},
+                ],
+            )
+        )
+
+        # Convert to DataFrame
+        df = dataset.to_dataframe()
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert list(df.columns) == ["input", "output", "metadata"]
+
+        # Extract data from DataFrame
+        inputs = df["input"].tolist()
+        outputs = df["output"].tolist()
+        metadata = df["metadata"].tolist()
+
+        # Create new dataset from DataFrame data
+        new_name = f"test_from_df_{uuid.uuid4().hex[:8]}"
+        new_dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=new_name, inputs=inputs, outputs=outputs, metadata=metadata
+            )
+        )
+
+        assert len(new_dataset) == 2
+        assert new_dataset[0]["input"] == dataset[0]["input"]
+        assert new_dataset[0]["output"] == dataset[0]["output"]
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_dataset_examples_parameter(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        # Create source dataset
+        source_name = f"test_source_{uuid.uuid4().hex[:8]}"
+        source = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=source_name,
+                inputs=[{"q": "Q1"}, {"q": "Q2"}, {"q": "Q3"}],
+                outputs=[{"a": "A1"}, {"a": "A2"}, {"a": "A3"}],
+                metadata=[{"idx": 1}, {"idx": 2}, {"idx": 3}],
+            )
+        )
+
+        # Create target dataset with single example from source
+        target_name = f"test_target_{uuid.uuid4().hex[:8]}"
+        target = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=target_name,
+                examples=source[0],  # Single example
+            )
+        )
+
+        assert len(target) == 1
+        assert target[0]["input"] == {"q": "Q1"}
+        assert target[0]["output"] == {"a": "A1"}
+
+        # Add multiple examples
+        updated = await _await_or_return(
+            Client().datasets.add_examples_to_dataset(
+                dataset=target,
+                examples=source.examples[1:3],  # Multiple examples
+            )
+        )
+
+        assert len(updated) == 3
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_dataset_identifier_flexibility(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_flex_{uuid.uuid4().hex[:8]}"
+
+        # Create dataset
+        dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=unique_name,
+                inputs=[{"text": "test"}],
+                outputs=[{"result": "success"}],
+            )
+        )
+
+        # Get by ID
+        by_id = await _await_or_return(Client().datasets.get_dataset(dataset=dataset.id))
+        assert by_id.id == dataset.id
+
+        # Get by name
+        by_name = await _await_or_return(Client().datasets.get_dataset(dataset=unique_name))
+        assert by_name.id == dataset.id
+
+        # Get by dataset object
+        by_obj = await _await_or_return(Client().datasets.get_dataset(dataset=dataset))
+        assert by_obj.id == dataset.id
+
+        # Get by dict
+        by_dict = await _await_or_return(
+            Client().datasets.get_dataset(dataset={"id": dataset.id, "name": unique_name})
+        )
+        assert by_dict.id == dataset.id
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    async def test_error_handling(
+        self,
+        is_async: bool,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = _get_user(_MEMBER).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        import httpx
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        # Test dataset not found
+        with pytest.raises(ValueError, match="Dataset not found"):
+            await _await_or_return(
+                Client().datasets.get_dataset(dataset="non_existent_dataset_xyz123")
+            )
+
+        # Test invalid input data
+        with pytest.raises(ValueError, match="inputs must be non-empty"):
+            await _await_or_return(
+                Client().datasets.create_dataset(
+                    dataset_name="test",
+                    inputs=[],
+                    outputs=[],
+                )
+            )
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    async def test_dataset_examples_direct_pass(
+        self,
+        is_async: bool,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that dataset.examples can be passed directly to add_examples_to_dataset."""
+        user = _get_user(role_or_user).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        # Create source dataset with multiple examples
+        source_name = f"test_source_{uuid.uuid4().hex[:8]}"
+        source_dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=source_name,
+                inputs=[
+                    {"question": "What is Python?", "difficulty": "easy"},
+                    {"question": "Explain async/await", "difficulty": "medium"},
+                    {"question": "What are metaclasses?", "difficulty": "hard"},
+                ],
+                outputs=[
+                    {"answer": "A programming language", "confidence": 0.95},
+                    {"answer": "Concurrency primitives", "confidence": 0.85},
+                    {"answer": "Classes that create classes", "confidence": 0.80},
+                ],
+                metadata=[
+                    {"topic": "basics", "reviewed": True},
+                    {"topic": "concurrency", "reviewed": True},
+                    {"topic": "advanced", "reviewed": False},
+                ],
+            )
+        )
+
+        assert len(source_dataset) == 3
+
+        # Create empty target dataset
+        target_name = f"test_target_{uuid.uuid4().hex[:8]}"
+        target_dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=target_name,
+                inputs=[{"placeholder": "initial"}],
+                outputs=[{"placeholder": "initial"}],
+            )
+        )
+
+        assert len(target_dataset) == 1
+
+        # Pass dataset.examples directly to add_examples_to_dataset
+        updated_dataset = await _await_or_return(
+            Client().datasets.add_examples_to_dataset(
+                dataset=target_dataset,
+                examples=source_dataset.examples,  # Direct pass of examples list
+            )
+        )
+
+        # Should have original + all source examples
+        assert len(updated_dataset) == 4
+
+        # Verify the examples were copied correctly
+        # Skip the first example (placeholder) and compare the rest
+        for i, source_example in enumerate(source_dataset.examples):
+            target_example = updated_dataset.examples[i + 1]  # +1 to skip placeholder
+
+            # Compare the content (excluding IDs which will be different)
+            assert target_example["input"] == source_example["input"]
+            assert target_example["output"] == source_example["output"]
+            assert target_example["metadata"] == source_example["metadata"]
+
+        # Also test passing a subset of examples
+        subset_target_name = f"test_subset_{uuid.uuid4().hex[:8]}"
+        subset_dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                dataset_name=subset_target_name,
+                examples=source_dataset.examples[:2],  # Only first 2 examples
+            )
+        )
+
+        assert len(subset_dataset) == 2
+        assert subset_dataset[0]["input"]["question"] == "What is Python?"
+        assert subset_dataset[1]["input"]["question"] == "Explain async/await"


### PR DESCRIPTION
Adds methods to work with datasets to the Phoenix client. Some usage examples:


## Getting datasets and dataset versions
```python
# Get dataset by name or ID
dataset = client.datasets.get_dataset(dataset="my-dataset")
dataset = client.datasets.get_dataset(dataset="RGF0YXNldDoy", version_id="RGF0YXNldFZlcnNpb246Mw")

# Get dataset versions
versions = client.datasets.get_dataset_versions(dataset="my-dataset", limit=10)
```

## Creating datasets
```python
# From dictionaries
dataset = client.datasets.create_dataset(
    dataset_name="qa-dataset",
    inputs=[{"question": "What is 2+2?"}],
    outputs=[{"answer": "4"}],
)

# From DatasetExample objects
examples = [
    {"id": "1", "input": {"q": "Hello"}, "output": {"a": "Hi"}, "metadata": {"score": 0.9}}
]
dataset = client.datasets.create_dataset(
    dataset_name="chat-dataset",
    examples=examples
)

# From pandas DataFrame
df = pd.DataFrame({
    "prompt": ["Hello", "Hi"],
    "response": ["Hi!", "Hello!"],
})
dataset = client.datasets.create_dataset(
    dataset_name="greetings",
    dataframe=df,
    input_keys=["prompt"],
    output_keys=["response"],
)

# From CSV file
dataset = client.datasets.create_dataset(
    dataset_name="data",
    csv_file_path="data.csv",
    input_keys=["question"],
    output_keys=["answer"]
)
```

## Adding examples to datasets
```python
# add examples to a dataset
client.datasets.add_examples_to_dataset(
    dataset="qa-dataset",
    inputs=[{"question": "Who wrote Hamlet?"}],
    outputs=[{"answer": "Shakespeare"}]
)

# add examples from an existing dataset to a new one
old_dataset = client.datasets.get_dataset(dataset="old_dataset")
client.datasets.add_examples_to_dataset(
    dataset="new_dataset",
    examples=old_dataset.examples,
)
```

