### PR TITLE
fix: restrict version of fastapi instrumentor for container builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ container = [
   "openai>=1.0.0",
   "azure-identity",
   "aiohttp",  # used by azure-identity via azure.core.pipeline.transport
-  # caveat: opentelemetry dependencies must be pinned to the
-  # version published on the same date, e.g. 1.33.1/0.54b1
+  # Note: when updating opentelemetry dependencies, all packages must use versions
+  # released on the same date (e.g., 1.33.1/0.54b1) to ensure compatibility.
   "opentelemetry-sdk==1.33.1",
   "opentelemetry-proto==1.33.1",
   "opentelemetry-exporter-otlp==1.33.1",


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/8473