### PR TITLE
refactor: Migrate AnnotationSummary tooltips and Metadata tooltip to new component

### DIFF
--- a/app/src/components/annotation/AnnotationTooltip.tsx
+++ b/app/src/components/annotation/AnnotationTooltip.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from "react";
-import { Pressable } from "react-aria";
 
 import {
   Flex,
   RichTooltip,
   Text,
   TooltipTrigger,
+  TriggerWrap,
   View,
 } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/utility/Truncate";
@@ -31,9 +31,7 @@ export function AnnotationTooltip({
 }) {
   return (
     <TooltipTrigger delay={500}>
-      <Pressable>
-        <div>{children}</div>
-      </Pressable>
+      <TriggerWrap>{children}</TriggerWrap>
       <RichTooltip offset={3}>
         <Flex
           direction={layout === "horizontal" ? "row" : "column"}

--- a/app/src/components/tooltip/RichTooltip.tsx
+++ b/app/src/components/tooltip/RichTooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, Ref } from "react";
+import { CSSProperties, forwardRef, ReactNode, Ref } from "react";
 import { Tooltip as AriaTooltip } from "react-aria-components";
 import { css } from "@emotion/react";
 
@@ -6,7 +6,12 @@ import { Heading, Text, View } from "@phoenix/components";
 
 import { richTooltipCSS } from "./styles";
 import { TooltipProps } from "./types";
-export interface RichTooltipProps extends TooltipProps {}
+export interface RichTooltipProps extends TooltipProps {
+  /**
+   * The width of the tooltip. If not provided, the tooltip will grow up to 300px to fit the content.
+   */
+  width?: CSSProperties["width"];
+}
 
 /**
  * RichTooltip component
@@ -15,10 +20,15 @@ export interface RichTooltipProps extends TooltipProps {}
  * Ideal when you need more than a short sentence. If you only need a simple, brief tooltip, use the Tooltip component instead.
  */
 function RichTooltip(props: RichTooltipProps, ref: Ref<HTMLDivElement>) {
-  const { children, css: propCSS, ...otherProps } = props;
+  const { children, css: propCSS, width, ...otherProps } = props;
 
   return (
-    <AriaTooltip {...otherProps} ref={ref} css={css(richTooltipCSS, propCSS)}>
+    <AriaTooltip
+      {...otherProps}
+      ref={ref}
+      css={css(richTooltipCSS, propCSS)}
+      style={width ? { width } : { maxWidth: "300px" }}
+    >
       {children}
     </AriaTooltip>
   );

--- a/app/src/components/tooltip/RichTooltip.tsx
+++ b/app/src/components/tooltip/RichTooltip.tsx
@@ -8,6 +8,12 @@ import { richTooltipCSS } from "./styles";
 import { TooltipProps } from "./types";
 export interface RichTooltipProps extends TooltipProps {}
 
+/**
+ * RichTooltip component
+ *
+ * Use this component for tooltips that require rich content, such as description lists, charts, titles with paragraphs, or other complex layouts.
+ * Ideal when you need more than a short sentence. If you only need a simple, brief tooltip, use the Tooltip component instead.
+ */
 function RichTooltip(props: RichTooltipProps, ref: Ref<HTMLDivElement>) {
   const { children, css: propCSS, ...otherProps } = props;
 

--- a/app/src/components/tooltip/Tooltip.tsx
+++ b/app/src/components/tooltip/Tooltip.tsx
@@ -11,7 +11,6 @@ import { TooltipProps } from "./types";
  * Use this component for simple tooltips that display short sentences or brief information.
  * Ideal for single-line or very concise text. For more complex content (e.g., description lists, charts, titles with paragraphs), use the RichTooltip component instead.
  */
-
 function Tooltip(props: TooltipProps, ref: Ref<HTMLDivElement>) {
   const { css: propCSS, ...otherProps } = props;
 

--- a/app/src/components/tooltip/Tooltip.tsx
+++ b/app/src/components/tooltip/Tooltip.tsx
@@ -5,6 +5,13 @@ import { css } from "@emotion/react";
 import { tooltipCSS } from "./styles";
 import { TooltipProps } from "./types";
 
+/**
+ * Tooltip component
+ *
+ * Use this component for simple tooltips that display short sentences or brief information.
+ * Ideal for single-line or very concise text. For more complex content (e.g., description lists, charts, titles with paragraphs), use the RichTooltip component instead.
+ */
+
 function Tooltip(props: TooltipProps, ref: Ref<HTMLDivElement>) {
   const { css: propCSS, ...otherProps } = props;
 

--- a/app/src/components/tooltip/TriggerWrap.tsx
+++ b/app/src/components/tooltip/TriggerWrap.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Pressable } from "react-aria";
+
+/**
+ * TriggerWrap
+ *
+ * This component is used to wrap non-focusable elements (such as text or
+ * graphics) so that they can be used as a trigger for tooltips. It ensures
+ * the wrapped element is focusable and accessible for keyboard and mouse
+ * interactions, which is required for tooltip triggers.
+ */
+export function TriggerWrap({
+  children,
+  ...props
+}: { children: React.ReactNode } & Omit<
+  React.ComponentProps<typeof Pressable>,
+  "children"
+>) {
+  return (
+    <Pressable {...props}>
+      <div>{children}</div>
+    </Pressable>
+  );
+}

--- a/app/src/components/tooltip/index.tsx
+++ b/app/src/components/tooltip/index.tsx
@@ -1,6 +1,7 @@
 export { TooltipTrigger, OverlayArrow } from "react-aria-components";
 export { Tooltip } from "./Tooltip";
 export { TooltipArrow } from "./TooltipArrow";
+export { TriggerWrap } from "./TriggerWrap";
 export {
   RichTooltip,
   RichTooltipTitle,

--- a/app/src/components/tooltip/styles.ts
+++ b/app/src/components/tooltip/styles.ts
@@ -75,7 +75,6 @@ export const richTooltipCSS = css`
   forced-color-adjust: none;
   outline: none;
   padding: var(--ac-global-dimension-static-size-200);
-  max-width: 300px;
   min-width: 200px;
   font-size: var(--ac-global-font-size-s);
   /* fixes FF gap */

--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -1,11 +1,17 @@
 import React, { startTransition, Suspense, useEffect } from "react";
+import { Pressable } from "react-aria";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import { useParams } from "react-router";
 import { Cell, Pie, PieChart } from "recharts";
 
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
-import { Flex, Text, Token, View } from "@phoenix/components";
+import {
+  Flex,
+  RichTooltip,
+  Text,
+  Token,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
 import { AnnotationConfig } from "@phoenix/components/annotation";
 import { MeanScore } from "@phoenix/components/annotation/MeanScore";
 import {
@@ -271,26 +277,28 @@ export function SummaryValue({
   }
 
   return (
-    <TooltipTrigger delay={0} placement="bottom">
-      <TriggerWrap>
-        <SummaryValuePreview
-          name={name}
-          meanScore={meanScore}
-          labelFractions={labelFractions}
-          size={size}
-          disableAnimation={disableAnimation}
-          meanScoreFallback={meanScoreFallback}
-          annotationConfig={annotationConfig}
-        />
-      </TriggerWrap>
-      <HelpTooltip>
+    <TooltipTrigger delay={0}>
+      <Pressable>
+        <div>
+          <SummaryValuePreview
+            name={name}
+            meanScore={meanScore}
+            labelFractions={labelFractions}
+            size={size}
+            disableAnimation={disableAnimation}
+            meanScoreFallback={meanScoreFallback}
+            annotationConfig={annotationConfig}
+          />
+        </div>
+      </Pressable>
+      <RichTooltip placement="bottom">
         <SummaryValueBreakdown
           annotationName={name}
           labelFractions={labelFractions}
           meanScore={meanScore}
           annotationConfig={annotationConfig}
         />
-      </HelpTooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }
@@ -446,30 +454,32 @@ export function SummaryValueLabels({
     return null;
   }
   return (
-    <TooltipTrigger delay={0} placement="bottom">
-      <TriggerWrap>
-        <Flex
-          direction="row"
-          alignItems="center"
-          gap="size-50"
-          // Shrinks the container of tokens to allow for the + count to be visible
-          // while still truncating the biggest label
-          // otherwise, just shrink the container slightly for padding
-          maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
-        >
-          <Token style={{ maxWidth: "100%" }}>
-            <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
-          </Token>
-          {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
-        </Flex>
-      </TriggerWrap>
-      <HelpTooltip>
+    <TooltipTrigger delay={0}>
+      <Pressable>
+        <div>
+          <Flex
+            direction="row"
+            alignItems="center"
+            gap="size-50"
+            // Shrinks the container of tokens to allow for the + count to be visible
+            // while still truncating the biggest label
+            // otherwise, just shrink the container slightly for padding
+            maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
+          >
+            <Token style={{ maxWidth: "100%" }}>
+              <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
+            </Token>
+            {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
+          </Flex>
+        </div>
+      </Pressable>
+      <RichTooltip placement="bottom">
         <SummaryValueBreakdown
           annotationName={name}
           labelFractions={labelFractions}
           annotationConfig={annotationConfig}
         />
-      </HelpTooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }

--- a/app/src/pages/project/AnnotationSummary.tsx
+++ b/app/src/pages/project/AnnotationSummary.tsx
@@ -1,5 +1,4 @@
 import React, { startTransition, Suspense, useEffect } from "react";
-import { Pressable } from "react-aria";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import { useParams } from "react-router";
 import { Cell, Pie, PieChart } from "recharts";
@@ -10,6 +9,7 @@ import {
   Text,
   Token,
   TooltipTrigger,
+  TriggerWrap,
   View,
 } from "@phoenix/components";
 import { AnnotationConfig } from "@phoenix/components/annotation";
@@ -278,19 +278,17 @@ export function SummaryValue({
 
   return (
     <TooltipTrigger delay={0}>
-      <Pressable>
-        <div>
-          <SummaryValuePreview
-            name={name}
-            meanScore={meanScore}
-            labelFractions={labelFractions}
-            size={size}
-            disableAnimation={disableAnimation}
-            meanScoreFallback={meanScoreFallback}
-            annotationConfig={annotationConfig}
-          />
-        </div>
-      </Pressable>
+      <TriggerWrap>
+        <SummaryValuePreview
+          name={name}
+          meanScore={meanScore}
+          labelFractions={labelFractions}
+          size={size}
+          disableAnimation={disableAnimation}
+          meanScoreFallback={meanScoreFallback}
+          annotationConfig={annotationConfig}
+        />
+      </TriggerWrap>
       <RichTooltip placement="bottom">
         <SummaryValueBreakdown
           annotationName={name}
@@ -455,24 +453,22 @@ export function SummaryValueLabels({
   }
   return (
     <TooltipTrigger delay={0}>
-      <Pressable>
-        <div>
-          <Flex
-            direction="row"
-            alignItems="center"
-            gap="size-50"
-            // Shrinks the container of tokens to allow for the + count to be visible
-            // while still truncating the biggest label
-            // otherwise, just shrink the container slightly for padding
-            maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
-          >
-            <Token style={{ maxWidth: "100%" }}>
-              <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
-            </Token>
-            {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
-          </Flex>
-        </div>
-      </Pressable>
+      <TriggerWrap>
+        <Flex
+          direction="row"
+          alignItems="center"
+          gap="size-50"
+          // Shrinks the container of tokens to allow for the + count to be visible
+          // while still truncating the biggest label
+          // otherwise, just shrink the container slightly for padding
+          maxWidth={hasMoreThanOneLabel ? "80%" : "99%"}
+        >
+          <Token style={{ maxWidth: "100%" }}>
+            <Truncate maxWidth="100%">{largestFractionLabel}</Truncate>
+          </Token>
+          {hasMoreThanOneLabel && <Token>+ {totalCount}</Token>}
+        </Flex>
+      </TriggerWrap>
       <RichTooltip placement="bottom">
         <SummaryValueBreakdown
           annotationName={name}

--- a/app/src/pages/project/MetadataTooltip.tsx
+++ b/app/src/pages/project/MetadataTooltip.tsx
@@ -53,7 +53,7 @@ export function MetadataTooltip({
       <Pressable>
         <div>{children}</div>
       </Pressable>
-      <RichTooltip offset={3}>
+      <RichTooltip offset={3} width={width}>
         <Flex direction="row" wrap="nowrap" gap="size-100">
           <Flex flexBasis="40%">
             <Flex direction="column" gap="size-100" width="100%">

--- a/app/src/pages/project/MetadataTooltip.tsx
+++ b/app/src/pages/project/MetadataTooltip.tsx
@@ -1,9 +1,14 @@
 import { CSSProperties, ReactNode } from "react";
+import { Pressable } from "react-aria";
 import { css } from "@emotion/react";
 
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
-import { Flex, Text, View } from "@phoenix/components";
+import {
+  Flex,
+  RichTooltip,
+  Text,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { toPythonPrimitiveStr } from "@phoenix/utils/pythonUtils";
 
@@ -44,9 +49,11 @@ export function MetadataTooltip({
   }));
 
   return (
-    <TooltipTrigger delay={500} offset={3}>
-      <TriggerWrap>{children}</TriggerWrap>
-      <HelpTooltip UNSAFE_style={{ minWidth: width }}>
+    <TooltipTrigger delay={500}>
+      <Pressable>
+        <div>{children}</div>
+      </Pressable>
+      <RichTooltip offset={3}>
         <Flex direction="row" wrap="nowrap" gap="size-100">
           <Flex flexBasis="40%">
             <Flex direction="column" gap="size-100" width="100%">
@@ -141,7 +148,7 @@ export function MetadataTooltip({
             </Flex>
           </View>
         </Flex>
-      </HelpTooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }

--- a/app/src/pages/project/MetadataTooltip.tsx
+++ b/app/src/pages/project/MetadataTooltip.tsx
@@ -1,5 +1,4 @@
 import { CSSProperties, ReactNode } from "react";
-import { Pressable } from "react-aria";
 import { css } from "@emotion/react";
 
 import {
@@ -7,6 +6,7 @@ import {
   RichTooltip,
   Text,
   TooltipTrigger,
+  TriggerWrap,
   View,
 } from "@phoenix/components";
 import { Truncate } from "@phoenix/components/utility/Truncate";
@@ -50,9 +50,7 @@ export function MetadataTooltip({
 
   return (
     <TooltipTrigger delay={500}>
-      <Pressable>
-        <div>{children}</div>
-      </Pressable>
+      <TriggerWrap>{children}</TriggerWrap>
       <RichTooltip offset={3} width={width}>
         <Flex direction="row" wrap="nowrap" gap="size-100">
           <Flex flexBasis="40%">


### PR DESCRIPTION
This PR migrates tooltips within `MetadataTooltip.tsx` and `AnnotationSummary.tsx` to the new rich tooltip component. This includes adding a `width` prop to `RichTooltip` that when set will override the existing max width of 300px. This is needed to preserve the existing behavior of `MetadataTooltip` having a width of 800px.

<details>
<summary>
Screenshots
</summary>

### MetadataTooltip
before:
![image](https://github.com/user-attachments/assets/20c4b4c3-7843-48a0-a31f-08fa3eddc1c5)

after:
![image](https://github.com/user-attachments/assets/7461f3ad-b364-476b-9647-2b95d5a7de6f)


### SummaryValue

before:
![image](https://github.com/user-attachments/assets/cd080096-5882-4541-ad63-6233ce48e5aa)

after:
![image](https://github.com/user-attachments/assets/cf18b94c-acc0-4f1a-8674-481814c803e5)


### SummaryValueLabels

before:
![image](https://github.com/user-attachments/assets/21b56cad-7189-4e46-9447-3ccb692a987b)

after:
![image](https://github.com/user-attachments/assets/d79fb711-8bbe-449b-a36f-f76a190aac07)


</details>
