### PR TITLE
fix(cost): fallback to input/output base rate for unrecognized token types

### DIFF
--- a/src/phoenix/server/cost_tracking/cost_details_calculator.py
+++ b/src/phoenix/server/cost_tracking/cost_details_calculator.py
@@ -150,11 +150,8 @@ class SpanCostDetailsCalculator:
                 continue
 
             # Calculate cost if calculator exists for this token type
-            cost = (
-                calculators[token_type].calculate_cost(attributes, tokens)
-                if token_type in calculators
-                else None
-            )
+            # input/output are guaranteed to exist
+            cost = calculators[token_type].calculate_cost(attributes, tokens)
 
             # Calculate cost per token (avoid division by zero)
             cost_per_token = cost / tokens if cost and tokens else None

--- a/src/phoenix/server/cost_tracking/cost_details_calculator.py
+++ b/src/phoenix/server/cost_tracking/cost_details_calculator.py
@@ -109,11 +109,12 @@ class SpanCostDetailsCalculator:
                     tokens = max(0, int(token_count))
 
                     # Calculate cost if calculator exists for this token type
-                    cost = (
-                        calculators[token_type].calculate_cost(attributes, tokens)
-                        if token_type in calculators
-                        else None
-                    )
+                    if token_type in calculators:
+                        calculator = calculators[token_type]
+                    else:
+                        key = "input" if is_prompt else "output"
+                        calculator = calculators[key]
+                    cost = calculator.calculate_cost(attributes, tokens)
 
                     # Calculate cost per token (avoid division by zero)
                     cost_per_token = cost / tokens if cost and tokens else None

--- a/src/phoenix/server/cost_tracking/cost_details_calculator.py
+++ b/src/phoenix/server/cost_tracking/cost_details_calculator.py
@@ -117,7 +117,7 @@ class SpanCostDetailsCalculator:
                     cost = calculator.calculate_cost(attributes, tokens)
 
                     # Calculate cost per token (avoid division by zero)
-                    cost_per_token = cost / tokens if cost and tokens else None
+                    cost_per_token = cost / tokens if tokens else None
 
                     detail = models.SpanCostDetail(
                         token_type=token_type,

--- a/src/phoenix/server/cost_tracking/cost_details_calculator.py
+++ b/src/phoenix/server/cost_tracking/cost_details_calculator.py
@@ -21,14 +21,23 @@ class SpanCostDetailsCalculator:
     This calculator processes both detailed token counts (from span attributes) and
     aggregated token totals to provide comprehensive cost analysis for prompt and
     completion tokens. It handles multiple token types (e.g., "input", "output",
-    "system", "user", etc.) and calculates costs using configured pricing models.
+    "image", "audio", "video", "document", "reasoning", etc.) and calculates costs
+    using configured pricing models with fallback behavior.
+
+    **Fallback Behavior:**
+    - If a specific token type has a configured calculator, it uses that calculator
+    - If no specific calculator exists, it falls back to the default calculator:
+      - Prompt tokens (is_prompt=True) fall back to "input" calculator
+      - Completion tokens (is_prompt=False) fall back to "output" calculator
+
+    This ensures all token types get cost calculations even if not explicitly configured.
 
     The calculator expects token prices to include at least:
-    - An "input" token type for prompt tokens
-    - An "output" token type for completion tokens
+    - An "input" token type for prompt tokens (used as fallback for unconfigured prompt token types)
+    - An "output" token type for completion tokens (used as fallback for unconfigured completion token types)
 
     Additional token types can be configured for more granular cost tracking.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -73,14 +82,23 @@ class SpanCostDetailsCalculator:
         This method processes token usage in two phases:
         1. **Detailed token processing**: Extracts specific token counts from span attributes
            (e.g., "llm.token_count.prompt_details", "llm.token_count.completion_details")
-           and calculates costs for each token type found.
+           and calculates costs for each token type found. Uses fallback behavior for
+           token types without specific calculators.
 
         2. **Aggregated token processing**: For default token types ("input"/"output") that
            weren't found in detailed processing, calculates remaining tokens by subtracting
            detailed counts from total aggregated tokens.
 
+        **Fallback Calculation Logic:**
+        - For each token type in detailed processing:
+          - If a specific calculator exists for the token type, use it
+          - Otherwise, fall back to the default calculator ("input" for prompt tokens,
+            "output" for completion tokens)
+        - This ensures all token types receive cost calculations regardless of
+          specific calculator configuration
+
         Args:
-            span: The span containing token usage data and attributes for cost calculation.
+            attributes: Dictionary containing span attributes with token usage data.
 
         Returns:
             List of SpanCostDetail objects containing token counts, costs, and cost-per-token
@@ -88,8 +106,9 @@ class SpanCostDetailsCalculator:
 
         Note:
             - Token counts are validated and converted to non-negative integers
-            - Costs are calculated only if a calculator exists for the token type
+            - All token types receive cost calculations via fallback mechanism
             - Cost-per-token is calculated only when both cost and token count are positive
+            - If cost is 0.0, cost-per-token will be None (not 0.0) due to falsy evaluation
         """
         prompt_details: dict[_TokenType, models.SpanCostDetail] = {}
         completion_details: dict[_TokenType, models.SpanCostDetail] = {}
@@ -108,10 +127,13 @@ class SpanCostDetailsCalculator:
                         continue
                     tokens = max(0, int(token_count))
 
-                    # Calculate cost if calculator exists for this token type
+                    # Calculate cost using specific calculator or fallback to default
                     if token_type in calculators:
+                        # Use specific calculator for this token type
                         calculator = calculators[token_type]
                     else:
+                        # Fallback to default calculator: "input" for prompts,
+                        # "output" for completions
                         key = "input" if is_prompt else "output"
                         calculator = calculators[key]
                     cost = calculator.calculate_cost(attributes, tokens)
@@ -149,7 +171,7 @@ class SpanCostDetailsCalculator:
             if tokens <= 0:
                 continue
 
-            # input/output are guaranteed to exist
+            # Calculate cost using guaranteed default calculator (input/output are required)
             cost = calculators[token_type].calculate_cost(attributes, tokens)
 
             # Calculate cost per token (avoid division by zero)

--- a/src/phoenix/server/cost_tracking/cost_details_calculator.py
+++ b/src/phoenix/server/cost_tracking/cost_details_calculator.py
@@ -149,7 +149,6 @@ class SpanCostDetailsCalculator:
             if tokens <= 0:
                 continue
 
-            # Calculate cost if calculator exists for this token type
             # input/output are guaranteed to exist
             cost = calculators[token_type].calculate_cost(attributes, tokens)
 

--- a/tests/unit/server/cost_tracking/test_cost_details_calculator.py
+++ b/tests/unit/server/cost_tracking/test_cost_details_calculator.py
@@ -659,8 +659,8 @@ class TestSpanCostDetailsCalculator:
                 },
                 {
                     "image": _Cost(
-                        tokens=100, cost=0.0, cost_per_token=None
-                    ),  # Falls back to input with 0 rate, so cost_per_token is None
+                        tokens=100, cost=0.0, cost_per_token=0.0
+                    ),  # Falls back to input with 0 rate, so cost_per_token is 0.0
                 },
                 {
                     "output": _Cost(tokens=50, cost=0.1, cost_per_token=0.002),

--- a/tests/unit/server/cost_tracking/test_cost_details_calculator.py
+++ b/tests/unit/server/cost_tracking/test_cost_details_calculator.py
@@ -32,10 +32,20 @@ class TestSpanCostDetailsCalculator:
 
     - Basic functionality with aggregated token counts
     - Detailed token processing with specific token types
+    - Fallback behavior when token types don't have specific calculators
     - Edge cases (floats, negatives, invalid types)
     - Mixed scenarios (some token types have calculators, others don't)
     - Error conditions (missing required token types)
     - Zero cost rate behavior
+    - Token accounting edge cases (detailed tokens exceeding totals)
+    - Missing or malformed data handling
+
+    **Key Testing Areas:**
+    - Fallback calculation: Token types without specific calculators fall back to
+      "input" (for prompt tokens) or "output" (for completion tokens)
+    - Remaining token calculation: When detailed tokens are less than total tokens
+    - Cost-per-token edge cases: Proper handling of None vs 0.0 values
+    - Data validation: Graceful handling of invalid or missing token data
 
     Test Strategy:
     1. Parametrized tests cover the main functionality with various scenarios

--- a/tests/unit/server/cost_tracking/test_cost_details_calculator.py
+++ b/tests/unit/server/cost_tracking/test_cost_details_calculator.py
@@ -141,8 +141,8 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "audio": _Cost(tokens=20),
-                    "video": _Cost(tokens=80),
+                    "audio": _Cost(tokens=20, cost=0.02, cost_per_token=0.001),
+                    "video": _Cost(tokens=80, cost=0.08, cost_per_token=0.001),
                 },
                 {
                     "output": _Cost(tokens=50, cost=0.1, cost_per_token=0.002),
@@ -174,13 +174,23 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=30),
-                    "audio": _Cost(tokens=40),
-                    "video": _Cost(tokens=50),
-                    "document": _Cost(tokens=80),
+                    "image": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "audio": _Cost(
+                        tokens=40, cost=0.04, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "video": _Cost(
+                        tokens=50, cost=0.05, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "document": _Cost(
+                        tokens=80, cost=0.08, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                 },
                 {
-                    "reasoning": _Cost(tokens=60),
+                    "reasoning": _Cost(
+                        tokens=60, cost=0.12, cost_per_token=0.002
+                    ),  # Falls back to output calculator
                     "output": _Cost(tokens=40, cost=0.08, cost_per_token=0.002),
                 },
                 [
@@ -209,9 +219,13 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=30),
+                    "image": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                     "audio": _Cost(tokens=40, cost=0.02, cost_per_token=0.0005),
-                    "video": _Cost(tokens=30),
+                    "video": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                 },
                 {
                     "reasoning": _Cost(tokens=25, cost=0.075, cost_per_token=0.003),
@@ -243,8 +257,12 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=10),
-                    "audio": _Cost(tokens=20),
+                    "image": _Cost(
+                        tokens=10, cost=0.01, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "audio": _Cost(
+                        tokens=20, cost=0.02, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                     "input": _Cost(tokens=70, cost=0.07, cost_per_token=0.001),
                 },
                 {
@@ -273,8 +291,12 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=0),
-                    "audio": _Cost(tokens=0),
+                    "image": _Cost(
+                        tokens=0, cost=0.0, cost_per_token=None
+                    ),  # Falls back to input calculator, but 0 tokens
+                    "audio": _Cost(
+                        tokens=0, cost=0.0, cost_per_token=None
+                    ),  # Falls back to input calculator, but 0 tokens
                     "input": _Cost(tokens=100, cost=0.1, cost_per_token=0.001),
                 },
                 {
@@ -333,12 +355,20 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=30),
-                    "audio": _Cost(tokens=30),
+                    "image": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "audio": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                 },
                 {
-                    "reasoning": _Cost(tokens=15),
-                    "video": _Cost(tokens=15),
+                    "reasoning": _Cost(
+                        tokens=15, cost=0.03, cost_per_token=0.002
+                    ),  # Falls back to output calculator
+                    "video": _Cost(
+                        tokens=15, cost=0.03, cost_per_token=0.002
+                    ),  # Falls back to output calculator
                 },
                 [
                     models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
@@ -366,12 +396,20 @@ class TestSpanCostDetailsCalculator:
                     }
                 },
                 {
-                    "image": _Cost(tokens=3000),
-                    "audio": _Cost(tokens=4000),
-                    "video": _Cost(tokens=3000),
+                    "image": _Cost(
+                        tokens=3000, cost=3.0, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "audio": _Cost(
+                        tokens=4000, cost=4.0, cost_per_token=0.001
+                    ),  # Falls back to input calculator
+                    "video": _Cost(
+                        tokens=3000, cost=3.0, cost_per_token=0.001
+                    ),  # Falls back to input calculator
                 },
                 {
-                    "reasoning": _Cost(tokens=2000),
+                    "reasoning": _Cost(
+                        tokens=2000, cost=4.0, cost_per_token=0.002
+                    ),  # Falls back to output calculator
                     "output": _Cost(tokens=3000, cost=6.0, cost_per_token=0.002),
                 },
                 [
@@ -420,6 +458,220 @@ class TestSpanCostDetailsCalculator:
                     models.TokenPrice(token_type="reasoning", is_prompt=False, base_rate=0.003),
                 ],
                 id="all_calculators_scenario",
+            ),
+            # Additional missing test cases
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 100,
+                            "completion": 50,
+                            "prompt_details": {
+                                "image": 30,
+                            },
+                            "completion_details": {
+                                "reasoning": 20,
+                            },
+                        }
+                    }
+                },
+                {
+                    "image": _Cost(
+                        tokens=30, cost=0.03, cost_per_token=0.001
+                    ),  # Falls back to input
+                    "input": _Cost(tokens=70, cost=0.07, cost_per_token=0.001),  # Remaining tokens
+                },
+                {
+                    "reasoning": _Cost(
+                        tokens=20, cost=0.04, cost_per_token=0.002
+                    ),  # Falls back to output
+                    "output": _Cost(tokens=30, cost=0.06, cost_per_token=0.002),  # Remaining tokens
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="detailed_tokens_with_remaining",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 50,
+                            # Missing completion
+                        }
+                    }
+                },
+                {
+                    "input": _Cost(tokens=50, cost=0.05, cost_per_token=0.001),
+                },
+                {},  # No completion details
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="only_prompt_tokens",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "completion": 30,
+                            # Missing prompt
+                        }
+                    }
+                },
+                {},  # No prompt details
+                {
+                    "output": _Cost(tokens=30, cost=0.06, cost_per_token=0.002),
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="only_completion_tokens",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 50,
+                            "completion": 30,
+                            "prompt_details": {},  # Empty details dict
+                            "completion_details": {},  # Empty details dict
+                        }
+                    }
+                },
+                {
+                    "input": _Cost(tokens=50, cost=0.05, cost_per_token=0.001),
+                },
+                {
+                    "output": _Cost(tokens=30, cost=0.06, cost_per_token=0.002),
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="empty_details_dicts",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 50,
+                            "completion": 30,
+                            "prompt_details": "not_a_dict",  # Invalid type
+                            "completion_details": None,  # Invalid type
+                        }
+                    }
+                },
+                {
+                    "input": _Cost(tokens=50, cost=0.05, cost_per_token=0.001),
+                },
+                {
+                    "output": _Cost(tokens=30, cost=0.06, cost_per_token=0.002),
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="invalid_details_types",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 100,
+                            "completion": 50,
+                            "prompt_details": {
+                                "image": 50,
+                                "audio": 60,  # Sum exceeds prompt total
+                            },
+                            "completion_details": {
+                                "reasoning": 40,
+                                "video": 20,  # Sum exceeds completion total
+                            },
+                        }
+                    }
+                },
+                {
+                    "image": _Cost(
+                        tokens=50, cost=0.05, cost_per_token=0.001
+                    ),  # Falls back to input
+                    "audio": _Cost(
+                        tokens=60, cost=0.06, cost_per_token=0.001
+                    ),  # Falls back to input
+                },
+                {
+                    "reasoning": _Cost(
+                        tokens=40, cost=0.08, cost_per_token=0.002
+                    ),  # Falls back to output
+                    "video": _Cost(
+                        tokens=20, cost=0.04, cost_per_token=0.002
+                    ),  # Falls back to output
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="detailed_tokens_exceed_totals",
+            ),
+            # Zero cost rate scenarios
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 100,
+                            "completion": 50,
+                        }
+                    }
+                },
+                {
+                    "input": _Cost(
+                        tokens=100, cost=0.0, cost_per_token=None
+                    ),  # 0.0 cost means None cost_per_token
+                },
+                {
+                    "output": _Cost(
+                        tokens=50, cost=0.0, cost_per_token=None
+                    ),  # 0.0 cost means None cost_per_token
+                },
+                [
+                    models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.0),
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.0),
+                ],
+                id="zero_cost_rates",
+            ),
+            pytest.param(
+                {
+                    "llm": {
+                        "token_count": {
+                            "prompt": 100,
+                            "completion": 50,
+                            "prompt_details": {
+                                "image": 100,
+                            },
+                            "completion_details": {
+                                "output": 50,
+                            },
+                        }
+                    }
+                },
+                {
+                    "image": _Cost(
+                        tokens=100, cost=0.0, cost_per_token=None
+                    ),  # Falls back to input with 0 rate, so cost_per_token is None
+                },
+                {
+                    "output": _Cost(tokens=50, cost=0.1, cost_per_token=0.002),
+                },
+                [
+                    models.TokenPrice(
+                        token_type="input", is_prompt=True, base_rate=0.0
+                    ),  # Zero rate
+                    models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+                ],
+                id="zero_cost_rate_with_fallback",
             ),
         ],
     )
@@ -512,3 +764,79 @@ class TestSpanCostDetailsCalculator:
                     models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
                 ]
             )
+
+    def test_missing_token_count_section(self) -> None:
+        """
+        Test handling of spans without token count data.
+
+        This test verifies that the calculator gracefully handles:
+        - Missing llm.token_count entirely
+        - Malformed token_count structure
+        - Non-dict token_count values
+        """
+        calculator = SpanCostDetailsCalculator(
+            [
+                models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+            ]
+        )
+
+        # Test missing llm.token_count entirely
+        result = calculator.calculate_details({"llm": {}})
+        assert result == []
+
+        # Test missing llm section entirely
+        result = calculator.calculate_details({"other": "data"})
+        assert result == []
+
+        # Test non-dict token_count
+        result = calculator.calculate_details({"llm": {"token_count": "not_a_dict"}})
+        assert result == []
+
+        result = calculator.calculate_details({"llm": {"token_count": None}})
+        assert result == []
+
+        result = calculator.calculate_details({"llm": {"token_count": 123}})
+        assert result == []
+
+    def test_cost_per_token_edge_cases(self) -> None:
+        """
+        Test edge cases for cost_per_token calculation.
+
+        This test verifies proper handling of:
+        - Cost per token when cost is None (no calculator available)
+        - Cost per token when cost is 0 but tokens > 0
+        - Cost per token when both cost and tokens are 0
+        """
+        # Create calculator without specific calculators for image/audio
+        calculator = SpanCostDetailsCalculator(
+            [
+                models.TokenPrice(token_type="input", is_prompt=True, base_rate=0.001),
+                models.TokenPrice(token_type="output", is_prompt=False, base_rate=0.002),
+            ]
+        )
+
+        # Test case where we have tokens but cost is calculated (fallback behavior)
+        result = calculator.calculate_details(
+            {
+                "llm": {
+                    "token_count": {
+                        "prompt": 100,
+                        "completion": 50,
+                        "prompt_details": {"image": 50},
+                        "completion_details": {"reasoning": 25},
+                    }
+                }
+            }
+        )
+
+        # Verify that all details have proper cost_per_token calculations
+        for detail in result:
+            if detail.tokens and detail.tokens > 0:
+                if detail.cost is not None and detail.cost > 0:
+                    assert detail.cost_per_token is not None
+                    assert detail.cost_per_token == detail.cost / detail.tokens
+                elif detail.cost == 0.0:
+                    assert detail.cost_per_token == 0.0
+            else:
+                assert detail.cost_per_token is None


### PR DESCRIPTION
## Summary by Sourcery

Implement fallback in cost_details_calculator to use input or output base rate calculators for unrecognized token types and ensure cost_per_token is derived when both cost and tokens are available, and expand unit tests to cover fallback behavior and various edge cases.

Bug Fixes:
- Handle unrecognized token types by falling back to input or output calculators instead of leaving cost as None.

Enhancements:
- Always compute cost using fallback input/output calculators for unknown token types.
- Calculate cost_per_token only when both cost and token count are present and non-zero.

Tests:
- Update existing unit tests to verify cost and cost_per_token in fallback scenarios.
- Add new pytest cases for missing token_count sections, invalid detail types, totals exceeding counts, zero-cost rates, and cost_per_token edge conditions.