### PR TITLE
ci(cost): add retry to python unit tests with fail fast to mitigate ci failures

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -403,10 +403,10 @@ jobs:
         run: sudo apt-get -yqq install postgresql
       - name: Run tests with PostgreSQL (Linux)
         if: runner.os == 'Linux'
-        run: uvx --with tox-uv tox run -e unit_tests -- -ra --run-postgres
+        run: uvx --with tox-uv tox run -e unit_tests -- -ra --run-postgres -x --reruns 10
       - name: Run tests without PostgreSQL (non-Linux)
         if: runner.os != 'Linux'
-        run: uvx --with tox-uv tox run -e unit_tests -- -ra -x
+        run: uvx --with tox-uv tox run -e unit_tests -- -ra -x --reruns 10
 
   type-check-integration-tests:
     name: Type Check Integration Tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,6 +5,7 @@ pytest-asyncio==0.25.1
 uvloop; platform_system != 'Windows'
 pydantic>=1.0,!=2.0.*,<3
 pyright[nodejs]==1.1.394
+pytest-rerunfailures
 deepdiff==8.2.0
 anthropic==0.49.0
 openai==1.62.0

--- a/requirements/integration-tests.txt
+++ b/requirements/integration-tests.txt
@@ -11,7 +11,6 @@ psutil
 psycopg[binary,pool]
 pyjwt
 pytest-randomly
-pytest-rerunfailures
 pytest-smtpd
 types-beautifulsoup4
 types-psutil


### PR DESCRIPTION
resolves #8201

## Summary by Sourcery

Add robust cost tracking and generative model management across the stack and improve CI reliability

New Features:
- Persist LLM span costs by introducing GenerativeModel, TokenPrice, SpanCost and SpanCostDetail entities and relationships
- Capture and calculate span-level cost in the ingestion pipelines via a new SpanCostCalculator daemon and model lookup
- Expose cost summaries and breakdowns in GraphQL (costSummary, costDetailSummaryEntries) on Span, Trace, ExperimentRun, Experiment, ProjectSession, Project
- Add CRUD mutations for generative models (createModel, updateModel, deleteModel) and seed models from manifest on startup
- Provide a settings UI for generative models (list, create, edit, clone, delete) with token price configuration and cost display components
- Display cost metrics in playground, session details, project page, spans and traces tables via a new TokenCosts component
- Introduce a ProjectMetricsPage with a new “Metrics” tab for visualizing feedback, traces, tokens, duration, and cost charts
- Update Python CI workflow to retry flaky unit tests up to 10 times with fail-fast

Enhancements:
- Implement regex specificity scoring and priority rules for cost model lookup
- Upgrade openinference-semantic-conventions dependency and refine UI styles (sticky headers, interactive tables, IconButton)

Build:
- Add retries (--reruns 10) and fail-fast flags to Python CI steps