### PR TITLE
fix(cost): display cumulative cost on spans table when root spans only mode is selected

### DIFF
--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -198,8 +198,8 @@ export function SpansTable(props: SpansTableProps) {
                 statusCode
                 startTime
                 latencyMs
-                tokenCountTotal
-                cumulativeTokenCountTotal
+                tokenCountTotal @skip(if: $rootSpansOnly)
+                cumulativeTokenCountTotal @include(if: $rootSpansOnly)
                 spanId
                 trace {
                   id
@@ -233,7 +233,12 @@ export function SpansTable(props: SpansTableProps) {
                   precision
                   hit
                 }
-                costSummary {
+                costSummary @skip(if: $rootSpansOnly) {
+                  total {
+                    cost
+                  }
+                }
+                cumulativeCostSummary @include(if: $rootSpansOnly) {
                   total {
                     cost
                   }
@@ -507,9 +512,12 @@ export function SpansTable(props: SpansTableProps) {
       },
     },
     {
-      header: "total cost",
-      accessorKey: "costSummary.total.cost",
+      header: rootSpansOnly ? "cumulative cost" : "total cost",
+      accessorKey: rootSpansOnly
+        ? "cumulativeCostSummary.total.cost"
+        : "costSummary.total.cost",
       id: "tokenCostTotal",
+      enableSorting: rootSpansOnly ? false : true, // TODO: add sorting for cumulative cost
       cell: ({ row, getValue }) => {
         const value = getValue();
         if (value === null || typeof value !== "number") {

--- a/app/src/pages/project/__generated__/ProjectPageQueriesSpansQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/ProjectPageQueriesSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<949f9cb6228eaf838b848b18924dda0a>>
+ * @generated SignedSource<<1fc3d30ada9859c7fc6da82d1c635871>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -253,13 +253,6 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "tokenCountTotal",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
                             "name": "cumulativeTokenCountTotal",
                             "storageKey": null
                           },
@@ -446,7 +439,7 @@ return {
                             "args": null,
                             "concreteType": "SpanCostSummary",
                             "kind": "LinkedField",
-                            "name": "costSummary",
+                            "name": "cumulativeCostSummary",
                             "plural": false,
                             "selections": [
                               {
@@ -646,12 +639,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8b29f31efc471ba60d5c8cd4cbad20d9",
+    "cacheID": "0fbdac6466b6b18e40803a2b786c3443",
     "id": null,
     "metadata": {},
     "name": "ProjectPageQueriesSpansQuery",
     "operationKind": "query",
-    "text": "query ProjectPageQueriesSpansQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        costSummary {\n          total {\n            cost\n          }\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query ProjectPageQueriesSpansQuery(\n  $id: ID!\n  $timeRange: TimeRange!\n  $orphanSpanAsRootSpan: Boolean!\n) {\n  project: node(id: $id) {\n    __typename\n    ...SpansTable_spans\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: 30, sort: {col: startTime, dir: desc}, rootSpansOnly: true, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        cumulativeCostSummary {\n          total {\n            cost\n          }\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTableSpansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6d7acc92bb8a55c09022337a7df181b0>>
+ * @generated SignedSource<<0b29de3c256bd93356eccb28523bf38d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -162,6 +162,26 @@ v17 = [
 ],
 v18 = [
   {
+    "alias": null,
+    "args": null,
+    "concreteType": "CostBreakdown",
+    "kind": "LinkedField",
+    "name": "total",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "cost",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
+v19 = [
+  {
     "alias": "value",
     "args": null,
     "kind": "ScalarField",
@@ -169,14 +189,14 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -323,18 +343,52 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "tokenCountTotal",
-                            "storageKey": null
+                            "condition": "rootSpansOnly",
+                            "kind": "Condition",
+                            "passingValue": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "tokenCountTotal",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SpanCostSummary",
+                                "kind": "LinkedField",
+                                "name": "costSummary",
+                                "plural": false,
+                                "selections": (v18/*: any*/),
+                                "storageKey": null
+                              }
+                            ]
                           },
                           {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "cumulativeTokenCountTotal",
-                            "storageKey": null
+                            "condition": "rootSpansOnly",
+                            "kind": "Condition",
+                            "passingValue": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cumulativeTokenCountTotal",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SpanCostSummary",
+                                "kind": "LinkedField",
+                                "name": "cumulativeCostSummary",
+                                "plural": false,
+                                "selections": (v18/*: any*/),
+                                "storageKey": null
+                              }
+                            ]
                           },
                           {
                             "alias": null,
@@ -369,7 +423,7 @@ return {
                             "kind": "LinkedField",
                             "name": "input",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -379,7 +433,7 @@ return {
                             "kind": "LinkedField",
                             "name": "output",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -392,8 +446,8 @@ return {
                             "selections": [
                               (v15/*: any*/),
                               (v16/*: any*/),
-                              (v19/*: any*/),
                               (v20/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -460,7 +514,7 @@ return {
                                     "name": "fraction",
                                     "storageKey": null
                                   },
-                                  (v19/*: any*/)
+                                  (v20/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -509,35 +563,6 @@ return {
                                 "args": null,
                                 "kind": "ScalarField",
                                 "name": "hit",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SpanCostSummary",
-                            "kind": "LinkedField",
-                            "name": "costSummary",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "CostBreakdown",
-                                "kind": "LinkedField",
-                                "name": "total",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "cost",
-                                    "storageKey": null
-                                  }
-                                ],
                                 "storageKey": null
                               }
                             ],
@@ -611,8 +636,8 @@ return {
                                                 "name": "values",
                                                 "plural": true,
                                                 "selections": [
-                                                  (v19/*: any*/),
-                                                  (v20/*: any*/)
+                                                  (v20/*: any*/),
+                                                  (v21/*: any*/)
                                                 ],
                                                 "storageKey": null
                                               }
@@ -719,16 +744,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "58aa6cafafa7f616abb44ef94b763f21",
+    "cacheID": "5f9e585bb2257496e63fdf986dfca4b4",
     "id": null,
     "metadata": {},
     "name": "SpansTableSpansQuery",
     "operationKind": "query",
-    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 30\n  $orphanSpanAsRootSpan: Boolean\n  $rootSpansOnly: Boolean = true\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_xYL0c\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans_xYL0c on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: $first, after: $after, sort: $sort, rootSpansOnly: $rootSpansOnly, filterCondition: $filterCondition, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal\n        cumulativeTokenCountTotal\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        costSummary {\n          total {\n            cost\n          }\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query SpansTableSpansQuery(\n  $after: String = null\n  $filterCondition: String = null\n  $first: Int = 30\n  $orphanSpanAsRootSpan: Boolean\n  $rootSpansOnly: Boolean = true\n  $sort: SpanSort = {col: startTime, dir: desc}\n  $timeRange: TimeRange\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SpansTable_spans_xYL0c\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SpanColumnSelector_annotations on Project {\n  spanAnnotationNames\n}\n\nfragment SpansTable_spans_xYL0c on Project {\n  name\n  ...SpanColumnSelector_annotations\n  spans(first: $first, after: $after, sort: $sort, rootSpansOnly: $rootSpansOnly, filterCondition: $filterCondition, orphanSpanAsRootSpan: $orphanSpanAsRootSpan, timeRange: $timeRange) {\n    edges {\n      span: node {\n        id\n        spanKind\n        name\n        metadata\n        statusCode\n        startTime\n        latencyMs\n        tokenCountTotal @skip(if: $rootSpansOnly)\n        costSummary @skip(if: $rootSpansOnly) {\n          total {\n            cost\n          }\n        }\n        cumulativeTokenCountTotal @include(if: $rootSpansOnly)\n        cumulativeCostSummary @include(if: $rootSpansOnly) {\n          total {\n            cost\n          }\n        }\n        spanId\n        trace {\n          id\n          traceId\n        }\n        input {\n          value: truncatedValue\n        }\n        output {\n          value: truncatedValue\n        }\n        spanAnnotations {\n          id\n          name\n          label\n          score\n          annotatorKind\n          createdAt\n        }\n        spanAnnotationSummaries {\n          labelFractions {\n            fraction\n            label\n          }\n          meanScore\n          name\n        }\n        documentRetrievalMetrics {\n          evaluationName\n          ndcg\n          precision\n          hit\n        }\n        ...AnnotationSummaryGroup\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "57172213447c80d4600ee6be8eb67626";
+(node as any).hash = "e587056de0604255ba7974c4a3aa4296";
 
 export default node;

--- a/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1d2c5a6937395fe14d8940ca86b8f5fb>>
+ * @generated SignedSource<<bf2471ed8328333a9c038f46cd1015ac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,12 +19,17 @@ export type SpansTable_spans$data = {
   readonly spans: {
     readonly edges: ReadonlyArray<{
       readonly span: {
-        readonly costSummary: {
+        readonly costSummary?: {
           readonly total: {
             readonly cost: number | null;
           };
         } | null;
-        readonly cumulativeTokenCountTotal: number | null;
+        readonly cumulativeCostSummary?: {
+          readonly total: {
+            readonly cost: number | null;
+          };
+        } | null;
+        readonly cumulativeTokenCountTotal?: number | null;
         readonly documentRetrievalMetrics: ReadonlyArray<{
           readonly evaluationName: string;
           readonly hit: number | null;
@@ -61,7 +66,7 @@ export type SpansTable_spans$data = {
         readonly spanKind: SpanKind;
         readonly startTime: string;
         readonly statusCode: SpanStatusCode;
-        readonly tokenCountTotal: number | null;
+        readonly tokenCountTotal?: number | null;
         readonly trace: {
           readonly id: string;
           readonly traceId: string;
@@ -100,6 +105,26 @@ v2 = {
 },
 v3 = [
   {
+    "alias": null,
+    "args": null,
+    "concreteType": "CostBreakdown",
+    "kind": "LinkedField",
+    "name": "total",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "cost",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
+v4 = [
+  {
     "alias": "value",
     "args": null,
     "kind": "ScalarField",
@@ -107,7 +132,7 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -278,18 +303,52 @@ return {
                   "storageKey": null
                 },
                 {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "tokenCountTotal",
-                  "storageKey": null
+                  "condition": "rootSpansOnly",
+                  "kind": "Condition",
+                  "passingValue": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "tokenCountTotal",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanCostSummary",
+                      "kind": "LinkedField",
+                      "name": "costSummary",
+                      "plural": false,
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    }
+                  ]
                 },
                 {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "cumulativeTokenCountTotal",
-                  "storageKey": null
+                  "condition": "rootSpansOnly",
+                  "kind": "Condition",
+                  "passingValue": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "cumulativeTokenCountTotal",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanCostSummary",
+                      "kind": "LinkedField",
+                      "name": "cumulativeCostSummary",
+                      "plural": false,
+                      "selections": (v3/*: any*/),
+                      "storageKey": null
+                    }
+                  ]
                 },
                 {
                   "alias": null,
@@ -324,7 +383,7 @@ return {
                   "kind": "LinkedField",
                   "name": "input",
                   "plural": false,
-                  "selections": (v3/*: any*/),
+                  "selections": (v4/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -334,7 +393,7 @@ return {
                   "kind": "LinkedField",
                   "name": "output",
                   "plural": false,
-                  "selections": (v3/*: any*/),
+                  "selections": (v4/*: any*/),
                   "storageKey": null
                 },
                 {
@@ -347,7 +406,7 @@ return {
                   "selections": [
                     (v2/*: any*/),
                     (v1/*: any*/),
-                    (v4/*: any*/),
+                    (v5/*: any*/),
                     {
                       "alias": null,
                       "args": null,
@@ -395,7 +454,7 @@ return {
                           "name": "fraction",
                           "storageKey": null
                         },
-                        (v4/*: any*/)
+                        (v5/*: any*/)
                       ],
                       "storageKey": null
                     },
@@ -444,35 +503,6 @@ return {
                       "args": null,
                       "kind": "ScalarField",
                       "name": "hit",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "SpanCostSummary",
-                  "kind": "LinkedField",
-                  "name": "costSummary",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "concreteType": "CostBreakdown",
-                      "kind": "LinkedField",
-                      "name": "total",
-                      "plural": false,
-                      "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "kind": "ScalarField",
-                          "name": "cost",
-                          "storageKey": null
-                        }
-                      ],
                       "storageKey": null
                     }
                   ],
@@ -549,6 +579,6 @@ return {
 };
 })();
 
-(node as any).hash = "57172213447c80d4600ee6be8eb67626";
+(node as any).hash = "e587056de0604255ba7974c4a3aa4296";
 
 export default node;


### PR DESCRIPTION
resolves #8303

## Summary by Sourcery

Display cumulative cost in the spans table when root spans only mode is selected by updating GraphQL queries and table configuration.

Bug Fixes:
- Show cumulativeCostSummary.total.cost instead of costSummary.total.cost for root spans only mode

Enhancements:
- Use @include/@skip directives to fetch cumulativeTokenCountTotal and cumulativeCostSummary only in root spans only mode
- Dynamically update the column header, accessorKey, and disable sorting for cumulative cost when root spans only is enabled