### PR TITLE
refactor: simplify insert step for span costs

### DIFF
--- a/src/phoenix/server/daemons/span_cost_calculator.py
+++ b/src/phoenix/server/daemons/span_cost_calculator.py
@@ -44,8 +44,6 @@ class SpanCostCalculator(DaemonTask):
                 await self._insert_costs()
             except Exception as e:
                 logger.exception(f"Failed to insert costs: {e}")
-            finally:
-                self._queue.clear()
             await sleep(self._SLEEP_INTERVAL)
 
     async def _insert_costs(self) -> None:
@@ -68,6 +66,9 @@ class SpanCostCalculator(DaemonTask):
                 session.add_all(costs)
         except Exception as e:
             logger.exception(f"Failed to insert costs: {e}")
+        finally:
+            # Clear the queue after processing
+            self._queue.clear()
 
     def put_nowait(self, item: SpanCostCalculatorQueueItem) -> None:
         self._queue.append(item)


### PR DESCRIPTION
## Summary by Sourcery

Simplify the span cost insertion routine by consolidating all calculated costs into a single batch insert and removing unnecessary grouping structures.

Enhancements:
- Remove per-model defaultdict and consolidate costs into a single list
- Batch insert all span costs in one database session instead of per-model
- Clear the processing queue in a finally block after insertion
- Skip entries that fail cost calculation rather than appending null values