### PR TITLE
docs: Update docs for air-gapped env var

### DIFF
--- a/docs/section-self-hosting/configuration.md
+++ b/docs/section-self-hosting/configuration.md
@@ -27,6 +27,7 @@ The following environment variables will control how your phoenix server runs.
 * **PHOENIX\_HOST:** The host to run the phoenix server. Defaults to 0.0.0.0
 * **PHOENIX\_HOST\_ROOT\_PATH:** The root path prefix for your application. If provided, allows Phoenix to run behind a reverse proxy at the specified subpath. See an example [here](https://github.com/Arize-ai/phoenix/tree/main/examples/reverse-proxy).
 * **PHOENIX\_WORKING\_DIR:** The directory in which to save, load, and export data. This directory must be accessible by both the Phoenix server and the notebook environment. Defaults to `~/.phoenix/`
+* **PHOENIX\_ALLOW\_EXTERNAL\_RESOURCES:** Controls whether external resources (such as Google Fonts) are loaded in the web interface. Defaults to `true`. Set to `false` in air-gapped environments to prevent external requests that can cause UI loading delays. Available since version 11.15.0.
 * **PHOENIX\_SQL\_DATABASE\_URL:** The SQL database URL to use when logging traces and evals. if you plan on using SQLite, it's advised to to use a persistent volume and simply point the `PHOENIX_WORKING_DIR` to that volume. If URL is not specified, by default Phoenix starts with a file-based SQLite database in a temporary folder, the location of which will be shown at startup. Phoenix also supports PostgresSQL as shown below:
   * PostgreSQL, e.g. `postgresql://@host/dbname?user=user&password=password` or `postgresql://user:password@host/dbname`
   * SQLite, e.g. `sqlite:///path/to/database.db`

--- a/docs/section-self-hosting/deployment-options/docker.md
+++ b/docs/section-self-hosting/deployment-options/docker.md
@@ -145,6 +145,34 @@ docker compose up --build
 
 Note that the above setup is using your local disc as a volume mount to store the postgres data. For production deployments you will have to setup a persistent volume.
 
+## Air-Gapped Deployments
+
+For air-gapped environments where external network access is restricted, you should disable external resource loading to improve UI performance. This prevents Phoenix from attempting to load external resources like Google Fonts, which can cause UI loading delays in environments without internet access.
+
+Add the `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` environment variable to your Docker configuration:
+
+```yaml
+# docker-compose.yml for air-gapped environments
+services:
+  phoenix:
+    image: arizephoenix/phoenix:latest # Must be version 11.15.0 or later
+    ports:
+      - 6006:6006  # PHOENIX_PORT
+      - 4317:4317  # PHOENIX_GRPC_PORT
+    environment:
+      - PHOENIX_WORKING_DIR=/mnt/data
+      - PHOENIX_ALLOW_EXTERNAL_RESOURCES=false  # Disable external resources for air-gapped environments
+    volumes:
+      - phoenix_data:/mnt/data   # PHOENIX_WORKING_DIR
+volumes:
+  phoenix_data:
+    driver: local
+```
+
+{% hint style="info" %}
+The `PHOENIX_ALLOW_EXTERNAL_RESOURCES` environment variable was added in Phoenix version 11.15.0. Setting it to `false` is only necessary in air-gapped deployments where external network access is not available.
+{% endhint %}
+
 ## SQLite
 
 You can also run Phonix using SQLite with a persistent disc attached:

--- a/docs/section-self-hosting/deployment-options/docker.md
+++ b/docs/section-self-hosting/deployment-options/docker.md
@@ -145,34 +145,6 @@ docker compose up --build
 
 Note that the above setup is using your local disc as a volume mount to store the postgres data. For production deployments you will have to setup a persistent volume.
 
-## Air-Gapped Deployments
-
-For air-gapped environments where external network access is restricted, you should disable external resource loading to improve UI performance. This prevents Phoenix from attempting to load external resources like Google Fonts, which can cause UI loading delays in environments without internet access.
-
-Add the `PHOENIX_ALLOW_EXTERNAL_RESOURCES=false` environment variable to your Docker configuration:
-
-```yaml
-# docker-compose.yml for air-gapped environments
-services:
-  phoenix:
-    image: arizephoenix/phoenix:latest # Must be version 11.15.0 or later
-    ports:
-      - 6006:6006  # PHOENIX_PORT
-      - 4317:4317  # PHOENIX_GRPC_PORT
-    environment:
-      - PHOENIX_WORKING_DIR=/mnt/data
-      - PHOENIX_ALLOW_EXTERNAL_RESOURCES=false  # Disable external resources for air-gapped environments
-    volumes:
-      - phoenix_data:/mnt/data   # PHOENIX_WORKING_DIR
-volumes:
-  phoenix_data:
-    driver: local
-```
-
-{% hint style="info" %}
-The `PHOENIX_ALLOW_EXTERNAL_RESOURCES` environment variable was added in Phoenix version 11.15.0. Setting it to `false` is only necessary in air-gapped deployments where external network access is not available.
-{% endhint %}
-
 ## SQLite
 
 You can also run Phonix using SQLite with a persistent disc attached:

--- a/docs/section-self-hosting/misc/frequently-asked-questions.md
+++ b/docs/section-self-hosting/misc/frequently-asked-questions.md
@@ -3,3 +3,30 @@
 ### Permission denied writing to disc
 
 Some phoenix containers run as nonroot and therefore must be granted explicit write permissions to the mounted disc (see [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)). Phoenix 4.1.3 and above run as root by default to avoid this. However there are `debug` and `nonroot` variants of the image as well.
+
+### How do I configure Phoenix for air-gapped deployments?
+
+For air-gapped environments where external network access is restricted, you should disable external resource loading to improve UI performance. This prevents Phoenix from attempting to load external resources like Google Fonts, which can cause UI loading delays (10-20 seconds) in environments without internet access.
+
+Set the `PHOENIX_ALLOW_EXTERNAL_RESOURCES` environment variable to `false`:
+
+**Docker Example:**
+```yaml
+services:
+  phoenix:
+    image: arizephoenix/phoenix:latest # Must be version 11.15.0 or later
+    ports:
+      - 6006:6006
+      - 4317:4317
+    environment:
+      - PHOENIX_ALLOW_EXTERNAL_RESOURCES=false
+```
+
+**Environment Variable:**
+```bash
+export PHOENIX_ALLOW_EXTERNAL_RESOURCES=false
+```
+
+{% hint style="info" %}
+The `PHOENIX_ALLOW_EXTERNAL_RESOURCES` environment variable was added in Phoenix version 11.15.0. It defaults to `true` and only needs to be set to `false` in air-gapped deployments where external network access is not available.
+{% endhint %}


### PR DESCRIPTION
Add documentation for the `PHOENIX_ALLOW_EXTERNAL_RESOURCES` environment variable to guide users on its use in air-gapped deployments (available since v11.15.0).

---
[Slack Thread](https://arize-ai.slack.com/archives/C04QMRADE1L/p1753828873882209?thread_ts=1753828873.882209&cid=C04QMRADE1L)

<a href="https://cursor.com/background-agent?bcId=bc-7be4bf31-be41-4597-a6a0-a00844d10cc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7be4bf31-be41-4597-a6a0-a00844d10cc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>