### PR TITLE
feat: add tooltips to tops bar charts

### DIFF
--- a/app/src/pages/project/TopModelsByCost.tsx
+++ b/app/src/pages/project/TopModelsByCost.tsx
@@ -6,11 +6,16 @@ import {
   CartesianGrid,
   Legend,
   ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
 
+import { Text } from "@phoenix/components";
 import {
+  ChartTooltip,
+  ChartTooltipItem,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultXAxisProps,
@@ -19,6 +24,44 @@ import {
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
 import type { TopModelsByCostQuery } from "@phoenix/pages/project/__generated__/TopModelsByCostQuery.graphql";
+import { costFormatter } from "@phoenix/utils/numberFormatUtils";
+
+function TooltipContent({
+  active,
+  payload,
+  label,
+}: TooltipContentProps<number, string>) {
+  const colors = useCategoryChartColors();
+
+  if (active && payload && payload.length) {
+    const promptCost = payload[0]?.value ?? null;
+    const completionCost = payload[1]?.value ?? null;
+
+    return (
+      <ChartTooltip>
+        {label && (
+          <Text weight="heavy" size="S">
+            {label}
+          </Text>
+        )}
+        <ChartTooltipItem
+          color={colors.category1}
+          shape="circle"
+          name="Prompt cost"
+          value={costFormatter(promptCost)}
+        />
+        <ChartTooltipItem
+          color={colors.category2}
+          shape="circle"
+          name="Completion cost"
+          value={costFormatter(completionCost)}
+        />
+      </ChartTooltip>
+    );
+  }
+
+  return null;
+}
 
 export function TopModelsByCost({ projectId }: { projectId: string }) {
   const { timeRange } = useTimeRange();
@@ -78,6 +121,11 @@ export function TopModelsByCost({ projectId }: { projectId: string }) {
         barSize={6}
       >
         <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+        <Tooltip
+          content={TooltipContent}
+          // TODO formalize this
+          cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+        />
         <XAxis
           {...defaultXAxisProps}
           type="number"

--- a/app/src/pages/project/TopModelsByToken.tsx
+++ b/app/src/pages/project/TopModelsByToken.tsx
@@ -6,11 +6,16 @@ import {
   CartesianGrid,
   Legend,
   ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
   XAxis,
   YAxis,
 } from "recharts";
 
+import { Text } from "@phoenix/components";
 import {
+  ChartTooltip,
+  ChartTooltipItem,
   defaultCartesianGridProps,
   defaultLegendProps,
   defaultXAxisProps,
@@ -19,6 +24,44 @@ import {
 } from "@phoenix/components/chart";
 import { useTimeRange } from "@phoenix/components/datetime";
 import type { TopModelsByTokenQuery } from "@phoenix/pages/project/__generated__/TopModelsByTokenQuery.graphql";
+import { intFormatter } from "@phoenix/utils/numberFormatUtils";
+
+function TooltipContent({
+  active,
+  payload,
+  label,
+}: TooltipContentProps<number, string>) {
+  const colors = useCategoryChartColors();
+
+  if (active && payload && payload.length) {
+    const promptTokens = payload[0]?.value ?? null;
+    const completionTokens = payload[1]?.value ?? null;
+
+    return (
+      <ChartTooltip>
+        {label && (
+          <Text weight="heavy" size="S">
+            {label}
+          </Text>
+        )}
+        <ChartTooltipItem
+          color={colors.category1}
+          shape="circle"
+          name="Prompt tokens"
+          value={intFormatter(promptTokens)}
+        />
+        <ChartTooltipItem
+          color={colors.category2}
+          shape="circle"
+          name="Completion tokens"
+          value={intFormatter(completionTokens)}
+        />
+      </ChartTooltip>
+    );
+  }
+
+  return null;
+}
 
 export function TopModelsByToken({ projectId }: { projectId: string }) {
   const { timeRange } = useTimeRange();
@@ -80,6 +123,11 @@ export function TopModelsByToken({ projectId }: { projectId: string }) {
         barSize={6}
       >
         <CartesianGrid {...defaultCartesianGridProps} vertical={false} />
+        <Tooltip
+          content={TooltipContent}
+          // TODO formalize this
+          cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
+        />
         <XAxis {...defaultXAxisProps} type="number" tickLine={false} />
         <YAxis
           {...defaultYAxisProps}


### PR DESCRIPTION
Adds tooltips to TopModelsByCost and TopModelsByToken bar charts

<img width="516" height="289" alt="image" src="https://github.com/user-attachments/assets/fb371681-3fd6-4bb8-af36-55b7ad446114" />

<img width="516" height="289" alt="image" src="https://github.com/user-attachments/assets/34dbe140-00c0-44e2-9ffc-cb09e80b7894" />
