### PR TITLE
chore: add cc licenses

### DIFF
--- a/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
+++ b/tutorials/courses/evals/evals_that_work/evals_that_work.ipynb
@@ -4,6 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- SPDX-License-Identifier: CC-BY-NC-SA-4.0 -->\n",
+    "\n",
+    "*This notebook is © [Braintrust Cookbook](https://www.braintrust.dev/docs/cookbook/recipes/Text2SQL-Data) and licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).*  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<center>\n",
     "    <p style=\"text-align:center\">\n",
     "        <img alt=\"phoenix logo\" src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/9e6101d95936f4bd4d390efc9ce646dc6937fb2d/images/socal/github-large-banner-phoenix.jpg\" width=\"1000\"/>\n",

--- a/tutorials/experiments/txt2sql.ipynb
+++ b/tutorials/experiments/txt2sql.ipynb
@@ -4,6 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<!-- SPDX-License-Identifier: CC-BY-NC-SA-4.0 -->\n",
+    "\n",
+    "*This notebook is © [Braintrust Cookbook](https://www.braintrust.dev/docs/cookbook/recipes/Text2SQL-Data) and licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).*  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<center>\n",
     "    <p style=\"text-align:center\">\n",
     "        <img alt=\"phoenix logo\" src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/9e6101d95936f4bd4d390efc9ce646dc6937fb2d/images/socal/github-large-banner-phoenix.jpg\" width=\"1000\"/>\n",


### PR DESCRIPTION
## Summary by Sourcery

Add CC BY-NC-SA 4.0 license headers to tutorial notebooks and remove the outdated txt2sql tutorial notebook

Documentation:
- Add SPDX license header and CC BY-NC-SA 4.0 notice to tutorials/courses/evals_that_work.ipynb

Chores:
- Remove the tutorials/experiments/txt2sql.ipynb file