### PR TITLE
feat(cost): plumb through cost and tokens

### DIFF
--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -34,6 +34,7 @@ import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useWordColor } from "@phoenix/hooks/useWordColor";
 import {
+  costFormatter,
   floatFormatter,
   formatPercent,
 } from "@phoenix/utils/numberFormatUtils";
@@ -149,6 +150,20 @@ export function ExperimentsTable({
                 averageRunLatencyMs
                 project {
                   id
+                }
+                costSummary {
+                  total {
+                    tokens
+                    cost
+                  }
+                  prompt {
+                    tokens
+                    cost
+                  }
+                  completion {
+                    tokens
+                    cost
+                  }
                 }
                 annotationSummaries {
                   annotationName
@@ -306,6 +321,34 @@ export function ExperimentsTable({
           return "--";
         }
         return <LatencyText latencyMs={value} />;
+      },
+    },
+    {
+      header: "cost",
+      accessorKey: "costSummary.total.cost",
+      meta: {
+        textAlign: "right",
+      },
+      cell: ({ getValue }) => {
+        const value = getValue();
+        if (value === null || typeof value !== "number") {
+          return "--";
+        }
+        return <Text>{`$${costFormatter(value)}`}</Text>;
+      },
+    },
+    {
+      header: "tokens",
+      accessorKey: "costSummary.total.tokens",
+      meta: {
+        textAlign: "right",
+      },
+      cell: ({ getValue }) => {
+        const value = getValue();
+        if (value === null || typeof value !== "number") {
+          return "--";
+        }
+        return <Text>{`${value}`}</Text>;
       },
     },
     {

--- a/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9802d63232cb94fe44c76458925e772f>>
+ * @generated SignedSource<<944b1428de4f675089b9b9b7a6397816>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,20 @@ export type ExperimentsTableFragment$data = {
           readonly meanScore: number | null;
         }>;
         readonly averageRunLatencyMs: number | null;
+        readonly costSummary: {
+          readonly completion: {
+            readonly cost: number | null;
+            readonly tokens: number | null;
+          };
+          readonly prompt: {
+            readonly cost: number | null;
+            readonly tokens: number | null;
+          };
+          readonly total: {
+            readonly cost: number | null;
+            readonly tokens: number | null;
+          };
+        };
         readonly createdAt: string;
         readonly description: string | null;
         readonly errorRate: number | null;
@@ -65,7 +79,23 @@ v2 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokens",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "cost",
+    "storageKey": null
+  }
+];
 return {
   "argumentDefinitions": [
     {
@@ -232,6 +262,47 @@ return {
                 {
                   "alias": null,
                   "args": null,
+                  "concreteType": "SpanCostSummary",
+                  "kind": "LinkedField",
+                  "name": "costSummary",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CostBreakdown",
+                      "kind": "LinkedField",
+                      "name": "total",
+                      "plural": false,
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CostBreakdown",
+                      "kind": "LinkedField",
+                      "name": "prompt",
+                      "plural": false,
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CostBreakdown",
+                      "kind": "LinkedField",
+                      "name": "completion",
+                      "plural": false,
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
                   "concreteType": "ExperimentAnnotationSummary",
                   "kind": "LinkedField",
                   "name": "annotationSummaries",
@@ -314,6 +385,6 @@ return {
 };
 })();
 
-(node as any).hash = "c7c7580fe40888ceb86a1701fe4eedf4";
+(node as any).hash = "6ffa602034c8f755f2d1e8c9c2aa39bb";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b805551efeb33a4523d2cd91cd449b38>>
+ * @generated SignedSource<<dc6c1a32ed5f1a733697601bbc62c310>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,7 +82,23 @@ v5 = {
   "kind": "ScalarField",
   "name": "annotationName",
   "storageKey": null
-};
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokens",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "cost",
+    "storageKey": null
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -251,6 +267,47 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "concreteType": "SpanCostSummary",
+                            "kind": "LinkedField",
+                            "name": "costSummary",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "total",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "prompt",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "completion",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "ExperimentAnnotationSummary",
                             "kind": "LinkedField",
                             "name": "annotationSummaries",
@@ -340,16 +397,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1d386e93c6999945aa9ca5e5c67ed5d9",
+    "cacheID": "71600dd65428d25ce1b2d41c72e5568b",
     "id": null,
     "metadata": {},
     "name": "ExperimentsTableQuery",
     "operationKind": "query",
-    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c7c7580fe40888ceb86a1701fe4eedf4";
+(node as any).hash = "6ffa602034c8f755f2d1e8c9c2aa39bb";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/experimentsLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c902610e020d1d1216507ac4c47cf91f>>
+ * @generated SignedSource<<4736802751aabea9b1e7da842fd32d4a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -113,6 +113,22 @@ v7 = [
     "kind": "Literal",
     "name": "first",
     "value": 100
+  }
+],
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "tokens",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "cost",
+    "storageKey": null
   }
 ];
 return {
@@ -290,6 +306,47 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "concreteType": "SpanCostSummary",
+                            "kind": "LinkedField",
+                            "name": "costSummary",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "total",
+                                "plural": false,
+                                "selections": (v8/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "prompt",
+                                "plural": false,
+                                "selections": (v8/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CostBreakdown",
+                                "kind": "LinkedField",
+                                "name": "completion",
+                                "plural": false,
+                                "selections": (v8/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "ExperimentAnnotationSummary",
                             "kind": "LinkedField",
                             "name": "annotationSummaries",
@@ -380,12 +437,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9b6f82293b5d03e1df6d2e1ba93bf21c",
+    "cacheID": "6eef09cdb83b93063583483d4c2e2469",
     "id": null,
     "metadata": {},
     "name": "experimentsLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentsLoaderQuery(\n  $id: ID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n      firstExperiment: experiments(first: 1) {\n        edges {\n          node {\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query experimentsLoaderQuery(\n  $id: ID!\n) {\n  dataset: node(id: $id) {\n    __typename\n    id\n    ... on Dataset {\n      ...ExperimentsTableFragment\n      firstExperiment: experiments(first: 1) {\n        edges {\n          node {\n            id\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        averageRunLatencyMs\n        project {\n          id\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Plumbing through cost and tokens to the experiments table. Note the backend is not doing the right thing here.

https://www.loom.com/share/e8e2386fb50048de8901c8860d50479b

## Summary by Sourcery

Expose cost and token usage data in the experiments table by adding costSummary GraphQL fields and new 'cost' and 'tokens' columns.

New Features:
- Add a 'cost' column to show experiment cost
- Add a 'tokens' column to show token usage for each experiment

Enhancements:
- Expand ExperimentsTable GraphQL fragments to include costSummary fields