### PR TITLE
chore: ignore graphql schema from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs
+app/schema.graphql


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add GraphQL schema pattern to .prettierignore to exclude it from formatting