### PR TITLE
docs: Update OpenInference JS tracer documentation

### DIFF
--- a/docs/section-integrations/frameworks/beeai/beeai-tracing-js.md
+++ b/docs/section-integrations/frameworks/beeai/beeai-tracing-js.md
@@ -127,6 +127,39 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 If traces aren't appearing, a common cause is an outdated `beeai-framework` package. Check the diagnostic logs for version or initialization errors and update your package as needed.
 
+## Custom Tracer Provider
+
+You can specify a custom tracer provider for BeeAI instrumentation in multiple ways:
+
+### Method 1: Pass tracerProvider on instantiation
+
+```typescript
+const beeAIInstrumentation = new BeeAIInstrumentation({
+  tracerProvider: customTracerProvider,
+});
+beeAIInstrumentation.manuallyInstrument(beeaiFramework);
+```
+
+### Method 2: Set tracerProvider after instantiation
+
+```typescript
+const beeAIInstrumentation = new BeeAIInstrumentation();
+beeAIInstrumentation.setTracerProvider(customTracerProvider);
+beeAIInstrumentation.manuallyInstrument(beeaiFramework);
+```
+
+### Method 3: Pass tracerProvider to registerInstrumentations
+
+```typescript
+const beeAIInstrumentation = new BeeAIInstrumentation();
+beeAIInstrumentation.manuallyInstrument(beeaiFramework);
+
+registerInstrumentations({
+  instrumentations: [beeAIInstrumentation],
+  tracerProvider: customTracerProvider,
+});
+```
+
 ## Resources
 
 * [BeeAI Framework GitHub](https://github.com/i-am-bee/beeai-framework)

--- a/docs/section-integrations/frameworks/langchain/langchain.js.md
+++ b/docs/section-integrations/frameworks/langchain/langchain.js.md
@@ -37,6 +37,39 @@ Instrumentation version >1.0.0 supports both attribute masking and context attri
 
 <table data-full-width="false"><thead><tr><th width="226">Instrumentation Version</th><th width="177" align="center">LangChain ^0.3.0</th><th width="181" align="center">LangChain ^0.2.0</th><th align="center">LangChain ^0.1.0</th></tr></thead><tbody><tr><td>>1.0.0</td><td align="center">✅</td><td align="center">✅</td><td align="center">✅</td></tr><tr><td>>0.2.0</td><td align="center">❌</td><td align="center">✅</td><td align="center">✅</td></tr><tr><td>>0.1.0</td><td align="center">❌</td><td align="center">❌</td><td align="center">✅</td></tr></tbody></table>
 
+## Custom Tracer Provider
+
+You can specify a custom tracer provider for LangChain instrumentation in multiple ways:
+
+### Method 1: Pass tracerProvider on instantiation
+
+```typescript
+const lcInstrumentation = new LangChainInstrumentation({
+  tracerProvider: customTracerProvider,
+});
+lcInstrumentation.manuallyInstrument(CallbackManagerModule);
+```
+
+### Method 2: Set tracerProvider after instantiation
+
+```typescript
+const lcInstrumentation = new LangChainInstrumentation();
+lcInstrumentation.setTracerProvider(customTracerProvider);
+lcInstrumentation.manuallyInstrument(CallbackManagerModule);
+```
+
+### Method 3: Pass tracerProvider to registerInstrumentations
+
+```typescript
+const lcInstrumentation = new LangChainInstrumentation();
+lcInstrumentation.manuallyInstrument(CallbackManagerModule);
+
+registerInstrumentations({
+  instrumentations: [lcInstrumentation],
+  tracerProvider: customTracerProvider,
+});
+```
+
 ## Resources
 
 * [Example project](https://github.com/Arize-ai/openinference/blob/main/js/packages/openinference-instrumentation-langchain/examples)

--- a/docs/section-integrations/llm-providers/openai/openai-node.js-sdk.md
+++ b/docs/section-integrations/llm-providers/openai/openai-node.js-sdk.md
@@ -96,6 +96,39 @@ openai.chat.completions
 
 After setting up instrumentation and running your  OpenAI application, traces will appear in the Phoenix UI for visualization and analysis.
 
+## Custom Tracer Provider
+
+You can specify a custom tracer provider for OpenAI instrumentation in multiple ways:
+
+### Method 1: Pass tracerProvider on instantiation
+
+```typescript
+const instrumentation = new OpenAIInstrumentation({
+  tracerProvider: customTracerProvider,
+});
+instrumentation.manuallyInstrument(OpenAI);
+```
+
+### Method 2: Set tracerProvider after instantiation
+
+```typescript
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.setTracerProvider(customTracerProvider);
+instrumentation.manuallyInstrument(OpenAI);
+```
+
+### Method 3: Pass tracerProvider to registerInstrumentations
+
+```typescript
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.manuallyInstrument(OpenAI);
+
+registerInstrumentations({
+  instrumentations: [instrumentation],
+  tracerProvider: customTracerProvider,
+});
+```
+
 ## Resources
 
 * [Example project](https://github.com/Arize-ai/openinference/tree/main/js/examples/openai)

--- a/docs/tracing/how-to-tracing/setup-tracing/javascript.md
+++ b/docs/tracing/how-to-tracing/setup-tracing/javascript.md
@@ -521,3 +521,68 @@ const doWork = (parent, i) => {
 ```
 
 All other APIs behave the same when you use `sdk-trace-base` compared with the Node.js SDKs.
+
+## Specifying a Custom Tracer Provider
+
+OpenInference JavaScript instrumentations support specifying a custom tracer provider in multiple ways. This is useful when you need to use a different tracer provider than the default global one, or when you want to have more control over the tracing configuration.
+
+### Method 1: Pass tracerProvider on instantiation
+
+You can pass a custom tracer provider directly to the instrumentation when creating it:
+
+```typescript
+// Create a custom tracer provider
+const customTracerProvider = new NodeTracerProvider({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: "custom-service",
+    [SEMRESATTRS_PROJECT_NAME]: "custom-project",
+  }),
+  spanProcessors: [
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: `http://localhost:6006/v1/traces`,
+      })
+    ),
+  ],
+});
+
+// Pass the custom tracer provider to the instrumentation
+const instrumentation = new OpenAIInstrumentation({
+  tracerProvider: customTracerProvider,
+});
+instrumentation.manuallyInstrument(OpenAI);
+```
+
+### Method 2: Set tracerProvider after instantiation
+
+You can set a tracer provider after creating the instrumentation:
+
+```typescript
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.setTracerProvider(customTracerProvider);
+instrumentation.manuallyInstrument(OpenAI);
+```
+
+### Method 3: Pass tracerProvider to registerInstrumentations
+
+You can also specify the tracer provider when registering instrumentations:
+
+```typescript
+const instrumentation = new OpenAIInstrumentation();
+instrumentation.manuallyInstrument(OpenAI);
+
+registerInstrumentations({
+  instrumentations: [instrumentation],
+  tracerProvider: customTracerProvider,
+});
+```
+
+### Supported Instrumentations
+
+This functionality is supported across all OpenInference JavaScript instrumentations:
+
+- **LangChain JS**: `@arizeai/openinference-instrumentation-langchain`
+- **BeeAI**: `@arizeai/openinference-instrumentation-beeai`
+- **OpenAI JS**: `@arizeai/openinference-instrumentation-openai`
+
+For specific examples with each instrumentation, see their respective documentation pages in the [Integrations section](../../section-integrations/).


### PR DESCRIPTION
Update JavaScript instrumentation documentation to show how to specify a custom tracer provider.