### PR TITLE
chore: clean nb

### DIFF
--- a/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
+++ b/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
@@ -878,7 +878,8 @@
    "source": [
     "# Sources\n",
     "\n",
-    "[An LLM-as-Judge Won't Save The Product—Fixing Your Process Will](https://eugeneyan.com/writing/eval-process/) by Ziyou Yan (April 2025, eugeneyan.com)"
+    "[An LLM-as-Judge Won't Save The Product—Fixing Your Process Will](https://eugeneyan.com/writing/eval-process/) by Ziyou Yan (April 2025, eugeneyan.com)\n",
+    "[LLM Eval for TxtToSql](https://www.braintrust.dev/docs/cookbook/recipes/Text2SQL-Data)"
    ]
   },
   {
@@ -888,14 +889,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "phoenix",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "name": "python",
-   "version": "3.12.7"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/experiments/txt2sql.ipynb
+++ b/tutorials/experiments/txt2sql.ipynb
@@ -683,14 +683,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "phoenix",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "name": "python",
-   "version": "3.12.7"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Clean up Jupyter notebook metadata and update tutorial sources

Chores:
- Clean notebook metadata by removing kernelspec entries and explicit Python version info
- Add new source link for LLM Eval for TxtToSql in the evaluations tutorial