### PR TITLE
Feat: Update to postgres 16 in kustomize manifest

### DIFF
--- a/kustomize/base/postgres.yaml
+++ b/kustomize/base/postgres.yaml
@@ -50,7 +50,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: "postgres:16"
+        image: "postgres:16.7.8"
         imagePullPolicy: Always
         name: postgres
         ports:

--- a/kustomize/base/postgres.yaml
+++ b/kustomize/base/postgres.yaml
@@ -50,7 +50,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: "postgres:12"
+        image: "postgres:16"
         imagePullPolicy: Always
         name: postgres
         ports:

--- a/kustomize/base/postgres.yaml
+++ b/kustomize/base/postgres.yaml
@@ -50,7 +50,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: "postgres:16.7.8"
+        image: "postgres:16.7"
         imagePullPolicy: Always
         name: postgres
         ports:


### PR DESCRIPTION
Update the Postgres image to version 16 to keep consistency with the rest of the repository.

## Summary by Sourcery

Enhancements:
- Upgrade Postgres image from version 12 to version 16 in kustomize/base/postgres.yaml