### PR TITLE
fix: Ensure experiment and example dialogs have consistent behavior / styles

### DIFF
--- a/app/src/pages/example/EditExampleButton.tsx
+++ b/app/src/pages/example/EditExampleButton.tsx
@@ -1,41 +1,33 @@
-import { ReactNode, useState } from "react";
-
-import { DialogContainer } from "@arizeai/components";
-
-import { Button, Icon, Icons } from "@phoenix/components";
+import {
+  Button,
+  DialogTrigger,
+  Icon,
+  Icons,
+  Modal,
+  ModalOverlay,
+} from "@phoenix/components";
 
 import { EditExampleDialog, EditExampleDialogProps } from "./EditExampleDialog";
 
 type EditExampleButtonProps = EditExampleDialogProps;
+
 export function EditExampleButton(props: EditExampleButtonProps) {
   const { onCompleted, ...dialogProps } = props;
-  const [dialog, setDialog] = useState<ReactNode>(null);
   return (
-    <>
-      <Button
-        size="S"
-        leadingVisual={<Icon svg={<Icons.EditOutline />} />}
-        onPress={() =>
-          setDialog(
-            <EditExampleDialog
-              {...dialogProps}
-              onCompleted={() => {
-                setDialog(null);
-                onCompleted();
-              }}
-            />
-          )
-        }
-      >
+    <DialogTrigger>
+      <Button size="S" leadingVisual={<Icon svg={<Icons.EditOutline />} />}>
         Edit Example
       </Button>
-      <DialogContainer
-        type="slideOver"
-        isDismissable
-        onDismiss={() => setDialog(null)}
-      >
-        {dialog}
-      </DialogContainer>
-    </>
+      <ModalOverlay>
+        <Modal variant="slideover" size="L">
+          <EditExampleDialog
+            {...dialogProps}
+            onCompleted={() => {
+              onCompleted();
+            }}
+          />
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   );
 }

--- a/app/src/pages/example/ExampleDetailsDialog.tsx
+++ b/app/src/pages/example/ExampleDetailsDialog.tsx
@@ -8,16 +8,14 @@ import { Card, CardProps } from "@arizeai/components";
 import {
   CopyToClipboardButton,
   Dialog,
+  DialogCloseButton,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogTitleExtra,
-  DialogTrigger,
   Flex,
   Heading,
   LinkButton,
-  Modal,
-  ModalOverlay,
   View,
 } from "@phoenix/components";
 import { JSONBlock } from "@phoenix/components/code";
@@ -32,13 +30,7 @@ import { ExampleExperimentRunsTable } from "./ExampleExperimentRunsTable";
 /**
  * A Slide-over that shows the details of a dataset example.
  */
-export function ExampleDetailsDialog({
-  exampleId,
-  onDismiss,
-}: {
-  exampleId: string;
-  onDismiss: () => void;
-}) {
+export function ExampleDetailsDialog({ exampleId }: { exampleId: string }) {
   const [fetchKey, setFetchKey] = useState(0);
   const data = useLazyLoadQuery<ExampleDetailsDialogQuery>(
     graphql`
@@ -91,110 +83,90 @@ export function ExampleDetailsDialog({
   const { input, output, metadata } = revision;
   const notifySuccess = useNotifySuccess();
   return (
-    <DialogTrigger
-      isOpen
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          onDismiss();
-        }
-      }}
-    >
-      <ModalOverlay>
-        <Modal size="L" variant="slideover">
-          <Dialog>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Example: {exampleId}</DialogTitle>
-                <DialogTitleExtra>
-                  <Flex direction="row" gap="size-100">
-                    {sourceSpanInfo ? (
-                      <LinkButton
-                        size="S"
-                        to={`/projects/${sourceSpanInfo.projectId}/traces/${sourceSpanInfo.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${sourceSpanInfo.id}`}
-                      >
-                        View Source Span
-                      </LinkButton>
-                    ) : null}
-                    <EditExampleButton
-                      exampleId={exampleId as string}
-                      currentRevision={revision}
-                      onCompleted={() => {
-                        notifySuccess({
-                          title: "Example updated",
-                          message: `Example ${exampleId} has been updated.`,
-                        });
-                        setFetchKey((key) => key + 1);
-                      }}
-                    />
-                  </Flex>
-                </DialogTitleExtra>
-              </DialogHeader>
-              <PanelGroup direction="vertical" autoSaveId="example-panel-group">
-                <Panel defaultSize={65}>
-                  <div
-                    css={css`
-                      overflow-y: auto;
-                      height: 100%;
-                    `}
-                  >
-                    <Flex direction="row" justifyContent="center">
-                      <View
-                        width="900px"
-                        paddingStart="auto"
-                        paddingEnd="auto"
-                        paddingTop="size-200"
-                        paddingBottom="size-200"
-                      >
-                        <Flex direction="column" gap="size-200">
-                          <Card
-                            title="Input"
-                            {...defaultCardProps}
-                            extra={<CopyToClipboardButton text={input} />}
-                          >
-                            <JSONBlock value={input} />
-                          </Card>
-                          <Card
-                            title="Output"
-                            {...defaultCardProps}
-                            extra={<CopyToClipboardButton text={output} />}
-                          >
-                            <JSONBlock value={output} />
-                          </Card>
-                          <Card
-                            title="Metadata"
-                            {...defaultCardProps}
-                            extra={<CopyToClipboardButton text={metadata} />}
-                          >
-                            <JSONBlock value={metadata} />
-                          </Card>
-                        </Flex>
-                      </View>
-                    </Flex>
-                  </div>
-                </Panel>
-                <PanelResizeHandle css={resizeHandleCSS} />
-                <Panel defaultSize={35}>
-                  <Flex direction="column" height="100%">
-                    <View
-                      paddingStart="size-200"
-                      paddingEnd="size-200"
-                      paddingTop="size-100"
-                      paddingBottom="size-100"
-                      borderBottomColor="dark"
-                      borderBottomWidth="thin"
-                      flex="none"
+    <Dialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Example: {exampleId}</DialogTitle>
+          <DialogTitleExtra>
+            {sourceSpanInfo ? (
+              <LinkButton
+                size="S"
+                to={`/projects/${sourceSpanInfo.projectId}/traces/${sourceSpanInfo.traceId}?${SELECTED_SPAN_NODE_ID_PARAM}=${sourceSpanInfo.id}`}
+              >
+                View Source Span
+              </LinkButton>
+            ) : null}
+            <EditExampleButton
+              exampleId={exampleId as string}
+              currentRevision={revision}
+              onCompleted={() => {
+                notifySuccess({
+                  title: "Example updated",
+                  message: `Example ${exampleId} has been updated.`,
+                });
+                setFetchKey((key) => key + 1);
+              }}
+            />
+            <DialogCloseButton />
+          </DialogTitleExtra>
+        </DialogHeader>
+        <PanelGroup direction="vertical" autoSaveId="example-panel-group">
+          <Panel defaultSize={65}>
+            <div
+              css={css`
+                overflow-y: auto;
+                height: 100%;
+              `}
+            >
+              <Flex direction="row" justifyContent="center">
+                <View width="900px" padding="size-200">
+                  <Flex direction="column" gap="size-200">
+                    <Card
+                      title="Input"
+                      {...defaultCardProps}
+                      extra={<CopyToClipboardButton text={input} />}
                     >
-                      <Heading level={3}>Experiment Runs</Heading>
-                    </View>
-                    <ExampleExperimentRunsTable example={data.example} />
+                      <JSONBlock value={input} />
+                    </Card>
+                    <Card
+                      title="Output"
+                      {...defaultCardProps}
+                      extra={<CopyToClipboardButton text={output} />}
+                    >
+                      <JSONBlock value={output} />
+                    </Card>
+                    <Card
+                      title="Metadata"
+                      {...defaultCardProps}
+                      extra={<CopyToClipboardButton text={metadata} />}
+                    >
+                      <JSONBlock value={metadata} />
+                    </Card>
                   </Flex>
-                </Panel>
-              </PanelGroup>
-            </DialogContent>
-          </Dialog>
-        </Modal>
-      </ModalOverlay>
-    </DialogTrigger>
+                </View>
+              </Flex>
+            </div>
+          </Panel>
+          <PanelResizeHandle css={resizeHandleCSS} />
+          <Panel defaultSize={35}>
+            <Flex direction="column" height="100%">
+              <View
+                paddingStart="size-200"
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderBottomColor="dark"
+                borderBottomWidth="thin"
+                flex="none"
+              >
+                <Heading level={3}>Experiment Runs</Heading>
+              </View>
+              <ExampleExperimentRunsTable example={data.example} />
+            </Flex>
+          </Panel>
+        </PanelGroup>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/app/src/pages/example/ExamplePage.tsx
+++ b/app/src/pages/example/ExamplePage.tsx
@@ -1,4 +1,8 @@
+import { Suspense } from "react";
+import { DialogTrigger } from "react-aria-components";
 import { useNavigate, useParams } from "react-router";
+
+import { Loading, Modal, ModalOverlay } from "@phoenix/components";
 
 import { ExampleDetailsDialog } from "./ExampleDetailsDialog";
 
@@ -9,11 +13,21 @@ export function ExamplePage() {
   const { exampleId, datasetId } = useParams();
   const navigate = useNavigate();
   return (
-    <ExampleDetailsDialog
-      exampleId={exampleId as string}
-      onDismiss={() => {
-        navigate(`/datasets/${datasetId}/examples`);
+    <DialogTrigger
+      isOpen
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          navigate(`/datasets/${datasetId}/examples`);
+        }
       }}
-    />
+    >
+      <ModalOverlay>
+        <Modal variant="slideover" size="L">
+          <Suspense fallback={<Loading />}>
+            <ExampleDetailsDialog exampleId={exampleId as string} />
+          </Suspense>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   );
 }

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -21,7 +21,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
-import { ActionMenu, Card, CardProps, Item } from "@arizeai/components";
+import { Card, CardProps } from "@arizeai/components";
 
 import {
   Button,
@@ -33,8 +33,11 @@ import {
   Heading,
   Icon,
   Icons,
+  ListBox,
+  ListBoxItem,
   Modal,
   ModalOverlay,
+  Popover,
   Text,
   View,
   ViewSummaryAside,
@@ -283,11 +286,10 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                     View Example
                   </Button>
                   <ModalOverlay>
-                    <Modal variant="slideover" size="fullscreen">
+                    <Modal variant="slideover" size="L">
                       <Suspense>
                         <ExampleDetailsDialog
                           exampleId={row.original.example.id}
-                          onDismiss={() => {}}
                         />
                       </Suspense>
                     </Modal>
@@ -683,33 +685,46 @@ function ExperimentRowActionMenu(props: {
         e.stopPropagation();
       }}
     >
-      <ActionMenu
-        buttonSize="compact"
-        align="end"
-        onAction={(firedAction) => {
-          const action = firedAction as ExperimentRowAction;
-          switch (action) {
-            case ExperimentRowAction.GO_TO_EXAMPLE: {
-              return navigate(`/datasets/${datasetId}/examples/${exampleId}`);
-            }
-            default: {
-              assertUnreachable(action);
-            }
-          }
-        }}
-      >
-        <Item key={ExperimentRowAction.GO_TO_EXAMPLE}>
-          <Flex
-            direction={"row"}
-            gap="size-75"
-            justifyContent={"start"}
-            alignItems={"center"}
-          >
-            <Icon svg={<Icons.ExternalLinkOutline />} />
-            <Text>Go to example</Text>
-          </Flex>
-        </Item>
-      </ActionMenu>
+      <DialogTrigger>
+        <Button
+          size="S"
+          leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
+        />
+        <Popover>
+          <Dialog>
+            {({ close }) => (
+              <ListBox
+                style={{ minHeight: "auto" }}
+                onAction={(firedAction) => {
+                  const action = firedAction as ExperimentRowAction;
+                  switch (action) {
+                    case ExperimentRowAction.GO_TO_EXAMPLE: {
+                      navigate(`/datasets/${datasetId}/examples/${exampleId}`);
+                      break;
+                    }
+                    default: {
+                      assertUnreachable(action);
+                    }
+                  }
+                  close();
+                }}
+              >
+                <ListBoxItem id={ExperimentRowAction.GO_TO_EXAMPLE}>
+                  <Flex
+                    direction="row"
+                    gap="size-75"
+                    justifyContent="start"
+                    alignItems="center"
+                  >
+                    <Icon svg={<Icons.ExternalLinkOutline />} />
+                    <Text>Go to example</Text>
+                  </Flex>
+                </ListBoxItem>
+              </ListBox>
+            )}
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
     </div>
   );
 }
@@ -1049,6 +1064,7 @@ function TraceDetailsDialog({
           <DialogTitle>{title}</DialogTitle>
           <DialogTitleExtra>
             <Button
+              size="S"
               onPress={() =>
                 navigate(`/projects/${projectId}/traces/${traceId}`)
               }

--- a/app/src/pages/playground/PlaygroundExamplePage.tsx
+++ b/app/src/pages/playground/PlaygroundExamplePage.tsx
@@ -1,4 +1,8 @@
+import { Suspense } from "react";
+import { DialogTrigger } from "react-aria-components";
 import { useSearchParams } from "react-router";
+
+import { Loading, Modal, ModalOverlay } from "@phoenix/components";
 
 import { ExampleDetailsDialog } from "../example/ExampleDetailsDialog";
 
@@ -13,14 +17,24 @@ export function PlaygroundExamplePage() {
     return null;
   }
   return (
-    <ExampleDetailsDialog
-      exampleId={exampleId as string}
-      onDismiss={() => {
-        setSearchParams((prev) => {
-          prev.delete("exampleId");
-          return prev;
-        });
+    <DialogTrigger
+      isOpen
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          setSearchParams((prev) => {
+            prev.delete("exampleId");
+            return prev;
+          });
+        }
       }}
-    />
+    >
+      <ModalOverlay>
+        <Modal variant="slideover" size="L">
+          <Suspense fallback={<Loading />}>
+            <ExampleDetailsDialog exampleId={exampleId as string} />
+          </Suspense>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   );
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/e014345a-3e4d-4694-9cac-d113e68aa90c

## Summary by Sourcery

Standardize dialog behavior and styling across example and experiment pages and refactor action menus for consistency

Enhancements:
- Standardize slide-over dialogs for examples and edits using DialogTrigger, ModalOverlay, and fixed size
- Add DialogCloseButton and onOpenChange handlers to replace manual dismiss props
- Unify modal variant and size for experiment example viewer to "slideover" size "L"
- Refactor experiment row action menu to use Popover + ListBox within a DialogTrigger
- Consistently apply button sizes for dialog triggers and navigation actions
- Remove custom DialogContainer from EditExampleButton in favor of common dialog pattern