### PR TITLE
chore: add CC BY-NC-SA 4.0 attribution to Evals that Work notebook

### DIFF
--- a/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
+++ b/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
@@ -4,6 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- SPDX-License-Identifier: CC-BY-NC-SA-4.0 -->\n",
+    "\n",
+    "*This notebook is © [Braintrust Cookbook](https://www.braintrust.dev/docs/cookbook/recipes/Text2SQL-Data) and licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).*  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<center>\n",
     "    <p style=\"text-align:center\">\n",
     "        <img alt=\"phoenix logo\" src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/9e6101d95936f4bd4d390efc9ce646dc6937fb2d/images/socal/github-large-banner-phoenix.jpg\" width=\"1000\"/>\n",


### PR DESCRIPTION
# Summary
Add Creative Commons Attribution-NonCommercial-ShareAlike 4.0 (CC BY-NC-SA 4.0) attribution to the Evals that Work notebook so that it complies with the terms of the original Braintrust Cookbook content.

# Changes
tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
– Inserted an SPDX header (<!-- SPDX-License-Identifier: CC-BY-NC-SA-4.0 -->) and a brief attribution notice at the very top of the notebook, pointing back to “Braintrust Cookbook” and linking to the license.

# Why this is needed
## Verbatim reuse of Braintrust content
The “Evals that Work” notebook is a near-verbatim copy of the Braintrust Cookbook’s “LLM Eval for Text2SQL” example (structure, prose, code cells, prompt wording). Under CC BY-NC-SA 4.0, any reuse must:
- Display an attribution notice crediting the original author (“Braintrust Cookbook”).
- Ensure all derivatives remain under CC BY-NC-SA (share-alike).
- Prohibit any commercial exploitation (non-commercial).

# Current violation
The upstream repo has republished our content without:
- Crediting “Braintrust Cookbook” or linking back to the original source.
- Enforcing share-alike or non-commercial requirements.

## Summary by Sourcery

Documentation:
- Insert an SPDX CC-BY-NC-SA-4.0 header and link back to Braintrust Cookbook at the top of the notebook