### PR TITLE
feat: read OTEL_EXPORTER_OTLP_ENDPOINT when PHOENIX_COLLECTOR_ENDPOINT is missing

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/constants.py
+++ b/packages/phoenix-client/src/phoenix/client/constants.py
@@ -4,6 +4,8 @@ DEFAULT_TIMEOUT = httpx.Timeout(timeout=600.0, connect=5.0)
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=1000, max_keepalive_connections=100)
 
+ENV_OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
 # Phoenix environment variables
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_GRPC_PORT = "PHOENIX_GRPC_PORT"

--- a/packages/phoenix-client/src/phoenix/client/utils/config.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/config.py
@@ -4,6 +4,7 @@ from typing import Optional, overload
 import httpx
 
 from phoenix.client.constants import (
+    ENV_OTEL_EXPORTER_OTLP_ENDPOINT,
     ENV_PHOENIX_API_KEY,
     ENV_PHOENIX_CLIENT_HEADERS,
     ENV_PHOENIX_COLLECTOR_ENDPOINT,
@@ -61,7 +62,7 @@ def get_env_client_headers() -> dict[str, str]:
 
 
 def get_env_collector_endpoint() -> Optional[str]:
-    return getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)
+    return getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
 
 
 def get_base_url() -> httpx.URL:

--- a/packages/phoenix-client/tests/phoenix/client/utils/test_config.py
+++ b/packages/phoenix-client/tests/phoenix/client/utils/test_config.py
@@ -1,0 +1,27 @@
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from phoenix.client.utils.config import get_env_collector_endpoint
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        ({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        (
+            {
+                "PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            },
+            "http://localhost:6006",
+        ),
+        ({}, None),
+    ],
+)
+def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]) -> None:
+    with patch.dict(os.environ, env, clear=True):
+        assert get_env_collector_endpoint() == expected

--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -6,7 +6,9 @@ from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Environment variables specific to the subpackage
+ENV_OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+# Phoenix environment variables
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
 ENV_PHOENIX_GRPC_PORT = "PHOENIX_GRPC_PORT"
 ENV_PHOENIX_PROJECT_NAME = "PHOENIX_PROJECT_NAME"
@@ -20,7 +22,7 @@ See https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-default-port"""
 
 
 def get_env_collector_endpoint() -> Optional[str]:
-    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)
+    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or os.getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
 
 
 def get_env_project_name() -> str:

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -1,0 +1,27 @@
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from phoenix.otel.otel import get_env_collector_endpoint
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        ({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        (
+            {
+                "PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            },
+            "http://localhost:6006",
+        ),
+        ({}, None),
+    ],
+)
+def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]) -> None:
+    with patch.dict(os.environ, env, clear=True):
+        assert get_env_collector_endpoint() == expected

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from phoenix.otel.otel import get_env_collector_endpoint
+from phoenix.otel.settings import get_env_collector_endpoint
 
 
 @pytest.mark.parametrize(

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+ENV_OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
 # Phoenix environment variables
 ENV_PHOENIX_PORT = "PHOENIX_PORT"
 ENV_PHOENIX_GRPC_PORT = "PHOENIX_GRPC_PORT"
@@ -1271,7 +1273,7 @@ def get_env_host_root_path() -> str:
 
 
 def get_env_collector_endpoint() -> Optional[str]:
-    return getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)
+    return getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
 
 
 def get_env_project_name() -> str:

--- a/src/phoenix/tests/test_config.py
+++ b/src/phoenix/tests/test_config.py
@@ -1,0 +1,27 @@
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from phoenix.config import get_env_collector_endpoint
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        ({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:6006"}, "http://localhost:6006"),
+        (
+            {
+                "PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:6006",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+            },
+            "http://localhost:6006",
+        ),
+        ({}, None),
+    ],
+)
+def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]) -> None:
+    with patch.dict(os.environ, env, clear=True):
+        assert get_env_collector_endpoint() == expected


### PR DESCRIPTION
This allows less configuration for those who set OTEL_EXPORTER_OTLP_ENDPOINT to the same HTTP url as phoenix OTLP (e.g. http://localhost:6006)

fixes #8061

## Summary by Sourcery

Use OTEL_EXPORTER_OTLP_ENDPOINT as a fallback for the collector endpoint when PHOENIX_COLLECTOR_ENDPOINT is missing, and add corresponding unit tests to ensure correct behavior.

New Features:
- Fallback to OTEL_EXPORTER_OTLP_ENDPOINT when PHOENIX_COLLECTOR_ENDPOINT is not set in both server and client configurations

Enhancements:
- Introduce ENV_OTEL_EXPORTER_OTLP_ENDPOINT constant in server and client codebases

Tests:
- Add unit tests to verify get_env_collector_endpoint respects the new OTEL_EXPORTER_OTLP_ENDPOINT fallback in both server and client