### PR TITLE
feat(helm): add support for imagePullSecrets to the helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -115,6 +115,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | securityContext.pod | object | `{"enabled":true,"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"},"seLinuxOptions":{},"supplementalGroups":[],"sysctls":[],"windowsOptions":{}}` | Pod-level security context settings. When enabled=true, the entire object (excluding 'enabled') is rendered directly as the pod securityContext |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
 | serviceAccount.create | bool | `false` | Create a ServiceAccount for Phoenix |
+| serviceAccount.imagePullSecrets | list | `[]` | List of image pull secrets for the ServiceAccount (if using private container registries) |
 | serviceAccount.name | string | `""` | Name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name. If not set and create is false, uses default ServiceAccount |
 | server.annotations | object | `{}` | Annotations to add to the Phoenix service |
 | server.enablePrometheus | bool | `false` | Enable Prometheus metrics endpoint on port 9090 |

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -123,3 +123,9 @@ spec:
           emptyDir: {}
         {{- end }}
       {{- end }}
+      {{- if .Values.serviceAccount.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.serviceAccount.imagePullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}

--- a/helm/templates/phoenix/serviceaccount.yaml
+++ b/helm/templates/phoenix/serviceaccount.yaml
@@ -10,4 +10,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- range .Values.serviceAccount.imagePullSecrets }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -421,6 +421,9 @@ serviceAccount:
   name: ""
   # -- Annotations to add to the ServiceAccount
   annotations: {}
+  # -- Image pull secrets for private container registries
+  # -- List of Kubernetes secrets to use for pulling images from private registries
+  imagePullSecrets: []
 
 # -- Health check configuration
 healthChecks:


### PR DESCRIPTION
fix #8299

## Summary by Sourcery

Add configurable imagePullSecrets support to the Helm chart for private container registries

New Features:
- Allow specifying imagePullSecrets under serviceAccount in values.yaml

Enhancements:
- Render imagePullSecrets in both the ServiceAccount and Deployment templates when provided

Documentation:
- Document the serviceAccount.imagePullSecrets option in the Helm chart README