### PR TITLE
refactor: migrate more tooltips to phoenix library

### DIFF
--- a/app/src/components/CopyToClipboardButton.tsx
+++ b/app/src/components/CopyToClipboardButton.tsx
@@ -2,9 +2,14 @@ import { RefObject, useCallback, useState } from "react";
 import copy from "copy-to-clipboard";
 import { css } from "@emotion/react";
 
-import { Tooltip, TooltipTrigger } from "@arizeai/components";
-
-import { Button, ButtonProps, Icon, Icons } from "@phoenix/components";
+import {
+  Button,
+  ButtonProps,
+  Icon,
+  Icons,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
 
 const SHOW_COPIED_TIMEOUT_MS = 2000;
 
@@ -45,7 +50,7 @@ export function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
   }, [text]);
   return (
     <div className="copy-to-clipboard-button" css={copyToClipboardButtonCSS}>
-      <TooltipTrigger delay={0} offset={5}>
+      <TooltipTrigger delay={0}>
         <Button
           size={size}
           leadingVisual={
@@ -56,7 +61,7 @@ export function CopyToClipboardButton(props: CopyToClipboardButtonProps) {
           onPress={onPress}
           {...otherProps}
         />
-        <Tooltip>Copy</Tooltip>
+        <Tooltip offset={5}>Copy</Tooltip>
       </TooltipTrigger>
     </div>
   );

--- a/app/src/components/filter/PrimaryInferencesTimeRange.tsx
+++ b/app/src/components/filter/PrimaryInferencesTimeRange.tsx
@@ -1,11 +1,6 @@
 import { css } from "@emotion/react";
 
-import {
-  FieldColorDesignation,
-  HelpTooltip,
-  TooltipTrigger,
-  TriggerWrap,
-} from "@arizeai/components";
+import { FieldColorDesignation } from "@arizeai/components";
 
 import {
   Button,
@@ -13,11 +8,13 @@ import {
   Label,
   ListBox,
   Popover,
+  RichTooltip,
   Select,
   SelectChevronUpDownIcon,
   SelectItem,
   SelectValue,
   Text,
+  TooltipTrigger,
 } from "@phoenix/components";
 import { useInferences } from "@phoenix/contexts";
 import { TimePreset, useTimeRange } from "@phoenix/contexts/TimeRangeContext";
@@ -66,88 +63,83 @@ export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
     <div css={triggerWrapCSS}>
       <FieldColorDesignation color={"designationTurquoise"}>
         <TooltipTrigger>
-          <TriggerWrap>
-            <Select
-              selectedKey={selectedTimePreset}
-              data-testid="inferences-time-range"
-              aria-label={`Time range for the primary inferences`}
-              onSelectionChange={(key) => {
-                if (key !== selectedTimePreset) {
-                  setTimePreset(key as TimePreset);
-                }
-              }}
-              css={primaryInferencesSelectCSS}
-            >
-              <Label>{nameAbbr} inferences</Label>
-              <Button>
-                <SelectValue />
-                <SelectChevronUpDownIcon />
-              </Button>
-              <Text slot="description">{""}</Text>
-              <Popover>
-                <ListBox>
-                  <SelectItem key={TimePreset.all} id={TimePreset.all}>
-                    All
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.last_hour}
-                    id={TimePreset.last_hour}
-                  >
-                    Last Hour
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.last_day}
-                    id={TimePreset.last_day}
-                  >
-                    Last Day
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.last_week}
-                    id={TimePreset.last_week}
-                  >
-                    Last Week
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.last_month}
-                    id={TimePreset.last_month}
-                  >
-                    Last Month
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.last_3_months}
-                    id={TimePreset.last_3_months}
-                  >
-                    Last 3 Months
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.first_hour}
-                    id={TimePreset.first_hour}
-                  >
-                    First Hour
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.first_day}
-                    id={TimePreset.first_day}
-                  >
-                    First Day
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.first_week}
-                    id={TimePreset.first_week}
-                  >
-                    First Week
-                  </SelectItem>
-                  <SelectItem
-                    key={TimePreset.first_month}
-                    id={TimePreset.first_month}
-                  >
-                    First Month
-                  </SelectItem>
-                </ListBox>
-              </Popover>
-            </Select>
-          </TriggerWrap>
-          <HelpTooltip>
+          <Select
+            selectedKey={selectedTimePreset}
+            data-testid="inferences-time-range"
+            aria-label={`Time range for the primary inferences`}
+            onSelectionChange={(key) => {
+              if (key !== selectedTimePreset) {
+                setTimePreset(key as TimePreset);
+              }
+            }}
+            css={primaryInferencesSelectCSS}
+          >
+            <Label>{nameAbbr} inferences</Label>
+            <Button>
+              <SelectValue />
+              <SelectChevronUpDownIcon />
+            </Button>
+            <Text slot="description">{""}</Text>
+            <Popover>
+              <ListBox>
+                <SelectItem key={TimePreset.all} id={TimePreset.all}>
+                  All
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_hour}
+                  id={TimePreset.last_hour}
+                >
+                  Last Hour
+                </SelectItem>
+                <SelectItem key={TimePreset.last_day} id={TimePreset.last_day}>
+                  Last Day
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_week}
+                  id={TimePreset.last_week}
+                >
+                  Last Week
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_month}
+                  id={TimePreset.last_month}
+                >
+                  Last Month
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.last_3_months}
+                  id={TimePreset.last_3_months}
+                >
+                  Last 3 Months
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_hour}
+                  id={TimePreset.first_hour}
+                >
+                  First Hour
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_day}
+                  id={TimePreset.first_day}
+                >
+                  First Day
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_week}
+                  id={TimePreset.first_week}
+                >
+                  First Week
+                </SelectItem>
+                <SelectItem
+                  key={TimePreset.first_month}
+                  id={TimePreset.first_month}
+                >
+                  First Month
+                </SelectItem>
+              </ListBox>
+            </Popover>
+          </Select>
+          <RichTooltip>
             <section
               css={css`
                 h4 {
@@ -159,7 +151,7 @@ export function PrimaryInferencesTimeRange(_: PrimaryInferencesTimeRangeProps) {
               <div>start: {fullTimeFormatter(timeRange.start)}</div>
               <div>end: {fullTimeFormatter(timeRange.end)}</div>
             </section>
-          </HelpTooltip>
+          </RichTooltip>
         </TooltipTrigger>
       </FieldColorDesignation>
     </div>

--- a/app/src/components/filter/ReferenceInferencesTimeRange.tsx
+++ b/app/src/components/filter/ReferenceInferencesTimeRange.tsx
@@ -1,14 +1,16 @@
 import { timeFormat } from "d3-time-format";
 import { css } from "@emotion/react";
 
-import {
-  FieldColorDesignation,
-  Tooltip,
-  TooltipTrigger,
-  TriggerWrap,
-} from "@arizeai/components";
+import { FieldColorDesignation } from "@arizeai/components";
 
-import { Input, Label, TextField } from "@phoenix/components";
+import {
+  Input,
+  Label,
+  TextField,
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
+} from "@phoenix/components";
 import { useInferences } from "@phoenix/contexts";
 
 const timeFormatter = timeFormat("%x %X");
@@ -36,19 +38,20 @@ export function ReferenceInferencesTimeRange({
     >
       <FieldColorDesignation color={"designationPurple"}>
         <TooltipTrigger>
-          <TriggerWrap>
-            <TextField
-              isReadOnly
-              aria-label={"reference inferences time range"}
-              value={`${timeFormatter(timeRange.start)} - ${timeFormatter(
-                timeRange.end
-              )}`}
-            >
-              <Label>{`${nameAbbr} inferences`}</Label>
-              <Input />
-            </TextField>
-          </TriggerWrap>
-          <Tooltip>The static time range of the reference inferences</Tooltip>
+          <TextField
+            isReadOnly
+            aria-label={"reference inferences time range"}
+            value={`${timeFormatter(timeRange.start)} - ${timeFormatter(
+              timeRange.end
+            )}`}
+          >
+            <Label>{`${nameAbbr} inferences`}</Label>
+            <Input />
+          </TextField>
+          <Tooltip>
+            <TooltipArrow />
+            The static time range of the reference inferences
+          </Tooltip>
         </TooltipTrigger>
       </FieldColorDesignation>
     </div>

--- a/app/src/components/pointcloud/CanvasModeRadioGroup.tsx
+++ b/app/src/components/pointcloud/CanvasModeRadioGroup.tsx
@@ -1,12 +1,12 @@
 import { css } from "@emotion/react";
 
-import { Tooltip, TooltipTrigger } from "@arizeai/components";
-
 import {
   Icon,
   Icons,
   ToggleButton,
   ToggleButtonGroup,
+  Tooltip,
+  TooltipTrigger,
 } from "@phoenix/components";
 import { CanvasMode } from "@phoenix/store";
 
@@ -46,21 +46,25 @@ export function CanvasModeRadioGroup(props: CanvasModeRadioGroupProps) {
         }
       }}
     >
-      <TooltipTrigger placement="top" delay={0} offset={10}>
+      <TooltipTrigger delay={0}>
         <ToggleButton aria-label="Move" id={CanvasMode.move}>
           <div css={radioItemCSS}>
             <Icon svg={<Icons.MoveFilled />} /> Move
           </div>
         </ToggleButton>
-        <Tooltip>Move around the canvas using orbital controls</Tooltip>
+        <Tooltip placement="top" offset={10}>
+          Move around the canvas using orbital controls
+        </Tooltip>
       </TooltipTrigger>
-      <TooltipTrigger placement="top" delay={0} offset={10}>
+      <TooltipTrigger delay={0}>
         <ToggleButton aria-label="Select" id={CanvasMode.select}>
           <div css={radioItemCSS}>
             <Icon svg={<Icons.LassoOutline />} /> Select
           </div>
         </ToggleButton>
-        <Tooltip>Select points using the lasso tool</Tooltip>
+        <Tooltip placement="top" offset={10}>
+          Select points using the lasso tool
+        </Tooltip>
       </TooltipTrigger>
     </ToggleButtonGroup>
   );

--- a/app/src/components/pointcloud/PointCloud.tsx
+++ b/app/src/components/pointcloud/PointCloud.tsx
@@ -3,11 +3,6 @@ import { useContextBridge } from "@react-three/drei";
 import { css, ThemeContext as EmotionThemeContext } from "@emotion/react";
 
 import {
-  ActionTooltip,
-  TooltipTrigger,
-  TriggerWrap,
-} from "@arizeai/components";
-import {
   Axes,
   getThreeDimensionalBounds,
   LassoSelect,
@@ -17,7 +12,14 @@ import {
   ThreeDimensionalControls,
 } from "@arizeai/point-cloud";
 
-import { Button, Heading, Icon, Icons } from "@phoenix/components";
+import {
+  Button,
+  Heading,
+  Icon,
+  Icons,
+  RichTooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
 import { UNKNOWN_COLOR } from "@phoenix/constants/pointCloudConstants";
 import {
   InferencesContext,
@@ -70,9 +72,11 @@ const PointCloudInfo = function PointCloudInfo() {
     <section
       css={css`
         width: 300px;
-        padding: var(--ac-global-dimension-static-size-100);
       `}
     >
+      <Heading level={2} weight="heavy" style={{ marginBottom: 8 }}>
+        Point Cloud Summary
+      </Heading>
       <dl css={descriptionListCSS}>
         <div>
           <dt>Timestamp</dt>
@@ -180,17 +184,15 @@ function CanvasTools() {
  */
 function CanvasInfo() {
   return (
-    <TooltipTrigger placement="bottom left" delay={0}>
-      <TriggerWrap>
-        <Button
-          size="S"
-          leadingVisual={<Icon svg={<Icons.InfoOutline />} />}
-          aria-label="Information bout the point-cloud display"
-        />
-      </TriggerWrap>
-      <ActionTooltip title={"Point Cloud Summary"}>
+    <TooltipTrigger delay={0}>
+      <Button
+        size="S"
+        leadingVisual={<Icon svg={<Icons.InfoOutline />} />}
+        aria-label="Information bout the point-cloud display"
+      />
+      <RichTooltip placement="bottom left">
         <PointCloudInfo />
-      </ActionTooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }

--- a/app/src/components/trace/AnnotationConfigList.tsx
+++ b/app/src/components/trace/AnnotationConfigList.tsx
@@ -9,8 +9,6 @@ import {
 import { useNavigate } from "react-router";
 import { css } from "@emotion/react";
 
-import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
 import {
   Button,
   Flex,
@@ -22,6 +20,9 @@ import {
   ListBoxItem,
   Text,
   TextField,
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
   View,
 } from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
@@ -299,16 +300,17 @@ export function AnnotationConfigList(props: {
                   <Input placeholder="Search annotation configs" />
                 </TextField>
                 <TooltipTrigger>
-                  <TriggerWrap>
-                    <Button
-                      aria-label="Create annotation config"
-                      onPress={() => {
-                        navigate("/settings/annotations");
-                      }}
-                      leadingVisual={<Icon svg={<Icons.PlusCircleOutline />} />}
-                    />
-                  </TriggerWrap>
-                  <Tooltip>Create new annotation config</Tooltip>
+                  <Button
+                    aria-label="Create annotation config"
+                    onPress={() => {
+                      navigate("/settings/annotations");
+                    }}
+                    leadingVisual={<Icon svg={<Icons.PlusCircleOutline />} />}
+                  />
+                  <Tooltip placement="bottom">
+                    <TooltipArrow />
+                    Create new annotation config
+                  </Tooltip>
                 </TooltipTrigger>
               </Flex>
             </View>

--- a/app/src/pages/embedding/MetricSelector.tsx
+++ b/app/src/pages/embedding/MetricSelector.tsx
@@ -2,19 +2,20 @@ import { Key, useCallback, useTransition } from "react";
 import { graphql, useFragment } from "react-relay";
 import { css } from "@emotion/react";
 
-import { Tooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
 import {
   Button,
   Heading,
   Label,
   ListBox,
   Popover,
+  RichTooltip,
   Select,
   SelectChevronUpDownIcon,
   SelectItem,
   SelectValue,
   Text,
+  TooltipArrow,
+  TooltipTrigger,
 } from "@phoenix/components";
 import { useInferences, usePointCloudContext } from "@phoenix/contexts";
 import {
@@ -224,32 +225,31 @@ export function MetricSelector({
 
   return (
     <TooltipTrigger delay={0}>
-      <TriggerWrap>
-        <Select
-          selectedKey={metric ? getMetricKey(metric) : undefined}
-          onSelectionChange={onSelectionChange}
-          placeholder="Select a metric..."
-          isDisabled={loading}
-          aria-label="Analysis metric"
-          css={metricSelectorCSS}
-        >
-          <Label>Metric</Label>
-          <Button>
-            <SelectValue />
-            <SelectChevronUpDownIcon />
-          </Button>
-          <Popover>
-            <ListBox>
-              {allMetrics.map((metric) => (
-                <SelectItem key={metric.key} id={metric.key}>
-                  {metric.label}
-                </SelectItem>
-              ))}
-            </ListBox>
-          </Popover>
-        </Select>
-      </TriggerWrap>
-      <Tooltip>
+      <Select
+        selectedKey={metric ? getMetricKey(metric) : undefined}
+        onSelectionChange={onSelectionChange}
+        placeholder="Select a metric..."
+        isDisabled={loading}
+        aria-label="Analysis metric"
+        css={metricSelectorCSS}
+      >
+        <Label>Metric</Label>
+        <Button>
+          <SelectValue />
+          <SelectChevronUpDownIcon />
+        </Button>
+        <Popover>
+          <ListBox>
+            {allMetrics.map((metric) => (
+              <SelectItem key={metric.key} id={metric.key}>
+                {metric.label}
+              </SelectItem>
+            ))}
+          </ListBox>
+        </Popover>
+      </Select>
+      <RichTooltip>
+        <TooltipArrow />
         <section
           css={css`
             h4 {
@@ -269,7 +269,7 @@ export function MetricSelector({
             highlight areas where the data quality is degrading.
           </Text>
         </section>
-      </Tooltip>
+      </RichTooltip>
     </TooltipTrigger>
   );
 }

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -382,8 +382,6 @@ function FilterConditionBuilder(props: {
       width="500px"
       padding="size-200"
       borderRadius="medium"
-      borderWidth="thin"
-      borderColor="light"
       backgroundColor="light"
     >
       <Flex direction="column" gap="size-100">

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -1,4 +1,10 @@
-import { startTransition, useDeferredValue, useEffect, useState } from "react";
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useParams } from "react-router";
 import {
   autocompletion,
@@ -11,16 +17,21 @@ import CodeMirror, { EditorView, keymap } from "@uiw/react-codemirror";
 import { fetchQuery, graphql } from "relay-runtime";
 import { css } from "@emotion/react";
 
-import {
-  AddonBefore,
-  Field,
-  HelpTooltip,
-  PopoverTrigger,
-  TooltipTrigger,
-  TriggerWrap,
-} from "@arizeai/components";
+import { AddonBefore, Field } from "@arizeai/components";
 
-import { Button, Flex, Icon, Icons, Text, View } from "@phoenix/components";
+import {
+  Button,
+  DialogTrigger,
+  Flex,
+  Icon,
+  IconButton,
+  Icons,
+  Popover,
+  Text,
+  Tooltip,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
 import { useTheme } from "@phoenix/contexts";
 import environment from "@phoenix/RelayEnvironment";
 
@@ -261,6 +272,8 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
 
   const { projectId } = useParams();
 
+  const filterConditionFieldRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     isConditionValid(deferredFilterCondition, projectId as string).then(
       (result) => {
@@ -284,6 +297,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
       data-is-invalid={hasError}
       className="span-filter-condition-field"
       css={fieldCSS}
+      ref={filterConditionFieldRef}
     >
       <Flex direction="row">
         <AddonBefore>
@@ -322,37 +336,34 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
         >
           <Icon svg={<Icons.CloseCircleOutline />} />
         </button>
-        <PopoverTrigger placement="bottom right">
-          <TriggerWrap>
-            <button
-              css={css`
-                color: var(--ac-global-text-color-700);
-                background-color: var(--ac-global-color-grey-300);
-                padding-left: var(--ac-global-dimension-static-size-100);
-                padding-right: var(--ac-global-dimension-static-size-100);
-                height: 100%;
-              `}
-              className="button--reset"
-            >
-              <Icon svg={<Icons.PlusCircleOutline />} />
-            </button>
-          </TriggerWrap>
-          <FilterConditionBuilder
-            onAddFilterConditionSnippet={appendFilterCondition}
-          />
-        </PopoverTrigger>
+        <DialogTrigger>
+          <IconButton
+            css={css`
+              color: var(--ac-global-text-color-700);
+              background-color: var(--ac-global-color-grey-300);
+              padding-left: var(--ac-global-dimension-static-size-100);
+              padding-right: var(--ac-global-dimension-static-size-100);
+              height: 100%;
+            `}
+            className="button--reset"
+          >
+            <Icon svg={<Icons.PlusCircleOutline />} />
+          </IconButton>
+          <Popover placement="bottom right">
+            <FilterConditionBuilder
+              onAddFilterConditionSnippet={appendFilterCondition}
+            />
+          </Popover>
+        </DialogTrigger>
       </Flex>
-      <TooltipTrigger isOpen={hasError && isFocused} placement="bottom">
-        <TriggerWrap>
-          <div />
-        </TriggerWrap>
-        <HelpTooltip>
+      <TooltipTrigger isOpen={hasError && isFocused}>
+        <Tooltip placement="bottom" triggerRef={filterConditionFieldRef}>
           {errorMessage != "" ? (
             <Text color="danger">{errorMessage}</Text>
           ) : (
             <Text color="success">Valid Expression</Text>
           )}
-        </HelpTooltip>
+        </Tooltip>
       </TooltipTrigger>
     </div>
   );

--- a/app/src/pages/trace/SessionDetails.tsx
+++ b/app/src/pages/trace/SessionDetails.tsx
@@ -1,9 +1,14 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
-import { HelpTooltip, TooltipTrigger, TriggerWrap } from "@arizeai/components";
-
-import { Flex, Text, View } from "@phoenix/components";
+import {
+  Flex,
+  RichTooltip,
+  Text,
+  TooltipTrigger,
+  TriggerWrap,
+  View,
+} from "@phoenix/components";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { SessionTokenCount } from "@phoenix/components/trace/SessionTokenCount";
 import { SESSION_DETAILS_PAGE_SIZE } from "@phoenix/pages/trace/constants";
@@ -59,13 +64,13 @@ function SessionDetailsHeader({
             <Text elementType="h3" size="S" color="text-700">
               Total Cost
             </Text>
-            <TooltipTrigger delay={0} placement="bottom">
+            <TooltipTrigger delay={0}>
               <TriggerWrap>
                 <Text size="L">
                   {costFormatter(costSummary.total?.cost ?? 0)}
                 </Text>
               </TriggerWrap>
-              <HelpTooltip>
+              <RichTooltip placement="bottom">
                 <View width="size-2400">
                   <Flex direction="column">
                     <Flex justifyContent="space-between">
@@ -86,7 +91,7 @@ function SessionDetailsHeader({
                     </Flex>
                   </Flex>
                 </View>
-              </HelpTooltip>
+              </RichTooltip>
             </TooltipTrigger>
           </Flex>
         ) : null}


### PR DESCRIPTION
This PR migrates some more usages of the old tooltip component over to the newer phoenix components.

<details>
<summary>

### SpanFilterConditionField
</summary>
(same approach as https://github.com/Arize-ai/phoenix/pull/8469/files#diff-d3aa568be43f3d409c6851e027eb8c41db10bc4f9a7868f978ce9ed742240ebf)

#### add filter popover

before:
<img width="539" height="586" alt="image" src="https://github.com/user-attachments/assets/1e0dea3d-ad31-46bb-9acf-ae30fb6bc885" />


after:
<img width="545" height="586" alt="image" src="https://github.com/user-attachments/assets/f952721d-6cee-4540-8a3a-07a13fe3b235" />


#### invalid filter error message

before:
<img width="1243" height="111" alt="image" src="https://github.com/user-attachments/assets/16d2846e-13de-4b24-a91b-ec65c655fdbc" />


after:
<img width="1248" height="100" alt="image" src="https://github.com/user-attachments/assets/8133d432-bd8e-4d59-8eb7-3aac2a848ab0" />
</details>

<details>
<summary>

### SessionDetailsHeader

</summary>

before:

<img width="430" height="216" alt="image" src="https://github.com/user-attachments/assets/09af57ef-fbd7-4fe2-9d85-24f0e059004b" />

after:

<img width="430" height="216" alt="image" src="https://github.com/user-attachments/assets/bd244e5a-7a02-4d0b-9d5c-0501154680ba" />

</details>

<details>
<summary>

### Embeddings Page
</summary>

#### MetricSelector

before:
<img width="222" height="420" alt="image" src="https://github.com/user-attachments/assets/6af6150a-0356-41c0-ad56-bc6a695a56a0" />

after:
<img width="369" height="317" alt="image" src="https://github.com/user-attachments/assets/23d259d9-c79c-4697-bced-bb15ad36877f" />

#### PrimaryInferencesTimeRange

before:
<img width="269" height="223" alt="image" src="https://github.com/user-attachments/assets/7556bfc3-27de-4e33-867f-e6693b7fd5d8" />

after:
<img width="258" height="205" alt="image" src="https://github.com/user-attachments/assets/08947a61-a14a-4853-be3f-a7066ea1a501" />

#### ReferenceInferencesTimeRange

before:
<img width="398" height="150" alt="image" src="https://github.com/user-attachments/assets/08d65fbc-bb7d-4ce2-81b3-62603145cbbf" />


after:
<img width="398" height="150" alt="image" src="https://github.com/user-attachments/assets/c6050636-3f3e-4983-8e3e-876026fbc60f" />

#### CanvasModeRadioGroup

before:
not sure why, but the old tooltips didn't seem to be working here

after:
<img width="233" height="140" alt="image" src="https://github.com/user-attachments/assets/616139b9-6ea6-4a1e-8702-b6038d3a6b90" />
<img width="233" height="140" alt="image" src="https://github.com/user-attachments/assets/aec1ef1e-9840-4f54-a1c4-3b723bf30429" />

#### PointCloud Summary

before:
<img width="374" height="342" alt="image" src="https://github.com/user-attachments/assets/372ac1c6-a387-48f8-bbf0-236afc049fbf" />

after:
<img width="374" height="342" alt="image" src="https://github.com/user-attachments/assets/8de33cdc-e149-4f96-86a4-029e4cb88309" />

</details>

<details>
<summary>

### AnnotationConfigList

</summary>

(create annotation button)

before:
<img width="317" height="116" alt="image" src="https://github.com/user-attachments/assets/f9bb0db7-4850-4e59-95ec-0dae3216279e" />

after:
<img width="317" height="124" alt="image" src="https://github.com/user-attachments/assets/2d0f5331-820f-4a2c-bb9f-4bc2d023a671" />

</details>

<details>
<summary>

### CopyToClipboardButton

</summary>
before:
another case where the old tooltip didn't work, not sure why

after:
<img width="321" height="142" alt="image" src="https://github.com/user-attachments/assets/7e0feca2-f1b4-48a9-a76c-2dedc268611f" />

</details>