### PR TITLE
feat: Add serialization/deserialization methods to client Datasets

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -178,6 +178,83 @@ class Dataset:
 
         return pd.DataFrame.from_records(records).set_index("example_id")  # pyright: ignore[reportUnknownMemberType]
 
+    def to_json(self) -> dict[str, Any]:
+        """
+        Convert the dataset to a JSON-serializable dictionary.
+
+        Example:
+            >>> dataset = client.datasets.get_dataset(dataset="my-dataset")
+            >>> json_data = dataset.to_json()
+            >>> restored = Dataset.from_json(json_data)
+        """
+        return {
+            # Core v1.Dataset fields
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "metadata": deepcopy(self.metadata),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            # Additional fields from DatasetWithExampleCount and ListDatasetExamplesData
+            "example_count": self.example_count,
+            "version_id": self.version_id,
+            "examples": deepcopy(self.examples),
+        }
+
+    @classmethod
+    def from_json(cls, json_data: dict[str, Any]) -> "Dataset":
+        """
+        Create a Dataset instance from a JSON-serializable dictionary.
+
+        Args:
+            json_data: Dictionary containing dataset information, typically from to_json()
+
+        Returns:
+            A Dataset instance with the provided data
+
+        Raises:
+            ValueError: If required fields are missing from json_data
+            KeyError: If json_data is missing required keys
+
+        Example:
+            >>> json_data = dataset.to_json()
+            >>> restored = Dataset.from_json(json_data)
+            >>> assert restored.id == dataset.id
+        """
+        required_fields = {"id", "name", "version_id", "examples"}
+        if not all(field in json_data for field in required_fields):
+            missing = required_fields - set(json_data.keys())
+            raise ValueError(f"Missing required fields in json_data: {missing}")
+
+        # Reconstruct dataset_info structure
+        dataset_info = {
+            "id": json_data["id"],
+            "name": json_data["name"],
+        }
+
+        if json_data.get("description") is not None:
+            dataset_info["description"] = json_data["description"]
+
+        if json_data.get("metadata"):
+            dataset_info["metadata"] = json_data["metadata"]
+
+        if json_data.get("created_at"):
+            dataset_info["created_at"] = json_data["created_at"]
+
+        if json_data.get("updated_at"):
+            dataset_info["updated_at"] = json_data["updated_at"]
+
+        if json_data.get("example_count") is not None:
+            dataset_info["example_count"] = json_data["example_count"]
+
+        # Reconstruct examples_data structure
+        examples_data = {
+            "version_id": json_data["version_id"],
+            "examples": json_data["examples"],
+        }
+
+        return cls(dataset_info, examples_data)  # type: ignore[arg-type]
+
 
 # Type alias for flexible dataset identification
 DatasetIdentifier = Union[

--- a/tests/integration/client/test_datasets.py
+++ b/tests/integration/client/test_datasets.py
@@ -500,3 +500,115 @@ Who wrote Hamlet?,Shakespeare,literature
         assert len(subset_dataset) == 2
         assert subset_dataset[0]["input"]["question"] == "What is Python?"
         assert subset_dataset[1]["input"]["question"] == "Explain async/await"
+
+    @pytest.mark.parametrize("is_async", [True, False])
+    @pytest.mark.parametrize("role_or_user", [_MEMBER, _ADMIN])
+    async def test_dataset_json_round_trip(
+        self,
+        is_async: bool,
+        role_or_user: _RoleOrUser,
+        _get_user: _GetUser,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that Dataset.to_json() and Dataset.from_json() work correctly for round-tripping."""
+        user = _get_user(role_or_user).log_in()
+        monkeypatch.setenv("PHOENIX_API_KEY", user.create_api_key())
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+        from phoenix.client.resources.datasets import Dataset
+
+        Client = AsyncClient if is_async else SyncClient  # type: ignore[unused-ignore]
+
+        unique_name = f"test_json_roundtrip_{uuid.uuid4().hex[:8]}"
+
+        original_dataset = await _await_or_return(
+            Client().datasets.create_dataset(
+                name=unique_name,
+                inputs=[
+                    {
+                        "question": "What is machine learning?",
+                        "context": "AI basics",
+                        "difficulty": 1,
+                    },
+                    {
+                        "question": "Explain neural networks",
+                        "context": "Deep learning",
+                        "difficulty": 3,
+                    },
+                    {
+                        "question": "What is overfitting?",
+                        "context": "Model training",
+                        "difficulty": 2,
+                    },
+                ],
+                outputs=[
+                    {
+                        "answer": "A subset of AI",
+                        "confidence": 0.9,
+                        "sources": ["textbook", "paper"],
+                    },
+                    {"answer": "Interconnected nodes", "confidence": 0.85, "sources": ["lecture"]},
+                    {
+                        "answer": "Model memorizes training data",
+                        "confidence": 0.95,
+                        "sources": ["docs"],
+                    },
+                ],
+                metadata=[
+                    {"topic": "basics", "reviewed": True, "tags": ["ml", "ai"]},
+                    {"topic": "deep-learning", "reviewed": False, "tags": ["neural", "networks"]},
+                    {
+                        "topic": "training",
+                        "reviewed": True,
+                        "tags": ["overfitting", "generalization"],
+                    },
+                ],
+                dataset_description="Test dataset for JSON round-trip functionality",
+            )
+        )
+
+        json_data = original_dataset.to_json()
+
+        assert json_data["id"] == original_dataset.id
+        assert json_data["name"] == original_dataset.name
+        assert json_data["description"] == original_dataset.description
+        assert json_data["version_id"] == original_dataset.version_id
+        assert json_data["example_count"] == original_dataset.example_count
+        assert len(json_data["examples"]) == len(original_dataset.examples)
+
+        if json_data.get("created_at"):
+            assert isinstance(json_data["created_at"], str)
+        if json_data.get("updated_at"):
+            assert isinstance(json_data["updated_at"], str)
+
+        restored_dataset = Dataset.from_json(json_data)
+
+        assert restored_dataset.id == original_dataset.id
+        assert restored_dataset.name == original_dataset.name
+        assert restored_dataset.description == original_dataset.description
+        assert restored_dataset.version_id == original_dataset.version_id
+        assert restored_dataset.example_count == original_dataset.example_count
+        assert restored_dataset.metadata == original_dataset.metadata
+        assert len(restored_dataset.examples) == len(original_dataset.examples)
+
+        if original_dataset.created_at:
+            assert restored_dataset.created_at == original_dataset.created_at
+        if original_dataset.updated_at:
+            assert restored_dataset.updated_at == original_dataset.updated_at
+
+        for i, original_example in enumerate(original_dataset.examples):
+            restored_example = restored_dataset.examples[i]
+
+            assert restored_example["id"] == original_example["id"]
+            assert restored_example["input"] == original_example["input"]
+            assert restored_example["output"] == original_example["output"]
+            assert restored_example["metadata"] == original_example["metadata"]
+
+        assert len(restored_dataset) == len(original_dataset)
+        assert list(restored_dataset) == list(original_dataset)
+        assert restored_dataset[0] == original_dataset[0]
+
+        invalid_json = {"id": "test", "name": "test"}
+        with pytest.raises(ValueError, match="Missing required fields"):
+            Dataset.from_json(invalid_json)


### PR DESCRIPTION
- Adds `to_json` and `from_json` methods to phoenix client Dataset objects, enabling serialization

```
dataset = client.datasets.get_dataset(dataset="my-dataset")
json_data = dataset.to_json()
restored = Dataset.from_json(json_data)
```