### PR TITLE
docs: add js documentation

### DIFF
--- a/js/README.MD
+++ b/js/README.MD
@@ -17,3 +17,54 @@ A collection of Deno Jupyter notebooks that demonstrate how to interact with Pho
 ### [phoenix-experiment-runner](./examples/apps/phoenix-experiment-runner/)
 
 An example app that uses the phoenix-client and @clack/prompts to run experiments interactively.
+
+## Development Guide
+
+Below is how to setup the tooling for the JS monorepo.
+
+## PNPM
+
+This repository is managed as a monorepo using [pnpm workspaces](https://pnpm.io/workspaces). Follow these steps to get your environment set up:
+
+### 1. Install pnpm (if you don't have it)
+
+```sh
+npm install -g pnpm
+```
+
+### 2. Install all dependencies for all packages
+
+From the root of the repository, run:
+
+```sh
+pnpm install
+```
+
+This will install dependencies for all packages in the monorepo.
+
+### 3. Run scripts across all packages
+
+You can run scripts (like build, lint, test, prettier) across all packages using pnpm's recursive mode:
+
+```sh
+pnpm run -r build      # Build all packages
+pnpm run -r lint       # Lint all packages
+pnpm run -r test       # Run tests for all packages (if defined)
+pnpm run -r prettier:check # Check formatting for all packages
+```
+
+### Changesets
+
+The changes to the packages managed by this repo are tracked via changesets. Changesets are similar to semantic commits in that they describe the changes made to the codebase. However, changesets track changes to all the packages by committing changesets to the `.changeset` directory. If you make a change to a package, you should create a changeset for it via:
+
+```sh
+pnpm changeset
+```
+
+and commit it in your PR.
+
+A changeset is an intent to release a set of packages at particular semver bump types with a summary of the changes made.
+
+Once your PR is merged, Github Actions will create a release PR. Once the release PR is merged, new versions of any changed packages will be published to npm.
+
+For a detailed explanation of changesets, consult the [official documentation](https://github.com/changesets/changesets).

--- a/js/packages/phoenix-client/DEVELOPMENT.md
+++ b/js/packages/phoenix-client/DEVELOPMENT.md
@@ -1,0 +1,24 @@
+# Development Guide for @arizeai/phoenix-client
+
+## Code Generation
+
+The Phoenix client uses code generation to keep its TypeScript types and API interfaces in sync with the backend OpenAPI schema.
+
+- The OpenAPI schema (`openapi.json`) is located in the `schemas/` directory at the root of the repository.
+- The client uses [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) to generate TypeScript types and API interfaces from this schema.
+- The generated code is output to `src/__generated__/api/v1.ts` in the `phoenix-client` package.
+
+### How to Regenerate the Client
+
+If the OpenAPI schema changes (for example, after updating the backend or pulling new changes):
+
+1. Make sure you have the latest `openapi.json` in the `schemas/` directory.
+2. Run the codegen script from the `phoenix-client` directory:
+
+   ```sh
+   pnpm run generate
+   ```
+
+3. Commit the updated generated file if there are changes.
+
+**Note:** Always regenerate and commit the generated code when the OpenAPI schema changes to ensure the client stays up to date.


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive development documentation for the JavaScript monorepo and the phoenix-client package

Documentation:
- Add a Development Guide to the root js/README.md covering pnpm workspace setup, scripts for build/lint/test/prettier, and changeset-based release workflow
- Add a DEVELOPMENT.md in phoenix-client with instructions for generating and committing TypeScript client code from the OpenAPI schema