### PR TITLE
ci: remove timeout from span exporter fixtures

### DIFF
--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -487,7 +487,6 @@ def _http_span_exporter(
     exporter = OTLPSpanExporter(
         endpoint=endpoint,
         headers=headers,
-        timeout=1,
         certificate_file=app.certificate_file,
         client_key_file=app.client_key_file,
         client_certificate_file=app.client_certificate_file,
@@ -506,7 +505,6 @@ def _grpc_span_exporter(
     return OTLPSpanExporter(
         endpoint=endpoint,
         headers=headers,
-        timeout=1,
         credentials=_load_credentials(
             certificate_file=app.certificate_file,
             client_key_file=app.client_key_file,


### PR DESCRIPTION
(due to what i think is an incorrect [implementation](https://github.com/open-telemetry/opentelemetry-python/blob/57cb935e88123569063df8d4e471bee62e1a3d6b/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py#L165)) this parameter can result in negative values causing the exporter to crash