### PR TITLE
ci(cost): fix model mutations tests

### DIFF
--- a/tests/unit/server/api/mutations/test_model_mutations.py
+++ b/tests/unit/server/api/mutations/test_model_mutations.py
@@ -21,9 +21,11 @@ class TestModelMutations:
             isOverride
             createdAt
             updatedAt
-            tokenCost {
-              input
-              output
+            tokenPrices {
+              tokenType
+              kind
+              costPerToken
+              costPerMillionTokens
             }
           }
         }
@@ -39,9 +41,11 @@ class TestModelMutations:
             isOverride
             createdAt
             updatedAt
-            tokenCost {
-              input
-              output
+            tokenPrices {
+              tokenType
+              kind
+              costPerToken
+              costPerMillionTokens
             }
           }
         }
@@ -73,8 +77,16 @@ class TestModelMutations:
                 "provider": "openai",
                 "namePattern": "gpt-*",
                 "costs": [
-                    {"tokenType": "input", "costPerToken": 0.001},
-                    {"tokenType": "output", "costPerToken": 0.002},
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 0.001 * 1_000_000,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 0.002 * 1_000_000,
+                    },
                 ],
             }
         }
@@ -94,11 +106,22 @@ class TestModelMutations:
         assert created_model.pop("isOverride") is True
         assert isinstance(created_model.pop("createdAt"), str)
         assert isinstance(created_model.pop("updatedAt"), str)
-        token_cost = created_model.pop("tokenCost")
+        token_prices = created_model.pop("tokenPrices")
+        assert token_prices == [
+            {
+                "tokenType": "input",
+                "kind": "PROMPT",
+                "costPerToken": 0.001,
+                "costPerMillionTokens": 0.001 * 1_000_000,
+            },
+            {
+                "tokenType": "output",
+                "kind": "COMPLETION",
+                "costPerToken": 0.002,
+                "costPerMillionTokens": 0.002 * 1_000_000,
+            },
+        ]
         assert not created_model
-        assert token_cost.pop("input") == 0.001
-        assert token_cost.pop("output") == 0.002
-        assert not token_cost
 
         # Update model
         update_variables = {
@@ -108,8 +131,16 @@ class TestModelMutations:
                 "provider": "anthropic",
                 "namePattern": "claude-*",
                 "costs": [
-                    {"tokenType": "input", "costPerToken": 0.003},
-                    {"tokenType": "output", "costPerToken": 0.004},
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 0.003 * 1_000_000,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 0.004 * 1_000_000,
+                    },
                 ],
             }
         }
@@ -129,11 +160,21 @@ class TestModelMutations:
         assert updated_model.pop("isOverride") is True
         assert isinstance(updated_model.pop("createdAt"), str)
         assert isinstance(updated_model.pop("updatedAt"), str)
-        token_cost = updated_model.pop("tokenCost")
-        assert not updated_model
-        assert token_cost.pop("input") == 0.003
-        assert token_cost.pop("output") == 0.004
-        assert not token_cost
+        token_prices = updated_model.pop("tokenPrices")
+        assert token_prices == [
+            {
+                "tokenType": "input",
+                "kind": "PROMPT",
+                "costPerToken": 0.003,
+                "costPerMillionTokens": 0.003 * 1_000_000,
+            },
+            {
+                "tokenType": "output",
+                "kind": "COMPLETION",
+                "costPerToken": 0.004,
+                "costPerMillionTokens": 0.004 * 1_000_000,
+            },
+        ]
 
         # Delete model
         delete_variables = {
@@ -169,7 +210,11 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -183,7 +228,11 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -197,8 +246,16 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -212,8 +269,16 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "[",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -249,8 +314,16 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -265,8 +338,16 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -281,7 +362,11 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -296,7 +381,11 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "gpt-*",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -311,8 +400,16 @@ class TestModelMutations:
                         "provider": "openai",
                         "namePattern": "[",
                         "costs": [
-                            {"tokenType": "input", "costPerToken": 0.001},
-                            {"tokenType": "output", "costPerToken": 0.002},
+                            {
+                                "tokenType": "input",
+                                "kind": "PROMPT",
+                                "costPerMillionTokens": 0.001 * 1_000_000,
+                            },
+                            {
+                                "tokenType": "output",
+                                "kind": "COMPLETION",
+                                "costPerMillionTokens": 0.002 * 1_000_000,
+                            },
                         ],
                     }
                 },
@@ -349,8 +446,16 @@ class TestModelMutations:
                 "provider": "anthropic",
                 "namePattern": "claude-*",
                 "costs": [
-                    {"tokenType": "input", "costPerToken": 0.003},
-                    {"tokenType": "output", "costPerToken": 0.004},
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 0.003 * 1_000_000,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 0.004 * 1_000_000,
+                    },
                 ],
             }
         }
@@ -378,8 +483,16 @@ class TestModelMutations:
                 "provider": "anthropic",
                 "namePattern": "claude-*",
                 "costs": [
-                    {"tokenType": "input", "costPerToken": 0.003},
-                    {"tokenType": "output", "costPerToken": 0.004},
+                    {
+                        "tokenType": "input",
+                        "kind": "PROMPT",
+                        "costPerMillionTokens": 0.003 * 1_000_000,
+                    },
+                    {
+                        "tokenType": "output",
+                        "kind": "COMPLETION",
+                        "costPerMillionTokens": 0.004 * 1_000_000,
+                    },
                 ],
             }
         }


### PR DESCRIPTION
resolves #8201

## Summary by Sourcery

Add comprehensive LLM cost‐tracking support across the stack and fix CI command. Introduce new DB tables and SQLAlchemy models for generative models, token prices, span costs, and cost details. Implement backend cost pipeline—including a cost lookup, cost calculator, daemons, GraphQL fields, mutations, and data loaders—and expose pricing CRUD in settings. Surface cost summaries and breakdowns in the UI via a new TokenCosts component and updated table cells. Add migration, scripts, and extensive tests for cost logic. Finally, adjust CI to remove the "-x" flag so all tests run under PostgreSQL.

New Features:
- Create generative_models, token_prices, span_costs, and span_cost_details tables and SQLAlchemy models
- Implement cost calculation daemon and span cost detail calculator to persist per‐span costs
- Expose costSummary and costDetailSummaryEntries fields on Span, Trace, Experiment, Project, etc.
- Add GraphQL mutations for creating/updating/deleting GenerativeModel and settings UI for managing prices
- Introduce TokenCosts component and display cost data in tables, dialogs, and headers

Enhancements:
- Convert cost lookup to database‐backed async loader and add prioritization by override/specificity
- Add data loaders for span cost summaries and last‐used model times

Build:
- Add Alembic migration for cost‐related tables

CI:
- Remove the "-x" flag in Python CI step to ensure tests always run with --run-postgres

Tests:
- Add unit tests covering cost lookup, detail calculation, regex specificity, model mutations, and helper functions