### PR TITLE
enhancement(evals): add priority for LLM client selection

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/__init__.py
@@ -1,8 +1,10 @@
 """Adapters for different LLM SDKs and providers."""
 
+# ruff: noqa: I001
+# customizing the import order to prioritize the openai adapter over the others
+from .openai import OpenAIAdapter
 from .langchain import LangChainModelAdapter
 from .litellm import LiteLLMAdapter
-from .openai import OpenAIAdapter
 
 __all__ = [
     "LangChainModelAdapter",

--- a/packages/phoenix-evals/src/phoenix/evals/llm/registries.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/registries.py
@@ -168,7 +168,7 @@ def adapter_availability_table() -> str:
 
     if all_providers:
         table_width = _calculate_table_width(all_providers)
-        output.append("\n📦 AVAILABLE PROVIDERS")
+        output.append("\n📦 AVAILABLE PROVIDERS (sorted by client priority)")
         output.append("-" * table_width)
         output.append(_get_consolidated_provider_table(all_providers))
     else:


### PR DESCRIPTION
When instantiating a new LLM wrapper, prefer OpenAI over Langchain over LiteLLM when selecting which SDK to use (if no client is specified). 

`show_provider_availability` orders the results based on this priority. 

Closes #8867 