### PR TITLE
chore: minor bump on phoenix version after adding phoenix-support mcp-tool

### DIFF
--- a/js/.changeset/clean-rings-change.md
+++ b/js/.changeset/clean-rings-change.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-mcp": minor
+---
+
+add phoenix-support tool


### PR DESCRIPTION
## Summary by Sourcery

Add the phoenix-support tool to the phoenix-mcp package and bump its version to a new minor release

New Features:
- Add phoenix-support tool to phoenix-mcp

Chores:
- Bump @arizeai/phoenix-mcp to minor version via changeset