### PR TITLE
docs:  fix loopback address being used for routing

### DIFF
--- a/docs/section-self-hosting/deployment-options/docker.md
+++ b/docs/section-self-hosting/deployment-options/docker.md
@@ -49,7 +49,7 @@ docker run -p 6006:6006 -p 4317:4317 -i -t arizephoenix/phoenix:latest
 
 See  for details on the ports for the container.
 
-Navigate to [http://0.0.0.0:6006](http://0.0.0.0:6006) and you should see your local Arize Phoenix
+Navigate to [http://localhost:6006](http://localhost:6006) and you should see your local Arize Phoenix
 {% endtab %}
 {% endtabs %}
 

--- a/docs/tracing/llm-traces-1/quickstart-tracing-python.md
+++ b/docs/tracing/llm-traces-1/quickstart-tracing-python.md
@@ -41,7 +41,7 @@ Having trouble finding your endpoint? Check out [Finding your Phoenix Endpoint](
 import os
 
 # Update this with your self-hosted endpoint
-PHOENIX_ENDPOINT = "http://0.0.0.0:6006/v1/traces"
+PHOENIX_ENDPOINT = "http://localhost:6006/v1/traces"
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
- **Revert "feat(otel): support tracer provider arguments"**
- **docs: fix loopback address being used for routing**

## Summary by Sourcery

Revert the tracer-provider-args feature and streamline Phoenix OpenTelemetry registration, bump phoenix-otel to v0.12.0, fix routing examples, enrich API docs, and overhaul documentation structure and formatting.

New Features:
- Add API reference entries for experiment runs (GET/POST /v1/experiments/{experiment_id}/runs) and new annotation configs and span annotations endpoints.

Bug Fixes:
- Fix documentation examples to use `localhost` instead of `0.0.0.0` for loopback routing.

Enhancements:
- Revert support for arbitrary tracer provider kwargs, simplify `register()` to always inject a project resource and set verbose=false, and bump phoenix-otel to v0.12.0 with updated dependencies.
- Add return-type hints across tests and clean up fixtures.

Documentation:
- Normalize heading levels, fix broken and update links, add emojis and formatting in release notes, restructure SUMMARY navigation by removing outdated concept pages, and introduce new guides (annotating auto-instrumented spans and Braintrust FAQ).