### PR TITLE
fix(helm): improve labels consistency

### DIFF
--- a/helm/templates/phoenix/ingress.yaml
+++ b/helm/templates/phoenix/ingress.yaml
@@ -4,8 +4,9 @@ kind: Ingress
 metadata:
   name: "{{ template "phoenix.ingress" . }}"
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.ingress.labels }}
   labels:
+    app: {{ .Release.Name }}
+{{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 {{- if .Values.ingress.annotations}}

--- a/helm/templates/phoenix/secret.yaml
+++ b/helm/templates/phoenix/secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: {{ .Values.auth.name }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ .Release.Name }}
 type: Opaque
 data:
 {{- if .Values.auth.secret }}

--- a/helm/templates/phoenix/service.yaml
+++ b/helm/templates/phoenix/service.yaml
@@ -14,6 +14,7 @@ metadata:
 {{- end }}
 {{- if or .Values.server.labels .Values.service.labels }}
   labels:
+    app: {{ .Release.Name }}
 {{- if .Values.server.labels }}
 {{ toYaml .Values.server.labels | indent 4 }}
 {{- end }}
@@ -29,6 +30,6 @@ spec:
     - name: {{ template "phoenix.appPortName" . }}
       port: {{ template "phoenix.appPort" . }}
     - name: {{ template "phoenix.metricsPortName" . }}
-      port: {{ template "phoenix.metricsPort" . }} 
+      port: {{ template "phoenix.metricsPort" . }}
   selector:
     app: {{ .Release.Name }}


### PR DESCRIPTION
(no issue)
At the moment, a cleanup command like 
```sh
kubectl delete all,configmap,secret,pvc,ingress -l app=my-release -n my-namespace
```
would not cleanup everything created by the chart due to the inconsistent labels. This PR fixes that.

## Summary by Sourcery

Standardize the "app" label across Helm chart resources to ensure consistent cleanup by label selector

Bug Fixes:
- Ensure kubectl cleanup commands target all chart resources by unifying labels

Enhancements:
- Add app: {{ .Release.Name }} label to Phoenix Ingress
- Add app: {{ .Release.Name }} label to Phoenix Secret
- Add app: {{ .Release.Name }} label to Phoenix Service