### PR TITLE
fix(cost): validate regex before creating or updating generative model

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2088,6 +2088,7 @@ type Query {
   """
   dbStorageCapacityBytes: Float
   dbTableStats: [DbTableStats!]!
+  validateRegularExpression(regex: String!): ValidationResult!
 }
 
 input RemoveAnnotationConfigFromProjectInput {

--- a/src/phoenix/server/api/mutations/model_mutations.py
+++ b/src/phoenix/server/api/mutations/model_mutations.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional
 
 import strawberry
@@ -76,6 +77,8 @@ class ModelMutationMixin:
             raise BadRequest("input cost is required")
         if "output" not in cost_types:
             raise BadRequest("output cost is required")
+        if not _is_valid_regex(input.name_pattern):
+            raise BadRequest("name_pattern is not a valid regex")
         costs = [
             models.ModelCost(
                 token_type=cost.token_type,
@@ -118,6 +121,8 @@ class ModelMutationMixin:
             raise BadRequest("input cost is required")
         if "output" not in cost_types:
             raise BadRequest("output cost is required")
+        if not _is_valid_regex(input.name_pattern):
+            raise BadRequest("name_pattern is not a valid regex")
         costs = [
             models.ModelCost(
                 token_type=cost.token_type,
@@ -184,3 +189,14 @@ class ModelMutationMixin:
             model=to_gql_generative_model(model),
             query=Query(),
         )
+
+
+def _is_valid_regex(maybe_regex: str) -> bool:
+    """
+    Returns True if the given string is a valid regex, False otherwise.
+    """
+    try:
+        re.compile(maybe_regex)
+        return True
+    except re.error:
+        return False

--- a/src/phoenix/server/api/mutations/model_mutations.py
+++ b/src/phoenix/server/api/mutations/model_mutations.py
@@ -77,8 +77,7 @@ class ModelMutationMixin:
             raise BadRequest("input cost is required")
         if "output" not in cost_types:
             raise BadRequest("output cost is required")
-        if not _is_valid_regex(input.name_pattern):
-            raise BadRequest("name_pattern is not a valid regex")
+        _ensure_valid_regex(input.name_pattern)
         costs = [
             models.ModelCost(
                 token_type=cost.token_type,
@@ -121,8 +120,7 @@ class ModelMutationMixin:
             raise BadRequest("input cost is required")
         if "output" not in cost_types:
             raise BadRequest("output cost is required")
-        if not _is_valid_regex(input.name_pattern):
-            raise BadRequest("name_pattern is not a valid regex")
+        _ensure_valid_regex(input.name_pattern)
         costs = [
             models.ModelCost(
                 token_type=cost.token_type,
@@ -191,12 +189,11 @@ class ModelMutationMixin:
         )
 
 
-def _is_valid_regex(maybe_regex: str) -> bool:
+def _ensure_valid_regex(maybe_regex: str) -> None:
     """
-    Returns True if the given string is a valid regex, False otherwise.
+    Raises a BadRequest error if the given string is not a valid regex.
     """
     try:
         re.compile(maybe_regex)
-        return True
-    except re.error:
-        return False
+    except re.error as error:
+        raise BadRequest(f"Invalid regex: {str(error)}")

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from datetime import datetime
 from typing import Iterable, Iterator, Optional, Union, cast
@@ -1005,6 +1006,14 @@ class Query:
             DbTableStats(table_name=table_name, num_bytes=num_bytes)
             for table_name, num_bytes in stats
         ]
+
+    @strawberry.field
+    def validate_regular_expression(self, regex: str) -> ValidationResult:
+        try:
+            re.compile(regex)
+            return ValidationResult(is_valid=True, error_message=None)
+        except re.error as error:
+            return ValidationResult(is_valid=False, error_message=str(error))
 
 
 def _consolidate_sqlite_db_table_stats(

--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -205,6 +205,21 @@ class TestModelMutations:
                 "Model with name 'default-model' already exists",
                 id="duplicate-default-model",
             ),
+            pytest.param(
+                {
+                    "input": {
+                        "name": "test-model",
+                        "provider": "openai",
+                        "namePattern": "[",
+                        "costs": [
+                            {"tokenType": "input", "costPerToken": 0.001},
+                            {"tokenType": "output", "costPerToken": 0.002},
+                        ],
+                    }
+                },
+                "name_pattern is not a valid regex",
+                id="invalid-regex",
+            ),
         ],
     )
     async def test_create_model_with_invalid_input_raises_expected_error(
@@ -287,6 +302,22 @@ class TestModelMutations:
                 },
                 "output cost is required",
                 id="missing-output-cost",
+            ),
+            pytest.param(
+                {
+                    "input": {
+                        "id": str(GlobalID(GenerativeModel.__name__, str(1))),
+                        "name": "updated-model",
+                        "provider": "openai",
+                        "namePattern": "[",
+                        "costs": [
+                            {"tokenType": "input", "costPerToken": 0.001},
+                            {"tokenType": "output", "costPerToken": 0.002},
+                        ],
+                    }
+                },
+                "name_pattern is not a valid regex",
+                id="invalid-regex",
             ),
         ],
     )

--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -217,7 +217,7 @@ class TestModelMutations:
                         ],
                     }
                 },
-                "name_pattern is not a valid regex",
+                "Invalid regex: unterminated character set at position 0",
                 id="invalid-regex",
             ),
         ],
@@ -316,7 +316,7 @@ class TestModelMutations:
                         ],
                     }
                 },
-                "name_pattern is not a valid regex",
+                "Invalid regex: unterminated character set at position 0",
                 id="invalid-regex",
             ),
         ],


### PR DESCRIPTION
- adds validation for name pattern to be a regex (we may wish to move this into the ORM layer eventually)
- adds tests
- adds query to validate regex, needed for the model form below

resolves #8026

![Screenshot 2025-06-19 at 4 13 18 PM](https://github.com/user-attachments/assets/28e7851d-d2a4-4145-95bf-6bd64844a42d)