### PR TITLE
docs(cost): add cost docs to nav

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -69,6 +69,8 @@
     * [Import Existing Traces](tracing/how-to-tracing/importing-and-exporting-traces/importing-existing-traces.md)
     * [Export Data & Query Spans](tracing/how-to-tracing/importing-and-exporting-traces/extract-data-from-spans.md)
     * [Exporting Annotated Spans](tracing/how-to-tracing/importing-and-exporting-traces/exporting-annotated-spans.md)
+  * [Cost Tracking](tracing/how-to-tracing/cost-tracking/README.md)
+  
   * [Advanced](tracing/how-to-tracing/advanced/README.md)
     * [Mask Span Attributes](tracing/how-to-tracing/advanced/masking-span-attributes.md)
     * [Suppress Tracing](tracing/how-to-tracing/advanced/suppress-tracing.md)


### PR DESCRIPTION
- **docs: Removing get_current_span for langchain specifically (GITBOOK-1274)**
- **docs: Phoenix Cloud Quickstart Updates (GITBOOK-1276)**
- **GITBOOK-25: Update Integrations with Phoenix Cloud instructions**
- **GITBOOK-20: Updating FAQs for Phoenix Cloud**
- **GITBOOK-26: Phoenix cloud instruction updates**
- **docs: Phoenix cloud instruction updates (GITBOOK-1278)**
- **GITBOOK-27: No subject**
- **docs(cost): fix linking on nav**

## Summary by Sourcery

Update documentation navigation to include the Cost Tracking section and correct navigation links

Documentation:
- Add Cost Tracking entry to the tracing navigation sidebar
- Fix linking for cost documentation in the navigation