### PR TITLE
ci: restrict chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,11 @@
 name: "Chromatic"
 
-on: push
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
We ran out of credits already so we need to restrict

## Summary by Sourcery

CI:
- Limit the GitHub Actions Chromatic workflow trigger to the main branch and app/** path