### PR TITLE
feat(cost): metrics tab behind a feature flag

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -75,6 +75,7 @@ import {
   ProfilePage,
   ProjectIndexPage,
   projectLoader,
+  ProjectMetricsPage,
   ProjectPage,
   ProjectSessionsPage,
   ProjectsPage,
@@ -187,6 +188,7 @@ const router = createBrowserRouter(
                   />
                 </Route>
                 <Route path="config" element={<ProjectConfigPage />} />
+                <Route path="metrics" element={<ProjectMetricsPage />} />
               </Route>
             </Route>
           </Route>

--- a/app/src/contexts/FeatureFlagsContext.tsx
+++ b/app/src/contexts/FeatureFlagsContext.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContainer, Switch } from "@arizeai/components";
 
 import { View } from "@phoenix/components";
 
-type FeatureFlag = "dashboards";
+type FeatureFlag = "dashboards" | "projectMetricsTab";
 export type FeatureFlagsContextType = {
   featureFlags: Record<FeatureFlag, boolean>;
   setFeatureFlags: (featureFlags: Record<FeatureFlag, boolean>) => void;
@@ -15,6 +15,7 @@ export const LOCAL_STORAGE_FEATURE_FLAGS_KEY = "arize-phoenix-feature-flags";
 
 const DEFAULT_FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
   dashboards: false,
+  projectMetricsTab: false,
 };
 
 function getFeatureFlags(): Record<FeatureFlag, boolean> {

--- a/app/src/pages/project/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/ProjectMetricsPage.tsx
@@ -1,0 +1,122 @@
+import { Layouts, Responsive, WidthProvider } from "react-grid-layout";
+import { css } from "@emotion/react";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const layouts: Layouts = {
+  lg: [
+    { i: "feedback", x: 0, y: 0, w: 6, h: 4 },
+    { i: "traces", x: 6, y: 0, w: 6, h: 4 },
+    { i: "duration", x: 0, y: 4, w: 6, h: 4 },
+    { i: "tokens", x: 6, y: 4, w: 6, h: 4 },
+    { i: "cost", x: 0, y: 8, w: 12, h: 4 },
+  ],
+};
+
+import { forwardRef } from "react";
+
+import { Heading, Text, View } from "@phoenix/components";
+
+interface MetricPanelHeaderProps {
+  title: string;
+  subtitle?: string;
+}
+
+function MetricPanelHeader({ title, subtitle }: MetricPanelHeaderProps) {
+  return (
+    <div
+      css={css`
+        padding: var(--ac-global-dimension-size-100)
+          var(--ac-global-dimension-size-200);
+        border-bottom: 1px solid var(--ac-global-color-grey-200);
+        display: flex;
+        flex-direction: row;
+        gap: var(--ac-global-dimension-size-100);
+      `}
+      className="dashboard-panel-header"
+    >
+      <Heading>{title}</Heading>
+      {subtitle && <Text>{subtitle}</Text>}
+    </div>
+  );
+}
+
+interface MetricPanelProps extends MetricPanelHeaderProps {
+  children: React.ReactNode;
+}
+
+export const MetricPanel = forwardRef(function MetricPanel(
+  { title, children }: MetricPanelProps,
+  ref: React.Ref<HTMLDivElement>
+) {
+  return (
+    <View
+      borderWidth="thin"
+      borderColor="dark"
+      borderRadius="medium"
+      height="100%"
+      width="100%"
+      data-testid={`dashboard-panel`}
+      backgroundColor="grey-75"
+      ref={ref}
+    >
+      <MetricPanelHeader title={title} />
+      {children}
+    </View>
+  );
+});
+
+export function ProjectMetricsPage() {
+  return (
+    <main
+      css={css`
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+        overflow-y: auto;
+        flex: 1 1 auto;
+      `}
+    >
+      <ResponsiveGridLayout
+        className="layout"
+        layouts={layouts}
+        breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+        cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
+        rowHeight={80}
+        containerPadding={[16, 16]}
+        isResizable={false}
+        isDraggable={false}
+        draggableHandle=".dashboard-panel-header"
+      >
+        <div key="feedback">
+          <MetricPanel title="Feedback scores" subtitle="Daily averages">
+            {"Feedback scores chart goes here"}
+          </MetricPanel>
+        </div>
+        <div key="traces">
+          <MetricPanel title="Number of traces" subtitle="Daily totals">
+            {"Number of traces chart goes here"}
+          </MetricPanel>
+        </div>
+        <div key="duration">
+          <MetricPanel title="Duration" subtitle="Daily quantiles in seconds">
+            {"Duration chart goes here"}
+          </MetricPanel>
+        </div>
+        <div key="tokens">
+          <MetricPanel title="Token usage" subtitle="Daily totals">
+            {"Token usage chart goes here"}
+          </MetricPanel>
+        </div>
+        <div key="cost">
+          <MetricPanel
+            title="Estimated cost"
+            subtitle="Total daily cost in USD"
+          >
+            {"Estimated cost chart goes here"}
+          </MetricPanel>
+        </div>
+      </ResponsiveGridLayout>
+    </main>
+  );
+}

--- a/app/src/pages/project/ProjectPage.tsx
+++ b/app/src/pages/project/ProjectPage.tsx
@@ -21,6 +21,7 @@ import {
   ConnectedLastNTimeRangePicker,
   useTimeRange,
 } from "@phoenix/components/datetime";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { useProjectContext } from "@phoenix/contexts/ProjectContext";
 import { StreamStateProvider } from "@phoenix/contexts/StreamStateContext";
 import { useProjectRootPath } from "@phoenix/hooks/useProjectRootPath";
@@ -81,7 +82,7 @@ export function ProjectPage() {
   );
 }
 
-const TABS = ["spans", "traces", "sessions", "config"] as const;
+const TABS = ["spans", "traces", "sessions", "config", "metrics"] as const;
 
 /**
  * Type guard for the tab path in the URL
@@ -95,6 +96,7 @@ const TAB_INDEX_MAP: Record<(typeof TABS)[number], number> = {
   traces: 1,
   sessions: 2,
   config: 3,
+  metrics: 4,
 };
 
 export function ProjectPageContent({
@@ -149,6 +151,7 @@ export function ProjectPageContent({
     ProjectPageQueriesProjectConfigQuery
   );
   const tabIndex = isTab(tab) ? TAB_INDEX_MAP[tab] : 0;
+  const showMetricsTab = useFeatureFlag("projectMetricsTab");
   useEffect(() => {
     if (tabIndex === 0) {
       loadSpansQuery({
@@ -205,6 +208,9 @@ export function ProjectPageContent({
         } else if (index === 3) {
           // navigate to the config tab
           navigate(`${rootPath}/config`);
+        } else if (index === 4) {
+          // navigate to the metrics tab
+          navigate(`${rootPath}/metrics`);
         } else {
           // navigate to the spans tab
           navigate(`${rootPath}/spans`);
@@ -247,6 +253,7 @@ export function ProjectPageContent({
               <Tab id="traces">Traces</Tab>
               <Tab id="sessions">Sessions</Tab>
               <Tab id="config">Config</Tab>
+              {showMetricsTab ? <Tab id="metrics">Metrics</Tab> : null}
             </TabList>
             <LazyTabPanel padded={false} id="spans">
               <Outlet />
@@ -258,6 +265,9 @@ export function ProjectPageContent({
               <Outlet />
             </LazyTabPanel>
             <LazyTabPanel padded={false} id="config">
+              <Outlet />
+            </LazyTabPanel>
+            <LazyTabPanel padded={false} id="metrics">
               <Outlet />
             </LazyTabPanel>
           </Tabs>

--- a/app/src/pages/project/index.tsx
+++ b/app/src/pages/project/index.tsx
@@ -4,3 +4,4 @@ export * from "./ProjectSessionsPage";
 export * from "./ProjectSpansPage";
 export * from "./ProjectTracesPage";
 export * from "./projectLoader";
+export * from "./ProjectMetricsPage";


### PR DESCRIPTION
resolves #8081 
<img width="1925" alt="Screenshot 2025-06-13 at 4 43 15 PM" src="https://github.com/user-attachments/assets/aed811cb-5137-43b9-ac49-dc3db488bdc9" />

## Summary by Sourcery

Introduce end-to-end cost tracking and reporting, including new database tables, GraphQL schema changes, data loaders, and UI components, and expose a Metrics tab behind a feature flag.

New Features:
- Compute and persist token-level cost per span in a new span_costs table.
- Define configurable model cost metadata in new models and model_costs tables with CRUD GraphQL mutations and settings UI.
- Expose a unified `TokenCost` type and cost fields on `Span`, `Project`, and `Model` in the GraphQL API.
- Display total and breakdown of costs in the project header and spans table.
- Add a new Metrics tab to the project view (hidden by default via the `projectMetricsTab` feature flag) with dashboard panels including estimated cost charts.

Enhancements:
- Split GraphQL model types into `Model`, `InferenceModel`, and `ModelInterface` and refactor resolvers to load costs.
- Implement Alembic migration for cost tables and update bulk inserter and facilitator to seed cost data during ingestion.
- Add DataLoaders for span, token, and model total costs and wire them into the server context.
- Introduce `formatCost` formatter for dollar values and adapt UI components to use it.

Tests:
- Update `test_cost_lookup` unit tests to account for the new `model_id` field in `ModelTokenCost`.