### PR TITLE
feat(experiments): experiment progress chart

### DIFF
--- a/app/src/hooks/useWordColor.ts
+++ b/app/src/hooks/useWordColor.ts
@@ -1,11 +1,10 @@
 import { useMemo } from "react";
-import { interpolateSinebow } from "d3-scale-chromatic";
+
+import { getWordColor } from "@phoenix/utils/colorUtils";
 
 export const useWordColor = (word: string) => {
   const color = useMemo(() => {
-    // Derive a color from the label first character
-    const charCode = word.charCodeAt(0);
-    return interpolateSinebow((charCode % 26) / 26);
+    return getWordColor(word);
   }, [word]);
   return color;
 };

--- a/app/src/pages/experiments/ExperimentsChart.tsx
+++ b/app/src/pages/experiments/ExperimentsChart.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+
+import { Loading } from "@phoenix/components";
+
+import { ExperimentsLineChart } from "./ExperimentsLineChart";
+
+export function ExperimentsChart({ datasetId }: { datasetId: string }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ExperimentsLineChart datasetId={datasetId} />
+    </Suspense>
+  );
+}

--- a/app/src/pages/experiments/ExperimentsLineChart.tsx
+++ b/app/src/pages/experiments/ExperimentsLineChart.tsx
@@ -1,0 +1,255 @@
+/**
+ * A line chart of the experiments for a given dataset.
+ * This in the future might be extended for more use cases.
+ */
+import { useMemo } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+import { format } from "d3-format";
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Flex, Text } from "@phoenix/components";
+import {
+  ChartTooltip,
+  ChartTooltipItem,
+  useChartColors,
+} from "@phoenix/components/chart";
+import { SequenceNumberToken } from "@phoenix/components/experiment/SequenceNumberToken";
+import { getWordColor } from "@phoenix/utils/colorUtils";
+
+import type { ExperimentsLineChartQuery } from "./__generated__/ExperimentsLineChartQuery.graphql";
+
+export type ExperimentsLineChartData = {
+  iteration: number;
+  avgLatency: number;
+  [scoreKey: string]: number | string;
+};
+
+const chartMargins = { top: 8, right: 18, left: 18, bottom: 58 };
+
+const numberFormatter = new Intl.NumberFormat([], {
+  maximumFractionDigits: 4,
+});
+
+const latencyFormatter = (value: number | null | undefined) => {
+  if (typeof value !== "number") return "--";
+  return `${format(".1f")(value / 1000)}s`;
+};
+
+function TooltipContent({
+  active,
+  payload,
+  label,
+}: TooltipProps<number, string>) {
+  const { gray300 } = useChartColors();
+  // Use the same color logic as the chart lines
+  if (active && payload && payload.length) {
+    // Filter out avgLatency and show all other annotation scores
+    const annotationEntries = payload.filter(
+      (p) => p.dataKey !== "avgLatency" && typeof p.value === "number"
+    );
+    // Sequence number is the x value (label)
+    return (
+      <ChartTooltip>
+        <Flex direction="row" alignItems="center" gap="size-100">
+          <Text weight="heavy" size="S">
+            Experiment
+          </Text>
+          <SequenceNumberToken sequenceNumber={Number(label)} />
+        </Flex>
+        {annotationEntries.map((entry) => (
+          <ChartTooltipItem
+            key={String(entry.dataKey)}
+            color={getWordColor(String(entry.dataKey))}
+            shape="line"
+            name={
+              String(entry.dataKey).charAt(0).toUpperCase() +
+              String(entry.dataKey).slice(1)
+            }
+            value={
+              typeof entry.value === "number"
+                ? numberFormatter.format(entry.value)
+                : "--"
+            }
+          />
+        ))}
+        {/* Avg Latency */}
+        {(() => {
+          const entry = payload.find((p) => p.dataKey === "avgLatency");
+          if (!entry) return null;
+          return (
+            <ChartTooltipItem
+              key="avgLatency"
+              color={gray300}
+              shape="square"
+              name="avg latency"
+              value={latencyFormatter(entry.value as number)}
+            />
+          );
+        })()}
+      </ChartTooltip>
+    );
+  }
+  return null;
+}
+
+export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
+  const data = useLazyLoadQuery<ExperimentsLineChartQuery>(
+    graphql`
+      query ExperimentsLineChartQuery($id: ID!) {
+        dataset: node(id: $id) {
+          ... on Dataset {
+            experiments(first: 50) {
+              edges {
+                experiment: node {
+                  id
+                  sequenceNumber
+                  averageRunLatencyMs
+                  annotationSummaries {
+                    annotationName
+                    meanScore
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    { id: datasetId }
+  );
+
+  const { chartData, scoreKeys } = useMemo(() => {
+    const allAnnotationNames = new Set<string>();
+    const chartData = (data.dataset?.experiments?.edges ?? [])
+      .map((edge) => {
+        const exp = edge.experiment;
+        const scores: Record<string, number | undefined> = {};
+        const summaries = exp.annotationSummaries;
+        for (const summary of summaries) {
+          allAnnotationNames.add(summary.annotationName);
+          scores[summary.annotationName] = summary.meanScore ?? undefined;
+        }
+        return {
+          iteration: exp.sequenceNumber,
+          avgLatency: exp.averageRunLatencyMs ?? undefined,
+          ...scores,
+        };
+      })
+      .filter((dataPoint) => dataPoint !== null)
+      .sort((a, b) => a.iteration - b.iteration);
+    return { chartData, scoreKeys: Array.from(allAnnotationNames) };
+  }, [data.dataset?.experiments?.edges]);
+
+  const { gray300 } = useChartColors();
+  // Memoize colors for each annotation name (scoreKey) using the same logic as useWordColor
+  const lineColors = useMemo(() => {
+    const colorMap: Record<string, string> = {};
+    for (const key of scoreKeys) {
+      colorMap[key] = getWordColor(key);
+    }
+    return colorMap;
+  }, [scoreKeys]);
+
+  // Memoize yDomain calculation
+  const yDomain = useMemo(() => {
+    let minScore = Infinity;
+    let maxScore = -Infinity;
+    for (const dataPoint of chartData) {
+      for (const scoreKey of scoreKeys) {
+        const scoreValue = dataPoint[scoreKey as keyof typeof dataPoint];
+        if (typeof scoreValue === "number") {
+          if (scoreValue < minScore) minScore = scoreValue;
+          if (scoreValue > maxScore) maxScore = scoreValue;
+        }
+      }
+    }
+    // If the min score is 0 and the max score is 1, return [0, 1] for consistency
+    return minScore >= 0 && maxScore <= 1 ? [0, 1] : undefined;
+  }, [chartData, scoreKeys]);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ComposedChart
+        data={chartData}
+        margin={chartMargins}
+        syncId="dimensionDetails"
+      >
+        <defs>
+          <linearGradient id="latencyBarColor" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={gray300} stopOpacity={0.3} />
+            <stop offset="95%" stopColor={gray300} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid
+          strokeDasharray="4 4"
+          stroke="var(--ac-global-color-grey-500)"
+          strokeOpacity={0.5}
+        />
+        <XAxis
+          dataKey="iteration"
+          tick={{ fontSize: 12, fill: "var(--ac-global-text-color-700)" }}
+        />
+        <YAxis
+          stroke="var(--ac-global-color-grey-500)"
+          label={{
+            value: "Score",
+            angle: -90,
+            position: "insideLeft",
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
+          }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
+          domain={yDomain}
+        />
+        <YAxis
+          yAxisId="right"
+          orientation="right"
+          stroke="var(--ac-global-color-grey-500)"
+          label={{
+            value: "avg latency",
+            angle: 90,
+            position: "insideRight",
+            style: {
+              textAnchor: "middle",
+              fill: "var(--ac-global-text-color-900)",
+            },
+          }}
+          style={{ fill: "var(--ac-global-text-color-700)" }}
+          tickFormatter={latencyFormatter}
+        />
+
+        <Bar
+          yAxisId="right"
+          dataKey="avgLatency"
+          fill="url(#latencyBarColor)"
+          spacing={3}
+        />
+        {scoreKeys.map((key) => (
+          <Line
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stroke={lineColors[key]}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+            yAxisId={0}
+          />
+        ))}
+        <Tooltip content={<TooltipContent />} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/app/src/pages/experiments/ExperimentsPage.tsx
+++ b/app/src/pages/experiments/ExperimentsPage.tsx
@@ -8,11 +8,15 @@ import { resizeHandleCSS } from "@phoenix/components/resize";
 import { ExperimentsChart } from "@phoenix/pages/experiments/ExperimentsChart";
 import { experimentsLoader } from "@phoenix/pages/experiments/experimentsLoader";
 
+import { ExperimentsEmpty } from "./ExperimentsEmpty";
 import { ExperimentsTable } from "./ExperimentsTable";
 
 export function ExperimentsPage() {
   const loaderData = useLoaderData<typeof experimentsLoader>();
   invariant(loaderData, "loaderData is required");
+  if (!loaderData.dataset.firstExperiment?.edges.length) {
+    return <ExperimentsEmpty />;
+  }
   return (
     <>
       <PanelGroup direction="vertical" autoSaveId="experiments-layout">

--- a/app/src/pages/experiments/ExperimentsPage.tsx
+++ b/app/src/pages/experiments/ExperimentsPage.tsx
@@ -1,7 +1,11 @@
 import { Suspense } from "react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Outlet, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
+import { Heading, View } from "@phoenix/components";
+import { resizeHandleCSS } from "@phoenix/components/resize";
+import { ExperimentsChart } from "@phoenix/pages/experiments/ExperimentsChart";
 import { experimentsLoader } from "@phoenix/pages/experiments/experimentsLoader";
 
 import { ExperimentsTable } from "./ExperimentsTable";
@@ -11,7 +15,20 @@ export function ExperimentsPage() {
   invariant(loaderData, "loaderData is required");
   return (
     <>
-      <ExperimentsTable dataset={loaderData.dataset} />
+      <PanelGroup direction="vertical" autoSaveId="experiments-layout">
+        <Panel order={0} minSize={20} maxSize={30} defaultSize={20} collapsible>
+          <View paddingX="size-200" paddingY="size-100">
+            <Heading level={2}>Experiments Analysis</Heading>
+          </View>
+          <ExperimentsChart datasetId={loaderData.dataset.id} />
+        </Panel>
+        <PanelResizeHandle css={resizeHandleCSS} />
+        <Panel order={1}>
+          <View height="100%" overflow="hidden" flex="1 1 auto">
+            <ExperimentsTable dataset={loaderData.dataset} />
+          </View>
+        </Panel>
+      </PanelGroup>
       <Suspense>
         <Outlet />
       </Suspense>

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -418,7 +418,7 @@ export function ExperimentsTable({
   return (
     <div
       css={css`
-        flex: 1 1 auto;
+        height: 100%;
         overflow: auto;
       `}
       ref={tableContainerRef}

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -45,7 +45,6 @@ import { ExperimentsTableQuery } from "./__generated__/ExperimentsTableQuery.gra
 import { DownloadExperimentActionMenu } from "./DownloadExperimentActionMenu";
 import { ErrorRateCell } from "./ErrorRateCell";
 import { ExperimentSelectionToolbar } from "./ExperimentSelectionToolbar";
-import { ExperimentsEmpty } from "./ExperimentsEmpty";
 
 const PAGE_SIZE = 100;
 
@@ -361,14 +360,11 @@ export function ExperimentsTable({
     getCoreRowModel: getCoreRowModel(),
   });
 
-  const rows = table.getRowModel().rows;
   const selectedRows = table.getSelectedRowModel().rows;
   const selectedExperiments = selectedRows.map((row) => row.original);
   const clearSelection = useCallback(() => {
     setRowSelection({});
   }, [setRowSelection]);
-
-  const isEmpty = rows.length === 0;
 
   const fetchMoreOnBottomReached = useCallback(
     (containerRefElement?: HTMLDivElement | null) => {
@@ -410,10 +406,6 @@ export function ExperimentsTable({
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getFlatHeaders, columnSizingInfo, columnSizingState]);
-
-  if (isEmpty) {
-    return <ExperimentsEmpty />;
-  }
 
   return (
     <div

--- a/app/src/pages/experiments/__generated__/ExperimentsLineChartQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsLineChartQuery.graphql.ts
@@ -1,0 +1,209 @@
+/**
+ * @generated SignedSource<<bc93cd9ff1fdb575e1dc5056bfeb8d17>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ExperimentsLineChartQuery$variables = {
+  id: string;
+};
+export type ExperimentsLineChartQuery$data = {
+  readonly dataset: {
+    readonly experiments?: {
+      readonly edges: ReadonlyArray<{
+        readonly experiment: {
+          readonly annotationSummaries: ReadonlyArray<{
+            readonly annotationName: string;
+            readonly meanScore: number | null;
+          }>;
+          readonly averageRunLatencyMs: number | null;
+          readonly id: string;
+          readonly sequenceNumber: number;
+        };
+      }>;
+    };
+  };
+};
+export type ExperimentsLineChartQuery = {
+  response: ExperimentsLineChartQuery$data;
+  variables: ExperimentsLineChartQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "ExperimentConnection",
+      "kind": "LinkedField",
+      "name": "experiments",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ExperimentEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "experiment",
+              "args": null,
+              "concreteType": "Experiment",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v2/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "sequenceNumber",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "averageRunLatencyMs",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ExperimentAnnotationSummary",
+                  "kind": "LinkedField",
+                  "name": "annotationSummaries",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "annotationName",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "meanScore",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "experiments(first:50)"
+    }
+  ],
+  "type": "Dataset",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ExperimentsLineChartQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ExperimentsLineChartQuery",
+    "selections": [
+      {
+        "alias": "dataset",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b4d31338866ff8be645d6601e1e15dc2",
+    "id": null,
+    "metadata": {},
+    "name": "ExperimentsLineChartQuery",
+    "operationKind": "query",
+    "text": "query ExperimentsLineChartQuery(\n  $id: ID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    ... on Dataset {\n      experiments(first: 50) {\n        edges {\n          experiment: node {\n            id\n            sequenceNumber\n            averageRunLatencyMs\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3eade40b47d598c5387d90e7740a457a";
+
+export default node;

--- a/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<082786df9f023fdb249b88fb74e2b7df>>
+ * @generated SignedSource<<c902610e020d1d1216507ac4c47cf91f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,13 @@ export type experimentsLoaderQuery$variables = {
 };
 export type experimentsLoaderQuery$data = {
   readonly dataset: {
+    readonly firstExperiment?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+        };
+      }>;
+    };
     readonly id: string;
     readonly " $fragmentSpreads": FragmentRefs<"ExperimentsTableFragment">;
   };
@@ -46,21 +53,62 @@ v2 = {
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v3 = [
+  (v2/*: any*/)
+],
+v4 = {
+  "alias": "firstExperiment",
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 1
+    }
+  ],
+  "concreteType": "ExperimentConnection",
+  "kind": "LinkedField",
+  "name": "experiments",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExperimentEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Experiment",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": (v3/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "experiments(first:1)"
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotationName",
   "storageKey": null
 },
-v5 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -90,7 +138,8 @@ return {
                 "args": null,
                 "kind": "FragmentSpread",
                 "name": "ExperimentsTableFragment"
-              }
+              },
+              (v4/*: any*/)
             ],
             "type": "Dataset",
             "abstractKey": null
@@ -116,7 +165,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v5/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -129,7 +178,7 @@ return {
                 "name": "experimentAnnotationSummaries",
                 "plural": true,
                 "selections": [
-                  (v4/*: any*/),
+                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -149,7 +198,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "ExperimentConnection",
                 "kind": "LinkedField",
                 "name": "experiments",
@@ -235,9 +284,7 @@ return {
                             "kind": "LinkedField",
                             "name": "project",
                             "plural": false,
-                            "selections": [
-                              (v2/*: any*/)
-                            ],
+                            "selections": (v3/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -248,7 +295,7 @@ return {
                             "name": "annotationSummaries",
                             "plural": true,
                             "selections": [
-                              (v4/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -277,7 +324,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
@@ -315,13 +362,14 @@ return {
               },
               {
                 "alias": null,
-                "args": (v5/*: any*/),
+                "args": (v7/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "ExperimentsTable_experiments",
                 "kind": "LinkedHandle",
                 "name": "experiments"
-              }
+              },
+              (v4/*: any*/)
             ],
             "type": "Dataset",
             "abstractKey": null
@@ -332,16 +380,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "408cf8f25f19c40db245b9f45d2a5ed2",
+    "cacheID": "9b6f82293b5d03e1df6d2e1ba93bf21c",
     "id": null,
     "metadata": {},
     "name": "experimentsLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentsLoaderQuery(\n  $id: ID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query experimentsLoaderQuery(\n  $id: ID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n      firstExperiment: experiments(first: 1) {\n        edges {\n          node {\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e0d13b10fa634c6bea5220505e0229a3";
+(node as any).hash = "c59bc7ec0e8d304bf7c2c46cee4e82d2";
 
 export default node;

--- a/app/src/pages/experiments/experimentsLoader.tsx
+++ b/app/src/pages/experiments/experimentsLoader.tsx
@@ -18,6 +18,13 @@ export async function experimentsLoader(args: LoaderFunctionArgs) {
           id
           ... on Dataset {
             ...ExperimentsTableFragment
+            firstExperiment: experiments(first: 1) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
           }
         }
       }

--- a/app/src/utils/colorUtils.ts
+++ b/app/src/utils/colorUtils.ts
@@ -1,0 +1,6 @@
+import { interpolateSinebow } from "d3-scale-chromatic";
+
+export const getWordColor = (word: string) => {
+  const charCode = word.charCodeAt(0);
+  return interpolateSinebow((charCode % 26) / 26);
+};


### PR DESCRIPTION
resolves #7825 


https://github.com/user-attachments/assets/5cd5bc82-c9ba-45df-b01f-392b8bc37fdf


## Summary by Sourcery

Add a new interactive chart next to the experiments table to display experiment metrics over time, unify color logic via a utility function, and update the tutorial notebook with the latest dependencies and example outputs.

New Features:
- Add a collapsible experiments chart panel above the experiments table on the ExperimentsPage
- Implement a new ExperimentsLineChart component to visualize annotation scores and latency over experiment iterations
- Introduce ExperimentsChart wrapper and getWordColor utility for consistent color derivation

Enhancements:
- Refactor useWordColor hook to leverage the shared getWordColor util
- Adjust ExperimentsTable styles to occupy full container height
- Bump arize-phoenix dependency to >=10.0.0 and add execution outputs in the txt2sql tutorial notebook for clarity