### PR TITLE
refactor(auth): Perform logout over GET instead of POST

### DIFF
--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - feat/version-10
       - feat/openid-only
+      - cephalization/handoff-logout-to-oidc
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - feat/version-10
       - feat/openid-only
-      - cephalization/handoff-logout-to-oidc
+      - cephalization/get-logout-refactor
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-build-experimental.yml
+++ b/.github/workflows/docker-build-experimental.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - feat/version-10
       - feat/openid-only
-      - cephalization/get-logout-refactor
 
 jobs:
   push_to_registry:

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -80,22 +80,23 @@ function SideNav() {
   const hasInferences = useMemo(() => {
     return window.Config.hasInferences;
   }, []);
-  const notifyError = useNotifyError();
   const { authenticationEnabled } = useFunctionality();
-  const navigate = useNavigate();
-  const onLogout = useCallback(async () => {
-    const response = await fetch(prependBasename("/auth/logout"), {
-      method: "POST",
-    });
-    if (response.ok) {
-      navigate(window.Config.basicAuthDisabled ? "/logout" : "/login");
-      return;
-    }
-    notifyError({
-      title: "Logout Failed",
-      message: "Failed to log out: " + response.statusText,
-    });
-  }, [navigate, notifyError]);
+  const onLogout = useCallback(() => {
+    window.location.replace(prependBasename("/auth/logout"));
+  }, []);
+  // const onLogout = useCallback(async () => {
+  //   const response = await fetch(prependBasename("/auth/logout"), {
+  //     method: "POST",
+  //   });
+  //   if (response.ok) {
+  //     navigate(window.Config.basicAuthDisabled ? "/logout" : "/login");
+  //     return;
+  //   }
+  //   notifyError({
+  //     title: "Logout Failed",
+  //     message: "Failed to log out: " + response.statusText,
+  //   });
+  // }, [navigate, notifyError]);
   return (
     <SideNavbar>
       <Brand />

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useCallback, useMemo } from "react";
-import { Outlet, useNavigate } from "react-router";
+import { Outlet } from "react-router";
 import { css } from "@emotion/react";
 
 import { Flex, Icon, Icons, Loading } from "@phoenix/components";
@@ -14,7 +14,6 @@ import {
   ThemeToggle,
   TopNavbar,
 } from "@phoenix/components/nav";
-import { useNotifyError } from "@phoenix/contexts";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useFunctionality } from "@phoenix/contexts/FunctionalityContext";
 import { prependBasename } from "@phoenix/utils/routingUtils";
@@ -84,19 +83,6 @@ function SideNav() {
   const onLogout = useCallback(() => {
     window.location.replace(prependBasename("/auth/logout"));
   }, []);
-  // const onLogout = useCallback(async () => {
-  //   const response = await fetch(prependBasename("/auth/logout"), {
-  //     method: "POST",
-  //   });
-  //   if (response.ok) {
-  //     navigate(window.Config.basicAuthDisabled ? "/logout" : "/login");
-  //     return;
-  //   }
-  //   notifyError({
-  //     title: "Logout Failed",
-  //     message: "Failed to log out: " + response.statusText,
-  //   });
-  // }, [navigate, notifyError]);
   return (
     <SideNavbar>
       <Brand />

--- a/src/phoenix/server/api/routers/auth.py
+++ b/src/phoenix/server/api/routers/auth.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from starlette.status import (
     HTTP_204_NO_CONTENT,
+    HTTP_302_FOUND,
     HTTP_401_UNAUTHORIZED,
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
@@ -120,7 +121,7 @@ async def login(request: Request) -> Response:
     return response
 
 
-@router.post("/logout")
+@router.get("/logout")
 async def logout(
     request: Request,
 ) -> Response:
@@ -138,7 +139,8 @@ async def logout(
         user_id = subject
     if user_id:
         await token_store.log_out(user_id)
-    response = Response(status_code=HTTP_204_NO_CONTENT)
+    redirect_url = "/logout" if get_env_disable_basic_auth() else "/login"
+    response = Response(status_code=HTTP_302_FOUND, headers={"Location": redirect_url})
     response = delete_access_token_cookie(response)
     response = delete_refresh_token_cookie(response)
     response = delete_oauth2_state_cookie(response)

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -1009,7 +1009,7 @@ def _log_out(
     auth: Optional[_SecurityArtifact] = None,
     /,
 ) -> None:
-    resp = _httpx_client(auth).post("auth/logout")
+    resp = _httpx_client(auth).get("auth/logout")
     resp.raise_for_status()
     tokens = _extract_tokens(resp.headers, "set-cookie")
     for k in _COOKIE_NAMES:

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -1009,8 +1009,13 @@ def _log_out(
     auth: Optional[_SecurityArtifact] = None,
     /,
 ) -> None:
-    resp = _httpx_client(auth).get("auth/logout")
-    resp.raise_for_status()
+    resp = _httpx_client(auth).get("auth/logout", follow_redirects=False)
+    try:
+        resp.raise_for_status()
+    except HTTPStatusError as e:
+        if e.response.status_code != 302:
+            raise
+        assert e.response.headers["location"] in ("/login", "/logout")
     tokens = _extract_tokens(resp.headers, "set-cookie")
     for k in _COOKIE_NAMES:
         assert tokens[k] == '""'

--- a/tests/integration/auth/test_auth.py
+++ b/tests/integration/auth/test_auth.py
@@ -527,7 +527,12 @@ class TestLogOut:
     ) -> None:
         u = _get_user(role_or_user)
         refresh_token = u.log_in().tokens.refresh_token
-        refresh_token.log_out()
+        # Explicitly check for 302 response from logout
+        client = _httpx_client(refresh_token)
+        response = client.get("auth/logout", follow_redirects=False)
+        assert response.status_code == 302
+        # Optionally, check the redirect location
+        assert response.headers["location"] in ("/login", "/logout")
 
     def test_log_out_does_not_raise_exception(self) -> None:
         _log_out()


### PR DESCRIPTION
Replace the POST logout flow with a GET endpoint instead.

This allows the logout flow to be intercepted by reverse proxies and other custom authentication flows that users may have configured.

## Summary by Sourcery

Refactor the logout flow to use a GET endpoint with a redirect response instead of issuing a POST request and handling it in JavaScript

Enhancements:
- Switch the backend logout route from POST to GET and return a 302 redirect to the appropriate page
- Simplify the frontend logout handler to call window.location.replace on the logout URL instead of using fetch and manual navigation