### PR TITLE
feat: Paginate session details view

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { isNumber, isString } from "lodash";
+import { debounce, isNumber, isString } from "lodash";
 import { css } from "@emotion/react";
 
 import {
@@ -283,6 +283,11 @@ export function SessionDetailsTraceList({
     [hasNext, isLoadingNext, loadNext]
   );
 
+  const debouncedFetchMoreOnBottomReached = useMemo(
+    () => debounce(fetchMoreOnBottomReached, 100),
+    [fetchMoreOnBottomReached]
+  );
+
   return (
     <div
       css={css`
@@ -290,7 +295,9 @@ export function SessionDetailsTraceList({
         flex: 1 1 auto;
         overflow: auto;
       `}
-      onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
+      onScroll={(e) =>
+        debouncedFetchMoreOnBottomReached(e.target as HTMLDivElement)
+      }
     >
       {sessionRootSpans.map(({ traceId, rootSpan }, index) => (
         <View
@@ -322,6 +329,11 @@ export function SessionDetailsTraceList({
           borderBottomColor={"dark"}
           borderBottomWidth={"thin"}
           padding="size-200"
+          ref={(el) => {
+            if (el) {
+              el.scrollIntoView({ behavior: "smooth" });
+            }
+          }}
         >
           <Loading />
         </View>

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -93,10 +93,8 @@ function RootSpanMessage({
 
 type SessionTraceRootSpan = NonNullable<
   NonNullable<
-    NonNullable<
-      SessionDetailsTraceList_traces$data["traces"]["edges"][number]["trace"]
-    >["rootSpan"]
-  >
+    SessionDetailsTraceList_traces$data["traces"]["edges"][number]["trace"]
+  >["rootSpan"]
 >;
 
 type RootSpanProps = {
@@ -214,12 +212,10 @@ export function SessionDetailsTraceList({
       fragment SessionDetailsTraceList_traces on ProjectSession
       @refetchable(queryName: "SessionDetailsTraceListRefetchQuery")
       @argumentDefinitions(
-        first: { type: "Int", defaultValue: 100 }
+        first: { type: "Int", defaultValue: 50 }
         after: { type: "String", defaultValue: null }
-        before: { type: "String", defaultValue: null }
-        last: { type: "Int", defaultValue: null }
       ) {
-        traces(first: $first, after: $after, before: $before, last: $last)
+        traces(first: $first, after: $after)
           @connection(key: "SessionDetailsTraceList_traces") {
           edges {
             trace: node {

--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { graphql, usePaginationFragment } from "react-relay";
-import { debounce, isNumber, isString } from "lodash";
+import { isNumber, isString, throttle } from "lodash";
 import { css } from "@emotion/react";
 
 import {
@@ -274,7 +274,7 @@ export function SessionDetailsTraceList({
     (containerRefElement?: HTMLDivElement | null) => {
       if (containerRefElement) {
         const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
-        const withinRange = scrollHeight - scrollTop - clientHeight < 300;
+        const withinRange = scrollHeight - scrollTop - clientHeight < 1024;
         if (withinRange && !isLoadingNext && hasNext) {
           loadNext(SESSION_DETAILS_PAGE_SIZE);
         }
@@ -284,7 +284,7 @@ export function SessionDetailsTraceList({
   );
 
   const debouncedFetchMoreOnBottomReached = useMemo(
-    () => debounce(fetchMoreOnBottomReached, 100),
+    () => throttle(fetchMoreOnBottomReached, 100),
     [fetchMoreOnBottomReached]
   );
 
@@ -329,11 +329,6 @@ export function SessionDetailsTraceList({
           borderBottomColor={"dark"}
           borderBottomWidth={"thin"}
           padding="size-200"
-          ref={(el) => {
-            if (el) {
-              el.scrollIntoView({ behavior: "smooth" });
-            }
-          }}
         >
           <Loading />
         </View>

--- a/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a45eddfcf756cc72c6176f873ca2145d>>
+ * @generated SignedSource<<f46bf95e3c5f318e0f5335ad15c7726e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -661,20 +661,6 @@ return {
                         "kind": "ScalarField",
                         "name": "hasNextPage",
                         "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasPreviousPage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "startCursor",
-                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -701,12 +687,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "263dc0bc7f8cd52de77d768f0e701975",
+    "cacheID": "795d193957768efba1a5ee0ff2d5e568",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: ID!\n  $first: Int\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n          costPerToken\n        }\n        prompt {\n          cost\n          tokens\n          costPerToken\n        }\n        completion {\n          cost\n          tokens\n          costPerToken\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsQuery(\n  $id: ID!\n  $first: Int\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n          costPerToken\n        }\n        prompt {\n          cost\n          tokens\n          costPerToken\n        }\n        completion {\n          cost\n          tokens\n          costPerToken\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a45eddfcf756cc72c6176f873ca2145d>>
+ * @generated SignedSource<<87e1d9d5c15b0c95dc14a1bcc5529962>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,214 +10,114 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type SessionDetailsQuery$variables = {
+export type SessionDetailsTraceListRefetchQuery$variables = {
+  after?: string | null;
+  before?: string | null;
   first?: number | null;
   id: string;
+  last?: number | null;
 };
-export type SessionDetailsQuery$data = {
-  readonly session: {
-    readonly costSummary?: {
-      readonly completion: {
-        readonly cost: number | null;
-        readonly costPerToken: number | null;
-        readonly tokens: number | null;
-      };
-      readonly prompt: {
-        readonly cost: number | null;
-        readonly costPerToken: number | null;
-        readonly tokens: number | null;
-      };
-      readonly total: {
-        readonly cost: number | null;
-        readonly costPerToken: number | null;
-        readonly tokens: number | null;
-      };
-    };
-    readonly latencyP50?: number | null;
-    readonly numTraces?: number;
-    readonly sessionId?: string;
-    readonly tokenUsage?: {
-      readonly total: number;
-    };
+export type SessionDetailsTraceListRefetchQuery$data = {
+  readonly node: {
     readonly " $fragmentSpreads": FragmentRefs<"SessionDetailsTraceList_traces">;
   };
 };
-export type SessionDetailsQuery = {
-  response: SessionDetailsQuery$data;
-  variables: SessionDetailsQuery$variables;
+export type SessionDetailsTraceListRefetchQuery = {
+  response: SessionDetailsTraceListRefetchQuery$data;
+  variables: SessionDetailsTraceListRefetchQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "first"
+  "name": "after"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "before"
+},
+v2 = {
+  "defaultValue": 100,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "id"
 },
-v2 = [
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "last"
+},
+v5 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "numTraces",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "TokenUsage",
-  "kind": "LinkedField",
-  "name": "tokenUsage",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "total",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cost",
-  "storageKey": null
-},
 v6 = [
-  (v5/*: any*/),
   {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "tokens",
-    "storageKey": null
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
   },
   {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "costPerToken",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "SpanCostSummary",
-  "kind": "LinkedField",
-  "name": "costSummary",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "CostBreakdown",
-      "kind": "LinkedField",
-      "name": "total",
-      "plural": false,
-      "selections": (v6/*: any*/),
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "CostBreakdown",
-      "kind": "LinkedField",
-      "name": "prompt",
-      "plural": false,
-      "selections": (v6/*: any*/),
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "CostBreakdown",
-      "kind": "LinkedField",
-      "name": "completion",
-      "plural": false,
-      "selections": (v6/*: any*/),
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "sessionId",
-  "storageKey": null
-},
-v9 = {
-  "alias": "latencyP50",
-  "args": [
-    {
-      "kind": "Literal",
-      "name": "probability",
-      "value": 0.5
-    }
-  ],
-  "kind": "ScalarField",
-  "name": "traceLatencyMsQuantile",
-  "storageKey": "traceLatencyMsQuantile(probability:0.5)"
-},
-v10 = [
+    "kind": "Variable",
+    "name": "before",
+    "variableName": "before"
+  },
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "last",
+    "variableName": "last"
   }
 ],
-v11 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v12 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v15 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "score",
   "storageKey": null
 },
-v16 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -237,36 +137,27 @@ return {
   "fragment": {
     "argumentDefinitions": [
       (v0/*: any*/),
-      (v1/*: any*/)
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "SessionDetailsQuery",
+    "name": "SessionDetailsTraceListRefetchQuery",
     "selections": [
       {
-        "alias": "session",
-        "args": (v2/*: any*/),
+        "alias": null,
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "kind": "InlineFragment",
-            "selections": [
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
-              (v9/*: any*/),
-              {
-                "args": (v10/*: any*/),
-                "kind": "FragmentSpread",
-                "name": "SessionDetailsTraceList_traces"
-              }
-            ],
-            "type": "ProjectSession",
-            "abstractKey": null
+            "args": (v6/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SessionDetailsTraceList_traces"
           }
         ],
         "storageKey": null
@@ -278,33 +169,31 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
+      (v0/*: any*/),
       (v1/*: any*/),
-      (v0/*: any*/)
+      (v2/*: any*/),
+      (v4/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
-    "name": "SessionDetailsQuery",
+    "name": "SessionDetailsTraceListRefetchQuery",
     "selections": [
       {
-        "alias": "session",
-        "args": (v2/*: any*/),
+        "alias": null,
+        "args": (v5/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v11/*: any*/),
-          (v12/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v3/*: any*/),
-              (v4/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
-              (v9/*: any*/),
               {
                 "alias": null,
-                "args": (v10/*: any*/),
+                "args": (v6/*: any*/),
                 "concreteType": "TraceConnection",
                 "kind": "LinkedField",
                 "name": "traces",
@@ -326,7 +215,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v12/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -342,7 +231,7 @@ return {
                             "name": "rootSpan",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -358,7 +247,7 @@ return {
                                 "name": "project",
                                 "plural": false,
                                 "selections": [
-                                  (v12/*: any*/),
+                                  (v8/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -383,7 +272,7 @@ return {
                                             "name": "node",
                                             "plural": false,
                                             "selections": [
-                                              (v11/*: any*/),
+                                              (v7/*: any*/),
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
@@ -401,8 +290,8 @@ return {
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
-                                                  (v12/*: any*/),
-                                                  (v13/*: any*/),
+                                                  (v8/*: any*/),
+                                                  (v9/*: any*/),
                                                   {
                                                     "alias": null,
                                                     "args": null,
@@ -418,8 +307,8 @@ return {
                                                     "name": "values",
                                                     "plural": true,
                                                     "selections": [
-                                                      (v14/*: any*/),
-                                                      (v15/*: any*/)
+                                                      (v10/*: any*/),
+                                                      (v11/*: any*/)
                                                     ],
                                                     "storageKey": null
                                                   }
@@ -430,7 +319,7 @@ return {
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
-                                                  (v12/*: any*/)
+                                                  (v8/*: any*/)
                                                 ],
                                                 "type": "Node",
                                                 "abstractKey": "__isNode"
@@ -454,7 +343,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "input",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -464,7 +353,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "output",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -490,7 +379,13 @@ return {
                                     "name": "total",
                                     "plural": false,
                                     "selections": [
-                                      (v5/*: any*/)
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "cost",
+                                        "storageKey": null
+                                      }
                                     ],
                                     "storageKey": null
                                   }
@@ -526,10 +421,10 @@ return {
                                 "name": "spanAnnotations",
                                 "plural": true,
                                 "selections": [
-                                  (v12/*: any*/),
-                                  (v13/*: any*/),
-                                  (v14/*: any*/),
-                                  (v15/*: any*/),
+                                  (v8/*: any*/),
+                                  (v9/*: any*/),
+                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -566,7 +461,7 @@ return {
                                         "name": "profilePictureUrl",
                                         "storageKey": null
                                       },
-                                      (v12/*: any*/)
+                                      (v8/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -596,7 +491,7 @@ return {
                                         "name": "fraction",
                                         "storageKey": null
                                       },
-                                      (v14/*: any*/)
+                                      (v10/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -607,7 +502,7 @@ return {
                                     "name": "meanScore",
                                     "storageKey": null
                                   },
-                                  (v13/*: any*/)
+                                  (v9/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -632,8 +527,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/),
-                          (v12/*: any*/)
+                          (v7/*: any*/),
+                          (v8/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -684,7 +579,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v10/*: any*/),
+                "args": (v6/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "SessionDetailsTraceList_traces",
@@ -701,16 +596,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "263dc0bc7f8cd52de77d768f0e701975",
+    "cacheID": "585b064dcb7e9860e35c35b8933cd6bd",
     "id": null,
     "metadata": {},
-    "name": "SessionDetailsQuery",
+    "name": "SessionDetailsTraceListRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsQuery(\n  $id: ID!\n  $first: Int\n) {\n  session: node(id: $id) {\n    __typename\n    ... on ProjectSession {\n      numTraces\n      tokenUsage {\n        total\n      }\n      costSummary {\n        total {\n          cost\n          tokens\n          costPerToken\n        }\n        prompt {\n          cost\n          tokens\n          costPerToken\n        }\n        completion {\n          cost\n          tokens\n          costPerToken\n        }\n      }\n      sessionId\n      latencyP50: traceLatencyMsQuantile(probability: 0.5)\n      ...SessionDetailsTraceList_traces_3ASum4\n    }\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_3ASum4 on ProjectSession {\n  traces(first: $first) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $before: String = null\n  $first: Int = 100\n  $last: Int = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_pbnwq\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_pbnwq on ProjectSession {\n  traces(first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c8ad1e535b56f210e7ce26e611df2971";
+(node as any).hash = "4f755c1245300a8e7837f2b66c8955ad";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceListRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<87e1d9d5c15b0c95dc14a1bcc5529962>>
+ * @generated SignedSource<<d3ad7773bb0c6e137f00fd35974107c3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,10 +12,8 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SessionDetailsTraceListRefetchQuery$variables = {
   after?: string | null;
-  before?: string | null;
   first?: number | null;
   id: string;
-  last?: number | null;
 };
 export type SessionDetailsTraceListRefetchQuery$data = {
   readonly node: {
@@ -28,39 +26,31 @@ export type SessionDetailsTraceListRefetchQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "after"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "before"
-},
-v2 = {
-  "defaultValue": 100,
-  "kind": "LocalArgument",
-  "name": "first"
-},
-v3 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "last"
-},
-v5 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 50,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v6 = [
+v2 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -68,56 +58,46 @@ v6 = [
   },
   {
     "kind": "Variable",
-    "name": "before",
-    "variableName": "before"
-  },
-  {
-    "kind": "Variable",
     "name": "first",
     "variableName": "first"
-  },
-  {
-    "kind": "Variable",
-    "name": "last",
-    "variableName": "last"
   }
 ],
-v7 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v8 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v11 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "score",
   "storageKey": null
 },
-v12 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -135,27 +115,21 @@ v12 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SessionDetailsTraceListRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v5/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "args": (v6/*: any*/),
+            "args": (v2/*: any*/),
             "kind": "FragmentSpread",
             "name": "SessionDetailsTraceList_traces"
           }
@@ -168,32 +142,26 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v4/*: any*/),
-      (v3/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SessionDetailsTraceListRefetchQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v5/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v7/*: any*/),
-          (v8/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v2/*: any*/),
                 "concreteType": "TraceConnection",
                 "kind": "LinkedField",
                 "name": "traces",
@@ -215,7 +183,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -231,7 +199,7 @@ return {
                             "name": "rootSpan",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
+                              (v4/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -247,7 +215,7 @@ return {
                                 "name": "project",
                                 "plural": false,
                                 "selections": [
-                                  (v8/*: any*/),
+                                  (v4/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -272,7 +240,7 @@ return {
                                             "name": "node",
                                             "plural": false,
                                             "selections": [
-                                              (v7/*: any*/),
+                                              (v3/*: any*/),
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
@@ -290,8 +258,8 @@ return {
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
-                                                  (v8/*: any*/),
-                                                  (v9/*: any*/),
+                                                  (v4/*: any*/),
+                                                  (v5/*: any*/),
                                                   {
                                                     "alias": null,
                                                     "args": null,
@@ -307,8 +275,8 @@ return {
                                                     "name": "values",
                                                     "plural": true,
                                                     "selections": [
-                                                      (v10/*: any*/),
-                                                      (v11/*: any*/)
+                                                      (v6/*: any*/),
+                                                      (v7/*: any*/)
                                                     ],
                                                     "storageKey": null
                                                   }
@@ -319,7 +287,7 @@ return {
                                               {
                                                 "kind": "InlineFragment",
                                                 "selections": [
-                                                  (v8/*: any*/)
+                                                  (v4/*: any*/)
                                                 ],
                                                 "type": "Node",
                                                 "abstractKey": "__isNode"
@@ -343,7 +311,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "input",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -353,7 +321,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "output",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -421,10 +389,10 @@ return {
                                 "name": "spanAnnotations",
                                 "plural": true,
                                 "selections": [
-                                  (v8/*: any*/),
-                                  (v9/*: any*/),
-                                  (v10/*: any*/),
-                                  (v11/*: any*/),
+                                  (v4/*: any*/),
+                                  (v5/*: any*/),
+                                  (v6/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -461,7 +429,7 @@ return {
                                         "name": "profilePictureUrl",
                                         "storageKey": null
                                       },
-                                      (v8/*: any*/)
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -491,7 +459,7 @@ return {
                                         "name": "fraction",
                                         "storageKey": null
                                       },
-                                      (v10/*: any*/)
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -502,7 +470,7 @@ return {
                                     "name": "meanScore",
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -527,8 +495,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
-                          (v8/*: any*/)
+                          (v3/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -556,20 +524,6 @@ return {
                         "kind": "ScalarField",
                         "name": "hasNextPage",
                         "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasPreviousPage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "startCursor",
-                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -579,7 +533,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v2/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "SessionDetailsTraceList_traces",
@@ -596,16 +550,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "585b064dcb7e9860e35c35b8933cd6bd",
+    "cacheID": "6bfe4c6249ceafe0512025aee1284ed2",
     "id": null,
     "metadata": {},
     "name": "SessionDetailsTraceListRefetchQuery",
     "operationKind": "query",
-    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $before: String = null\n  $first: Int = 100\n  $last: Int = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_pbnwq\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_pbnwq on ProjectSession {\n  traces(first: $first, after: $after, before: $before, last: $last) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query SessionDetailsTraceListRefetchQuery(\n  $after: String = null\n  $first: Int = 50\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...SessionDetailsTraceList_traces_2HEEH6\n    id\n  }\n}\n\nfragment AnnotationSummaryGroup on Span {\n  project {\n    id\n    annotationConfigs {\n      edges {\n        node {\n          __typename\n          ... on AnnotationConfigBase {\n            __isAnnotationConfigBase: __typename\n            annotationType\n          }\n          ... on CategoricalAnnotationConfig {\n            id\n            name\n            optimizationDirection\n            values {\n              label\n              score\n            }\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n      }\n    }\n  }\n  spanAnnotations {\n    id\n    name\n    label\n    score\n    annotatorKind\n    createdAt\n    user {\n      username\n      profilePictureUrl\n      id\n    }\n  }\n  spanAnnotationSummaries {\n    labelFractions {\n      fraction\n      label\n    }\n    meanScore\n    name\n  }\n}\n\nfragment SessionDetailsTraceList_traces_2HEEH6 on ProjectSession {\n  traces(first: $first, after: $after) {\n    edges {\n      trace: node {\n        id\n        traceId\n        rootSpan {\n          id\n          attributes\n          project {\n            id\n          }\n          input {\n            value\n            mimeType\n          }\n          output {\n            value\n            mimeType\n          }\n          cumulativeTokenCountTotal\n          cumulativeCostSummary {\n            total {\n              cost\n            }\n          }\n          latencyMs\n          startTime\n          spanId\n          ...AnnotationSummaryGroup\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4f755c1245300a8e7837f2b66c8955ad";
+(node as any).hash = "9c7d6aa1353830d854fcd750f19fec8f";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b44118782a4154b7efae4528801037f>>
+ * @generated SignedSource<<6d652387c93be7644a070d235044c398>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,28 +90,18 @@ return {
       "name": "after"
     },
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "before"
-    },
-    {
-      "defaultValue": 100,
+      "defaultValue": 50,
       "kind": "LocalArgument",
       "name": "first"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "last"
     }
   ],
   "kind": "Fragment",
   "metadata": {
     "connection": [
       {
-        "count": null,
-        "cursor": null,
-        "direction": "bidirectional",
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
         "path": (v0/*: any*/)
       }
     ],
@@ -121,10 +111,7 @@ return {
           "count": "first",
           "cursor": "after"
         },
-        "backward": {
-          "count": "last",
-          "cursor": "before"
-        },
+        "backward": null,
         "path": (v0/*: any*/)
       },
       "fragmentPathInResult": [
@@ -336,20 +323,6 @@ return {
               "kind": "ScalarField",
               "name": "hasNextPage",
               "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "hasPreviousPage",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "startCursor",
-              "storageKey": null
             }
           ],
           "storageKey": null
@@ -364,6 +337,6 @@ return {
 };
 })();
 
-(node as any).hash = "4f755c1245300a8e7837f2b66c8955ad";
+(node as any).hash = "9c7d6aa1353830d854fcd750f19fec8f";
 
 export default node;

--- a/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
+++ b/app/src/pages/trace/__generated__/SessionDetailsTraceList_traces.graphql.ts
@@ -1,0 +1,369 @@
+/**
+ * @generated SignedSource<<8b44118782a4154b7efae4528801037f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type MimeType = "json" | "text";
+import { FragmentRefs } from "relay-runtime";
+export type SessionDetailsTraceList_traces$data = {
+  readonly id: string;
+  readonly traces: {
+    readonly edges: ReadonlyArray<{
+      readonly trace: {
+        readonly id: string;
+        readonly rootSpan: {
+          readonly attributes: string;
+          readonly cumulativeCostSummary: {
+            readonly total: {
+              readonly cost: number | null;
+            };
+          } | null;
+          readonly cumulativeTokenCountTotal: number | null;
+          readonly id: string;
+          readonly input: {
+            readonly mimeType: MimeType;
+            readonly value: string;
+          } | null;
+          readonly latencyMs: number | null;
+          readonly output: {
+            readonly mimeType: MimeType;
+            readonly value: string;
+          } | null;
+          readonly project: {
+            readonly id: string;
+          };
+          readonly spanId: string;
+          readonly startTime: string;
+          readonly " $fragmentSpreads": FragmentRefs<"AnnotationSummaryGroup">;
+        } | null;
+        readonly traceId: string;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "SessionDetailsTraceList_traces";
+};
+export type SessionDetailsTraceList_traces$key = {
+  readonly " $data"?: SessionDetailsTraceList_traces$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SessionDetailsTraceList_traces">;
+};
+
+import SessionDetailsTraceListRefetchQuery_graphql from './SessionDetailsTraceListRefetchQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "traces"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "mimeType",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "before"
+    },
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "first"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "last"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": null,
+        "direction": "bidirectional",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": {
+          "count": "last",
+          "cursor": "before"
+        },
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": SessionDetailsTraceListRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "SessionDetailsTraceList_traces",
+  "selections": [
+    {
+      "alias": "traces",
+      "args": null,
+      "concreteType": "TraceConnection",
+      "kind": "LinkedField",
+      "name": "__SessionDetailsTraceList_traces_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "TraceEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "trace",
+              "args": null,
+              "concreteType": "Trace",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "traceId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Span",
+                  "kind": "LinkedField",
+                  "name": "rootSpan",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "attributes",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Project",
+                      "kind": "LinkedField",
+                      "name": "project",
+                      "plural": false,
+                      "selections": [
+                        (v1/*: any*/)
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanIOValue",
+                      "kind": "LinkedField",
+                      "name": "input",
+                      "plural": false,
+                      "selections": (v2/*: any*/),
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanIOValue",
+                      "kind": "LinkedField",
+                      "name": "output",
+                      "plural": false,
+                      "selections": (v2/*: any*/),
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "cumulativeTokenCountTotal",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "SpanCostSummary",
+                      "kind": "LinkedField",
+                      "name": "cumulativeCostSummary",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "CostBreakdown",
+                          "kind": "LinkedField",
+                          "name": "total",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "cost",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "latencyMs",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "startTime",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "spanId",
+                      "storageKey": null
+                    },
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "AnnotationSummaryGroup"
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Trace",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasPreviousPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "startCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "ProjectSession",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "4f755c1245300a8e7837f2b66c8955ad";
+
+export default node;

--- a/app/src/pages/trace/constants.ts
+++ b/app/src/pages/trace/constants.ts
@@ -1,1 +1,1 @@
-export const SESSION_DETAILS_PAGE_SIZE = 100;
+export const SESSION_DETAILS_PAGE_SIZE = 50;

--- a/app/src/pages/trace/constants.ts
+++ b/app/src/pages/trace/constants.ts
@@ -1,0 +1,1 @@
+export const SESSION_DETAILS_PAGE_SIZE = 100;

--- a/scripts/generate_spans_for_large_session/generate_spans_for_large_session.py
+++ b/scripts/generate_spans_for_large_session/generate_spans_for_large_session.py
@@ -1,0 +1,111 @@
+from io import StringIO
+from random import randint, sample
+from secrets import token_hex
+
+import numpy as np
+import pandas as pd
+from faker import Faker
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+fake = Faker()
+
+endpoint = "http://localhost:6006/v1/traces"
+
+tracer_provider = TracerProvider(resource=Resource({"openinference.project.name": "SESSIONS_TEST"}))
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+tracer = tracer_provider.get_tracer(__name__)
+
+
+# Convert the tab-delimited string into a DataFrame
+model_provider_data = """
+claude-3-5-sonnet-latest,anthropic
+gemini-pro,google
+gpt-4o,openai
+"""
+
+df = pd.read_csv(StringIO(model_provider_data.strip()), names=["model_name", "provider"], dtype=str)
+
+
+def random_split(total: int, n: int = 5, alpha: float = 1.0) -> list[int]:
+    """
+    Generate n random numbers that sum to total using Dirichlet distribution.
+
+    Args:
+        total (int): The total sum that the generated numbers should add up to
+        n (int, optional): Number of random numbers to generate. Defaults to 5.
+        alpha (float, optional): Concentration parameter for Dirichlet distribution.
+            Higher values make the distribution more uniform. Defaults to 1.0.
+
+    Returns:
+        numpy.ndarray: Array of n integers that sum to total
+    """
+    # Generate proportions
+    proportions = np.random.dirichlet([alpha] * n)
+
+    # Scale and take floor
+    scaled = proportions * total
+    numbers = np.floor(scaled).astype(int)
+
+    # Distribute the remainder
+    remainder = total - np.sum(numbers)
+
+    # Add 1 to the positions with largest fractional parts
+    fractional_parts = scaled - numbers
+    indices = np.argsort(fractional_parts)[-remainder:]
+    numbers[indices] += 1
+
+    return numbers.tolist()  # type: ignore
+
+
+def llm_span(session_id: str) -> None:
+    """
+    Generate a synthetic LLM span with random token counts and model information.
+
+    Creates a span with the following attributes:
+    - openinference.span.kind: Set to "LLM"
+    - llm.token_count.prompt: Random number between 1000-10000
+    - llm.token_count.completion: Random number between 1000-10000
+    - llm.token_count.total: Sum of prompt and completion tokens
+    - llm.token_count.prompt_details.*: Random split of prompt tokens for various details
+    - llm.token_count.completion_details.*: Random split of completion tokens for various details
+    - llm.provider: Random provider from the model list
+    - llm.model_name: Random model name from the model list
+    """
+    with tracer.start_as_current_span(token_hex(6)) as span:
+        span.set_attribute("openinference.span.kind", "LLM")
+        upperbound = 10 ** sample(range(2, 9), k=1)[0]
+        prompt, completion = randint(10, upperbound), randint(10, upperbound)
+        span.set_attribute("llm.token_count.prompt", prompt)
+        span.set_attribute("llm.token_count.completion", completion)
+        span.set_attribute("llm.token_count.total", prompt + completion)
+        for prefix, (total, subtotals) in {
+            "prompt_details": (
+                prompt,
+                ["audio", "video", "image", "document", "cached_read", "cache_write"],
+            ),
+            "completion_details": (
+                completion,
+                ["audio", "video", "image", "document", "reasoning"],
+            ),
+        }.items():
+            if not (keys := sample(subtotals, k=randint(0, len(subtotals)))):
+                continue
+            for key, value in zip(keys, random_split(total, n=len(keys) + 1)):
+                span.set_attribute(f"llm.token_count.{prefix}.{key}", value)
+        row = df.sample(1).iloc[0]
+        span.set_attribute("llm.provider", str(row.provider))
+        span.set_attribute("llm.model_name", str(row.model_name))
+        span.set_attribute("output.value", fake.sentence())
+        span.set_attribute("input.value", fake.sentence())
+        span.set_attribute("session.id", session_id)
+
+
+session_id = f"session_{randint(0, 10000)}"
+for _ in range(500):
+    llm_span(session_id)
+
+
+tracer_provider.force_flush()

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -108,8 +108,6 @@ class ProjectSession(Node):
             select(models.Trace)
             .filter_by(project_session_rowid=self.id_attr)
             .order_by(models.Trace.start_time)
-            # TODO: limit to first + 1 to determine whether there's a next page
-            # and then fetch the next page, including it in the response
         )
         async with info.context.db() as session:
             traces = await session.stream_scalars(stmt)

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -108,7 +108,8 @@ class ProjectSession(Node):
             select(models.Trace)
             .filter_by(project_session_rowid=self.id_attr)
             .order_by(models.Trace.start_time)
-            .limit(first)
+            # TODO: limit to first + 1 to determine whether there's a next page
+            # and then fetch the next page, including it in the response
         )
         async with info.context.db() as session:
             traces = await session.stream_scalars(stmt)


### PR DESCRIPTION
Resolves #8325

## Summary by Sourcery

Implement pagination for the session details trace list with infinite scrolling, refactor the GraphQL queries to use a Relay pagination fragment with a defined page size, and introduce a test utility script to generate large synthetic session spans.

New Features:
- Add Relay-based pagination to the session details trace list to load additional traces on scroll
- Define SESSION_DETAILS_PAGE_SIZE constant for controlling page size
- Create generate_spans_for_large_session script to synthesize LLM spans for testing large sessions

Enhancements:
- Refactor SessionDetails and SessionDetailsTraceList components to use usePaginationFragment and replace full trace fetch with fragment refetch
- Convert trace list container from View to a scrollable div with onScroll handler

Chores:
- Add TODO in ProjectSession resolver to cap query for next page detection