### PR TITLE
refactor: update recharts usage to v3 api

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -54,7 +54,7 @@
     "react-resizable": "^3.0.5",
     "react-resizable-panels": "^2.1.7",
     "react-router": "^7.5.2",
-    "recharts": "^2.12.7",
+    "recharts": "^3.1.0",
     "relay-runtime": "^19.0.0",
     "remark-gfm": "^4.0.0",
     "shade": "^0.1.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 1.1.0
       '@arizeai/point-cloud':
         specifier: ^3.0.6
-        version: 3.0.6(@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(react@18.3.1)(three-stdlib@2.30.4(three@0.139.2))(three@0.139.2)
+        version: 3.0.6(@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(react@18.3.1)(three-stdlib@2.30.4(three@0.139.2))(three@0.139.2)
       '@codemirror/autocomplete':
         specifier: 6.12.0
         version: 6.12.0(@codemirror/language@6.10.3)(@codemirror/state@6.5.2)(@codemirror/view@6.29.0)(@lezer/common@1.2.1)
@@ -74,7 +74,7 @@ importers:
         version: 3.26.0(react@18.3.1)
       '@react-three/drei':
         specifier: ^9.108.4
-        version: 9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
+        version: 9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
       '@react-three/fiber':
         specifier: 8.0.12
         version: 8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
@@ -160,8 +160,8 @@ importers:
         specifier: ^7.5.2
         version: 7.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
-        specifier: ^2.12.7
-        version: 2.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.1.0
+        version: 3.1.0(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1)
       relay-runtime:
         specifier: ^19.0.0
         version: 19.0.0
@@ -194,7 +194,7 @@ importers:
         version: 3.23.3(zod@3.23.8)
       zustand:
         specifier: ^4.5.4
-        version: 4.5.4(@types/react@18.3.10)(react@18.3.1)
+        version: 4.5.4(@types/react@18.3.10)(immer@10.1.1)(react@18.3.1)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^3.2.2
@@ -1980,6 +1980,17 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@reduxjs/toolkit@2.8.2':
+    resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/pluginutils@5.1.3':
     resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
     engines: {node: '>=14.0.0'}
@@ -2112,6 +2123,12 @@ packages:
 
   '@shikijs/vscode-textmate@9.3.0':
     resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-actions@8.4.6':
     resolution: {integrity: sha512-vbplwjMj7UXbdzoFhQkqFHLQAPJX8OVGTM9Q+yjuWDHViaKKUlgRWp0jclT7aIDNJQU2a6wJbTimHgJeF16Vhg==}
@@ -2453,6 +2470,9 @@ packages:
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -3310,6 +3330,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.39.7:
+    resolution: {integrity: sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -3428,8 +3451,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -3446,10 +3469,6 @@ packages:
 
   fast-equals@4.0.3:
     resolution: {integrity: sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==}
-
-  fast-equals@5.0.1:
-    resolution: {integrity: sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==}
-    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -3720,6 +3739,9 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
   import-fresh@2.0.0:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
@@ -4662,6 +4684,18 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -4692,12 +4726,6 @@ packages:
       react-dom:
         optional: true
 
-  react-smooth@4.0.1:
-    resolution: {integrity: sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-
   react-stately@3.38.0:
     resolution: {integrity: sha512-zS06DsDhH44z7bsOkMHJ0gnjuLO3UWZ33l7JOgFscrv1qa33IG9fn707sI7GAJdLgDiWXJbeFvXdix2jR1fU1w==}
     peerDependencies:
@@ -4723,19 +4751,25 @@ packages:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
     engines: {node: '>= 4'}
 
-  recharts-scale@0.4.5:
-    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
-
-  recharts@2.12.7:
-    resolution: {integrity: sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==}
-    engines: {node: '>=14'}
+  recharts@3.1.0:
+    resolution: {integrity: sha512-NqAqQcGBmLrfDs2mHX/bz8jJCQtG2FeXfE0GqpZmIuXIjkpIwj8sd9ad0WyvKiBKPd8ZgNG0hL85c8sFDwascw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4796,6 +4830,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -5381,8 +5418,8 @@ packages:
   vfile@6.0.2:
     resolution: {integrity: sha512-zND7NlS8rJYb/sPqkb13ZvbbUoExdbi4w3SfRrMq6R3FvnLQmmfpajJNITuuYm6AZ5uao9vy4BAos3EXBPf2rg==}
 
-  victory-vendor@36.9.2:
-    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.0.9:
     resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
@@ -5735,9 +5772,9 @@ snapshots:
 
   '@arizeai/openinference-semantic-conventions@1.1.0': {}
 
-  '@arizeai/point-cloud@3.0.6(@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(react@18.3.1)(three-stdlib@2.30.4(three@0.139.2))(three@0.139.2)':
+  '@arizeai/point-cloud@3.0.6(@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(react@18.3.1)(three-stdlib@2.30.4(three@0.139.2))(three@0.139.2)':
     dependencies:
-      '@react-three/drei': 9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
+      '@react-three/drei': 9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
       '@react-three/fiber': 8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)
       react: 18.3.1
       three: 0.139.2
@@ -7864,7 +7901,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)':
+  '@react-three/drei@9.108.4(@react-three/fiber@8.0.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2))(@types/react@18.3.10)(@types/three@0.149.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.139.2)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@mediapipe/tasks-vision': 0.10.8
@@ -7888,7 +7925,7 @@ snapshots:
       three-mesh-bvh: 0.7.6(three@0.139.2)
       three-stdlib: 2.30.4(three@0.139.2)
       troika-three-text: 0.49.1(three@0.139.2)
-      tunnel-rat: 0.1.2(@types/react@18.3.10)(react@18.3.1)
+      tunnel-rat: 0.1.2(@types/react@18.3.10)(immer@10.1.1)(react@18.3.1)
       utility-types: 3.11.0
       uuid: 9.0.1
       zustand: 3.7.2(react@18.3.1)
@@ -8160,6 +8197,18 @@ snapshots:
       '@react-types/shared': 3.29.1(react@18.3.1)
       react: 18.3.1
 
+  '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 10.1.1
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1)
+
   '@rollup/pluginutils@5.1.3(rollup@4.40.1)':
     dependencies:
       '@types/estree': 1.0.6
@@ -8266,6 +8315,10 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@9.3.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-actions@8.4.6(storybook@8.4.6(prettier@3.3.3))':
     dependencies:
@@ -8680,6 +8733,8 @@ snapshots:
   '@types/unist@2.0.10': {}
 
   '@types/unist@3.0.2': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -9771,6 +9826,8 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  es-toolkit@1.39.7: {}
+
   esbuild-register@3.6.0(esbuild@0.25.3):
     dependencies:
       debug: 4.3.7
@@ -9954,7 +10011,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eventemitter3@4.0.7: {}
+  eventemitter3@5.0.1: {}
 
   expect-type@1.1.0: {}
 
@@ -9965,8 +10022,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-equals@4.0.3: {}
-
-  fast-equals@5.0.1: {}
 
   fast-glob@3.3.2:
     dependencies:
@@ -10286,6 +10341,8 @@ snapshots:
   ignore@5.3.1: {}
 
   immediate@3.0.6: {}
+
+  immer@10.1.1: {}
 
   import-fresh@2.0.0:
     dependencies:
@@ -11535,6 +11592,15 @@ snapshots:
       react: 18.3.1
       scheduler: 0.21.0
 
+  react-redux@9.2.0(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.5.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.10
+      redux: 5.0.1
+
   react-refresh@0.14.2: {}
 
   react-relay@19.0.0(react@18.3.1):
@@ -11569,14 +11635,6 @@ snapshots:
       turbo-stream: 2.4.0
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
-
-  react-smooth@4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      fast-equals: 5.0.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-stately@3.38.0(react@18.3.1):
     dependencies:
@@ -11635,27 +11693,36 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.6.3
 
-  recharts-scale@0.4.5:
+  recharts@3.1.0(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1):
     dependencies:
-      decimal.js-light: 2.5.1
-
-  recharts@2.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
+      '@reduxjs/toolkit': 2.8.2(react-redux@9.2.0(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       clsx: 2.1.1
-      eventemitter3: 4.0.7
-      lodash: 4.17.21
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.39.7
+      eventemitter3: 5.0.1
+      immer: 10.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-is: 16.13.1
-      react-smooth: 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      recharts-scale: 0.4.5
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@18.3.10)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
       tiny-invariant: 1.3.3
-      victory-vendor: 36.9.2
+      use-sync-external-store: 1.5.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
 
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -11750,6 +11817,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -12208,9 +12277,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tunnel-rat@0.1.2(@types/react@18.3.10)(react@18.3.1):
+  tunnel-rat@0.1.2(@types/react@18.3.10)(immer@10.1.1)(react@18.3.1):
     dependencies:
-      zustand: 4.5.4(@types/react@18.3.10)(react@18.3.1)
+      zustand: 4.5.4(@types/react@18.3.10)(immer@10.1.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -12417,7 +12486,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  victory-vendor@36.9.2:
+  victory-vendor@37.3.6:
     dependencies:
       '@types/d3-array': 3.2.1
       '@types/d3-ease': 3.0.2
@@ -12702,11 +12771,12 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  zustand@4.5.4(@types/react@18.3.10)(react@18.3.1):
+  zustand@4.5.4(@types/react@18.3.10)(immer@10.1.1)(react@18.3.1):
     dependencies:
       use-sync-external-store: 1.2.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.10
+      immer: 10.1.1
       react: 18.3.1
 
   zwitch@2.0.4: {}

--- a/app/src/components/chart/defaults.tsx
+++ b/app/src/components/chart/defaults.tsx
@@ -1,4 +1,4 @@
-import { ReferenceLineProps, TooltipProps, XAxisProps } from "recharts";
+import { LabelProps, TooltipProps, XAxisProps } from "recharts";
 
 /**
  * Re-usable default props for the XAxis component.
@@ -13,15 +13,16 @@ export const defaultTimeXAxisProps: XAxisProps = {
   padding: "gap",
 };
 
-export const defaultSelectedTimestampReferenceLineProps: ReferenceLineProps = {
+export const defaultSelectedTimestampReferenceLineProps = {
   stroke: "var(--ac-global-color-grey-900)",
-  label: {
-    value: "▼",
-    position: "top",
-    style: {
-      fill: "#fabe32",
-      fontSize: "var(--ac-global-font-size-xs)",
-    },
+};
+
+export const defaultSelectedTimestampReferenceLineLabelProps: LabelProps = {
+  value: "▼",
+  position: "top",
+  style: {
+    fill: "#fabe32",
+    fontSize: "var(--ac-global-font-size-xs)",
   },
 };
 

--- a/app/src/pages/dashboard/DashboardBarChart.tsx
+++ b/app/src/pages/dashboard/DashboardBarChart.tsx
@@ -4,7 +4,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -34,7 +34,7 @@ export function DashboardBarChart({ data, scale }: DashboardBarChartProps) {
     active,
     payload,
     label,
-  }: TooltipProps<number, string>) => {
+  }: TooltipContentProps<number, string>) => {
     if (!active || !payload || !payload.length) return null;
 
     const data = payload[0];
@@ -42,9 +42,11 @@ export function DashboardBarChart({ data, scale }: DashboardBarChartProps) {
 
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={barColor}
           name="Traces"
@@ -105,10 +107,7 @@ export function DashboardBarChart({ data, scale }: DashboardBarChartProps) {
           strokeOpacity={0.5}
         />
 
-        <Tooltip
-          {...defaultBarChartTooltipProps}
-          content={<TooltipContent />}
-        />
+        <Tooltip {...defaultBarChartTooltipProps} content={TooltipContent} />
 
         <Bar dataKey="value" fill={`url(#${barGradientId})`} />
       </BarChart>

--- a/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCardinalityTimeSeries.tsx
@@ -5,7 +5,7 @@ import {
   ComposedChart,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -41,7 +41,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { color } = useColors();
   if (active && payload && payload.length) {
     const cardinality = payload[0]?.value ?? null;
@@ -52,9 +52,11 @@ function TooltipContent({
 
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={color}
           name="Cardinality"
@@ -156,7 +158,7 @@ export function DimensionCardinalityTimeSeries({
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
         <Area
           type="monotone"
           dataKey="value"

--- a/app/src/pages/dimension/DimensionCountTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionCountTimeSeries.tsx
@@ -5,7 +5,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -41,7 +41,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { barColor } = useColors();
   if (active && payload && payload.length) {
     const count = payload[0]?.value ?? null;
@@ -49,9 +49,11 @@ function TooltipContent({
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={barColor}
           shape="square"
@@ -154,10 +156,7 @@ export function DimensionCountTimeSeries({
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip
-          {...defaultBarChartTooltipProps}
-          content={<TooltipContent />}
-        />
+        <Tooltip {...defaultBarChartTooltipProps} content={TooltipContent} />
         <Bar dataKey="value" fill="url(#countBarColor)" spacing={5} />
       </BarChart>
     </ResponsiveContainer>

--- a/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
+++ b/app/src/pages/dimension/DimensionDriftBreakdownSegmentBarChart.tsx
@@ -8,7 +8,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -49,7 +49,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<BarChartItem["primaryPercent"], BarChartItem["name"]>) {
+}: TooltipContentProps<BarChartItem["primaryPercent"], BarChartItem["name"]>) {
   const { primaryBarColor, referenceBarColor } = useColors();
   if (active && payload && payload.length) {
     const primaryLabel = payload[0]?.payload?.primaryName;
@@ -258,7 +258,7 @@ export function DimensionDriftBreakdownSegmentBarChart(props: {
             />
             <Tooltip
               {...defaultBarChartTooltipProps}
-              content={<TooltipContent />}
+              content={TooltipContent}
             />
             <Bar
               dataKey="primaryPercent"

--- a/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionDriftTimeSeries.tsx
@@ -5,14 +5,15 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  Label,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
-import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
+import { CategoricalChartFunc } from "recharts/types/chart/types";
 import { css } from "@emotion/react";
 
 import { Icon, Icons, Text } from "@phoenix/components";
@@ -20,6 +21,7 @@ import {
   ChartTooltip,
   ChartTooltipDivider,
   ChartTooltipItem,
+  defaultSelectedTimestampReferenceLineLabelProps,
   defaultSelectedTimestampReferenceLineProps,
   defaultTimeXAxisProps,
   useChartColors,
@@ -48,16 +50,18 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { color } = useColors();
   if (active && payload && payload.length) {
     const euclideanDistance = payload[1]?.value ?? null;
 
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={color}
           name="PSI"
@@ -164,13 +168,22 @@ export function DimensionDriftTimeSeries({
   const onClick: CategoricalChartFunc = useCallback(
     (state) => {
       // Parse out the timestamp from the first chart
-      const { activePayload } = state;
-      if (activePayload != null && activePayload.length > 0) {
-        const payload = activePayload[0].payload;
+      const { activeIndex } = state;
+      let index: number | undefined;
+      if (typeof activeIndex === "number") {
+        index = activeIndex;
+      } else if (
+        typeof activeIndex === "string" &&
+        !isNaN(Number(activeIndex))
+      ) {
+        index = Number(activeIndex);
+      }
+      if (typeof index === "number" && chartData[index]) {
+        const payload = chartData[index];
         setSelectedTimestamp(new Date(payload.timestamp));
       }
     },
-    [setSelectedTimestamp]
+    [setSelectedTimestamp, chartData]
   );
 
   const { color, barColor } = useColors();
@@ -227,7 +240,7 @@ export function DimensionDriftTimeSeries({
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
         <Bar
           yAxisId="right"
           dataKey="traffic"
@@ -245,6 +258,9 @@ export function DimensionDriftTimeSeries({
           <ReferenceLine
             {...defaultSelectedTimestampReferenceLineProps}
             x={selectedTimestamp.getTime()}
+            label={
+              <Label {...defaultSelectedTimestampReferenceLineLabelProps} />
+            }
           />
         ) : null}
       </ComposedChart>

--- a/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionPercentEmptyTimeSeries.tsx
@@ -5,7 +5,7 @@ import {
   Line,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -40,7 +40,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { color } = useColors();
   if (active && payload && payload.length) {
     const percentEmpty = payload[0]?.value ?? null;
@@ -50,9 +50,11 @@ function TooltipContent({
         : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={color}
           name="% Empty"
@@ -152,7 +154,7 @@ export function DimensionPercentEmptyTimeSeries({
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
         <Line
           type="monotone"
           dataKey="value"

--- a/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
+++ b/app/src/pages/dimension/DimensionQuantilesTimeSeries.tsx
@@ -10,7 +10,7 @@ import {
   Line,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -72,15 +72,17 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number | Array<number | string>, string>) {
+}: TooltipContentProps<number | Array<number | string>, string>) {
   const { outerColor, innerColor, lineColor } = useColors();
   if (active && payload && payload.length) {
     const data: ChartDataItem = payload[0].payload;
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={outerColor}
           name="p99"
@@ -281,7 +283,7 @@ export function DimensionQuantilesTimeSeries({
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
         <Legend
           onClick={selectChartItem}
           onMouseOver={handleLegendMouseOver}

--- a/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
+++ b/app/src/pages/dimension/DimensionSegmentsBarChart.tsx
@@ -7,7 +7,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -40,9 +40,9 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<BarChartItem["percent"], BarChartItem["name"]>) {
+}: TooltipContentProps<BarChartItem["percent"], BarChartItem["name"]>) {
   const { color } = useColors();
-  if (active && payload && payload.length) {
+  if (active && payload && payload.length && typeof label === "string") {
     const value = payload[0]?.value;
     return (
       <ChartTooltip>
@@ -162,10 +162,7 @@ export function DimensionSegmentsBarChart(props: {
           stroke="var(--ac-global-color-grey-500)"
           strokeOpacity={0.5}
         />
-        <Tooltip
-          {...defaultBarChartTooltipProps}
-          content={<TooltipContent />}
-        />
+        <Tooltip {...defaultBarChartTooltipProps} content={TooltipContent} />
         <Bar
           dataKey="percent"
           fill="url(#dimensionSegmentsBarColor)"

--- a/app/src/pages/embedding/MetricTimeSeries.tsx
+++ b/app/src/pages/embedding/MetricTimeSeries.tsx
@@ -5,14 +5,15 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  Label,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
-import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
+import { CategoricalChartFunc } from "recharts/types/chart/types";
 import { css } from "@emotion/react";
 
 import { Content, ContextualHelp } from "@arizeai/components";
@@ -62,7 +63,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { color, barColor } = useColors();
   if (active && payload && payload.length) {
     const metricValue = payload[1]?.value ?? null;
@@ -75,9 +76,11 @@ function TooltipContent({
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={color}
           name={payload[1]?.payload.metricName ?? "Metric"}
@@ -282,18 +285,6 @@ export function MetricTimeSeries({
     samplingIntervalMinutes: granularity.samplingIntervalMinutes,
   });
 
-  const onClick: CategoricalChartFunc = useCallback(
-    (state) => {
-      // Parse out the timestamp from the first chart
-      const { activePayload } = state;
-      if (activePayload != null && activePayload.length > 0) {
-        const payload = activePayload[0].payload;
-        setSelectedTimestamp(new Date(payload.timestamp));
-      }
-    },
-    [setSelectedTimestamp]
-  );
-
   const chartPrimaryRawData = getChartPrimaryData({ data, metric });
   const chartSecondaryRawData = getTrafficData(data);
   const trafficDataMap =
@@ -317,6 +308,27 @@ export function MetricTimeSeries({
   const metricDescription = getMetricDescription(metric);
 
   const { color, barColor } = useColors();
+
+  const onClick: CategoricalChartFunc = useCallback(
+    (state) => {
+      // Parse out the timestamp from the first chart
+      const { activeIndex } = state;
+      let index: number | undefined;
+      if (typeof activeIndex === "number") {
+        index = activeIndex;
+      } else if (
+        typeof activeIndex === "string" &&
+        !isNaN(Number(activeIndex))
+      ) {
+        index = Number(activeIndex);
+      }
+      if (typeof index === "number" && chartData[index]) {
+        const payload = chartData[index];
+        setSelectedTimestamp(new Date(payload.timestamp));
+      }
+    },
+    [setSelectedTimestamp, chartData]
+  );
   return (
     <section
       css={css`
@@ -405,7 +417,7 @@ export function MetricTimeSeries({
               stroke="var(--ac-global-color-grey-500)"
               strokeOpacity={0.5}
             />
-            <Tooltip content={<TooltipContent />} />
+            <Tooltip content={TooltipContent} />
             <Bar
               yAxisId="right"
               dataKey="traffic"
@@ -424,6 +436,16 @@ export function MetricTimeSeries({
               <ReferenceLine
                 {...defaultSelectedTimestampReferenceLineProps}
                 x={selectedTimestamp.getTime()}
+                label={
+                  <Label
+                    value="▼"
+                    position="top"
+                    style={{
+                      fill: "#fabe32",
+                      fontSize: "var(--ac-global-font-size-xs)",
+                    }}
+                  />
+                }
               />
             ) : null}
           </ComposedChart>

--- a/app/src/pages/experiments/ExperimentsLineChart.tsx
+++ b/app/src/pages/experiments/ExperimentsLineChart.tsx
@@ -12,7 +12,7 @@ import {
   Line,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -49,7 +49,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const { gray300 } = useChartColors();
   // Use the same color logic as the chart lines
   if (active && payload && payload.length) {
@@ -245,7 +245,7 @@ export function ExperimentsLineChart({ datasetId }: { datasetId: string }) {
             yAxisId={0}
           />
         ))}
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
       </ComposedChart>
     </ResponsiveContainer>
   );

--- a/app/src/pages/project/TraceCountTimeSeries.tsx
+++ b/app/src/pages/project/TraceCountTimeSeries.tsx
@@ -5,7 +5,7 @@ import {
   Legend,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -87,7 +87,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const SemanticChartColors = useSemanticChartColors();
   const chartColors = useChartColors();
   if (active && payload && payload.length) {
@@ -101,9 +101,11 @@ function TooltipContent({
         : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={SemanticChartColors.danger}
           shape="circle"
@@ -171,7 +173,7 @@ export function TraceCountTimeSeries() {
           vertical={false}
         />
         <Tooltip
-          content={<TooltipContent />}
+          content={TooltipContent}
           // TODO formalize this
           cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
         />

--- a/app/src/pages/settings/DBUsagePieChart.tsx
+++ b/app/src/pages/settings/DBUsagePieChart.tsx
@@ -7,7 +7,7 @@ import {
   PieChart,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
 } from "recharts";
 
 import { ChartTooltip, ChartTooltipItem } from "@phoenix/components/chart";
@@ -17,7 +17,10 @@ import { storageSizeFormatter } from "@phoenix/utils/storageSizeFormatUtils";
 import { DBUsagePieChart_data$key } from "./__generated__/DBUsagePieChart_data.graphql";
 
 const REMAINING_TEXT = "remaining";
-function TooltipContent({ active, payload }: TooltipProps<number, string>) {
+function TooltipContent({
+  active,
+  payload,
+}: TooltipContentProps<number, string>) {
   if (active && payload && payload.length) {
     return (
       <ChartTooltip>
@@ -96,7 +99,7 @@ export function DBUsagePieChart({
             />
           ))}
         </Pie>
-        <Tooltip content={<TooltipContent />} />
+        <Tooltip content={TooltipContent} />
         <text
           x="50%"
           y="50%"

--- a/app/stories/StackedTimeSeriesBarChart.stories.tsx
+++ b/app/stories/StackedTimeSeriesBarChart.stories.tsx
@@ -6,7 +6,7 @@ import {
   Legend,
   ResponsiveContainer,
   Tooltip,
-  TooltipProps,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
@@ -146,7 +146,7 @@ function TooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
+}: TooltipContentProps<number, string>) {
   const chartColors = useChartColors();
   if (active && payload && payload.length) {
     const metricValue = payload[1]?.value ?? null;
@@ -159,9 +159,11 @@ function TooltipContent({
       typeof count === "number" ? numberFormatter.format(count) : "--";
     return (
       <ChartTooltip>
-        <Text weight="heavy" size="S">{`${fullTimeFormatter(
-          new Date(label)
-        )}`}</Text>
+        {label && (
+          <Text weight="heavy" size="S">{`${fullTimeFormatter(
+            new Date(label)
+          )}`}</Text>
+        )}
         <ChartTooltipItem
           color={chartColors.red300}
           shape="circle"
@@ -246,7 +248,7 @@ function StackedBarChart({
             vertical={false}
           />
           <Tooltip
-            content={<TooltipContent />}
+            content={TooltipContent}
             cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
           />
           <Bar dataKey="error" stackId="a" fill={colors[firstColor]} />


### PR DESCRIPTION
This PR re-upgrades recharts to v3, and aligns our charting to align with the updated v3 API.

The main breaking changes addressed here are:

> Update TooltipProps to TooltipContentProps when using Tooltip's content prop (custom tooltip)
> Update TooltipContentProps type's label prop to be undefined | string | or number rather than just string

from their [migration guide](https://github.com/recharts/recharts/wiki/3.0-migration-guide).

This also re-works some onClick handlers to no longer rely on state that has been removed, and updates ReferenceLine usage to align more closely with [docs](https://recharts.org/en-US/api/ReferenceLine) to fix type errors.