### PR TITLE
refactor: refactor to use an mcp client

### DIFF
--- a/js/packages/phoenix-mcp/package.json
+++ b/js/packages/phoenix-mcp/package.json
@@ -10,8 +10,7 @@
     "build": "tsc && chmod 755 build/index.js",
     "dev": "source .env && tsx src/index.ts -- --apiKey $PHOENIX_API_KEY --baseUrl $PHOENIX_BASE_URL",
     "typecheck": "tsc --noEmit",
-    "inspect": "pnpm run build && npx -y @modelcontextprotocol/inspector -- node build/index.js",
-    "test": "tsx src/test.ts"
+    "inspect": "pnpm run build && npx -y @modelcontextprotocol/inspector -- node build/index.js"
   },
   "files": [
     "build"

--- a/js/packages/phoenix-mcp/package.json
+++ b/js/packages/phoenix-mcp/package.json
@@ -10,7 +10,8 @@
     "build": "tsc && chmod 755 build/index.js",
     "dev": "source .env && tsx src/index.ts -- --apiKey $PHOENIX_API_KEY --baseUrl $PHOENIX_BASE_URL",
     "typecheck": "tsc --noEmit",
-    "inspect": "pnpm run build && npx -y @modelcontextprotocol/inspector -- node build/index.js"
+    "inspect": "pnpm run build && npx -y @modelcontextprotocol/inspector -- node build/index.js",
+    "test": "tsx src/test.ts"
   },
   "files": [
     "build"
@@ -23,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@arizeai/phoenix-client": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.13.3",
     "glob": "^11.0.1",
     "minimist": "^1.2.8",
     "zod": "^3.24.2"

--- a/js/packages/phoenix-mcp/src/supportTools.ts
+++ b/js/packages/phoenix-mcp/src/supportTools.ts
@@ -5,7 +5,7 @@ import z from "zod";
 
 const PHOENIX_SUPPORT_DESCRIPTION = `Get help with Phoenix and OpenInference.
 
-- Tracing AI apllications via OpenInference and OpenTelemetry
+- Tracing AI applications via OpenInference and OpenTelemetry
 - Phoenix datasets, experiments, and prompt management
 - Phoenix Evals and Annotations
 
@@ -57,7 +57,7 @@ export async function callRunLLMChat({
     },
   });
 
-  // Extract text content from the result
+  // There's usually only one content item, but we'll handle multiple for safety
   if (result.content && Array.isArray(result.content)) {
     const textContent = result.content
       .filter((item) => item.type === "text")

--- a/js/packages/phoenix-mcp/src/supportTools.ts
+++ b/js/packages/phoenix-mcp/src/supportTools.ts
@@ -1,281 +1,84 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import z from "zod";
 
-/**
- * Configuration constants for external service integrations
- */
-const RUNLLM_CONFIG = {
-  ENDPOINT: "https://mcp.runllm.com/mcp/",
-  ASSISTANT_NAME: "arize-phoenix",
-  HEADERS: {
-    "assistant-name": "arize-phoenix",
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-  },
-} as const;
+const PHOENIX_SUPPORT_DESCRIPTION = `Get help with Phoenix and OpenInference.
 
-const MCP_CONSTANTS = {
-  JSONRPC_VERSION: "2.0",
-  METHODS: {
-    TOOLS_LIST: "tools/list",
-    TOOLS_CALL: "tools/call",
-  },
-} as const;
-
-const PHOENIX_SUPPORT_DESCRIPTION = `Get help and support for Arize Phoenix and AI observability questions.
-
-- Tracing and debugging AI applications
+- Tracing AI apllications via OpenInference and OpenTelemetry
 - Phoenix datasets, experiments, and prompt management
-- Best practices for AI observability
+- Phoenix Evals and Annotations
 
-Use this tool when you need expert assistance with Arize Phoenix features, troubleshooting,
-or general AI observability guidance.
-
+Use this tool when you need assistance with Phoenix features, troubleshooting,
+or best practices.
 
 Expected return:
-  Expert guidance and information about Arize Phoenix and AI observability practices.`;
+  Expert guidance about how to use and integrate Phoenix`;
 
-interface MCPRequest {
-  jsonrpc: string;
-  id: number;
-  method: string;
-  params?: Record<string, unknown>;
-}
-
-interface MCPResponse {
-  jsonrpc: string;
-  id: number;
-  result?: {
-    tools?: Tool[];
-    content?: ContentItem[];
-    [key: string]: unknown;
-  };
-  error?: {
-    code: number;
-    message: string;
-  };
-}
-
-interface Tool {
-  name: string;
-  description?: string;
-  inputSchema?: Record<string, unknown>;
-}
-
-interface ContentItem {
-  type: string;
-  text?: string;
-}
-
-async function runLLMEndpoint(question: string): Promise<string> {
-  const url = RUNLLM_CONFIG.ENDPOINT;
-  const headers = RUNLLM_CONFIG.HEADERS;
-
-  try {
-    // Skip tool discovery for performance - we know 'chat' exists
-    // ------------------------------------------------------------------
-    // Call the 'chat' tool directly with the provided message
-    // ------------------------------------------------------------------
-    const callRequest: MCPRequest = {
-      jsonrpc: MCP_CONSTANTS.JSONRPC_VERSION,
-      id: 1,
-      method: MCP_CONSTANTS.METHODS.TOOLS_CALL,
-      params: {
-        name: "chat",
-        arguments: { message: question },
+/**
+ * Creates an MCP client connected to the RunLLM server via HTTP
+ */
+async function createRunLLMClient(): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL("https://mcp.runllm.com/mcp/"),
+    {
+      requestInit: {
+        headers: {
+          "assistant-name": "arize-phoenix",
+        },
       },
-    };
-
-    const chatResponse = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(callRequest),
-      signal: AbortSignal.timeout(60000), // 60 second timeout
-    });
-
-    if (!chatResponse.ok) {
-      throw new Error(`HTTP error! status: ${chatResponse.status}`);
     }
+  );
 
-    const chatContentType = chatResponse.headers.get("content-type");
+  const client = new Client({
+    name: "runllm-client",
+    version: "1.0.0",
+  });
 
-    if (chatContentType?.includes("text/event-stream")) {
-      // Handle SSE stream for chat response with timeout
-      if (!chatResponse.body) {
-        throw new Error(
-          "runLLM endpoint returned SSE response without a readable body stream"
-        );
-      }
-
-      const reader = chatResponse.body.getReader();
-      const decoder = new TextDecoder();
-      let accumulatedData = ""; // Accumulate data across chunks
-
-      try {
-        let done, value;
-        do {
-          ({ done, value } = await reader.read());
-
-          if (done) {
-            // Try to parse any remaining accumulated data
-            if (accumulatedData.length > 0) {
-              try {
-                const msg: MCPResponse = JSON.parse(accumulatedData);
-                if (msg.id === 1 && msg.result && msg.result.content) {
-                  const content = msg.result.content || [];
-                  for (const item of content) {
-                    if (item.type === "text" && item.text) {
-                      try {
-                        const parsedResponse = JSON.parse(item.text);
-                        if (parsedResponse.response) {
-                          return parsedResponse.response;
-                        }
-                      } catch (e) {
-                        return item.text;
-                      }
-                    }
-                  }
-                }
-              } catch (e) {
-                // Could not parse final accumulated data
-              }
-            }
-          } else {
-            const chunk = decoder.decode(value, { stream: true });
-            const lines = chunk.split("\n");
-
-            for (const line of lines) {
-              if (line.startsWith("data:")) {
-                const payload = line.slice(5).trim();
-
-                // Check for [DONE] marker
-                if (payload === "[DONE]") {
-                  break;
-                }
-
-                // Accumulate data instead of parsing each chunk individually
-                accumulatedData += payload;
-
-                // Try to parse the accumulated JSON
-                try {
-                  const msg: MCPResponse = JSON.parse(accumulatedData);
-                  if (msg.id === 1 && msg.result) {
-                    const texts: string[] = [];
-                    const content = msg.result.content || [];
-
-                    for (const item of content) {
-                      if (item.type === "text" && item.text) {
-                        // Parse the JSON response from runLLM
-                        try {
-                          const parsedResponse = JSON.parse(item.text);
-                          if (parsedResponse.response) {
-                            return parsedResponse.response;
-                          }
-                        } catch (e) {
-                          // If not JSON, use raw text
-                          texts.push(item.text);
-                        }
-                      }
-                    }
-
-                    if (texts.length > 0) {
-                      return texts.join("\n");
-                    }
-                  }
-
-                  // If we successfully parsed, reset accumulated data for next message
-                  accumulatedData = "";
-                } catch (e) {
-                  // Continue accumulating - JSON is not yet complete
-                }
-              } else if (line.trim() === "") {
-                // Empty line (heartbeat)
-              } else if (accumulatedData.length > 0) {
-                accumulatedData += line;
-
-                // Try to parse the updated accumulated data
-                try {
-                  const msg: MCPResponse = JSON.parse(accumulatedData);
-                  if (msg.id === 1 && msg.result) {
-                    const texts: string[] = [];
-                    const content = msg.result.content || [];
-
-                    for (const item of content) {
-                      if (item.type === "text" && item.text) {
-                        // Parse the JSON response from runLLM
-                        try {
-                          const parsedResponse = JSON.parse(item.text);
-                          if (parsedResponse.response) {
-                            return parsedResponse.response;
-                          }
-                        } catch (e) {
-                          // If not JSON, use raw text
-                          texts.push(item.text);
-                        }
-                      }
-                    }
-
-                    if (texts.length > 0) {
-                      return texts.join("\n");
-                    }
-                  }
-
-                  // If we successfully parsed, reset accumulated data
-                  accumulatedData = "";
-                } catch (e) {
-                  // Continue accumulating - JSON is still not yet complete
-                }
-              }
-            }
-          }
-        } while (!done);
-      } finally {
-        // Clean up reader if needed
-      }
-
-      return "No response received from chat tool";
-    } else {
-      // Handle regular JSON response
-      const data: MCPResponse = await chatResponse.json();
-      if (data.result && data.result.content) {
-        const texts: string[] = [];
-        const content = data.result.content || [];
-
-        for (const item of content) {
-          if (item.type === "text" && item.text) {
-            // Parse the JSON response from runLLM
-            try {
-              const parsedResponse = JSON.parse(item.text);
-              if (parsedResponse.response) {
-                return parsedResponse.response;
-              }
-            } catch (e) {
-              // If not JSON, use raw text
-              texts.push(item.text);
-            }
-          }
-        }
-
-        if (texts.length > 0) {
-          return texts.join("\n");
-        }
-      } else {
-        // No result or content in JSON response
-      }
-    }
-
-    return "No response received from chat tool";
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    // eslint-disable-next-line no-console
-    console.error("Error calling runLLM endpoint:", errorMessage);
-    return "An unexpected error occurred while processing your request.";
-  }
+  await client.connect(transport);
+  return client;
 }
 
-export const initializeSupportTools = ({ server }: { server: McpServer }) => {
+/**
+ * Calls the chat tool on the RunLLM MCP server
+ */
+export async function callRunLLMChat({
+  question,
+}: {
+  question: string;
+}): Promise<string> {
+  const client = await createRunLLMClient();
+
+  // Call the chat tool with the user's question
+  const result = await client.callTool({
+    name: "chat",
+    arguments: {
+      message: question,
+    },
+  });
+
+  // Extract text content from the result
+  if (result.content && Array.isArray(result.content)) {
+    const textContent = result.content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join("\n");
+
+    if (textContent) {
+      return textContent;
+    }
+  }
+
+  return "No response received from support";
+}
+
+export const initializeSupportTools = async ({
+  server,
+}: {
+  server: McpServer;
+}) => {
   server.tool(
-    "phoenix_support",
+    "phoenix-support",
     PHOENIX_SUPPORT_DESCRIPTION,
     {
       question: z
@@ -285,7 +88,7 @@ export const initializeSupportTools = ({ server }: { server: McpServer }) => {
         ),
     },
     async ({ question }) => {
-      const result = await runLLMEndpoint(question);
+      const result = await callRunLLMChat({ question });
       return {
         content: [
           {

--- a/js/packages/phoenix-mcp/src/supportTools.ts
+++ b/js/packages/phoenix-mcp/src/supportTools.ts
@@ -7,7 +7,7 @@ const PHOENIX_SUPPORT_DESCRIPTION = `Get help with Phoenix and OpenInference.
 
 - Tracing AI applications via OpenInference and OpenTelemetry
 - Phoenix datasets, experiments, and prompt management
-- Phoenix Evals and Annotations
+- Phoenix evals and annotations
 
 Use this tool when you need assistance with Phoenix features, troubleshooting,
 or best practices.

--- a/js/packages/phoenix-mcp/src/test.ts
+++ b/js/packages/phoenix-mcp/src/test.ts
@@ -1,4 +1,0 @@
-import { callRunLLMChat } from "./supportTools.js";
-
-const result = await callRunLLMChat({ question: "What is Phoenix?" });
-console.log(result);

--- a/js/packages/phoenix-mcp/src/test.ts
+++ b/js/packages/phoenix-mcp/src/test.ts
@@ -1,0 +1,4 @@
+import { callRunLLMChat } from "./supportTools.js";
+
+const result = await callRunLLMChat({ question: "What is Phoenix?" });
+console.log(result);

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../phoenix-client
       '@modelcontextprotocol/sdk':
-        specifier: ^1.12.0
-        version: 1.12.0
+        specifier: ^1.13.3
+        version: 1.13.3
       glob:
         specifier: ^11.0.1
         version: 11.0.2
@@ -542,8 +542,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/sdk@1.12.0':
-    resolution: {integrity: sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==}
+  '@modelcontextprotocol/sdk@1.13.3':
+    resolution: {integrity: sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==}
     engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1427,9 +1427,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  eventsource-parser@3.0.2:
-    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
-    engines: {node: '>=18.0.0'}
+  eventsource-parser@3.0.3:
+    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+    engines: {node: '>=20.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -3096,13 +3096,14 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.12.0':
+  '@modelcontextprotocol/sdk@1.13.3':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
+      eventsource-parser: 3.0.3
       express: 5.1.0
       express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
@@ -3584,14 +3585,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@6.3.5(@types/node@20.17.50)(tsx@4.19.4)(yaml@2.8.0))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@20.17.50)(tsx@4.19.4)(yaml@2.8.0)
-
   '@vitest/mocker@2.1.9(vite@6.3.5(@types/node@22.15.21)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -4066,11 +4059,11 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  eventsource-parser@3.0.2: {}
+  eventsource-parser@3.0.3: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.0.3
 
   expect-type@1.2.1: {}
 
@@ -5290,7 +5283,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.17.50)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.3.5(@types/node@20.17.50)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 2.1.9(vite@6.3.5(@types/node@22.15.21)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9


### PR DESCRIPTION
## Summary by Sourcery

Refactor Phoenix MCP support tools to use the official MCP client for server communication instead of manual HTTP calls and SSE parsing, simplify tool initialization, and update dependencies.

New Features:
- Introduce createRunLLMClient function to establish an MCP client connection via HTTP
- Add callRunLLMChat helper to invoke the chat tool through the MCP client

Enhancements:
- Remove manual fetch and JSON-RPC/SSE parsing logic in favor of SDK client methods
- Change support tool registration to asynchronous initialization and rename tool to "phoenix-support"
- Update support tool description content for clarity and scope

Build:
- Bump @modelcontextprotocol/sdk dependency to ^1.13.3
- Add a test script entry in package.json

Tests:
- Add `test` script in package.json to run support tool tests via tsx