### PR TITLE
fix: Support ISO8601 strings during experiment eval upsert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ dev = [
   "uvloop; platform_system != 'Windows'",
   "grpc-interceptor[testing]",
   "types-jsonschema",
+  "types-python-dateutil",
 ]
 embeddings = [
   "fast-hdbscan>=0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "authlib",
   "arize-phoenix-client",
   "email-validator",
+  "python-dateutil",
 ]
 dynamic = ["version"]
 

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -24,6 +24,7 @@ types-cachetools
 types-jsonschema
 types-protobuf
 types-psutil
+types-python-dateutil
 types-requests
 types-setuptools
 types-tabulate

--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any, Literal, Optional
 
+from dateutil.parser import isoparse
 from fastapi import APIRouter, HTTPException
 from pydantic import Field
 from starlette.requests import Request
@@ -95,8 +96,8 @@ async def upsert_experiment_evaluation(
             explanation=explanation,
             error=error,
             metadata_=metadata,  # `metadata_` must match database
-            start_time=datetime.fromisoformat(start_time),
-            end_time=datetime.fromisoformat(end_time),
+            start_time=isoparse(start_time),
+            end_time=isoparse(end_time),
             trace_id=payload.get("trace_id"),
         )
         dialect = SupportedSQLDialect(session.bind.dialect.name)


### PR DESCRIPTION
Python pre-3.11 does not parse standards compliant ISO8601 timestamps without a 3rd party util. We already had the recommended util installed, so now we use that.

Need to port all callsites of datetime.fromisoformat to this new function in the future.

https://docs.python.org/3.9/library/datetime.html#datetime.datetime.fromisoformat

## Summary by Sourcery

Bug Fixes:
- Use isoparse instead of datetime.fromisoformat for start_time and end_time to handle full ISO8601 strings.