### PR TITLE
docs: promote the sub-packages higher

### DIFF
--- a/api_reference/source/index.md
+++ b/api_reference/source/index.md
@@ -40,6 +40,15 @@ html_theme.sidebar_secondary.remove: true
 
 Welcome to Arize Phoenix's API reference. This reference details Phoenix's API and how to use its various features. To get a complete guide on how to use Phoenix, including tutorials, quickstarts, and concept explanations, see the [complete documentation](https://arize.com/docs/phoenix).
 
+## Sub-Pachages
+
+The `arize-phoenix` package includes the entire Phoenix platfom. However if you have deployed the Phoenix platform, there are light-weight Python sub-packages that can be used in conjunction with the platfrom.
+
+- **[arize-phoenix-otel](https://phoenix-otel.readthedocs.io/)** - Provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-aware defaults
+- **[arize-phoenix-client](https://phoenix-client.readthedocs.io/)** -Lightweight client for interacting with the Phoenix server via its OpenAPI REST interface
+
+- **[arize-phoenix-evals](https://phoenix-evals.readthedocs.io/)** - Tooling to evaluate LLM applications including RAG relevance, answer relevance, and more
+
 ```{seealso}
 Want to become a member of Phoenix's community? Check out our [Slack](https://arize-ai.slack.com/join/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q#/shared-invite/email) and [GitHub repository](https://arize.com/docs/phoenix)!
 ```
@@ -55,7 +64,3 @@ api/evals
 api/experiments
 api/inferences_schema
 ```
-
-## Related Documentation
-
-- **[Phoenix OTEL API Reference](https://arize-phoenix-otel.readthedocs.io/)** - Dedicated documentation for the `arize-phoenix-otel` package, providing OpenTelemetry integration with Phoenix-aware defaults.


### PR DESCRIPTION
## Summary by Sourcery

Elevate and enrich the API reference by introducing a dedicated “Sub-Packages” section to list and link lightweight Phoenix sub-packages and remove the obsolete “Related Documentation” section.

Documentation:
- Add a “Sub-Packages” section with descriptions and links for arize-phoenix-otel, arize-phoenix-client, and arize-phoenix-evals.
- Remove the outdated “Related Documentation” section at the bottom of the index.