### PR TITLE
feat(cost): sort sessions table by cost

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1782,6 +1782,7 @@ enum ProjectSessionColumn {
   endTime
   tokenCountTotal
   numTraces
+  costTotal
 }
 
 """A connection to a list of items."""

--- a/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SessionsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5c66c09a65863774d39ebefb20d4d3e>>
+ * @generated SignedSource<<41fb6d610ae3a7e82506f09150a63c5c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ProjectSessionColumn = "endTime" | "numTraces" | "startTime" | "tokenCountTotal";
+export type ProjectSessionColumn = "costTotal" | "endTime" | "numTraces" | "startTime" | "tokenCountTotal";
 export type SortDir = "asc" | "desc";
 export type ProjectSessionSort = {
   col: ProjectSessionColumn;

--- a/src/phoenix/server/api/input_types/ProjectSessionSort.py
+++ b/src/phoenix/server/api/input_types/ProjectSessionSort.py
@@ -13,6 +13,7 @@ class ProjectSessionColumn(Enum):
     endTime = auto()
     tokenCountTotal = auto()
     numTraces = auto()
+    costTotal = auto()
 
     @property
     def data_type(self) -> CursorSortColumnDataType:
@@ -20,6 +21,8 @@ class ProjectSessionColumn(Enum):
             return CursorSortColumnDataType.INT
         if self is ProjectSessionColumn.startTime or self is ProjectSessionColumn.endTime:
             return CursorSortColumnDataType.DATETIME
+        if self is ProjectSessionColumn.costTotal:
+            return CursorSortColumnDataType.FLOAT
         assert_never(self)
 
 


### PR DESCRIPTION
resolves #8157

## Summary by Sourcery

Implement end-to-end LLM cost tracking: store span costs, aggregate cost summaries across spans, traces, sessions and projects; extend GraphQL schema and React UI to manage generative models and display cost data; add sorting, formatting, and management interfaces for token-based pricing.

New Features:
- Persist span-level LLM cost and breakdown details in new SpanCost and SpanCostDetail tables
- Compute token-based costs during span ingestion and chat subscriptions
- Expose costSummary and costDetailSummaryEntries on GraphQL types (Span, Trace, Session, Project, GenerativeModel)
- Add mutations and queries for CRUD operations on generative models and their token costs
- Introduce cost column, sorting and tooltip breakdown in Sessions and Spans tables
- Implement a TokenCosts component for inline cost display with detailed tooltip
- Add a new ‘Metrics’ dashboard tab including estimated cost panel

Enhancements:
- Extend cost formatting utilities for dollar values
- Improve table styling (CellTop, interactiveTableCSS) and IconButton component
- Refactor GraphQL connections for models and rename models field to generativeModels

Build:
- Add Alembic migration to create generative_models, model_costs, span_costs, and span_cost_details tables
- Bump openinference-semantic-conventions dependency

Tests:
- Add unit tests for ModelCostLookup behavior
- Add integration tests for create/update/delete generative model mutations

Chores:
- Add scripts for generating synthetic spans for cost calculations and processing LiteLLM pricing data
- Include Storybook stories for IconButton, ModelForm, and cost components