### PR TITLE
refactor: replace ProgressCircle component

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -184,6 +184,11 @@ module.exports = {
         module: "@arizeai/components",
         use: "Tooltip or RichTooltip from @phoenix/components",
       },
+      {
+        name: "ProgressCircle",
+        module: "@arizeai/components",
+        use: "import { ProgressCircle } from '@phoenix/components'",
+      },
     ],
     "no-duplicate-imports": "error",
   },

--- a/app/src/components/LoadingMask.tsx
+++ b/app/src/components/LoadingMask.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 
-import { ProgressCircle } from "@arizeai/components";
+import { ProgressCircle } from "@phoenix/components";
 
 export const LoadingMask = () => {
   return (

--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -53,3 +53,4 @@ export * from "./select";
 export * from "./media";
 export * from "./dialog";
 export * from "./tooltip";
+export * from "./progress-circle";

--- a/app/src/components/loading/Loading.tsx
+++ b/app/src/components/loading/Loading.tsx
@@ -1,9 +1,7 @@
 import { ComponentProps } from "react";
 import { css } from "@emotion/react";
 
-import { ProgressCircle } from "@arizeai/components";
-
-import { Text } from "@phoenix/components";
+import { ProgressCircle, Text } from "@phoenix/components";
 
 type LoadingProps = {
   message?: string;

--- a/app/src/components/progress-circle/ProgressCircle.tsx
+++ b/app/src/components/progress-circle/ProgressCircle.tsx
@@ -1,0 +1,72 @@
+import { ProgressBar } from "react-aria-components";
+import { css } from "@emotion/react";
+
+import {
+  CENTER,
+  CIRCUMFERENCE,
+  progressCircleIndeterminateCSS,
+  RADIUS,
+  SIZES,
+  STROKE_WIDTHS,
+} from "./styles";
+import type { ProgressCircleProps } from "./types";
+
+function ProgressCircle({
+  isIndeterminate,
+  value,
+  size = "M",
+}: ProgressCircleProps) {
+  return (
+    <ProgressBar
+      aria-label="Loading…"
+      value={value}
+      isIndeterminate={isIndeterminate}
+      css={css(
+        isIndeterminate ? progressCircleIndeterminateCSS(size) : undefined
+      )}
+    >
+      {({ percentage }) => (
+        <>
+          <svg
+            width={SIZES[size]}
+            height={SIZES[size]}
+            viewBox={`0 0 ${SIZES[size]} ${SIZES[size]}`}
+            fill="none"
+            className="progress-circle__svg"
+          >
+            {/* Background track */}
+            <circle
+              cx={CENTER(size)}
+              cy={CENTER(size)}
+              r={RADIUS(size)}
+              stroke="var(--ac-global-color-grey-300)"
+              strokeWidth={STROKE_WIDTHS[size]}
+            />
+            {/* Progress arc */}
+            <circle
+              cx={CENTER(size)}
+              cy={CENTER(size)}
+              r={RADIUS(size)}
+              stroke="var(--ac-global-color-primary)"
+              strokeWidth={STROKE_WIDTHS[size]}
+              strokeDasharray={
+                isIndeterminate
+                  ? undefined
+                  : `${CIRCUMFERENCE(size)} ${CIRCUMFERENCE(size)}`
+              }
+              strokeDashoffset={
+                isIndeterminate
+                  ? undefined
+                  : CIRCUMFERENCE(size) -
+                    ((percentage ?? 0) / 100) * CIRCUMFERENCE(size)
+              }
+              className="progress-circle__arc"
+            />
+          </svg>
+        </>
+      )}
+    </ProgressBar>
+  );
+}
+
+export { ProgressCircle };

--- a/app/src/components/progress-circle/index.tsx
+++ b/app/src/components/progress-circle/index.tsx
@@ -1,0 +1,1 @@
+export { ProgressCircle } from "./ProgressCircle";

--- a/app/src/components/progress-circle/styles.ts
+++ b/app/src/components/progress-circle/styles.ts
@@ -31,21 +31,21 @@ const dash = (size: Size) => keyframes`
     stroke-dasharray: ${DASH_SHORT(size)}, ${CIRCUMFERENCE(size)};
     stroke-dashoffset: 0;
   }
-  30% {
+  80% {
     stroke-dasharray: ${DASH_LONG(size)}, ${CIRCUMFERENCE(size)};
-    stroke-dashoffset: 0;
+    stroke-dashoffset: ${-1 * CIRCUMFERENCE(size)};
   }
   100% {
     stroke-dasharray: ${DASH_SHORT(size)}, ${CIRCUMFERENCE(size)};
-    stroke-dashoffset: ${-1 * CIRCUMFERENCE(size)};
+    stroke-dashoffset: ${-1 * CIRCUMFERENCE(size) * 1.25};
   }
 `;
 
 export const progressCircleIndeterminateCSS = (size: Size) => css`
   .progress-circle__svg {
-    animation: ${spin} 1.2s linear infinite;
+    animation: ${spin} 3s linear infinite;
   }
   .progress-circle__arc {
-    animation: ${dash(size)} 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    animation: ${dash(size)} 3s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   }
 `;

--- a/app/src/components/progress-circle/styles.ts
+++ b/app/src/components/progress-circle/styles.ts
@@ -1,0 +1,51 @@
+import { css, keyframes } from "@emotion/react";
+
+import type { Size } from "./types";
+
+export const SIZES = {
+  S: 18,
+  M: 32,
+};
+
+export const STROKE_WIDTHS = {
+  S: 2,
+  M: 3,
+};
+
+export const CENTER = (size: Size) => SIZES[size] / 2;
+export const RADIUS = (size: Size) => SIZES[size] / 2 - STROKE_WIDTHS[size];
+export const CIRCUMFERENCE = (size: Size) => 2 * Math.PI * RADIUS(size);
+export const DASH_SHORT = (size: Size) => CIRCUMFERENCE(size) * 0.25;
+export const DASH_LONG = (size: Size) => CIRCUMFERENCE(size) * 0.75;
+
+// Keyframes for spinning the arc
+const spin = keyframes`
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+// Keyframes for animating the arc length (dasharray)
+const dash = (size: Size) => keyframes`
+  0% {
+    stroke-dasharray: ${DASH_SHORT(size)}, ${CIRCUMFERENCE(size)};
+    stroke-dashoffset: 0;
+  }
+  30% {
+    stroke-dasharray: ${DASH_LONG(size)}, ${CIRCUMFERENCE(size)};
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dasharray: ${DASH_SHORT(size)}, ${CIRCUMFERENCE(size)};
+    stroke-dashoffset: ${-1 * CIRCUMFERENCE(size)};
+  }
+`;
+
+export const progressCircleIndeterminateCSS = (size: Size) => css`
+  .progress-circle__svg {
+    animation: ${spin} 1.2s linear infinite;
+  }
+  .progress-circle__arc {
+    animation: ${dash(size)} 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  }
+`;

--- a/app/src/components/progress-circle/types.ts
+++ b/app/src/components/progress-circle/types.ts
@@ -1,0 +1,7 @@
+export type Size = "S" | "M";
+
+export interface ProgressCircleProps {
+  isIndeterminate?: boolean;
+  value?: number;
+  size?: Size;
+}

--- a/app/stories/Loading.stories.tsx
+++ b/app/stories/Loading.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Loading } from "@phoenix/components";
+
+const meta: Meta<typeof Loading> = {
+  title: "Loading",
+  component: Loading,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Loading>;
+
+/**
+ * Loading component displays a progress circle with optional message
+ */
+export const Default: Story = {
+  args: {},
+};
+
+/**
+ * Loading with a custom message
+ */
+export const WithMessage: Story = {
+  args: {
+    message: "Loading data...",
+  },
+};
+
+/**
+ * Loading with different sizes
+ */
+
+export const Small: Story = {
+  args: {
+    message: "Small loading indicator",
+    size: "S",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    message: "Medium loading indicator",
+    size: "M",
+  },
+};
+
+/**
+ * Loading without message
+ */
+export const NoMessage: Story = {
+  args: {
+    message: undefined,
+  },
+};

--- a/app/stories/ProgressCircle.stories.tsx
+++ b/app/stories/ProgressCircle.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ProgressCircle } from "../src/components/progress-circle/ProgressCircle";
+import type { ProgressCircleProps } from "../src/components/progress-circle/types";
+
+const meta: Meta<typeof ProgressCircle> = {
+  title: "ProgressCircle",
+  component: ProgressCircle,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A circular progress indicator for loading or progress feedback. Supports determinate and indeterminate states.",
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: "number", min: 0, max: 100 },
+      description: "Current progress value (0-100). Ignored if indeterminate.",
+      defaultValue: 50,
+    },
+    isIndeterminate: {
+      control: "boolean",
+      description: "Whether the progress is indeterminate (spinning animation)",
+      defaultValue: false,
+    },
+    size: {
+      control: { type: "radio" },
+      options: ["S", "M"],
+      description: "Size of the progress circle",
+      defaultValue: "M",
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressCircle>;
+
+export const Determinate: Story = {
+  args: {
+    value: 60,
+    isIndeterminate: false,
+    size: "M",
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    isIndeterminate: true,
+    size: "M",
+  },
+};
+
+export const Sizes: Story = {
+  render: (args: ProgressCircleProps) => (
+    <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+      <ProgressCircle {...args} size="S" />
+      <ProgressCircle {...args} size="M" />
+    </div>
+  ),
+  args: {
+    value: 75,
+    isIndeterminate: false,
+  },
+};


### PR DESCRIPTION
This PR adds a new ProgressCircle component built on top of react-aria-components's ProgressBar, to replace the old ProgressCircle from @phoenix/components. The spinner SVG is copied from their example [here](https://react-spectrum.adobe.com/react-aria/ProgressBar.html#circular). Otherwise it roughly matches the old ProgressCircle, with a couple tweaks made based on input from @rickarize: 
- "large" variant is removed since we weren't using it anywhere
- animation timing adjusted to be slower


before:

https://github.com/user-attachments/assets/403969d0-47a8-4967-8449-f07513f31039

after:

https://github.com/user-attachments/assets/e7f93b79-ba62-4bd3-bfec-bb48948ded49

This component is primarily used by our Loading component throughout the app, as data loads in:

https://github.com/user-attachments/assets/641b755c-d8e6-4410-86eb-42c6ef0d852c


