### PR TITLE
refactor(cost): use BigInteger for primary keys

### DIFF
--- a/src/phoenix/db/migrations/versions/a20694b15f82_cost.py
+++ b/src/phoenix/db/migrations/versions/a20694b15f82_cost.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
         "generative_models",
         sa.Column(
             "id",
-            sa.Integer,
+            sa.BigInteger,
             primary_key=True,
         ),
         sa.Column(
@@ -69,7 +69,7 @@ def upgrade() -> None:
         "token_prices",
         sa.Column(
             "id",
-            sa.Integer,
+            sa.BigInteger,
             primary_key=True,
         ),
         sa.Column(
@@ -93,7 +93,7 @@ def upgrade() -> None:
         "span_costs",
         sa.Column(
             "id",
-            sa.Integer,
+            sa.BigInteger,
             primary_key=True,
         ),
         sa.Column(
@@ -134,7 +134,7 @@ def upgrade() -> None:
         "span_cost_details",
         sa.Column(
             "id",
-            sa.Integer,
+            sa.BigInteger,
             primary_key=True,
         ),
         sa.Column(

--- a/src/phoenix/db/migrations/versions/a20694b15f82_cost.py
+++ b/src/phoenix/db/migrations/versions/a20694b15f82_cost.py
@@ -17,13 +17,18 @@ down_revision: Union[str, None] = "6a88424799fe"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+_Integer = sa.Integer().with_variant(
+    sa.BigInteger(),
+    "postgresql",
+)
+
 
 def upgrade() -> None:
     op.create_table(
         "generative_models",
         sa.Column(
             "id",
-            sa.BigInteger,
+            _Integer,
             primary_key=True,
         ),
         sa.Column(
@@ -69,7 +74,7 @@ def upgrade() -> None:
         "token_prices",
         sa.Column(
             "id",
-            sa.BigInteger,
+            _Integer,
             primary_key=True,
         ),
         sa.Column(
@@ -93,7 +98,7 @@ def upgrade() -> None:
         "span_costs",
         sa.Column(
             "id",
-            sa.BigInteger,
+            _Integer,
             primary_key=True,
         ),
         sa.Column(
@@ -134,7 +139,7 @@ def upgrade() -> None:
         "span_cost_details",
         sa.Column(
             "id",
-            sa.BigInteger,
+            _Integer,
             primary_key=True,
         ),
         sa.Column(

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     JSON,
     NUMERIC,
     TIMESTAMP,
+    BigInteger,
     Boolean,
     CheckConstraint,
     ColumnElement,
@@ -440,7 +441,6 @@ class Base(DeclarativeBase):
 
 class ProjectTraceRetentionPolicy(Base):
     __tablename__ = "project_trace_retention_policies"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     cron_expression: Mapped[TraceRetentionCronExpression] = mapped_column(
         _TraceRetentionCronExpression, nullable=False
@@ -1337,6 +1337,7 @@ CostType: TypeAlias = Literal["DEFAULT", "OVERRIDE"]
 
 class GenerativeModel(Base):
     __tablename__ = "generative_models"
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     provider: Mapped[Optional[str]]
     start_time: Mapped[Optional[datetime]]
@@ -1362,7 +1363,9 @@ class GenerativeModel(Base):
 
 class TokenPrice(Base):
     __tablename__ = "token_prices"
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     model_id: Mapped[int] = mapped_column(
+        BigInteger,
         ForeignKey("generative_models.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -1563,7 +1566,7 @@ class ProjectAnnotationConfig(Base):
 
 class SpanCost(Base):
     __tablename__ = "span_costs"
-
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     span_rowid: Mapped[int] = mapped_column(
         ForeignKey("spans.id", ondelete="CASCADE"),
         nullable=False,
@@ -1668,7 +1671,9 @@ class SpanCost(Base):
 
 class SpanCostDetail(Base):
     __tablename__ = "span_cost_details"
+    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     span_cost_id: Mapped[int] = mapped_column(
+        BigInteger,
         ForeignKey("span_costs.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -419,7 +419,7 @@ class ExperimentRunOutput(TypedDict, total=False):
 
 
 class Base(DeclarativeBase):
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True)
     # Enforce best practices for naming constraints
     # https://alembic.sqlalchemy.org/en/latest/naming.html#integration-of-naming-conventions-into-operations-autogenerate
     metadata = MetaData(
@@ -1337,7 +1337,6 @@ CostType: TypeAlias = Literal["DEFAULT", "OVERRIDE"]
 
 class GenerativeModel(Base):
     __tablename__ = "generative_models"
-    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     provider: Mapped[Optional[str]]
     start_time: Mapped[Optional[datetime]]
@@ -1363,9 +1362,7 @@ class GenerativeModel(Base):
 
 class TokenPrice(Base):
     __tablename__ = "token_prices"
-    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
     model_id: Mapped[int] = mapped_column(
-        BigInteger,
         ForeignKey("generative_models.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -1545,7 +1542,6 @@ class PromptVersionTag(Base):
 class AnnotationConfig(Base):
     __tablename__ = "annotation_configs"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     config: Mapped[AnnotationConfigType] = mapped_column(_AnnotationConfig, nullable=False)
 
@@ -1553,7 +1549,6 @@ class AnnotationConfig(Base):
 class ProjectAnnotationConfig(Base):
     __tablename__ = "project_annotation_configs"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
     project_id: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -1566,7 +1561,7 @@ class ProjectAnnotationConfig(Base):
 
 class SpanCost(Base):
     __tablename__ = "span_costs"
-    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
+
     span_rowid: Mapped[int] = mapped_column(
         ForeignKey("spans.id", ondelete="CASCADE"),
         nullable=False,
@@ -1671,7 +1666,7 @@ class SpanCost(Base):
 
 class SpanCostDetail(Base):
     __tablename__ = "span_cost_details"
-    id: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
+
     span_cost_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("span_costs.id", ondelete="CASCADE"),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     JSON,
     NUMERIC,
     TIMESTAMP,
-    BigInteger,
     Boolean,
     CheckConstraint,
     ColumnElement,
@@ -1388,7 +1387,6 @@ class TokenPrice(Base):
 
 class PromptLabel(Base):
     __tablename__ = "prompt_labels"
-
     name: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     description: Mapped[Optional[str]]
     color: Mapped[str] = mapped_column(String, nullable=True)
@@ -1403,7 +1401,6 @@ class PromptLabel(Base):
 
 class Prompt(Base):
     __tablename__ = "prompts"
-
     source_prompt_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("prompts.id", ondelete="SET NULL"),
         index=True,
@@ -1441,7 +1438,6 @@ class Prompt(Base):
 
 class PromptPromptLabel(Base):
     __tablename__ = "prompts_prompt_labels"
-
     prompt_label_id: Mapped[int] = mapped_column(
         ForeignKey("prompt_labels.id", ondelete="CASCADE"),
         index=True,
@@ -1541,14 +1537,12 @@ class PromptVersionTag(Base):
 
 class AnnotationConfig(Base):
     __tablename__ = "annotation_configs"
-
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     config: Mapped[AnnotationConfigType] = mapped_column(_AnnotationConfig, nullable=False)
 
 
 class ProjectAnnotationConfig(Base):
     __tablename__ = "project_annotation_configs"
-
     project_id: Mapped[int] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -1666,9 +1660,7 @@ class SpanCost(Base):
 
 class SpanCostDetail(Base):
     __tablename__ = "span_cost_details"
-
     span_cost_id: Mapped[int] = mapped_column(
-        BigInteger,
         ForeignKey("span_costs.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -313,3 +313,8 @@ def test_up_and_down_migrations(
         _up(_engine, _alembic_config, "6a88424799fe")
         _down(_engine, _alembic_config, "8a3764fe7f1a")
     _up(_engine, _alembic_config, "6a88424799fe")
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "a20694b15f82")
+        _down(_engine, _alembic_config, "6a88424799fe")
+    _up(_engine, _alembic_config, "a20694b15f82")


### PR DESCRIPTION
resolves #8231

## Summary by Sourcery

Refactor several primary key columns to use BigInteger and update migrations and tests accordingly

Enhancements:
- Convert id columns and related foreign keys for generative_models, token_prices, span_costs, and span_cost_details to BigInteger
- Remove legacy Integer id mapping from project_trace_retention_policies model
- Update Alembic migration definitions to create BigInteger primary keys for affected tables

Tests:
- Extend integration tests to repeatedly apply and revert the new migration for BigInteger IDs