### PR TITLE
docs: Update documentation for span feedback context manager

### DIFF
--- a/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
@@ -18,54 +18,147 @@ The `capture_span_context` context manager allows you to:
 * Retrieve span contexts for later use in feedback systems
 * Maintain a clean separation between span creation and annotation logic
 * Apply feedback to spans without needing to track span IDs manually
+* Access both the first and last spans in a trace topology for targeted feedback
+
+## Understanding Span Topology
+
+When your LLM application executes, it creates a hierarchy of spans representing different operations. For example, when using a framework like LlamaIndex, you might have:
+
+```
+llama-index (root span)
+  ├── get_span (query processing)
+  │     └── get_span (LLM call)
+  └── get_span (response formatting)
+```
+
+The `capture_span_context` context manager helps you easily access:
+- **First span**: The root span of your operation (useful for high-level feedback and evaluations)
+- **Last span**: The most recent span created (often the final LLM call, useful for LLM-specific feedback)
 
 ## Usage
 
-You can use the captured span contexts to implement custom feedback logic. The captured span contexts integrate seamlessly with Phoenix's annotation system:
+### Accessing First and Last Spans
 
 ```python
 from openinference.instrumentation import capture_span_context
-from opentelemetry.trace.span import format_span_id
 from phoenix.client import Client
 
 client = Client()
 
 def process_llm_request_with_feedback(prompt: str):
     with capture_span_context() as capture:
-        # Make LLM call (auto-instrumented)
-        response = llm.invoke("Generate a summary")
-        # Get user feedback (simulated)
-        user_feedback = get_user_feedback(response)
+        # This creates multiple spans in a hierarchy
+        chat_engine = index.as_chat_engine()
+        response = chat_engine.chat("Hello, how are you?")
         
-        # Method 1: Get span ID using get_last_span_id (most recent span)
+        # Get the first span (root level - good for overall evaluation)
+        first_span_id = capture.get_first_span_id()
+        if first_span_id:
+            # Apply high-level feedback or evaluation scores
+            client.annotations.add_span_annotation(
+                annotation_name="overall_quality",
+                annotator_kind="HUMAN",
+                span_id=first_span_id,
+                label="excellent",
+                score=5,
+                explanation="The overall response quality was excellent"
+            )
+        
+        # Get the last span (often the LLM call - good for LLM-specific feedback)
         last_span_id = capture.get_last_span_id()
-        # Apply feedback to the most recent span
         if last_span_id:
+            # Apply LLM-specific feedback
             client.annotations.add_span_annotation(
-                annotation_name="user_feedback",
-                annotator_kind="HUMAN",
+                annotation_name="llm_response_quality",
+                annotator_kind="HUMAN", 
                 span_id=last_span_id,
-                label=user_feedback.label,
-                score=user_feedback.score,
-                explanation=user_feedback.explanation
+                label="helpful",
+                score=4,
+                explanation="The LLM provided a helpful and relevant response"
+            )
+```
+
+### When to Use First vs Last Spans
+
+**Use the first span (`get_first_span_id()`) when:**
+- Adding human feedback about the overall experience
+- Recording evaluation scores for the entire request/response cycle
+- Tracking session-level or conversation-level metadata
+- Applying business logic annotations that span the entire operation
+
+**Use the last span (`get_last_span_id()`) when:**
+- The last span represents an LLM invocation
+- You want to annotate the final output or generation step
+- Applying feedback specifically to the model's response quality
+- Recording model-specific metrics or evaluations
+
+### Complete Example: Multi-Level Feedback
+
+```python
+from openinference.instrumentation import capture_span_context
+from phoenix.client import Client
+
+client = Client()
+
+def chat_with_comprehensive_feedback(user_input: str):
+    with capture_span_context() as capture:
+        # Auto-instrumented LLM framework call
+        chat_engine = index.as_chat_engine()
+        response = chat_engine.chat(user_input)
+        
+        # Simulate getting user feedback
+        user_rating = get_user_rating(response)  # Returns 1-5 score
+        
+        # Apply feedback to the first span (overall experience)
+        first_span_id = capture.get_first_span_id()
+        if first_span_id:
+            client.annotations.add_span_annotation(
+                annotation_name="user_experience",
+                annotator_kind="HUMAN",
+                span_id=first_span_id,
+                label="satisfied" if user_rating >= 4 else "unsatisfied",
+                score=user_rating,
+                explanation=f"User rated the overall experience: {user_rating}/5"
             )
         
-        # Method 2: Get all captured span contexts and iterate
-        span_contexts = capture.get_span_contexts()
-        # Apply feedback to all captured spans
-        for span_context in span_contexts:
-            # Convert span context to span ID for annotation
-            span_id = format_span_id(span_context.span_id)
+        # Apply feedback to the last span (typically the LLM response)
+        last_span_id = capture.get_last_span_id()
+        if last_span_id and last_span_id != first_span_id:  # Avoid duplicate annotations
+            # Run an evaluation on the LLM response
+            relevance_score = evaluate_relevance(user_input, response)
             
-            # Add annotation to Phoenix
             client.annotations.add_span_annotation(
-                annotation_name="user_feedback_all",
-                annotator_kind="HUMAN",
-                span_id=span_id,
-                label=user_feedback.label,
-                score=user_feedback.score,
-                explanation=user_feedback.explanation
+                annotation_name="relevance",
+                annotator_kind="LLM",
+                span_id=last_span_id,
+                score=relevance_score,
+                explanation="Automated relevance evaluation of the LLM response"
             )
+```
+
+### Working with All Captured Spans
+
+You can also access all spans for more complex annotation scenarios:
+
+```python
+with capture_span_context() as capture:
+    # Make LLM call (auto-instrumented)
+    response = llm.invoke("Generate a summary")
+    
+    # Get all captured span contexts
+    span_contexts = capture.get_span_contexts()
+    
+    # Apply different feedback logic to different spans
+    for i, span_context in enumerate(span_contexts):
+        span_id = format_span_id(span_context.span_id)
+        
+        client.annotations.add_span_annotation(
+            annotation_name="span_order",
+            annotator_kind="CODE",
+            span_id=span_id,
+            label=f"span_{i}",
+            metadata={"position": i, "total_spans": len(span_contexts)}
+        )
 ```
 
 #### Working with Multiple Span Types
@@ -90,6 +183,17 @@ with capture_span_context() as capture:
         apply_llm_feedback(span_context)
 ```
 
+### Best Practices
+
+1. **Hierarchical Feedback**: Use first spans for high-level feedback (user experience, overall quality) and last spans for specific component feedback (LLM response quality, retrieval relevance)
+
+2. **Avoid Duplicate Annotations**: Check if `first_span_id == last_span_id` to avoid applying the same annotation twice when there's only one span
+
+3. **Context-Aware Annotations**: Use the span topology to understand what each span represents in your application flow
+
+4. **Deferred Annotation**: Capture spans first, then apply annotations after the main operation completes to avoid interfering with execution
+
 ### Resources
 
 * [OpenInference](https://github.com/Arize-ai/openinference)
+* [Phoenix Client Documentation](../../../api-reference/phoenix-client.md)

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
@@ -34,6 +34,7 @@ framework (root span)
 The `capture_span_context` context manager helps you easily access:
 - **First span**: The root span of your operation (useful for high-level feedback and evaluations)
 - **Last span**: The most recent span created (often the final LLM call, useful for LLM-specific feedback)
+- **All spans**: A complete list of all spans created within the context (useful for comprehensive analysis)
 
 ## Usage
 

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
@@ -146,4 +146,4 @@ with capture_span_context() as capture:
 ### Resources
 
 * [OpenInference](https://github.com/Arize-ai/openinference)
-* [Phoenix Client Documentation](../../../api-reference/phoenix-client.md)
+* [Phoenix Client Documentation](https://arize-phoenix.readthedocs.io/projects/client/en/latest/)

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
@@ -94,48 +94,7 @@ def process_llm_request_with_feedback(prompt: str):
 - Applying feedback specifically to the model's response quality
 - Recording model-specific metrics or evaluations
 
-### Complete Example: Multi-Level Feedback
 
-```python
-from openinference.instrumentation import capture_span_context
-from phoenix.client import Client
-
-client = Client()
-
-def chat_with_comprehensive_feedback(user_input: str):
-    with capture_span_context() as capture:
-        # Auto-instrumented framework call
-        response = framework.process(user_input)
-        
-        # Simulate getting user feedback
-        user_rating = get_user_rating(response)  # Returns 1-5 score
-        
-        # Apply feedback to the first span (overall experience)
-        first_span_id = capture.get_first_span_id()
-        if first_span_id:
-            client.annotations.add_span_annotation(
-                annotation_name="user_experience",
-                annotator_kind="HUMAN",
-                span_id=first_span_id,
-                label="satisfied" if user_rating >= 4 else "unsatisfied",
-                score=user_rating,
-                explanation=f"User rated the overall experience: {user_rating}/5"
-            )
-        
-        # Apply feedback to the last span (typically the LLM response)
-        last_span_id = capture.get_last_span_id()
-        if last_span_id and last_span_id != first_span_id:  # Avoid duplicate annotations
-            # Run an evaluation on the LLM response
-            relevance_score = evaluate_relevance(user_input, response)
-            
-            client.annotations.add_span_annotation(
-                annotation_name="relevance",
-                annotator_kind="LLM",
-                span_id=last_span_id,
-                score=relevance_score,
-                explanation="Automated relevance evaluation of the LLM response"
-            )
-```
 
 ### Working with All Captured Spans
 
@@ -184,15 +143,7 @@ with capture_span_context() as capture:
         apply_llm_feedback(span_context)
 ```
 
-### Best Practices
 
-1. **Hierarchical Feedback**: Use first spans for high-level feedback (user experience, overall quality) and last spans for specific component feedback (LLM response quality, retrieval relevance)
-
-2. **Avoid Duplicate Annotations**: Check if `first_span_id == last_span_id` to avoid applying the same annotation twice when there's only one span
-
-3. **Context-Aware Annotations**: Use the span topology to understand what each span represents in your application flow
-
-4. **Deferred Annotation**: Capture spans first, then apply annotations after the main operation completes to avoid interfering with execution
 
 ### Resources
 

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/annotating-auto-instrumented-spans.md
@@ -85,8 +85,6 @@ def process_llm_request_with_feedback(prompt: str):
 **Use the first span (`get_first_span_id()`) when:**
 - Adding user feedback about the overall experience
 - Recording evaluation scores for the entire request/response cycle
-- Tracking session-level or conversation-level metadata
-- Applying business logic annotations that span the entire operation
 
 **Use the last span (`get_last_span_id()`) when:**
 - The last span represents an LLM invocation


### PR DESCRIPTION
Update `capture_span_context` documentation to guide users on attaching feedback to first/last spans in a trace topology.

---
[Slack Thread](https://arize-ai.slack.com/archives/C04QMRADE1L/p1753829806020569?thread_ts=1753829806.020569&cid=C04QMRADE1L)

<a href="https://cursor.com/background-agent?bcId=bc-4d15fa42-62bb-45b1-96f1-dfa0d53d4d6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d15fa42-62bb-45b1-96f1-dfa0d53d4d6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>