### PR TITLE
feat(costs): Implement rich token count and cost breakdowns

### DIFF
--- a/app/src/components/RichTokenCostBreakdown.tsx
+++ b/app/src/components/RichTokenCostBreakdown.tsx
@@ -29,7 +29,7 @@ export function RichTokenBreakdown({
     color: segment.color || getChartColor(index, colors),
   }));
   return (
-    <Flex direction="column" gap="size-100">
+    <Flex direction="column" gap="size-150">
       {/* Totals */}
       <Flex direction="row" gap="size-200" justifyContent="space-between">
         <Text weight="heavy">Total {valueLabel}</Text>

--- a/app/src/components/RichTokenCostBreakdown.tsx
+++ b/app/src/components/RichTokenCostBreakdown.tsx
@@ -39,7 +39,7 @@ export function RichTokenBreakdown({
       </Flex>
       {/* Segment graph */}
       <SegmentChart
-        height={12}
+        height={6}
         totalValue={totalValue}
         segments={segmentsWithColor}
       />

--- a/app/src/components/RichTokenCostBreakdown.tsx
+++ b/app/src/components/RichTokenCostBreakdown.tsx
@@ -1,0 +1,76 @@
+import {
+  getChartColor,
+  useChartColors,
+} from "@phoenix/components/chart/colors";
+import { SegmentChart } from "@phoenix/components/chart/SegmentChart";
+import { Text } from "@phoenix/components/content";
+import { Flex } from "@phoenix/components/layout";
+
+type RichTokenCostBreakdownProps = {
+  valueLabel: string;
+  totalValue: number;
+  formatter: (value: number) => string;
+  segments: {
+    name: string;
+    value: number;
+    color?: string;
+  }[];
+};
+
+export function RichTokenBreakdown({
+  valueLabel,
+  totalValue,
+  formatter,
+  segments,
+}: RichTokenCostBreakdownProps) {
+  const colors = useChartColors();
+  const segmentsWithColor = segments.map((segment, index) => ({
+    ...segment,
+    color: segment.color || getChartColor(index, colors),
+  }));
+  return (
+    <Flex direction="column" gap="size-100">
+      {/* Totals */}
+      <Flex direction="row" gap="size-200" justifyContent="space-between">
+        <Text weight="heavy">Total {valueLabel}</Text>
+        <Flex direction="row" gap="size-400">
+          <Text weight="heavy">{formatter(totalValue)}</Text>
+        </Flex>
+      </Flex>
+      {/* Segment graph */}
+      <SegmentChart
+        height={12}
+        totalValue={totalValue}
+        segments={segmentsWithColor}
+      />
+      {/* Segment table */}
+      <Flex direction="column" gap="size-100">
+        {segmentsWithColor.map((segment) => {
+          return (
+            <Flex
+              key={segment.name}
+              direction="row"
+              gap="size-200"
+              justifyContent="space-between"
+            >
+              <Flex direction="row" gap="size-100" alignItems="center">
+                <div
+                  style={{
+                    backgroundColor: segment.color,
+                    width: 8,
+                    height: 8,
+                    borderRadius: "100%",
+                  }}
+                />
+                <Text weight="heavy">{segment.name}</Text>
+              </Flex>
+              <Flex direction="row" gap="size-400">
+                <Text weight="heavy">{formatter(segment.value)}</Text>
+              </Flex>
+            </Flex>
+          );
+        })}
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -60,7 +60,8 @@ export const SegmentChart = ({
   return (
     <div style={{ height: `${height}px` }} css={chartContainerCSS}>
       {segments.map((segment, index) => {
-        const percentage = (segment.value / totalValue) * 100;
+        const percentage =
+          totalValue > 0 ? (segment.value / totalValue) * 100 : 0;
         const color = segment.color || getChartColor(index, colors);
         return (
           <div

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -8,7 +8,7 @@ const chartContainerCSS = css`
   flex-direction: row;
   overflow: hidden;
   border-radius: 8px;
-  gap: 4px;
+  gap: 2px;
 `;
 
 const chartSegmentCSS = css`

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -85,6 +85,7 @@ export const SegmentChart = ({ height = 12, segments }: SegmentChartProps) => {
                 dataKey={name}
                 fill={colorByNameMap[name]}
                 stackId="a"
+                isAnimationActive={false}
                 // if there is only one segment, we want to round all corners
                 radius={arr.length > 1 ? radius : DEFAULT_RADIUS}
               />

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -1,8 +1,21 @@
-import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { css } from "@emotion/react";
 
 import { getChartColor, useChartColors } from "./colors";
 
-const DEFAULT_RADIUS: [number, number, number, number] = [8, 8, 8, 8];
+const chartContainerCSS = css`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+  border-radius: 8px;
+  gap: 4px;
+`;
+
+const chartSegmentCSS = css`
+  height: 100%;
+  flex-shrink: 0;
+  flex-grow: 0;
+`;
 
 export type SegmentChartProps = {
   /**
@@ -43,62 +56,23 @@ export const SegmentChart = ({
   // this is useful for cases where the total value is not known ahead of time
   const totalValue =
     _totalValue ?? segments.reduce((acc, segment) => acc + segment.value, 0);
-  // Transform the segments into a format that recharts can use
-  const data = [
-    segments.reduce(
-      (acc, segment) => {
-        acc[segment.name] = segment.value / totalValue;
-        return acc;
-      },
-      {} as Record<string, number>
-    ),
-  ];
-  // map the segment names to their colors
-  const colorByNameMap = segments.reduce(
-    (acc, segment, index) => {
-      acc[segment.name] = segment.color || getChartColor(index, colors);
-      return acc;
-    },
-    {} as Record<string, string>
-  );
 
   return (
-    <div style={{ width: "100%", height }}>
-      <ResponsiveContainer width="100%" height={height}>
-        <BarChart
-          style={{ display: "flex" }}
-          margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-          data={data}
-          barSize="100%"
-          layout="vertical"
-        >
-          {/* recharts has a weird bug where you can not render a vertical bar chart without x and y axes */}
-          {/* so we hide them and use the dataKey to set the x and y axes */}
-          <XAxis type="number" hide />
-          <YAxis type="category" hide />
-          {Object.keys(data[0]).map((name, index, arr) => {
-            const first = index === 0;
-            const last = index === arr.length - 1;
-            // round the corners of terminal bars, but not the center bars
-            const radius: [number, number, number, number] = first
-              ? [8, 0, 0, 8]
-              : last
-                ? [0, 8, 8, 0]
-                : [0, 0, 0, 0];
-            return (
-              <Bar
-                key={name}
-                dataKey={name}
-                fill={colorByNameMap[name]}
-                stackId="a"
-                isAnimationActive={false}
-                // if there is only one segment, we want to round all corners
-                radius={arr.length > 1 ? radius : DEFAULT_RADIUS}
-              />
-            );
-          })}
-        </BarChart>
-      </ResponsiveContainer>
+    <div style={{ height: `${height}px` }} css={chartContainerCSS}>
+      {segments.map((segment, index) => {
+        const percentage = (segment.value / totalValue) * 100;
+        const color = segment.color || getChartColor(index, colors);
+        return (
+          <div
+            key={segment.name}
+            css={chartSegmentCSS}
+            style={{
+              width: `${percentage}%`,
+              backgroundColor: color,
+            }}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -1,0 +1,97 @@
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+
+import { getChartColor, useChartColors } from "./colors";
+
+const DEFAULT_RADIUS: [number, number, number, number] = [8, 8, 8, 8];
+
+export type SegmentChartProps = {
+  /**
+   * The height of the chart in pixels.
+   * Note: Values less than 12 pixels will cause rendering issues.
+   * @default 12
+   */
+  height?: number;
+  /**
+   * The total value of the chart
+   */
+  totalValue: number;
+  /**
+   * The segments to display in the chart
+   */
+  segments: {
+    /**
+     * The name of the segment
+     */
+    name: string;
+    /**
+     * The value of the segment
+     */
+    value: number;
+    /**
+     * Optional color override for the segment
+     */
+    color?: string;
+  }[];
+};
+
+export const SegmentChart = ({ height = 12, segments }: SegmentChartProps) => {
+  const colors = useChartColors();
+
+  // Transform the segments into a format that recharts can use
+  const totalValue = segments.reduce((acc, segment) => acc + segment.value, 0);
+  const data = [
+    segments.reduce(
+      (acc, segment) => {
+        acc[segment.name] = segment.value / totalValue;
+        return acc;
+      },
+      {} as Record<string, number>
+    ),
+  ];
+  // map the segment names to their colors
+  const colorByNameMap = segments.reduce(
+    (acc, segment, index) => {
+      acc[segment.name] = segment.color || getChartColor(index, colors);
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+
+  return (
+    <div style={{ width: "100%", height }}>
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart
+          margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+          data={data}
+          barSize="100%"
+          layout="vertical"
+        >
+          {/* recharts has a weird bug where you can not render a vertical bar chart without x and y axes */}
+          {/* so we hide them and use the dataKey to set the x and y axes */}
+          <XAxis type="number" hide />
+          <YAxis type="category" hide />
+          {Object.keys(data[0]).map((name, index, arr) => {
+            const first = index === 0;
+            const last = index === arr.length - 1;
+            // round the corners of terminal bars, but not the center bars
+            const radius: [number, number, number, number] = first
+              ? [8, 0, 0, 8]
+              : last
+                ? [0, 8, 8, 0]
+                : [0, 0, 0, 0];
+            return (
+              <Bar
+                key={name}
+                dataKey={name}
+                fill={colorByNameMap[name]}
+                stackId="a"
+                // if there is only one segment, we want to round all corners
+                radius={arr.length > 1 ? radius : DEFAULT_RADIUS}
+              />
+            );
+          })}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/app/src/components/chart/SegmentChart.tsx
+++ b/app/src/components/chart/SegmentChart.tsx
@@ -7,14 +7,13 @@ const DEFAULT_RADIUS: [number, number, number, number] = [8, 8, 8, 8];
 export type SegmentChartProps = {
   /**
    * The height of the chart in pixels.
-   * Note: Values less than 12 pixels will cause rendering issues.
-   * @default 12
+   * @default 6
    */
   height?: number;
   /**
    * The total value of the chart
    */
-  totalValue: number;
+  totalValue?: number;
   /**
    * The segments to display in the chart
    */
@@ -34,11 +33,17 @@ export type SegmentChartProps = {
   }[];
 };
 
-export const SegmentChart = ({ height = 12, segments }: SegmentChartProps) => {
+export const SegmentChart = ({
+  height = 6,
+  segments,
+  totalValue: _totalValue,
+}: SegmentChartProps) => {
   const colors = useChartColors();
-
+  // if the total value is not provided, we calculate it from the segments
+  // this is useful for cases where the total value is not known ahead of time
+  const totalValue =
+    _totalValue ?? segments.reduce((acc, segment) => acc + segment.value, 0);
   // Transform the segments into a format that recharts can use
-  const totalValue = segments.reduce((acc, segment) => acc + segment.value, 0);
   const data = [
     segments.reduce(
       (acc, segment) => {
@@ -61,6 +66,7 @@ export const SegmentChart = ({ height = 12, segments }: SegmentChartProps) => {
     <div style={{ width: "100%", height }}>
       <ResponsiveContainer width="100%" height={height}>
         <BarChart
+          style={{ display: "flex" }}
           margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
           data={data}
           barSize="100%"

--- a/app/src/components/chart/colors.tsx
+++ b/app/src/components/chart/colors.tsx
@@ -108,3 +108,40 @@ export const useChartColors = (): ChartColors => {
   const { theme } = useTheme();
   return useMemo(() => (theme === "dark" ? darkColors : lightColors), [theme]);
 };
+
+/**
+ * Returns a color from the chart colors based on the incoming index
+ * The colors are grouped into 5 shades of each color group
+ *
+ * @example
+ * ```ts
+ * getChartColor(0, ChartColors) // returns ChartColors.blue500
+ * getChartColor(1, ChartColors) // returns ChartColors.orange500
+ * getChartColor(2, ChartColors) // returns ChartColors.purple500
+ * getChartColor(3, ChartColors) // returns ChartColors.pink500
+ * getChartColor(4, ChartColors) // returns ChartColors.gray500
+ * getChartColor(5, ChartColors) // returns ChartColors.blue400
+ * getChartColor(6, ChartColors) // returns ChartColors.orange400
+ * // ...
+ * ```
+ * @param index - item index that will be mapped into a color
+ * @param colors - the colors to use, typically the result of useChartColors()
+ * @returns a color from the chart colors based on the incoming index
+ */
+export const getChartColor = (index: number, colors: ChartColors) => {
+  const colorGroups = [
+    ["blue", 5],
+    ["orange", 5],
+    ["purple", 5],
+    ["pink", 5],
+    ["gray", 5],
+  ] as const;
+  const groupCount = colorGroups.length;
+  const groupIndex = index % groupCount;
+  const shadeIndex = Math.floor(index / groupCount);
+  const [group, maxShades] = colorGroups[groupIndex];
+  // reduce in shades by 100 for each group, each iteration
+  const shade = 500 - 100 * (shadeIndex % maxShades);
+  const colorKey = `${group}${shade}` as keyof ChartColors;
+  return colors[colorKey] || colors.default;
+};

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -9,6 +9,7 @@ import {
   RichTooltip,
   Text,
   TextErrorBoundaryFallback,
+  TooltipArrow,
   TooltipTrigger,
   View,
 } from "@phoenix/components";
@@ -149,6 +150,7 @@ export function ProjectPageHeader(props: {
                   <Text size="L">{intFormatter(tokenCountTotal)}</Text>
                 </Focusable>
                 <RichTooltip placement="bottom">
+                  <TooltipArrow />
                   <View width="size-3600">
                     <RichTokenBreakdown
                       valueLabel="tokens"
@@ -158,10 +160,12 @@ export function ProjectPageHeader(props: {
                         {
                           name: "Prompt",
                           value: tokenCountPrompt,
+                          color: "rgba(254, 119, 99, 1)",
                         },
                         {
                           name: "Completion",
                           value: tokenCountCompletion,
+                          color: "rgba(98, 104, 239, 1)",
                         },
                       ]}
                     />
@@ -180,6 +184,7 @@ export function ProjectPageHeader(props: {
                   </Text>
                 </Focusable>
                 <RichTooltip placement="bottom">
+                  <TooltipArrow />
                   <View width="size-3600">
                     <RichTokenBreakdown
                       valueLabel="cost"
@@ -189,10 +194,12 @@ export function ProjectPageHeader(props: {
                         {
                           name: "Prompt",
                           value: data?.costSummary?.prompt?.cost ?? 0,
+                          color: "rgba(254, 119, 99, 1)",
                         },
                         {
                           name: "Completion",
                           value: data?.costSummary?.completion?.cost ?? 0,
+                          color: "rgba(98, 104, 239, 1)",
                         },
                       ]}
                     />

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -1,23 +1,21 @@
 import { ReactNode, startTransition, useEffect } from "react";
+import { Focusable } from "react-aria";
 import { graphql, useRefetchableFragment } from "react-relay";
 import { css } from "@emotion/react";
-
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
 
 import {
   ErrorBoundary,
   Flex,
+  RichTooltip,
   Text,
   TextErrorBoundaryFallback,
+  TooltipTrigger,
   View,
 } from "@phoenix/components";
+import { RichTokenBreakdown } from "@phoenix/components/RichTokenCostBreakdown";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { useStreamState } from "@phoenix/contexts/StreamStateContext";
-import {
-  costFormatter,
-  formatInt,
-  intFormatter,
-} from "@phoenix/utils/numberFormatUtils";
+import { costFormatter, intFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import { ProjectPageHeader_stats$key } from "./__generated__/ProjectPageHeader_stats.graphql";
 import { ProjectPageHeaderQuery } from "./__generated__/ProjectPageHeaderQuery.graphql";
@@ -146,78 +144,60 @@ export function ProjectPageHeader(props: {
               <Text elementType="h3" size="S" color="text-700">
                 Total Tokens
               </Text>
-              <TooltipTrigger delay={0} placement="bottom">
-                <TriggerWrap>
+              <TooltipTrigger delay={0}>
+                <Focusable>
                   <Text size="L">{intFormatter(tokenCountTotal)}</Text>
-                </TriggerWrap>
-                <HelpTooltip>
-                  <View width="size-2400">
-                    <Flex direction="column">
-                      <Flex justifyContent="space-between">
-                        <Text>Prompt Tokens</Text>
-                        <Text>
-                          {typeof tokenCountPrompt === "number"
-                            ? formatInt(tokenCountPrompt)
-                            : "--"}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Completion Tokens</Text>
-                        <Text>
-                          {typeof tokenCountCompletion === "number"
-                            ? formatInt(tokenCountCompletion)
-                            : "--"}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Total Tokens</Text>
-                        <Text>
-                          {typeof tokenCountTotal === "number"
-                            ? formatInt(tokenCountTotal)
-                            : "--"}
-                        </Text>
-                      </Flex>
-                    </Flex>
+                </Focusable>
+                <RichTooltip placement="bottom">
+                  <View width="size-3600">
+                    <RichTokenBreakdown
+                      valueLabel="tokens"
+                      totalValue={tokenCountTotal}
+                      formatter={intFormatter}
+                      segments={[
+                        {
+                          name: "Prompt",
+                          value: tokenCountPrompt,
+                        },
+                        {
+                          name: "Completion",
+                          value: tokenCountCompletion,
+                        },
+                      ]}
+                    />
                   </View>
-                </HelpTooltip>
+                </RichTooltip>
               </TooltipTrigger>
             </Flex>
             <Flex direction="column" flex="none">
               <Text elementType="h3" size="S" color="text-700">
                 Total Cost
               </Text>
-              <TooltipTrigger delay={0} placement="bottom">
-                <TriggerWrap>
+              <TooltipTrigger delay={0}>
+                <Focusable>
                   <Text size="L">
                     {costFormatter(data?.costSummary?.total?.cost ?? 0)}
                   </Text>
-                </TriggerWrap>
-                <HelpTooltip>
-                  <View width="size-2400">
-                    <Flex direction="column">
-                      <Flex justifyContent="space-between">
-                        <Text>Prompt Cost</Text>
-                        <Text>
-                          {costFormatter(data?.costSummary?.prompt?.cost ?? 0)}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Completion Cost</Text>
-                        <Text>
-                          {costFormatter(
-                            data?.costSummary?.completion?.cost ?? 0
-                          )}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="space-between">
-                        <Text>Total Cost</Text>
-                        <Text>
-                          {costFormatter(data?.costSummary?.total?.cost ?? 0)}
-                        </Text>
-                      </Flex>
-                    </Flex>
+                </Focusable>
+                <RichTooltip placement="bottom">
+                  <View width="size-3600">
+                    <RichTokenBreakdown
+                      valueLabel="cost"
+                      totalValue={data?.costSummary?.total?.cost ?? 0}
+                      formatter={costFormatter}
+                      segments={[
+                        {
+                          name: "Prompt",
+                          value: data?.costSummary?.prompt?.cost ?? 0,
+                        },
+                        {
+                          name: "Completion",
+                          value: data?.costSummary?.completion?.cost ?? 0,
+                        },
+                      ]}
+                    />
                   </View>
-                </HelpTooltip>
+                </RichTooltip>
               </TooltipTrigger>
             </Flex>
             <Flex direction="column" flex="none">

--- a/app/src/utils/numberFormatUtils.ts
+++ b/app/src/utils/numberFormatUtils.ts
@@ -14,7 +14,7 @@ type MaybeNumberFormatFn = (maybeNumber: MaybeNumber) => string;
 export function formatInt(int: number): string {
   const absInt = Math.abs(int);
   if (absInt < 1000000) return format(",")(int);
-  return format("0.2s")(int);
+  return format("0.2s")(int).replace("G", "B").replace("k", "K");
 }
 
 /**


### PR DESCRIPTION
Additionally update the Int formatter to display `K, M, B` instead of `k, M, G`

![2025-06-23 19 41 50](https://github.com/user-attachments/assets/b58749f1-c6c7-4291-8757-6208f2497706)

## Summary by Sourcery

Implement rich breakdown tooltips for token counts and costs by adding chart-based components and utilities, and update integer formatting to use uppercase units

New Features:
- Add RichTokenBreakdown component for token and cost breakdowns with segment chart and table
- Replace basic tooltips in project header with RichTooltip showing rich token and cost breakdowns
- Introduce SegmentChart component to render stacked bar charts for segment visualization
- Add getChartColor utility to map segment indices to consistent chart colors

Enhancements:
- Update formatInt to use uppercase 'K', 'M', 'B' unit suffixes instead of lowercase and 'G'