### PR TITLE
fix: remove version upperbound on protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "typing-extensions>=4.6",
   "scipy",
   "wrapt>=1.17.2",
-  "protobuf>=4.25.8, <6.0",
+  "protobuf>=4.25.8",
   "grpcio",
   "grpc-interceptor",
   "tqdm",


### PR DESCRIPTION
resolves #8036

OTEL supports [v6](https://github.com/open-telemetry/opentelemetry-python/blame/14401e1dd82852fdea76ecf4d720fbd74834b705/opentelemetry-proto/pyproject.toml#L28)