### PR TITLE
feat(cost): move actions into the headers in playground

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -975,7 +975,7 @@ export const derivedCSS = (theme: ThemeContextType["theme"]) => css`
 
     --ac-highlight-foreground: var(--ac-global-text-color-900);
     --ac-highlight-background: var(--ac-global-color-primary-100);
-    --ac-hover-background: var(--ac-global-color-primary-50);
+    --ac-hover-background: var(--ac-global-color-primary-100);
     --ac-focus-ring-color: var(--ac-global-color-primary-500);
 
     // Text

--- a/app/src/components/button/IconButton.tsx
+++ b/app/src/components/button/IconButton.tsx
@@ -1,0 +1,112 @@
+import { ReactNode } from "react";
+import { Button, ButtonProps } from "react-aria-components";
+import { css, SerializedStyles } from "@emotion/react";
+
+import { ColorValue, TextColorValue } from "../types";
+import { ComponentSize } from "../types/sizing";
+import { colorValue } from "../utils";
+
+const getIconButtonColor = (color: TextColorValue): string => {
+  if (color === "inherit") {
+    return "inherit";
+  }
+  if (color.startsWith("text-")) {
+    const [, num] = color.split("-");
+    return `var(--ac-global-text-color-${num})`;
+  }
+  return colorValue(color as ColorValue);
+};
+
+export interface IconButtonProps extends Omit<ButtonProps, "children"> {
+  /**
+   * The size of the button
+   * @default 'M'
+   */
+  size?: Omit<ComponentSize, "L">;
+  /**
+   * The icon to display
+   */
+  children: ReactNode;
+  /**
+   * The color of the button and icon
+   * @default 'text-700'
+   */
+  color?: TextColorValue;
+  /**
+   * Custom CSS styles
+   */
+  css?: SerializedStyles;
+}
+
+const iconButtonCSS = (color: TextColorValue) => css`
+  --icon-button-font-size-s: var(--ac-global-font-size-l);
+  --icon-button-font-size-m: var(--ac-global-font-size-xl);
+  --icon-button-font-size-l: var(--ac-global-font-size-2xl);
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: var(--ac-global-border-size-thin) solid transparent;
+  border-radius: var(--ac-global-rounding-small);
+  color: ${getIconButtonColor(color)};
+  background-color: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+
+  &[data-size="S"] {
+    width: 30px;
+    height: 30px;
+    .ac-icon-wrap {
+      font-size: var(--icon-button-font-size-s);
+    }
+  }
+
+  &[data-size="M"] {
+    width: 38px;
+    height: 38px;
+    .ac-icon-wrap {
+      font-size: var(--icon-button-font-size-m);
+    }
+  }
+
+  .ac-icon-wrap {
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+  }
+
+  &[data-hovered] {
+    background-color: var(--ac-hover-background);
+    .ac-icon-wrap {
+      opacity: 1;
+    }
+  }
+
+  &[data-pressed] {
+    background-color: var(--ac-global-color-primary-100);
+    color: var(--ac-global-text-color-900);
+  }
+
+  &[data-focus-visible] {
+    outline: var(--ac-global-border-size-thick) solid var(--ac-focus-ring-color);
+    outline-offset: var(--ac-global-border-offset-thin);
+  }
+
+  &[data-disabled] {
+    opacity: var(--ac-global-opacity-disabled);
+    cursor: not-allowed;
+  }
+`;
+
+export function IconButton({
+  size = "M",
+  color = "text-700",
+  children,
+  ...props
+}: IconButtonProps) {
+  return (
+    <Button css={iconButtonCSS(color)} data-size={size} {...props}>
+      {children}
+    </Button>
+  );
+}

--- a/app/src/components/button/index.tsx
+++ b/app/src/components/button/index.tsx
@@ -1,5 +1,6 @@
 export * from "./Button";
 export * from "./LinkButton";
 export * from "./ExternalLinkButton";
+export * from "./IconButton";
 export type * from "./types";
 export * from "./styles";

--- a/app/src/components/table/CellTop.tsx
+++ b/app/src/components/table/CellTop.tsx
@@ -1,25 +1,58 @@
-import { PropsWithChildren } from "react";
-
-import { Flex, View } from "@phoenix/components";
+import { ReactNode } from "react";
+import { css } from "@emotion/react";
 
 /**
  * A component that renders a row at the top of a table cell
  */
 export function CellTop({
   children,
-}: PropsWithChildren<{
-  children: React.ReactNode;
-}>) {
+  extra,
+}: {
+  children?: ReactNode;
+  /**
+   * Additional content like controls that will be placed on the right
+   */
+  extra?: ReactNode;
+}) {
   return (
-    <View
-      paddingX="size-100"
-      paddingY="size-50"
-      borderBottomWidth="thin"
-      borderColor="grey-100"
-    >
-      <Flex direction="row" gap="size-100" alignItems="center">
-        {children}
-      </Flex>
-    </View>
+    <div css={cellTopCSS}>
+      <div css={childrenWrapCSS}>{children}</div>
+      <div css={extraCSS}>{extra}</div>
+    </div>
   );
 }
+
+const cellTopCSS = css`
+  padding: 0 var(--ac-global-dimension-static-size-100) 0
+    var(--ac-global-dimension-static-size-200);
+  border-bottom: var(--ac-global-border-size-thin) solid
+    var(--ac-global-color-grey-200);
+  background-color: var(--ac-global-color-grey-50);
+  min-height: 39px;
+  display: flex;
+  flex-direction: row;
+  gap: var(--ac-global-dimension-static-size-100);
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  flex: none;
+`;
+
+const childrenWrapCSS = css`
+  height: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+`;
+
+const extraCSS = css`
+  display: flex;
+  flex-direction: row;
+  gap: var(--ac-global-dimension-static-size-50);
+  align-items: center;
+  flex: none;
+`;

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -78,9 +78,6 @@ export const tableCSS = css`
           border-bottom: 1px solid var(--ac-global-border-color-default);
         }
       }
-      &:hover {
-        background-color: rgba(var(--ac-global-color-grey-300-rgb), 0.3);
-      }
       & > td {
         padding: var(--ac-global-dimension-size-100)
           var(--ac-global-dimension-size-200);
@@ -105,8 +102,19 @@ export const borderedTableCSS = css`
   }
 `;
 
+export const interactiveTableCSS = css`
+  tbody:not(.is-empty) {
+    tr {
+      &:hover {
+        background-color: var(--ac-hover-background);
+      }
+    }
+  }
+`;
+
 export const selectableTableCSS = css(
   tableCSS,
+  interactiveTableCSS,
   css`
     tbody:not(.is-empty) {
       tr {

--- a/app/src/pages/playground/PlaygroundErrorWrap.tsx
+++ b/app/src/pages/playground/PlaygroundErrorWrap.tsx
@@ -1,12 +1,14 @@
 import { ReactNode } from "react";
 
-import { Flex, Icon, Icons, Text } from "@phoenix/components";
+import { Flex, Icon, Icons, Text, View } from "@phoenix/components";
 
 export function PlaygroundErrorWrap({ children }: { children: ReactNode }) {
   return (
-    <Flex direction="row" gap="size-50" alignItems="center">
-      <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
-      <Text color="danger">{children}</Text>
-    </Flex>
+    <View padding="size-200">
+      <Flex direction="row" gap="size-50" alignItems="center">
+        <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
+        <Text color="danger">{children}</Text>
+      </Flex>
+    </View>
   );
 }

--- a/app/src/pages/playground/PlaygroundToolCall.tsx
+++ b/app/src/pages/playground/PlaygroundToolCall.tsx
@@ -79,6 +79,7 @@ export function PlaygroundToolCall({
       css={css`
         text-wrap: wrap;
         margin: var(--ac-global-dimension-static-size-100) 0;
+        margin-block: 0;
       `}
     >
       {functionDisplay.name}(

--- a/app/stories/IconButton.stories.tsx
+++ b/app/stories/IconButton.stories.tsx
@@ -1,0 +1,333 @@
+import { Meta, StoryFn } from "@storybook/react";
+import { css } from "@emotion/react";
+
+import { Button } from "../src/components/button/Button";
+import {
+  IconButton,
+  IconButtonProps,
+} from "../src/components/button/IconButton";
+import { Icon } from "../src/components/icon/Icon";
+import {
+  AlertTriangleOutline,
+  ArrowRight,
+  CloseOutline,
+  EditOutline,
+  PlusOutline,
+  SearchOutline,
+  SettingsOutline,
+  TrashOutline,
+} from "../src/components/icon/Icons";
+
+const meta: Meta = {
+  title: "IconButton",
+  component: IconButton,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["S", "M", "L"],
+    },
+    color: {
+      control: { type: "select" },
+      options: [
+        "text-300",
+        "text-500",
+        "text-700",
+        "text-900",
+        "blue-600",
+        "red-600",
+        "green-600",
+        "orange-600",
+        "inherit",
+      ],
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+    },
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<IconButtonProps> = (args) => <IconButton {...args} />;
+
+/**
+ * IconButtons are used to perform actions with just an icon
+ */
+export const Default = Template.bind({});
+
+Default.args = {
+  children: <Icon svg={<SearchOutline />} />,
+  "aria-label": "Search",
+};
+
+/**
+ * Different sizes available for IconButton
+ */
+export const Sizes = () => (
+  <div
+    css={css`
+      display: flex;
+      align-items: center;
+      gap: var(--ac-global-dimension-size-200);
+    `}
+  >
+    <IconButton size="S" aria-label="Small search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton size="M" aria-label="Medium search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton size="L" aria-label="Large search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+  </div>
+);
+
+/**
+ * Various icons in IconButtons
+ */
+export const DifferentIcons = () => (
+  <div
+    css={css`
+      display: flex;
+      align-items: center;
+      gap: var(--ac-global-dimension-size-200);
+      flex-wrap: wrap;
+    `}
+  >
+    <IconButton aria-label="Search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton aria-label="Settings">
+      <Icon svg={<SettingsOutline />} />
+    </IconButton>
+    <IconButton aria-label="Delete">
+      <Icon svg={<TrashOutline />} />
+    </IconButton>
+    <IconButton aria-label="Edit">
+      <Icon svg={<EditOutline />} />
+    </IconButton>
+    <IconButton aria-label="Add">
+      <Icon svg={<PlusOutline />} />
+    </IconButton>
+    <IconButton aria-label="Close">
+      <Icon svg={<CloseOutline />} />
+    </IconButton>
+    <IconButton aria-label="Next">
+      <Icon svg={<ArrowRight />} />
+    </IconButton>
+  </div>
+);
+
+/**
+ * IconButton in disabled state
+ */
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  children: <Icon svg={<SettingsOutline />} />,
+  isDisabled: true,
+  "aria-label": "Settings (disabled)",
+};
+
+/**
+ * IconButton with custom styling
+ */
+export const CustomStyling = Template.bind({});
+
+CustomStyling.args = {
+  children: <Icon svg={<SearchOutline />} />,
+  "aria-label": "Custom search",
+  css: css`
+    --ac-global-text-color-700: var(--ac-global-color-blue-600);
+    &[data-hovered] {
+      background-color: var(--ac-global-color-blue-100);
+      --ac-global-text-color-900: var(--ac-global-color-blue-800);
+    }
+  `,
+};
+
+/**
+ * Different sizes with different icons
+ */
+export const SizeVariations = () => (
+  <div
+    css={css`
+      display: flex;
+      align-items: center;
+      gap: var(--ac-global-dimension-size-300);
+    `}
+  >
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--ac-global-dimension-size-100);
+      `}
+    >
+      <IconButton size="S" aria-label="Small add">
+        <Icon svg={<PlusOutline />} />
+      </IconButton>
+      <span
+        css={css`
+          font-size: var(--ac-global-font-size-xs);
+          color: var(--ac-global-text-color-500);
+        `}
+      >
+        Small
+      </span>
+    </div>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--ac-global-dimension-size-100);
+      `}
+    >
+      <IconButton size="M" aria-label="Medium edit">
+        <Icon svg={<EditOutline />} />
+      </IconButton>
+      <span
+        css={css`
+          font-size: var(--ac-global-font-size-xs);
+          color: var(--ac-global-text-color-500);
+        `}
+      >
+        Medium
+      </span>
+    </div>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--ac-global-dimension-size-100);
+      `}
+    >
+      <IconButton size="L" aria-label="Large delete">
+        <Icon svg={<TrashOutline />} />
+      </IconButton>
+      <span
+        css={css`
+          font-size: var(--ac-global-font-size-xs);
+          color: var(--ac-global-text-color-500);
+        `}
+      >
+        Large
+      </span>
+    </div>
+  </div>
+);
+
+/**
+ * IconButton with onPress handler
+ */
+export const Interactive = Template.bind({});
+
+Interactive.args = {
+  children: <Icon svg={<SearchOutline />} />,
+  "aria-label": "Interactive search",
+  onPress: () => alert("IconButton pressed!"),
+};
+
+/**
+ * IconButtons with different colors using the color prop
+ */
+export const ButtonColors = () => (
+  <div
+    css={css`
+      display: flex;
+      align-items: center;
+      gap: var(--ac-global-dimension-size-200);
+      flex-wrap: wrap;
+    `}
+  >
+    <IconButton aria-label="Default color">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton color="text-500" aria-label="Muted search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton color="blue-600" aria-label="Blue search">
+      <Icon svg={<SearchOutline />} />
+    </IconButton>
+    <IconButton color="red-600" aria-label="Red delete">
+      <Icon svg={<TrashOutline />} />
+    </IconButton>
+    <IconButton color="green-600" aria-label="Green success">
+      <Icon svg={<PlusOutline />} />
+    </IconButton>
+    <IconButton color="orange-600" aria-label="Orange warning">
+      <Icon svg={<AlertTriangleOutline />} />
+    </IconButton>
+  </div>
+);
+
+/**
+ * Comparison of IconButtons with regular Buttons that have leadingVisual icons
+ * to verify proper size alignment
+ */
+export const SizeComparison = () => (
+  <div
+    css={css`
+      display: flex;
+      flex-direction: column;
+      gap: var(--ac-global-dimension-size-300);
+    `}
+  >
+    {/* Small Size Comparison */}
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        gap: var(--ac-global-dimension-size-200);
+      `}
+    >
+      <span
+        css={css`
+          font-size: var(--ac-global-font-size-xs);
+          color: var(--ac-global-text-color-500);
+          width: 60px;
+        `}
+      >
+        Small:
+      </span>
+      <IconButton size="S" aria-label="Small icon button">
+        <Icon svg={<SearchOutline />} />
+      </IconButton>
+      <Button size="S" leadingVisual={<Icon svg={<SearchOutline />} />}>
+        Button
+      </Button>
+    </div>
+
+    {/* Medium Size Comparison */}
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        gap: var(--ac-global-dimension-size-200);
+      `}
+    >
+      <span
+        css={css`
+          font-size: var(--ac-global-font-size-xs);
+          color: var(--ac-global-text-color-500);
+          width: 60px;
+        `}
+      >
+        Medium:
+      </span>
+      <IconButton size="M" aria-label="Medium icon button">
+        <Icon svg={<EditOutline />} />
+      </IconButton>
+      <Button size="M" leadingVisual={<Icon svg={<EditOutline />} />}>
+        Button
+      </Button>
+    </div>
+  </div>
+);

--- a/app/stories/IconButton.stories.tsx
+++ b/app/stories/IconButton.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta = {
   argTypes: {
     size: {
       control: { type: "select" },
-      options: ["S", "M", "L"],
+      options: ["S", "M"],
     },
     color: {
       control: { type: "select" },
@@ -78,9 +78,6 @@ export const Sizes = () => (
       <Icon svg={<SearchOutline />} />
     </IconButton>
     <IconButton size="M" aria-label="Medium search">
-      <Icon svg={<SearchOutline />} />
-    </IconButton>
-    <IconButton size="L" aria-label="Large search">
       <Icon svg={<SearchOutline />} />
     </IconButton>
   </div>
@@ -199,26 +196,6 @@ export const SizeVariations = () => (
         `}
       >
         Medium
-      </span>
-    </div>
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--ac-global-dimension-size-100);
-      `}
-    >
-      <IconButton size="L" aria-label="Large delete">
-        <Icon svg={<TrashOutline />} />
-      </IconButton>
-      <span
-        css={css`
-          font-size: var(--ac-global-font-size-xs);
-          color: var(--ac-global-text-color-500);
-        `}
-      >
-        Large
       </span>
     </div>
   </div>


### PR DESCRIPTION
move actions for experiments into the CellTop

<img width="1603" alt="Screenshot 2025-06-19 at 12 37 48 PM" src="https://github.com/user-attachments/assets/1cd122e2-029f-4961-94bc-cebcd7c695bc" />

## Summary by Sourcery

Move experiment action controls and metadata into the CellTop header component for table cells and update related styling

Enhancements:
- Replace CellWithControlsWrap in example cells with the new CellTop component to unify header layout
- Refactor span metadata and example action buttons into CellTop and remove the legacy SpanMetadata component
- Adjust CellTop styling with background color, border tweaks, and flex layout for children and extra controls
- Remove hover background effect from table rows to align with updated styles

Documentation:
- Add a basic GridTable story in Storybook