### PR TITLE
fix: change session filter subquery to select distinct

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -335,9 +335,9 @@ class Project(Node):
             if time_range.end:
                 stmt = stmt.where(table.start_time < time_range.end)
         if filter_io_substring:
-            filter_subq = (
-                stmt.with_only_columns(distinct(table.id).label("id"))
-                .join_from(table, models.Trace)
+            filter_stmt = (
+                select(distinct(models.Trace.project_session_rowid).label("id"))
+                .filter_by(project_rowid=self.project_rowid)
                 .join_from(models.Trace, models.Span)
                 .where(models.Span.parent_id.is_(None))
                 .where(
@@ -352,7 +352,13 @@ class Project(Node):
                         ),
                     )
                 )
-            ).subquery()
+            )
+            if time_range:
+                if time_range.start:
+                    filter_stmt = filter_stmt.where(time_range.start <= models.Trace.start_time)
+                if time_range.end:
+                    filter_stmt = filter_stmt.where(models.Trace.start_time < time_range.end)
+            filter_subq = filter_stmt.subquery()
             stmt = stmt.join(filter_subq, table.id == filter_subq.c.id)
         if sort:
             key: ColumnElement[Any]


### PR DESCRIPTION
This change eliminates the join to project_sessions after a user reported that PostgreSQL's query planner was generating an inefficient execution plan. We tested several alternative approaches on the user's PostgreSQL instance, and the query in this PR delivered the best runtime. Note that I was not able to reproduce the issue on my machine--all the different queries we tested performed similarly on my local PostgreSQL instance.