### PR TITLE
fix(cost): raise error on model name collision

### DIFF
--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -333,6 +333,35 @@ class TestModelMutations:
         assert result.errors[0].message == "Cannot update default model"
         assert result.data is None
 
+    async def test_updating_model_to_conflicting_name_fails_with_expected_error(
+        self,
+        gql_client: AsyncGraphQLClient,
+        default_model: models.GenerativeModel,
+        custom_model: models.GenerativeModel,
+    ) -> None:
+        model_id = str(GlobalID(GenerativeModel.__name__, str(custom_model.id)))
+        variables = {
+            "input": {
+                "id": model_id,
+                "name": "default-model",  # conflicts with the default_model name
+                "provider": "anthropic",
+                "namePattern": "claude-*",
+                "costs": [
+                    {"tokenType": "input", "costPerToken": 0.003},
+                    {"tokenType": "output", "costPerToken": 0.004},
+                ],
+            }
+        }
+
+        result = await gql_client.execute(
+            query=self.QUERY,
+            variables=variables,
+            operation_name="UpdateModelMutation",
+        )
+        assert len(result.errors) == 1
+        assert result.errors[0].message == "Model with name 'default-model' already exists"
+        assert result.data is None
+
     @pytest.mark.parametrize(
         "variables,expected_error_message",
         [
@@ -411,6 +440,33 @@ async def default_model(db: DbSessionFactory) -> models.GenerativeModel:
                 models.ModelCost(
                     token_type="output",
                     cost_per_token=0.002,
+                ),
+            ],
+        )
+        session.add(model)
+        await session.flush()
+    return model
+
+
+@pytest.fixture
+async def custom_model(db: DbSessionFactory) -> models.GenerativeModel:
+    """
+    Inserts a custom model with input and output costs.
+    """
+    async with db() as session:
+        model = models.GenerativeModel(
+            name="custom-model",
+            provider="anthropic",
+            name_pattern="claude-*",
+            is_override=True,
+            costs=[
+                models.ModelCost(
+                    token_type="input",
+                    cost_per_token=0.003,
+                ),
+                models.ModelCost(
+                    token_type="output",
+                    cost_per_token=0.004,
                 ),
             ],
         )

--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -190,6 +190,21 @@ class TestModelMutations:
                 "output cost is required",
                 id="missing-output-cost",
             ),
+            pytest.param(
+                {
+                    "input": {
+                        "name": "default-model",
+                        "provider": "openai",
+                        "namePattern": "gpt-*",
+                        "costs": [
+                            {"tokenType": "input", "costPerToken": 0.001},
+                            {"tokenType": "output", "costPerToken": 0.002},
+                        ],
+                    }
+                },
+                "Model with name 'default-model' already exists",
+                id="duplicate-default-model",
+            ),
         ],
     )
     async def test_create_model_with_invalid_input_raises_expected_error(
@@ -197,6 +212,7 @@ class TestModelMutations:
         gql_client: AsyncGraphQLClient,
         variables: dict[str, Any],
         expected_error_message: str,
+        default_model: models.GenerativeModel,
     ) -> None:
         result = await gql_client.execute(
             query=self.QUERY,


### PR DESCRIPTION
resolves #8040

## Summary by Sourcery

Implement end-to-end cost tracking for generative workloads by introducing persistent model definitions with per-token pricing, calculating and storing span‐level token/audio costs, aggregating project costs, and raising errors on duplicate model names.

New Features:
- Persist generative models and per-token costs in new DB tables and calculate span-level costs
- Expose GraphQL CRUD mutations (createModel, updateModel, deleteModel) for managing model cost configurations
- Add cost fields to GraphQL types for Span, Project, and Query and surface total/prompt/completion costs in UI components
- Introduce settings UI to list, add, edit, clone, and delete cost models

Bug Fixes:
- Enforce unique generative model names and raise Conflict on name collisions

Enhancements:
- Refactor cost lookup to load patterns and overrides from the database instead of static JSON
- Add DataLoaders for efficient batch loading of span and project token costs
- Rename and reorganize ModelPage to ModelInferencesPage and introduce a feature-flagged metrics tab

Deployment:
- Add Alembic migration to create generative_models, model_costs, and span_costs tables

Tests:
- Add unit tests for cost lookup behavior and model mutation operations