### PR TITLE
ci: chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 22.12.0
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.2.0
       - name: Install dependencies
         working-directory: ./app
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
adds CI to build storybook and adds chromatic reviews when necessary.

## Summary by Sourcery

CI:
- Add `.github/workflows/chromatic.yml` that sets up Node 22.12, pnpm, and runs Chromatic with the project token