### PR TITLE
fix: De-duplicate dialog code in model delete dialog

### DIFF
--- a/app/src/pages/settings/DeleteModelButton.tsx
+++ b/app/src/pages/settings/DeleteModelButton.tsx
@@ -82,13 +82,7 @@ function DeleteModelDialogContent({
   ]);
 
   return (
-    <Dialog>
-      <DialogHeader>
-        <DialogTitle>Delete Model</DialogTitle>
-        <DialogTitleExtra>
-          <DialogCloseButton slot="close" />
-        </DialogTitleExtra>
-      </DialogHeader>
+    <div>
       <View padding="size-200">
         <Text color="danger">
           {`Are you sure you want to delete the "${modelName}" model? This action cannot be undone and all services dependent on this model, including associated costs, will be affected.`}
@@ -117,7 +111,7 @@ function DeleteModelDialogContent({
           </Button>
         </Flex>
       </View>
-    </Dialog>
+    </div>
   );
 }
 


### PR DESCRIPTION
<img width="975" alt="image" src="https://github.com/user-attachments/assets/d0fe11f2-fa1c-4b90-9ce8-f47dc4981fc5" />

Resolves #8159

## Summary by Sourcery

Deduplicate the model deletion dialog by removing the custom <Dialog> wrapper and header markup in DeleteModelButton and replacing it with a generic container

Enhancements:
- Extract common deletion dialog structure to avoid repeating <Dialog> elements
- Replace <Dialog> component with a standard <div> wrapper in DeleteModelDialogContent