### PR TITLE
fix: bump target to support async queue drain

### DIFF
--- a/js/.changeset/mean-pears-pump.md
+++ b/js/.changeset/mean-pears-pump.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-client": patch
+"@arizeai/phoenix-evals": patch
+"@arizeai/phoenix-mcp": patch
+---
+
+bump target JS to es2017 for native async

--- a/js/tsconfig.base.json
+++ b/js/tsconfig.base.json
@@ -4,7 +4,7 @@
     "incremental": true /* Save .tsbuildinfo files to allow for incremental compilation of projects. */,
     "composite": true /* Enable constraints that allow a TypeScript project to be used with project references. */,
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
       "esnext"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,


### PR DESCRIPTION
Without this commonjs import (e.x. tsx was failing). Thanks to the suggestion in #8559 - this is the simplest solution and probably a reasonable baseline as 2017 is quite a reasonable target.