### PR TITLE
fix: Add error boundaries to project metrics

### DIFF
--- a/app/src/pages/project/metrics/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/metrics/ProjectMetricsPage.tsx
@@ -157,10 +157,7 @@ export function ProjectMetricsPage() {
             title="Traces over time"
             subtitle="Overall volume of traces"
           >
-            <TraceCountTimeSeries
-              projectId={projectId}
-              timeRange={timeRange}
-            />
+            <TraceCountTimeSeries projectId={projectId} timeRange={timeRange} />
           </MetricPanel>
           <MetricPanel
             title="Traces with errors"
@@ -232,10 +229,7 @@ export function ProjectMetricsPage() {
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
-          <MetricPanel
-            title="Tool spans"
-            subtitle="Tool span count over time"
-          >
+          <MetricPanel title="Tool spans" subtitle="Tool span count over time">
             <ToolSpanCountTimeSeries
               projectId={projectId}
               timeRange={timeRange}

--- a/app/src/pages/project/metrics/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/metrics/ProjectMetricsPage.tsx
@@ -136,122 +136,144 @@ export function ProjectMetricsPage() {
         overflow-y: auto;
       `}
     >
-      <ErrorBoundary>
-        {isOpenTimeRange && (
-          <Alert variant="info" banner title="Time Range Adjusted">
-            {`This view does not support open-ended time ranges. Your time range has
+      {isOpenTimeRange && (
+        <Alert variant="info" banner title="Time Range Adjusted">
+          {`This view does not support open-ended time ranges. Your time range has
           been set to ${fullTimeFormatter(timeRange.start)} to ${fullTimeFormatter(timeRange.end)}`}
-          </Alert>
-        )}
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            gap: var(--ac-global-dimension-size-200);
-            padding: var(--ac-global-dimension-size-200);
-          `}
-        >
-          <Flex direction="row" gap="size-200">
-            <MetricPanel
-              title="Traces over time"
-              subtitle="Overall volume of traces"
-            >
+        </Alert>
+      )}
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: var(--ac-global-dimension-size-200);
+          padding: var(--ac-global-dimension-size-200);
+        `}
+      >
+        <Flex direction="row" gap="size-200">
+          <MetricPanel
+            title="Traces over time"
+            subtitle="Overall volume of traces"
+          >
+            <ErrorBoundary>
               <TraceCountTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel
-              title="Traces with errors"
-              subtitle="Overall volume of traces with errors"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel
+            title="Traces with errors"
+            subtitle="Overall volume of traces with errors"
+          >
+            <ErrorBoundary>
               <TraceErrorsTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-          </Flex>
-          <Flex direction="row" gap="size-200">
-            <MetricPanel title="Trace Latency" subtitle="Latency percentiles">
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+        <Flex direction="row" gap="size-200">
+          <MetricPanel title="Trace Latency" subtitle="Latency percentiles">
+            <ErrorBoundary>
               <TraceLatencyPercentilesTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel
-              title="Annotation scores"
-              subtitle="Average annotation scores"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel
+            title="Annotation scores"
+            subtitle="Average annotation scores"
+          >
+            <ErrorBoundary>
               <SpanAnnotationScoreTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-          </Flex>
-          <Flex direction="row" gap="size-200">
-            <MetricPanel title="Cost" subtitle="Estimated cost in USD">
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+        <Flex direction="row" gap="size-200">
+          <MetricPanel title="Cost" subtitle="Estimated cost in USD">
+            <ErrorBoundary>
               <TraceTokenCostTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel title="Top models by cost">
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel title="Top models by cost">
+            <ErrorBoundary>
               <TopModelsByCost projectId={projectId} timeRange={timeRange} />
-            </MetricPanel>
-          </Flex>
-          <Flex direction="row" gap="size-200">
-            <MetricPanel
-              title="Token usage"
-              subtitle="Token usage by prompt and completion"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+        <Flex direction="row" gap="size-200">
+          <MetricPanel
+            title="Token usage"
+            subtitle="Token usage by prompt and completion"
+          >
+            <ErrorBoundary>
               <TraceTokenCountTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel title="Top models by tokens">
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel title="Top models by tokens">
+            <ErrorBoundary>
               <TopModelsByToken projectId={projectId} timeRange={timeRange} />
-            </MetricPanel>
-          </Flex>
-          <Flex direction="row" gap="size-200">
-            <MetricPanel title="LLM spans" subtitle="LLM span count over time">
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+        <Flex direction="row" gap="size-200">
+          <MetricPanel title="LLM spans" subtitle="LLM span count over time">
+            <ErrorBoundary>
               <LLMSpanCountTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel
-              title="LLM spans with errors"
-              subtitle="LLM spans with errors over time"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel
+            title="LLM spans with errors"
+            subtitle="LLM spans with errors over time"
+          >
+            <ErrorBoundary>
               <LLMSpanErrorsTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-          </Flex>
-          <Flex direction="row" gap="size-200">
-            <MetricPanel
-              title="Tool spans"
-              subtitle="Tool span count over time"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+        <Flex direction="row" gap="size-200">
+          <MetricPanel
+            title="Tool spans"
+            subtitle="Tool span count over time"
+          >
+            <ErrorBoundary>
               <ToolSpanCountTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-            <MetricPanel
-              title="Tool spans with errors"
-              subtitle="Tool spans with errors over time"
-            >
+            </ErrorBoundary>
+          </MetricPanel>
+          <MetricPanel
+            title="Tool spans with errors"
+            subtitle="Tool spans with errors over time"
+          >
+            <ErrorBoundary>
               <ToolSpanErrorsTimeSeries
                 projectId={projectId}
                 timeRange={timeRange}
               />
-            </MetricPanel>
-          </Flex>
-        </div>
-      </ErrorBoundary>
+            </ErrorBoundary>
+          </MetricPanel>
+        </Flex>
+      </div>
     </main>
   );
 }

--- a/app/src/pages/project/metrics/ProjectMetricsPage.tsx
+++ b/app/src/pages/project/metrics/ProjectMetricsPage.tsx
@@ -93,7 +93,9 @@ export const MetricPanel = forwardRef(function MetricPanel(
             height: 190px;
           `}
         >
-          <Suspense fallback={<Loading />}>{children}</Suspense>
+          <ErrorBoundary>
+            <Suspense fallback={<Loading />}>{children}</Suspense>
+          </ErrorBoundary>
         </div>
       </div>
     </View>
@@ -155,59 +157,47 @@ export function ProjectMetricsPage() {
             title="Traces over time"
             subtitle="Overall volume of traces"
           >
-            <ErrorBoundary>
-              <TraceCountTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <TraceCountTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel
             title="Traces with errors"
             subtitle="Overall volume of traces with errors"
           >
-            <ErrorBoundary>
-              <TraceErrorsTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <TraceErrorsTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
           <MetricPanel title="Trace Latency" subtitle="Latency percentiles">
-            <ErrorBoundary>
-              <TraceLatencyPercentilesTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <TraceLatencyPercentilesTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel
             title="Annotation scores"
             subtitle="Average annotation scores"
           >
-            <ErrorBoundary>
-              <SpanAnnotationScoreTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <SpanAnnotationScoreTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
           <MetricPanel title="Cost" subtitle="Estimated cost in USD">
-            <ErrorBoundary>
-              <TraceTokenCostTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <TraceTokenCostTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel title="Top models by cost">
-            <ErrorBoundary>
-              <TopModelsByCost projectId={projectId} timeRange={timeRange} />
-            </ErrorBoundary>
+            <TopModelsByCost projectId={projectId} timeRange={timeRange} />
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
@@ -215,38 +205,30 @@ export function ProjectMetricsPage() {
             title="Token usage"
             subtitle="Token usage by prompt and completion"
           >
-            <ErrorBoundary>
-              <TraceTokenCountTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <TraceTokenCountTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel title="Top models by tokens">
-            <ErrorBoundary>
-              <TopModelsByToken projectId={projectId} timeRange={timeRange} />
-            </ErrorBoundary>
+            <TopModelsByToken projectId={projectId} timeRange={timeRange} />
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
           <MetricPanel title="LLM spans" subtitle="LLM span count over time">
-            <ErrorBoundary>
-              <LLMSpanCountTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <LLMSpanCountTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel
             title="LLM spans with errors"
             subtitle="LLM spans with errors over time"
           >
-            <ErrorBoundary>
-              <LLMSpanErrorsTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <LLMSpanErrorsTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
         </Flex>
         <Flex direction="row" gap="size-200">
@@ -254,23 +236,19 @@ export function ProjectMetricsPage() {
             title="Tool spans"
             subtitle="Tool span count over time"
           >
-            <ErrorBoundary>
-              <ToolSpanCountTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <ToolSpanCountTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
           <MetricPanel
             title="Tool spans with errors"
             subtitle="Tool spans with errors over time"
           >
-            <ErrorBoundary>
-              <ToolSpanErrorsTimeSeries
-                projectId={projectId}
-                timeRange={timeRange}
-              />
-            </ErrorBoundary>
+            <ToolSpanErrorsTimeSeries
+              projectId={projectId}
+              timeRange={timeRange}
+            />
           </MetricPanel>
         </Flex>
       </div>

--- a/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
+++ b/app/src/pages/project/metrics/SpanAnnotationScoreTimeSeries.tsx
@@ -167,7 +167,6 @@ export function SpanAnnotationScoreTimeSeries({
           dataKey="timestamp"
           tickFormatter={(x) => timeTickFormatter(x)}
           interval={interval}
-          padding={{ left: 50, right: 50 }}
         />
         <YAxis
           width={55}

--- a/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
+++ b/app/src/pages/project/metrics/TraceLatencyPercentilesTimeSeries.tsx
@@ -167,7 +167,6 @@ export function TraceLatencyPercentilesTimeSeries({
           {...defaultXAxisProps}
           dataKey="timestamp"
           interval={interval}
-          padding={{ left: 50, right: 50 }}
           tickFormatter={(x) => timeTickFormatter(x)}
         />
         <YAxis


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add individual error boundaries to each metric on the ProjectMetrics page and remove the top-level boundary to prevent single metric failures from crashing the entire page.

---

[Slack Thread](https://arize-ai.slack.com/archives/C04QMRADE1L/p1753491816465649?thread_ts=1753491816.465649&cid=C04QMRADE1L) • [Open in Web](https://cursor.com/agents?id=bc-ec9984a1-5242-47c9-b6f2-586724be494c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ec9984a1-5242-47c9-b6f2-586724be494c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)