### PR TITLE
feat(helm): enable zero downtime rollouts

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -57,9 +57,27 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | database.postgres.schema | string | `""` | PostgreSQL schema to use (PHOENIX_SQL_DATABASE_SCHEMA) |
 | database.postgres.user | string | `"postgres"` | PostgreSQL username (PHOENIX_POSTGRES_USER) |
 | database.url | string | `""` | Full database connection URL (overrides postgres settings if provided), recommend to disable postgres if using own |
+| deployment.strategy.maxSurge | string | `"25%"` | Maximum number of pods that can be created above desired replica count during update (can be absolute number or percentage) |
+| deployment.strategy.maxUnavailable | string | `"25%"` | Maximum number of pods that can be unavailable during update (can be absolute number or percentage) |
+| healthChecks.livenessProbe.failureThreshold | int | `3` | Number of failures before container is restarted |
+| healthChecks.livenessProbe.initialDelaySeconds | int | `0` | Initial delay before liveness probe starts |
+| healthChecks.livenessProbe.periodSeconds | int | `10` | How often to perform the liveness probe |
+| healthChecks.livenessProbe.successThreshold | int | `1` | Number of consecutive successes for the probe to be considered successful |
+| healthChecks.livenessProbe.timeoutSeconds | int | `5` | Timeout for liveness probe |
+| healthChecks.readinessProbe.failureThreshold | int | `3` | Number of failures before pod is marked unready |
+| healthChecks.readinessProbe.initialDelaySeconds | int | `0` | Initial delay before readiness probe starts |
+| healthChecks.readinessProbe.periodSeconds | int | `5` | How often to perform the readiness probe |
+| healthChecks.readinessProbe.successThreshold | int | `1` | Number of consecutive successes for the probe to be considered successful |
+| healthChecks.readinessProbe.timeoutSeconds | int | `3` | Timeout for readiness probe |
+| healthChecks.startupProbe.enabled | bool | `true` | Enable startup probe |
+| healthChecks.startupProbe.failureThreshold | int | `30` | Number of failures before container is considered failed to start |
+| healthChecks.startupProbe.initialDelaySeconds | int | `1` | Initial delay before startup probe starts |
+| healthChecks.startupProbe.periodSeconds | int | `1` | How often to perform the startup probe |
+| healthChecks.startupProbe.successThreshold | int | `1` | Number of consecutive successes for the probe to be considered successful |
+| healthChecks.startupProbe.timeoutSeconds | int | `1` | Timeout for startup probe |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Phoenix container (Always, IfNotPresent, or Never) |
 | image.repository | string | `"arizephoenix/phoenix"` | Docker image repository for Phoenix |
-| image.tag | string | `"version-10.5.0-nonroot"` | Docker image tag/version to deploy |
+| image.tag | string | `"version-10.11.0-nonroot"` | Docker image tag/version to deploy |
 | ingress.annotations | object | `{}` | Annotations to add to the ingress resource |
 | ingress.apiPath | string | `"/"` | Path prefix for the Phoenix API |
 | ingress.enabled | bool | `true` | Enable ingress controller for external access |
@@ -97,6 +115,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | postgresql.primary.persistentVolumeClaimRetentionPolicy.whenDeleted | string | `"Retain"` | Volume retention behavior that applies when the StatefulSet is deleted |
 | postgresql.primary.persistentVolumeClaimRetentionPolicy.whenScaled | string | `"Retain"` | Volume retention behavior when the replica count of the StatefulSet is reduced |
 | postgresql.primary.service.ports.postgresql | string | `"5432"` | Port to run postgres service on |
+| replicaCount | int | `2` | Number of Phoenix pod replicas (set to 2+ for zero downtime updates) |
 | server.annotations | object | `{}` | Annotations to add to the Phoenix service |
 | server.enablePrometheus | bool | `false` | Enable Prometheus metrics endpoint on port 9090 |
 | server.grpcPort | int | `4317` | Port for OpenTelemetry gRPC collector (PHOENIX_GRPC_PORT) |

--- a/helm/README.md
+++ b/helm/README.md
@@ -115,7 +115,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | postgresql.primary.persistentVolumeClaimRetentionPolicy.whenDeleted | string | `"Retain"` | Volume retention behavior that applies when the StatefulSet is deleted |
 | postgresql.primary.persistentVolumeClaimRetentionPolicy.whenScaled | string | `"Retain"` | Volume retention behavior when the replica count of the StatefulSet is reduced |
 | postgresql.primary.service.ports.postgresql | string | `"5432"` | Port to run postgres service on |
-| replicaCount | int | `2` | Number of Phoenix pod replicas (set to 2+ for zero downtime updates) |
+| replicaCount | int | `1` | Number of Phoenix pod replicas |
 | server.annotations | object | `{}` | Annotations to add to the Phoenix service |
 | server.enablePrometheus | bool | `false` | Enable Prometheus metrics endpoint on port 9090 |
 | server.grpcPort | int | `4317` | Port for OpenTelemetry gRPC collector (PHOENIX_GRPC_PORT) |

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
 spec:
-  replicas: {{ .Values.replicaCount | default 2 }}
+  replicas: {{ .Values.replicaCount | default 1 }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -9,7 +9,12 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
 spec:
-  replicas: {{ .Values.replicaCount | default 1 }}
+  replicas: {{ .Values.replicaCount | default 2 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.deployment.strategy.maxUnavailable | default "25%" }}
+      maxSurge: {{ .Values.deployment.strategy.maxSurge | default "25%" }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}
@@ -26,6 +31,35 @@ spec:
             - containerPort: {{ .Values.server.port | default 6006 }}
             - containerPort: 9090
             - containerPort: {{ .Values.server.grpcPort | default 4317 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.server.port | default 6006 }}
+            initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.healthChecks.livenessProbe.failureThreshold | default 3 }}
+            successThreshold: {{ .Values.healthChecks.livenessProbe.successThreshold | default 1 }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ .Values.server.port | default 6006 }}
+            initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds | default 3 }}
+            failureThreshold: {{ .Values.healthChecks.readinessProbe.failureThreshold | default 3 }}
+            successThreshold: {{ .Values.healthChecks.readinessProbe.successThreshold | default 1 }}
+          {{- if .Values.healthChecks.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.server.port | default 6006 }}
+            initialDelaySeconds: {{ .Values.healthChecks.startupProbe.initialDelaySeconds | default 1 }}
+            periodSeconds: {{ .Values.healthChecks.startupProbe.periodSeconds | default 1 }}
+            timeoutSeconds: {{ .Values.healthChecks.startupProbe.timeoutSeconds | default 1 }}
+            failureThreshold: {{ .Values.healthChecks.startupProbe.failureThreshold | default 30 }}
+            successThreshold: {{ .Values.healthChecks.startupProbe.successThreshold | default 1 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-configmap

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,7 +3,7 @@
 # Each value corresponds to an environment variable described in https://arize.com/docs/phoenix/self-hosting/configuration.
 
 # Replica count
-# -- Number of Phoenix pod replicas (set to 2+ for zero downtime updates)
+# -- Number of Phoenix pod replicas
 replicaCount: 1
 
 # Deployment strategy

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,18 @@
 # This file contains configuration values for deploying Phoenix via Helm.
 # Each value corresponds to an environment variable described in https://arize.com/docs/phoenix/self-hosting/configuration.
 
+# Replica count
+# -- Number of Phoenix pod replicas (set to 2+ for zero downtime updates)
+replicaCount: 2
+
+# Deployment strategy
+deployment:
+  strategy:
+    # -- Maximum number of pods that can be unavailable during update (can be absolute number or percentage)
+    maxUnavailable: "25%"
+    # -- Maximum number of pods that can be created above desired replica count during update
+    maxSurge: "25%"
+
 # ADDONS
 # - Ingress
 # - Postgres
@@ -290,3 +302,41 @@ image:
 
   # -- Docker image tag/version to deploy
   tag: version-10.11.0-nonroot
+
+# Health check configuration
+healthChecks:
+  livenessProbe:
+    # -- Initial delay before liveness probe starts
+    initialDelaySeconds: 0
+    # -- How often to perform the liveness probe
+    periodSeconds: 10
+    # -- Timeout for liveness probe
+    timeoutSeconds: 5
+    # -- Number of failures before container is restarted
+    failureThreshold: 3
+    # -- Number of consecutive successes for the probe to be considered successful
+    successThreshold: 1
+  readinessProbe:
+    # -- Initial delay before readiness probe starts
+    initialDelaySeconds: 0
+    # -- How often to perform the readiness probe
+    periodSeconds: 5
+    # -- Timeout for readiness probe
+    timeoutSeconds: 3
+    # -- Number of failures before pod is marked unready
+    failureThreshold: 3
+    # -- Number of consecutive successes for the probe to be considered successful
+    successThreshold: 1
+  startupProbe:
+    # -- Enable startup probe
+    enabled: true
+    # -- Initial delay before startup probe starts
+    initialDelaySeconds: 1
+    # -- How often to perform the startup probe
+    periodSeconds: 1
+    # -- Timeout for startup probe
+    timeoutSeconds: 1
+    # -- Number of failures before container is considered failed to start
+    failureThreshold: 30
+    # -- Number of consecutive successes for the probe to be considered successful
+    successThreshold: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 # Replica count
 # -- Number of Phoenix pod replicas (set to 2+ for zero downtime updates)
-replicaCount: 2
+replicaCount: 1
 
 # Deployment strategy
 deployment:


### PR DESCRIPTION
I noticed that there is a brief downtime every time I change the helm chart configuration.

Looking into the helm chart, I found it lacks proper health check configuration. Which results in the container being immediately considered as available, even if the process has not started yet.

I also added a deployment strategy and exposed values to configure it to the user needs. The defined values are the defaults in Kubernetes, if you omit the whole section.

Hope this change helps to improve the self-hosting experience of phoenix.
Thanks for the great work! :)

## Summary by Sourcery

Enable zero downtime rollouts in the Helm chart by adding a rolling update deployment strategy, default replica count, and configurable health checks.

New Features:
- Introduce a RollingUpdate deployment strategy with user-configurable maxUnavailable and maxSurge values
- Expose replicaCount (default 2) to support multiple pods for zero downtime updates
- Add configurable liveness, readiness, and startup probes with sensible defaults

Documentation:
- Update Helm README to document new deployment.strategy, replicaCount, and healthChecks values