### PR TITLE
fix(cost): display cost for playground runs over a dataset

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -95,6 +95,7 @@ import {
   extractVariablesFromInstance,
   getChatCompletionOverDatasetInput,
 } from "./playgroundUtils";
+import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
 
 const PAGE_SIZE = 10;
 
@@ -371,12 +372,16 @@ const MemoizedExampleOutputCell = memo(function ExampleOutputCell({
 });
 
 function SpanMetadata({ span }: { span: Span }) {
+  const totalCost = span.cost?.total;
   return (
     <Flex direction="row" gap="size-100" alignItems="center">
       <TokenCount
         tokenCountTotal={span.tokenCountTotal || 0}
         nodeId={span.id}
       />
+      {totalCost != null && (
+        <TokenCosts totalCost={totalCost} nodeId={span.id} />
+      )}
       <LatencyText latencyMs={span.latencyMs || 0} />
     </Flex>
   );
@@ -997,6 +1002,9 @@ graphql`
         span {
           id
           tokenCountTotal
+          cost {
+            total
+          }
           latencyMs
           project {
             id
@@ -1038,6 +1046,9 @@ graphql`
             span {
               id
               tokenCountTotal
+              cost {
+                total
+              }
               latencyMs
               project {
                 id

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -52,6 +52,7 @@ import { JSONText } from "@phoenix/components/code/JSONText";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { SELECTED_SPAN_NODE_ID_PARAM } from "@phoenix/constants/searchParams";
 import { useNotifyError } from "@phoenix/contexts";
@@ -95,7 +96,6 @@ import {
   extractVariablesFromInstance,
   getChatCompletionOverDatasetInput,
 } from "./playgroundUtils";
-import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
 
 const PAGE_SIZE = 10;
 

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bc70cb511fb085bcad8b42f945780758>>
+ * @generated SignedSource<<4a55359b8f9165c92cb542c16246d28b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,6 +75,9 @@ export type PlaygroundDatasetExamplesTableMutation$data = {
           readonly context: {
             readonly traceId: string;
           };
+          readonly cost: {
+            readonly total: number | null;
+          } | null;
           readonly id: string;
           readonly latencyMs: number | null;
           readonly project: {
@@ -229,6 +232,24 @@ v3 = [
                       {
                         "alias": null,
                         "args": null,
+                        "concreteType": "TokenCost",
+                        "kind": "LinkedField",
+                        "name": "cost",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "total",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "kind": "ScalarField",
                         "name": "latencyMs",
                         "storageKey": null
@@ -335,16 +356,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "a5d1d9b9e0ebf2f32f8398b5bca3b281",
+    "cacheID": "8462a4e51fe119bfd6721b44ea644bd6",
     "id": null,
     "metadata": {},
     "name": "PlaygroundDatasetExamplesTableMutation",
     "operationKind": "mutation",
-    "text": "mutation PlaygroundDatasetExamplesTableMutation(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    experimentId\n    examples {\n      datasetExampleId\n      experimentRunId\n      result {\n        __typename\n        ... on ChatCompletionMutationError {\n          message\n        }\n        ... on ChatCompletionMutationPayload {\n          content\n          errorMessage\n          span {\n            id\n            tokenCountTotal\n            latencyMs\n            project {\n              id\n            }\n            context {\n              traceId\n            }\n          }\n          toolCalls {\n            id\n            function {\n              name\n              arguments\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation PlaygroundDatasetExamplesTableMutation(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    experimentId\n    examples {\n      datasetExampleId\n      experimentRunId\n      result {\n        __typename\n        ... on ChatCompletionMutationError {\n          message\n        }\n        ... on ChatCompletionMutationPayload {\n          content\n          errorMessage\n          span {\n            id\n            tokenCountTotal\n            cost {\n              total\n            }\n            latencyMs\n            project {\n              id\n            }\n            context {\n              traceId\n            }\n          }\n          toolCalls {\n            id\n            function {\n              name\n              arguments\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4ecdd2ca5fbbdf4a9ae185fa02f8b013";
+(node as any).hash = "c93b6beaa17a375bda37093da5fbd32d";
 
 export default node;

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cab1f1a8831b7127a8c85028a69943b6>>
+ * @generated SignedSource<<4be3eabe43713738fe23453d76147073>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,6 +78,9 @@ export type PlaygroundDatasetExamplesTableSubscription$data = {
       readonly context: {
         readonly traceId: string;
       };
+      readonly cost: {
+        readonly total: number | null;
+      } | null;
       readonly id: string;
       readonly latencyMs: number | null;
       readonly project: {
@@ -244,6 +247,24 @@ v4 = [
               {
                 "alias": null,
                 "args": null,
+                "concreteType": "TokenCost",
+                "kind": "LinkedField",
+                "name": "cost",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "total",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "kind": "ScalarField",
                 "name": "latencyMs",
                 "storageKey": null
@@ -330,16 +351,16 @@ return {
     "selections": (v4/*: any*/)
   },
   "params": {
-    "cacheID": "bb84c1ad8f99fe16260cf38ec9dee07b",
+    "cacheID": "2e2072b28f6f44528460a0ed06351d01",
     "id": null,
     "metadata": {},
     "name": "PlaygroundDatasetExamplesTableSubscription",
     "operationKind": "subscription",
-    "text": "subscription PlaygroundDatasetExamplesTableSubscription(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    ... on TextChunk {\n      content\n      datasetExampleId\n    }\n    ... on ToolCallChunk {\n      id\n      datasetExampleId\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionExperiment {\n      experiment {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      datasetExampleId\n      span {\n        id\n        tokenCountTotal\n        latencyMs\n        project {\n          id\n        }\n        context {\n          traceId\n        }\n      }\n      experimentRun {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      datasetExampleId\n      message\n    }\n  }\n}\n"
+    "text": "subscription PlaygroundDatasetExamplesTableSubscription(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    ... on TextChunk {\n      content\n      datasetExampleId\n    }\n    ... on ToolCallChunk {\n      id\n      datasetExampleId\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionExperiment {\n      experiment {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      datasetExampleId\n      span {\n        id\n        tokenCountTotal\n        cost {\n          total\n        }\n        latencyMs\n        project {\n          id\n        }\n        context {\n          traceId\n        }\n      }\n      experimentRun {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      datasetExampleId\n      message\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b6c2a6c5c219eec0eb92826f7df62d24";
+(node as any).hash = "f3537f757880e5c6db9299cab3819452";
 
 export default node;


### PR DESCRIPTION


https://github.com/user-attachments/assets/65f49779-b350-4d9f-a83e-bca1f23de7fa



resolves #8048

## Summary by Sourcery

Implement end-to-end cost tracking and display by introducing database support for LLM model pricing and span costs, integrating cost calculation into ingestion and playground flows, exposing cost details in the GraphQL API and UI, and providing CRUD operations for managing model cost configurations.

New Features:
- Persist and expose per-span token cost breakdown (input, output, prompt, completion, audio, cache, reasoning, and total) in the database and GraphQL schema
- Add CRUD GraphQL mutations and DB models (GenerativeModel, ModelCost) to configure and manage generative model token pricing
- Extend the UI (project header, spans table, playground runs, settings) to display cost metrics and interactive cost breakdowns
- Introduce a metrics dashboard page skeleton (ProjectMetricsPage) for visualizing cost data

Enhancements:
- Refactor cost lookup to load pricing patterns from the database with override support and asynchronous initialization
- Introduce DataLoaders for token costs, span costs, and model total costs with two-tier caching for efficient query performance
- Add Alembic migration to create cost-related tables (generative_models, model_costs, span_costs)

Tests:
- Update unit tests for cost lookup to include model_id in ModelTokenCost
- Add integration tests for GraphQL model mutations (create, update, delete) with cost validation