### PR TITLE
feat: add environment variable for support email to be included in error messages

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -246,7 +246,10 @@ The URL to use for redirecting to a management interface that may be hosting Pho
 the current user is within PHOENIX_ADMINS, a link will be added to the navigation menu to return to
 this URL.
 """
-
+ENV_PHOENIX_SUPPORT_EMAIL = "PHOENIX_SUPPORT_EMAIL"
+"""
+The email address to include in error messages.
+"""
 
 # SMTP settings
 ENV_PHOENIX_SMTP_HOSTNAME = "PHOENIX_SMTP_HOSTNAME"
@@ -1599,6 +1602,19 @@ def get_env_management_url() -> Optional[str]:
     return getenv(ENV_PHOENIX_MANAGEMENT_URL)
 
 
+def get_env_support_email() -> Optional[str]:
+    return getenv(ENV_PHOENIX_SUPPORT_EMAIL)
+
+
+def validate_env_support_email() -> None:
+    if not (email := get_env_support_email()):
+        return
+    try:
+        validate_email(email, check_deliverability=False)
+    except EmailNotValidError as e:
+        raise ValueError(f"Invalid email in {ENV_PHOENIX_SUPPORT_EMAIL}: '{email}'") from e
+
+
 def verify_server_environment_variables() -> None:
     """Verify that the environment variables are set correctly. Raises an error otherwise."""
     get_env_root_url()
@@ -1607,6 +1623,7 @@ def verify_server_environment_variables() -> None:
     get_env_database_allocated_storage_capacity_gibibytes()
     get_env_database_usage_email_warning_threshold_percentage()
     get_env_database_usage_insertion_blocking_threshold_percentage()
+    validate_env_support_email()
 
     # Notify users about deprecated environment variables if they are being used.
     if os.getenv("PHOENIX_ENABLE_WEBSOCKETS") is not None:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -248,7 +248,11 @@ this URL.
 """
 ENV_PHOENIX_SUPPORT_EMAIL = "PHOENIX_SUPPORT_EMAIL"
 """
-The email address to include in error messages.
+The support email address to display in error messages and notifications.
+
+When set, this email will be included in error messages for insufficient storage
+conditions and database usage notification emails, providing users with a direct
+contact for assistance. If not set, error messages will not include contact information.
 """
 
 # SMTP settings
@@ -1603,10 +1607,22 @@ def get_env_management_url() -> Optional[str]:
 
 
 def get_env_support_email() -> Optional[str]:
+    """
+    Get the support email address from the PHOENIX_SUPPORT_EMAIL environment variable.
+
+    Returns:
+        The support email address if set, None otherwise.
+    """
     return getenv(ENV_PHOENIX_SUPPORT_EMAIL)
 
 
 def validate_env_support_email() -> None:
+    """
+    Validate the support email address configured in PHOENIX_SUPPORT_EMAIL.
+
+    Raises:
+        ValueError: If the email address is invalid.
+    """
     if not (email := get_env_support_email()):
         return
     try:

--- a/src/phoenix/server/api/auth.py
+++ b/src/phoenix/server/api/auth.py
@@ -3,8 +3,10 @@ from typing import Any
 
 from strawberry import Info
 from strawberry.permission import BasePermission
+from typing_extensions import override
 
-from phoenix.server.api.exceptions import Unauthorized
+from phoenix.config import get_env_support_email
+from phoenix.server.api.exceptions import InsufficientStorage, Unauthorized
 from phoenix.server.bearer_auth import PhoenixUser
 
 
@@ -20,14 +22,23 @@ class IsNotReadOnly(Authorization):
         return not info.context.read_only
 
 
-class IsLocked(Authorization):
+class IsLocked(BasePermission):
     """
     Disables mutations and subscriptions that create or update data but allows
     queries and delete mutations.
     """
 
-    message = "Operations that write or modify data are locked"
+    @override
+    def on_unauthorized(self) -> None:
+        message = (
+            "Database operations are disabled due to insufficient storage. "
+            "Please delete old data or increase storage."
+        )
+        if support_email := get_env_support_email():
+            message += f" Need help? Contact us at {support_email}"
+        raise InsufficientStorage(message)
 
+    @override
     def has_permission(self, source: Any, info: Info, **kwargs: Any) -> bool:
         return not (info.context.db.should_not_insert_or_update or info.context.locked)
 

--- a/src/phoenix/server/api/exceptions.py
+++ b/src/phoenix/server/api/exceptions.py
@@ -27,6 +27,12 @@ class Unauthorized(CustomGraphQLError):
     """
 
 
+class InsufficientStorage(CustomGraphQLError):
+    """
+    An error raised when the database has insufficient storage to complete a request.
+    """
+
+
 class Conflict(CustomGraphQLError):
     """
     An error raised when a mutation cannot be completed due to a conflict with

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -55,6 +55,25 @@ def require_admin(request: Request) -> None:
 
 
 def is_not_locked(request: Request) -> None:
+    """
+    FastAPI dependency to ensure database operations are not locked due to insufficient storage.
+
+    This dependency checks if data insertion and update operations are disabled due to
+    storage capacity limits. When storage thresholds are exceeded, it raises an HTTP 507
+    error with actionable guidance for users.
+
+    Usage:
+        Add as a dependency to any route that modifies data:
+
+            @router.post("/create-data", dependencies=[Depends(is_not_locked)])
+            async def create_data(...):
+                ...
+
+    Raises:
+        HTTPException: HTTP 507 Insufficient Storage when database operations are locked.
+            The error includes guidance on resolving storage issues and support contact
+            information if configured.
+    """
     if request.app.state.db.should_not_insert_or_update:
         detail = (
             "Database operations are disabled due to insufficient storage. "

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -25,6 +25,7 @@ Usage:
 from fastapi import HTTPException, Request
 from fastapi import status as fastapi_status
 
+from phoenix.config import get_env_support_email
 from phoenix.server.bearer_auth import PhoenixUser
 
 
@@ -55,8 +56,13 @@ def require_admin(request: Request) -> None:
 
 def is_not_locked(request: Request) -> None:
     if request.app.state.db.should_not_insert_or_update:
+        detail = (
+            "Database operations are disabled due to insufficient storage. "
+            "Please delete old data or increase storage."
+        )
+        if support_email := get_env_support_email():
+            detail += f" Need help? Contact us at {support_email}"
         raise HTTPException(
             status_code=fastapi_status.HTTP_507_INSUFFICIENT_STORAGE,
-            detail="Operations that insert or update database "
-            "records are currently not allowed.",
+            detail=detail,
         )

--- a/src/phoenix/server/email/sender.py
+++ b/src/phoenix/server/email/sender.py
@@ -8,7 +8,7 @@ from anyio import to_thread
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from typing_extensions import TypeAlias
 
-from phoenix.config import get_env_root_url
+from phoenix.config import get_env_root_url, get_env_support_email
 
 EMAIL_TEMPLATE_FOLDER = Path(__file__).parent / "templates"
 
@@ -96,6 +96,7 @@ class SimpleEmailSender:
             current_usage_gibibytes=current_usage_gibibytes,
             allocated_storage_gibibytes=allocated_storage_gibibytes,
             notification_threshold_percentage=notification_threshold_percentage,
+            support_email=get_env_support_email(),
         )
 
         msg = EmailMessage()

--- a/src/phoenix/server/email/templates/db_disk_usage_notification.html
+++ b/src/phoenix/server/email/templates/db_disk_usage_notification.html
@@ -12,5 +12,8 @@
 <p><strong>Usage Percentage:</strong> {{ ((current_usage_gibibytes / allocated_storage_gibibytes) * 100)|round(1) }}%</p>
 <p><strong>Notification Threshold:</strong> {{ notification_threshold_percentage }}%</p>
 <p>Please consider removing old data or increasing your storage allocation to prevent interruption.</p>
+{% if support_email %}
+<p>If you need assistance, please contact support at <a id="support-email" href="mailto:{{ support_email }}">{{ support_email }}</a>.</p>
+{% endif %}
 </body>
 </html>

--- a/tests/integration/server/test_db_disk_usage_monitor.py
+++ b/tests/integration/server/test_db_disk_usage_monitor.py
@@ -83,6 +83,11 @@ def _env_database_usage() -> dict[str, str]:
 
 
 @pytest.fixture(scope="module")
+def _support_email() -> str:
+    return f"{token_hex(8)}@{token_hex(8)}.com"
+
+
+@pytest.fixture(scope="module")
 def _env(
     _env_database: dict[str, str],
     _env_ports: dict[str, str],
@@ -90,6 +95,7 @@ def _env(
     _env_smtp: dict[str, str],
     _env_admin: dict[str, str],
     _env_database_usage: dict[str, str],
+    _support_email: str,
 ) -> dict[str, str]:
     """Combine all environment variable configurations for testing."""
     return {
@@ -99,6 +105,7 @@ def _env(
         **_env_smtp,
         **_env_admin,
         **_env_database_usage,
+        "PHOENIX_SUPPORT_EMAIL": _support_email,
     }
 
 
@@ -117,6 +124,7 @@ class TestDbDiskUsageMonitor:
         _smtpd: AuthController,
         _admin_email: str,
         _admin_secret: _AdminSecret,
+        _support_email: str,
     ) -> None:
         """
         Comprehensive test of the database disk usage monitor functionality.
@@ -162,6 +170,9 @@ class TestDbDiskUsageMonitor:
                 assert (soup := _extract_html(message))
                 assert soup.title
                 assert soup.title.string == "Database Usage Notification"
+                assert (
+                    _support_email in soup.get_text()
+                ), f"Support email {_support_email} should appear in email content"
                 received_email = True
             except AssertionError:
                 if retries_left:

--- a/tests/integration/server/test_db_disk_usage_monitor.py
+++ b/tests/integration/server/test_db_disk_usage_monitor.py
@@ -274,12 +274,12 @@ class TestDbDiskUsageMonitor:
         # GraphQL mutations that create new data (API keys, datasets, etc.)
         # should be blocked because they involve database insertions.
         # The system should return "locked" errors for these operations.
-        with pytest.raises(Exception, match="locked"):
+        with pytest.raises(Exception, match="storage"):
             _create_api_key(_app, access_token)
 
         for field in ['createDataset(input:{name:"' + token_hex(8) + '"}){dataset{id}}']:
             query = "mutation{" + field + "}"
-            with pytest.raises(Exception, match="locked"):
+            with pytest.raises(Exception, match="storage"):
                 _gql(_app, access_token, query=query)
 
         # ========================================================================


### PR DESCRIPTION
resolves [#8530](https://github.com/Arize-ai/phoenix/issues/8530)

This PR enhances error messaging when database operations are blocked due to insufficient storage by adding optional support email contact information. The changes introduce a new PHOENIX_SUPPORT_EMAIL environment variable and integrate it across GraphQL authorization (IsLocked class), REST API authorization (is_not_locked function), gRPC interceptors (DbDiskUsageInterceptor), and database usage notification emails. When configured, error messages now include actionable guidance like "Database operations are disabled due to insufficient storage. Please delete old data or increase storage. Need help? Contact us at {support_email}" instead of generic "operations not allowed" messages. This provides users with clear next steps and direct access to support when storage thresholds are exceeded, improving the overall user experience during critical storage situations. All changes maintain backward compatibility and only display the support contact when the environment variable is configured.
