### PR TITLE
feat(cost): add tooltip, add it to icon buttons

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1030,7 +1030,7 @@ export const derivedCSS = (theme: ThemeContextType["theme"]) => css`
     );
 
     // Style for tooltips
-    --ac-global-tooltip-background-color: var(--ac-global-color-grey-100);
+    --ac-global-tooltip-background-color: var(--ac-global-color-grey-50);
     --ac-global-tooltip-border-color: var(--ac-global-color-grey-300);
 
     --ac-global-rounding-xsmall: var(--ac-global-dimension-static-size-25);

--- a/app/src/components/tooltip/Tooltip.tsx
+++ b/app/src/components/tooltip/Tooltip.tsx
@@ -1,0 +1,17 @@
+import { forwardRef, Ref } from "react";
+import { Tooltip as AriaTooltip } from "react-aria-components";
+import { css } from "@emotion/react";
+
+import { tooltipCSS } from "./styles";
+import { TooltipProps } from "./types";
+
+function Tooltip(props: TooltipProps, ref: Ref<HTMLDivElement>) {
+  const { css: propCSS, ...otherProps } = props;
+
+  return (
+    <AriaTooltip {...otherProps} ref={ref} css={css(tooltipCSS, propCSS)} />
+  );
+}
+
+const _Tooltip = forwardRef(Tooltip);
+export { _Tooltip as Tooltip };

--- a/app/src/components/tooltip/TooltipArrow.tsx
+++ b/app/src/components/tooltip/TooltipArrow.tsx
@@ -1,28 +1,21 @@
 import { forwardRef, Ref } from "react";
 import { OverlayArrow } from "react-aria-components";
-import { css, SerializedStyles } from "@emotion/react";
 
-const arrowCSS = css`
-  & svg {
-    display: block;
-    fill: var(--ac-global-tooltip-background-color);
-    stroke: var(--ac-global-tooltip-border-color);
-    stroke-width: 1px;
-  }
-`;
+import { classNames } from "@arizeai/components";
 
-export interface TooltipArrowProps {
-  /**
-   * Custom CSS to apply to the arrow
-   */
-  css?: SerializedStyles;
-}
+import { StylableProps } from "../types";
+
+export interface TooltipArrowProps extends StylableProps {}
 
 function TooltipArrow(props: TooltipArrowProps, ref: Ref<HTMLDivElement>) {
   const { css: propCSS } = props;
 
   return (
-    <OverlayArrow ref={ref} css={css(arrowCSS, propCSS)}>
+    <OverlayArrow
+      ref={ref}
+      css={propCSS}
+      className={classNames("react-aria-OverlayArrow")}
+    >
       <svg width={8} height={8} viewBox="0 0 8 8">
         <path d="M0 0 L4 4 L8 0" />
       </svg>

--- a/app/src/components/tooltip/TooltipArrow.tsx
+++ b/app/src/components/tooltip/TooltipArrow.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, Ref } from "react";
+import { OverlayArrow } from "react-aria-components";
+import { css, SerializedStyles } from "@emotion/react";
+
+const arrowCSS = css`
+  & svg {
+    display: block;
+    fill: var(--ac-global-tooltip-background-color);
+    stroke: var(--ac-global-tooltip-border-color);
+    stroke-width: 1px;
+  }
+`;
+
+export interface TooltipArrowProps {
+  /**
+   * Custom CSS to apply to the arrow
+   */
+  css?: SerializedStyles;
+}
+
+function TooltipArrow(props: TooltipArrowProps, ref: Ref<HTMLDivElement>) {
+  const { css: propCSS } = props;
+
+  return (
+    <OverlayArrow ref={ref} css={css(arrowCSS, propCSS)}>
+      <svg width={8} height={8} viewBox="0 0 8 8">
+        <path d="M0 0 L4 4 L8 0" />
+      </svg>
+    </OverlayArrow>
+  );
+}
+
+const _TooltipArrow = forwardRef(TooltipArrow);
+export { _TooltipArrow as TooltipArrow };

--- a/app/src/components/tooltip/index.tsx
+++ b/app/src/components/tooltip/index.tsx
@@ -1,0 +1,5 @@
+export { TooltipTrigger, OverlayArrow } from "react-aria-components";
+export { Tooltip } from "./Tooltip";
+export { TooltipArrow } from "./TooltipArrow";
+export type { TooltipProps } from "./types";
+export type { TooltipArrowProps } from "./TooltipArrow";

--- a/app/src/components/tooltip/styles.ts
+++ b/app/src/components/tooltip/styles.ts
@@ -1,0 +1,64 @@
+import { css } from "@emotion/react";
+
+export const tooltipCSS = css`
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  border-radius: var(--ac-global-rounding-small);
+  background: var(--ac-global-tooltip-background-color);
+  border: var(--ac-global-border-size-thin) solid
+    var(--ac-global-tooltip-border-color);
+  color: var(--ac-global-text-color-900);
+  forced-color-adjust: none;
+  outline: none;
+  padding: var(--ac-global-dimension-static-size-100)
+    var(--ac-global-dimension-static-size-200);
+  max-width: 150px;
+  font-size: var(--ac-global-font-size-s);
+  /* fixes FF gap */
+  transform: translate3d(0, 0, 0);
+  transition:
+    transform 200ms,
+    opacity 200ms;
+
+  &[data-entering],
+  &[data-exiting] {
+    transform: var(--tooltip-origin);
+    opacity: 0;
+  }
+
+  &[data-placement="top"] {
+    margin-bottom: var(--ac-global-dimension-static-size-100);
+    --tooltip-origin: translateY(4px);
+  }
+
+  &[data-placement="bottom"] {
+    margin-top: var(--ac-global-dimension-static-size-100);
+    --tooltip-origin: translateY(-4px);
+
+    & .react-aria-OverlayArrow svg {
+      transform: rotate(180deg);
+    }
+  }
+
+  &[data-placement="right"] {
+    margin-left: var(--ac-global-dimension-static-size-100);
+    --tooltip-origin: translateX(-4px);
+
+    & .react-aria-OverlayArrow svg {
+      transform: rotate(90deg);
+    }
+  }
+
+  &[data-placement="left"] {
+    margin-right: var(--ac-global-dimension-static-size-100);
+    --tooltip-origin: translateX(4px);
+
+    & .react-aria-OverlayArrow svg {
+      transform: rotate(-90deg);
+    }
+  }
+
+  & .react-aria-OverlayArrow svg {
+    display: block;
+    fill: var(--ac-global-tooltip-background-color);
+  }
+`;

--- a/app/src/components/tooltip/styles.ts
+++ b/app/src/components/tooltip/styles.ts
@@ -60,5 +60,7 @@ export const tooltipCSS = css`
   & .react-aria-OverlayArrow svg {
     display: block;
     fill: var(--ac-global-tooltip-background-color);
+    stroke: var(--ac-global-tooltip-border-color);
+    stroke-width: 1px;
   }
 `;

--- a/app/src/components/tooltip/types.tsx
+++ b/app/src/components/tooltip/types.tsx
@@ -1,0 +1,5 @@
+import { TooltipProps as AriaTooltipProps } from "react-aria-components";
+
+import { StylableProps } from "@phoenix/components/types";
+
+export interface TooltipProps extends AriaTooltipProps, StylableProps {}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -45,6 +45,11 @@ import {
   ViewSummaryAside,
 } from "@phoenix/components";
 import {
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+} from "@phoenix/components/tooltip";
+import {
   AnnotationLabel,
   AnnotationTooltip,
 } from "@phoenix/components/annotation";
@@ -296,18 +301,24 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             <>
               <CellTop
                 extra={
-                  <IconButton
-                    size="S"
-                    onPress={() => {
-                      setDialog(
-                        <ExampleDetailsDialog
-                          exampleId={row.original.example.id}
-                        />
-                      );
-                    }}
-                  >
-                    <Icon svg={<Icons.ExpandOutline />} />
-                  </IconButton>
+                  <TooltipTrigger>
+                    <IconButton
+                      size="S"
+                      onPress={() => {
+                        setDialog(
+                          <ExampleDetailsDialog
+                            exampleId={row.original.example.id}
+                          />
+                        );
+                      }}
+                    >
+                      <Icon svg={<Icons.ExpandOutline />} />
+                    </IconButton>
+                    <Tooltip>
+                      <TooltipArrow />
+                      view example
+                    </Tooltip>
+                  </TooltipTrigger>
                 }
               >
                 <Text
@@ -397,42 +408,54 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
         const projectId = run?.trace?.projectId;
         if (traceId && projectId) {
           traceButton = (
-            <IconButton
-              className="trace-button"
-              size="S"
-              aria-label="View run trace"
-              onPress={() => {
-                setDialog(
-                  <TraceDetailsDialog
-                    traceId={traceId}
-                    projectId={projectId}
-                    title={`Experiment Run Trace`}
-                  />
-                );
-              }}
-            >
-              <Icon svg={<Icons.Trace />} />
-            </IconButton>
+            <TooltipTrigger>
+              <IconButton
+                className="trace-button"
+                size="S"
+                aria-label="View run trace"
+                onPress={() => {
+                  setDialog(
+                    <TraceDetailsDialog
+                      traceId={traceId}
+                      projectId={projectId}
+                      title={`Experiment Run Trace`}
+                    />
+                  );
+                }}
+              >
+                <Icon svg={<Icons.Trace />} />
+              </IconButton>
+              <Tooltip>
+                <TooltipArrow />
+                view run trace
+              </Tooltip>
+            </TooltipTrigger>
           );
         }
         const runControls = (
           <>
-            <IconButton
-              className="expand-button"
-              size="S"
-              aria-label="View example run details"
-              onPress={() => {
-                setDialog(
-                  <SelectedExampleDialog
-                    selectedExample={row.original}
-                    datasetId={datasetId}
-                    experimentInfoById={experimentInfoById}
-                  />
-                );
-              }}
-            >
-              <Icon svg={<Icons.ExpandOutline />} />
-            </IconButton>
+            <TooltipTrigger>
+              <IconButton
+                className="expand-button"
+                size="S"
+                aria-label="View example run details"
+                onPress={() => {
+                  setDialog(
+                    <SelectedExampleDialog
+                      selectedExample={row.original}
+                      datasetId={datasetId}
+                      experimentInfoById={experimentInfoById}
+                    />
+                  );
+                }}
+              >
+                <Icon svg={<Icons.ExpandOutline />} />
+              </IconButton>
+              <Tooltip>
+                <TooltipArrow />
+                view experiment run
+              </Tooltip>
+            </TooltipTrigger>
             {traceButton}
           </>
         );
@@ -717,10 +740,16 @@ function ExperimentRowActionMenu(props: {
       }}
     >
       <DialogTrigger>
-        <Button
-          size="S"
-          leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
-        />
+        <TooltipTrigger>
+          <Button
+            size="S"
+            leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
+          />
+          <Tooltip>
+            <TooltipArrow />
+            More actions
+          </Tooltip>
+        </TooltipTrigger>
         <Popover>
           <Dialog>
             {({ close }) => (

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -45,11 +45,6 @@ import {
   ViewSummaryAside,
 } from "@phoenix/components";
 import {
-  Tooltip,
-  TooltipArrow,
-  TooltipTrigger,
-} from "@phoenix/components/tooltip";
-import {
   AnnotationLabel,
   AnnotationTooltip,
 } from "@phoenix/components/annotation";
@@ -71,6 +66,11 @@ import {
 } from "@phoenix/components/table";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+} from "@phoenix/components/tooltip";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { Truncate } from "@phoenix/components/utility/Truncate";

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -31,6 +31,7 @@ import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TextCell } from "@phoenix/components/table/TextCell";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
+import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useWordColor } from "@phoenix/hooks/useWordColor";
 import {
@@ -324,7 +325,7 @@ export function ExperimentsTable({
       },
     },
     {
-      header: "cost",
+      header: "total cost",
       accessorKey: "costSummary.total.cost",
       meta: {
         textAlign: "right",
@@ -338,17 +339,14 @@ export function ExperimentsTable({
       },
     },
     {
-      header: "tokens",
+      header: "total tokens",
       accessorKey: "costSummary.total.tokens",
       meta: {
         textAlign: "right",
       },
       cell: ({ getValue }) => {
         const value = getValue();
-        if (value === null || typeof value !== "number") {
-          return "--";
-        }
-        return <Text>{`${value}`}</Text>;
+        return <TokenCount>{value as number | null}</TokenCount>;
       },
     },
     {

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -51,6 +51,11 @@ import { JSONText } from "@phoenix/components/code/JSONText";
 import { CellTop } from "@phoenix/components/table";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+} from "@phoenix/components/tooltip";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SpanTokenCount } from "@phoenix/components/trace/SpanTokenCount";
 import { TokenCosts } from "@phoenix/components/trace/TokenCosts";
@@ -274,9 +279,15 @@ function ExampleOutputContent({
         <>
           {hasExperimentRun && (
             <DialogTrigger>
-              <IconButton size="S" aria-label="View experiment run details">
-                <Icon svg={<Icons.ExpandOutline />} />
-              </IconButton>
+              <TooltipTrigger>
+                <IconButton size="S" aria-label="View experiment run details">
+                  <Icon svg={<Icons.ExpandOutline />} />
+                </IconButton>
+                <Tooltip>
+                  <TooltipArrow />
+                  view experiment run
+                </Tooltip>
+              </TooltipTrigger>
               <ModalOverlay>
                 <Modal variant="slideover" size="L">
                   <PlaygroundExperimentRunDetailsDialog
@@ -289,9 +300,15 @@ function ExampleOutputContent({
           {hasSpan && (
             <>
               <DialogTrigger>
-                <IconButton size="S" aria-label="View run trace">
-                  <Icon svg={<Icons.Trace />} />
-                </IconButton>
+                <TooltipTrigger>
+                  <IconButton size="S" aria-label="View run trace">
+                    <Icon svg={<Icons.Trace />} />
+                  </IconButton>
+                  <Tooltip>
+                    <TooltipArrow />
+                    view run trace
+                  </Tooltip>
+                </TooltipTrigger>
                 <ModalOverlay>
                   <Modal size="fullscreen" variant="slideover">
                     <PlaygroundRunTraceDetailsDialog
@@ -811,18 +828,24 @@ export function PlaygroundDatasetExamplesTable({
           <>
             <CellTop
               extra={
-                <IconButton
-                  size="S"
-                  aria-label="View example details"
-                  onPress={() => {
-                    setSearchParams((prev) => {
-                      prev.set("exampleId", row.original.id);
-                      return prev;
-                    });
-                  }}
-                >
-                  <Icon svg={<Icons.ExpandOutline />} />
-                </IconButton>
+                <TooltipTrigger>
+                  <IconButton
+                    size="S"
+                    aria-label="View example details"
+                    onPress={() => {
+                      setSearchParams((prev) => {
+                        prev.set("exampleId", row.original.id);
+                        return prev;
+                      });
+                    }}
+                  >
+                    <Icon svg={<Icons.ExpandOutline />} />
+                  </IconButton>
+                  <Tooltip>
+                    <TooltipArrow />
+                    view example
+                  </Tooltip>
+                </TooltipTrigger>
               }
             >
               <Text

--- a/app/src/pages/settings/ModelsTable.tsx
+++ b/app/src/pages/settings/ModelsTable.tsx
@@ -17,6 +17,11 @@ import {
   selectableTableCSS,
 } from "@phoenix/components/table/styles";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+} from "@phoenix/components/tooltip";
 import { EditModelButton } from "@phoenix/pages/settings/EditModelButton";
 import { getProviderName } from "@phoenix/utils/generativeUtils";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -271,17 +276,37 @@ export function ModelsTable(props: ModelsTableProps) {
               width="100%"
               justifyContent="end"
             >
-              {isOverride && <EditModelButton modelId={row.original.id} />}
-              <CloneModelButton
-                modelId={row.original.id}
-                connectionId={connectionId}
-              />
               {isOverride && (
-                <DeleteModelButton
+                <TooltipTrigger>
+                  <EditModelButton modelId={row.original.id} />
+                  <Tooltip>
+                    <TooltipArrow />
+                    Edit model
+                  </Tooltip>
+                </TooltipTrigger>
+              )}
+              <TooltipTrigger>
+                <CloneModelButton
                   modelId={row.original.id}
-                  modelName={row.original.name}
                   connectionId={connectionId}
                 />
+                <Tooltip>
+                  <TooltipArrow />
+                  Clone model
+                </Tooltip>
+              </TooltipTrigger>
+              {isOverride && (
+                <TooltipTrigger>
+                  <DeleteModelButton
+                    modelId={row.original.id}
+                    modelName={row.original.name}
+                    connectionId={connectionId}
+                  />
+                  <Tooltip>
+                    <TooltipArrow />
+                    Delete model
+                  </Tooltip>
+                </TooltipTrigger>
               )}
             </Flex>
           );

--- a/app/stories/Tooltip.stories.tsx
+++ b/app/stories/Tooltip.stories.tsx
@@ -1,0 +1,314 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button, Icon, Icons } from "@phoenix/components";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipProps,
+  TooltipTrigger,
+} from "@phoenix/components/tooltip";
+
+/**
+ * Tooltips display helpful information when users hover over, focus on, or tap an element.
+ * They provide contextual information without cluttering the interface and are fully accessible.
+ * The tooltip component wraps react-aria-components' Tooltip with Phoenix design system styling.
+ */
+const meta = {
+  title: "Tooltip",
+  component: Tooltip,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    placement: {
+      control: "select",
+      options: [
+        "top",
+        "bottom",
+        "left",
+        "right",
+        "top start",
+        "top end",
+        "bottom start",
+        "bottom end",
+        "left top",
+        "left bottom",
+        "right top",
+        "right bottom",
+      ],
+      description:
+        "The placement of the tooltip relative to the trigger element",
+      defaultValue: "top",
+    },
+    offset: {
+      control: "number",
+      description: "The offset distance from the trigger element",
+      defaultValue: 8,
+    },
+    crossOffset: {
+      control: "number",
+      description: "The cross-axis offset from the trigger element",
+      defaultValue: 0,
+    },
+    isEntering: {
+      control: "boolean",
+      description: "Whether the tooltip is in the entering animation state",
+      defaultValue: false,
+    },
+    isExiting: {
+      control: "boolean",
+      description: "Whether the tooltip is in the exiting animation state",
+      defaultValue: false,
+    },
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The default tooltip shows helpful information when hovering over a trigger element.
+ */
+export const Default: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Hover me</Button>
+      <Tooltip {...args}>This is a helpful tooltip</Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "top",
+  },
+};
+
+/**
+ * Tooltips can include an arrow pointing to the trigger element for better visual connection.
+ */
+export const WithArrow: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Hover for tooltip with arrow</Button>
+      <Tooltip {...args}>
+        <TooltipArrow />
+        This tooltip has an arrow pointing to the trigger
+      </Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "top",
+  },
+};
+
+/**
+ * Tooltips can be positioned on different sides of the trigger element.
+ */
+export const TopPlacement: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Top tooltip</Button>
+      <Tooltip {...args}>Tooltip positioned above the trigger</Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "top",
+  },
+};
+
+export const BottomPlacement: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Bottom tooltip</Button>
+      <Tooltip {...args}>Tooltip positioned below the trigger</Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "bottom",
+  },
+};
+
+export const LeftPlacement: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Left tooltip</Button>
+      <Tooltip {...args}>Tooltip positioned to the left</Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "left",
+  },
+};
+
+export const RightPlacement: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Right tooltip</Button>
+      <Tooltip {...args}>Tooltip positioned to the right</Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "right",
+  },
+};
+
+/**
+ * Tooltips work with different types of trigger elements, not just buttons.
+ */
+export const WithIconButton: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button variant="quiet" size="S">
+        <Icon svg={<Icons.InfoOutline />} />
+      </Button>
+      <Tooltip {...args}>
+        <TooltipArrow />
+        This tooltip explains what the info icon does
+      </Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "top",
+  },
+};
+
+/**
+ * Tooltips can contain longer text content that will wrap appropriately.
+ */
+export const LongContent: Story = {
+  render: (args: TooltipProps) => (
+    <TooltipTrigger>
+      <Button>Long tooltip content</Button>
+      <Tooltip {...args}>
+        This is a longer tooltip that demonstrates how the component handles
+        multiple lines of text. The tooltip will wrap content appropriately
+        within its maximum width constraints.
+      </Tooltip>
+    </TooltipTrigger>
+  ),
+  args: {
+    placement: "top",
+  },
+};
+
+/**
+ * Multiple tooltips can be used together. They support global delay behavior
+ * where subsequent tooltips show immediately after the first one.
+ */
+export const MultipleTooltips: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+      <TooltipTrigger>
+        <Button size="S">First</Button>
+        <Tooltip placement="top">First tooltip</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <Button size="S">Second</Button>
+        <Tooltip placement="top">Second tooltip</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <Button size="S">Third</Button>
+        <Tooltip placement="top">Third tooltip</Tooltip>
+      </TooltipTrigger>
+    </div>
+  ),
+};
+
+/**
+ * Demonstration of all available placements in a grid layout.
+ */
+export const AllPlacements: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 120px)",
+        gap: "50px",
+        padding: "100px",
+        justifyItems: "center",
+      }}
+    >
+      {/* Top row */}
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Top</Button>
+        <Tooltip placement="top">Top placement</Tooltip>
+      </TooltipTrigger>
+      <div></div>
+
+      {/* Middle row */}
+      <TooltipTrigger>
+        <Button size="S">Left</Button>
+        <Tooltip placement="left">Left placement</Tooltip>
+      </TooltipTrigger>
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Right</Button>
+        <Tooltip placement="right">Right placement</Tooltip>
+      </TooltipTrigger>
+
+      {/* Bottom row */}
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Bottom</Button>
+        <Tooltip placement="bottom">Bottom placement</Tooltip>
+      </TooltipTrigger>
+      <div></div>
+    </div>
+  ),
+};
+
+/**
+ * Demonstration of tooltips with arrows on all placements.
+ */
+export const AllPlacementsWithArrows: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 120px)",
+        gap: "50px",
+        padding: "100px",
+        justifyItems: "center",
+      }}
+    >
+      {/* Top row */}
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Top</Button>
+        <Tooltip placement="top">
+          <TooltipArrow />
+          Top with arrow
+        </Tooltip>
+      </TooltipTrigger>
+      <div></div>
+
+      {/* Middle row */}
+      <TooltipTrigger>
+        <Button size="S">Left</Button>
+        <Tooltip placement="left">
+          <TooltipArrow />
+          Left with arrow
+        </Tooltip>
+      </TooltipTrigger>
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Right</Button>
+        <Tooltip placement="right">
+          <TooltipArrow />
+          Right with arrow
+        </Tooltip>
+      </TooltipTrigger>
+
+      {/* Bottom row */}
+      <div></div>
+      <TooltipTrigger>
+        <Button size="S">Bottom</Button>
+        <Tooltip placement="bottom">
+          <TooltipArrow />
+          Bottom with arrow
+        </Tooltip>
+      </TooltipTrigger>
+      <div></div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Create an initial draft of icons and add them to the Icon only buttons on experiments.

https://github.com/user-attachments/assets/c9ca7310-9458-4fdb-bee0-301e153f89e9

## Summary by Sourcery

Add a new Tooltip component to the design system and apply tooltips to existing icon-only buttons across experiment and playground tables.

New Features:
- Introduce Tooltip and TooltipArrow components with emotion styling and type definitions

Enhancements:
- Wrap existing IconButton and Button triggers in TooltipTrigger and Tooltip to provide contextual tooltips for viewing examples, run traces, and more actions
- Adjust global tooltip background color variable to improve contrast

Documentation:
- Add Storybook stories for Tooltip showcasing placements, arrow usage, long content, and multiple tooltip examples