### PR TITLE
docs: deprecated/removed smolagents classes in tracing docs

### DIFF
--- a/docs/tracing/integrations-tracing/hfsmolagents.md
+++ b/docs/tracing/integrations-tracing/hfsmolagents.md
@@ -156,20 +156,16 @@ Create your Hugging Face Model, and at every run, traces will be sent to Phoenix
 from smolagents import (
     CodeAgent,
     ToolCallingAgent,
-    ManagedAgent,
     DuckDuckGoSearchTool,
     VisitWebpageTool,
-    HfApiModel,
+    InferenceClientModel,
 )
 
-model = HfApiModel()
+model = InferenceClientModel()
 
-agent = ToolCallingAgent(
+managed_agent = ToolCallingAgent(
     tools=[DuckDuckGoSearchTool(), VisitWebpageTool()],
     model=model,
-)
-managed_agent = ManagedAgent(
-    agent=agent,
     name="managed_agent",
     description="This is an agent that can do web search.",
 )


### PR DESCRIPTION
Fix deprecated/removed `smolagents` classes in tracing docs.

## Summary by Sourcery

Align tracing integration docs with the updated smolagents API by replacing removed classes and adjusting the code example accordingly

Documentation:
- Replace deprecated HfApiModel with InferenceClientModel in the code sample
- Remove ManagedAgent usage and instantiate ToolCallingAgent directly with an updated variable name