### PR TITLE
refactor: migrate List component

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -204,6 +204,16 @@ module.exports = {
         module: "@arizeai/components",
         use: "import { Breadcrumb } from '@phoenix/components'",
       },
+      {
+        name: "List",
+        module: "@arizeai/components",
+        use: "import { List } from '@phoenix/components'",
+      },
+      {
+        name: "ListItem",
+        module: "@arizeai/components",
+        use: "import { ListItem } from '@phoenix/components'",
+      },
     ],
     "no-duplicate-imports": "error",
   },

--- a/app/src/components/button/IconButton.tsx
+++ b/app/src/components/button/IconButton.tsx
@@ -22,7 +22,7 @@ export interface IconButtonProps extends Omit<ButtonProps, "children"> {
    * The size of the button
    * @default 'M'
    */
-  size?: Omit<ComponentSize, "L">;
+  size?: Exclude<ComponentSize, "L">;
   /**
    * The icon to display
    */

--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -55,3 +55,4 @@ export * from "./dialog";
 export * from "./tooltip";
 export * from "./breadcrumbs";
 export * from "./progress";
+export * from "./list";

--- a/app/src/components/list/List.tsx
+++ b/app/src/components/list/List.tsx
@@ -1,14 +1,14 @@
-import { forwardRef, PropsWithChildren, Ref } from "react";
+import { forwardRef, Ref } from "react";
 
 import { listCSS } from "./styles";
 import { ListProps } from "./types";
 
 function List(
-  { listSize = "M", children }: PropsWithChildren<ListProps>,
+  { listSize = "M", children, ...otherProps }: ListProps,
   ref: Ref<HTMLUListElement>
 ) {
   return (
-    <ul ref={ref} css={listCSS} data-list-size={listSize}>
+    <ul ref={ref} css={listCSS} data-list-size={listSize} {...otherProps}>
       {children}
     </ul>
   );

--- a/app/src/components/list/List.tsx
+++ b/app/src/components/list/List.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, PropsWithChildren, Ref } from "react";
+
+import { listCSS } from "./styles";
+import { ListProps } from "./types";
+
+function List(
+  { listSize = "M", children }: PropsWithChildren<ListProps>,
+  ref: Ref<HTMLUListElement>
+) {
+  return (
+    <ul ref={ref} css={listCSS} data-list-size={listSize}>
+      {children}
+    </ul>
+  );
+}
+
+const _List = forwardRef(List);
+export { _List as List };

--- a/app/src/components/list/List.tsx
+++ b/app/src/components/list/List.tsx
@@ -4,11 +4,11 @@ import { listCSS } from "./styles";
 import { ListProps } from "./types";
 
 function List(
-  { listSize = "M", children, ...otherProps }: ListProps,
+  { size = "M", children, ...otherProps }: ListProps,
   ref: Ref<HTMLUListElement>
 ) {
   return (
-    <ul ref={ref} css={listCSS} data-list-size={listSize} {...otherProps}>
+    <ul ref={ref} css={listCSS} data-list-size={size} {...otherProps}>
       {children}
     </ul>
   );

--- a/app/src/components/list/ListItem.tsx
+++ b/app/src/components/list/ListItem.tsx
@@ -1,7 +1,14 @@
-import { forwardRef, HTMLProps } from "react";
+import { forwardRef, HTMLProps, Ref } from "react";
 
-function ListItem({ children, ...props }: HTMLProps<HTMLLIElement>) {
-  return <li {...props}>{children}</li>;
+function ListItem(
+  { children, ...props }: HTMLProps<HTMLLIElement>,
+  ref: Ref<HTMLLIElement>
+) {
+  return (
+    <li ref={ref} {...props}>
+      {children}
+    </li>
+  );
 }
 
 const _ListItem = forwardRef(ListItem);

--- a/app/src/components/list/ListItem.tsx
+++ b/app/src/components/list/ListItem.tsx
@@ -1,7 +1,7 @@
-import { forwardRef, PropsWithChildren } from "react";
+import { forwardRef, HTMLProps } from "react";
 
-function ListItem({ children }: PropsWithChildren) {
-  return <li>{children}</li>;
+function ListItem({ children, ...props }: HTMLProps<HTMLLIElement>) {
+  return <li {...props}>{children}</li>;
 }
 
 const _ListItem = forwardRef(ListItem);

--- a/app/src/components/list/ListItem.tsx
+++ b/app/src/components/list/ListItem.tsx
@@ -1,0 +1,8 @@
+import { forwardRef, PropsWithChildren } from "react";
+
+function ListItem({ children }: PropsWithChildren) {
+  return <li>{children}</li>;
+}
+
+const _ListItem = forwardRef(ListItem);
+export { _ListItem as ListItem };

--- a/app/src/components/list/index.ts
+++ b/app/src/components/list/index.ts
@@ -1,0 +1,2 @@
+export * from "./List";
+export * from "./ListItem";

--- a/app/src/components/list/styles.ts
+++ b/app/src/components/list/styles.ts
@@ -1,0 +1,17 @@
+import { css } from "@emotion/react";
+
+export const listCSS = css`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  & li {
+    position: relative;
+    padding: var(--ac-global-dimension-static-size-200);
+  }
+  &[data-list-size="S"] {
+    & li {
+      padding: var(--ac-global-dimension-static-size-100);
+    }
+  }
+`;

--- a/app/src/components/list/styles.ts
+++ b/app/src/components/list/styles.ts
@@ -8,10 +8,24 @@ export const listCSS = css`
   & li {
     position: relative;
     padding: var(--ac-global-dimension-static-size-200);
+
+    &:not(:first-of-type)::after {
+      content: " ";
+      border-top: 1px solid var(--ac-global-border-color-default);
+      position: absolute;
+      left: var(--ac-global-dimension-static-size-200);
+      right: 0;
+      top: 0;
+    }
   }
+
   &[data-list-size="S"] {
     & li {
       padding: var(--ac-global-dimension-static-size-100);
+
+      &:not(:first-of-type)::after {
+        left: var(--ac-global-dimension-static-size-100);
+      }
     }
   }
 `;

--- a/app/src/components/list/types.ts
+++ b/app/src/components/list/types.ts
@@ -5,5 +5,5 @@ export interface ListProps {
    * The size of the list
    * @default 'M'
    */
-  listSize?: Omit<ComponentSize, "L">;
+  listSize?: Exclude<ComponentSize, "L">;
 }

--- a/app/src/components/list/types.ts
+++ b/app/src/components/list/types.ts
@@ -2,10 +2,10 @@ import { HTMLProps } from "react";
 
 import { ComponentSize } from "@phoenix/components/types";
 
-export interface ListProps extends HTMLProps<HTMLUListElement> {
+export interface ListProps extends Omit<HTMLProps<HTMLUListElement>, "size"> {
   /**
    * The size of the list
    * @default 'M'
    */
-  listSize?: Exclude<ComponentSize, "L">;
+  size?: Exclude<ComponentSize, "L">;
 }

--- a/app/src/components/list/types.ts
+++ b/app/src/components/list/types.ts
@@ -1,6 +1,8 @@
+import { HTMLProps } from "react";
+
 import { ComponentSize } from "@phoenix/components/types";
 
-export interface ListProps {
+export interface ListProps extends HTMLProps<HTMLUListElement> {
   /**
    * The size of the list
    * @default 'M'

--- a/app/src/components/list/types.ts
+++ b/app/src/components/list/types.ts
@@ -1,0 +1,9 @@
+import { ComponentSize } from "@phoenix/components/types";
+
+export interface ListProps {
+  /**
+   * The size of the list
+   * @default 'M'
+   */
+  listSize?: Omit<ComponentSize, "L">;
+}

--- a/app/src/components/progress/types.ts
+++ b/app/src/components/progress/types.ts
@@ -7,7 +7,7 @@ export interface ProgressCircleProps extends ReactAriaProgressBarProps {
    * The size of the progress circle
    * @default 'M'
    */
-  size?: Omit<ComponentSize, "L">;
+  size?: Exclude<ComponentSize, "L">;
 }
 
 export interface ProgressBarProps extends ReactAriaProgressBarProps {

--- a/app/src/pages/embedding/ExportSelectionButton.tsx
+++ b/app/src/pages/embedding/ExportSelectionButton.tsx
@@ -5,7 +5,7 @@ import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
 import CodeMirror from "@uiw/react-codemirror";
 import { css } from "@emotion/react";
 
-import { Download, List, ListItem } from "@arizeai/components";
+import { Download } from "@arizeai/components";
 
 import {
   Alert,
@@ -18,6 +18,8 @@ import {
   DisclosureTrigger,
   Icon,
   Icons,
+  List,
+  ListItem,
   Loading,
   Modal,
   ModalOverlay,

--- a/app/src/pages/prompt/PromptInvocationParameters.tsx
+++ b/app/src/pages/prompt/PromptInvocationParameters.tsx
@@ -67,7 +67,7 @@ export function PromptInvocationParameters({
   }
 
   return (
-    <List listSize="S">
+    <List size="S">
       {parameters.map(({ key, value }, i) => (
         <ListItem key={`${key}-${i}`}>
           <PromptInvocationParameterItem keyName={key} value={value} />

--- a/app/src/pages/prompt/PromptInvocationParameters.tsx
+++ b/app/src/pages/prompt/PromptInvocationParameters.tsx
@@ -2,9 +2,7 @@ import { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 import isObject from "lodash/isObject";
 
-import { List, ListItem } from "@arizeai/components";
-
-import { Flex, Text, View } from "@phoenix/components";
+import { Flex, List, ListItem, Text, View } from "@phoenix/components";
 import { safelyStringifyJSON } from "@phoenix/utils/jsonUtils";
 
 import { PromptInvocationParameters__main$key } from "./__generated__/PromptInvocationParameters__main.graphql";
@@ -69,7 +67,7 @@ export function PromptInvocationParameters({
   }
 
   return (
-    <List listSize="small">
+    <List listSize="S">
       {parameters.map(({ key, value }, i) => (
         <ListItem key={`${key}-${i}`}>
           <PromptInvocationParameterItem keyName={key} value={value} />

--- a/app/src/pages/prompt/PromptLLM.tsx
+++ b/app/src/pages/prompt/PromptLLM.tsx
@@ -1,13 +1,13 @@
 import { PropsWithChildren } from "react";
 import { graphql, useFragment } from "react-relay";
 
-import { List, ListItem } from "@arizeai/components";
-
 import {
   Disclosure,
   DisclosurePanel,
   DisclosureTrigger,
   Flex,
+  List,
+  ListItem,
   Text,
   View,
 } from "@phoenix/components";
@@ -20,7 +20,7 @@ const ModelProviderItem = ({
 }: PropsWithChildren<{
   keyName: string;
 }>) => (
-  <ListItem listSize="small">
+  <ListItem>
     <View paddingStart="size-100" paddingEnd="size-100">
       <Flex direction="row" justifyContent="space-between">
         <Text size="XS" color="text-700">
@@ -50,7 +50,7 @@ export function PromptLLM({ promptVersion }: PromptLLMProps) {
     <Disclosure id="llm">
       <DisclosureTrigger>LLM</DisclosureTrigger>
       <DisclosurePanel>
-        <List listSize="small">
+        <List listSize="S">
           <ModelProviderItem keyName="Model">{data.model}</ModelProviderItem>
           <ModelProviderItem keyName="Provider">
             {ModelProviders[data.provider as ModelProvider] ?? data.provider}

--- a/app/src/pages/prompt/PromptLLM.tsx
+++ b/app/src/pages/prompt/PromptLLM.tsx
@@ -50,7 +50,7 @@ export function PromptLLM({ promptVersion }: PromptLLMProps) {
     <Disclosure id="llm">
       <DisclosureTrigger>LLM</DisclosureTrigger>
       <DisclosurePanel>
-        <List listSize="S">
+        <List size="S">
           <ModelProviderItem keyName="Model">{data.model}</ModelProviderItem>
           <ModelProviderItem keyName="Provider">
             {ModelProviders[data.provider as ModelProvider] ?? data.provider}

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -22,8 +22,6 @@ import {
   Content,
   ContextualHelp,
   EmptyGraphic,
-  List,
-  ListItem,
   TabbedCard,
 } from "@arizeai/components";
 import {
@@ -56,6 +54,8 @@ import {
   Keyboard,
   LazyTabPanel,
   LinkButton,
+  List,
+  ListItem,
   Loading,
   Modal,
   ModalOverlay,

--- a/app/stories/List.stories.tsx
+++ b/app/stories/List.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { List, ListItem } from "@phoenix/components";
+
+const meta: Meta<typeof List> = {
+  title: "List",
+  component: List,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    listSize: {
+      control: { type: "select" },
+      options: ["S", "M"],
+      description: "The size of the list items",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default list with medium size
+ */
+export const Default: Story = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem>First item</ListItem>
+      <ListItem>Second item</ListItem>
+      <ListItem>Third item</ListItem>
+    </List>
+  ),
+  args: {
+    listSize: "M",
+  },
+};
+
+/**
+ * List with small size for more compact display
+ */
+export const Small: Story = {
+  render: (args) => (
+    <List {...args}>
+      <ListItem>First item</ListItem>
+      <ListItem>Second item</ListItem>
+      <ListItem>Third item</ListItem>
+    </List>
+  ),
+  args: {
+    listSize: "S",
+  },
+};

--- a/app/stories/List.stories.tsx
+++ b/app/stories/List.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof List> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    listSize: {
+    size: {
       control: { type: "select" },
       options: ["S", "M"],
       description: "The size of the list items",
@@ -26,14 +26,14 @@ type Story = StoryObj<typeof meta>;
  */
 export const Default: Story = {
   render: (args) => (
-    <List {...args}>
+    <List {...args} style={{ color: "var(--ac-global-text-color-900)" }}>
       <ListItem>First item</ListItem>
       <ListItem>Second item</ListItem>
       <ListItem>Third item</ListItem>
     </List>
   ),
   args: {
-    listSize: "M",
+    size: "M",
   },
 };
 
@@ -42,13 +42,13 @@ export const Default: Story = {
  */
 export const Small: Story = {
   render: (args) => (
-    <List {...args}>
+    <List {...args} style={{ color: "var(--ac-global-text-color-900)" }}>
       <ListItem>First item</ListItem>
       <ListItem>Second item</ListItem>
       <ListItem>Third item</ListItem>
     </List>
   ),
   args: {
-    listSize: "S",
+    size: "S",
   },
 };


### PR DESCRIPTION
This adds a new List component to replace the old one from @arize/components. I only copied over the variants we're currently using, which include a small and medium size list. Other than that, all the styles are copied over from the old component. The only differences are:

- renamed sizing from small/default to S/M to better align with Phoenix's sizing conventions
- removed listSize prop from ListItem. since ListItem inherits its sizing from List, I thought it would be best to have one spot to specify list sizing to keep things simple and reduce ambiguity.


#### Prompts page: model config
Both the "LLM" and "Invocation parameters" section are each their own List.

before:
<img width="864" height="459" alt="image" src="https://github.com/user-attachments/assets/0241947a-0abe-4fe0-b71c-1c01871d169b" />


after:
<img width="864" height="459" alt="image" src="https://github.com/user-attachments/assets/97b35566-36e7-4ec9-8d0a-a39ed3dc98bf" />


#### Embeddings page: cluster exports list

before:
<img width="703" height="448" alt="image" src="https://github.com/user-attachments/assets/0f16e9f2-396a-447a-b7eb-278a33f8f3fa" />

after:
<img width="703" height="448" alt="image" src="https://github.com/user-attachments/assets/c6a45b7d-bd2d-4fb0-9d2f-ab7ca637660c" />

#### Span details: events list

before:
<img width="558" height="269" alt="image" src="https://github.com/user-attachments/assets/a521182a-3542-4816-aa5d-93b295d28598" />

after:
<img width="558" height="269" alt="image" src="https://github.com/user-attachments/assets/50b3389a-0440-446e-815b-48f4ed87d551" />

