### PR TITLE
feat: playground move metrics to top

### DIFF
--- a/app/src/components/table/CellTop.tsx
+++ b/app/src/components/table/CellTop.tsx
@@ -1,0 +1,25 @@
+import { PropsWithChildren } from "react";
+
+import { Flex, View } from "@phoenix/components";
+
+/**
+ * A component that renders a row at the top of a table cell
+ */
+export function CellTop({
+  children,
+}: PropsWithChildren<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <View
+      paddingX="size-100"
+      paddingY="size-50"
+      borderBottomWidth="thin"
+      borderColor="grey-100"
+    >
+      <Flex direction="row" gap="size-100" alignItems="center">
+        {children}
+      </Flex>
+    </View>
+  );
+}

--- a/app/src/components/table/index.tsx
+++ b/app/src/components/table/index.tsx
@@ -8,3 +8,4 @@ export * from "./CellWithControlsWrapper";
 export * from "./LoadMoreRow";
 export * from "./TableEmpty";
 export * from "./TableEmptyWrap";
+export * from "./CellTop";

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -155,7 +155,7 @@ const cellWithControlsWrapCSS = css`
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   height: 100%;
   min-height: 75px;
   .controls {
@@ -321,6 +321,7 @@ function ExampleOutputContent({
 
   return (
     <CellWithControlsWrap controls={spanControls}>
+      {hasSpan ? <SpanMetadata span={span} /> : null}
       <View padding="size-200">
         <Flex direction={"column"} gap="size-200">
           {errorMessage != null ? (
@@ -334,7 +335,6 @@ function ExampleOutputContent({
                 )
               )
             : null}
-          {hasSpan ? <SpanMetadata span={span} /> : null}
         </Flex>
       </View>
     </CellWithControlsWrap>
@@ -374,16 +374,23 @@ const MemoizedExampleOutputCell = memo(function ExampleOutputCell({
 function SpanMetadata({ span }: { span: Span }) {
   const totalCost = span.cost?.total;
   return (
-    <Flex direction="row" gap="size-100" alignItems="center">
-      <TokenCount
-        tokenCountTotal={span.tokenCountTotal || 0}
-        nodeId={span.id}
-      />
-      {totalCost != null && (
-        <TokenCosts totalCost={totalCost} nodeId={span.id} />
-      )}
-      <LatencyText latencyMs={span.latencyMs || 0} />
-    </Flex>
+    <View
+      paddingX="size-100"
+      paddingY="size-50"
+      borderBottomWidth="thin"
+      borderColor="grey-100"
+    >
+      <Flex direction="row" gap="size-100" alignItems="center">
+        <LatencyText latencyMs={span.latencyMs || 0} size="S" />
+        <TokenCount
+          tokenCountTotal={span.tokenCountTotal || 0}
+          nodeId={span.id}
+        />
+        {totalCost != null && (
+          <TokenCosts totalCost={totalCost} nodeId={span.id} />
+        )}
+      </Flex>
+    </View>
   );
 }
 

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -49,6 +49,7 @@ import {
 } from "@phoenix/components";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
 import { JSONText } from "@phoenix/components/code/JSONText";
+import { CellTop } from "@phoenix/components/table";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
@@ -176,7 +177,7 @@ const cellWithControlsWrapCSS = css`
 
 const cellControlsCSS = css`
   position: absolute;
-  top: -4px;
+  top: calc(-1 * var(--ac-global-dimension-static-size-200));
   right: var(--ac-global-dimension-static-size-100);
   display: flex;
   flex-direction: row;
@@ -374,23 +375,16 @@ const MemoizedExampleOutputCell = memo(function ExampleOutputCell({
 function SpanMetadata({ span }: { span: Span }) {
   const totalCost = span.cost?.total;
   return (
-    <View
-      paddingX="size-100"
-      paddingY="size-50"
-      borderBottomWidth="thin"
-      borderColor="grey-100"
-    >
-      <Flex direction="row" gap="size-100" alignItems="center">
-        <LatencyText latencyMs={span.latencyMs || 0} size="S" />
-        <TokenCount
-          tokenCountTotal={span.tokenCountTotal || 0}
-          nodeId={span.id}
-        />
-        {totalCost != null && (
-          <TokenCosts totalCost={totalCost} nodeId={span.id} />
-        )}
-      </Flex>
-    </View>
+    <CellTop>
+      <LatencyText latencyMs={span.latencyMs || 0} size="S" />
+      <TokenCount
+        tokenCountTotal={span.tokenCountTotal || 0}
+        nodeId={span.id}
+      />
+      {totalCost != null && (
+        <TokenCosts totalCost={totalCost} nodeId={span.id} />
+      )}
+    </CellTop>
   );
 }
 


### PR DESCRIPTION
resolves #8085

<img width="1785" alt="Screenshot 2025-06-18 at 8 41 43 AM" src="https://github.com/user-attachments/assets/ae84d79a-869c-4c31-8b0b-9fdb295e6a0a" />


## Summary by Sourcery

Move span metrics to the top of the playground example output cells and refine their layout and styling

Enhancements:
- Align the cell controls wrapper to the top (flex-start) instead of center
- Render span metadata only once at the top of each example output cell
- Wrap span metadata in a padded container with a bottom border, reorder metrics (latency first) and adjust latency text size