### PR TITLE
feat(evals): return exact token-usage via `include_token_usage` flag in `llm_classify`

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/classify.py
@@ -105,6 +105,7 @@ def llm_classify(
     provide_explanation: bool = False,
     include_prompt: bool = False,
     include_response: bool = False,
+    include_token_usage: bool = False,
     include_exceptions: bool = False,
     max_retries: int = 10,
     exit_on_error: bool = True,

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -147,7 +147,7 @@ class AnthropicModel(BaseModel):
             **invocation_parameters,
         )
 
-        usage = getattr(response, "usage", None)
+        usage = response.get("usage", None)
 
         if usage is not None:
             input_tokens = usage.get("input_tokens", 0)
@@ -209,7 +209,7 @@ class AnthropicModel(BaseModel):
             **invocation_parameters,
         )
 
-        usage = getattr(response, "usage", None)
+        usage = response.get("usage", None)
 
         if usage is not None:
             input_tokens = usage.get("input_tokens", 0)

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -132,7 +132,7 @@ class AnthropicModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         # instruction is an invalid input to Anthropic models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         if isinstance(prompt, str):
@@ -194,7 +194,7 @@ class AnthropicModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         # instruction is an invalid input to Anthropic models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         if isinstance(prompt, str):

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Generator, Optional, Sequence, Tuple
+from typing import Any, Dict, Generator, Optional, Sequence, Tuple
 
 from typing_extensions import TypeVar, Union
 
@@ -97,13 +97,17 @@ class BaseModel(ABC):
     def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Any) -> str:
         raise NotImplementedError
 
-    async def _async_generate_with_meta(self, *args, **kwds) -> Tuple[str, Optional[dict]]:
+    async def _async_generate_with_meta(
+        self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         """Default shim — subclasses return (text, usage_dict)."""
-        return await self._async_generate(*args, **kwds), None
+        return await self._async_generate(prompt=prompt, **kwargs), None
 
-    def _generate_with_meta(self, *args, **kwds) -> Tuple[str, Optional[dict]]:
+    def _generate_with_meta(
+        self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         """Sync version."""
-        return self._generate(*args, **kwds), None
+        return self._generate(prompt=prompt, **kwargs), None
 
     @staticmethod
     def _raise_import_error(

--- a/packages/phoenix-evals/src/phoenix/evals/models/base.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Generator, Optional, Sequence
+from typing import Any, Generator, Optional, Sequence, Tuple
 
 from typing_extensions import TypeVar, Union
 
@@ -96,6 +96,14 @@ class BaseModel(ABC):
     @abstractmethod
     def _generate(self, prompt: Union[str, MultimodalPrompt], **kwargs: Any) -> str:
         raise NotImplementedError
+
+    async def _async_generate_with_meta(self, *args, **kwds) -> Tuple[str, Optional[dict]]:
+        """Default shim — subclasses return (text, usage_dict)."""
+        return await self._async_generate(*args, **kwds), None
+
+    def _generate_with_meta(self, *args, **kwds) -> Tuple[str, Optional[dict]]:
+        """Sync version."""
+        return self._generate(*args, **kwds), None
 
     @staticmethod
     def _raise_import_error(

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -134,7 +134,7 @@ class BedrockModel(BaseModel):
         body = self._create_request_body(prompt)
         response = self._rate_limited_completion(**body)
 
-        usage = getattr(response, "usage", None)
+        usage = response.get("usage", None)
 
         if usage is not None:
             input_tokens = usage.get("inputTokens", 0)

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -123,7 +123,7 @@ class BedrockModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         # the legacy "instruction" parameter from llm_classify is intended to indicate a
         # system instruction, but not all models supported by Bedrock support system instructions
         _ = kwargs.pop("instruction", None)
@@ -159,7 +159,7 @@ class BedrockModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
@@ -114,7 +114,7 @@ class LiteLLMModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 
@@ -139,7 +139,7 @@ class LiteLLMModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/litellm.py
@@ -154,7 +154,7 @@ class LiteLLMModel(BaseModel):
             request_timeout=self.request_timeout,
             **self.model_kwargs,
         )
-        return str(response.choices[0].message.content), getattr(response, "usage", None)
+        return str(response.choices[0].message.content), response.get("usage", None)
 
     def _get_messages_from_prompt(self, prompt: MultimodalPrompt) -> List[Dict[str, str]]:
         # LiteLLM requires prompts in the format of messages

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -121,7 +121,7 @@ class MistralAIModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 
@@ -177,7 +177,7 @@ class MistralAIModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -136,7 +136,7 @@ class MistralAIModel(BaseModel):
             **invocation_parameters,
         )
 
-        return str(response), getattr(response, "usage", None)
+        return str(response), response.get("usage", None)
 
     def _rate_limited_completion(self, **kwargs: Any) -> Any:
         @self._rate_limiter.limit
@@ -192,7 +192,7 @@ class MistralAIModel(BaseModel):
             **invocation_parameters,
         )
 
-        return str(response), getattr(response, "usage", None)
+        return str(response), response.get("usage", None)
 
     async def _async_rate_limited_completion(self, **kwargs: Any) -> Any:
         @self._rate_limiter.alimit

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -398,11 +398,11 @@ class OpenAIModel(BaseModel):
         )
         choice = response["choices"][0]
         if self._model_uses_legacy_completion_api:
-            return str(choice["text"])
+            return str(choice["text"]), response.get("usage", None)
         message = choice["message"]
         if function_call := message.get("function_call"):
-            return str(function_call.get("arguments") or "")
-        return str(message["content"]), getattr(response, "usage", None)
+            return str(function_call.get("arguments") or ""), response.get("usage", None)
+        return str(message["content"]), response.get("usage", None)
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
@@ -422,11 +422,11 @@ class OpenAIModel(BaseModel):
         )
         choice = response["choices"][0]
         if self._model_uses_legacy_completion_api:
-            return str(choice["text"])
+            return str(choice["text"]), response.get("usage", None)
         message = choice["message"]
         if function_call := message.get("function_call"):
-            return str(function_call.get("arguments") or "")
-        return str(message["content"]), getattr(response, "usage", None)
+            return str(function_call.get("arguments") or ""), response.get("usage", None)
+        return str(message["content"]), response.get("usage", None)
 
     async def _async_rate_limited_completion(self, **kwargs: Any) -> Any:
         @self._rate_limiter.alimit

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -382,7 +382,7 @@ class OpenAIModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 
@@ -406,7 +406,7 @@ class OpenAIModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Any
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         if isinstance(prompt, str):
             prompt = MultimodalPrompt.from_string(prompt)
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
@@ -193,7 +193,7 @@ class GeminiModel(BaseModel):
             **kwargs,
         )
 
-        usage = getattr(response, "usageMetadata", None)
+        usage = response.get("usage", None)
 
         if usage is not None:
             input_tokens = usage.get("promptTokenCount", 0)
@@ -259,7 +259,7 @@ class GeminiModel(BaseModel):
             **kwargs,
         )
 
-        usage = getattr(response, "usageMetadata", None)
+        usage = response.get("usage", None)
 
         if usage is not None:
             input_tokens = usage.get("promptTokenCount", 0)

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
@@ -169,7 +169,7 @@ class GeminiModel(BaseModel):
 
     def _generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         # instruction is an invalid input to Gemini models, it is passed in by
         # BaseEvalModel.__call__ and needs to be removed
         kwargs.pop("instruction", None)
@@ -237,7 +237,7 @@ class GeminiModel(BaseModel):
 
     async def _async_generate_with_meta(
         self, prompt: Union[str, MultimodalPrompt], **kwargs: Dict[str, Any]
-    ) -> Tuple[str, Optional[dict]]:
+    ) -> Tuple[str, Optional[Dict[str, int]]]:
         kwargs.pop("instruction", None)
 
         if isinstance(prompt, str):

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -4,6 +4,7 @@ from typing import List
 from unittest.mock import MagicMock, patch
 
 import httpx
+import numpy as np
 import pandas as pd
 import pytest
 import respx
@@ -1684,3 +1685,87 @@ def test_llm_classify_cot(openai_api_key: str) -> None:
         )
         assert result["label"].iloc[0] == "not correct"
         assert NOT_PARSABLE not in result["label"].tolist()
+
+
+def _patch_usage(model, prompt_tokens: int | None, completion_tokens: int | None):
+    """
+    Helper: monkey-patch both sync & async meta generators on `model`
+    so they return a deterministic usage payload.
+    """
+    usage_dict = (
+        None
+        if prompt_tokens is None and completion_tokens is None
+        else {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": (prompt_tokens or 0) + (completion_tokens or 0),
+        }
+    )
+
+    return (
+        patch.object(model, "_generate_with_meta", return_value=("relevant", usage_dict)),
+        patch.object(
+            model,
+            "_async_generate_with_meta",
+            return_value=("relevant", usage_dict),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "include_flag,prompt_toks,comp_toks,expect_cols,expect_total_nan",
+    [
+        # ideal-path: flag ON + provider supplies counts
+        (True, 7, 5, True, False),
+        #  flag OFF  →  no columns even if provider supplies counts
+        (False, 7, 5, False, None),  # expect_cols=False, expect_total_nan unused
+        #  flag ON but provider returns None  →  cols present, NaNs inside
+        (True, None, None, True, True),
+    ],
+    ids=["flag_on_with_counts", "flag_off", "flag_on_no_counts"],
+)
+def test_llm_classify_token_usage_columns(
+    include_flag: bool,
+    prompt_toks: int | None,
+    comp_toks: int | None,
+    expect_cols: bool,
+    expect_total_nan: bool | None,
+):
+    """
+    Covers three scenarios:
+
+    • include_token_usage=True  w/ real counts
+    • include_token_usage=False (default)
+    • include_token_usage=True  but provider doesn't return usage
+    """
+    model = OpenAIModel()
+    dataframe = pd.DataFrame([{"input": "X", "reference": "Y"}])
+
+    with ExitStack() as stack:
+        for ctx in _patch_usage(model, prompt_toks, comp_toks):
+            stack.enter_context(ctx)
+
+        out = llm_classify(
+            data=dataframe,
+            template=RAG_RELEVANCY_PROMPT_TEMPLATE,
+            model=model,
+            rails=["relevant", "unrelated"],
+            include_token_usage=include_flag,
+            run_sync=True,  # avoid event-loop edge-cases in unit test
+            use_function_calling_if_available=False,
+        )
+
+    cols_present = {"prompt_tokens", "completion_tokens", "total_tokens"} <= set(out.columns)
+    assert cols_present is expect_cols, "column presence mismatch"
+
+    if not expect_cols:
+        return
+
+    if expect_total_nan:
+        assert np.isnan(out.loc[0, "prompt_tokens"])
+        assert np.isnan(out.loc[0, "completion_tokens"])
+        assert out.loc[0, "total_tokens"] == 0
+    else:
+        assert out.loc[0, "prompt_tokens"] == prompt_toks
+        assert out.loc[0, "completion_tokens"] == comp_toks
+        assert out.loc[0, "total_tokens"] == prompt_toks + comp_toks


### PR DESCRIPTION
`fixes #8666`

### What and why

`llm_classify` previously returned only the LLM’s text response.
Downstream users had to approximate prompt and completion token counts for billing or performance analysis.
This change adds an optional `include_token_usage` flag so callers can request exact counts reported by the provider.

### Implementation details

* **Model layer**

  * Added `_generate_with_meta` and `_async_generate_with_meta` to `BaseModel`.
  * Implemented both methods in `OpenAIModel`, returning `(text, usage_dict)`.
* **Classification flow**

  * Extended `llm_classify` signature with `include_token_usage: bool = False`.
  * When the flag is `True`, the result DataFrame gains three columns:

    * `prompt_tokens`
    * `completion_tokens`
    * `total_tokens`
* **Tests**

  * New tests verify:

    * correct counts when the flag is on
    * absence of columns when the flag is off
    * graceful handling when a provider supplies no usage data.