### PR TITLE
feat(cost): More clearly represent the relationship between model and provider during model configuration

### DIFF
--- a/app/src/components/token/Token.tsx
+++ b/app/src/components/token/Token.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from "react";
+import React, { forwardRef, HTMLProps, Ref } from "react";
 import { css } from "@emotion/react";
 
 import { Icon, Icons } from "@phoenix/components";
@@ -146,18 +146,21 @@ function TokenLeadingVisual({
  * 3. Removable: Wrapped child content, sibling to a remove button (onRemove)
  * 4. Full Interactive: Wrapped sibling buttons with child content in the non-remove button
  */
-function Token({
-  children,
-  isDisabled,
-  css: cssProp,
-  color = "var(--ac-global-color-grey-300)",
-  onPress,
-  onRemove,
-  size = "M",
-  style,
-  leadingVisual,
-  ...rest
-}: TokenProps) {
+function Token(
+  {
+    children,
+    isDisabled,
+    css: cssProp,
+    color = "var(--ac-global-color-grey-300)",
+    onPress,
+    onRemove,
+    size = "M",
+    style,
+    leadingVisual,
+    ...rest
+  }: TokenProps,
+  ref: Ref<HTMLDivElement>
+) {
   const { theme } = useTheme();
 
   /**
@@ -234,6 +237,7 @@ function Token({
 
   return (
     <div
+      ref={ref}
       css={css(tokenBaseCSS, cssProp)}
       // @ts-expect-error --px-token-color is a custom property
       style={{ "--ac-internal-token-color": color, ...style }}
@@ -249,5 +253,6 @@ function Token({
   );
 }
 
-export { Token };
+const _Token = forwardRef(Token);
+export { _Token as Token };
 export type { TokenProps };

--- a/app/src/pages/settings/ModelForm.tsx
+++ b/app/src/pages/settings/ModelForm.tsx
@@ -86,12 +86,14 @@ function ModelProviderComboBox({
   onChange,
   onBlur,
   invalid,
+  description,
 }: {
   value: string;
   onChange: (key: Key | null) => void;
   onBlur: () => void;
   error?: string;
   invalid: boolean;
+  description?: string;
 }) {
   return (
     <ComboBox
@@ -114,6 +116,7 @@ function ModelProviderComboBox({
       isInvalid={invalid}
       size="M"
       allowsCustomValue
+      description={description}
     >
       {PROVIDER_OPTIONS.map((item) => (
         <ComboBoxItem key={item.key} textValue={item.key} id={item.key}>
@@ -238,29 +241,10 @@ export function ModelForm({
                 size="S"
               >
                 <Label>Model name*</Label>
-                <Input placeholder="e.g., gpt-4, claude-3-sonnet" />
+                <Input placeholder="e.g. gpt-4, claude-3-sonnet" />
                 {error?.message && <FieldError>{error.message}</FieldError>}
               </TextField>
             )}
-          />
-
-          <Controller
-            name="provider"
-            control={control}
-            render={({
-              field: { onChange, onBlur, value },
-              fieldState: { invalid, error },
-            }) => {
-              return (
-                <ModelProviderComboBox
-                  value={value ?? ""}
-                  onChange={onChange}
-                  onBlur={onBlur}
-                  error={error?.message}
-                  invalid={invalid}
-                />
-              );
-            }}
           />
           <Controller
             name="namePattern"
@@ -281,12 +265,32 @@ export function ModelForm({
                   onChange(value);
                   regexFieldProps.onChange(value);
                 }}
+                size="S"
                 onBlur={onBlur}
-                size="M"
-                description="Regular expression to match model names during trace ingestion"
-                // label="Name pattern*"
+                placeholder="e.g. ^gpt-4$, ^claude-3-sonnet$"
+                description="Regular expression to match model names during trace ingestion."
+                label="Name pattern*"
               />
             )}
+          />
+          <Controller
+            name="provider"
+            control={control}
+            render={({
+              field: { onChange, onBlur, value },
+              fieldState: { invalid, error },
+            }) => {
+              return (
+                <ModelProviderComboBox
+                  value={value ?? ""}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  error={error?.message}
+                  invalid={invalid}
+                  description="Only models with this provider will be matched by the name pattern."
+                />
+              );
+            }}
           />
           <Controller
             name="startTime"

--- a/app/src/pages/settings/ModelsTable.tsx
+++ b/app/src/pages/settings/ModelsTable.tsx
@@ -212,7 +212,7 @@ export function ModelsTable({
         },
       },
       {
-        header: "name pattern",
+        header: "match pattern",
         accessorKey: "namePattern",
         cell: ({ row }) => {
           const namePattern = row.original.namePattern;


### PR DESCRIPTION
Updates model table and model form table to more clearly explain the relationship between name pattern matching and the provider. De-emphasize provider as a field that should be set by default.

Additionally fixes some minor issues with field labeling and tooltip nullish cost display.

### Model table changes

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/dd8b0fba-5478-4afb-999c-1f8f30664a72" />

Provider still searchable

<img width="1343" alt="image" src="https://github.com/user-attachments/assets/0082231b-19ae-49e8-8061-49789f5416d0" />

Has explanatory tooltip

<img width="1348" alt="image" src="https://github.com/user-attachments/assets/d287155e-b765-4162-b8b6-0f2bbc446fa1" />


### Model form changes

<img width="705" alt="image" src="https://github.com/user-attachments/assets/d5e27d1d-dc11-4203-b008-bde08c4d5246" />


Resolves #8260
Resolves #8259

## Summary by Sourcery

Clarify the relationship between model name patterns and providers by reorganizing form fields, enhancing table cells with inline icons and tooltips, updating UI components for better descriptions and focus support, and fixing cost display and placeholder issues.

Bug Fixes:
- Ensure nullish token cost displays as "--" instead of a default value.
- Fix example placeholder format for model name input.

Enhancements:
- Reposition provider selection below the name pattern in the model form with descriptive text to clarify matching behavior.
- Accept a description prop in ModelProviderComboBox and standardize placeholder and label text.
- Embed provider icons and explanatory tooltips inline within the name pattern column of the models table.
- Hide the standalone provider column by default and update column pinning to only pin the model name.
- Forward refs in the Token component to enable proper focus and tooltip interactions.