### PR TITLE
fix: chunk deletion of project sessions

### DIFF
--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -50,13 +50,12 @@ class ProjectMutationMixin:
             session_ids_to_delete = [
                 id_ for id_ in set(deleted_trace_project_session_ids) if id_ is not None
             ]
-            if session_ids_to_delete:
-                # Process deletions in chunks of 10000 to avoid PostgreSQL argument limit
-                chunk_size = 10000
-                for i in range(0, len(session_ids_to_delete), chunk_size):
-                    chunk = session_ids_to_delete[i : i + chunk_size]
-                    await session.execute(
-                        delete(models.ProjectSession).where(models.ProjectSession.id.in_(chunk))
-                    )
+            # Process deletions in chunks of 10000 to avoid PostgreSQL argument limit
+            chunk_size = 10000
+            for i in range(0, len(session_ids_to_delete), chunk_size):
+                chunk = session_ids_to_delete[i : i + chunk_size]
+                await session.execute(
+                    delete(models.ProjectSession).where(models.ProjectSession.id.in_(chunk))
+                )
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -46,16 +46,18 @@ class ProjectMutationMixin:
         if input.end_time:
             delete_statement = delete_statement.where(models.Trace.start_time < input.end_time)
         async with info.context.db() as session:
-            deleted_trace_project_session_ids = (await session.scalars(delete_statement)).all()
-            if deleted_trace_project_session_ids:
+            deleted_trace_project_session_ids = await session.scalars(delete_statement)
+            # Filter out None values and convert to set for efficient lookups
+            session_ids_to_delete = {
+                id for id in deleted_trace_project_session_ids if id is not None
+            }
+            if session_ids_to_delete:
                 # Process deletions in chunks of 10000 to avoid PostgreSQL argument limit
                 chunk_size = 10000
-                for i in range(0, len(deleted_trace_project_session_ids), chunk_size):
-                    chunk = deleted_trace_project_session_ids[i : i + chunk_size]
+                for i in range(0, len(session_ids_to_delete), chunk_size):
+                    chunk = list(session_ids_to_delete)[i : i + chunk_size]
                     await session.execute(
-                        delete(models.ProjectSession).where(
-                            models.ProjectSession.id.in_(set(chunk))
-                        )
+                        delete(models.ProjectSession).where(models.ProjectSession.id.in_(chunk))
                     )
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()

--- a/src/phoenix/server/api/mutations/project_mutations.py
+++ b/src/phoenix/server/api/mutations/project_mutations.py
@@ -52,10 +52,9 @@ class ProjectMutationMixin:
             ]
             # Process deletions in chunks of 10000 to avoid PostgreSQL argument limit
             chunk_size = 10000
+            stmt = delete(models.ProjectSession)
             for i in range(0, len(session_ids_to_delete), chunk_size):
                 chunk = session_ids_to_delete[i : i + chunk_size]
-                await session.execute(
-                    delete(models.ProjectSession).where(models.ProjectSession.id.in_(chunk))
-                )
+                await session.execute(stmt.where(models.ProjectSession.id.in_(chunk)))
         info.context.event_queue.put(SpanDeleteEvent((project_id,)))
         return Query()

--- a/tests/unit/server/api/mutations/test_project_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_mutations.py
@@ -104,6 +104,10 @@ class TestProjectMutations:
             newest_trace = await session.get(models.Trace, traces[0].id)
             assert newest_trace is not None, "Newest trace should remain"
 
+            # The newest project session should remain since its trace remains
+            newest_session = await session.get(models.ProjectSession, project_sessions[0].id)
+            assert newest_session is not None, "Newest project session should remain"
+
             # The two oldest traces and their sessions should be deleted since they're
             # before end_time
             for i in range(1, n):

--- a/tests/unit/server/api/mutations/test_project_mutations.py
+++ b/tests/unit/server/api/mutations/test_project_mutations.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+from ....graphql import AsyncGraphQLClient
+
+
+class TestProjectMutations:
+    async def test_clear_project(
+        self,
+        db: DbSessionFactory,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        """Test the clear_project mutation's selective deletion functionality.
+
+        This test verifies the clear_project mutation's ability to:
+        1. Delete traces that start before the specified end_time
+        2. Preserve traces that start after the specified end_time
+        3. Delete project sessions when all their associated traces are deleted
+        4. Handle traces without associated sessions correctly
+
+        Test Setup:
+        - Creates a project
+        - Creates three traces with different timestamps:
+          * Trace 0 (newest): At base_start_time
+          * Trace 1: At base_start_time - 1 day
+          * Trace 2 (oldest): At base_start_time - 2 days
+        - Creates project sessions for Trace 0 and Trace 1
+        - Sets end_time to base_start_time - 12 hours to test selective deletion
+
+        Expected Results:
+        - Trace 0 and its session should be preserved (after end_time)
+        - Trace 1, Trace 2, and their sessions should be deleted (before end_time)
+        """  # noqa: E501
+        project_name = token_hex(8)
+        traces: list[models.Trace] = []
+        project_sessions: list[models.ProjectSession] = []
+        async with db() as session:
+            # Create a new project
+            project = models.Project(name=project_name)
+            session.add(project)
+            await session.flush()
+
+            # Create three traces with different timestamps
+            n = 3  # Number of traces to create
+            base_start_time = datetime.now(timezone.utc)
+            for i in range(n):
+                start_time = base_start_time - timedelta(days=i)
+                if i == n - 1:
+                    # Last trace has no associated session
+                    project_session_id = None
+                else:
+                    # Create a project session for the first two traces
+                    project_session = models.ProjectSession(
+                        project_id=project.id,
+                        session_id=token_hex(8),
+                        start_time=start_time,
+                        end_time=start_time + timedelta(hours=1),
+                    )
+                    project_sessions.append(project_session)
+                    session.add(project_session)
+                    await session.flush()
+                    project_session_id = project_session.id
+
+                # Create a trace
+                trace = models.Trace(
+                    project_rowid=project.id,
+                    trace_id=token_hex(16),
+                    start_time=start_time,
+                    end_time=start_time + timedelta(hours=1),
+                    project_session_rowid=project_session_id,
+                )
+                traces.append(trace)
+                session.add(trace)
+                await session.flush()
+
+        # Execute clear_project mutation with end_time between the newest and second newest traces
+        # This should delete the two oldest traces and their sessions, but preserve the newest trace
+        end_time = base_start_time - timedelta(hours=12)  # 12 hours after the second newest trace
+        result = await gql_client.execute(
+            query="""
+            mutation($input: ClearProjectInput!) {
+                clearProject(input: $input) {
+                    __typename
+                }
+            }
+            """,
+            variables={
+                "input": {
+                    "id": str(GlobalID("Project", str(project.id))),
+                    "endTime": end_time.isoformat(),
+                }
+            },
+        )
+        assert not result.errors
+
+        # Verify the results
+        async with db() as session:
+            # The newest trace should remain since it's after end_time
+            newest_trace = await session.get(models.Trace, traces[0].id)
+            assert newest_trace is not None, "Newest trace should remain"
+
+            # The two oldest traces and their sessions should be deleted since they're
+            # before end_time
+            for i in range(1, n):
+                old_trace = await session.get(models.Trace, traces[i].id)
+                assert old_trace is None, f"Trace {i} should be deleted"
+
+                if i < n - 1:
+                    session_obj = await session.get(models.ProjectSession, project_sessions[i].id)
+                    assert session_obj is None, f"Session {i} should be deleted"


### PR DESCRIPTION
resolves #8096

## Summary by Sourcery

Fix the ClearProject mutation to batch-delete ProjectSession records in 10,000-ID chunks and properly collect deletion IDs as a list

Bug Fixes:
- Convert trace project session IDs to a list before deletion
- Process session deletions in 10,000‐ID chunks to avoid PostgreSQL argument limits