### PR TITLE
fix: Use correct join conditions for experiment cost resolvers

### DIFF
--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_experiment.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_experiment.py
@@ -31,9 +31,8 @@ class SpanCostSummaryByExperimentDataLoader(DataLoader[Key, Result]):
                 coalesce(func.sum(models.SpanCost.total_tokens), 0).label("total_tokens"),
             )
             .select_from(models.ExperimentRun)
-            .join(models.Trace, models.ExperimentRun.trace_id == models.Trace.id)
-            .join(models.Span, models.Span.trace_rowid == models.Trace.id)
-            .join(models.SpanCost, models.Span.id == models.SpanCost.span_rowid)
+            .join(models.Trace, models.ExperimentRun.trace_id == models.Trace.trace_id)
+            .join(models.SpanCost, models.SpanCost.trace_rowid == models.Trace.id)
             .where(models.ExperimentRun.experiment_id.in_(keys))
             .group_by(models.ExperimentRun.experiment_id)
         )

--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_experiment_run.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_experiment_run.py
@@ -31,9 +31,8 @@ class SpanCostSummaryByExperimentRunDataLoader(DataLoader[Key, Result]):
                 coalesce(func.sum(models.SpanCost.total_tokens), 0).label("total_tokens"),
             )
             .select_from(models.ExperimentRun)
-            .join(models.Trace, models.ExperimentRun.trace_id == models.Trace.id)
-            .join(models.Span, models.Span.trace_rowid == models.Trace.id)
-            .join(models.SpanCost, models.Span.id == models.SpanCost.span_rowid)
+            .join(models.Trace, models.ExperimentRun.trace_id == models.Trace.trace_id)
+            .join(models.SpanCost, models.SpanCost.trace_rowid == models.Trace.id)
             .where(models.ExperimentRun.id.in_(keys))
             .group_by(models.ExperimentRun.id)
         )

--- a/src/phoenix/server/api/types/Experiment.py
+++ b/src/phoenix/server/api/types/Experiment.py
@@ -172,7 +172,7 @@ class Experiment(Node):
             .join(models.SpanCost, models.SpanCostDetail.span_cost_id == models.SpanCost.id)
             .join(models.Span, models.SpanCost.span_rowid == models.Span.id)
             .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-            .join(models.ExperimentRun, models.ExperimentRun.trace_id == models.Trace.id)
+            .join(models.ExperimentRun, models.ExperimentRun.trace_id == models.Trace.trace_id)
             .where(models.ExperimentRun.experiment_id == experiment_id)
             .group_by(models.SpanCostDetail.token_type, models.SpanCostDetail.is_prompt)
         )

--- a/src/phoenix/server/api/types/ExperimentRun.py
+++ b/src/phoenix/server/api/types/ExperimentRun.py
@@ -138,7 +138,7 @@ class ExperimentRun(Node):
             .join(models.SpanCost, models.SpanCostDetail.span_cost_id == models.SpanCost.id)
             .join(models.Span, models.SpanCost.span_rowid == models.Span.id)
             .join(models.Trace, models.Span.trace_rowid == models.Trace.id)
-            .join(models.ExperimentRun, models.ExperimentRun.trace_id == models.Trace.id)
+            .join(models.ExperimentRun, models.ExperimentRun.trace_id == models.Trace.trace_id)
             .where(models.ExperimentRun.id == run_id)
             .group_by(models.SpanCostDetail.token_type, models.SpanCostDetail.is_prompt)
         )


### PR DESCRIPTION
resolves #8216 

The existing resolvers join on the wrong ids (trace_ids <-> trace.id)

## Summary by Sourcery

Fix join conditions in experiment cost resolvers to correctly associate ExperimentRun with Trace and SpanCost entities across the dataloaders and GraphQL types

Bug Fixes:
- Use ExperimentRun.trace_id to join against Trace.trace_id instead of Trace.id in span cost summary loaders and cost detail resolvers
- Join SpanCost directly on trace_rowid to Trace.id and remove the incorrect intermediate Span join