### PR TITLE
feat: Support server-side logout flow via env vars

### DIFF
--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -85,7 +85,7 @@ function SideNav() {
   const navigate = useNavigate();
   const onLogout = useCallback(async () => {
     if (window.Config.proxyLogout) {
-      window.location.href = prependBasename("/auth/logout");
+      window.location.replace(prependBasename("/auth/logout"));
       return;
     }
     const response = await fetch(prependBasename("/auth/logout"), {

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -84,6 +84,10 @@ function SideNav() {
   const { authenticationEnabled } = useFunctionality();
   const navigate = useNavigate();
   const onLogout = useCallback(async () => {
+    if (window.Config.proxyLogout) {
+      window.location.href = prependBasename("/auth/logout");
+      return;
+    }
     const response = await fetch(prependBasename("/auth/logout"), {
       method: "POST",
     });

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -22,6 +22,7 @@ declare global {
       authenticationEnabled: boolean;
       basicAuthDisabled: boolean;
       oAuth2Idps: OAuth2Idp[];
+      proxyLogout: boolean;
     };
   }
 }

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -288,6 +288,12 @@ Whether to verify client certificates for mutual TLS (mTLS) authentication.
 When set to true, clients must provide valid certificates signed by the CA specified in
 PHOENIX_TLS_CA_FILE.
 """
+ENV_PHOENIX_PROXY_LOGOUT = "PHOENIX_PROXY_LOGOUT"
+"""
+Whether to enable proxy-compatible logout handling. When set to true, the server will handle the
+logout process instead of the client. This is useful when the client is not able to handle the
+logout process, e.g., when Phoenix is deployed behind a reverse proxy.
+"""
 
 
 @dataclass(frozen=True)
@@ -1518,6 +1524,10 @@ def get_env_allowed_origins() -> Optional[list[str]]:
         return None
 
     return allowed_origins.split(",")
+
+
+def get_env_proxy_logout() -> bool:
+    return _bool_val(ENV_PHOENIX_PROXY_LOGOUT, False)
 
 
 def verify_server_environment_variables() -> None:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -214,6 +214,7 @@ class AppConfig(NamedTuple):
     oauth2_idps: Sequence[OAuth2Idp]
     basic_auth_disabled: bool = False
     auto_login_idp_name: Optional[str] = None
+    proxy_logout: bool = False
 
 
 class Static(StaticFiles):
@@ -279,6 +280,7 @@ class Static(StaticFiles):
                     "oauth2_idps": self._app_config.oauth2_idps,
                     "basic_auth_disabled": self._app_config.basic_auth_disabled,
                     "auto_login_idp_name": self._app_config.auto_login_idp_name,
+                    "proxy_logout": self._app_config.proxy_logout,
                 },
             )
         except Exception as e:
@@ -792,6 +794,7 @@ def create_app(
     basic_auth_disabled: bool = False,
     bulk_inserter_factory: Optional[Callable[..., BulkInserter]] = None,
     allowed_origins: Optional[list[str]] = None,
+    proxy_logout: bool = False,
 ) -> FastAPI:
     verify_server_environment_variables()
     if model.embedding_dimensions:
@@ -964,6 +967,7 @@ def create_app(
                     oauth2_idps=oauth2_idps,
                     basic_auth_disabled=basic_auth_disabled,
                     auto_login_idp_name=auto_login_idp_name,
+                    proxy_logout=proxy_logout,
                 ),
             ),
             name="static",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -34,6 +34,7 @@ from phoenix.config import (
     get_env_oauth2_settings,
     get_env_password_reset_token_expiry,
     get_env_port,
+    get_env_proxy_logout,
     get_env_refresh_token_expiry,
     get_env_smtp_hostname,
     get_env_smtp_mail_from,
@@ -451,6 +452,7 @@ def main() -> None:
         email_sender=email_sender,
         oauth2_client_configs=get_env_oauth2_settings(),
         allowed_origins=allowed_origins,
+        proxy_logout=get_env_proxy_logout(),
     )
 
     # Configure server with TLS if enabled

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -86,6 +86,7 @@
               oAuth2Idps: {{ oauth2_idps | tojson }},
               basicAuthDisabled: Boolean("{{basic_auth_disabled}}" == "True"),
               websocketsEnabled: Boolean("{{websockets_enabled}}" == "True"),
+              proxyLogout: Boolean("{{proxy_logout}}" == "True"),
           }),
           writable: false
       });

--- a/tox.ini
+++ b/tox.ini
@@ -311,6 +311,7 @@ pass_env =
   PHOENIX_DISABLE_BASIC_AUTH
   PHOENIX_ALLOWED_ORIGINS
   PHOENIX_LOGGING_LEVEL
+  PHOENIX_PROXY_LOGOUT
 commands_pre =
   uv tool install -U --force arize-phoenix@. \
     --reinstall-package arize-phoenix \


### PR DESCRIPTION
In cases where Phoenix is behind a reverse proxy, and auth is handled by that proxy, oidc, etc, it would be useful for Phoenix to optionally hard navigate to `/auth/logout` (following redirects) and letting the proxy server handle logout as desired.

## Summary by Sourcery

Enable proxy-compatible server-side logout by introducing a new environment variable and wiring it through the backend and frontend.

New Features:
- Introduce PHOENIX_PROXY_LOGOUT environment variable and get_env_proxy_logout helper to toggle proxy-based logout flow
- Propagate a proxy_logout flag through AppConfig into the index.html template and global window configuration
- Update the client-side logout handler to perform a hard navigation to /auth/logout when proxy_logout is enabled

Build:
- Add PHOENIX_PROXY_LOGOUT to tox.ini’s pass_env configuration