### PR TITLE
fix(cost): incorrect regex match method for model name

### DIFF
--- a/src/phoenix/server/cost_tracking/cost_model_lookup.py
+++ b/src/phoenix/server/cost_tracking/cost_model_lookup.py
@@ -109,7 +109,7 @@ class CostModelLookup:
             model
             for model in self._models
             if (not model.start_time or model.start_time <= start_time)
-            and model.name_pattern.match(model_name)
+            and model.name_pattern.search(model_name)
         ]
         if not candidates:
             return None


### PR DESCRIPTION
`.match()` - Always starts from the beginning of the string (not line)
`.search()` - Searches anywhere in the string