### PR TITLE
ci: fix docker build by removing missing split function

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_ENV
           echo "VERSION=${GITHUB_REF#refs/tags/arize-phoenix-v}" >> $GITHUB_OUTPUT
+          echo "MAJOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f1)" >> $GITHUB_ENV
+          echo "MINOR_VERSION=$(echo ${GITHUB_REF#refs/tags/arize-phoenix-v} | cut -d. -f2)" >> $GITHUB_ENV
 
       - name: Set BASE_IMAGE environment variable
         id: set-base-image
@@ -73,12 +75,12 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: |
-            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0]) || '' }}
-            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}.{3}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], split(env.VERSION, '.')[1]) || '' }}
+            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION) || '' }}
+            ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}.{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION) || '' }}
             ${{ matrix.variant == 'root' && format('{0}/{1}:version-{2}', env.REGISTRY, env.IMAGE_NAME, env.VERSION) || '' }}
             ${{ matrix.variant == 'root' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], matrix.variant) || '' }}
-            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}.{3}-{4}', env.REGISTRY, env.IMAGE_NAME, split(env.VERSION, '.')[0], split(env.VERSION, '.')[1], matrix.variant) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, matrix.variant) || '' }}
+            ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}.{3}-{4}', env.REGISTRY, env.IMAGE_NAME, env.MAJOR_VERSION, env.MINOR_VERSION, matrix.variant) || '' }}
             ${{ matrix.variant != 'root' && format('{0}/{1}:version-{2}-{3}', env.REGISTRY, env.IMAGE_NAME, env.VERSION, matrix.variant) || '' }}
             ${{ matrix.variant != 'root' && format('{0}/{1}:latest-{2}', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary by Sourcery

Fix the Docker build release workflow by extracting version components from the Git tag and updating image tag formatting to remove the unsupported split function.

CI:
- Add MAJOR_VERSION and MINOR_VERSION environment variables by parsing the Git tag ref with cut
- Replace split() calls in Docker image tag definitions with the new MAJOR_VERSION and MINOR_VERSION variables