### PR TITLE
fix: (soft) delete obsolete built-in models only if they're childless

### DIFF
--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -519,4 +519,5 @@ async def _ensure_model_costs(db: DbSessionFactory) -> None:
             sa.update(models.GenerativeModel)
             .values(deleted_at=sa.func.now())
             .where(models.GenerativeModel.id.in_([m.id for m in remaining_models]))
+            .where(~sa.exists().where(models.GenerativeModel.id == models.SpanCost.model_id))
         )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Only soft-delete childless generative models when they become obsolete by adding a condition to exclude models with existing SpanCost entries.