### PR TITLE
fix: remove extra join in query for span cost summary

### DIFF
--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
@@ -124,13 +124,13 @@ def _get_stmt(
     )
 
     if start_time:
-        stmt = stmt.where(start_time <= models.Span.start_time)
+        stmt = stmt.where(start_time <= models.Trace.start_time)
     if end_time:
-        stmt = stmt.where(models.Span.start_time < end_time)
+        stmt = stmt.where(models.Trace.start_time < end_time)
 
     if filter_condition:
         sf = SpanFilter(filter_condition)
-        stmt = sf(stmt)
+        stmt = sf(stmt.join_from(models.SpanCost, models.Span))
 
     project_ids = [rowid for rowid in params]
     stmt = stmt.where(pid.in_(project_ids))

--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
@@ -119,8 +119,7 @@ def _get_stmt(
             coalesce(func.sum(models.SpanCost.completion_tokens), 0).label("completion_tokens"),
             coalesce(func.sum(models.SpanCost.total_tokens), 0).label("total_tokens"),
         )
-        .select_from(models.Trace)
-        .join(models.SpanCost, models.Trace.id == models.SpanCost.trace_rowid)
+        .join_from(models.SpanCost, models.Trace)
         .group_by(pid)
     )
 

--- a/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
+++ b/src/phoenix/server/api/dataloaders/span_cost_summary_by_project.py
@@ -120,8 +120,7 @@ def _get_stmt(
             coalesce(func.sum(models.SpanCost.total_tokens), 0).label("total_tokens"),
         )
         .select_from(models.Trace)
-        .join(models.Span, models.Span.trace_rowid == models.Trace.id)
-        .join(models.SpanCost, models.Span.id == models.SpanCost.span_rowid)
+        .join(models.SpanCost, models.Trace.id == models.SpanCost.trace_rowid)
         .group_by(pid)
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Fix span cost summary query by removing the extra join to Span and joining SpanCost directly to Trace.

Bug Fixes:
- Remove redundant join on Span in span cost summary query
- Adjust join condition to link SpanCost directly to Trace using trace_rowid