### PR TITLE
feat: Add environment variable setting for default retention policy

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -295,6 +295,10 @@ Whether to verify client certificates for mutual TLS (mTLS) authentication.
 When set to true, clients must provide valid certificates signed by the CA specified in
 PHOENIX_TLS_CA_FILE.
 """
+ENV_PHOENIX_DEFAULT_RETENTION_POLICY_DAYS = "PHOENIX_DEFAULT_RETENTION_POLICY_DAYS"
+"""
+The default retention policy for traces in days.
+"""
 
 
 @dataclass(frozen=True)
@@ -454,6 +458,19 @@ def get_env_tls_verify_client() -> bool:
         if the environment variable is not set.
     """  # noqa: E501
     return _bool_val(ENV_PHOENIX_TLS_VERIFY_CLIENT, False)
+
+
+def get_env_default_retention_policy_days() -> int:
+    """
+    Gets the value of the PHOENIX_DEFAULT_RETENTION_POLICY_DAYS environment variable.
+
+    Returns:
+        int: True if client certificate verification is enabled, False otherwise. Defaults to False
+        if the environment variable is not set.
+    """  # noqa: E501
+    days = _int_val(ENV_PHOENIX_DEFAULT_RETENTION_POLICY_DAYS, 0)
+    assert days >= 0
+    return days
 
 
 def get_env_tls_config() -> Optional[TLSConfig]:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -469,7 +469,8 @@ def get_env_default_retention_policy_days() -> int:
         int: Number of days for the default retention policy. Defaults to 0 if the environment variable is not set.
     """  # noqa: E501
     days = _int_val(ENV_PHOENIX_DEFAULT_RETENTION_POLICY_DAYS, 0)
-    assert days >= 0
+    if days < 0:
+        raise ValueError("PHOENIX_DEFAULT_RETENTION_POLICY_DAYS must be non-negative")
     return days
 
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -462,11 +462,11 @@ def get_env_tls_verify_client() -> bool:
 
 def get_env_default_retention_policy_days() -> int:
     """
-    Gets the value of the PHOENIX_DEFAULT_RETENTION_POLICY_DAYS environment variable.
+    Returns the number of days for the default retention policy as set by the
+    PHOENIX_DEFAULT_RETENTION_POLICY_DAYS environment variable, defaulting to 0 if not set.
 
     Returns:
-        int: True if client certificate verification is enabled, False otherwise. Defaults to False
-        if the environment variable is not set.
+        int: Number of days for the default retention policy. Defaults to 0 if the environment variable is not set.
     """  # noqa: E501
     days = _int_val(ENV_PHOENIX_DEFAULT_RETENTION_POLICY_DAYS, 0)
     assert days >= 0

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -21,6 +21,7 @@ from phoenix.auth import (
 from phoenix.config import (
     get_env_admins,
     get_env_default_admin_initial_password,
+    get_env_default_retention_policy_days,
     get_env_disable_basic_auth,
 )
 from phoenix.db import models
@@ -249,7 +250,9 @@ async def _ensure_default_project_trace_retention_policy(db: DbSessionFactory) -
         ):
             return
         cron_expression = TraceRetentionCronExpression(root="0 0 * * 0")
-        rule = TraceRetentionRule(root=MaxDaysRule(max_days=0))
+        rule = TraceRetentionRule(
+            root=MaxDaysRule(max_days=get_env_default_retention_policy_days())
+        )
         await session.execute(
             sa.insert(models.ProjectTraceRetentionPolicy),
             [


### PR DESCRIPTION
## Summary by Sourcery

Add an environment variable to configure the default trace retention policy and apply it in the database facilitator

New Features:
- Introduce PHOENIX_DEFAULT_RETENTION_POLICY_DAYS environment variable and constant
- Implement get_env_default_retention_policy_days() to parse the new environment variable

Enhancements:
- Use get_env_default_retention_policy_days() in ProjectTraceRetentionPolicy default rule instead of a hardcoded value