### PR TITLE
fix: Improve error message for missing email scope

### DIFF
--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -241,8 +241,6 @@ def _parse_user_info(user_info: dict[str, Any]) -> UserInfo:
     """
     assert isinstance(subject := user_info.get("sub"), (str, int))
     idp_user_id = str(subject)
-
-    # Check if email is present and is a string
     email = user_info.get("email")
     if not isinstance(email, str):
         raise MissingEmailScope(
@@ -554,7 +552,9 @@ class NotInvited(Exception):
 
 
 class MissingEmailScope(Exception):
-    """Raised when the OIDC provider does not return the email scope."""
+    """
+    Raised when the OIDC provider does not return the email scope.
+    """
 
     pass
 

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -169,7 +169,11 @@ async def create_tokens(
             error=f"OAuth2 IDP {idp_name} does not appear to support OpenID Connect.",
         )
     user_info = await oauth2_client.parse_id_token(token_data, nonce=stored_nonce)
-    user_info = _parse_user_info(user_info)
+    try:
+        user_info = _parse_user_info(user_info)
+    except MissingEmailScope as error:
+        return _redirect_to_login(request=request, error=str(error))
+    
     try:
         async with request.app.state.db() as session:
             user = await _process_oauth2_user(
@@ -237,7 +241,15 @@ def _parse_user_info(user_info: dict[str, Any]) -> UserInfo:
     """
     assert isinstance(subject := user_info.get("sub"), (str, int))
     idp_user_id = str(subject)
-    assert isinstance(email := user_info.get("email"), str)
+    
+    # Check if email is present and is a string
+    email = user_info.get("email")
+    if not isinstance(email, str):
+        raise MissingEmailScope(
+            "The OIDC provider did not return the email scope. "
+            "Please ensure your OIDC provider is configured to include the 'email' scope."
+        )
+    
     assert isinstance(username := user_info.get("name"), str) or username is None
     assert (
         isinstance(profile_picture_url := user_info.get("picture"), str)
@@ -538,6 +550,11 @@ class SignInNotAllowed(Exception):
 
 
 class NotInvited(Exception):
+    pass
+
+
+class MissingEmailScope(Exception):
+    """Raised when the OIDC provider does not return the email scope."""
     pass
 
 

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -244,8 +244,7 @@ def _parse_user_info(user_info: dict[str, Any]) -> UserInfo:
     email = user_info.get("email")
     if not isinstance(email, str):
         raise MissingEmailScope(
-            "The OIDC provider did not return the email scope. "
-            "Please ensure your OIDC provider is configured to include the 'email' scope."
+            "Please ensure your OIDC provider is configured to use the 'email' scope."
         )
 
     assert isinstance(username := user_info.get("name"), str) or username is None

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -173,7 +173,7 @@ async def create_tokens(
         user_info = _parse_user_info(user_info)
     except MissingEmailScope as error:
         return _redirect_to_login(request=request, error=str(error))
-    
+
     try:
         async with request.app.state.db() as session:
             user = await _process_oauth2_user(
@@ -241,7 +241,7 @@ def _parse_user_info(user_info: dict[str, Any]) -> UserInfo:
     """
     assert isinstance(subject := user_info.get("sub"), (str, int))
     idp_user_id = str(subject)
-    
+
     # Check if email is present and is a string
     email = user_info.get("email")
     if not isinstance(email, str):
@@ -249,7 +249,7 @@ def _parse_user_info(user_info: dict[str, Any]) -> UserInfo:
             "The OIDC provider did not return the email scope. "
             "Please ensure your OIDC provider is configured to include the 'email' scope."
         )
-    
+
     assert isinstance(username := user_info.get("name"), str) or username is None
     assert (
         isinstance(profile_picture_url := user_info.get("picture"), str)
@@ -555,6 +555,7 @@ class NotInvited(Exception):
 
 class MissingEmailScope(Exception):
     """Raised when the OIDC provider does not return the email scope."""
+
     pass
 
 


### PR DESCRIPTION
Improve OIDC error handling to provide a user-friendly message when the email scope is not returned from the OIDC provider.

resolves #8418