### PR TITLE
fix: Fix audio and image message roles for OpenAI 

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -295,7 +295,7 @@ class OpenAIModel(BaseModel):
                     raise PhoenixUnsupportedAudioFormat(f"Unsupported audio format: {format}")
                 messages.append(
                     {
-                        "role": system_role,
+                        "role": "user",
                         "content": [
                             {
                                 "type": "input_audio",
@@ -316,7 +316,7 @@ class OpenAIModel(BaseModel):
                     raise ValueError("Only base64 encoded images or image URLs are supported")
                 messages.append(
                     {
-                        "role": system_role,
+                        "role": "user",
                         "content": [
                             {
                                 "type": "image_url",


### PR DESCRIPTION
We previously used the `system` role for image and audio message parts but OpenAI requires the message role to be `user`. This PR updates the logic in `openai.py` to accommodate this change

## Summary by Sourcery

Bug Fixes:
- Change audio and image message roles from system to user for OpenAI compatibility