### PR TITLE
feat: publish major and minor version tags to docker

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -73,12 +73,14 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: |
+            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0]) || '' }}
+            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}.{3}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], split(env.VERSION, '.')[1]) || '' }}
             ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, env.VERSION) || '' }}
-            ${{ matrix.variant == 'nonroot' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
-            ${{ matrix.variant == 'debug' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
             ${{ matrix.variant == 'root' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'nonroot' && format('{0}/{1}:latest-nonroot', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant == 'debug' && format('{0}/{1}:latest-debug', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], matrix.variant) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}.{3}-{4}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], split(env.VERSION, '.')[1], matrix.variant) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:latest-{2}', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}


### PR DESCRIPTION
This publishes major and minor version tags to docker so you can indicate a preferred version without locking to a patch.

Fixes #8031

## Summary by Sourcery

Publish major and minor Docker tags by enhancing tag generation logic in the docker-build-release CI workflow, allowing semantic version tagging without tying to specific patch releases.

New Features:
- Publish Docker image tags for major versions (version-X) and minor versions (version-X.Y).

Enhancements:
- Extend tag generation for non-root and debug variants to include major and minor version tags alongside full and latest tags.

CI:
- Update docker-build-release GitHub Actions workflow to generate and push the new tags.