### PR TITLE
feat: Add link back to customizable Management URL

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2717,7 +2717,7 @@ type User implements Node {
   authMethod: AuthMethod!
   role: UserRole!
   apiKeys: [UserApiKey!]!
-  managementUrl: String
+  isManagementUser: Boolean!
 }
 
 type UserApiKey implements ApiKey & Node {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2717,6 +2717,7 @@ type User implements Node {
   authMethod: AuthMethod!
   role: UserRole!
   apiKeys: [UserApiKey!]!
+  managementUrl: String
 }
 
 type UserApiKey implements ApiKey & Node {

--- a/app/src/components/icon/Icons.tsx
+++ b/app/src/components/icon/Icons.tsx
@@ -2073,6 +2073,26 @@ export const SearchOutline = () => (
   </svg>
 );
 
+export const Server = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    style={{ fill: "none" }}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+    <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+    <line x1="6" y1="6" x2="6.01" y2="6"></line>
+    <line x1="6" y1="18" x2="6.01" y2="18"></line>
+  </svg>
+);
+
 export const Settings = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g data-name="Layer 2">

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 
 import { Icon, Icons, Text } from "@phoenix/components";
 import { GitHubStarCount } from "@phoenix/components/nav/GitHubStarCount";
-import { useTheme } from "@phoenix/contexts";
+import { useTheme, useViewer } from "@phoenix/contexts";
 
 import { Logo } from "./Logo";
 
@@ -193,3 +193,20 @@ export function NavButton(props: {
     </button>
   );
 }
+
+export const ManagementLink = () => {
+  const { viewer } = useViewer();
+
+  if (viewer?.managementUrl) {
+    return (
+      <li key="management">
+        <ExternalLink
+          href={viewer.managementUrl}
+          leadingVisual={<Icon svg={<Icons.ExternalLinkOutline />} />}
+          text="Management console"
+        />
+      </li>
+    );
+  }
+  return null;
+};

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -88,9 +88,15 @@ function ExternalLink(props: {
   leadingVisual: ReactNode;
   trailingVisual?: ReactNode;
   text: string;
+  replaceTab?: boolean;
 }) {
   return (
-    <a href={props.href} target="_blank" css={navLinkCSS} rel="noreferrer">
+    <a
+      href={props.href}
+      target={props.replaceTab ? undefined : "_blank"}
+      css={navLinkCSS}
+      rel="noreferrer"
+    >
       {props.leadingVisual}
       <Text>{props.text}</Text>
       {props.trailingVisual}
@@ -197,13 +203,14 @@ export function NavButton(props: {
 export const ManagementLink = () => {
   const { viewer } = useViewer();
 
-  if (viewer?.managementUrl) {
+  if (viewer?.isManagementUser && window.Config.managementUrl) {
     return (
       <li key="management">
         <ExternalLink
-          href={viewer.managementUrl}
+          href={window.Config.managementUrl}
           leadingVisual={<Icon svg={<Icons.Server />} />}
-          text="Management console"
+          text="Management Console"
+          replaceTab
         />
       </li>
     );

--- a/app/src/components/nav/Navbar.tsx
+++ b/app/src/components/nav/Navbar.tsx
@@ -202,7 +202,7 @@ export const ManagementLink = () => {
       <li key="management">
         <ExternalLink
           href={viewer.managementUrl}
-          leadingVisual={<Icon svg={<Icons.ExternalLinkOutline />} />}
+          leadingVisual={<Icon svg={<Icons.Server />} />}
           text="Management console"
         />
       </li>

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -51,7 +51,7 @@ export function ViewerProvider({
           username
           email
           profilePictureUrl
-          managementUrl
+          isManagementUser
           role {
             name
           }

--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -51,6 +51,7 @@ export function ViewerProvider({
           username
           email
           profilePictureUrl
+          managementUrl
           role {
             name
           }

--- a/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9280ee4229ca6447e7c366bb655446e5>>
+ * @generated SignedSource<<7682165efeee36179feb871060b9b84f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,7 +90,7 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "managementUrl",
+            "name": "isManagementUser",
             "storageKey": null
           },
           {
@@ -153,16 +153,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ef3cf4ba9ff51c25d101a025673f20a0",
+    "cacheID": "79221da09cbb1334cb0c446af434f607",
     "id": null,
     "metadata": {},
     "name": "ViewerContextRefetchQuery",
     "operationKind": "query",
-    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    managementUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c342cd404dcae6cd4462617b20e66e18";
+(node as any).hash = "d85505e5f9dffd2a1c791f8e0007ab61";
 
 export default node;

--- a/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContextRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<96a6d4e8817fc4fccbf8fa9d822dccfc>>
+ * @generated SignedSource<<9280ee4229ca6447e7c366bb655446e5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -89,6 +89,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "managementUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "UserRole",
             "kind": "LinkedField",
             "name": "role",
@@ -146,16 +153,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2d36bdc877f31e905f8b8f3bf9b04689",
+    "cacheID": "ef3cf4ba9ff51c25d101a025673f20a0",
     "id": null,
     "metadata": {},
     "name": "ViewerContextRefetchQuery",
     "operationKind": "query",
-    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query ViewerContextRefetchQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    managementUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bec0ae2a629134a5b9afe1846eaec2c9";
+(node as any).hash = "c342cd404dcae6cd4462617b20e66e18";
 
 export default node;

--- a/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<182814a87c4adafdb4661f66d85e669b>>
+ * @generated SignedSource<<9f5ba56af0a7dc9aed2aec5873981c6d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type ViewerContext_viewer$data = {
     readonly authMethod: AuthMethod;
     readonly email: string;
     readonly id: string;
-    readonly managementUrl: string | null;
+    readonly isManagementUser: boolean;
     readonly profilePictureUrl: string | null;
     readonly role: {
       readonly name: string;
@@ -85,7 +85,7 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "managementUrl",
+          "name": "isManagementUser",
           "storageKey": null
         },
         {
@@ -126,6 +126,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "c342cd404dcae6cd4462617b20e66e18";
+(node as any).hash = "d85505e5f9dffd2a1c791f8e0007ab61";
 
 export default node;

--- a/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
+++ b/app/src/contexts/__generated__/ViewerContext_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c9290a3698614800d03b84a2b77f8bc>>
+ * @generated SignedSource<<182814a87c4adafdb4661f66d85e669b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type ViewerContext_viewer$data = {
     readonly authMethod: AuthMethod;
     readonly email: string;
     readonly id: string;
+    readonly managementUrl: string | null;
     readonly profilePictureUrl: string | null;
     readonly role: {
       readonly name: string;
@@ -83,6 +84,13 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
+          "kind": "ScalarField",
+          "name": "managementUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "UserRole",
           "kind": "LinkedField",
           "name": "role",
@@ -118,6 +126,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "bec0ae2a629134a5b9afe1846eaec2c9";
+(node as any).hash = "c342cd404dcae6cd4462617b20e66e18";
 
 export default node;

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -169,9 +169,6 @@ function SideNav() {
           </li>
           {authenticationEnabled && (
             <>
-              <Suspense>
-                <ManagementLink />
-              </Suspense>
               <li key="profile">
                 <NavLink
                   to="/profile"
@@ -179,6 +176,9 @@ function SideNav() {
                   leadingVisual={<Icon svg={<Icons.PersonOutline />} />}
                 />
               </li>
+              <Suspense>
+                <ManagementLink />
+              </Suspense>
               <li key="logout">
                 <NavButton
                   text="Log Out"

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -7,6 +7,7 @@ import {
   Brand,
   DocsLink,
   GitHubLink,
+  ManagementLink,
   NavBreadcrumb,
   NavButton,
   NavLink,
@@ -168,6 +169,9 @@ function SideNav() {
           </li>
           {authenticationEnabled && (
             <>
+              <Suspense>
+                <ManagementLink />
+              </Suspense>
               <li key="profile">
                 <NavLink
                   to="/profile"

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<667fbd723d6636eb8e32bf79292a51d6>>
+ * @generated SignedSource<<e85d2d9b22f0e148a088a916d6082442>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -120,7 +120,7 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "managementUrl",
+            "name": "isManagementUser",
             "storageKey": null
           },
           {
@@ -184,12 +184,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6b7bceb77e19c676224ee7f9dca48e58",
+    "cacheID": "909f2b392805d784bcac384c6d208692",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    managementUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5089ff4d6b89235bf38f885a33703324>>
+ * @generated SignedSource<<667fbd723d6636eb8e32bf79292a51d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -119,6 +119,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "managementUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "UserRole",
             "kind": "LinkedField",
             "name": "role",
@@ -177,12 +184,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0ed2fca00364586fcdb81df0d8cb934c",
+    "cacheID": "6b7bceb77e19c676224ee7f9dca48e58",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    managementUrl\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -22,6 +22,7 @@ declare global {
       authenticationEnabled: boolean;
       basicAuthDisabled: boolean;
       oAuth2Idps: OAuth2Idp[];
+      managementUrl?: string | null;
     };
   }
 }

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -223,6 +223,11 @@ Examples:
     - With a sub-path: "https://example.com/phoenix"
     - Without a sub-path: "https://phoenix.example.com"
 """
+ENV_PHOENIX_MANAGEMENT_URL = "PHOENIX_MANAGEMENT_URL"
+"""
+The URL to use for a management interface that may be hosting Phoenix. If set, a link will be added
+to the navigation menu to return to this URL if the user is an admin.
+"""
 
 
 # SMTP settings
@@ -1538,6 +1543,13 @@ def get_env_fullstory_org() -> Optional[str]:
         Optional[str]: The FullStory organization ID if set, None otherwise.
     """
     return getenv(ENV_PHOENIX_FULLSTORY_ORG)
+
+
+def get_env_management_url() -> Optional[str]:
+    """
+    Gets the value of the PHOENIX_MANAGEMENT_URL environment variable.
+    """
+    return getenv(ENV_PHOENIX_MANAGEMENT_URL)
 
 
 def verify_server_environment_variables() -> None:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -225,8 +225,9 @@ Examples:
 """
 ENV_PHOENIX_MANAGEMENT_URL = "PHOENIX_MANAGEMENT_URL"
 """
-The URL to use for a management interface that may be hosting Phoenix. If set, a link will be added
-to the navigation menu to return to this URL if the user is an admin.
+The URL to use for redirecting to a management interface that may be hosting Phoenix. If set, and
+the current user is within PHOENIX_ADMINS, a link will be added to the navigation menu to return to
+this URL.
 """
 
 
@@ -823,7 +824,7 @@ def get_env_csrf_trusted_origins() -> list[str]:
 
 def get_env_admins() -> dict[str, str]:
     """
-    Parse the PHOENIX_ADMINS environment variable to extract the comma separated pairs of
+    Parse the PHOENIX_ADMINS environment variable to extract the semicolon separated pairs of
     username and email. The last equal sign (=) in each pair is used to separate the username from
     the email.
 

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -7,6 +7,7 @@ from strawberry import Private
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
+from phoenix.config import get_env_management_url
 from phoenix.db import models
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
@@ -41,6 +42,10 @@ class User(Node):
                 select(models.ApiKey).where(models.ApiKey.user_id == self.id_attr)
             )
         return [to_gql_api_key(api_key) for api_key in api_keys]
+
+    @strawberry.field
+    async def management_url(self, info: Info[Context, None]) -> Optional[str]:
+        return get_env_management_url()
 
 
 def to_gql_user(user: models.User, api_keys: Optional[list[models.ApiKey]] = None) -> User:

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -7,7 +7,7 @@ from strawberry import Private
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
-from phoenix.config import get_env_admins, get_env_management_url
+from phoenix.config import get_env_admins
 from phoenix.db import models
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
@@ -44,13 +44,13 @@ class User(Node):
         return [to_gql_api_key(api_key) for api_key in api_keys]
 
     @strawberry.field
-    async def management_url(self) -> Optional[str]:
+    async def is_management_user(self) -> bool:
         initial_admins = get_env_admins()
         # this field is only visible to initial admins as they are the ones likely to have access to
         # a management interface / the phoenix environment.
         if self.email in initial_admins or self.email == "admin@localhost":
-            return get_env_management_url()
-        return None
+            return True
+        return False
 
 
 def to_gql_user(user: models.User, api_keys: Optional[list[models.ApiKey]] = None) -> User:

--- a/src/phoenix/server/api/types/User.py
+++ b/src/phoenix/server/api/types/User.py
@@ -7,7 +7,7 @@ from strawberry import Private
 from strawberry.relay import Node, NodeID
 from strawberry.types import Info
 
-from phoenix.config import get_env_management_url
+from phoenix.config import get_env_admins, get_env_management_url
 from phoenix.db import models
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
@@ -44,8 +44,13 @@ class User(Node):
         return [to_gql_api_key(api_key) for api_key in api_keys]
 
     @strawberry.field
-    async def management_url(self, info: Info[Context, None]) -> Optional[str]:
-        return get_env_management_url()
+    async def management_url(self) -> Optional[str]:
+        initial_admins = get_env_admins()
+        # this field is only visible to initial admins as they are the ones likely to have access to
+        # a management interface / the phoenix environment.
+        if self.email in initial_admins or self.email == "admin@localhost":
+            return get_env_management_url()
+        return None
 
 
 def to_gql_user(user: models.User, api_keys: Optional[list[models.ApiKey]] = None) -> User:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -231,6 +231,8 @@ class AppConfig(NamedTuple):
     auto_login_idp_name: Optional[str] = None
     fullstory_org: Optional[str] = None
     """ FullStory organization ID for web analytics tracking """
+    management_url: Optional[str] = None
+    """ URL for a phoenix management interface, only visible to management users """
 
 
 class Static(StaticFiles):
@@ -297,6 +299,7 @@ class Static(StaticFiles):
                     "basic_auth_disabled": self._app_config.basic_auth_disabled,
                     "auto_login_idp_name": self._app_config.auto_login_idp_name,
                     "fullstory_org": self._app_config.fullstory_org,
+                    "management_url": self._app_config.management_url,
                 },
             )
         except Exception as e:
@@ -847,6 +850,7 @@ def create_app(
     basic_auth_disabled: bool = False,
     bulk_inserter_factory: Optional[Callable[..., BulkInserter]] = None,
     allowed_origins: Optional[list[str]] = None,
+    management_url: Optional[str] = None,
 ) -> FastAPI:
     verify_server_environment_variables()
     if model.embedding_dimensions:
@@ -1026,6 +1030,7 @@ def create_app(
                     basic_auth_disabled=basic_auth_disabled,
                     auto_login_idp_name=auto_login_idp_name,
                     fullstory_org=Settings.fullstory_org,
+                    management_url=management_url,
                 ),
             ),
             name="static",

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -32,6 +32,7 @@ from phoenix.config import (
     get_env_log_migrations,
     get_env_logging_level,
     get_env_logging_mode,
+    get_env_management_url,
     get_env_oauth2_settings,
     get_env_password_reset_token_expiry,
     get_env_port,
@@ -377,6 +378,7 @@ def main() -> None:
     )
 
     allowed_origins = get_env_allowed_origins()
+    management_url = get_env_management_url()
 
     # Get TLS configuration
     tls_enabled_for_http = get_env_tls_enabled_for_http()
@@ -455,6 +457,7 @@ def main() -> None:
         email_sender=email_sender,
         oauth2_client_configs=get_env_oauth2_settings(),
         allowed_origins=allowed_origins,
+        management_url=management_url,
     )
 
     # Configure server with TLS if enabled

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -110,6 +110,7 @@
               oAuth2Idps: {{ oauth2_idps | tojson }},
               basicAuthDisabled: Boolean("{{basic_auth_disabled}}" == "True"),
               websocketsEnabled: Boolean("{{websockets_enabled}}" == "True"),
+              managementUrl: {{management_url | tojson}},
           }),
           writable: false
       });


### PR DESCRIPTION
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f97cb60d-0abf-4959-9007-5e845483650e" />

Link appears when:
- url is provided to PHOENIX_MANAGEMENT_URL env var
- User is logged in as default admin, or, admin declared in PHOENIX_ADMINS env var

Because of those conditions, the URL is served via graphql in the viewer model, rather than the window global.

Resolves #8310

## Summary by Sourcery

Add a customizable management console link to the navbar for admin users when a PHOENIX_MANAGEMENT_URL is configured, exposing it via GraphQL and backend configuration.

New Features:
- Introduce PHOENIX_MANAGEMENT_URL environment variable support in backend config
- Expose a managementUrl field on the User GraphQL type for initial or default admin users
- Render a “Management console” link with a new server icon in the navigation menu when the management URL is available