### PR TITLE
fix: format x axis labels on tops bar charts consistently with tooltips

### DIFF
--- a/app/src/pages/project/TopModelsByCost.tsx
+++ b/app/src/pages/project/TopModelsByCost.tsx
@@ -130,7 +130,7 @@ export function TopModelsByCost({ projectId }: { projectId: string }) {
           {...defaultXAxisProps}
           type="number"
           tickLine={false}
-          tickFormatter={(value) => `$${value}`}
+          tickFormatter={costFormatter}
         />
         <YAxis
           {...defaultYAxisProps}

--- a/app/src/pages/project/TopModelsByToken.tsx
+++ b/app/src/pages/project/TopModelsByToken.tsx
@@ -128,7 +128,12 @@ export function TopModelsByToken({ projectId }: { projectId: string }) {
           // TODO formalize this
           cursor={{ fill: "var(--chart-tooltip-cursor-fill-color)" }}
         />
-        <XAxis {...defaultXAxisProps} type="number" tickLine={false} />
+        <XAxis
+          {...defaultXAxisProps}
+          type="number"
+          tickLine={false}
+          tickFormatter={intFormatter}
+        />
         <YAxis
           {...defaultYAxisProps}
           dataKey="model"


### PR DESCRIPTION
This updates the `tickFormatter` used on the tops bar charts x-axes to be consistent with the formatting used in the tooltips.

<img width="1632" height="350" alt="image" src="https://github.com/user-attachments/assets/e9f389b2-a19c-4186-8836-8af9b584bf98" />
