### PR TITLE
docs: fix js readme

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -75,4 +75,4 @@ Within the [react](https://react.dev) app, there is additional `state` and `cont
 
 The phoenix app is a client-side only SPA (single-page application), meaning that it entirely manages the routing of the pages via [react-router](https://reactrouter.com/en/main). `react-router` is leveraged to provide nested routing (e.g. rendering different parts of the UI based on the path) and is also utilized to load data as routes change (see [loaders](https://reactrouter.com/en/main/route/loader)).
 
-All UI components used in Phoenix are managed by Arize's design system and `@arizeai/components`. Arize also maintains `@arizeai/point-cloud` a 3D visualization library built on top of [threejs](https://threejs.org/) and [react-three-fiber](https://docs.pmnd.rs/react-three-fiber/getting-started/introduction).
+All UI components used in Phoenix are being migrated from `@arizeai/components` to be self-contained within Phoenix using `react-aria-components`. Arize also maintains `@arizeai/point-cloud` a 3D visualization library built on top of [threejs](https://threejs.org/) and [react-three-fiber](https://docs.pmnd.rs/react-three-fiber/getting-started/introduction).


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update Phoenix app README to note migration of UI components from @arizeai/components to self-contained react-aria-components