### PR TITLE
refactor: migrate AnnotationTooltip to phoenix component

### DIFF
--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -2,11 +2,10 @@ import React, { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 import { css } from "@emotion/react";
 
-import { Flex, Text } from "@phoenix/components";
+import { Flex } from "@phoenix/components";
 import { AnnotationSummaryGroup$key } from "@phoenix/components/annotation/__generated__/AnnotationSummaryGroup.graphql";
 import { AnnotationLabel } from "@phoenix/components/annotation/AnnotationLabel";
 import { AnnotationSummaryPopover } from "@phoenix/components/annotation/AnnotationSummaryPopover";
-import { AnnotationTooltip } from "@phoenix/components/annotation/AnnotationTooltip";
 import {
   Summary,
   SummaryValue,
@@ -210,22 +209,16 @@ export const AnnotationSummaryGroupStacks = ({
           return null;
         }
         return (
-          <AnnotationTooltip
-            key={latestAnnotation.id}
-            leadingExtra={<Text weight="heavy">Latest annotation</Text>}
-            annotation={latestAnnotation}
-          >
-            <Summary name={latestAnnotation.name}>
-              <SummaryValue
-                name={latestAnnotation.name}
-                meanScore={summary.meanScore}
-                labelFractions={summary.labelFractions}
-                annotationConfig={
-                  categoricalAnnotationConfigsByName[latestAnnotation.name]
-                }
-              />
-            </Summary>
-          </AnnotationTooltip>
+          <Summary name={latestAnnotation.name} key={latestAnnotation.id}>
+            <SummaryValue
+              name={latestAnnotation.name}
+              meanScore={summary.meanScore}
+              labelFractions={summary.labelFractions}
+              annotationConfig={
+                categoricalAnnotationConfigsByName[latestAnnotation.name]
+              }
+            />
+          </Summary>
         );
       })}
     </Flex>

--- a/app/src/components/annotation/AnnotationTooltip.tsx
+++ b/app/src/components/annotation/AnnotationTooltip.tsx
@@ -1,8 +1,13 @@
-import { CSSProperties, ReactNode } from "react";
+import { ReactNode } from "react";
+import { Pressable } from "react-aria";
 
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
-import { Flex, Text, View } from "@phoenix/components";
+import {
+  Flex,
+  RichTooltip,
+  Text,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
 
@@ -16,7 +21,6 @@ export function AnnotationTooltip({
   children,
   extra,
   layout = "vertical",
-  width,
   leadingExtra,
 }: {
   leadingExtra?: ReactNode;
@@ -24,12 +28,13 @@ export function AnnotationTooltip({
   children: ReactNode;
   layout?: "horizontal" | "vertical";
   extra?: ReactNode;
-  width?: CSSProperties["width"];
 }) {
   return (
-    <TooltipTrigger delay={500} offset={3}>
-      <TriggerWrap>{children}</TriggerWrap>
-      <HelpTooltip UNSAFE_style={{ minWidth: width }}>
+    <TooltipTrigger delay={500}>
+      <Pressable>
+        <div>{children}</div>
+      </Pressable>
+      <RichTooltip offset={3}>
         <Flex
           direction={layout === "horizontal" ? "row" : "column"}
           alignItems="start"
@@ -107,7 +112,7 @@ export function AnnotationTooltip({
           </Flex>
           {extra}
         </Flex>
-      </HelpTooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }


### PR DESCRIPTION
This migrates `AnnotationTooltip` from the old `@arizeai/components` tooltip to the newer `@phoenix/components` version. There are three usages of `AnnotationTooltip`:

### `AnnotationSummaryGroup`
**Before**
Both the annotation label and value trigger different tooltips:

(label, using old component)
![image](https://github.com/user-attachments/assets/4d3ee4ca-c22e-4950-becd-b55140048dbd)


(value, using new component)
![image](https://github.com/user-attachments/assets/e56e95a2-0789-4ad5-8b7e-191b0602c0d8)


**After**
This PR removes the tooltip from the label. Talked this through with @cephalization, and we think the label tooltip is not super valuable, and is hard to trigger anyway with the larger value tooltip target right beneath it.


### `ExampleExperimentRunsTable`
**Before, using old component**
![image](https://github.com/user-attachments/assets/d9d98b6f-bd73-4a25-9961-4f2ade057a13)


**After, using new component**

![image](https://github.com/user-attachments/assets/1615f7b5-074d-433a-8802-60cd0cc503b6)

### `ExperimentCompareTable`
**Before, using old component**
![image](https://github.com/user-attachments/assets/78c1ad99-f976-4e3d-b91b-8176e96a0099)


**After, using new component**

![image](https://github.com/user-attachments/assets/a6968297-3f75-40c4-adf7-d6ef94879984)

## Summary by Sourcery

Migrate AnnotationTooltip to use the Phoenix tooltip implementation and standardize its usage across components

Enhancements:
- Replace old @arizeai/components TooltipTrigger and HelpTooltip with @phoenix/components TooltipTrigger, Pressable, and RichTooltip in AnnotationTooltip
- Remove the redundant label tooltip in AnnotationSummaryGroup, retaining only the value tooltip
- Update tooltip usage in ExampleExperimentRunsTable and ExperimentCompareTable to the new Phoenix-based component