### PR TITLE
feat: [ts] get dataset by version

### DIFF
--- a/js/.changeset/wise-beds-rush.md
+++ b/js/.changeset/wise-beds-rush.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+get dataset with versionId

--- a/js/packages/phoenix-client/src/datasets/getDataset.ts
+++ b/js/packages/phoenix-client/src/datasets/getDataset.ts
@@ -6,19 +6,23 @@ import { getDatasetInfo } from "./getDatasetInfo";
 
 export type GetDatasetParams = ClientFn & {
   dataset: DatasetSelector;
+  versionId?: string;
 };
 
 /**
- * Get dataset info and the examples from the latest version of the dataset
+ * Get dataset info and examples from the dataset
+ * @param dataset - Dataset selector (ID or name)
+ * @param versionId - Optional specific version ID (if omitted, returns data from the latest version)
  */
 export async function getDataset({
   client: _client,
   dataset,
+  versionId,
 }: GetDatasetParams): Promise<Dataset> {
   const client = _client || createClient();
   const [datasetInfo, datasetExamples] = await Promise.all([
     getDatasetInfo({ client, dataset }),
-    getDatasetExamples({ client, dataset }),
+    getDatasetExamples({ client, dataset, versionId }),
   ]);
   return {
     ...datasetInfo,

--- a/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
@@ -22,7 +22,6 @@ export async function getDatasetExamples({
   const client = _client || createClient();
 
   let datasetId: string;
-  const targetVersionId: string | undefined = versionId;
 
   if ("datasetName" in dataset) {
     const datasetInfo = await getDatasetInfoByName({
@@ -39,9 +38,9 @@ export async function getDatasetExamples({
       path: {
         id: datasetId,
       },
-      query: targetVersionId
+      query: versionId
         ? {
-            version_id: targetVersionId,
+            version_id: versionId,
           }
         : undefined,
     },

--- a/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
@@ -24,14 +24,7 @@ export async function getDatasetExamples({
   let datasetId: string;
   const targetVersionId: string | undefined = versionId;
 
-  if ("datasetVersionId" in dataset) {
-    // If selecting by version ID, we need to get the dataset ID first
-    // For now, we'll use the version ID as both dataset ID and version ID
-    // This will need to be updated when we have a way to resolve version ID to dataset ID
-    throw new Error(
-      "Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName with optional versionId parameter."
-    );
-  } else if ("datasetName" in dataset) {
+  if ("datasetName" in dataset) {
     const datasetInfo = await getDatasetInfoByName({
       client,
       datasetName: dataset.datasetName,

--- a/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetExamples.ts
@@ -20,7 +20,7 @@ export async function getDatasetExamples({
   versionId,
 }: GetDatasetExamplesParams): Promise<DatasetExamples> {
   const client = _client || createClient();
-  
+
   let datasetId: string;
   const targetVersionId: string | undefined = versionId;
 
@@ -28,7 +28,9 @@ export async function getDatasetExamples({
     // If selecting by version ID, we need to get the dataset ID first
     // For now, we'll use the version ID as both dataset ID and version ID
     // This will need to be updated when we have a way to resolve version ID to dataset ID
-    throw new Error("Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName with optional versionId parameter.");
+    throw new Error(
+      "Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName with optional versionId parameter."
+    );
   } else if ("datasetName" in dataset) {
     const datasetInfo = await getDatasetInfoByName({
       client,
@@ -44,12 +46,14 @@ export async function getDatasetExamples({
       path: {
         id: datasetId,
       },
-      query: targetVersionId ? {
-        version_id: targetVersionId,
-      } : undefined,
+      query: targetVersionId
+        ? {
+            version_id: targetVersionId,
+          }
+        : undefined,
     },
   });
-  
+
   invariant(response.data?.data, "Failed to get dataset examples");
   const examplesData = response.data.data;
   return {

--- a/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
@@ -11,13 +11,17 @@ export type GetDatasetInfoParams = ClientFn & {
 /**
  * Get an overview of the information in a dataset
  * Note: this does not include the examples contained in the dataset
+ * Dataset info is not version-specific, only examples are versioned
  */
 export async function getDatasetInfo({
   client: _client,
   dataset,
 }: GetDatasetInfoParams): Promise<DatasetInfo> {
   const client = _client || createClient();
-  if ("datasetName" in dataset) {
+  
+  if ("datasetVersionId" in dataset) {
+    throw new Error("Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName.");
+  } else if ("datasetName" in dataset) {
     return await getDatasetInfoByName({
       client,
       datasetName: dataset.datasetName,

--- a/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
@@ -18,9 +18,11 @@ export async function getDatasetInfo({
   dataset,
 }: GetDatasetInfoParams): Promise<DatasetInfo> {
   const client = _client || createClient();
-  
+
   if ("datasetVersionId" in dataset) {
-    throw new Error("Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName.");
+    throw new Error(
+      "Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName."
+    );
   } else if ("datasetName" in dataset) {
     return await getDatasetInfoByName({
       client,

--- a/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
+++ b/js/packages/phoenix-client/src/datasets/getDatasetInfo.ts
@@ -19,11 +19,7 @@ export async function getDatasetInfo({
 }: GetDatasetInfoParams): Promise<DatasetInfo> {
   const client = _client || createClient();
 
-  if ("datasetVersionId" in dataset) {
-    throw new Error(
-      "Selecting by datasetVersionId is not yet implemented. Please use datasetId or datasetName."
-    );
-  } else if ("datasetName" in dataset) {
+  if ("datasetName" in dataset) {
     return await getDatasetInfoByName({
       client,
       datasetName: dataset.datasetName,

--- a/js/packages/phoenix-client/src/datasets/index.ts
+++ b/js/packages/phoenix-client/src/datasets/index.ts
@@ -2,5 +2,4 @@ export * from "./createDataset";
 export * from "./getDataset";
 export * from "./getDatasetExamples";
 export * from "./appendDatasetExamples";
-export * from "./getDatasetExamples";
 export * from "./getDatasetInfo";

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -3,9 +3,7 @@ import { Node } from "./core";
 /**
  * A dataset can be identified by its datasetId, datasetName, or datasetVersionId
  */
-export type DatasetSelector =
-  | { datasetId: string }
-  | { datasetName: string }
+export type DatasetSelector = { datasetId: string } | { datasetName: string };
 
 /**
  * Parameters for selecting a specific version of a dataset

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -6,7 +6,6 @@ import { Node } from "./core";
 export type DatasetSelector =
   | { datasetId: string }
   | { datasetName: string }
-  | { datasetVersionId: string };
 
 /**
  * Parameters for selecting a specific version of a dataset

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -1,10 +1,20 @@
 import { Node } from "./core";
 
 /**
- * A dataset can be identified by its datasetId
- * TODO: add support for datasetVersionId via discriminated union
+ * A dataset can be identified by its datasetId, datasetName, or datasetVersionId
  */
-export type DatasetSelector = { datasetId: string } | { datasetName: string };
+export type DatasetSelector = 
+  | { datasetId: string }
+  | { datasetName: string }
+  | { datasetVersionId: string };
+
+/**
+ * Parameters for selecting a specific version of a dataset
+ */
+export interface DatasetVersionSelector {
+  dataset: DatasetSelector;
+  versionId?: string;
+}
 
 /**
  * Overview information about a dataset
@@ -13,6 +23,15 @@ export interface DatasetInfo extends Node {
   name: string;
   description?: string | null;
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Information about a dataset version
+ */
+export interface DatasetVersionInfo extends Node {
+  description?: string | null;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
 }
 
 /**
@@ -46,3 +65,10 @@ export interface ExampleWithId extends Example, Node {
  * A dataset is a collection of examples for an AI task
  */
 export interface Dataset extends DatasetInfo, DatasetExamples, Node {}
+
+/**
+ * A dataset with its version information
+ */
+export interface DatasetWithVersion extends Dataset {
+  versionInfo: DatasetVersionInfo;
+}

--- a/js/packages/phoenix-client/src/types/datasets.ts
+++ b/js/packages/phoenix-client/src/types/datasets.ts
@@ -3,7 +3,7 @@ import { Node } from "./core";
 /**
  * A dataset can be identified by its datasetId, datasetName, or datasetVersionId
  */
-export type DatasetSelector = 
+export type DatasetSelector =
   | { datasetId: string }
   | { datasetName: string }
   | { datasetVersionId: string };

--- a/js/packages/phoenix-client/test/datasets/getDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/getDataset.test.ts
@@ -68,22 +68,22 @@ describe("getDataset", () => {
   });
 
   it("should support getting dataset by version ID", async () => {
-    const getDatasetExamplesSpy = vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
-      mockDatasetExamplesV2
-    );
+    const getDatasetExamplesSpy = vi
+      .spyOn(getDatasetExamplesModule, "getDatasetExamples")
+      .mockResolvedValue(mockDatasetExamplesV2);
     vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
       mockDatasetInfo
     );
 
-    const dataset = await getDataset({ 
+    const dataset = await getDataset({
       dataset: { datasetId: "dataset-123" },
-      versionId: "v2"
+      versionId: "v2",
     });
-    
+
     expect(getDatasetExamplesSpy).toHaveBeenCalledWith({
       client: expect.any(Object),
       dataset: { datasetId: "dataset-123" },
-      versionId: "v2"
+      versionId: "v2",
     });
     expect(dataset.versionId).toBe("v2");
     expect(dataset.examples.length).toBe(1);
@@ -98,10 +98,10 @@ describe("getDataset", () => {
       mockDatasetExamples
     );
 
-    const dataset = await getDataset({ 
-      dataset: { datasetId: "dataset-123" }
+    const dataset = await getDataset({
+      dataset: { datasetId: "dataset-123" },
     });
-    
+
     expect(dataset.versionId).toBe("v1");
     expect(dataset.examples.length).toBe(2);
   });

--- a/js/packages/phoenix-client/test/datasets/getDataset.test.ts
+++ b/js/packages/phoenix-client/test/datasets/getDataset.test.ts
@@ -30,6 +30,19 @@ const mockDatasetExamples = {
   ],
 };
 
+const mockDatasetExamplesV2 = {
+  versionId: "v2",
+  examples: [
+    {
+      id: "ex-3",
+      updatedAt: new Date("2024-01-03T00:00:00Z"),
+      input: { text: "input3" },
+      output: { text: "output3" },
+      metadata: {},
+    },
+  ],
+};
+
 describe("getDataset", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,6 +65,45 @@ describe("getDataset", () => {
     expect(examples.length).toBe(2);
     expect(examples[0]?.id).toBe("ex-1");
     expect(examples[1]?.id).toBe("ex-2");
+  });
+
+  it("should support getting dataset by version ID", async () => {
+    const getDatasetExamplesSpy = vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
+      mockDatasetExamplesV2
+    );
+    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
+      mockDatasetInfo
+    );
+
+    const dataset = await getDataset({ 
+      dataset: { datasetId: "dataset-123" },
+      versionId: "v2"
+    });
+    
+    expect(getDatasetExamplesSpy).toHaveBeenCalledWith({
+      client: expect.any(Object),
+      dataset: { datasetId: "dataset-123" },
+      versionId: "v2"
+    });
+    expect(dataset.versionId).toBe("v2");
+    expect(dataset.examples.length).toBe(1);
+    expect(dataset.examples[0]?.id).toBe("ex-3");
+  });
+
+  it("should work without versionId (uses latest version)", async () => {
+    vi.spyOn(getDatasetInfoModule, "getDatasetInfo").mockResolvedValue(
+      mockDatasetInfo
+    );
+    vi.spyOn(getDatasetExamplesModule, "getDatasetExamples").mockResolvedValue(
+      mockDatasetExamples
+    );
+
+    const dataset = await getDataset({ 
+      dataset: { datasetId: "dataset-123" }
+    });
+    
+    expect(dataset.versionId).toBe("v1");
+    expect(dataset.examples.length).toBe(2);
   });
 
   it("should propagate errors from getDatasetInfo", async () => {


### PR DESCRIPTION
#8570 

test output:

npx tsx test-client.ts
🧪 Testing Phoenix Client Dataset Version Support
📊 Dataset ID: RGF0YXNldDoyMA==
🔖 Version ID: RGF0YXNldFZlcnNpb246MjQ=
🌐 API Base URL: http://localhost:6006

Test 1: getDatasetExamples with versionId
✅ SUCCESS!
   Version ID returned: RGF0YXNldFZlcnNpb246MjQ=
   Number of examples: 11
   First example ID: RGF0YXNldEV4YW1wbGU6Njg=

Test 2: getDataset with versionId
✅ SUCCESS!
   Dataset ID: RGF0YXNldDoyMA==
   Dataset name: Dataset 2025-06-17T21:44:39.467Z
   Version ID: RGF0YXNldFZlcnNpb246MjQ=
   Number of examples: 11

Test 3: getDataset without versionId (should get latest)
✅ SUCCESS!
   Latest version ID: RGF0YXNldFZlcnNpb246MjQ=
   Number of examples: 11

📈 Version Comparison:
   Requested version: RGF0YXNldFZlcnNpb246MjQ=
   Latest version: RGF0YXNldFZlcnNpb246MjQ=
   Same version?: ✅ YES