### PR TITLE
feat: mcp add span annotation

### DIFF
--- a/js/packages/phoenix-client/src/spans/getSpanAnnotations.ts
+++ b/js/packages/phoenix-client/src/spans/getSpanAnnotations.ts
@@ -1,0 +1,131 @@
+import { createClient } from "../client";
+import { ClientFn } from "../types/core";
+import { operations } from "../__generated__/api/v1";
+import { ProjectSelector } from "../types/projects";
+
+/**
+ * Parameters to get span annotations from a project using auto-generated types
+ */
+interface GetSpanAnnotationsParams extends ClientFn {
+  /** The project to get span annotations from */
+  project: ProjectSelector;
+  /** One or more span IDs to fetch annotations for */
+  spanIds: string[];
+  /** Optional list of annotation names to include. If provided, only annotations with these names will be returned. 'note' annotations are excluded by default unless explicitly included in this list. */
+  includeAnnotationNames?: string[];
+  /** Optional list of annotation names to exclude from results. */
+  excludeAnnotationNames?: string[];
+  /** Pagination cursor */
+  cursor?: string | null;
+  /** Maximum number of annotations to return */
+  limit?: number;
+}
+
+type GetSpanAnnotationsResponse =
+  operations["listSpanAnnotationsBySpanIds"]["responses"]["200"];
+
+export type GetSpanAnnotationsResult = {
+  annotations: GetSpanAnnotationsResponse["content"]["application/json"]["data"];
+  nextCursor: GetSpanAnnotationsResponse["content"]["application/json"]["next_cursor"];
+};
+
+/**
+ * Get span annotations for a list of span IDs.
+ *
+ * This method allows you to retrieve annotations for specific spans within a project.
+ * You can filter annotations by name and support cursor-based pagination.
+ *
+ * @experimental this function is experimental and may change in the future
+ *
+ * @param params - The parameters to get span annotations
+ * @returns A paginated response containing annotations and optional next cursor
+ *
+ * @example
+ * ```ts
+ * // Get annotations for specific spans
+ * const result = await getSpanAnnotations({
+ *   client,
+ *   project: { projectName: "my-project" },
+ *   spanIds: ["span1", "span2", "span3"],
+ *   limit: 50
+ * });
+ *
+ * // Get specific annotation types
+ * const result = await getSpanAnnotations({
+ *   client,
+ *   project: { projectName: "my-project" },
+ *   spanIds: ["span1"],
+ *   includeAnnotationNames: ["quality_score", "sentiment"],
+ *   limit: 100
+ * });
+ *
+ * // Paginate through results
+ * let cursor: string | undefined;
+ * do {
+ *   const result = await getSpanAnnotations({
+ *     client,
+ *     project: { projectName: "my-project" },
+ *     spanIds: ["span1"],
+ *     cursor,
+ *     limit: 100
+ *   });
+ *
+ *   // Process annotations
+ *   result.annotations.forEach(annotation => {
+ *     console.log(`Annotation: ${annotation.name}, Label: ${annotation.result.label}`);
+ *   });
+ *
+ *   cursor = result.nextCursor || undefined;
+ * } while (cursor);
+ * ```
+ */
+export async function getSpanAnnotations({
+  client: _client,
+  project,
+  spanIds,
+  includeAnnotationNames,
+  excludeAnnotationNames,
+  cursor,
+  limit = 100,
+}: GetSpanAnnotationsParams): Promise<GetSpanAnnotationsResult> {
+  const client = _client ?? createClient();
+  const projectIdentifier =
+    "projectId" in project ? project.projectId : project.projectName;
+
+  const params: NonNullable<
+    operations["listSpanAnnotationsBySpanIds"]["parameters"]["query"]
+  > = {
+    span_ids: spanIds,
+    limit,
+  };
+
+  if (cursor) {
+    params.cursor = cursor;
+  }
+
+  if (includeAnnotationNames) {
+    params.include_annotation_names = includeAnnotationNames;
+  }
+
+  if (excludeAnnotationNames) {
+    params.exclude_annotation_names = excludeAnnotationNames;
+  }
+
+  const { data, error } = await client.GET(
+    "/v1/projects/{project_identifier}/span_annotations",
+    {
+      params: {
+        path: {
+          project_identifier: projectIdentifier,
+        },
+        query: params,
+      },
+    }
+  );
+
+  if (error) throw error;
+  return {
+    annotations: data?.data ?? [],
+    nextCursor: data?.next_cursor ?? null,
+  };
+}

--- a/js/packages/phoenix-client/src/spans/getSpanAnnotations.ts
+++ b/js/packages/phoenix-client/src/spans/getSpanAnnotations.ts
@@ -103,11 +103,11 @@ export async function getSpanAnnotations({
     params.cursor = cursor;
   }
 
-  if (includeAnnotationNames) {
+  if (includeAnnotationNames !== undefined) {
     params.include_annotation_names = includeAnnotationNames;
   }
 
-  if (excludeAnnotationNames) {
+  if (excludeAnnotationNames !== undefined) {
     params.exclude_annotation_names = excludeAnnotationNames;
   }
 

--- a/js/packages/phoenix-client/src/spans/index.ts
+++ b/js/packages/phoenix-client/src/spans/index.ts
@@ -1,3 +1,4 @@
 export * from "./addSpanAnnotation";
 export * from "./logSpanAnnotations";
 export * from "./getSpans";
+export * from "./getSpanAnnotations";

--- a/js/packages/phoenix-client/test/spans/getSpanAnnotations.test.ts
+++ b/js/packages/phoenix-client/test/spans/getSpanAnnotations.test.ts
@@ -92,7 +92,9 @@ describe("getSpanAnnotations", () => {
     });
 
     expect(result.annotations).toHaveLength(2);
-    // The mock returns both annotations, but in real usage this would filter
+    // Note: The mock response doesn't simulate filtering by annotation name,
+    // so we still get 2 annotations even though in real usage with
+    // includeAnnotationNames: ["quality_score"] we would expect only 1
     expect(result.annotations.some((a) => a.name === "quality_score")).toBe(
       true
     );
@@ -106,8 +108,22 @@ describe("getSpanAnnotations", () => {
     });
 
     expect(result.annotations).toHaveLength(2);
-    // The mock returns both annotations, but in real usage this would filter
+    // Note: The mock response doesn't simulate filtering by annotation name,
+    // so we still get 2 annotations even though in real usage with
+    // excludeAnnotationNames: ["note"] we would filter out note annotations
     expect(result.annotations.every((a) => a.name !== "note")).toBe(true);
+  });
+
+  it("should handle empty arrays for include/exclude filters", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456"],
+      includeAnnotationNames: [],
+      excludeAnnotationNames: [],
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.nextCursor).toBe("next-cursor-123");
   });
 
   it("should handle pagination with cursor", async () => {

--- a/js/packages/phoenix-client/test/spans/getSpanAnnotations.test.ts
+++ b/js/packages/phoenix-client/test/spans/getSpanAnnotations.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getSpanAnnotations } from "../../src/spans/getSpanAnnotations";
+
+// Mock the fetch module
+const mockGet = vi.fn();
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    GET: mockGet,
+  }),
+}));
+
+describe("getSpanAnnotations", () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+
+    // Default mock response
+    mockGet.mockResolvedValue({
+      data: {
+        next_cursor: "next-cursor-123",
+        data: [
+          {
+            id: "annotation-global-id-123",
+            span_id: "span-456",
+            name: "quality_score",
+            annotator_kind: "LLM",
+            result: {
+              label: "good",
+              score: 0.95,
+              explanation: null,
+            },
+            metadata: {
+              model: "gpt-4",
+              source: "test",
+            },
+            identifier: "test-identifier",
+          },
+          {
+            id: "annotation-global-id-124",
+            span_id: "span-457",
+            name: "sentiment",
+            annotator_kind: "HUMAN",
+            result: {
+              label: "positive",
+              score: 0.8,
+              explanation: "User expressed satisfaction",
+            },
+            metadata: {
+              reviewer: "john_doe",
+            },
+            identifier: "sentiment-001",
+          },
+        ],
+      },
+      error: null,
+    });
+  });
+
+  it("should get span annotations with basic parameters", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456", "span-457"],
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.annotations[0]?.span_id).toBe("span-456");
+    expect(result.annotations[0]?.name).toBe("quality_score");
+    expect(result.annotations[1]?.span_id).toBe("span-457");
+    expect(result.annotations[1]?.name).toBe("sentiment");
+    expect(result.nextCursor).toBe("next-cursor-123");
+  });
+
+  it("should get span annotations with all supported filter parameters", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456"],
+      includeAnnotationNames: ["quality_score"],
+      excludeAnnotationNames: ["note"],
+      cursor: "cursor-123",
+      limit: 50,
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.nextCursor).toBe("next-cursor-123");
+  });
+
+  it("should get span annotations with include annotation names filter", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456", "span-457"],
+      includeAnnotationNames: ["quality_score"],
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    // The mock returns both annotations, but in real usage this would filter
+    expect(result.annotations.some((a) => a.name === "quality_score")).toBe(
+      true
+    );
+  });
+
+  it("should get span annotations with exclude annotation names filter", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456", "span-457"],
+      excludeAnnotationNames: ["note"],
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    // The mock returns both annotations, but in real usage this would filter
+    expect(result.annotations.every((a) => a.name !== "note")).toBe(true);
+  });
+
+  it("should handle pagination with cursor", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456"],
+      cursor: "some-cursor-value",
+      limit: 25,
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.nextCursor).toBe("next-cursor-123");
+  });
+
+  it("should work with project ID instead of project name", async () => {
+    const result = await getSpanAnnotations({
+      project: { projectId: "project-123" },
+      spanIds: ["span-456"],
+    });
+
+    expect(result.annotations).toHaveLength(2);
+    expect(result.nextCursor).toBe("next-cursor-123");
+  });
+
+  it("should handle empty annotations response", async () => {
+    // Mock empty response
+    mockGet.mockResolvedValue({
+      data: {
+        next_cursor: null,
+        data: [],
+      },
+      error: null,
+    });
+
+    const result = await getSpanAnnotations({
+      project: { projectName: "test-project" },
+      spanIds: ["span-456"],
+    });
+
+    expect(result.annotations).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("should handle API errors", async () => {
+    // Mock error response
+    mockGet.mockResolvedValue({
+      data: null,
+      error: new Error("API Error"),
+    });
+
+    await expect(
+      getSpanAnnotations({
+        project: { projectName: "test-project" },
+        spanIds: ["span-456"],
+      })
+    ).rejects.toThrow("API Error");
+  });
+});

--- a/js/packages/phoenix-mcp/README.md
+++ b/js/packages/phoenix-mcp/README.md
@@ -20,6 +20,7 @@ Phoenix MCP Server is an implementation of the Model Context Protocol for the Ar
 You can use Phoenix MCP Server for:
 
 - **Projects Management**: List and explore projects that organize your observability data
+- **Spans & Annotations**: Retrieve spans and their annotations for analysis and debugging
 - **Prompts Management**: Create, list, update, and iterate on prompts
 - **Datasets**: Explore datasets, and syntesize new examples
 - **Experiments**: Pull experiment results and visualize them with the help of an LLM

--- a/js/packages/phoenix-mcp/src/index.ts
+++ b/js/packages/phoenix-mcp/src/index.ts
@@ -8,6 +8,7 @@ import { initializeDatasetTools } from "./datasetTools.js";
 import { initializeExperimentTools } from "./experimentTools.js";
 import { initializePromptTools } from "./promptTools.js";
 import { initializeProjectTools } from "./projectTools.js";
+import { initializeSpanTools } from "./spanTools.js";
 import { initializeReadmeResources } from "./readmeResource.js";
 
 const argv = minimist(process.argv.slice(2));
@@ -41,6 +42,7 @@ initializePromptTools({ client, server });
 initializeExperimentTools({ client, server });
 initializeDatasetTools({ client, server });
 initializeProjectTools({ client, server });
+initializeSpanTools({ client, server });
 
 async function main() {
   // Initialize readme resources first

--- a/js/packages/phoenix-mcp/src/spanTools.ts
+++ b/js/packages/phoenix-mcp/src/spanTools.ts
@@ -1,0 +1,200 @@
+import { PhoenixClient, Types } from "@arizeai/phoenix-client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import z from "zod";
+
+const GET_SPANS_DESCRIPTION = `Get spans from a project with filtering criteria.
+
+Spans represent individual operations or units of work within a trace. They contain timing information,
+attributes, and context about the operation being performed.
+
+Example usage:
+  Get recent spans from project "my-project"
+  Get spans in a time range from project "my-project"
+
+Expected return:
+  Object containing spans array and optional next cursor for pagination.
+  Example: {
+    "spans": [
+      {
+        "id": "span123",
+        "name": "http_request",
+        "context": {
+          "trace_id": "trace456",
+          "span_id": "span123"
+        },
+        "start_time": "2024-01-01T12:00:00Z",
+        "end_time": "2024-01-01T12:00:01Z",
+        "attributes": {
+          "http.method": "GET",
+          "http.url": "/api/users"
+        }
+      }
+    ],
+    "nextCursor": "cursor_for_pagination"
+  }`;
+
+const GET_SPAN_ANNOTATIONS_DESCRIPTION = `Get span annotations for a list of span IDs.
+
+Span annotations provide additional metadata, scores, or labels for spans. They can be created
+by humans, LLMs, or code and help in analyzing and categorizing spans.
+
+Example usage:
+  Get annotations for spans ["span1", "span2"] from project "my-project"
+  Get quality score annotations for span "span1" from project "my-project"
+
+Expected return:
+  Object containing annotations array and optional next cursor for pagination.
+  Example: {
+    "annotations": [
+      {
+        "id": "annotation123",
+        "span_id": "span1",
+        "name": "quality_score",
+        "result": {
+          "label": "good",
+          "score": 0.95,
+          "explanation": null
+        },
+        "annotator_kind": "LLM",
+        "metadata": {
+          "model": "gpt-4"
+        }
+      }
+    ],
+    "nextCursor": "cursor_for_pagination"
+  }`;
+
+export const initializeSpanTools = ({
+  client,
+  server,
+}: {
+  client: PhoenixClient;
+  server: McpServer;
+}) => {
+  server.tool(
+    "get-spans",
+    GET_SPANS_DESCRIPTION,
+    {
+      projectName: z.string(),
+      startTime: z.string().optional(),
+      endTime: z.string().optional(),
+      cursor: z.string().optional(),
+      limit: z.number().min(1).max(1000).default(100).optional(),
+    },
+    async ({ projectName, startTime, endTime, cursor, limit = 100 }) => {
+      const params: NonNullable<
+        Types["V1"]["operations"]["getSpans"]["parameters"]["query"]
+      > = {
+        limit,
+      };
+
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      if (startTime) {
+        params.start_time = startTime;
+      }
+
+      if (endTime) {
+        params.end_time = endTime;
+      }
+
+      const response = await client.GET(
+        "/v1/projects/{project_identifier}/spans",
+        {
+          params: {
+            path: {
+              project_identifier: projectName,
+            },
+            query: params,
+          },
+        }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                spans: response.data?.data ?? [],
+                nextCursor: response.data?.next_cursor ?? null,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    "get-span-annotations",
+    GET_SPAN_ANNOTATIONS_DESCRIPTION,
+    {
+      projectName: z.string(),
+      spanIds: z.array(z.string()),
+      includeAnnotationNames: z.array(z.string()).optional(),
+      excludeAnnotationNames: z.array(z.string()).optional(),
+      cursor: z.string().optional(),
+      limit: z.number().min(1).max(1000).default(100).optional(),
+    },
+    async ({
+      projectName,
+      spanIds,
+      includeAnnotationNames,
+      excludeAnnotationNames,
+      cursor,
+      limit = 100,
+    }) => {
+      const params: NonNullable<
+        Types["V1"]["operations"]["listSpanAnnotationsBySpanIds"]["parameters"]["query"]
+      > = {
+        span_ids: spanIds,
+        limit,
+      };
+
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      if (includeAnnotationNames) {
+        params.include_annotation_names = includeAnnotationNames;
+      }
+
+      if (excludeAnnotationNames) {
+        params.exclude_annotation_names = excludeAnnotationNames;
+      }
+
+      const response = await client.GET(
+        "/v1/projects/{project_identifier}/span_annotations",
+        {
+          params: {
+            path: {
+              project_identifier: projectName,
+            },
+            query: params,
+          },
+        }
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                annotations: response.data?.data ?? [],
+                nextCursor: response.data?.next_cursor ?? null,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+};


### PR DESCRIPTION
resolves #8143
<img width="596" alt="Screenshot 2025-06-20 at 9 07 53 PM" src="https://github.com/user-attachments/assets/31323bb9-435a-4cf0-b6b0-4fe1d978b320" />
<img width="752" alt="Screenshot 2025-06-20 at 9 05 24 PM" src="https://github.com/user-attachments/assets/8c902194-9c02-415d-ae78-19803fde92b3" />


## Summary by Sourcery

Add support for retrieving spans and their annotations by introducing new tools in the MCP server and a corresponding client API, with updated documentation and tests.

New Features:
- Add MCP server tools to retrieve spans and span annotations
- Introduce getSpanAnnotations client API for fetching span annotations

Enhancements:
- Export getSpanAnnotations in the Phoenix client spans index

Documentation:
- Update phoenix-mcp README to include spans & annotations feature

Tests:
- Add comprehensive unit tests for getSpanAnnotations covering filters, pagination, and error scenarios

## Summary by Sourcery

Add support for retrieving spans and their annotations by extending the MCP server with new span tools and exposing a corresponding client API, along with updated documentation and tests.

New Features:
- Add MCP server tools for fetching spans and span annotations
- Introduce getSpanAnnotations client API for retrieving span annotations

Enhancements:
- Export getSpanAnnotations in the Phoenix client spans index

Documentation:
- Update Phoenix MCP README to include spans & annotations feature

Tests:
- Add unit tests for getSpanAnnotations covering filtering, pagination, and error handling