### PR TITLE
feat: Experiment enhancements

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
@@ -167,6 +167,7 @@ def run_experiment(
     """
     if client is None:
         from phoenix.client.client import Client
+
         client = Client()
     return client.experiments.run_experiment(
         dataset=dataset,
@@ -348,6 +349,7 @@ async def async_run_experiment(
     """
     if client is None:
         from phoenix.client.client import AsyncClient
+
         client = AsyncClient()
     return await client.experiments.run_experiment(
         dataset=dataset,
@@ -409,6 +411,7 @@ def get_experiment(
     """
     if client is None:
         from phoenix.client.client import Client
+
         client = Client()
     return client.experiments.get_experiment(experiment_id=experiment_id)
 
@@ -461,6 +464,7 @@ async def async_get_experiment(
     """
     if client is None:
         from phoenix.client.client import AsyncClient
+
         client = AsyncClient()
     return await client.experiments.get_experiment(experiment_id=experiment_id)
 
@@ -550,6 +554,7 @@ def evaluate_experiment(
     """
     if client is None:
         from phoenix.client.client import Client
+
         client = Client()
     return client.experiments.evaluate_experiment(
         experiment=experiment,
@@ -654,6 +659,7 @@ async def async_evaluate_experiment(
     """
     if client is None:
         from phoenix.client.client import AsyncClient
+
         client = AsyncClient()
     return await client.experiments.evaluate_experiment(
         experiment=experiment,

--- a/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
@@ -1,6 +1,7 @@
-from typing import Any, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
-from phoenix.client.client import AsyncClient, Client
+if TYPE_CHECKING:
+    from phoenix.client.client import AsyncClient, Client
 from phoenix.client.resources.datasets import Dataset
 from phoenix.client.resources.experiments.types import (
     ExperimentEvaluators,
@@ -24,7 +25,7 @@ def run_experiment(
     dry_run: Union[bool, int] = False,
     print_summary: bool = True,
     timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
-    client: Optional[Client] = None,
+    client: Optional["Client"] = None,
 ) -> RanExperiment:
     """
     Run an experiment using a given dataset of examples.
@@ -164,7 +165,9 @@ def run_experiment(
             ...     experiment_name="greeting-experiment"
             ... )
     """
-    client = client or Client()
+    if client is None:
+        from phoenix.client.client import Client
+        client = Client()
     return client.experiments.run_experiment(
         dataset=dataset,
         task=task,
@@ -192,7 +195,7 @@ async def async_run_experiment(
     print_summary: bool = True,
     concurrency: int = 3,
     timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
-    client: Optional[AsyncClient] = None,
+    client: Optional["AsyncClient"] = None,
 ) -> RanExperiment:
     """
     Run an experiment using a given dataset of examples (async version).
@@ -343,7 +346,9 @@ async def async_run_experiment(
             ...     concurrency=5
             ... )
     """
-    client = client or AsyncClient()
+    if client is None:
+        from phoenix.client.client import AsyncClient
+        client = AsyncClient()
     return await client.experiments.run_experiment(
         dataset=dataset,
         task=task,
@@ -362,7 +367,7 @@ async def async_run_experiment(
 def get_experiment(
     *,
     experiment_id: str,
-    client: Optional[Client] = None,
+    client: Optional["Client"] = None,
 ) -> RanExperiment:
     """
     Get a completed experiment by ID.
@@ -402,14 +407,16 @@ def get_experiment(
             >>> client = Client()
             >>> experiment = client.experiments.get_experiment(experiment_id="123")
     """
-    client = client or Client()
+    if client is None:
+        from phoenix.client.client import Client
+        client = Client()
     return client.experiments.get_experiment(experiment_id=experiment_id)
 
 
 async def async_get_experiment(
     *,
     experiment_id: str,
-    client: Optional[AsyncClient] = None,
+    client: Optional["AsyncClient"] = None,
 ) -> RanExperiment:
     """
     Get a completed experiment by ID (async version).
@@ -452,7 +459,9 @@ async def async_get_experiment(
             >>> client = AsyncClient()
             >>> experiment = await client.experiments.get_experiment(experiment_id="123")
     """
-    client = client or AsyncClient()
+    if client is None:
+        from phoenix.client.client import AsyncClient
+        client = AsyncClient()
     return await client.experiments.get_experiment(experiment_id=experiment_id)
 
 
@@ -464,7 +473,7 @@ def evaluate_experiment(
     print_summary: bool = True,
     timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     rate_limit_errors: Optional[RateLimitErrors] = None,
-    client: Optional[Client] = None,
+    client: Optional["Client"] = None,
 ) -> RanExperiment:
     """
     Run evaluators on a completed experiment.
@@ -539,7 +548,9 @@ def evaluate_experiment(
             ...     evaluators=[accuracy_evaluator]
             ... )
     """
-    client = client or Client()
+    if client is None:
+        from phoenix.client.client import Client
+        client = Client()
     return client.experiments.evaluate_experiment(
         experiment=experiment,
         evaluators=evaluators,
@@ -559,7 +570,7 @@ async def async_evaluate_experiment(
     timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     concurrency: int = 3,
     rate_limit_errors: Optional[RateLimitErrors] = None,
-    client: Optional[AsyncClient] = None,
+    client: Optional["AsyncClient"] = None,
 ) -> RanExperiment:
     """
     Run evaluators on a completed experiment (async version).
@@ -641,7 +652,9 @@ async def async_evaluate_experiment(
             ...     concurrency=5
             ... )
     """
-    client = client or AsyncClient()
+    if client is None:
+        from phoenix.client.client import AsyncClient
+        client = AsyncClient()
     return await client.experiments.evaluate_experiment(
         experiment=experiment,
         evaluators=evaluators,

--- a/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
@@ -1,0 +1,753 @@
+from typing import Any, Mapping, Optional, Union
+
+import httpx
+
+from phoenix.client.client import AsyncClient, Client
+from phoenix.client.resources.datasets import Dataset
+from phoenix.client.resources.experiments.types import (
+    ExperimentEvaluators,
+    ExperimentTask,
+    RanExperiment,
+    RateLimitErrors,
+)
+
+DEFAULT_TIMEOUT_IN_SECONDS = 60
+
+
+def run_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.Client] = None,
+    dataset: Dataset,
+    task: ExperimentTask,
+    evaluators: Optional[ExperimentEvaluators] = None,
+    experiment_name: Optional[str] = None,
+    experiment_description: Optional[str] = None,
+    experiment_metadata: Optional[Mapping[str, Any]] = None,
+    rate_limit_errors: Optional[RateLimitErrors] = None,
+    dry_run: Union[bool, int] = False,
+    print_summary: bool = True,
+    timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+) -> RanExperiment:
+    """
+    Run an experiment using a given dataset of examples.
+
+    This function creates or configures a client and runs an experiment. An experiment is a
+    user-defined task that runs on each example in a dataset. The results from each experiment
+    can be evaluated using any number of evaluators to measure the behavior of the task. The
+    experiment and evaluation results are stored in the Phoenix database for comparison and analysis.
+
+    A `task` is either a synchronous function that returns a JSON serializable output. If the
+    `task` is a function of one argument then that argument will be bound to the `input` field
+    of the dataset example. Alternatively, the `task` can be a function of any combination of
+    specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+    - `example`: The dataset `Example` object with all associated fields
+
+    An `evaluator` is either a synchronous function that returns an evaluation result object,
+    which can take any of the following forms:
+
+    - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
+      explanation and metadata
+    - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
+    - a `float`, which will be interpreted as a score
+    - a `str`, which will be interpreted as a label
+    - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
+    - a dictionary with any of: "label", "score" and "explanation" keys
+
+    If the `evaluator` is a function of one argument then that argument will be bound to the
+    `output` of the task. Alternatively, the `evaluator` can be a function of any combination
+    of specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `output`: The output of the task
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+
+    Phoenix also provides pre-built evaluators in the `phoenix.experiments.evaluators` module.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.Client to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        dataset: The dataset on which to run the experiment.
+        task: The task to run on each example in the dataset.
+        evaluators: A single evaluator or sequence of evaluators used to evaluate the results
+            of the experiment. Defaults to None.
+        experiment_name: The name of the experiment. Defaults to None.
+        experiment_description: A description of the experiment. Defaults to None.
+        experiment_metadata: Metadata to associate with the experiment. Defaults to None.
+        rate_limit_errors: An exception or sequence of exceptions to adaptively throttle on.
+            Defaults to None.
+        dry_run: Run the experiment in dry-run mode. When set, experiment results will not be
+            recorded in Phoenix. If True, the experiment will run on a random dataset example.
+            If an integer, the experiment will run on a random sample of the dataset examples
+            of the given size. Defaults to False.
+        print_summary: Whether to print a summary of the experiment and evaluation results.
+            Defaults to True.
+        timeout: The timeout for the task execution in seconds. Use this to run longer tasks
+            to avoid re-queuing the same task multiple times. Defaults to 60.
+
+    Returns:
+        A dictionary containing the experiment results.
+
+    Raises:
+        ValueError: If dataset format is invalid or has no examples.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import run_experiment
+            >>> from phoenix.client import Client
+            >>> client = Client()
+            >>> dataset = client.datasets.get_dataset(dataset="my-dataset")
+            >>>
+            >>> def my_task(input):
+            ...     return f"Hello {input['name']}"
+            >>>
+            >>> experiment = run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment"
+            ... )
+
+        With client configuration:
+            >>> experiment = run_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment"
+            ... )
+
+        With evaluators:
+            >>> def accuracy_evaluator(output, expected):
+            ...     return 1.0 if output == expected['text'] else 0.0
+            >>>
+            >>> experiment = run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     evaluators=[accuracy_evaluator],
+            ...     experiment_name="evaluated-experiment"
+            ... )
+
+        Using dynamic binding for tasks:
+            >>> def my_task(input, metadata, expected):
+            ...     # Task can access multiple fields from the dataset example
+            ...     context = metadata.get("context", "")
+            ...     return f"Context: {context}, Input: {input}, Expected: {expected}"
+            >>>
+            >>> experiment = run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="dynamic-task"
+            ... )
+
+        Using dynamic binding for evaluators:
+            >>> def my_evaluator(output, input, expected, metadata):
+            ...     # Evaluator can access task output and example fields
+            ...     score = calculate_similarity(output, expected)
+            ...     return {"score": score, "label": "pass" if score > 0.8 else "fail"}
+            >>>
+            >>> experiment = run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     evaluators=[my_evaluator],
+            ...     experiment_name="dynamic-evaluator"
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import Client
+            >>> client = Client()
+            >>> experiment = client.experiments.run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment"
+            ... )
+    """
+    client = Client(base_url=base_url, api_key=api_key, headers=headers, http_client=http_client)
+    return client.experiments.run_experiment(
+        dataset=dataset,
+        task=task,
+        evaluators=evaluators,
+        experiment_name=experiment_name,
+        experiment_description=experiment_description,
+        experiment_metadata=experiment_metadata,
+        rate_limit_errors=rate_limit_errors,
+        dry_run=dry_run,
+        print_summary=print_summary,
+        timeout=timeout,
+    )
+
+
+async def async_run_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.AsyncClient] = None,
+    dataset: Dataset,
+    task: ExperimentTask,
+    evaluators: Optional[ExperimentEvaluators] = None,
+    experiment_name: Optional[str] = None,
+    experiment_description: Optional[str] = None,
+    experiment_metadata: Optional[Mapping[str, Any]] = None,
+    rate_limit_errors: Optional[RateLimitErrors] = None,
+    dry_run: Union[bool, int] = False,
+    print_summary: bool = True,
+    concurrency: int = 3,
+    timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+) -> RanExperiment:
+    """
+    Run an experiment using a given dataset of examples (async version).
+
+    This function creates or configures an async client and runs an experiment. An experiment is a
+    user-defined task that runs on each example in a dataset. The results from each experiment
+    can be evaluated using any number of evaluators to measure the behavior of the task. The
+    experiment and evaluation results are stored in the Phoenix database for comparison and analysis.
+
+    A `task` is either a synchronous or asynchronous function that returns a JSON serializable
+    output. If the `task` is a function of one argument then that argument will be bound to the
+    `input` field of the dataset example. Alternatively, the `task` can be a function of any
+    combination of specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+    - `example`: The dataset `Example` object with all associated fields
+
+    An `evaluator` is either a synchronous or asynchronous function that returns an evaluation
+    result object, which can take any of the following forms:
+
+    - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
+      explanation and metadata
+    - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
+    - a `float`, which will be interpreted as a score
+    - a `str`, which will be interpreted as a label
+    - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
+    - a dictionary with any of: "label", "score" and "explanation" keys
+
+    If the `evaluator` is a function of one argument then that argument will be bound to the
+    `output` of the task. Alternatively, the `evaluator` can be a function of any combination
+    of specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `output`: The output of the task
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+
+    Phoenix also provides pre-built evaluators in the `phoenix.experiments.evaluators` module.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.AsyncClient to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        dataset: The dataset on which to run the experiment.
+        task: The task to run on each example in the dataset.
+        evaluators: A single evaluator or sequence of evaluators used to evaluate the results
+            of the experiment. Defaults to None.
+        experiment_name: The name of the experiment. Defaults to None.
+        experiment_description: A description of the experiment. Defaults to None.
+        experiment_metadata: Metadata to associate with the experiment. Defaults to None.
+        rate_limit_errors: An exception or sequence of exceptions to adaptively throttle on.
+            Defaults to None.
+        dry_run: Run the experiment in dry-run mode. When set, experiment results will not be
+            recorded in Phoenix. If True, the experiment will run on a random dataset example.
+            If an integer, the experiment will run on a random sample of the dataset examples
+            of the given size. Defaults to False.
+        print_summary: Whether to print a summary of the experiment and evaluation results.
+            Defaults to True.
+        concurrency: Specifies the concurrency for task execution. Defaults to 3.
+        timeout: The timeout for the task execution in seconds. Use this to run longer tasks
+            to avoid re-queuing the same task multiple times. Defaults to 60.
+
+    Returns:
+        A dictionary containing the experiment results.
+
+    Raises:
+        ValueError: If dataset format is invalid or has no examples.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import async_run_experiment
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
+            >>> dataset = await client.datasets.get_dataset(dataset="my-dataset")
+            >>>
+            >>> async def my_task(input):
+            ...     return f"Hello {input['name']}"
+            >>>
+            >>> experiment = await async_run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment"
+            ... )
+
+        With client configuration:
+            >>> experiment = await async_run_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment"
+            ... )
+
+        With evaluators:
+            >>> async def accuracy_evaluator(output, expected):
+            ...     return 1.0 if output == expected['text'] else 0.0
+            >>>
+            >>> experiment = await async_run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     evaluators=[accuracy_evaluator],
+            ...     experiment_name="evaluated-experiment"
+            ... )
+
+        Using dynamic binding for tasks:
+            >>> async def my_task(input, metadata, expected):
+            ...     # Task can access multiple fields from the dataset example
+            ...     context = metadata.get("context", "")
+            ...     return f"Context: {context}, Input: {input}, Expected: {expected}"
+            >>>
+            >>> experiment = await async_run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="dynamic-task",
+            ...     concurrency=5
+            ... )
+
+        Using dynamic binding for evaluators:
+            >>> async def my_evaluator(output, input, expected, metadata):
+            ...     # Evaluator can access task output and example fields
+            ...     score = await calculate_similarity(output, expected)
+            ...     return {"score": score, "label": "pass" if score > 0.8 else "fail"}
+            >>>
+            >>> experiment = await async_run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     evaluators=[my_evaluator],
+            ...     experiment_name="dynamic-evaluator",
+            ...     concurrency=10
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
+            >>> experiment = await client.experiments.run_experiment(
+            ...     dataset=dataset,
+            ...     task=my_task,
+            ...     experiment_name="greeting-experiment",
+            ...     concurrency=5
+            ... )
+    """
+    client = AsyncClient(
+        base_url=base_url, api_key=api_key, headers=headers, http_client=http_client
+    )
+    return await client.experiments.run_experiment(
+        dataset=dataset,
+        task=task,
+        evaluators=evaluators,
+        experiment_name=experiment_name,
+        experiment_description=experiment_description,
+        experiment_metadata=experiment_metadata,
+        rate_limit_errors=rate_limit_errors,
+        dry_run=dry_run,
+        print_summary=print_summary,
+        concurrency=concurrency,
+        timeout=timeout,
+    )
+
+
+def get_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.Client] = None,
+    experiment_id: str,
+) -> RanExperiment:
+    """
+    Get a completed experiment by ID.
+
+    This function creates or configures a client and retrieves a completed experiment with all its
+    task runs and evaluation runs, returning a RanExperiment object that can be used with
+    evaluate_experiment to run additional evaluations.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.Client to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        experiment_id: The ID of the experiment to retrieve.
+
+    Returns:
+        A RanExperiment object containing the experiment data, task runs, and evaluation runs.
+
+    Raises:
+        ValueError: If the experiment is not found.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import get_experiment
+            >>> experiment = get_experiment(experiment_id="123")
+
+        With client configuration:
+            >>> experiment = get_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     experiment_id="123"
+            ... )
+
+        Using with evaluate_experiment:
+            >>> from phoenix.client.experiments import get_experiment, evaluate_experiment
+            >>> experiment = get_experiment(experiment_id="123")
+            >>> evaluated = evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[correctness_evaluator],
+            ...     print_summary=True,
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import Client
+            >>> client = Client()
+            >>> experiment = client.experiments.get_experiment(experiment_id="123")
+    """
+    client = Client(base_url=base_url, api_key=api_key, headers=headers, http_client=http_client)
+    return client.experiments.get_experiment(experiment_id=experiment_id)
+
+
+async def async_get_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.AsyncClient] = None,
+    experiment_id: str,
+) -> RanExperiment:
+    """
+    Get a completed experiment by ID (async version).
+
+    This function creates or configures an async client and retrieves a completed experiment with
+    all its task runs and evaluation runs, returning a RanExperiment object that can be used with
+    async_evaluate_experiment to run additional evaluations.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.AsyncClient to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        experiment_id: The ID of the experiment to retrieve.
+
+    Returns:
+        A RanExperiment object containing the experiment data, task runs, and evaluation runs.
+
+    Raises:
+        ValueError: If the experiment is not found.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import async_get_experiment
+            >>> experiment = await async_get_experiment(experiment_id="123")
+
+        With client configuration:
+            >>> experiment = await async_get_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     experiment_id="123"
+            ... )
+
+        Using with async_evaluate_experiment:
+            >>> from phoenix.client.experiments import async_get_experiment, async_evaluate_experiment
+            >>> experiment = await async_get_experiment(experiment_id="123")
+            >>> evaluated = await async_evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[correctness_evaluator],
+            ...     print_summary=True,
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
+            >>> experiment = await client.experiments.get_experiment(experiment_id="123")
+    """
+    client = AsyncClient(
+        base_url=base_url, api_key=api_key, headers=headers, http_client=http_client
+    )
+    return await client.experiments.get_experiment(experiment_id=experiment_id)
+
+
+def evaluate_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.Client] = None,
+    experiment: RanExperiment,
+    evaluators: ExperimentEvaluators,
+    dry_run: bool = False,
+    print_summary: bool = True,
+    timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    rate_limit_errors: Optional[RateLimitErrors] = None,
+) -> RanExperiment:
+    """
+    Run evaluators on a completed experiment.
+
+    This function creates or configures a client and runs evaluators on a completed experiment.
+    An evaluator is either a synchronous or asynchronous function that returns an evaluation
+    result object, which can take any of the following forms:
+
+    - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
+      explanation and metadata
+    - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
+    - a `float`, which will be interpreted as a score
+    - a `str`, which will be interpreted as a label
+    - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
+    - a dictionary with any of: "label", "score" and "explanation" keys
+
+    If the `evaluator` is a function of one argument then that argument will be bound to the
+    `output` of the task. Alternatively, the `evaluator` can be a function of any combination
+    of specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `output`: The output of the task
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+
+    Phoenix also provides pre-built evaluators in the `phoenix.experiments.evaluators` module.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.Client to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        experiment: The experiment to evaluate, returned from `run_experiment` or `get_experiment`.
+        evaluators: A single evaluator or sequence of evaluators used to evaluate the results
+            of the experiment.
+        dry_run: Run the evaluation in dry-run mode. When set, evaluation results will not be
+            recorded in Phoenix. Defaults to False.
+        print_summary: Whether to print a summary of the evaluation results. Defaults to True.
+        timeout: The timeout for the evaluation execution in seconds. Defaults to 60.
+        rate_limit_errors: An exception or sequence of exceptions to adaptively throttle on.
+            Defaults to None.
+
+    Returns:
+        A dictionary containing the evaluation results with the same format as run_experiment.
+
+    Raises:
+        ValueError: If no evaluators are provided or experiment has no runs.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import get_experiment, evaluate_experiment
+            >>> experiment = get_experiment(experiment_id="123")
+            >>> def accuracy_evaluator(output, expected):
+            ...     return 1.0 if output == expected else 0.0
+            >>> evaluated = evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator]
+            ... )
+
+        With client configuration:
+            >>> evaluated = evaluate_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator],
+            ...     dry_run=True,
+            ...     print_summary=True
+            ... )
+
+        Using dynamic binding for evaluators:
+            >>> def my_evaluator(output, input, expected, metadata):
+            ...     # Evaluator can access task output and example fields
+            ...     score = calculate_similarity(output, expected)
+            ...     return {"score": score, "label": "pass" if score > 0.8 else "fail"}
+            >>> evaluated = evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[my_evaluator]
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import Client
+            >>> client = Client()
+            >>> evaluated = client.experiments.evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator]
+            ... )
+    """
+    client = Client(base_url=base_url, api_key=api_key, headers=headers, http_client=http_client)
+    return client.experiments.evaluate_experiment(
+        experiment=experiment,
+        evaluators=evaluators,
+        dry_run=dry_run,
+        print_summary=print_summary,
+        timeout=timeout,
+        rate_limit_errors=rate_limit_errors,
+    )
+
+
+async def async_evaluate_experiment(
+    *,
+    base_url: Union[str, httpx.URL, None] = None,
+    api_key: Optional[str] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    http_client: Optional[httpx.AsyncClient] = None,
+    experiment: RanExperiment,
+    evaluators: ExperimentEvaluators,
+    dry_run: bool = False,
+    print_summary: bool = True,
+    timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
+    concurrency: int = 3,
+    rate_limit_errors: Optional[RateLimitErrors] = None,
+) -> RanExperiment:
+    """
+    Run evaluators on a completed experiment (async version).
+
+    This function creates or configures an async client and runs evaluators on a completed
+    experiment. An evaluator is either a synchronous or asynchronous function that returns an
+    evaluation result object, which can take any of the following forms:
+
+    - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
+      explanation and metadata
+    - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
+    - a `float`, which will be interpreted as a score
+    - a `str`, which will be interpreted as a label
+    - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
+    - a dictionary with any of: "label", "score" and "explanation" keys
+
+    If the `evaluator` is a function of one argument then that argument will be bound to the
+    `output` of the task. Alternatively, the `evaluator` can be a function of any combination
+    of specific argument names that will be bound to special values:
+
+    - `input`: The input field of the dataset example
+    - `output`: The output of the task
+    - `expected`: The expected or reference output of the dataset example
+    - `reference`: An alias for `expected`
+    - `metadata`: Metadata associated with the dataset example
+
+    Phoenix also provides pre-built evaluators in the `phoenix.experiments.evaluators` module.
+
+    Args:
+        base_url: The base URL for the API endpoint. If not provided, it will be read from the
+            environment variables or fall back to http://localhost:6006/.
+        api_key: The API key for authentication. If provided, it will be included in the
+            Authorization header as a bearer token. Defaults to None.
+        headers: Additional headers to be included in the HTTP requests. Defaults to None.
+            This is ignored if http_client is provided. Additional headers may be added from
+            the environment variables, but won't override specified values.
+        http_client: An instance of httpx.AsyncClient to be used for making HTTP requests. If not
+            provided, a new instance will be created. Defaults to None.
+        experiment: The experiment to evaluate, returned from `async_run_experiment` or
+            `async_get_experiment`.
+        evaluators: A single evaluator or sequence of evaluators used to evaluate the results
+            of the experiment.
+        dry_run: Run the evaluation in dry-run mode. When set, evaluation results will not be
+            recorded in Phoenix. Defaults to False.
+        print_summary: Whether to print a summary of the evaluation results. Defaults to True.
+        timeout: The timeout for the evaluation execution in seconds. Defaults to 60.
+        concurrency: Specifies the concurrency for evaluation execution. Defaults to 3.
+        rate_limit_errors: An exception or sequence of exceptions to adaptively throttle on.
+            Defaults to None.
+
+    Returns:
+        A dictionary containing the evaluation results with the same format as async_run_experiment.
+
+    Raises:
+        ValueError: If no evaluators are provided or experiment has no runs.
+        httpx.HTTPStatusError: If the API returns an error response.
+
+    Example:
+        Basic usage:
+            >>> from phoenix.client.experiments import async_get_experiment, async_evaluate_experiment
+            >>> experiment = await async_get_experiment(experiment_id="123")
+            >>> async def accuracy_evaluator(output, expected):
+            ...     return 1.0 if output == expected else 0.0
+            >>> evaluated = await async_evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator]
+            ... )
+
+        With client configuration:
+            >>> evaluated = await async_evaluate_experiment(
+            ...     base_url="https://app.phoenix.arize.com",
+            ...     api_key="your-api-key",
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator],
+            ...     dry_run=True,
+            ...     print_summary=True,
+            ...     concurrency=5
+            ... )
+
+        Using dynamic binding for evaluators:
+            >>> async def my_evaluator(output, input, expected, metadata):
+            ...     # Evaluator can access task output and example fields
+            ...     score = await calculate_similarity(output, expected)
+            ...     return {"score": score, "label": "pass" if score > 0.8 else "fail"}
+            >>> evaluated = await async_evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[my_evaluator],
+            ...     concurrency=10
+            ... )
+
+        Direct client usage (equivalent):
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
+            >>> evaluated = await client.experiments.evaluate_experiment(
+            ...     experiment=experiment,
+            ...     evaluators=[accuracy_evaluator],
+            ...     concurrency=5
+            ... )
+    """
+    client = AsyncClient(
+        base_url=base_url, api_key=api_key, headers=headers, http_client=http_client
+    )
+    return await client.experiments.evaluate_experiment(
+        experiment=experiment,
+        evaluators=evaluators,
+        dry_run=dry_run,
+        print_summary=print_summary,
+        timeout=timeout,
+        concurrency=concurrency,
+        rate_limit_errors=rate_limit_errors,
+    )

--- a/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
@@ -37,7 +37,8 @@ def run_experiment(
     This function creates or configures a client and runs an experiment. An experiment is a
     user-defined task that runs on each example in a dataset. The results from each experiment
     can be evaluated using any number of evaluators to measure the behavior of the task. The
-    experiment and evaluation results are stored in the Phoenix database for comparison and analysis.
+    experiment and evaluation results are stored in the Phoenix database for comparison and
+    analysis.
 
     A `task` is either a synchronous function that returns a JSON serializable output. If the
     `task` is a function of one argument then that argument will be bound to the `input` field
@@ -217,7 +218,8 @@ async def async_run_experiment(
     This function creates or configures an async client and runs an experiment. An experiment is a
     user-defined task that runs on each example in a dataset. The results from each experiment
     can be evaluated using any number of evaluators to measure the behavior of the task. The
-    experiment and evaluation results are stored in the Phoenix database for comparison and analysis.
+    experiment and evaluation results are stored in the Phoenix database for comparison and
+    analysis.
 
     A `task` is either a synchronous or asynchronous function that returns a JSON serializable
     output. If the `task` is a function of one argument then that argument will be bound to the
@@ -491,7 +493,10 @@ async def async_get_experiment(
             ... )
 
         Using with async_evaluate_experiment:
-            >>> from phoenix.client.experiments import async_get_experiment, async_evaluate_experiment
+            >>> from phoenix.client.experiments import (
+            ...     async_get_experiment,
+            ...     async_evaluate_experiment,
+            ... )
             >>> experiment = await async_get_experiment(experiment_id="123")
             >>> evaluated = await async_evaluate_experiment(
             ...     experiment=experiment,
@@ -699,7 +704,10 @@ async def async_evaluate_experiment(
 
     Example:
         Basic usage:
-            >>> from phoenix.client.experiments import async_get_experiment, async_evaluate_experiment
+            >>> from phoenix.client.experiments import (
+            ...     async_get_experiment,
+            ...     async_evaluate_experiment,
+            ... )
             >>> experiment = await async_get_experiment(experiment_id="123")
             >>> async def accuracy_evaluator(output, expected):
             ...     return 1.0 if output == expected else 0.0

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -711,47 +711,54 @@ class Experiments:
         task_runs: list[ExperimentRun] = []
         evaluation_runs: list[ExperimentEvaluationRun] = []
 
-        for run_data in runs_data:
+        for run_data in runs_data:  # pyright: ignore [reportUnknownVariableType]
             # Create task run
             task_run: ExperimentRun = {
-                "id": run_data["id"],
-                "dataset_example_id": run_data["dataset_example_id"],
+                "id": run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                "dataset_example_id": run_data["dataset_example_id"],  # pyright: ignore [reportUnknownArgumentType]
                 "experiment_id": experiment_id,
-                "repetition_number": run_data["repetition_number"],
-                "output": run_data["output"],
-                "start_time": run_data["start_time"],
-                "end_time": run_data["end_time"],
+                "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
+                "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
+                "start_time": run_data["start_time"],  # pyright: ignore [reportUnknownArgumentType]
+                "end_time": run_data["end_time"],  # pyright: ignore [reportUnknownArgumentType]
             }
 
             # Add optional fields if present
-            if run_data.get("trace_id"):
-                task_run["trace_id"] = run_data["trace_id"]
-            if run_data.get("error"):
-                task_run["error"] = run_data["error"]
+            if run_data.get("trace_id"):  # pyright: ignore [reportUnknownMemberType]
+                task_run["trace_id"] = run_data["trace_id"]  # pyright: ignore [reportUnknownArgumentType]
+            if run_data.get("error"):  # pyright: ignore [reportUnknownMemberType]
+                task_run["error"] = run_data["error"]  # pyright: ignore [reportUnknownArgumentType]
 
             task_runs.append(task_run)
 
             # Create evaluation runs from annotations if present
-            for annotation in run_data.get("annotations", []):
+            for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
-                if annotation.get("label") is not None or annotation.get("score") is not None or annotation.get("explanation") is not None:
-                    eval_result = {
-                        "label": annotation.get("label"),
-                        "score": annotation.get("score"),
-                        "explanation": annotation.get("explanation"),
-                    }
+                if (
+                    annotation.get("label") is not None
+                    or annotation.get("score") is not None
+                    or annotation.get("explanation") is not None
+                ):  # pyright: ignore [reportUnknownMemberType]
+                    eval_result = cast(
+                        EvaluationResult,
+                        {  # pyright: ignore [reportUnknownVariableType]
+                            "label": annotation.get("label"),  # pyright: ignore [reportUnknownMemberType]
+                            "score": annotation.get("score"),  # pyright: ignore [reportUnknownMemberType]
+                            "explanation": annotation.get("explanation"),  # pyright: ignore [reportUnknownMemberType]
+                        },
+                    )
 
                 eval_run = ExperimentEvaluationRun(
-                    id=annotation["id"],
-                    experiment_run_id=run_data["id"],
-                    start_time=datetime.fromisoformat(annotation["start_time"]),
-                    end_time=datetime.fromisoformat(annotation["end_time"]),
-                    name=annotation["name"],
-                    annotator_kind=annotation["annotator_kind"],
-                    error=annotation.get("error"),
-                    result=eval_result,
-                    trace_id=annotation.get("trace_id"),
-                    metadata=annotation.get("metadata", {}),
+                    id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
+                    experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                    start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                    end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                    name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
+                    annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
+                    error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    result=eval_result,  # pyright: ignore [reportArgumentType]
+                    trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
                 )
                 evaluation_runs.append(eval_run)
 
@@ -1592,47 +1599,54 @@ class AsyncExperiments:
         task_runs: list[ExperimentRun] = []
         evaluation_runs: list[ExperimentEvaluationRun] = []
 
-        for run_data in runs_data:
+        for run_data in runs_data:  # pyright: ignore [reportUnknownVariableType]
             # Create task run
             task_run: ExperimentRun = {
-                "id": run_data["id"],
-                "dataset_example_id": run_data["dataset_example_id"],
+                "id": run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                "dataset_example_id": run_data["dataset_example_id"],  # pyright: ignore [reportUnknownArgumentType]
                 "experiment_id": experiment_id,
-                "repetition_number": run_data["repetition_number"],
-                "output": run_data["output"],
-                "start_time": run_data["start_time"],
-                "end_time": run_data["end_time"],
+                "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
+                "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
+                "start_time": run_data["start_time"],  # pyright: ignore [reportUnknownArgumentType]
+                "end_time": run_data["end_time"],  # pyright: ignore [reportUnknownArgumentType]
             }
 
             # Add optional fields if present
-            if run_data.get("trace_id"):
-                task_run["trace_id"] = run_data["trace_id"]
-            if run_data.get("error"):
-                task_run["error"] = run_data["error"]
+            if run_data.get("trace_id"):  # pyright: ignore [reportUnknownMemberType]
+                task_run["trace_id"] = run_data["trace_id"]  # pyright: ignore [reportUnknownArgumentType]
+            if run_data.get("error"):  # pyright: ignore [reportUnknownMemberType]
+                task_run["error"] = run_data["error"]  # pyright: ignore [reportUnknownArgumentType]
 
             task_runs.append(task_run)
 
             # Create evaluation runs from annotations if present
-            for annotation in run_data.get("annotations", []):
+            for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
-                if annotation.get("label") is not None or annotation.get("score") is not None or annotation.get("explanation") is not None:
-                    eval_result = {
-                        "label": annotation.get("label"),
-                        "score": annotation.get("score"),
-                        "explanation": annotation.get("explanation"),
-                    }
+                if (
+                    annotation.get("label") is not None
+                    or annotation.get("score") is not None
+                    or annotation.get("explanation") is not None
+                ):  # pyright: ignore [reportUnknownMemberType]
+                    eval_result = cast(
+                        EvaluationResult,
+                        {  # pyright: ignore [reportUnknownVariableType]
+                            "label": annotation.get("label"),  # pyright: ignore [reportUnknownMemberType]
+                            "score": annotation.get("score"),  # pyright: ignore [reportUnknownMemberType]
+                            "explanation": annotation.get("explanation"),  # pyright: ignore [reportUnknownMemberType]
+                        },
+                    )
 
                 eval_run = ExperimentEvaluationRun(
-                    id=annotation["id"],
-                    experiment_run_id=run_data["id"],
-                    start_time=datetime.fromisoformat(annotation["start_time"]),
-                    end_time=datetime.fromisoformat(annotation["end_time"]),
-                    name=annotation["name"],
-                    annotator_kind=annotation["annotator_kind"],
-                    error=annotation.get("error"),
-                    result=eval_result,
-                    trace_id=annotation.get("trace_id"),
-                    metadata=annotation.get("metadata", {}),
+                    id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
+                    experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                    start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                    end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                    name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
+                    annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
+                    error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    result=eval_result,  # pyright: ignore [reportArgumentType]
+                    trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
                 )
                 evaluation_runs.append(eval_run)
 

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -715,8 +715,8 @@ class Experiments:
                 "experiment_id": experiment_id,
                 "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
                 "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
-                "start_time": run_data["start_time"],  # pyright: ignore [reportUnknownArgumentType]
-                "end_time": run_data["end_time"],  # pyright: ignore [reportUnknownArgumentType]
+                "start_time": datetime.fromisoformat(run_data["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                "end_time": datetime.fromisoformat(run_data["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
             }
 
             # Add optional fields if present
@@ -731,10 +731,10 @@ class Experiments:
             for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
                 if (
-                    annotation.get("label") is not None
-                    or annotation.get("score") is not None
-                    or annotation.get("explanation") is not None
-                ):  # pyright: ignore [reportUnknownMemberType]
+                    annotation.get("label") is not None  # pyright: ignore [reportUnknownMemberType]
+                    or annotation.get("score") is not None  # pyright: ignore [reportUnknownMemberType]
+                    or annotation.get("explanation") is not None  # pyright: ignore [reportUnknownMemberType]
+                ):
                     eval_result = cast(
                         EvaluationResult,
                         {  # pyright: ignore [reportUnknownVariableType]
@@ -1599,8 +1599,8 @@ class AsyncExperiments:
                 "experiment_id": experiment_id,
                 "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
                 "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
-                "start_time": run_data["start_time"],  # pyright: ignore [reportUnknownArgumentType]
-                "end_time": run_data["end_time"],  # pyright: ignore [reportUnknownArgumentType]
+                "start_time": datetime.fromisoformat(run_data["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                "end_time": datetime.fromisoformat(run_data["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
             }
 
             # Add optional fields if present
@@ -1615,10 +1615,10 @@ class AsyncExperiments:
             for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
                 eval_result = None
                 if (
-                    annotation.get("label") is not None
-                    or annotation.get("score") is not None
-                    or annotation.get("explanation") is not None
-                ):  # pyright: ignore [reportUnknownMemberType]
+                    annotation.get("label") is not None  # pyright: ignore [reportUnknownMemberType]
+                    or annotation.get("score") is not None  # pyright: ignore [reportUnknownMemberType]
+                    or annotation.get("explanation") is not None  # pyright: ignore [reportUnknownMemberType]
+                ):
                     eval_result = cast(
                         EvaluationResult,
                         {  # pyright: ignore [reportUnknownVariableType]

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -664,6 +664,16 @@ class Experiments:
         returning a RanExperiment object that can be used with evaluate_experiment to run
         additional evaluations.
 
+        Args:
+            experiment_id: The ID of the experiment to retrieve.
+
+        Returns:
+            A RanExperiment object containing the experiment data, task runs, and evaluation runs.
+
+        Raises:
+            ValueError: If the experiment is not found.
+            httpx.HTTPStatusError: If the API returns an error response.
+
         Example:
             >>> client = Client()
             >>> experiment = client.experiments.get_experiment(experiment_id="123")
@@ -674,16 +684,6 @@ class Experiments:
             ...     ],
             ...     print_summary=True,
             ... )
-
-        Args:
-            experiment_id: The ID of the experiment to retrieve.
-
-        Returns:
-            A RanExperiment object containing the experiment data, task runs, and evaluation runs.
-
-        Raises:
-            ValueError: If the experiment is not found.
-            httpx.HTTPStatusError: If the API returns an error response.
         """
         # Get experiment metadata using existing endpoint
         try:
@@ -1545,6 +1545,16 @@ class AsyncExperiments:
         returning a RanExperiment object that can be used with evaluate_experiment to run
         additional evaluations.
 
+        Args:
+            experiment_id: The ID of the experiment to retrieve.
+
+        Returns:
+            A RanExperiment object containing the experiment data, task runs, and evaluation runs.
+
+        Raises:
+            ValueError: If the experiment is not found.
+            httpx.HTTPStatusError: If the API returns an error response.
+
         Example:
             >>> client = AsyncClient()
             >>> experiment = await client.experiments.get_experiment(experiment_id="123")
@@ -1555,16 +1565,6 @@ class AsyncExperiments:
             ...     ],
             ...     print_summary=True,
             ... )
-
-        Args:
-            experiment_id: The ID of the experiment to retrieve.
-
-        Returns:
-            A RanExperiment object containing the experiment data, task runs, and evaluation runs.
-
-        Raises:
-            ValueError: If the experiment is not found.
-            httpx.HTTPStatusError: If the API returns an error response.
         """
         # Get experiment metadata using existing endpoint
         try:

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -751,7 +751,7 @@ class Experiments:
                 if eval_result is not None:
                     eval_run = ExperimentEvaluationRun(
                         id=f"ExperimentEvaluation:{len(evaluation_runs) + 1}",  # Generate temp ID
-                        experiment_run_id=run_data["id"], # pyright: ignore [reportUnknownArgumentType]
+                        experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
                         start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
                         end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
                         name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -708,27 +708,22 @@ class Experiments:
         evaluation_runs: list[ExperimentEvaluationRun] = []
 
         for run_data in runs_data:  # pyright: ignore [reportUnknownVariableType]
+            # Convert timestamps in-place to match run_experiment pattern
+            run_data["start_time"] = datetime.fromisoformat(run_data["start_time"])  # pyright: ignore [reportUnknownArgumentType]
+            run_data["end_time"] = datetime.fromisoformat(run_data["end_time"])  # pyright: ignore [reportUnknownArgumentType]
+
             # Create task run
-            task_run: ExperimentRun = {
-                "id": run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
-                "dataset_example_id": run_data["dataset_example_id"],  # pyright: ignore [reportUnknownArgumentType]
-                "experiment_id": experiment_id,
-                "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
-                "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
-                "start_time": datetime.fromisoformat(run_data["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                "end_time": datetime.fromisoformat(run_data["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
-            }
-
-            # Add optional fields if present
-            if run_data.get("trace_id"):  # pyright: ignore [reportUnknownMemberType]
-                task_run["trace_id"] = run_data["trace_id"]  # pyright: ignore [reportUnknownArgumentType]
-            if run_data.get("error"):  # pyright: ignore [reportUnknownMemberType]
-                task_run["error"] = run_data["error"]  # pyright: ignore [reportUnknownArgumentType]
-
+            task_run: ExperimentRun = cast(ExperimentRun, run_data)  # pyright: ignore [reportUnknownArgumentType]
+            task_run["experiment_id"] = experiment_id
             task_runs.append(task_run)
 
             # Create evaluation runs from annotations if present
             for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
+                # Check for required fields before processing
+                required_fields = ["id", "start_time", "end_time", "name", "annotator_kind"]
+                if not all(field in annotation for field in required_fields):  # pyright: ignore [reportUnknownMemberType]
+                    continue
+
                 eval_result = None
                 if (
                     annotation.get("label") is not None  # pyright: ignore [reportUnknownMemberType]
@@ -744,19 +739,21 @@ class Experiments:
                         },
                     )
 
-                eval_run = ExperimentEvaluationRun(
-                    id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
-                    experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
-                    start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                    end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                    name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
-                    annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
-                    error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                    result=eval_result,  # pyright: ignore [reportArgumentType]
-                    trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                    metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                )
-                evaluation_runs.append(eval_run)
+                # Only create evaluation runs for annotations that have evaluation data
+                if eval_result is not None:
+                    eval_run = ExperimentEvaluationRun(
+                        id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
+                        experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                        start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                        end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                        name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
+                        annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
+                        error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                        result=eval_result,  # pyright: ignore [reportArgumentType]
+                        trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                        metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    )
+                    evaluation_runs.append(eval_run)
 
         ran_experiment: RanExperiment = {
             "experiment_id": experiment_id,
@@ -1592,27 +1589,20 @@ class AsyncExperiments:
         evaluation_runs: list[ExperimentEvaluationRun] = []
 
         for run_data in runs_data:  # pyright: ignore [reportUnknownVariableType]
+            run_data["start_time"] = datetime.fromisoformat(run_data["start_time"])  # pyright: ignore [reportUnknownArgumentType]
+            run_data["end_time"] = datetime.fromisoformat(run_data["end_time"])  # pyright: ignore [reportUnknownArgumentType]
+
             # Create task run
-            task_run: ExperimentRun = {
-                "id": run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
-                "dataset_example_id": run_data["dataset_example_id"],  # pyright: ignore [reportUnknownArgumentType]
-                "experiment_id": experiment_id,
-                "repetition_number": run_data["repetition_number"],  # pyright: ignore [reportUnknownArgumentType]
-                "output": run_data["output"],  # pyright: ignore [reportUnknownArgumentType]
-                "start_time": datetime.fromisoformat(run_data["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                "end_time": datetime.fromisoformat(run_data["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
-            }
-
-            # Add optional fields if present
-            if run_data.get("trace_id"):  # pyright: ignore [reportUnknownMemberType]
-                task_run["trace_id"] = run_data["trace_id"]  # pyright: ignore [reportUnknownArgumentType]
-            if run_data.get("error"):  # pyright: ignore [reportUnknownMemberType]
-                task_run["error"] = run_data["error"]  # pyright: ignore [reportUnknownArgumentType]
-
+            task_run: ExperimentRun = cast(ExperimentRun, run_data)  # pyright: ignore [reportUnknownArgumentType]
+            task_run["experiment_id"] = experiment_id
             task_runs.append(task_run)
 
             # Create evaluation runs from annotations if present
             for annotation in run_data.get("annotations", []):  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
+                required_fields = ["id", "start_time", "end_time", "name", "annotator_kind"]
+                if not all(field in annotation for field in required_fields):  # pyright: ignore [reportUnknownMemberType]
+                    continue
+
                 eval_result = None
                 if (
                     annotation.get("label") is not None  # pyright: ignore [reportUnknownMemberType]
@@ -1628,19 +1618,20 @@ class AsyncExperiments:
                         },
                     )
 
-                eval_run = ExperimentEvaluationRun(
-                    id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
-                    experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
-                    start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                    end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
-                    name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
-                    annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
-                    error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                    result=eval_result,  # pyright: ignore [reportArgumentType]
-                    trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                    metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
-                )
-                evaluation_runs.append(eval_run)
+                if eval_result is not None:
+                    eval_run = ExperimentEvaluationRun(
+                        id=annotation["id"],  # pyright: ignore [reportUnknownArgumentType]
+                        experiment_run_id=run_data["id"],  # pyright: ignore [reportUnknownArgumentType]
+                        start_time=datetime.fromisoformat(annotation["start_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                        end_time=datetime.fromisoformat(annotation["end_time"]),  # pyright: ignore [reportUnknownArgumentType]
+                        name=annotation["name"],  # pyright: ignore [reportUnknownArgumentType]
+                        annotator_kind=annotation["annotator_kind"],  # pyright: ignore [reportUnknownArgumentType]
+                        error=annotation.get("error"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                        result=eval_result,  # pyright: ignore [reportArgumentType]
+                        trace_id=annotation.get("trace_id"),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                        metadata=annotation.get("metadata", {}),  # pyright: ignore [reportUnknownMemberType, reportUnknownArgumentType]
+                    )
+                    evaluation_runs.append(eval_run)
 
         ran_experiment: RanExperiment = {
             "experiment_id": experiment_id,

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -607,7 +607,7 @@ class Experiments:
             for run in all_runs:
                 run["start_time"] = datetime.fromisoformat(run["start_time"])
                 run["end_time"] = datetime.fromisoformat(run["end_time"])
-                task_runs_from_db.append(run)  # Already in TypedDict format
+                task_runs_from_db.append(run)
             task_runs = task_runs_from_db
 
             # Check if we got all expected runs
@@ -691,7 +691,6 @@ class Experiments:
                 raise ValueError(f"Experiment not found: {experiment_id}")
             raise
 
-                # Get experiment runs with real IDs
         try:
             runs_response = self._client.get(f"v1/experiments/{experiment_id}/runs")
             runs_response.raise_for_status()
@@ -716,7 +715,7 @@ class Experiments:
 
         json_lookup = {}
         for record in json_data:  # pyright: ignore [reportUnknownVariableType]
-            key = (record["example_id"], record["repetition_number"])  # pyright: ignore [reportUnknownMemberType]
+            key = (record["example_id"], record["repetition_number"])  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
             json_lookup[key] = record
 
         task_runs: list[ExperimentRun] = []
@@ -726,8 +725,8 @@ class Experiments:
             task_run: ExperimentRun = cast(ExperimentRun, run_data)  # pyright: ignore [reportUnknownArgumentType]
             task_runs.append(task_run)
 
-            lookup_key = (run_data["dataset_example_id"], run_data["repetition_number"])  # pyright: ignore [reportUnknownMemberType]
-            json_record = json_lookup.get(lookup_key)
+            lookup_key = (run_data["dataset_example_id"], run_data["repetition_number"])  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
+            json_record = json_lookup.get(lookup_key)  # pyright: ignore [reportUnknownVariableType, reportUnknownMemberType]
             if not json_record:
                 continue
 
@@ -1496,7 +1495,7 @@ class AsyncExperiments:
             for run in all_runs:
                 run["start_time"] = datetime.fromisoformat(run["start_time"])
                 run["end_time"] = datetime.fromisoformat(run["end_time"])
-                async_task_runs.append(run)  # Already in TypedDict format
+                async_task_runs.append(run)
             task_runs = async_task_runs
 
             # Check if we got all expected runs
@@ -1581,7 +1580,6 @@ class AsyncExperiments:
                 raise ValueError(f"Experiment not found: {experiment_id}")
             raise
 
-                # Get experiment runs with real IDs
         try:
             runs_response = await self._client.get(f"v1/experiments/{experiment_id}/runs")
             runs_response.raise_for_status()
@@ -1606,7 +1604,7 @@ class AsyncExperiments:
 
         json_lookup = {}
         for record in json_data:  # pyright: ignore [reportUnknownVariableType]
-            key = (record["example_id"], record["repetition_number"])  # pyright: ignore [reportUnknownMemberType]
+            key = (record["example_id"], record["repetition_number"])  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
             json_lookup[key] = record
 
         task_runs: list[ExperimentRun] = []
@@ -1616,8 +1614,8 @@ class AsyncExperiments:
             task_run: ExperimentRun = cast(ExperimentRun, run_data)  # pyright: ignore [reportUnknownArgumentType]
             task_runs.append(task_run)
 
-            lookup_key = (run_data["dataset_example_id"], run_data["repetition_number"])  # pyright: ignore [reportUnknownMemberType]
-            json_record = json_lookup.get(lookup_key)
+            lookup_key = (run_data["dataset_example_id"], run_data["repetition_number"])  # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
+            json_record = json_lookup.get(lookup_key)  # pyright: ignore [reportUnknownVariableType, reportUnknownMemberType]
             if not json_record:
                 continue
 

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -329,13 +329,11 @@ class Experiments:
     An `evaluator` is either a synchronous or asynchronous function that returns an evaluation
     result object, which can take any of the following forms:
 
-    - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
-      explanation and metadata
+    - an EvaluationResult dict with optional fields for score, label, explanation and metadata
     - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
     - a `float`, which will be interpreted as a score
     - a `str`, which will be interpreted as a label
     - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
-    - a dictionary with any of: "label", "score" and "explanation" keys
 
     If the `evaluator` is a function of one argument then that argument will be
     bound to the `output` of the task. Alternatively, the `evaluator` can be a function of any
@@ -421,10 +419,10 @@ class Experiments:
         behavior of the task. The experiment and evaluation results are stored in the Phoenix
         database for comparison and analysis.
 
-        A `task` is either a synchronous function that returns a JSON serializable
-        output. If the `task` is a function of one argument then that argument will be bound to the
-        `input` field of the dataset example. Alternatively, the `task` can be a function of any
-        combination of specific argument names that will be bound to special values:
+        A `task` is a synchronous function that returns a JSON serializable output. If the `task`
+        is a function of one argument then that argument will be bound to the `input` field of the
+        dataset example. Alternatively, the `task` can be a function of any combination of specific
+        argument names that will be bound to special values:
 
         - `input`: The input field of the dataset example
         - `expected`: The expected or reference output of the dataset example
@@ -435,13 +433,11 @@ class Experiments:
         An `evaluator` is either a synchronous function that returns an evaluation
         result object, which can take any of the following forms:
 
-        - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
-          explanation and metadata
+        - an EvaluationResult dict with optional fields for score, label, explanation and metadata
         - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
         - a `float`, which will be interpreted as a score
         - a `str`, which will be interpreted as a label
         - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
-        - a dictionary with any of: "label", "score" and "explanation" keys
 
         If the `evaluator` is a function of one argument then that argument will be
         bound to the `output` of the task. Alternatively, the `evaluator` can be a function of any
@@ -788,13 +784,11 @@ class Experiments:
         An `evaluator` is either a synchronous or asynchronous function that returns an evaluation
         result object, which can take any of the following forms:
 
-        - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
-          explanation and metadata
+        - an EvaluationResult dict with optional fields for score, label, explanation and metadata
         - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
         - a `float`, which will be interpreted as a score
         - a `str`, which will be interpreted as a label
         - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
-        - a dictionary with any of: "label", "score" and "explanation" keys
 
         Args:
             experiment: The experiment to evaluate, returned from `run_experiment`.
@@ -1321,13 +1315,11 @@ class AsyncExperiments:
         An `evaluator` is either a synchronous or asynchronous function that returns an evaluation
         result object, which can take any of the following forms:
 
-        - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
-          explanation and metadata
+        - an EvaluationResult dict with optional fields for score, label, explanation and metadata
         - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
         - a `float`, which will be interpreted as a score
         - a `str`, which will be interpreted as a label
         - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
-        - a dictionary with any of: "label", "score" and "explanation" keys
 
         If the `evaluator` is a function of one argument then that argument will be
         bound to the `output` of the task. Alternatively, the `evaluator` can be a function of any
@@ -1677,13 +1669,11 @@ class AsyncExperiments:
         An `evaluator` is either a synchronous function that returns an evaluation
         result object, which can take any of the following forms:
 
-        - phoenix.experiments.types.EvaluationResult with optional fields for score, label,
-          explanation and metadata
+        - an EvaluationResult dict with optional fields for score, label, explanation and metadata
         - a `bool`, which will be interpreted as a score of 0 or 1 plus a label of "True" or "False"
         - a `float`, which will be interpreted as a score
         - a `str`, which will be interpreted as a label
         - a 2-`tuple` of (`float`, `str`), which will be interpreted as (score, explanation)
-        - a dictionary with any of: "label", "score" and "explanation" keys
 
         Args:
             experiment: The experiment ID or RanExperiment object to evaluate.

--- a/tests/integration/client/test_experiments.py
+++ b/tests/integration/client/test_experiments.py
@@ -1233,7 +1233,9 @@ class TestEvaluateExperiment:
         assert retrieved_experiment["experiment_id"] == initial_result["experiment_id"]
         assert retrieved_experiment["dataset_id"] == initial_result["dataset_id"]
         assert len(retrieved_experiment["task_runs"]) == len(initial_result["task_runs"])
-        assert len(retrieved_experiment["evaluation_runs"]) == len(initial_result["evaluation_runs"])
+        assert len(retrieved_experiment["evaluation_runs"]) == len(
+            initial_result["evaluation_runs"]
+        )
 
         task_outputs = [run["output"] for run in retrieved_experiment["task_runs"]]
         assert "The answer is 4" in task_outputs
@@ -1263,11 +1265,13 @@ class TestEvaluateExperiment:
         assert len(final_result["evaluation_runs"]) == expected_eval_runs
 
         accuracy_evals = [
-            eval_run for eval_run in final_result["evaluation_runs"]
+            eval_run
+            for eval_run in final_result["evaluation_runs"]
             if eval_run.name == "accuracy_evaluator"
         ]
         length_evals = [
-            eval_run for eval_run in final_result["evaluation_runs"]
+            eval_run
+            for eval_run in final_result["evaluation_runs"]
             if eval_run.name == "length_evaluator"
         ]
 


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/5137

- Add `get_experiment` method to retrieve a completed experiment. This returns a `RanExperiment` object that can be used to run further evaluations on completed Experiment examples.
- Adds top level `run_experiment` `get_experiment` and `evaluate_experiment` imports to `phoenix.client.experiments`. These methods accept arguments to instantiate a client with which to connect to the Phoenix server.