### PR TITLE
fix: sql group by clause in query for top models

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1358,7 +1358,7 @@ class Project(Node):
                 .where(models.Trace.project_rowid == self.project_rowid)
                 .where(models.SpanCost.model_id.isnot(None))
                 .where(models.SpanCost.span_start_time >= time_range.start)
-                .group_by(models.SpanCost.model_id)
+                .group_by(models.GenerativeModel)
                 .order_by(func.sum(models.SpanCost.total_cost).desc())
             )
             if time_range.end:
@@ -1420,7 +1420,7 @@ class Project(Node):
                 .where(models.Trace.project_rowid == self.project_rowid)
                 .where(models.SpanCost.model_id.isnot(None))
                 .where(models.SpanCost.span_start_time >= time_range.start)
-                .group_by(models.SpanCost.model_id)
+                .group_by(models.GenerativeModel)
                 .order_by(func.sum(models.SpanCost.total_tokens).desc())
             )
             if time_range.end:

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1358,7 +1358,7 @@ class Project(Node):
                 .where(models.Trace.project_rowid == self.project_rowid)
                 .where(models.SpanCost.model_id.isnot(None))
                 .where(models.SpanCost.span_start_time >= time_range.start)
-                .group_by(models.GenerativeModel)
+                .group_by(models.GenerativeModel.id)
                 .order_by(func.sum(models.SpanCost.total_cost).desc())
             )
             if time_range.end:
@@ -1420,7 +1420,7 @@ class Project(Node):
                 .where(models.Trace.project_rowid == self.project_rowid)
                 .where(models.SpanCost.model_id.isnot(None))
                 .where(models.SpanCost.span_start_time >= time_range.start)
-                .group_by(models.GenerativeModel)
+                .group_by(models.GenerativeModel.id)
                 .order_by(func.sum(models.SpanCost.total_tokens).desc())
             )
             if time_range.end:


### PR DESCRIPTION
Fix GraphQL error on metrics page by correcting SQL GROUP BY clause for `GenerativeModel` objects.

The `top_models_by_cost` and `top_models_by_token_count` queries were selecting all columns from `generative_models` but only grouping by `model_id`, leading to a SQL GROUP BY violation. Changing the `group_by` to `models.GenerativeModel` ensures all selected columns are properly grouped, resolving the error.

---

[Slack Thread](https://arize-ai.slack.com/archives/C04QMRADE1L/p1753491639153009?thread_ts=1753491639.153009&cid=C04QMRADE1L) • [Open in Web](https://cursor.com/agents?id=bc-f7e946d8-4c54-4ea9-a314-9b53fc2f197a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f7e946d8-4c54-4ea9-a314-9b53fc2f197a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)