### PR TITLE
feat(experiments): make experiments table resizable

### DIFF
--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
@@ -107,7 +107,7 @@ const TableBody = <T extends { id: string }>({
 };
 
 // Memoized wrapper for table body to use during column resizing
-export const MemoizedTableBody = React.memo(
+export const MemoizedTableBody = memo(
   TableBody,
   (prev, next) => prev.table.options.data === next.table.options.data
 ) as typeof TableBody;
@@ -394,7 +394,7 @@ export function ExperimentsTable({
    * Calculate all column sizes at once as CSS variables for performance
    * @see https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
    */
-  const [columnSizeVars] = React.useMemo(() => {
+  const [columnSizeVars] = useMemo(() => {
     const headers = getFlatHeaders();
     const colSizes: { [key: string]: number } = {};
     for (let i = 0; i < headers.length; i++) {

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  Table,
   useReactTable,
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
@@ -20,12 +21,17 @@ import { Flex, Heading, Link, Text, View } from "@phoenix/components";
 import { AnnotationColorSwatch } from "@phoenix/components/annotation";
 import { SequenceNumberToken } from "@phoenix/components/experiment";
 import { ExperimentActionMenu } from "@phoenix/components/experiment/ExperimentActionMenu";
-import { CompactJSONCell, IntCell } from "@phoenix/components/table";
+import {
+  CompactJSONCell,
+  IntCell,
+  LoadMoreRow,
+} from "@phoenix/components/table";
 import { IndeterminateCheckboxCell } from "@phoenix/components/table/IndeterminateCheckboxCell";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useWordColor } from "@phoenix/hooks/useWordColor";
 import {
   floatFormatter,
@@ -42,6 +48,10 @@ import { ExperimentsEmpty } from "./ExperimentsEmpty";
 
 const PAGE_SIZE = 100;
 
+const defaultColumnSettings = {
+  minSize: 100,
+} satisfies Partial<ColumnDef<unknown>>;
+
 export function ExperimentsTable({
   dataset,
 }: {
@@ -49,6 +59,7 @@ export function ExperimentsTable({
 }) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [rowSelection, setRowSelection] = useState({});
+  const [columnSizing, setColumnSizing] = useState({});
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<ExperimentsTableQuery, ExperimentsTableFragment$key>(
       graphql`
@@ -111,10 +122,73 @@ export function ExperimentsTable({
       }),
     [data.experiments.edges]
   );
+
   type TableRow = (typeof tableData)[number];
+
+  const TableBody = ({
+    table,
+    hasNext,
+    onLoadNext,
+    isLoadingNext,
+    dataset,
+  }: {
+    table: Table<TableRow>;
+    hasNext: boolean;
+    onLoadNext: () => void;
+    isLoadingNext: boolean;
+    dataset: experimentsLoaderQuery$data["dataset"];
+  }) => {
+    const navigate = useNavigate();
+    return (
+      <tbody>
+        {table.getRowModel().rows.map((row) => {
+          return (
+            <tr
+              key={row.id}
+              onClick={() => {
+                navigate(
+                  `/datasets/${dataset.id}/compare?experimentId=${row.original.id}`
+                );
+              }}
+            >
+              {row.getVisibleCells().map((cell) => {
+                const colSizeVar = `--col-${cell.column.id}-size`;
+                return (
+                  <td
+                    key={cell.id}
+                    style={{
+                      width: `calc(var(${colSizeVar}) * 1px)`,
+                      maxWidth: `calc(var(${colSizeVar}) * 1px)`,
+                    }}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+        {hasNext ? (
+          <LoadMoreRow
+            onLoadMore={onLoadNext}
+            key="load-more"
+            isLoadingNext={isLoadingNext}
+          />
+        ) : null}
+      </tbody>
+    );
+  };
+
+  // Memoized wrapper for table body to use during column resizing
+  const MemoizedTableBody = React.memo(
+    TableBody,
+    (prev, next) => prev.table.options.data === next.table.options.data
+  ) as typeof TableBody;
+
   const baseColumns: ColumnDef<TableRow>[] = [
     {
       id: "select",
+      maxSize: 50,
       header: ({ table }) => (
         <IndeterminateCheckboxCell
           {...{
@@ -166,6 +240,7 @@ export function ExperimentsTable({
       cell: TimestampCell,
     },
   ];
+
   const annotationColumns: ColumnDef<TableRow>[] =
     data.experimentAnnotationSummaries.map((annotationSummary) => {
       const { annotationName, minScore, maxScore } = annotationSummary;
@@ -174,7 +249,6 @@ export function ExperimentsTable({
           <Flex
             direction="row"
             gap="size-100"
-            wrap
             alignItems="center"
             justifyContent="end"
           >
@@ -250,6 +324,7 @@ export function ExperimentsTable({
     },
     {
       id: "actions",
+      maxSize: 120,
       cell: ({ row }) => {
         const project = row.original.project;
         const metadata = row.original.metadata;
@@ -270,15 +345,21 @@ export function ExperimentsTable({
       },
     },
   ];
+
   const table = useReactTable<TableRow>({
     columns: [...baseColumns, ...annotationColumns, ...tailColumns],
     data: tableData,
-    getCoreRowModel: getCoreRowModel(),
     state: {
       rowSelection,
+      columnSizing,
     },
+    defaultColumn: defaultColumnSettings,
+    columnResizeMode: "onChange",
     onRowSelectionChange: setRowSelection,
+    onColumnSizingChange: setColumnSizing,
+    getCoreRowModel: getCoreRowModel(),
   });
+
   const rows = table.getRowModel().rows;
   const selectedRows = table.getSelectedRowModel().rows;
   const selectedExperiments = selectedRows.map((row) => row.original);
@@ -304,7 +385,28 @@ export function ExperimentsTable({
     },
     [hasNext, isLoadingNext, loadNext]
   );
-  const navigate = useNavigate();
+
+  const { columnSizingInfo, columnSizing: columnSizingState } =
+    table.getState();
+  const getFlatHeaders = table.getFlatHeaders;
+
+  /**
+   * Calculate all column sizes at once as CSS variables for performance
+   * @see https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
+   */
+  const [columnSizeVars] = React.useMemo(() => {
+    const headers = getFlatHeaders();
+    const colSizes: { [key: string]: number } = {};
+    for (let i = 0; i < headers.length; i++) {
+      const header = headers[i]!;
+      colSizes[`--header-${header.id}-size`] = header.getSize();
+      colSizes[`--col-${header.column.id}-size`] = header.column.getSize();
+    }
+    return [colSizes];
+    // Disabled lint as per tanstack docs linked above
+    // eslint-disable-next-line react-compiler/react-compiler
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getFlatHeaders, columnSizingInfo, columnSizingState]);
 
   if (isEmpty) {
     return <ExperimentsEmpty />;
@@ -315,51 +417,100 @@ export function ExperimentsTable({
       css={css`
         flex: 1 1 auto;
         overflow: auto;
-        width: table.getTotalSize();
       `}
       ref={tableContainerRef}
       onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
     >
-      <table css={selectableTableCSS}>
+      <table
+        css={css`
+          ${selectableTableCSS}
+          .resizer {
+            position: absolute;
+            right: 0;
+            top: 0;
+            height: 100%;
+            width: 5px;
+            background: rgba(0, 0, 0, 0.5);
+            cursor: col-resize;
+            user-select: none;
+            touch-action: none;
+            opacity: 0;
+          }
+
+          .resizer.isResizing {
+            background: blue;
+            opacity: 1;
+          }
+
+          th:hover .resizer {
+            opacity: 1;
+          }
+
+          th {
+            position: relative;
+          }
+        `}
+        style={{
+          ...columnSizeVars,
+          width: table.getTotalSize(),
+          minWidth: "100%",
+        }}
+      >
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <th
+                  colSpan={header.colSpan}
                   key={header.id}
+                  style={{
+                    width: `calc(var(--header-${header.id}-size) * 1px)`,
+                  }}
                   align={header.column.columnDef?.meta?.textAlign}
                 >
-                  <div>
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                  </div>
+                  {header.isPlaceholder ? null : (
+                    <>
+                      <div>
+                        <Truncate maxWidth="100%">
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                        </Truncate>
+                      </div>
+                      <div
+                        {...{
+                          onMouseDown: header.getResizeHandler(),
+                          onTouchStart: header.getResizeHandler(),
+                          className: `resizer ${
+                            header.column.getIsResizing() ? "isResizing" : ""
+                          }`,
+                        }}
+                      />
+                    </>
+                  )}
                 </th>
               ))}
             </tr>
           ))}
         </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr
-              key={row.id}
-              onClick={() => {
-                navigate(
-                  `/datasets/${dataset.id}/compare?experimentId=${row.original.id}`
-                );
-              }}
-            >
-              {row.getVisibleCells().map((cell) => {
-                return (
-                  <td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
+        {columnSizingInfo.isResizingColumn ? (
+          <MemoizedTableBody
+            table={table}
+            hasNext={hasNext}
+            onLoadNext={() => loadNext(PAGE_SIZE)}
+            isLoadingNext={isLoadingNext}
+            dataset={dataset}
+          />
+        ) : (
+          <TableBody
+            table={table}
+            hasNext={hasNext}
+            onLoadNext={() => loadNext(PAGE_SIZE)}
+            isLoadingNext={isLoadingNext}
+            dataset={dataset}
+          />
+        )}
       </table>
       {selectedRows.length ? (
         <ExperimentSelectionToolbar

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -33,11 +33,11 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useWordColor } from "@phoenix/hooks/useWordColor";
-import { makeSafeColumnId } from "@phoenix/utils/makeSafeColumnId";
 import {
   floatFormatter,
   formatPercent,
 } from "@phoenix/utils/numberFormatUtils";
+import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
 import { experimentsLoaderQuery$data } from "./__generated__/experimentsLoaderQuery.graphql";
 import type { ExperimentsTableFragment$key } from "./__generated__/ExperimentsTableFragment.graphql";

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -33,6 +33,7 @@ import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useWordColor } from "@phoenix/hooks/useWordColor";
+import { makeSafeColumnId } from "@phoenix/utils/makeSafeColumnId";
 import {
   floatFormatter,
   formatPercent,
@@ -79,7 +80,7 @@ const TableBody = <T extends { id: string }>({
             }}
           >
             {row.getVisibleCells().map((cell) => {
-              const colSizeVar = `--col-${cell.column.id}-size`;
+              const colSizeVar = `--col-${makeSafeColumnId(cell.column.id)}-size`;
               return (
                 <td
                   key={cell.id}
@@ -399,8 +400,10 @@ export function ExperimentsTable({
     const colSizes: { [key: string]: number } = {};
     for (let i = 0; i < headers.length; i++) {
       const header = headers[i]!;
-      colSizes[`--header-${header.id}-size`] = header.getSize();
-      colSizes[`--col-${header.column.id}-size`] = header.column.getSize();
+      colSizes[`--header-${makeSafeColumnId(header.id)}-size`] =
+        header.getSize();
+      colSizes[`--col-${makeSafeColumnId(header.column.id)}-size`] =
+        header.column.getSize();
     }
     return [colSizes];
     // Disabled lint as per tanstack docs linked above
@@ -437,7 +440,7 @@ export function ExperimentsTable({
                   colSpan={header.colSpan}
                   key={header.id}
                   style={{
-                    width: `calc(var(--header-${header.id}-size) * 1px)`,
+                    width: `calc(var(--header-${makeSafeColumnId(header.id)}-size) * 1px)`,
                   }}
                   align={header.column.columnDef?.meta?.textAlign}
                 >

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -572,7 +572,7 @@ export function SpansTable(props: SpansTableProps) {
    * and pass the column sizes down as CSS variables to the <table> element.
    * @see https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant
    */
-  const [columnSizeVars] = React.useMemo(() => {
+  const [columnSizeVars] = useMemo(() => {
     const headers = getFlatHeaders();
     const colSizes: { [key: string]: number } = {};
     for (let i = 0; i < headers.length; i++) {


### PR DESCRIPTION
## Summary by Sourcery

Enable column resizing for the experiments table by integrating TanStack Table’s column resizing API, adding CSS variables and resize handles, and optimizing rendering with a memoized table body.

Enhancements:
- Introduce columnSizing state, default column settings, columnResizeMode 'onChange', and onColumnSizingChange to activate resizing support.
- Apply CSS variables for dynamic column and header widths and update table styles to include resize handles with appropriate styling.
- Extract the table body into a separate component and memoize it to reduce re-renders during resizing operations.
- Set minimum and maximum sizes for key columns (e.g., select and actions) to enforce sensible width constraints.