### PR TITLE
chore: re-label urls to say localhost so that it mitigates confusion

### DIFF
--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -96,10 +96,7 @@ _WELCOME_MESSAGE = Environment(loader=BaseLoader()).from_string("""
 |  https://github.com/Arize-ai/phoenix
 |
 |  🌎 Join our Community 🌎
-|  https://arize-ai.slack.com/join/shared_invite/zt-2w57bhem8-hq24MB6u7yE_ZF_ilOYSBw#/shared-invite/email 
-|
-|  🚀 Phoenix Server 🚀
-|  Phoenix UI: {{ ui_path }}
+|  https://arize-ai.slack.com/join/shared_invite/zt-2w57bhem8-hq24MB6u7yE_ZF_ilOYSBw#/shared-invite/email
 |
 |  📚 Documentation 📚
 |  https://arize.com/docs/phoenix
@@ -391,7 +388,7 @@ def main() -> None:
     http_scheme = "https" if tls_enabled_for_http else "http"
     grpc_scheme = "https" if tls_enabled_for_grpc else "http"
     # Use localhost for display when host is the loopback address to make URLs clickable
-    display_host = "localhost" if host == "0.0.0.0" else host
+    display_host = "localhost" if host in ("0.0.0.0", "::") else host
     root_path = urljoin(f"{http_scheme}://{host}:{port}", host_root_path)
     display_root_path = urljoin(f"{http_scheme}://{display_host}:{port}", host_root_path)
     msg = _WELCOME_MESSAGE.render(

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -392,12 +392,13 @@ def main() -> None:
     grpc_scheme = "https" if tls_enabled_for_grpc else "http"
     # Use localhost for display when host is the loopback address to make URLs clickable
     display_host = "localhost" if host == "0.0.0.0" else host
-    root_path = urljoin(f"{http_scheme}://{display_host}:{port}", host_root_path)
+    root_path = urljoin(f"{http_scheme}://{host}:{port}", host_root_path)
+    display_root_path = urljoin(f"{http_scheme}://{display_host}:{port}", host_root_path)
     msg = _WELCOME_MESSAGE.render(
         version=phoenix_version,
-        ui_path=root_path,
+        ui_path=display_root_path,
         grpc_path=f"{grpc_scheme}://{display_host}:{get_env_grpc_port()}",
-        http_path=urljoin(root_path, "v1/traces"),
+        http_path=urljoin(display_root_path, "v1/traces"),
         storage=get_printable_db_url(db_connection_str),
         schema=get_env_database_schema(),
         auth_enabled=auth_settings.enable_auth,

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -91,12 +91,15 @@ _WELCOME_MESSAGE = Environment(loader=BaseLoader()).from_string("""
 ██║     ██║  ██║╚██████╔╝███████╗██║ ╚████║██║██╔╝ ██╗
 ╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝ v{{ version }}
 
+|  ⭐️⭐️⭐️ Support Open Source ⭐️⭐️⭐️
+|  ⭐️⭐️⭐️ Star on GitHub! ⭐️⭐️⭐️
+|  https://github.com/Arize-ai/phoenix
 |
 |  🌎 Join our Community 🌎
-|  https://arize-ai.slack.com/join/shared_invite/zt-2w57bhem8-hq24MB6u7yE_ZF_ilOYSBw#/shared-invite/email
+|  https://arize-ai.slack.com/join/shared_invite/zt-2w57bhem8-hq24MB6u7yE_ZF_ilOYSBw#/shared-invite/email 
 |
-|  ⭐️ Leave us a Star ⭐️
-|  https://github.com/Arize-ai/phoenix
+|  🚀 Phoenix Server 🚀
+|  Phoenix UI: {{ ui_path }}
 |
 |  📚 Documentation 📚
 |  https://arize.com/docs/phoenix
@@ -387,11 +390,13 @@ def main() -> None:
     # Print information about the server
     http_scheme = "https" if tls_enabled_for_http else "http"
     grpc_scheme = "https" if tls_enabled_for_grpc else "http"
-    root_path = urljoin(f"{http_scheme}://{host}:{port}", host_root_path)
+    # Use localhost for display when host is the loopback address to make URLs clickable
+    display_host = "localhost" if host == "0.0.0.0" else host
+    root_path = urljoin(f"{http_scheme}://{display_host}:{port}", host_root_path)
     msg = _WELCOME_MESSAGE.render(
         version=phoenix_version,
         ui_path=root_path,
-        grpc_path=f"{grpc_scheme}://{host}:{get_env_grpc_port()}",
+        grpc_path=f"{grpc_scheme}://{display_host}:{get_env_grpc_port()}",
         http_path=urljoin(root_path, "v1/traces"),
         storage=get_printable_db_url(db_connection_str),
         schema=get_env_database_schema(),


### PR DESCRIPTION
## Summary by Sourcery

Relabel server URLs to display localhost for loopback addresses and refresh the welcome banner layout

Enhancements:
- Substitute “localhost” for “0.0.0.0” when printing HTTP and gRPC endpoints to make URLs clickable
- Revamp the ASCII welcome message to reorder and relabel Slack, GitHub, UI, and documentation links with clear icons and spacing