### PR TITLE
feat: generate classification primitive

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/__init__.py
@@ -1,3 +1,3 @@
-from .wrapper import LLM, AsyncLLM, generate_classification_schema, show_provider_availability
+from .wrapper import LLM, AsyncLLM, show_provider_availability
 
-__all__ = ["LLM", "AsyncLLM", "show_provider_availability", "generate_classification_schema"]
+__all__ = ["LLM", "AsyncLLM", "show_provider_availability"]

--- a/packages/phoenix-evals/src/phoenix/evals/llm/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/__init__.py
@@ -1,3 +1,3 @@
-from .wrapper import LLM, AsyncLLM, show_provider_availability
+from .wrapper import LLM, AsyncLLM, generate_classification_schema, show_provider_availability
 
-__all__ = ["LLM", "AsyncLLM", "show_provider_availability"]
+__all__ = ["LLM", "AsyncLLM", "show_provider_availability", "generate_classification_schema"]

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -30,9 +30,10 @@ class LLMBase:
             )
 
         if by_provider:
-            # At this point, provider is guaranteed to be non-None due to by_provider check
-            provider_str: str = provider  # type: ignore
-            provider_registrations = PROVIDER_REGISTRY.get_provider_registrations(provider_str)
+            if provider is None:
+                raise ValueError("Provider must be specified for provider-based initialization")
+
+            provider_registrations = PROVIDER_REGISTRY.get_provider_registrations(provider)
             if not provider_registrations:
                 raise ValueError(f"Unknown provider '{provider}'. {adapter_availability_table()}")
 

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -127,7 +127,7 @@ class LLM(LLMBase):
     def generate_classification(
         self,
         prompt: Union[str, MultimodalPrompt],
-        labels: List[Union[Dict[str, str], str]],
+        labels: Union[List[str], Dict[str, str]],
         include_explanation: bool = True,
         description: Optional[str] = None,
         **kwargs: Any,
@@ -137,18 +137,30 @@ class LLM(LLMBase):
 
         Args:
             prompt: The prompt template to go with the tool call.
-            labels (list of dict or str): A list of labels OR a dictionary of labels and their
-                descriptions.
-                If list of strings, each string is a label.
-                If list of dicts, each dict represents a label and may contain:
-                    - 'name' (str): the label's constant value (required)
-                    - 'description' (str): a description for the label (optional)
+            labels: Either:
+                - A list of strings, where each string is a label
+                - A dictionary where keys are labels and values are descriptions
             include_explanation: Whether to prompt the LLM for an explanation.
             description: A description of the classification task.
             **kwargs: Additional keyword arguments to pass to the LLM SDK.
 
         Returns:
             The generated classification.
+
+        Examples:
+            >>> from phoenix.evals.llm import LLM
+            >>> llm = LLM(provider="openai", model="gpt-4o", client="openai")
+            >>> llm.generate_classification(
+            ...     prompt="Hello, world!",
+            ...     labels=["yes", "no"],
+            ... )
+            {"label": "yes", "explanation": "The answer is yes."}
+            >>> llm.generate_classification(
+            ...     prompt="Hello, world!",
+            ...     labels={"yes": "Positive response", "no": "Negative response"},
+            ...     include_explanation=False,
+            ... )
+            {"label": "yes"}
         """
         # Generate schema from labels
         schema = generate_classification_schema(labels, include_explanation, description)
@@ -223,7 +235,7 @@ class AsyncLLM(LLMBase):
     async def generate_classification(
         self,
         prompt: Union[str, MultimodalPrompt],
-        labels: List[Union[Dict[str, str], str]],
+        labels: Union[List[str], Dict[str, str]],
         include_explanation: bool = True,
         description: Optional[str] = None,
         **kwargs: Any,
@@ -233,12 +245,9 @@ class AsyncLLM(LLMBase):
 
         Args:
             prompt: The prompt template to go with the tool call.
-            labels (list of dict or str): A list of labels OR a dictionary of labels and their
-                descriptions.
-                If list of strings, each string is a label.
-                If list of dicts, each dict represents a label and may contain:
-                    - 'name' (str): the label's constant value (required)
-                    - 'description' (str): a description for the label (optional)
+            labels: Either:
+                - A list of strings, where each string is a label
+                - A dictionary where keys are labels and values are descriptions
             include_explanation: Whether to prompt the LLM for an explanation.
             description: A description of the classification task.
             **kwargs: Additional keyword arguments to pass to the LLM SDK.
@@ -248,7 +257,6 @@ class AsyncLLM(LLMBase):
         """
         # Generate schema from labels
         schema = generate_classification_schema(labels, include_explanation, description)
-
         return await self.generate_object(prompt, schema, **kwargs)
 
 

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -280,10 +280,9 @@ def generate_classification_schema(
     """
 
     # Validate labels
-    if not isinstance(labels, list):
-        raise ValueError("Labels must be a list.")
-
     if not labels:
+        raise ValueError("Labels must be a non-empty list.")
+    if not isinstance(labels, list):
         raise ValueError("Labels must be a non-empty list.")
 
     # Determine label type and validate consistency

--- a/packages/phoenix-evals/tests/phoenix/evals/llm/test_wrapper.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/llm/test_wrapper.py
@@ -1,0 +1,277 @@
+# type: ignore
+from typing import Any, Dict, List, Union
+
+import pytest
+
+from phoenix.evals.llm.wrapper import generate_classification_schema
+
+
+class TestGenerateClassificationSchema:
+    """Test cases for the generate_classification_schema function."""
+
+    @pytest.mark.parametrize(
+        "labels,expected_enum",
+        [
+            (["yes", "no"], ["yes", "no"]),
+            (["positive", "negative", "neutral"], ["positive", "negative", "neutral"]),
+            (["A", "B", "C", "D"], ["A", "B", "C", "D"]),
+            (["single"], ["single"]),
+        ],
+    )
+    def test_string_labels_generate_enum_schema(self, labels: List[str], expected_enum: List[str]):
+        """Test that string labels generate proper enum schema."""
+        schema = generate_classification_schema(labels)
+
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+        label_schema = schema["properties"]["label"]
+        assert label_schema["type"] == "string"
+        assert "enum" in label_schema
+        assert label_schema["enum"] == expected_enum
+        assert "oneOf" not in label_schema
+
+    @pytest.mark.parametrize(
+        "labels,expected_one_of",
+        [
+            (
+                [{"name": "yes"}, {"name": "no"}],
+                [{"const": "yes"}, {"const": "no"}],
+            ),
+            (
+                [
+                    {"name": "positive", "description": "Positive sentiment"},
+                    {"name": "negative", "description": "Negative sentiment"},
+                    {"name": "neutral", "description": "Neutral sentiment"},
+                ],
+                [
+                    {"const": "positive", "description": "Positive sentiment"},
+                    {"const": "negative", "description": "Negative sentiment"},
+                    {"const": "neutral", "description": "Neutral sentiment"},
+                ],
+            ),
+            (
+                [{"name": "single"}],
+                [{"const": "single"}],
+            ),
+        ],
+    )
+    def test_dict_labels_generate_one_of_schema(
+        self, labels: List[Dict[str, str]], expected_one_of: List[Dict[str, str]]
+    ):
+        """Test that dict labels generate proper oneOf schema."""
+        schema = generate_classification_schema(labels)
+
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+        label_schema = schema["properties"]["label"]
+        assert label_schema["type"] == "string"
+        assert "oneOf" in label_schema
+        assert label_schema["oneOf"] == expected_one_of
+        assert "enum" not in label_schema
+
+    @pytest.mark.parametrize(
+        "description,expected_description",
+        [
+            ("Test description", "Test description"),
+            ("", ""),
+            (
+                "A very long description with multiple words",
+                "A very long description with multiple words",
+            ),
+        ],
+    )
+    def test_description_is_added_to_label_schema(
+        self, description: str, expected_description: str
+    ):
+        """Test that description is properly added to the label schema."""
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels, description=description)
+
+        label_schema = schema["properties"]["label"]
+        if description:
+            assert "description" in label_schema
+            assert label_schema["description"] == expected_description
+        else:
+            assert "description" not in label_schema
+
+    @pytest.mark.parametrize(
+        "include_explanation,expected_properties,expected_required",
+        [
+            (True, ["explanation", "label"], ["explanation", "label"]),
+            (False, ["label"], ["label"]),
+        ],
+    )
+    def test_explanation_field_handling(
+        self,
+        include_explanation: bool,
+        expected_properties: List[str],
+        expected_required: List[str],
+    ):
+        """
+        Test that explanation field is properly handled based on include_explanation parameter.
+        """
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels, include_explanation=include_explanation)
+
+        properties = schema["properties"]
+        required = schema["required"]
+
+        assert list(properties.keys()) == expected_properties
+        assert required == expected_required
+
+        if include_explanation:
+            explanation_schema = properties["explanation"]
+            assert explanation_schema["type"] == "string"
+            assert explanation_schema["description"] == "A brief explanation of your reasoning."
+
+    def test_explanation_field_order(self):
+        """Test that explanation field appears before label field in properties."""
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels, include_explanation=True)
+
+        properties = list(schema["properties"].keys())
+        assert properties == ["explanation", "label"]
+
+    def test_required_fields_order(self):
+        """Test that required fields are in the correct order."""
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels, include_explanation=True)
+
+        required = schema["required"]
+        assert required == ["explanation", "label"]
+
+    @pytest.mark.parametrize(
+        "labels,description,include_explanation,expected_schema",
+        [
+            (
+                ["yes", "no"],
+                "Test description",
+                True,
+                {
+                    "type": "object",
+                    "properties": {
+                        "explanation": {
+                            "type": "string",
+                            "description": "A brief explanation of your reasoning.",
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Test description",
+                            "enum": ["yes", "no"],
+                        },
+                    },
+                    "required": ["explanation", "label"],
+                },
+            ),
+            (
+                [{"name": "yes"}, {"name": "no"}],
+                "Test description",
+                False,
+                {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "Test description",
+                            "oneOf": [{"const": "yes"}, {"const": "no"}],
+                        },
+                    },
+                    "required": ["label"],
+                },
+            ),
+        ],
+    )
+    def test_complete_schema_generation(
+        self,
+        labels: List[Union[Dict[str, str], str]],
+        description: str,
+        include_explanation: bool,
+        expected_schema: Dict[str, Any],
+    ):
+        """Test complete schema generation with various combinations of parameters."""
+        schema = generate_classification_schema(labels, include_explanation, description)
+        assert schema == expected_schema
+
+    @pytest.mark.parametrize(
+        "invalid_labels,expected_error",
+        [
+            (None, "Labels must be a non-empty list."),
+            ("not a list", "Labels must be a non-empty list."),
+            ([], "Labels must be a non-empty list."),
+            ([1, 2, 3], "Labels must be a list of dicts or a list of strings."),
+            (["yes", 123], "Labels must be a list of dicts or a list of strings."),
+            (
+                [{"name": "yes"}, "no"],
+                "Labels must be a list of dicts or a list of strings.",
+            ),
+            (
+                [{"name": "yes"}, {"invalid": "no"}],
+                "Each label must have a 'name' key.",
+            ),
+            ([{"name": "yes"}, {}], "Each label must have a 'name' key."),
+        ],
+    )
+    def test_invalid_inputs_raise_errors(self, invalid_labels: Any, expected_error: str):
+        """Test that invalid inputs raise appropriate ValueError exceptions."""
+        with pytest.raises(ValueError, match=expected_error):
+            generate_classification_schema(invalid_labels)
+
+    def test_dict_labels_with_optional_description(self):
+        """Test that dict labels with optional description field work correctly."""
+        labels = [
+            {"name": "yes", "description": "Positive response"},
+            {"name": "no"},  # No description
+            {"name": "maybe", "description": "Uncertain response"},
+        ]
+
+        schema = generate_classification_schema(labels)
+        label_schema = schema["properties"]["label"]
+        one_of = label_schema["oneOf"]
+
+        assert len(one_of) == 3
+        assert one_of[0] == {"const": "yes", "description": "Positive response"}
+        assert one_of[1] == {"const": "no"}
+        assert one_of[2] == {"const": "maybe", "description": "Uncertain response"}
+
+    def test_default_parameters(self):
+        """Test that default parameters work correctly."""
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels)
+
+        # Should include explanation by default
+        assert "explanation" in schema["properties"]
+        assert "explanation" in schema["required"]
+
+        # Should not have description by default
+        label_schema = schema["properties"]["label"]
+        assert "description" not in label_schema
+
+    def test_schema_structure_consistency(self):
+        """Test that the generated schema has consistent structure."""
+        labels = ["yes", "no"]
+        schema = generate_classification_schema(labels)
+
+        # Check top-level structure
+        assert isinstance(schema, dict)
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+        # Check properties structure
+        properties = schema["properties"]
+        assert isinstance(properties, dict)
+        assert "label" in properties
+
+        # Check label schema structure
+        label_schema = properties["label"]
+        assert isinstance(label_schema, dict)
+        assert label_schema["type"] == "string"
+
+        # Check required structure
+        required = schema["required"]
+        assert isinstance(required, list)
+        assert "label" in required


### PR DESCRIPTION
Adds a specialized `generate_classification` method to the `LLM` and `AsyncLLM` wrappers.

It takes either a list of labels or dictionary of label, description pairs and generates a valid schema to call `generate_object` under the hood. 