### PR TITLE
feat(cost): add graphql model resolver

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1248,6 +1248,36 @@ input Granularity {
 
 scalar Identifier
 
+type InferenceModel {
+  dimensions(first: Int = 50, last: Int, after: String, before: String, include: DimensionFilter, exclude: DimensionFilter): DimensionConnection!
+  primaryInferences: Inferences!
+  referenceInferences: Inferences
+  corpusInferences: Inferences
+  embeddingDimensions(first: Int = 50, last: Int, after: String, before: String): EmbeddingDimensionConnection!
+
+  """Returns exported file names sorted by descending modification time."""
+  exportedFiles: [ExportedFile!]!
+  performanceMetric(
+    metric: PerformanceMetricInput!
+    timeRange: TimeRange
+
+    """The inferences (primary or reference) to query"""
+    inferencesRole: InferencesRole = primary
+  ): Float
+
+  """
+  Returns the time series of the specified metric for data within a time range. Data points are generated starting at the end time and are separated by the sampling interval. Each data point is labeled by the end instant and contains data from their respective evaluation windows.
+  """
+  performanceTimeSeries(
+    metric: PerformanceMetricInput!
+    timeRange: TimeRange!
+    granularity: Granularity!
+
+    """The inferences (primary or reference) to query"""
+    inferencesRole: InferencesRole = primary
+  ): PerformanceTimeSeries!
+}
+
 type Inferences {
   """The start bookend of the data"""
   startTime: DateTime!
@@ -1351,34 +1381,35 @@ type MissingValueBin {
   name: String
 }
 
-type Model {
-  dimensions(first: Int = 50, last: Int, after: String, before: String, include: DimensionFilter, exclude: DimensionFilter): DimensionConnection!
-  primaryInferences: Inferences!
-  referenceInferences: Inferences
-  corpusInferences: Inferences
-  embeddingDimensions(first: Int = 50, last: Int, after: String, before: String): EmbeddingDimensionConnection!
+type Model implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+  name: String!
+  provider: String
+  namePattern: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 
-  """Returns exported file names sorted by descending modification time."""
-  exportedFiles: [ExportedFile!]!
-  performanceMetric(
-    metric: PerformanceMetricInput!
-    timeRange: TimeRange
+  """The generative provider if the model provider matches a known provider"""
+  generativeProvider: GenerativeProvider
+}
 
-    """The inferences (primary or reference) to query"""
-    inferencesRole: InferencesRole = primary
-  ): Float
+"""A connection to a list of items."""
+type ModelConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
 
-  """
-  Returns the time series of the specified metric for data within a time range. Data points are generated starting at the end time and are separated by the sampling interval. Each data point is labeled by the end instant and contains data from their respective evaluation windows.
-  """
-  performanceTimeSeries(
-    metric: PerformanceMetricInput!
-    timeRange: TimeRange!
-    granularity: Granularity!
+  """Contains the nodes in this connection"""
+  edges: [ModelEdge!]!
+}
 
-    """The inferences (primary or reference) to query"""
-    inferencesRole: InferencesRole = primary
-  ): PerformanceTimeSeries!
+"""An edge in a connection."""
+type ModelEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: Model!
 }
 
 enum ModelProvider {
@@ -1934,7 +1965,8 @@ type PromptVersionTagMutationPayload {
 
 type Query {
   modelProviders: [GenerativeProvider!]!
-  models(input: ModelsInput = null): [GenerativeModel!]!
+  models(first: Int = 50, last: Int, after: String, before: String): ModelConnection!
+  generativeModels(input: ModelsInput = null): [GenerativeModel!]!
   modelInvocationParameters(input: ModelsInput = null): [InvocationParameter!]!
   users(first: Int = 50, last: Int, after: String, before: String): UserConnection!
   userRoles: [UserRole!]!
@@ -1947,7 +1979,7 @@ type Query {
   compareExperiments(experimentIds: [ID!]!, filterCondition: String): [ExperimentComparison!]!
   validateExperimentRunFilterCondition(condition: String!, experimentIds: [ID!]!): ValidationResult!
   functionality: Functionality!
-  model: Model!
+  model: InferenceModel!
   node(id: ID!): Node!
   viewer: User
   prompts(first: Int = 50, last: Int, after: String, before: String): PromptConnection!

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1190,11 +1190,6 @@ input GenerativeCredentialInput {
   value: String!
 }
 
-type GenerativeModel {
-  name: String!
-  providerKey: GenerativeProviderKey!
-}
-
 input GenerativeModelInput {
   providerKey: GenerativeProviderKey!
   name: String!
@@ -1381,17 +1376,15 @@ type MissingValueBin {
   name: String
 }
 
-type Model implements Node {
+type Model implements Node & ModelInterface {
   """The Globally Unique ID of this object"""
   id: ID!
   name: String!
+  providerKey: GenerativeProviderKey
   provider: String
   namePattern: String!
   createdAt: DateTime!
   updatedAt: DateTime!
-
-  """The generative provider if the model provider matches a known provider"""
-  generativeProvider: GenerativeProvider
 }
 
 """A connection to a list of items."""
@@ -1410,6 +1403,11 @@ type ModelEdge {
 
   """The item at the end of the edge"""
   node: Model!
+}
+
+interface ModelInterface {
+  name: String!
+  providerKey: GenerativeProviderKey
 }
 
 enum ModelProvider {
@@ -1592,6 +1590,11 @@ input PerformanceMetricInput {
 
 type PerformanceTimeSeries implements TimeSeries {
   data: [TimeSeriesDataPoint!]!
+}
+
+type PlaygroundModel implements ModelInterface {
+  name: String!
+  providerKey: GenerativeProviderKey!
 }
 
 type Point2D {
@@ -1966,7 +1969,7 @@ type PromptVersionTagMutationPayload {
 type Query {
   modelProviders: [GenerativeProvider!]!
   models(first: Int = 50, last: Int, after: String, before: String): ModelConnection!
-  generativeModels(input: ModelsInput = null): [GenerativeModel!]!
+  playgroundModels(input: ModelsInput = null): [PlaygroundModel!]!
   modelInvocationParameters(input: ModelsInput = null): [InvocationParameter!]!
   users(first: Int = 50, last: Int, after: String, before: String): UserConnection!
   userRoles: [UserRole!]!

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
+import { modelsLoader } from "@phoenix/pages/models/modelsLoader";
 import { ModelsPage } from "@phoenix/pages/models/ModelsPage";
 import { SettingsAIProvidersPage } from "@phoenix/pages/settings/SettingsAIProvidersPage";
 import { settingsAIProvidersPageLoader } from "@phoenix/pages/settings/settingsAIProvidersPageLoader";
@@ -330,6 +331,7 @@ const router = createBrowserRouter(
           <Route
             path="/models"
             element={<ModelsPage />}
+            loader={modelsLoader}
             handle={{
               crumb: () => "models",
             }}

--- a/app/src/components/form/__generated__/DimensionPickerQuery.graphql.ts
+++ b/app/src/components/form/__generated__/DimensionPickerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<03b4c31264931d4accdcf8aaf607fd3a>>
+ * @generated SignedSource<<82fe27050c1e43c58c93c0cbc0142576>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,7 +36,7 @@ var v0 = [
   {
     "alias": null,
     "args": null,
-    "concreteType": "Model",
+    "concreteType": "InferenceModel",
     "kind": "LinkedField",
     "name": "model",
     "plural": false,

--- a/app/src/components/model/__generated__/ModelEmbeddingsTableEmbeddingDimensionsQuery.graphql.ts
+++ b/app/src/components/model/__generated__/ModelEmbeddingsTableEmbeddingDimensionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<df3467319c5599c9f2575888b76d78a3>>
+ * @generated SignedSource<<4976dcaf1674561e8ba5955d489f794d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,7 +112,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,

--- a/app/src/components/model/__generated__/ModelEmbeddingsTable_embeddingDimensions.graphql.ts
+++ b/app/src/components/model/__generated__/ModelEmbeddingsTable_embeddingDimensions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<757af1f9a6f573a29da962d02c5b9560>>
+ * @generated SignedSource<<734328b739994e2ebafd57cef92fe046>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -87,7 +87,7 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "Model",
+      "concreteType": "InferenceModel",
       "kind": "LinkedField",
       "name": "model",
       "plural": false,

--- a/app/src/components/model/__generated__/ModelSchemaTableDimensionsQuery.graphql.ts
+++ b/app/src/components/model/__generated__/ModelSchemaTableDimensionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f0034887de117ccb5732ca1d7a034f8>>
+ * @generated SignedSource<<1c6cfbcbc18ef976a7335e638f659e66>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -128,7 +128,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,

--- a/app/src/components/model/__generated__/ModelSchemaTable_dimensions.graphql.ts
+++ b/app/src/components/model/__generated__/ModelSchemaTable_dimensions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4c04691e02173dace538f50236d2363d>>
+ * @generated SignedSource<<64d4b8e726882c555dd01f6a5bb5073d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -112,7 +112,7 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "Model",
+      "concreteType": "InferenceModel",
       "kind": "LinkedField",
       "name": "model",
       "plural": false,

--- a/app/src/pages/__generated__/ModelRootQuery.graphql.ts
+++ b/app/src/pages/__generated__/ModelRootQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7ef464e58de44561a1b2fb1aaaae5f35>>
+ * @generated SignedSource<<4e4f67ae9ec7a3ad580f28ad465f28c8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,7 +62,7 @@ v1 = [
   {
     "alias": null,
     "args": null,
-    "concreteType": "Model",
+    "concreteType": "InferenceModel",
     "kind": "LinkedField",
     "name": "model",
     "plural": false,

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -138,7 +138,7 @@ export function MetricSelector({
   const [, startTransition] = useTransition();
   const data = useFragment<MetricSelector_dimensions$key>(
     graphql`
-      fragment MetricSelector_dimensions on Model {
+      fragment MetricSelector_dimensions on InferenceModel {
         numericDimensions: dimensions(include: { dataTypes: [numeric] }) {
           edges {
             node {

--- a/app/src/pages/embedding/__generated__/EmbeddingPageModelQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/EmbeddingPageModelQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<621d14a0b91e636f573d99f1ab1a5aaf>>
+ * @generated SignedSource<<d8fbd835f366cb8e01e8fa874e635509>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,7 +31,7 @@ const node: ConcreteRequest = {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,
@@ -57,7 +57,7 @@ const node: ConcreteRequest = {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,
@@ -132,12 +132,12 @@ const node: ConcreteRequest = {
     ]
   },
   "params": {
-    "cacheID": "4ccf476dd862525b059197daccd0d4d9",
+    "cacheID": "fd9d393b5de6aab89ac3f91ac93def55",
     "id": null,
     "metadata": {},
     "name": "EmbeddingPageModelQuery",
     "operationKind": "query",
-    "text": "query EmbeddingPageModelQuery {\n  model {\n    ...MetricSelector_dimensions\n  }\n}\n\nfragment MetricSelector_dimensions on Model {\n  numericDimensions: dimensions(include: {dataTypes: [numeric]}) {\n    edges {\n      node {\n        id\n        name\n        type\n      }\n    }\n  }\n}\n"
+    "text": "query EmbeddingPageModelQuery {\n  model {\n    ...MetricSelector_dimensions\n  }\n}\n\nfragment MetricSelector_dimensions on InferenceModel {\n  numericDimensions: dimensions(include: {dataTypes: [numeric]}) {\n    edges {\n      node {\n        id\n        name\n        type\n      }\n    }\n  }\n}\n"
   }
 };
 

--- a/app/src/pages/embedding/__generated__/ExportSelectionButtonExportsQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/ExportSelectionButtonExportsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58da5da829b681c5748df3ff99c05bfd>>
+ * @generated SignedSource<<d1bd97ba73cbf790a4702fbfc5c7beb2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -27,7 +27,7 @@ var v0 = [
   {
     "alias": null,
     "args": null,
-    "concreteType": "Model",
+    "concreteType": "InferenceModel",
     "kind": "LinkedField",
     "name": "model",
     "plural": false,

--- a/app/src/pages/embedding/__generated__/MetricSelector_dimensions.graphql.ts
+++ b/app/src/pages/embedding/__generated__/MetricSelector_dimensions.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<36523970ff07eec9b959c3a724f000b3>>
+ * @generated SignedSource<<a77fc0e595f1292092c13909147cf604>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -99,10 +99,10 @@ const node: ReaderFragment = {
       "storageKey": "dimensions(include:{\"dataTypes\":[\"numeric\"]})"
     }
   ],
-  "type": "Model",
+  "type": "InferenceModel",
   "abstractKey": null
 };
 
-(node as any).hash = "55d03de16503d7af254c17cef7d18ee0";
+(node as any).hash = "372c00c9d4e2e0512af55c958b21c5e0";
 
 export default node;

--- a/app/src/pages/embedding/__generated__/MetricTimeSeriesQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/MetricTimeSeriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf1a3901f2c37bfd131a8a5f70ddf024>>
+ * @generated SignedSource<<e4ef5a00b37fcb8c45662a6527f89ca5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -291,7 +291,7 @@ v18 = {
 v19 = {
   "alias": null,
   "args": null,
-  "concreteType": "Model",
+  "concreteType": "InferenceModel",
   "kind": "LinkedField",
   "name": "model",
   "plural": false,

--- a/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
+++ b/app/src/pages/embedding/__generated__/PointSelectionPanelContentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<93dc3f479dbc4178508d216a7629fbed>>
+ * @generated SignedSource<<6028367b5bffa47128923f1d5ee96fc1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -316,7 +316,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,
@@ -404,7 +404,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,

--- a/app/src/pages/model/__generated__/ModelInferencesPageQuery.graphql.ts
+++ b/app/src/pages/model/__generated__/ModelInferencesPageQuery.graphql.ts
@@ -8,401 +8,397 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest } from 'relay-runtime';
+import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ModelInferencesPageQuery$variables = {
   endTime: string;
   startTime: string;
 };
 export type ModelInferencesPageQuery$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"ModelEmbeddingsTable_embeddingDimensions" | "ModelSchemaTable_dimensions">;
+  readonly " $fragmentSpreads": FragmentRefs<
+    "ModelEmbeddingsTable_embeddingDimensions" | "ModelSchemaTable_dimensions"
+  >;
 };
 export type ModelInferencesPageQuery = {
   response: ModelInferencesPageQuery$data;
   variables: ModelInferencesPageQuery$variables;
 };
 
-const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "endTime"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "startTime"
-},
-v2 = [
-  {
-    "kind": "Variable",
-    "name": "endTime",
-    "variableName": "endTime"
-  },
-  {
-    "kind": "Variable",
-    "name": "startTime",
-    "variableName": "startTime"
-  }
-],
-v3 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 50
-  }
-],
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v6 = {
-  "fields": [
-    {
-      "kind": "Variable",
-      "name": "end",
-      "variableName": "endTime"
+const node: ConcreteRequest = (function () {
+  var v0 = {
+      defaultValue: null,
+      kind: "LocalArgument",
+      name: "endTime",
     },
-    {
-      "kind": "Variable",
-      "name": "start",
-      "variableName": "startTime"
-    }
-  ],
-  "kind": "ObjectValue",
-  "name": "timeRange"
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v8 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "__typename",
-    "storageKey": null
-  },
-  (v4/*: any*/)
-],
-v9 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "PageInfo",
-  "kind": "LinkedField",
-  "name": "pageInfo",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "endCursor",
-      "storageKey": null
+    v1 = {
+      defaultValue: null,
+      kind: "LocalArgument",
+      name: "startTime",
     },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "hasNextPage",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-};
-return {
-  "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "ModelInferencesPageQuery",
-    "selections": [
+    v2 = [
       {
-        "args": (v2/*: any*/),
-        "kind": "FragmentSpread",
-        "name": "ModelSchemaTable_dimensions"
+        kind: "Variable",
+        name: "endTime",
+        variableName: "endTime",
       },
       {
-        "args": (v2/*: any*/),
-        "kind": "FragmentSpread",
-        "name": "ModelEmbeddingsTable_embeddingDimensions"
-      }
+        kind: "Variable",
+        name: "startTime",
+        variableName: "startTime",
+      },
     ],
-    "type": "Query",
-    "abstractKey": null
-  },
-  "kind": "Request",
-  "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
-    "kind": "Operation",
-    "name": "ModelInferencesPageQuery",
-    "selections": [
+    v3 = [
       {
-        "alias": null,
-        "args": null,
-        "concreteType": "Model",
-        "kind": "LinkedField",
-        "name": "model",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": (v3/*: any*/),
-            "concreteType": "DimensionConnection",
-            "kind": "LinkedField",
-            "name": "dimensions",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "DimensionEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": "dimension",
-                    "args": null,
-                    "concreteType": "Dimension",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "type",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "dataType",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cardinality",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "cardinality"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "dataQualityMetric",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "percentEmpty",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "percentEmpty"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "dataQualityMetric",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "min",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "min"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "dataQualityMetric",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "mean",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "mean"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "dataQualityMetric",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "max",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "max"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "dataQualityMetric",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "psi",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "psi"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "driftMetric",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v7/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Dimension",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v9/*: any*/)
-            ],
-            "storageKey": "dimensions(first:50)"
-          },
-          {
-            "alias": null,
-            "args": (v3/*: any*/),
-            "filters": null,
-            "handle": "connection",
-            "key": "ModelSchemaTable_dimensions",
-            "kind": "LinkedHandle",
-            "name": "dimensions"
-          },
-          {
-            "alias": null,
-            "args": (v3/*: any*/),
-            "concreteType": "EmbeddingDimensionConnection",
-            "kind": "LinkedField",
-            "name": "embeddingDimensions",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "EmbeddingDimensionEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": "embedding",
-                    "args": null,
-                    "concreteType": "EmbeddingDimension",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      {
-                        "alias": "euclideanDistance",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "metric",
-                            "value": "euclideanDistance"
-                          },
-                          (v6/*: any*/)
-                        ],
-                        "kind": "ScalarField",
-                        "name": "driftMetric",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v7/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "EmbeddingDimension",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": (v8/*: any*/),
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v9/*: any*/)
-            ],
-            "storageKey": "embeddingDimensions(first:50)"
-          },
-          {
-            "alias": null,
-            "args": (v3/*: any*/),
-            "filters": null,
-            "handle": "connection",
-            "key": "ModelEmbeddingsTable_embeddingDimensions",
-            "kind": "LinkedHandle",
-            "name": "embeddingDimensions"
-          }
-        ],
-        "storageKey": null
-      }
-    ]
-  },
-  "params": {
-    "cacheID": "d4ce45828b9b8ab1f08d7bf38299a533",
-    "id": null,
-    "metadata": {},
-    "name": "ModelInferencesPageQuery",
-    "operationKind": "query",
-    "text": "query ModelInferencesPageQuery(\n  $startTime: DateTime!\n  $endTime: DateTime!\n) {\n  ...ModelSchemaTable_dimensions_3uKjWt\n  ...ModelEmbeddingsTable_embeddingDimensions_3uKjWt\n}\n\nfragment ModelEmbeddingsTable_embeddingDimensions_3uKjWt on Query {\n  model {\n    embeddingDimensions(first: 50) {\n      edges {\n        embedding: node {\n          id\n          name\n          euclideanDistance: driftMetric(metric: euclideanDistance, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ModelSchemaTable_dimensions_3uKjWt on Query {\n  model {\n    dimensions(first: 50) {\n      edges {\n        dimension: node {\n          id\n          name\n          type\n          dataType\n          cardinality: dataQualityMetric(metric: cardinality, timeRange: {start: $startTime, end: $endTime})\n          percentEmpty: dataQualityMetric(metric: percentEmpty, timeRange: {start: $startTime, end: $endTime})\n          min: dataQualityMetric(metric: min, timeRange: {start: $startTime, end: $endTime})\n          mean: dataQualityMetric(metric: mean, timeRange: {start: $startTime, end: $endTime})\n          max: dataQualityMetric(metric: max, timeRange: {start: $startTime, end: $endTime})\n          psi: driftMetric(metric: psi, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
-  }
-};
+        kind: "Literal",
+        name: "first",
+        value: 50,
+      },
+    ],
+    v4 = {
+      alias: null,
+      args: null,
+      kind: "ScalarField",
+      name: "id",
+      storageKey: null,
+    },
+    v5 = {
+      alias: null,
+      args: null,
+      kind: "ScalarField",
+      name: "name",
+      storageKey: null,
+    },
+    v6 = {
+      fields: [
+        {
+          kind: "Variable",
+          name: "end",
+          variableName: "endTime",
+        },
+        {
+          kind: "Variable",
+          name: "start",
+          variableName: "startTime",
+        },
+      ],
+      kind: "ObjectValue",
+      name: "timeRange",
+    },
+    v7 = {
+      alias: null,
+      args: null,
+      kind: "ScalarField",
+      name: "cursor",
+      storageKey: null,
+    },
+    v8 = [
+      {
+        alias: null,
+        args: null,
+        kind: "ScalarField",
+        name: "__typename",
+        storageKey: null,
+      },
+      v4 /*: any*/,
+    ],
+    v9 = {
+      alias: null,
+      args: null,
+      concreteType: "PageInfo",
+      kind: "LinkedField",
+      name: "pageInfo",
+      plural: false,
+      selections: [
+        {
+          alias: null,
+          args: null,
+          kind: "ScalarField",
+          name: "endCursor",
+          storageKey: null,
+        },
+        {
+          alias: null,
+          args: null,
+          kind: "ScalarField",
+          name: "hasNextPage",
+          storageKey: null,
+        },
+      ],
+      storageKey: null,
+    };
+  return {
+    fragment: {
+      argumentDefinitions: [v0 /*: any*/, v1 /*: any*/],
+      kind: "Fragment",
+      metadata: null,
+      name: "ModelInferencesPageQuery",
+      selections: [
+        {
+          args: v2 /*: any*/,
+          kind: "FragmentSpread",
+          name: "ModelSchemaTable_dimensions",
+        },
+        {
+          args: v2 /*: any*/,
+          kind: "FragmentSpread",
+          name: "ModelEmbeddingsTable_embeddingDimensions",
+        },
+      ],
+      type: "Query",
+      abstractKey: null,
+    },
+    kind: "Request",
+    operation: {
+      argumentDefinitions: [v1 /*: any*/, v0 /*: any*/],
+      kind: "Operation",
+      name: "ModelInferencesPageQuery",
+      selections: [
+        {
+          alias: null,
+          args: null,
+          concreteType: "InferenceModel",
+          kind: "LinkedField",
+          name: "model",
+          plural: false,
+          selections: [
+            {
+              alias: null,
+              args: v3 /*: any*/,
+              concreteType: "DimensionConnection",
+              kind: "LinkedField",
+              name: "dimensions",
+              plural: false,
+              selections: [
+                {
+                  alias: null,
+                  args: null,
+                  concreteType: "DimensionEdge",
+                  kind: "LinkedField",
+                  name: "edges",
+                  plural: true,
+                  selections: [
+                    {
+                      alias: "dimension",
+                      args: null,
+                      concreteType: "Dimension",
+                      kind: "LinkedField",
+                      name: "node",
+                      plural: false,
+                      selections: [
+                        v4 /*: any*/,
+                        v5 /*: any*/,
+                        {
+                          alias: null,
+                          args: null,
+                          kind: "ScalarField",
+                          name: "type",
+                          storageKey: null,
+                        },
+                        {
+                          alias: null,
+                          args: null,
+                          kind: "ScalarField",
+                          name: "dataType",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "cardinality",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "cardinality",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "dataQualityMetric",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "percentEmpty",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "percentEmpty",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "dataQualityMetric",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "min",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "min",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "dataQualityMetric",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "mean",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "mean",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "dataQualityMetric",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "max",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "max",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "dataQualityMetric",
+                          storageKey: null,
+                        },
+                        {
+                          alias: "psi",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "psi",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "driftMetric",
+                          storageKey: null,
+                        },
+                      ],
+                      storageKey: null,
+                    },
+                    v7 /*: any*/,
+                    {
+                      alias: null,
+                      args: null,
+                      concreteType: "Dimension",
+                      kind: "LinkedField",
+                      name: "node",
+                      plural: false,
+                      selections: v8 /*: any*/,
+                      storageKey: null,
+                    },
+                  ],
+                  storageKey: null,
+                },
+                v9 /*: any*/,
+              ],
+              storageKey: "dimensions(first:50)",
+            },
+            {
+              alias: null,
+              args: v3 /*: any*/,
+              filters: null,
+              handle: "connection",
+              key: "ModelSchemaTable_dimensions",
+              kind: "LinkedHandle",
+              name: "dimensions",
+            },
+            {
+              alias: null,
+              args: v3 /*: any*/,
+              concreteType: "EmbeddingDimensionConnection",
+              kind: "LinkedField",
+              name: "embeddingDimensions",
+              plural: false,
+              selections: [
+                {
+                  alias: null,
+                  args: null,
+                  concreteType: "EmbeddingDimensionEdge",
+                  kind: "LinkedField",
+                  name: "edges",
+                  plural: true,
+                  selections: [
+                    {
+                      alias: "embedding",
+                      args: null,
+                      concreteType: "EmbeddingDimension",
+                      kind: "LinkedField",
+                      name: "node",
+                      plural: false,
+                      selections: [
+                        v4 /*: any*/,
+                        v5 /*: any*/,
+                        {
+                          alias: "euclideanDistance",
+                          args: [
+                            {
+                              kind: "Literal",
+                              name: "metric",
+                              value: "euclideanDistance",
+                            },
+                            v6 /*: any*/,
+                          ],
+                          kind: "ScalarField",
+                          name: "driftMetric",
+                          storageKey: null,
+                        },
+                      ],
+                      storageKey: null,
+                    },
+                    v7 /*: any*/,
+                    {
+                      alias: null,
+                      args: null,
+                      concreteType: "EmbeddingDimension",
+                      kind: "LinkedField",
+                      name: "node",
+                      plural: false,
+                      selections: v8 /*: any*/,
+                      storageKey: null,
+                    },
+                  ],
+                  storageKey: null,
+                },
+                v9 /*: any*/,
+              ],
+              storageKey: "embeddingDimensions(first:50)",
+            },
+            {
+              alias: null,
+              args: v3 /*: any*/,
+              filters: null,
+              handle: "connection",
+              key: "ModelEmbeddingsTable_embeddingDimensions",
+              kind: "LinkedHandle",
+              name: "embeddingDimensions",
+            },
+          ],
+          storageKey: null,
+        },
+      ],
+    },
+    params: {
+      cacheID: "d4ce45828b9b8ab1f08d7bf38299a533",
+      id: null,
+      metadata: {},
+      name: "ModelInferencesPageQuery",
+      operationKind: "query",
+      text: "query ModelInferencesPageQuery(\n  $startTime: DateTime!\n  $endTime: DateTime!\n) {\n  ...ModelSchemaTable_dimensions_3uKjWt\n  ...ModelEmbeddingsTable_embeddingDimensions_3uKjWt\n}\n\nfragment ModelEmbeddingsTable_embeddingDimensions_3uKjWt on Query {\n  model {\n    embeddingDimensions(first: 50) {\n      edges {\n        embedding: node {\n          id\n          name\n          euclideanDistance: driftMetric(metric: euclideanDistance, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ModelSchemaTable_dimensions_3uKjWt on Query {\n  model {\n    dimensions(first: 50) {\n      edges {\n        dimension: node {\n          id\n          name\n          type\n          dataType\n          cardinality: dataQualityMetric(metric: cardinality, timeRange: {start: $startTime, end: $endTime})\n          percentEmpty: dataQualityMetric(metric: percentEmpty, timeRange: {start: $startTime, end: $endTime})\n          min: dataQualityMetric(metric: min, timeRange: {start: $startTime, end: $endTime})\n          mean: dataQualityMetric(metric: mean, timeRange: {start: $startTime, end: $endTime})\n          max: dataQualityMetric(metric: max, timeRange: {start: $startTime, end: $endTime})\n          psi: driftMetric(metric: psi, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n",
+    },
+  };
 })();
 
 (node as any).hash = "b4f2409b23d3c72afd3d9f43e813f1c9";

--- a/app/src/pages/model/__generated__/ModelInferencesPageQuery.graphql.ts
+++ b/app/src/pages/model/__generated__/ModelInferencesPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bdb77117d763dd2587c8047b877f717e>>
+ * @generated SignedSource<<7d1e48c6ab308024a8acfb20d0ab7cf2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,397 +8,401 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest } from "relay-runtime";
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ModelInferencesPageQuery$variables = {
   endTime: string;
   startTime: string;
 };
 export type ModelInferencesPageQuery$data = {
-  readonly " $fragmentSpreads": FragmentRefs<
-    "ModelEmbeddingsTable_embeddingDimensions" | "ModelSchemaTable_dimensions"
-  >;
+  readonly " $fragmentSpreads": FragmentRefs<"ModelEmbeddingsTable_embeddingDimensions" | "ModelSchemaTable_dimensions">;
 };
 export type ModelInferencesPageQuery = {
   response: ModelInferencesPageQuery$data;
   variables: ModelInferencesPageQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "endTime",
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "endTime"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "startTime"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "endTime",
+    "variableName": "endTime"
+  },
+  {
+    "kind": "Variable",
+    "name": "startTime",
+    "variableName": "startTime"
+  }
+],
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 50
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "fields": [
+    {
+      "kind": "Variable",
+      "name": "end",
+      "variableName": "endTime"
     },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "startTime",
+    {
+      "kind": "Variable",
+      "name": "start",
+      "variableName": "startTime"
+    }
+  ],
+  "kind": "ObjectValue",
+  "name": "timeRange"
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "__typename",
+    "storageKey": null
+  },
+  (v4/*: any*/)
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
     },
-    v2 = [
-      {
-        kind: "Variable",
-        name: "endTime",
-        variableName: "endTime",
-      },
-      {
-        kind: "Variable",
-        name: "startTime",
-        variableName: "startTime",
-      },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
     ],
-    v3 = [
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ModelInferencesPageQuery",
+    "selections": [
       {
-        kind: "Literal",
-        name: "first",
-        value: 50,
+        "args": (v2/*: any*/),
+        "kind": "FragmentSpread",
+        "name": "ModelSchemaTable_dimensions"
       },
-    ],
-    v4 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "id",
-      storageKey: null,
-    },
-    v5 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "name",
-      storageKey: null,
-    },
-    v6 = {
-      fields: [
-        {
-          kind: "Variable",
-          name: "end",
-          variableName: "endTime",
-        },
-        {
-          kind: "Variable",
-          name: "start",
-          variableName: "startTime",
-        },
-      ],
-      kind: "ObjectValue",
-      name: "timeRange",
-    },
-    v7 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "cursor",
-      storageKey: null,
-    },
-    v8 = [
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "__typename",
-        storageKey: null,
-      },
-      v4 /*: any*/,
+        "args": (v2/*: any*/),
+        "kind": "FragmentSpread",
+        "name": "ModelEmbeddingsTable_embeddingDimensions"
+      }
     ],
-    v9 = {
-      alias: null,
-      args: null,
-      concreteType: "PageInfo",
-      kind: "LinkedField",
-      name: "pageInfo",
-      plural: false,
-      selections: [
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "endCursor",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "hasNextPage",
-          storageKey: null,
-        },
-      ],
-      storageKey: null,
-    };
-  return {
-    fragment: {
-      argumentDefinitions: [v0 /*: any*/, v1 /*: any*/],
-      kind: "Fragment",
-      metadata: null,
-      name: "ModelInferencesPageQuery",
-      selections: [
-        {
-          args: v2 /*: any*/,
-          kind: "FragmentSpread",
-          name: "ModelSchemaTable_dimensions",
-        },
-        {
-          args: v2 /*: any*/,
-          kind: "FragmentSpread",
-          name: "ModelEmbeddingsTable_embeddingDimensions",
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [v1 /*: any*/, v0 /*: any*/],
-      kind: "Operation",
-      name: "ModelInferencesPageQuery",
-      selections: [
-        {
-          alias: null,
-          args: null,
-          concreteType: "InferenceModel",
-          kind: "LinkedField",
-          name: "model",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: v3 /*: any*/,
-              concreteType: "DimensionConnection",
-              kind: "LinkedField",
-              name: "dimensions",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: "DimensionEdge",
-                  kind: "LinkedField",
-                  name: "edges",
-                  plural: true,
-                  selections: [
-                    {
-                      alias: "dimension",
-                      args: null,
-                      concreteType: "Dimension",
-                      kind: "LinkedField",
-                      name: "node",
-                      plural: false,
-                      selections: [
-                        v4 /*: any*/,
-                        v5 /*: any*/,
-                        {
-                          alias: null,
-                          args: null,
-                          kind: "ScalarField",
-                          name: "type",
-                          storageKey: null,
-                        },
-                        {
-                          alias: null,
-                          args: null,
-                          kind: "ScalarField",
-                          name: "dataType",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "cardinality",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "cardinality",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "dataQualityMetric",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "percentEmpty",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "percentEmpty",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "dataQualityMetric",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "min",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "min",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "dataQualityMetric",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "mean",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "mean",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "dataQualityMetric",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "max",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "max",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "dataQualityMetric",
-                          storageKey: null,
-                        },
-                        {
-                          alias: "psi",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "psi",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "driftMetric",
-                          storageKey: null,
-                        },
-                      ],
-                      storageKey: null,
-                    },
-                    v7 /*: any*/,
-                    {
-                      alias: null,
-                      args: null,
-                      concreteType: "Dimension",
-                      kind: "LinkedField",
-                      name: "node",
-                      plural: false,
-                      selections: v8 /*: any*/,
-                      storageKey: null,
-                    },
-                  ],
-                  storageKey: null,
-                },
-                v9 /*: any*/,
-              ],
-              storageKey: "dimensions(first:50)",
-            },
-            {
-              alias: null,
-              args: v3 /*: any*/,
-              filters: null,
-              handle: "connection",
-              key: "ModelSchemaTable_dimensions",
-              kind: "LinkedHandle",
-              name: "dimensions",
-            },
-            {
-              alias: null,
-              args: v3 /*: any*/,
-              concreteType: "EmbeddingDimensionConnection",
-              kind: "LinkedField",
-              name: "embeddingDimensions",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: "EmbeddingDimensionEdge",
-                  kind: "LinkedField",
-                  name: "edges",
-                  plural: true,
-                  selections: [
-                    {
-                      alias: "embedding",
-                      args: null,
-                      concreteType: "EmbeddingDimension",
-                      kind: "LinkedField",
-                      name: "node",
-                      plural: false,
-                      selections: [
-                        v4 /*: any*/,
-                        v5 /*: any*/,
-                        {
-                          alias: "euclideanDistance",
-                          args: [
-                            {
-                              kind: "Literal",
-                              name: "metric",
-                              value: "euclideanDistance",
-                            },
-                            v6 /*: any*/,
-                          ],
-                          kind: "ScalarField",
-                          name: "driftMetric",
-                          storageKey: null,
-                        },
-                      ],
-                      storageKey: null,
-                    },
-                    v7 /*: any*/,
-                    {
-                      alias: null,
-                      args: null,
-                      concreteType: "EmbeddingDimension",
-                      kind: "LinkedField",
-                      name: "node",
-                      plural: false,
-                      selections: v8 /*: any*/,
-                      storageKey: null,
-                    },
-                  ],
-                  storageKey: null,
-                },
-                v9 /*: any*/,
-              ],
-              storageKey: "embeddingDimensions(first:50)",
-            },
-            {
-              alias: null,
-              args: v3 /*: any*/,
-              filters: null,
-              handle: "connection",
-              key: "ModelEmbeddingsTable_embeddingDimensions",
-              kind: "LinkedHandle",
-              name: "embeddingDimensions",
-            },
-          ],
-          storageKey: null,
-        },
-      ],
-    },
-    params: {
-      cacheID: "d4ce45828b9b8ab1f08d7bf38299a533",
-      id: null,
-      metadata: {},
-      name: "ModelInferencesPageQuery",
-      operationKind: "query",
-      text: "query ModelInferencesPageQuery(\n  $startTime: DateTime!\n  $endTime: DateTime!\n) {\n  ...ModelSchemaTable_dimensions_3uKjWt\n  ...ModelEmbeddingsTable_embeddingDimensions_3uKjWt\n}\n\nfragment ModelEmbeddingsTable_embeddingDimensions_3uKjWt on Query {\n  model {\n    embeddingDimensions(first: 50) {\n      edges {\n        embedding: node {\n          id\n          name\n          euclideanDistance: driftMetric(metric: euclideanDistance, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ModelSchemaTable_dimensions_3uKjWt on Query {\n  model {\n    dimensions(first: 50) {\n      edges {\n        dimension: node {\n          id\n          name\n          type\n          dataType\n          cardinality: dataQualityMetric(metric: cardinality, timeRange: {start: $startTime, end: $endTime})\n          percentEmpty: dataQualityMetric(metric: percentEmpty, timeRange: {start: $startTime, end: $endTime})\n          min: dataQualityMetric(metric: min, timeRange: {start: $startTime, end: $endTime})\n          mean: dataQualityMetric(metric: mean, timeRange: {start: $startTime, end: $endTime})\n          max: dataQualityMetric(metric: max, timeRange: {start: $startTime, end: $endTime})\n          psi: driftMetric(metric: psi, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n",
-    },
-  };
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ModelInferencesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "InferenceModel",
+        "kind": "LinkedField",
+        "name": "model",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "DimensionConnection",
+            "kind": "LinkedField",
+            "name": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "DimensionEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "dimension",
+                    "args": null,
+                    "concreteType": "Dimension",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "dataType",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "cardinality",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "cardinality"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "dataQualityMetric",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "percentEmpty",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "percentEmpty"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "dataQualityMetric",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "min",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "min"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "dataQualityMetric",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "mean",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "mean"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "dataQualityMetric",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "max",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "max"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "dataQualityMetric",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "psi",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "psi"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "driftMetric",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Dimension",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": "dimensions(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "ModelSchemaTable_dimensions",
+            "kind": "LinkedHandle",
+            "name": "dimensions"
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "EmbeddingDimensionConnection",
+            "kind": "LinkedField",
+            "name": "embeddingDimensions",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EmbeddingDimensionEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": "embedding",
+                    "args": null,
+                    "concreteType": "EmbeddingDimension",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": "euclideanDistance",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "metric",
+                            "value": "euclideanDistance"
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "kind": "ScalarField",
+                        "name": "driftMetric",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EmbeddingDimension",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v8/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": "embeddingDimensions(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "ModelEmbeddingsTable_embeddingDimensions",
+            "kind": "LinkedHandle",
+            "name": "embeddingDimensions"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d4ce45828b9b8ab1f08d7bf38299a533",
+    "id": null,
+    "metadata": {},
+    "name": "ModelInferencesPageQuery",
+    "operationKind": "query",
+    "text": "query ModelInferencesPageQuery(\n  $startTime: DateTime!\n  $endTime: DateTime!\n) {\n  ...ModelSchemaTable_dimensions_3uKjWt\n  ...ModelEmbeddingsTable_embeddingDimensions_3uKjWt\n}\n\nfragment ModelEmbeddingsTable_embeddingDimensions_3uKjWt on Query {\n  model {\n    embeddingDimensions(first: 50) {\n      edges {\n        embedding: node {\n          id\n          name\n          euclideanDistance: driftMetric(metric: euclideanDistance, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ModelSchemaTable_dimensions_3uKjWt on Query {\n  model {\n    dimensions(first: 50) {\n      edges {\n        dimension: node {\n          id\n          name\n          type\n          dataType\n          cardinality: dataQualityMetric(metric: cardinality, timeRange: {start: $startTime, end: $endTime})\n          percentEmpty: dataQualityMetric(metric: percentEmpty, timeRange: {start: $startTime, end: $endTime})\n          min: dataQualityMetric(metric: min, timeRange: {start: $startTime, end: $endTime})\n          mean: dataQualityMetric(metric: mean, timeRange: {start: $startTime, end: $endTime})\n          max: dataQualityMetric(metric: max, timeRange: {start: $startTime, end: $endTime})\n          psi: driftMetric(metric: psi, timeRange: {start: $startTime, end: $endTime})\n        }\n        cursor\n        node {\n          __typename\n          id\n        }\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "b4f2409b23d3c72afd3d9f43e813f1c9";

--- a/app/src/pages/models/ModelsPage.tsx
+++ b/app/src/pages/models/ModelsPage.tsx
@@ -1,8 +1,13 @@
+import { useLoaderData } from "react-router";
+
 import { Button, Flex, Heading, Icon, Icons, View } from "@phoenix/components";
 
+import { modelsLoader } from "./modelsLoader";
 import { ModelsTable } from "./ModelsTable";
 
 export function ModelsPage() {
+  const data = useLoaderData<typeof modelsLoader>();
+
   const handleAddModel = () => {
     // TODO: Implement add model functionality
   };
@@ -31,7 +36,7 @@ export function ModelsPage() {
           </Button>
         </Flex>
       </View>
-      <ModelsTable />
+      <ModelsTable query={data} />
     </Flex>
   );
 }

--- a/app/src/pages/models/__generated__/ModelsTableModelsQuery.graphql.ts
+++ b/app/src/pages/models/__generated__/ModelsTableModelsQuery.graphql.ts
@@ -1,0 +1,230 @@
+/**
+ * @generated SignedSource<<dde88f21e9ae15c69b7878c2bd77b78f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ModelsTableModelsQuery$variables = {
+  after?: string | null;
+  first?: number | null;
+};
+export type ModelsTableModelsQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"ModelsTable_models">;
+};
+export type ModelsTableModelsQuery = {
+  response: ModelsTableModelsQuery$data;
+  variables: ModelsTableModelsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 100,
+    "kind": "LocalArgument",
+    "name": "first"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ModelsTableModelsQuery",
+    "selections": [
+      {
+        "args": (v1/*: any*/),
+        "kind": "FragmentSpread",
+        "name": "ModelsTable_models"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ModelsTableModelsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ModelConnection",
+        "kind": "LinkedField",
+        "name": "models",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ModelEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "model",
+                "args": null,
+                "concreteType": "Model",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "provider",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "namePattern",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "providerKey",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "updatedAt",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Model",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "ModelsTable_models",
+        "kind": "LinkedHandle",
+        "name": "models"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "198d0de69bdaaab09195bc03e92f5839",
+    "id": null,
+    "metadata": {},
+    "name": "ModelsTableModelsQuery",
+    "operationKind": "query",
+    "text": "query ModelsTableModelsQuery(\n  $after: String = null\n  $first: Int = 100\n) {\n  ...ModelsTable_models_2HEEH6\n}\n\nfragment ModelsTable_models_2HEEH6 on Query {\n  models(first: $first, after: $after) {\n    edges {\n      model: node {\n        id\n        name\n        provider\n        namePattern\n        providerKey\n        createdAt\n        updatedAt\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "4340a3f9b67b1c440a40b5f4b5654baa";
+
+export default node;

--- a/app/src/pages/models/__generated__/ModelsTable_models.graphql.ts
+++ b/app/src/pages/models/__generated__/ModelsTable_models.graphql.ts
@@ -1,0 +1,219 @@
+/**
+ * @generated SignedSource<<08d34b5d6ee7804ba15158e2c57ccf47>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type GenerativeProviderKey = "ANTHROPIC" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+import { FragmentRefs } from "relay-runtime";
+export type ModelsTable_models$data = {
+  readonly models: {
+    readonly edges: ReadonlyArray<{
+      readonly model: {
+        readonly createdAt: string;
+        readonly id: string;
+        readonly name: string;
+        readonly namePattern: string;
+        readonly provider: string | null;
+        readonly providerKey: GenerativeProviderKey | null;
+        readonly updatedAt: string;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "ModelsTable_models";
+};
+export type ModelsTable_models$key = {
+  readonly " $data"?: ModelsTable_models$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ModelsTable_models">;
+};
+
+import ModelsTableModelsQuery_graphql from './ModelsTableModelsQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "models"
+];
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [],
+      "operation": ModelsTableModelsQuery_graphql
+    }
+  },
+  "name": "ModelsTable_models",
+  "selections": [
+    {
+      "alias": "models",
+      "args": null,
+      "concreteType": "ModelConnection",
+      "kind": "LinkedField",
+      "name": "__ModelsTable_models_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ModelEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "model",
+              "args": null,
+              "concreteType": "Model",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "provider",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "namePattern",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "providerKey",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "updatedAt",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Model",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "4340a3f9b67b1c440a40b5f4b5654baa";
+
+export default node;

--- a/app/src/pages/models/__generated__/modelsLoaderQuery.graphql.ts
+++ b/app/src/pages/models/__generated__/modelsLoaderQuery.graphql.ts
@@ -1,0 +1,210 @@
+/**
+ * @generated SignedSource<<ba85768c0d1fb334225fc5a97de5de56>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type modelsLoaderQuery$variables = Record<PropertyKey, never>;
+export type modelsLoaderQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"ModelsTable_models">;
+};
+export type modelsLoaderQuery = {
+  response: modelsLoaderQuery$data;
+  variables: modelsLoaderQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "modelsLoaderQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "ModelsTable_models"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "modelsLoaderQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ModelConnection",
+        "kind": "LinkedField",
+        "name": "models",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ModelEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "model",
+                "args": null,
+                "concreteType": "Model",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "provider",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "namePattern",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "providerKey",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "updatedAt",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Model",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v1/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "models(first:100)"
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "ModelsTable_models",
+        "kind": "LinkedHandle",
+        "name": "models"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "abd96f15e92ed594246b2ab8e537074d",
+    "id": null,
+    "metadata": {},
+    "name": "modelsLoaderQuery",
+    "operationKind": "query",
+    "text": "query modelsLoaderQuery {\n  ...ModelsTable_models\n}\n\nfragment ModelsTable_models on Query {\n  models(first: 100) {\n    edges {\n      model: node {\n        id\n        name\n        provider\n        namePattern\n        providerKey\n        createdAt\n        updatedAt\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f04f33c07ced7a01765ae6b7568b9e39";
+
+export default node;

--- a/app/src/pages/models/modelsLoader.ts
+++ b/app/src/pages/models/modelsLoader.ts
@@ -1,0 +1,27 @@
+import { fetchQuery, graphql } from "react-relay";
+import { LoaderFunctionArgs } from "react-router";
+
+import RelayEnvironment from "@phoenix/RelayEnvironment";
+
+import { modelsLoaderQuery } from "./__generated__/modelsLoaderQuery.graphql";
+
+/**
+ * Loads in the necessary page data for the models page
+ */
+export async function modelsLoader(_args: LoaderFunctionArgs) {
+  const data = await fetchQuery<modelsLoaderQuery>(
+    RelayEnvironment,
+    graphql`
+      query modelsLoaderQuery {
+        ...ModelsTable_models
+      }
+    `,
+    {}
+  ).toPromise();
+
+  if (!data) {
+    throw new Error("Failed to load models");
+  }
+
+  return data;
+}

--- a/app/src/pages/playground/ModelComboBox.tsx
+++ b/app/src/pages/playground/ModelComboBox.tsx
@@ -38,11 +38,11 @@ export function ModelComboBoxLoader({
 }) {
   const data = usePreloadedQuery(modelsQuery, queryReference);
   const items = useMemo((): ModelItem[] => {
-    return data.models.map((model) => ({
+    return data.playgroundModels.map((model) => ({
       name: model.name,
       id: model.name,
     }));
-  }, [data.models]);
+  }, [data.playgroundModels]);
 
   const [fieldState, setFieldState] = useState({
     selectedKey: modelName ?? null,
@@ -126,7 +126,7 @@ export function ModelComboBox(props: ModelComboBoxProps) {
 
 graphql`
   query ModelComboBoxQuery($providerKey: GenerativeProviderKey!) {
-    models(input: { providerKey: $providerKey }) {
+    playgroundModels(input: { providerKey: $providerKey }) {
       name
     }
   }

--- a/app/src/pages/playground/__generated__/ModelComboBoxQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/ModelComboBoxQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98be25cebdcae5fc6741a1edc7c10d6a>>
+ * @generated SignedSource<<289754c2234b8d54ccfe9fb7b6017770>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ModelComboBoxQuery$variables = {
   providerKey: GenerativeProviderKey;
 };
 export type ModelComboBoxQuery$data = {
-  readonly models: ReadonlyArray<{
+  readonly playgroundModels: ReadonlyArray<{
     readonly name: string;
   }>;
 };
@@ -47,9 +47,9 @@ v1 = [
         "name": "input"
       }
     ],
-    "concreteType": "GenerativeModel",
+    "concreteType": "PlaygroundModel",
     "kind": "LinkedField",
-    "name": "models",
+    "name": "playgroundModels",
     "plural": true,
     "selections": [
       {
@@ -81,16 +81,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "a3417a3b2ae9ad193a5fd68335cfd660",
+    "cacheID": "67fe753e1bc2ede814f616699bf7f3bb",
     "id": null,
     "metadata": {},
     "name": "ModelComboBoxQuery",
     "operationKind": "query",
-    "text": "query ModelComboBoxQuery(\n  $providerKey: GenerativeProviderKey!\n) {\n  models(input: {providerKey: $providerKey}) {\n    name\n  }\n}\n"
+    "text": "query ModelComboBoxQuery(\n  $providerKey: GenerativeProviderKey!\n) {\n  playgroundModels(input: {providerKey: $providerKey}) {\n    name\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fc5563c6dca10fdeda807cd7061e275a";
+(node as any).hash = "1e812293e1547b594275780290b294be";
 
 export default node;

--- a/app/src/store/__generated__/pointCloudStore_eventsQuery.graphql.ts
+++ b/app/src/store/__generated__/pointCloudStore_eventsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<131e459b758b47fb6368e9a60ee95195>>
+ * @generated SignedSource<<7eede205b203c5f9c57bfc514e649373>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -368,7 +368,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,
@@ -436,7 +436,7 @@ return {
       {
         "alias": null,
         "args": null,
-        "concreteType": "Model",
+        "concreteType": "InferenceModel",
         "kind": "LinkedField",
         "name": "model",
         "plural": false,

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -61,13 +61,13 @@ from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.ExperimentComparison import ExperimentComparison, RunComparisonItem
 from phoenix.server.api.types.ExperimentRun import ExperimentRun, to_gql_experiment_run
 from phoenix.server.api.types.Functionality import Functionality
-from phoenix.server.api.types.GenerativeModel import GenerativeModel
 from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
-from phoenix.server.api.types.InferencesRole import AncillaryInferencesRole, InferencesRole
 from phoenix.server.api.types.InferenceModel import InferenceModel
+from phoenix.server.api.types.InferencesRole import AncillaryInferencesRole, InferencesRole
 from phoenix.server.api.types.Model import Model
 from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, connection_from_list
+from phoenix.server.api.types.PlaygroundModel import PlaygroundModel
 from phoenix.server.api.types.Project import Project
 from phoenix.server.api.types.ProjectSession import ProjectSession, to_gql_project_session
 from phoenix.server.api.types.ProjectTraceRetentionPolicy import ProjectTraceRetentionPolicy
@@ -143,6 +143,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=2,
@@ -151,6 +152,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=3,
@@ -159,6 +161,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=4,
@@ -167,6 +170,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=5,
@@ -175,6 +179,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=6,
@@ -183,6 +188,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=7,
@@ -191,6 +197,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=8,
@@ -199,6 +206,7 @@ class Query:
                 name_pattern="o1-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             Model(
                 id_attr=9,
@@ -207,6 +215,7 @@ class Query:
                 name_pattern="o1-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OPENAI,
             ),
             # Anthropic Models
             Model(
@@ -216,6 +225,7 @@ class Query:
                 name_pattern="claude-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.ANTHROPIC,
             ),
             Model(
                 id_attr=11,
@@ -224,6 +234,7 @@ class Query:
                 name_pattern="claude-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.ANTHROPIC,
             ),
             Model(
                 id_attr=12,
@@ -232,6 +243,7 @@ class Query:
                 name_pattern="claude-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.ANTHROPIC,
             ),
             Model(
                 id_attr=13,
@@ -240,6 +252,7 @@ class Query:
                 name_pattern="claude-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.ANTHROPIC,
             ),
             # Google Models
             Model(
@@ -249,6 +262,7 @@ class Query:
                 name_pattern="gemini-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.GOOGLE,
             ),
             Model(
                 id_attr=15,
@@ -257,6 +271,7 @@ class Query:
                 name_pattern="gemini-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.GOOGLE,
             ),
             Model(
                 id_attr=16,
@@ -265,6 +280,7 @@ class Query:
                 name_pattern="gemini-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.GOOGLE,
             ),
             # DeepSeek Models
             Model(
@@ -274,6 +290,7 @@ class Query:
                 name_pattern="deepseek-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.DEEPSEEK,
             ),
             Model(
                 id_attr=18,
@@ -282,6 +299,7 @@ class Query:
                 name_pattern="deepseek-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.DEEPSEEK,
             ),
             # xAI Models
             Model(
@@ -291,6 +309,7 @@ class Query:
                 name_pattern="grok-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.XAI,
             ),
             Model(
                 id_attr=20,
@@ -299,6 +318,7 @@ class Query:
                 name_pattern="grok-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.XAI,
             ),
             # Ollama Models
             Model(
@@ -308,6 +328,7 @@ class Query:
                 name_pattern="llama-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=22,
@@ -316,6 +337,7 @@ class Query:
                 name_pattern="llama-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=23,
@@ -324,6 +346,7 @@ class Query:
                 name_pattern="mistral-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=24,
@@ -332,6 +355,7 @@ class Query:
                 name_pattern="codellama-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=25,
@@ -340,6 +364,7 @@ class Query:
                 name_pattern="phi-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=26,
@@ -348,6 +373,7 @@ class Query:
                 name_pattern="qwen-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             Model(
                 id_attr=27,
@@ -356,6 +382,7 @@ class Query:
                 name_pattern="gemma-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.OLLAMA,
             ),
             # Azure OpenAI Models (uses OpenAI models but deployed on Azure)
             Model(
@@ -365,6 +392,7 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.AZURE_OPENAI,
             ),
             Model(
                 id_attr=29,
@@ -373,26 +401,27 @@ class Query:
                 name_pattern="gpt-*",
                 created_at=datetime.now(timezone.utc),
                 updated_at=datetime.now(timezone.utc),
+                provider_key=GenerativeProviderKey.AZURE_OPENAI,
             ),
         ]
 
         return connection_from_list(data=synthetic_models, args=args)
 
     @strawberry.field
-    async def generative_models(self, input: Optional[ModelsInput] = None) -> list[GenerativeModel]:
+    async def playground_models(self, input: Optional[ModelsInput] = None) -> list[PlaygroundModel]:
         if input is not None and input.provider_key is not None:
             supported_model_names = PLAYGROUND_CLIENT_REGISTRY.list_models(input.provider_key)
             supported_models = [
-                GenerativeModel(name=model_name, provider_key=input.provider_key)
+                PlaygroundModel(name=model_name, provider_key=input.provider_key)
                 for model_name in supported_model_names
             ]
             return supported_models
 
         registered_models = PLAYGROUND_CLIENT_REGISTRY.list_all_models()
-        all_models: list[GenerativeModel] = []
+        all_models: list[PlaygroundModel] = []
         for provider_key, model_name in registered_models:
             if model_name is not None and provider_key is not None:
-                all_models.append(GenerativeModel(name=model_name, provider_key=provider_key))
+                all_models.append(PlaygroundModel(name=model_name, provider_key=provider_key))
         return all_models
 
     @strawberry.field

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -64,6 +64,7 @@ from phoenix.server.api.types.Functionality import Functionality
 from phoenix.server.api.types.GenerativeModel import GenerativeModel
 from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
 from phoenix.server.api.types.InferencesRole import AncillaryInferencesRole, InferencesRole
+from phoenix.server.api.types.InferenceModel import InferenceModel
 from phoenix.server.api.types.Model import Model
 from phoenix.server.api.types.node import from_global_id, from_global_id_with_expected_type
 from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, connection_from_list
@@ -114,7 +115,271 @@ class Query:
         ]
 
     @strawberry.field
-    async def models(self, input: Optional[ModelsInput] = None) -> list[GenerativeModel]:
+    async def models(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+    ) -> Connection[Model]:
+        args = ConnectionArgs(
+            first=first,
+            after=after if isinstance(after, CursorString) else None,
+            last=last,
+            before=before if isinstance(before, CursorString) else None,
+        )
+
+        # TODO: Replace with actual database query when model table is ready
+        # For now, using synthetic data
+        from datetime import datetime, timezone
+
+        synthetic_models = [
+            # OpenAI Models
+            Model(
+                id_attr=1,
+                name="gpt-4",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=2,
+                name="gpt-4-turbo",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=3,
+                name="gpt-4-turbo-preview",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=4,
+                name="gpt-4o",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=5,
+                name="gpt-4o-mini",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=6,
+                name="gpt-3.5-turbo",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=7,
+                name="gpt-3.5-turbo-instruct",
+                provider="openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=8,
+                name="o1-preview",
+                provider="openai",
+                name_pattern="o1-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=9,
+                name="o1-mini",
+                provider="openai",
+                name_pattern="o1-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # Anthropic Models
+            Model(
+                id_attr=10,
+                name="claude-3-sonnet",
+                provider="anthropic",
+                name_pattern="claude-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=11,
+                name="claude-3-haiku",
+                provider="anthropic",
+                name_pattern="claude-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=12,
+                name="claude-3-opus",
+                provider="anthropic",
+                name_pattern="claude-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=13,
+                name="claude-3.5-sonnet",
+                provider="anthropic",
+                name_pattern="claude-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # Google Models
+            Model(
+                id_attr=14,
+                name="gemini-pro",
+                provider="google",
+                name_pattern="gemini-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=15,
+                name="gemini-1.5-pro",
+                provider="google",
+                name_pattern="gemini-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=16,
+                name="gemini-1.5-flash",
+                provider="google",
+                name_pattern="gemini-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # DeepSeek Models
+            Model(
+                id_attr=17,
+                name="deepseek-v2",
+                provider="deepseek",
+                name_pattern="deepseek-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=18,
+                name="deepseek-coder",
+                provider="deepseek",
+                name_pattern="deepseek-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # xAI Models
+            Model(
+                id_attr=19,
+                name="grok-1",
+                provider="xai",
+                name_pattern="grok-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=20,
+                name="grok-2",
+                provider="xai",
+                name_pattern="grok-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # Ollama Models
+            Model(
+                id_attr=21,
+                name="llama-3.1-70b",
+                provider="ollama",
+                name_pattern="llama-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=22,
+                name="llama-3.1-8b",
+                provider="ollama",
+                name_pattern="llama-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=23,
+                name="mistral-7b",
+                provider="ollama",
+                name_pattern="mistral-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=24,
+                name="codellama-13b",
+                provider="ollama",
+                name_pattern="codellama-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=25,
+                name="phi-3-mini",
+                provider="ollama",
+                name_pattern="phi-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=26,
+                name="qwen-2.5-7b",
+                provider="ollama",
+                name_pattern="qwen-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=27,
+                name="gemma-2-9b",
+                provider="ollama",
+                name_pattern="gemma-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            # Azure OpenAI Models (uses OpenAI models but deployed on Azure)
+            Model(
+                id_attr=28,
+                name="gpt-4-azure",
+                provider="azure_openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+            Model(
+                id_attr=29,
+                name="gpt-35-turbo-azure",
+                provider="azure_openai",
+                name_pattern="gpt-*",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+        ]
+
+        return connection_from_list(data=synthetic_models, args=args)
+
+    @strawberry.field
+    async def generative_models(self, input: Optional[ModelsInput] = None) -> list[GenerativeModel]:
         if input is not None and input.provider_key is not None:
             supported_model_names = PLAYGROUND_CLIENT_REGISTRY.list_models(input.provider_key)
             supported_models = [
@@ -459,8 +724,8 @@ class Query:
         )
 
     @strawberry.field
-    def model(self) -> Model:
-        return Model()
+    def model(self) -> InferenceModel:
+        return InferenceModel()
 
     @strawberry.field
     async def node(self, id: GlobalID, info: Info[Context, None]) -> Node:

--- a/src/phoenix/server/api/types/GenerativeModel.py
+++ b/src/phoenix/server/api/types/GenerativeModel.py
@@ -1,9 +1,0 @@
-import strawberry
-
-from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
-
-
-@strawberry.type
-class GenerativeModel:
-    name: str
-    provider_key: GenerativeProviderKey

--- a/src/phoenix/server/api/types/InferenceModel.py
+++ b/src/phoenix/server/api/types/InferenceModel.py
@@ -1,0 +1,221 @@
+import asyncio
+from typing import Optional
+
+import strawberry
+from strawberry import UNSET, Info
+from strawberry.relay import Connection
+from typing_extensions import Annotated
+
+from phoenix.config import get_exported_files
+from phoenix.core.model_schema import PRIMARY, REFERENCE
+from phoenix.server.api.context import Context
+
+from ..input_types.DimensionFilter import DimensionFilter
+from ..input_types.Granularity import Granularity
+from ..input_types.PerformanceMetricInput import PerformanceMetricInput
+from ..input_types.TimeRange import TimeRange
+from .Dimension import Dimension, to_gql_dimension
+from .EmbeddingDimension import EmbeddingDimension, to_gql_embedding_dimension
+from .ExportedFile import ExportedFile
+from .Inferences import Inferences
+from .InferencesRole import AncillaryInferencesRole, InferencesRole
+from .pagination import ConnectionArgs, CursorString, connection_from_list
+from .TimeSeries import (
+    PerformanceTimeSeries,
+    ensure_timeseries_parameters,
+    get_timeseries_data,
+)
+
+
+@strawberry.type
+class InferenceModel:
+    @strawberry.field
+    def dimensions(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+        include: Optional[DimensionFilter] = UNSET,
+        exclude: Optional[DimensionFilter] = UNSET,
+    ) -> Connection[Dimension]:
+        model = info.context.model
+        return connection_from_list(
+            [
+                to_gql_dimension(index, dimension)
+                for index, dimension in enumerate(model.scalar_dimensions)
+                if (not isinstance(include, DimensionFilter) or include.matches(dimension))
+                and (not isinstance(exclude, DimensionFilter) or not exclude.matches(dimension))
+            ],
+            args=ConnectionArgs(
+                first=first,
+                after=after if isinstance(after, CursorString) else None,
+                last=last,
+                before=before if isinstance(before, CursorString) else None,
+            ),
+        )
+
+    @strawberry.field
+    def primary_inferences(self, info: Info[Context, None]) -> Inferences:
+        inferences = info.context.model[PRIMARY]
+        start, stop = inferences.time_range
+        return Inferences(
+            start_time=start,
+            end_time=stop,
+            record_count=len(inferences),
+            inferences=inferences,
+            inferences_role=InferencesRole.primary,
+            model=info.context.model,
+        )
+
+    @strawberry.field
+    def reference_inferences(self, info: Info[Context, None]) -> Optional[Inferences]:
+        if (inferences := info.context.model[REFERENCE]).empty:
+            return None
+        start, stop = inferences.time_range
+        return Inferences(
+            start_time=start,
+            end_time=stop,
+            record_count=len(inferences),
+            inferences=inferences,
+            inferences_role=InferencesRole.reference,
+            model=info.context.model,
+        )
+
+    @strawberry.field
+    def corpus_inferences(self, info: Info[Context, None]) -> Optional[Inferences]:
+        if info.context.corpus is None:
+            return None
+        if (inferences := info.context.corpus[PRIMARY]).empty:
+            return None
+        start, stop = inferences.time_range
+        return Inferences(
+            start_time=start,
+            end_time=stop,
+            record_count=len(inferences),
+            inferences=inferences,
+            inferences_role=AncillaryInferencesRole.corpus,
+            model=info.context.corpus,
+        )
+
+    @strawberry.field
+    def embedding_dimensions(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+    ) -> Connection[EmbeddingDimension]:
+        """
+        A non-trivial implementation should efficiently fetch only
+        the necessary books after the offset.
+        For simplicity, here we build the list and then slice it accordingly
+        """
+        model = info.context.model
+        return connection_from_list(
+            [
+                to_gql_embedding_dimension(index, embedding_dimension)
+                for index, embedding_dimension in enumerate(
+                    model.embedding_dimensions,
+                )
+            ],
+            args=ConnectionArgs(
+                first=first,
+                after=after if isinstance(after, CursorString) else None,
+                last=last,
+                before=before if isinstance(before, CursorString) else None,
+            ),
+        )
+
+    @strawberry.field(
+        description="Returns exported file names sorted by descending modification time.",
+    )  # type: ignore  # https://github.com/strawberry-graphql/strawberry/issues/1929
+    async def exported_files(
+        self,
+        info: Info[Context, None],
+    ) -> list[ExportedFile]:
+        loop = asyncio.get_running_loop()
+        return [
+            ExportedFile(file_name=path.stem)
+            for path in sorted(
+                await loop.run_in_executor(
+                    None,
+                    get_exported_files,
+                    info.context.export_path,
+                ),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        ]
+
+    @strawberry.field
+    def performance_metric(
+        self,
+        info: Info[Context, None],
+        metric: PerformanceMetricInput,
+        time_range: Optional[TimeRange] = UNSET,
+        inferences_role: Annotated[
+            Optional[InferencesRole],
+            strawberry.argument(
+                description="The inferences (primary or reference) to query",
+            ),
+        ] = InferencesRole.primary,
+    ) -> Optional[float]:
+        if not isinstance(inferences_role, InferencesRole):
+            inferences_role = InferencesRole.primary
+        model = info.context.model
+        inferences = model[inferences_role.value]
+        resolved_time_range, granularity = ensure_timeseries_parameters(
+            inferences,
+            time_range,
+        )
+        metric_instance = metric.metric_instance(model)
+        data = get_timeseries_data(
+            inferences,
+            metric_instance,
+            resolved_time_range,
+            granularity,
+        )
+        return data[0].value if len(data) else None
+
+    @strawberry.field(
+        description=(
+            "Returns the time series of the specified metric for data within a time range. Data"
+            " points are generated starting at the end time and are separated by the sampling"
+            " interval. Each data point is labeled by the end instant and contains data from their"
+            " respective evaluation windows."
+        )
+    )  # type: ignore  # https://github.com/strawberry-graphql/strawberry/issues/1929
+    def performance_time_series(
+        self,
+        info: Info[Context, None],
+        metric: PerformanceMetricInput,
+        time_range: TimeRange,
+        granularity: Granularity,
+        inferences_role: Annotated[
+            Optional[InferencesRole],
+            strawberry.argument(
+                description="The inferences (primary or reference) to query",
+            ),
+        ] = InferencesRole.primary,
+    ) -> PerformanceTimeSeries:
+        if not isinstance(inferences_role, InferencesRole):
+            inferences_role = InferencesRole.primary
+        model = info.context.model
+        inferences = model[inferences_role.value]
+        resolved_time_range, granularity = ensure_timeseries_parameters(
+            inferences,
+            time_range,
+            granularity,
+        )
+        metric_instance = metric.metric_instance(model)
+        return PerformanceTimeSeries(
+            data=get_timeseries_data(
+                inferences,
+                metric_instance,
+                resolved_time_range,
+                granularity,
+            )
+        )

--- a/src/phoenix/server/api/types/Model.py
+++ b/src/phoenix/server/api/types/Model.py
@@ -1,221 +1,71 @@
-import asyncio
+from datetime import datetime
 from typing import Optional
 
 import strawberry
-from strawberry import UNSET, Info
-from strawberry.relay import Connection
-from typing_extensions import Annotated
+from strawberry.relay import Node, NodeID
 
-from phoenix.config import get_exported_files
-from phoenix.core.model_schema import PRIMARY, REFERENCE
-from phoenix.server.api.context import Context
-
-from ..input_types.DimensionFilter import DimensionFilter
-from ..input_types.Granularity import Granularity
-from ..input_types.PerformanceMetricInput import PerformanceMetricInput
-from ..input_types.TimeRange import TimeRange
-from .Dimension import Dimension, to_gql_dimension
-from .EmbeddingDimension import EmbeddingDimension, to_gql_embedding_dimension
-from .ExportedFile import ExportedFile
-from .Inferences import Inferences
-from .InferencesRole import AncillaryInferencesRole, InferencesRole
-from .pagination import ConnectionArgs, CursorString, connection_from_list
-from .TimeSeries import (
-    PerformanceTimeSeries,
-    ensure_timeseries_parameters,
-    get_timeseries_data,
-)
+from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
 
 
 @strawberry.type
-class Model:
-    @strawberry.field
-    def dimensions(
-        self,
-        info: Info[Context, None],
-        first: Optional[int] = 50,
-        last: Optional[int] = UNSET,
-        after: Optional[CursorString] = UNSET,
-        before: Optional[CursorString] = UNSET,
-        include: Optional[DimensionFilter] = UNSET,
-        exclude: Optional[DimensionFilter] = UNSET,
-    ) -> Connection[Dimension]:
-        model = info.context.model
-        return connection_from_list(
-            [
-                to_gql_dimension(index, dimension)
-                for index, dimension in enumerate(model.scalar_dimensions)
-                if (not isinstance(include, DimensionFilter) or include.matches(dimension))
-                and (not isinstance(exclude, DimensionFilter) or not exclude.matches(dimension))
-            ],
-            args=ConnectionArgs(
-                first=first,
-                after=after if isinstance(after, CursorString) else None,
-                last=last,
-                before=before if isinstance(before, CursorString) else None,
-            ),
-        )
-
-    @strawberry.field
-    def primary_inferences(self, info: Info[Context, None]) -> Inferences:
-        inferences = info.context.model[PRIMARY]
-        start, stop = inferences.time_range
-        return Inferences(
-            start_time=start,
-            end_time=stop,
-            record_count=len(inferences),
-            inferences=inferences,
-            inferences_role=InferencesRole.primary,
-            model=info.context.model,
-        )
-
-    @strawberry.field
-    def reference_inferences(self, info: Info[Context, None]) -> Optional[Inferences]:
-        if (inferences := info.context.model[REFERENCE]).empty:
-            return None
-        start, stop = inferences.time_range
-        return Inferences(
-            start_time=start,
-            end_time=stop,
-            record_count=len(inferences),
-            inferences=inferences,
-            inferences_role=InferencesRole.reference,
-            model=info.context.model,
-        )
-
-    @strawberry.field
-    def corpus_inferences(self, info: Info[Context, None]) -> Optional[Inferences]:
-        if info.context.corpus is None:
-            return None
-        if (inferences := info.context.corpus[PRIMARY]).empty:
-            return None
-        start, stop = inferences.time_range
-        return Inferences(
-            start_time=start,
-            end_time=stop,
-            record_count=len(inferences),
-            inferences=inferences,
-            inferences_role=AncillaryInferencesRole.corpus,
-            model=info.context.corpus,
-        )
-
-    @strawberry.field
-    def embedding_dimensions(
-        self,
-        info: Info[Context, None],
-        first: Optional[int] = 50,
-        last: Optional[int] = UNSET,
-        after: Optional[CursorString] = UNSET,
-        before: Optional[CursorString] = UNSET,
-    ) -> Connection[EmbeddingDimension]:
-        """
-        A non-trivial implementation should efficiently fetch only
-        the necessary books after the offset.
-        For simplicity, here we build the list and then slice it accordingly
-        """
-        model = info.context.model
-        return connection_from_list(
-            [
-                to_gql_embedding_dimension(index, embedding_dimension)
-                for index, embedding_dimension in enumerate(
-                    model.embedding_dimensions,
-                )
-            ],
-            args=ConnectionArgs(
-                first=first,
-                after=after if isinstance(after, CursorString) else None,
-                last=last,
-                before=before if isinstance(before, CursorString) else None,
-            ),
-        )
+class Model(Node):
+    id_attr: NodeID[int]
+    name: str
+    provider: Optional[str]
+    name_pattern: str
+    created_at: datetime
+    updated_at: datetime
 
     @strawberry.field(
-        description="Returns exported file names sorted by descending modification time.",
-    )  # type: ignore  # https://github.com/strawberry-graphql/strawberry/issues/1929
-    async def exported_files(
-        self,
-        info: Info[Context, None],
-    ) -> list[ExportedFile]:
-        loop = asyncio.get_running_loop()
-        return [
-            ExportedFile(file_name=path.stem)
-            for path in sorted(
-                await loop.run_in_executor(
-                    None,
-                    get_exported_files,
-                    info.context.export_path,
-                ),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
-            )
-        ]
+        description="The generative provider if the model provider matches a known provider"
+    )
+    def generative_provider(self) -> Optional[GenerativeProvider]:
+        """
+        Attempts to match the model's provider to a known GenerativeProvider.
+        Returns None if no match is found.
+        """
+        if not self.provider:
+            return None
 
-    @strawberry.field
-    def performance_metric(
-        self,
-        info: Info[Context, None],
-        metric: PerformanceMetricInput,
-        time_range: Optional[TimeRange] = UNSET,
-        inferences_role: Annotated[
-            Optional[InferencesRole],
-            strawberry.argument(
-                description="The inferences (primary or reference) to query",
-            ),
-        ] = InferencesRole.primary,
-    ) -> Optional[float]:
-        if not isinstance(inferences_role, InferencesRole):
-            inferences_role = InferencesRole.primary
-        model = info.context.model
-        inferences = model[inferences_role.value]
-        resolved_time_range, granularity = ensure_timeseries_parameters(
-            inferences,
-            time_range,
-        )
-        metric_instance = metric.metric_instance(model)
-        data = get_timeseries_data(
-            inferences,
-            metric_instance,
-            resolved_time_range,
-            granularity,
-        )
-        return data[0].value if len(data) else None
+        # Try to match by provider string
+        provider_key = self._get_provider_key_from_string(self.provider)
+        if provider_key:
+            return GenerativeProvider(name=provider_key.value, key=provider_key)
 
-    @strawberry.field(
-        description=(
-            "Returns the time series of the specified metric for data within a time range. Data"
-            " points are generated starting at the end time and are separated by the sampling"
-            " interval. Each data point is labeled by the end instant and contains data from their"
-            " respective evaluation windows."
-        )
-    )  # type: ignore  # https://github.com/strawberry-graphql/strawberry/issues/1929
-    def performance_time_series(
-        self,
-        info: Info[Context, None],
-        metric: PerformanceMetricInput,
-        time_range: TimeRange,
-        granularity: Granularity,
-        inferences_role: Annotated[
-            Optional[InferencesRole],
-            strawberry.argument(
-                description="The inferences (primary or reference) to query",
-            ),
-        ] = InferencesRole.primary,
-    ) -> PerformanceTimeSeries:
-        if not isinstance(inferences_role, InferencesRole):
-            inferences_role = InferencesRole.primary
-        model = info.context.model
-        inferences = model[inferences_role.value]
-        resolved_time_range, granularity = ensure_timeseries_parameters(
-            inferences,
-            time_range,
-            granularity,
-        )
-        metric_instance = metric.metric_instance(model)
-        return PerformanceTimeSeries(
-            data=get_timeseries_data(
-                inferences,
-                metric_instance,
-                resolved_time_range,
-                granularity,
-            )
+        # Fallback: try to infer from model name
+        provider_key = GenerativeProvider._infer_model_provider_from_model_name(self.name)
+        if provider_key:
+            return GenerativeProvider(name=provider_key.value, key=provider_key)
+
+        return None
+
+    def _get_provider_key_from_string(self, provider_str: str) -> Optional[GenerativeProviderKey]:
+        """
+        Maps a provider string to a GenerativeProviderKey.
+        """
+        provider_mapping = {
+            "openai": GenerativeProviderKey.OPENAI,
+            "anthropic": GenerativeProviderKey.ANTHROPIC,
+            "azure_openai": GenerativeProviderKey.AZURE_OPENAI,
+            "azure openai": GenerativeProviderKey.AZURE_OPENAI,
+            "google": GenerativeProviderKey.GOOGLE,
+            "deepseek": GenerativeProviderKey.DEEPSEEK,
+            "xai": GenerativeProviderKey.XAI,
+            "ollama": GenerativeProviderKey.OLLAMA,
+        }
+
+        return provider_mapping.get(provider_str.lower())
+
+    @classmethod
+    def from_orm(cls, model_orm) -> "Model":
+        """
+        Convert a SQLAlchemy Model instance to a Strawberry Model type.
+        """
+        return cls(
+            id_attr=model_orm.id,
+            name=model_orm.name,
+            provider=model_orm.provider,
+            name_pattern=model_orm.name_pattern,
+            created_at=model_orm.created_at,
+            updated_at=model_orm.updated_at,
         )

--- a/src/phoenix/server/api/types/Model.py
+++ b/src/phoenix/server/api/types/Model.py
@@ -4,68 +4,16 @@ from typing import Optional
 import strawberry
 from strawberry.relay import Node, NodeID
 
-from phoenix.server.api.types.GenerativeProvider import GenerativeProvider, GenerativeProviderKey
+from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
+from phoenix.server.api.types.ModelInterface import ModelInterface
 
 
 @strawberry.type
-class Model(Node):
+class Model(Node, ModelInterface):
     id_attr: NodeID[int]
     name: str
     provider: Optional[str]
     name_pattern: str
     created_at: datetime
     updated_at: datetime
-
-    @strawberry.field(
-        description="The generative provider if the model provider matches a known provider"
-    )
-    def generative_provider(self) -> Optional[GenerativeProvider]:
-        """
-        Attempts to match the model's provider to a known GenerativeProvider.
-        Returns None if no match is found.
-        """
-        if not self.provider:
-            return None
-
-        # Try to match by provider string
-        provider_key = self._get_provider_key_from_string(self.provider)
-        if provider_key:
-            return GenerativeProvider(name=provider_key.value, key=provider_key)
-
-        # Fallback: try to infer from model name
-        provider_key = GenerativeProvider._infer_model_provider_from_model_name(self.name)
-        if provider_key:
-            return GenerativeProvider(name=provider_key.value, key=provider_key)
-
-        return None
-
-    def _get_provider_key_from_string(self, provider_str: str) -> Optional[GenerativeProviderKey]:
-        """
-        Maps a provider string to a GenerativeProviderKey.
-        """
-        provider_mapping = {
-            "openai": GenerativeProviderKey.OPENAI,
-            "anthropic": GenerativeProviderKey.ANTHROPIC,
-            "azure_openai": GenerativeProviderKey.AZURE_OPENAI,
-            "azure openai": GenerativeProviderKey.AZURE_OPENAI,
-            "google": GenerativeProviderKey.GOOGLE,
-            "deepseek": GenerativeProviderKey.DEEPSEEK,
-            "xai": GenerativeProviderKey.XAI,
-            "ollama": GenerativeProviderKey.OLLAMA,
-        }
-
-        return provider_mapping.get(provider_str.lower())
-
-    @classmethod
-    def from_orm(cls, model_orm) -> "Model":
-        """
-        Convert a SQLAlchemy Model instance to a Strawberry Model type.
-        """
-        return cls(
-            id_attr=model_orm.id,
-            name=model_orm.name,
-            provider=model_orm.provider,
-            name_pattern=model_orm.name_pattern,
-            created_at=model_orm.created_at,
-            updated_at=model_orm.updated_at,
-        )
+    provider_key: Optional[GenerativeProviderKey]

--- a/src/phoenix/server/api/types/ModelInterface.py
+++ b/src/phoenix/server/api/types/ModelInterface.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+import strawberry
+
+from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
+
+
+@strawberry.interface
+class ModelInterface:
+    name: str
+    provider_key: Optional[GenerativeProviderKey]

--- a/src/phoenix/server/api/types/PlaygroundModel.py
+++ b/src/phoenix/server/api/types/PlaygroundModel.py
@@ -1,0 +1,10 @@
+import strawberry
+
+from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
+from phoenix.server.api.types.ModelInterface import ModelInterface
+
+
+@strawberry.type
+class PlaygroundModel(ModelInterface):
+    name: str
+    provider_key: GenerativeProviderKey  # PlaygroundModel always has a provider_key


### PR DESCRIPTION
## Summary by Sourcery

Implement a Relay-compliant GraphQL Model resolver with pagination and decouple detailed inference fields into a new InferenceModel type

New Features:
- Add paginated `models` query returning `ModelConnection` of synthetic model entries
- Introduce `InferenceModel` GraphQL type for exposing dimensions, inferences, embeddings, exported files, and performance metrics/time series

Enhancements:
- Redefine `Model` type to implement Relay `Node` interface with core metadata and `generativeProvider` mapping
- Update schema to include `ModelEdge`/`ModelConnection` types and switch the `model` query to return `InferenceModel`
- Adjust frontend GraphQL fragments and regenerate TypeScript artifacts to align with updated schema

Chores:
- Regenerate generated GraphQL artifact files to reflect schema changes