### PR TITLE
docs: Readthedocs improvements on naming and structure

### DIFF
--- a/api_reference/source/conf.py
+++ b/api_reference/source/conf.py
@@ -70,7 +70,7 @@ def setup(app):
 
 # -- Project information -----------------------------------------------------
 
-project = "Phoenix API Reference"
+project = "Phoenix Python Reference"
 copyright = "2024, Arize AI"
 author = "Arize AI"
 
@@ -164,7 +164,7 @@ html_show_sphinx = False
 
 html_theme_options = {
     "logo": {
-        "text": "Phoenix API",
+        "text": "Phoenix Python",
         "image_light": "logo.png",
         "image_dark": "logo.png",
     },
@@ -181,7 +181,7 @@ html_theme_options = {
         },
     ],
     "external_links": [
-        {"name": "Docs", "url": "https://arize.com/docs/phoenix"},
+        {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
     ],
     "navbar_align": "content",
     "navbar_start": ["navbar-logo", "version-switcher"],

--- a/api_reference/source/index.md
+++ b/api_reference/source/index.md
@@ -7,7 +7,7 @@ myst:
 html_theme.sidebar_secondary.remove: true
 ---
 
-# Arize Phoenix API Reference
+# Arize Phoenix Python Reference
 
 <a target="_blank" href="https://phoenix.arize.com" style="background:none">
     <img alt="phoenix banner" src="_static/github-large-banner-phoenix.jpg" width="auto" height="auto"></img>
@@ -38,7 +38,7 @@ html_theme.sidebar_secondary.remove: true
 </div>
 <br/>
 
-Welcome to Arize Phoenix's API reference. This reference details Phoenix's API and how to use its various features. To get a complete guide on how to use Phoenix, including tutorials, quickstarts, and concept explanations, see the [complete documentation](https://arize.com/docs/phoenix).
+Welcome to Arize Phoenix's Python reference. This reference details Phoenix's Python API and how to use its various features. To get a complete guide on how to use Phoenix, including tutorials, quickstarts, and concept explanations, see the [complete documentation](https://arize.com/docs/phoenix).
 
 ## Sub-Packages
 

--- a/packages/phoenix-client/docs/source/conf.py
+++ b/packages/phoenix-client/docs/source/conf.py
@@ -98,7 +98,7 @@ html_show_sphinx = False
 
 html_theme_options = {
     "logo": {
-        "text": "Phoenix Client API",
+        "text": "Phoenix Client",
         "image_light": "logo.png",
         "image_dark": "logo.png",
     },

--- a/packages/phoenix-client/docs/source/conf.py
+++ b/packages/phoenix-client/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(BASE_DIR, "src", "phoenix"))
 
 # -- Project information -----------------------------------------------------
 
-project = "Phoenix Client API Reference"
+project = "Phoenix Client Reference"
 copyright = "2025, Arize AI"
 author = "Arize AI"
 
@@ -115,8 +115,8 @@ html_theme_options = {
         },
     ],
     "external_links": [
-        {"name": "Main Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
-        {"name": "Phoenix API Reference", "url": "https://arize-phoenix.readthedocs.io/"},
+        {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
+        {"name": "Python Reference", "url": "https://arize-phoenix.readthedocs.io/"},
     ],
     "navbar_align": "content",
     "navbar_start": ["navbar-logo"],

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -1,6 +1,94 @@
 # Phoenix Client Reference
 
-Welcome to the Phoenix Client Reference documentation. This package provides a Python client for interacting with the Phoenix platform.
+Welcome to the Phoenix Client Reference documentation. This package provides a lightweight Python client for interacting with the Phoenix platform via its OpenAPI REST interface.
+
+## Installation
+
+Install the Phoenix Client using pip:
+
+```bash
+pip install arize-phoenix-client
+```
+
+## Quick Start
+
+```python
+from phoenix.client import Client
+
+# Connect to your Phoenix server
+client = Client(base_url="http://localhost:6006")  # Default Phoenix server URL
+
+# Or connect to Phoenix Cloud or other hosted instances
+client = Client(
+    base_url="https://your-phoenix-instance.com",
+    api_key="your-api-key"
+)
+```
+
+## Client Resources
+
+The Phoenix Client organizes its functionality into **resources** that correspond to different aspects of the Phoenix platform. Each resource provides methods to interact with specific entities:
+
+### Projects Resource
+Access and manage your Phoenix projects:
+```python
+# List all projects
+projects = client.projects.list()
+
+# Get a specific project
+project = client.projects.get(project_name="my-project")
+```
+
+### Prompts Resource
+Manage prompt templates and versions:
+```python
+# Create a new prompt
+prompt = client.prompts.create(
+    name="my-prompt",
+    version=PromptVersion(...)
+)
+
+# Retrieve and use prompts
+prompt = client.prompts.get(prompt_identifier="my-prompt")
+```
+
+### Spans Resource
+Query and analyze trace spans:
+```python
+# Get spans from a project
+spans = client.spans.list(project_name="my-project")
+```
+
+### Annotations Resource  
+Work with human feedback and evaluations:
+```python
+# Add annotations to spans
+client.annotations.create(...)
+```
+
+## Authentication
+
+### API Key Authentication
+Set your API key via environment variable:
+```bash
+export PHOENIX_API_KEY="your-api-key"
+```
+
+Or pass it directly to the client:
+```python
+client = Client(api_key="your-api-key")
+```
+
+### Custom Headers (Phoenix Cloud)
+For Phoenix Cloud or custom authentication:
+```bash
+export PHOENIX_CLIENT_HEADERS="api-key=your-api-key"
+```
+
+Or programmatically:
+```python
+client = Client(headers={"api-key": "your-api-key"})
+```
 
 ## External Links
 
@@ -8,7 +96,7 @@ Welcome to the Phoenix Client Reference documentation. This package provides a P
 - [Python Reference](https://arize-phoenix.readthedocs.io/)
 - [GitHub Repository](https://github.com/Arize-ai/phoenix)
 
-## API Definition
+## API Reference
 
 ```{toctree}
 :maxdepth: 2

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -1,11 +1,11 @@
-# Phoenix Client API Reference
+# Phoenix Client Reference
 
-Welcome to the Phoenix Client API Reference documentation. This package provides a Python client for interacting with the Phoenix platform.
+Welcome to the Phoenix Client Reference documentation. This package provides a Python client for interacting with the Phoenix platform.
 
 ## External Links
 
 - [Main Phoenix Documentation](https://arize.com/docs/phoenix)
-- [Phoenix API Reference](https://arize-phoenix.readthedocs.io/)
+- [Python Reference](https://arize-phoenix.readthedocs.io/)
 - [GitHub Repository](https://github.com/Arize-ai/phoenix)
 
 ## API Definition

--- a/packages/phoenix-evals/docs/source/conf.py
+++ b/packages/phoenix-evals/docs/source/conf.py
@@ -98,7 +98,7 @@ html_show_sphinx = False
 
 html_theme_options = {
     "logo": {
-        "text": "Phoenix Evals API",
+        "text": "Phoenix Evals",
         "image_light": "logo.png",
         "image_dark": "logo.png",
     },

--- a/packages/phoenix-evals/docs/source/conf.py
+++ b/packages/phoenix-evals/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(BASE_DIR, "src", "phoenix"))
 
 # -- Project information -----------------------------------------------------
 
-project = "Phoenix Evals API Reference"
+project = "Phoenix Evals Reference"
 copyright = "2025, Arize AI"
 author = "Arize AI"
 
@@ -115,8 +115,8 @@ html_theme_options = {
         },
     ],
     "external_links": [
-        {"name": "Main Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
-        {"name": "Phoenix API Reference", "url": "https://arize-phoenix.readthedocs.io/"},
+        {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
+        {"name": "Python Reference", "url": "https://arize-phoenix.readthedocs.io/"},
     ],
     "navbar_align": "content",
     "navbar_start": ["navbar-logo"],

--- a/packages/phoenix-evals/docs/source/index.md
+++ b/packages/phoenix-evals/docs/source/index.md
@@ -1,6 +1,107 @@
 # Phoenix Evals Reference
 
-Welcome to the Phoenix Evals Reference documentation. This package provides evaluation tools and utilities for LLM applications.
+Welcome to the Phoenix Evals Reference documentation. This package provides evaluation tools and utilities for LLM applications, including tools to determine relevance, toxicity, hallucination detection, and much more.
+
+## Installation
+
+Install the Phoenix Evals package using pip:
+
+```bash
+pip install arize-phoenix-evals
+```
+
+## Quick Start
+
+```python
+import os
+from phoenix.evals import (
+    RAG_RELEVANCY_PROMPT_TEMPLATE,
+    RAG_RELEVANCY_PROMPT_RAILS_MAP,
+    OpenAIModel,
+    llm_classify,
+)
+
+# Set your API key
+os.environ["OPENAI_API_KEY"] = "your-openai-key"
+
+# Create a model
+model = OpenAIModel(model="gpt-4", temperature=0.0)
+
+# Evaluate your data
+rails = list(RAG_RELEVANCY_PROMPT_RAILS_MAP.values())
+results = llm_classify(df, model, RAG_RELEVANCY_PROMPT_TEMPLATE, rails)
+```
+
+## Package Structure
+
+Phoenix Evals organizes its functionality into several key components:
+
+### Core Functions
+The main evaluation functions that power the package:
+- **`llm_classify`**: Classify data using LLM-based evaluation
+- **`llm_generate`**: Generate text-based evaluations  
+- **`run_evals`**: Run comprehensive evaluation suites
+
+### Evaluators
+Pre-built evaluators for common evaluation tasks:
+- **`RelevanceEvaluator`**: Assess relevance of retrieved documents
+- **`HallucinationEvaluator`**: Detect hallucinations in responses
+- **`ToxicityEvaluator`**: Identify toxic content
+- **`QAEvaluator`**: Evaluate question-answering quality
+- **`SummarizationEvaluator`**: Assess summarization quality
+- **`SQLEvaluator`**: Validate SQL query generation
+
+### Models
+Support for multiple LLM providers:
+- **`OpenAIModel`**: OpenAI GPT models
+- **`AnthropicModel`**: Anthropic Claude models
+- **`GeminiModel`**: Google Gemini models
+- **`VertexAIModel`**: Google Vertex AI models
+- **`BedrockModel`**: AWS Bedrock models
+- **`LiteLLMModel`**: Universal provider interface
+- **`MistralAIModel`**: Mistral AI models
+
+### Templates
+Prompt templates for evaluation tasks:
+- **`PromptTemplate`**: Base template class
+- **`ClassificationTemplate`**: Templates for classification tasks
+- Pre-built templates like `RAG_RELEVANCY_PROMPT_TEMPLATE`
+
+### Utilities
+Helper functions for evaluation workflows:
+- **`download_benchmark_dataset`**: Access benchmark datasets
+- **`compute_precisions_at_k`**: Calculate precision metrics
+
+## Usage Examples
+
+### RAG Relevance Evaluation
+```python
+from phoenix.evals import RelevanceEvaluator, OpenAIModel
+
+model = OpenAIModel(model="gpt-4")
+evaluator = RelevanceEvaluator(model=model)
+
+# Evaluate relevance of documents to queries
+results = evaluator.evaluate(
+    input=queries,
+    reference=documents
+)
+```
+
+### Hallucination Detection
+```python
+from phoenix.evals import HallucinationEvaluator, OpenAIModel
+
+model = OpenAIModel(model="gpt-4")
+evaluator = HallucinationEvaluator(model=model)
+
+# Check for hallucinations in responses
+results = evaluator.evaluate(
+    input=questions,
+    output=responses,
+    reference=contexts
+)
+```
 
 ## External Links
 
@@ -8,7 +109,7 @@ Welcome to the Phoenix Evals Reference documentation. This package provides eval
 - [Python Reference](https://arize-phoenix.readthedocs.io/)
 - [GitHub Repository](https://github.com/Arize-ai/phoenix)
 
-## API Definition
+## API Reference
 
 ```{toctree}
 :maxdepth: 2

--- a/packages/phoenix-evals/docs/source/index.md
+++ b/packages/phoenix-evals/docs/source/index.md
@@ -1,11 +1,11 @@
-# Phoenix Evals API Reference
+# Phoenix Evals Reference
 
-Welcome to the Phoenix Evals API Reference documentation. This package provides evaluation tools and utilities for LLM applications.
+Welcome to the Phoenix Evals Reference documentation. This package provides evaluation tools and utilities for LLM applications.
 
 ## External Links
 
 - [Main Phoenix Documentation](https://arize.com/docs/phoenix)
-- [Phoenix API Reference](https://arize-phoenix.readthedocs.io/)
+- [Python Reference](https://arize-phoenix.readthedocs.io/)
 - [GitHub Repository](https://github.com/Arize-ai/phoenix)
 
 ## API Definition

--- a/packages/phoenix-otel/docs/source/conf.py
+++ b/packages/phoenix-otel/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(BASE_DIR, "src", "phoenix"))
 
 # -- Project information -----------------------------------------------------
 
-project = "Phoenix OTEL API Reference"
+project = "Phoenix OTEL Reference"
 copyright = "2025, Arize AI"
 author = "Arize AI"
 
@@ -114,8 +114,8 @@ html_theme_options = {
         },
     ],
     "external_links": [
-        {"name": "Main Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
-        {"name": "Phoenix API Reference", "url": "https://arize-phoenix.readthedocs.io/"},
+        {"name": "Phoenix Docs", "url": "https://arize.com/docs/phoenix"},
+        {"name": "Python Reference", "url": "https://arize-phoenix.readthedocs.io/"},
     ],
     "navbar_align": "content",
     "navbar_start": ["navbar-logo"],

--- a/packages/phoenix-otel/docs/source/index.md
+++ b/packages/phoenix-otel/docs/source/index.md
@@ -1,6 +1,6 @@
-# Phoenix OTEL API Reference
+# Phoenix OTEL Reference
 
-Welcome to the Phoenix OTEL API reference documentation. This package provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-aware defaults.
+Welcome to the Phoenix OTEL reference documentation. This package provides a lightweight wrapper around OpenTelemetry primitives with Phoenix-aware defaults.
 
 ## Overview
 
@@ -55,6 +55,6 @@ api/otel
 ## External Links
 
 - [Main Phoenix Documentation](https://arize.com/docs/phoenix)
-- [Phoenix API Reference](https://arize-phoenix.readthedocs.io/)
+- [Python Reference](https://arize-phoenix.readthedocs.io/)
 - [GitHub Repository](https://github.com/Arize-ai/phoenix)
 - [PyPI Package](https://pypi.org/project/arize-phoenix-otel/) 


### PR DESCRIPTION
Applying Feedback left by @mikeldking on Slack and in #7956

### Changes Made

**Rename API references to avoid REST API confusion:**
- Phoenix API Reference → Phoenix Python Reference
- Phoenix OTEL API Reference → Phoenix OTEL Reference  
- Phoenix Client/Evals API Reference → Phoenix Client/Evals Reference
- Update navbar buttons: "Docs" → "Phoenix Docs", "Phoenix API Reference" → "Python Reference"

**Enhance phoenix-client documentation:**
- Add pip install instructions and quick start examples
- Clarify that projects/prompts/spans are accessed via `client.resources` pattern
- Add authentication examples and resource usage patterns

**Enhance phoenix-evals documentation:**
- Add pip install instructions and quick start example
- Explain package organization around evaluators, core functions, and templates
- Provide concrete usage examples for common evaluation tasks