### PR TITLE
docs: update google-adk-tracing.md to align with openinference docs

### DIFF
--- a/docs/section-integrations/llm-providers/google-gen-ai/google-adk-tracing.md
+++ b/docs/section-integrations/llm-providers/google-gen-ai/google-adk-tracing.md
@@ -13,7 +13,7 @@ Launch Phoenix
 ### Install <a href="#install" id="install"></a>
 
 ```bash
-pip install openinference-instrumentation-google-adk google-adk arize-phoenix-otel
+pip install openinference-instrumentation-google-adk google-adk arize-phoenix-otel opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
 ### Setup <a href="#setup" id="setup"></a>
@@ -24,16 +24,19 @@ Set the `GOOGLE_API_KEY` environment variable. Refer to Google's [ADK documentat
 export GOOGLE_API_KEY=[your_key_here]
 ```
 
-Use the register function to connect your application to Phoenix.
+To enable automatic tracing for Google ADK SDK, initialize the `GoogleADKInstrumentor` and configure the OpenTelemetry tracer to export these traces to Phoenix
 
 ```python
-from phoenix.otel import register
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 
-# Configure the Phoenix tracer
-tracer_provider = register(
-  project_name="my-llm-app", # Default is 'default'
-  auto_instrument=True # Auto-instrument your app based on installed OI dependencies
-)
+endpoint = "http://127.0.0.1:6006/v1/traces"
+tracer_provider = trace_sdk.TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint)))
+
+GoogleADKInstrumentor().instrument(tracer_provider=tracer_provider)
 ```
 
 ### Observe <a href="#observe" id="observe"></a>
@@ -41,8 +44,7 @@ tracer_provider = register(
 Now that you have tracing setup, all Google ADK SDK requests will be streamed to Phoenix for observability and evaluation.
 
 ```python
-import nest_asyncio
-nest_asyncio.apply()
+import asyncio
 
 from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
@@ -79,27 +81,43 @@ agent = Agent(
    tools=[get_weather]
 )
 
-
-app_name = "test_instrumentation"
-user_id = "test_user"
-session_id = "test_session"
-runner = InMemoryRunner(agent=agent, app_name=app_name)
-session_service = runner.session_service
-await session_service.create_session(
-    app_name=app_name,
-    user_id=user_id,
-    session_id=session_id
-)
-async for event in runner.run_async(
-    user_id=user_id,
-    session_id=session_id,
-    new_message=types.Content(role="user", parts=[
-        types.Part(text="What is the weather in New York?")]
+async def main():
+    app_name = "test_instrumentation"
+    user_id = "test_user"
+    session_id = "test_session"
+    runner = InMemoryRunner(agent=agent, app_name=app_name)
+    session_service = runner.session_service
+    await session_service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id
     )
-):
-    if event.is_final_response():
-        print(event.content.parts[0].text.strip())
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=types.Content(role="user", parts=[
+            types.Part(text="What is the weather in New York?")]
+        )
+    ):
+        if event.is_final_response():
+            print(event.content.parts[0].text.strip())
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+You can now simply run the file:
+
+```python
+python your_file_name.py
+```
+
+And observe the traces at:
+
+```python
+http://localhost:6006/projects
+```
+
 
 {% hint style="info" %}
 This instrumentation will support additional features as the Google ADK SDK evolves. Refer to [this page](https://pypi.org/project/openinference-instrumentation-google-adk/#description) for the latest status.


### PR DESCRIPTION
#8561 

Updated the google-adk-tracing doc to align with [openinference](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-google-adk) documentation. 

Details:
- The current doc makes use of `phoenix.otel.registration` to register a tracer with auto instrumentation. However, for automatic google-adk tracing, `openinference-instrumentation-google-adk` instructs to make use of the `opentelemetry` sdk to create a trace provider and pass that trace provider to a `GoogleADKInstrumentor` object.
- Also fixed a typo where the main asynchronous execution of a google-adk agent wasn't wrapped in `async def main()`