### PR TITLE
refactor: card migration pt 3

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -219,6 +219,11 @@ module.exports = {
         module: "@arizeai/components",
         use: "import { ListItem } from '@phoenix/components'",
       },
+      {
+        name: "Card",
+        module: "@arizeai/components",
+        use: "import { Card } from '@phoenix/components'",
+      },
     ],
     "no-duplicate-imports": "error",
   },

--- a/app/src/components/card/Card.tsx
+++ b/app/src/components/card/Card.tsx
@@ -10,16 +10,20 @@ function Card(
   {
     title,
     titleExtra,
+    titleSeparator = true,
     subTitle,
     children,
     collapsible = false,
+    defaultOpen = true,
     extra,
     ...otherProps
   }: CardProps,
   ref: Ref<HTMLElement>
 ) {
   const { styleProps } = useStyleProps(otherProps, viewStyleProps);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(
+    collapsible ? !defaultOpen : false
+  );
 
   const headerId = useId();
   const collapseButtonId = useId();
@@ -46,6 +50,7 @@ function Card(
       className="card"
       data-collapsible={collapsible}
       data-collapsed={isCollapsed}
+      data-title-separator={titleSeparator}
       style={styleProps.style}
     >
       <header id={headerId}>

--- a/app/src/components/card/styles.ts
+++ b/app/src/components/card/styles.ts
@@ -56,6 +56,7 @@ export const cardCSS = (style?: CSSProperties) => css`
     /* Collapsible button styles */
     & .card__collapsible-button {
       display: flex;
+      flex: 1;
       flex-direction: row;
       align-items: center;
       text-align: left;
@@ -67,7 +68,7 @@ export const cardCSS = (style?: CSSProperties) => css`
     }
   }
 
-  &[data-collapsed="false"] > header {
+  &[data-collapsed="false"][data-title-separator="true"] > header {
     border-bottom: 1px solid var(--scope-border-color);
   }
 

--- a/app/src/components/card/types.ts
+++ b/app/src/components/card/types.ts
@@ -3,9 +3,35 @@ import { PropsWithChildren } from "react";
 import { ViewStyleProps } from "@phoenix/components/types";
 
 export interface CardProps extends PropsWithChildren<ViewStyleProps> {
+  /**
+   * The title of the card, displayed in the card header.
+   */
   title?: string | React.ReactNode;
+  /**
+   * Additional content displayed directly to the right of the title.
+   */
   titleExtra?: React.ReactNode;
+  /**
+   * Whether to show a separator between the card header and the card body.
+   * @default true
+   */
+  titleSeparator?: boolean; // TODO: add story
+  /**
+   * The subtitle of the card, displayed below the title.
+   */
   subTitle?: string;
+  /**
+   * Whether the card body can be collapsed.
+   * @default false
+   */
   collapsible?: boolean;
+  /**
+   * Whether the card body is open by default. Only applicable if `collapsible` is `true`.
+   * @default true
+   */
+  defaultOpen?: boolean; // TODO: add story
+  /**
+   * Additional content displayed on the right side of the card header.
+   */
   extra?: React.ReactNode;
 }

--- a/app/src/components/card/types.ts
+++ b/app/src/components/card/types.ts
@@ -15,7 +15,7 @@ export interface CardProps extends PropsWithChildren<ViewStyleProps> {
    * Whether to show a separator between the card header and the card body.
    * @default true
    */
-  titleSeparator?: boolean; // TODO: add story
+  titleSeparator?: boolean;
   /**
    * The subtitle of the card, displayed below the title.
    */
@@ -29,7 +29,7 @@ export interface CardProps extends PropsWithChildren<ViewStyleProps> {
    * Whether the card body is open by default. Only applicable if `collapsible` is `true`.
    * @default true
    */
-  defaultOpen?: boolean; // TODO: add story
+  defaultOpen?: boolean;
   /**
    * Additional content displayed on the right side of the card header.
    */

--- a/app/src/pages/settings/AnnotationConfigDialog.tsx
+++ b/app/src/pages/settings/AnnotationConfigDialog.tsx
@@ -1,10 +1,9 @@
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { css } from "@emotion/react";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   Dialog,
   FieldError,
   Flex,
@@ -147,8 +146,6 @@ export const AnnotationConfigDialog = ({
           title={
             mode === "new" ? "New Annotation Config" : "Edit Annotation Config"
           }
-          variant="compact"
-          bodyStyle={{ padding: 0 }}
         >
           <Form
             onSubmit={(e) => {

--- a/app/src/pages/settings/AnnotationConfigSelectionToolbar.tsx
+++ b/app/src/pages/settings/AnnotationConfigSelectionToolbar.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
 import { css } from "@emotion/react";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   Dialog,
   DialogTrigger,
   Flex,
@@ -94,11 +93,7 @@ export const AnnotationConfigSelectionToolbar = ({
                     `}
                   >
                     {({ close }) => (
-                      <Card
-                        title="Delete Annotation Config"
-                        bodyStyle={{ padding: 0 }}
-                        variant="compact"
-                      >
+                      <Card title="Delete Annotation Config">
                         <View padding="size-200">
                           <Text>
                             Are you sure you want to delete this annotation

--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -8,10 +8,9 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   CredentialField,
   CredentialInput,
   Dialog,
@@ -167,7 +166,7 @@ export function GenerativeProvidersCard({
   const rows = table.getRowModel().rows;
 
   return (
-    <Card title="AI Providers" bodyStyle={{ padding: 0 }} variant="compact">
+    <Card title="AI Providers">
       <table css={tableCSS}>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
+++ b/app/src/pages/settings/GlobalRetentionPolicyCard.tsx
@@ -3,10 +3,9 @@ import { Controller, useForm } from "react-hook-form";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { css } from "@emotion/react";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   FieldError,
   Flex,
   Form,
@@ -131,13 +130,7 @@ export const GlobalRetentionPolicyCard = () => {
   );
 
   return (
-    <Card
-      title="Default Project Retention Policy"
-      variant="compact"
-      bodyStyle={{
-        padding: 0,
-      }}
-    >
+    <Card title="Default Project Retention Policy">
       <View padding="size-200">
         <Flex direction="row" gap="size-200" justifyContent="space-between">
           <View paddingTop="size-100">

--- a/app/src/pages/settings/SettingsAnnotationsPage.tsx
+++ b/app/src/pages/settings/SettingsAnnotationsPage.tsx
@@ -1,10 +1,9 @@
 import { graphql, useFragment, useMutation } from "react-relay";
 import { useLoaderData, useRevalidator } from "react-router";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   DialogTrigger,
   Icon,
   Icons,
@@ -163,8 +162,6 @@ const SettingsAnnotations = ({
   return (
     <Card
       title="Annotation Configs"
-      variant="compact"
-      bodyStyle={{ padding: 0 }}
       extra={
         <DialogTrigger>
           <Button size="S">

--- a/app/src/pages/settings/SettingsDataPage.tsx
+++ b/app/src/pages/settings/SettingsDataPage.tsx
@@ -1,10 +1,9 @@
 import { useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   Dialog,
   DialogCloseButton,
   DialogContent,
@@ -30,8 +29,6 @@ export function SettingsDataPage() {
   return (
     <Card
       title="Retention Policies"
-      bodyStyle={{ padding: 0 }}
-      variant="compact"
       extra={
         <CanManageRetentionPolicy>
           <DialogTrigger>

--- a/app/src/pages/settings/SettingsGeneralPage.tsx
+++ b/app/src/pages/settings/SettingsGeneralPage.tsx
@@ -2,9 +2,8 @@ import { useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 import { css } from "@emotion/react";
 
-import { Card } from "@arizeai/components";
-
 import {
+  Card,
   CopyToClipboardButton,
   Flex,
   Input,
@@ -26,6 +25,7 @@ const formCSS = css`
     // Hacky solution to make the text fields fill the remaining space
     width: calc(100% - var(--ac-global-dimension-size-600));
   }
+  padding: var(--ac-global-dimension-size-200);
 `;
 
 export function SettingsGeneralPage() {
@@ -35,7 +35,7 @@ export function SettingsGeneralPage() {
     <Flex direction="column" gap="size-200" width="100%">
       <Flex direction="row" gap="size-200" alignItems="baseline">
         <View flex="2">
-          <Card title="Platform Settings" variant="compact">
+          <Card title="Platform Settings">
             <form css={formCSS}>
               <Flex direction="row" gap="size-100" alignItems="end">
                 <TextField value={BASE_URL} isReadOnly>
@@ -75,8 +75,10 @@ export function SettingsGeneralPage() {
           </Card>
         </View>
         <View flex="1" minWidth={280}>
-          <Card title="Database Usage" variant="compact">
-            <DBUsagePieChart query={loaderData} />
+          <Card title="Database Usage">
+            <View padding="size-200">
+              <DBUsagePieChart query={loaderData} />
+            </View>
           </Card>
         </View>
       </Flex>

--- a/app/src/pages/settings/SettingsModelsPage.tsx
+++ b/app/src/pages/settings/SettingsModelsPage.tsx
@@ -2,10 +2,9 @@ import { startTransition, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
-import { Card } from "@arizeai/components";
-
 import {
   Button,
+  Card,
   Flex,
   Input,
   ListBox,
@@ -91,7 +90,6 @@ export function SettingsModelsPage() {
       </Flex>
       <Card
         title="Models"
-        variant="compact"
         extra={
           <Flex direction="row" gap="size-200" alignItems="center">
             <Text color="text-500" size="S">
@@ -100,7 +98,6 @@ export function SettingsModelsPage() {
             <NewModelButton />
           </Flex>
         }
-        bodyStyle={{ padding: 0 }}
       >
         <ModelsTable modelsRef={data} kindFilter={kindFilter} search={search} />
       </Card>

--- a/app/src/pages/settings/UsersCard.tsx
+++ b/app/src/pages/settings/UsersCard.tsx
@@ -1,9 +1,7 @@
 import { ReactNode, Suspense, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { Card } from "@arizeai/components";
-
-import { Button, Icon, Icons, Loading, View } from "@phoenix/components";
+import { Button, Card, Icon, Icons, Loading, View } from "@phoenix/components";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
@@ -34,8 +32,6 @@ export function UsersCard() {
   return (
     <Card
       title="Users"
-      variant="compact"
-      bodyStyle={{ padding: 0, overflowX: "auto" }}
       extra={
         <Button
           onPress={() => {
@@ -70,15 +66,17 @@ export function UsersCard() {
         </Button>
       }
     >
-      <Suspense
-        fallback={
-          <View padding="size-200">
-            <Loading />
-          </View>
-        }
-      >
-        <UsersTable query={data} />
-      </Suspense>
+      <View overflow="auto">
+        <Suspense
+          fallback={
+            <View padding="size-200">
+              <Loading />
+            </View>
+          }
+        >
+          <UsersTable query={data} />
+        </Suspense>
+      </View>
       {dialog}
     </Card>
   );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -17,8 +17,6 @@ import CodeMirror, {
 import { css } from "@emotion/react";
 
 import {
-  Card,
-  CardProps,
   Content,
   ContextualHelp,
   EmptyGraphic,
@@ -38,6 +36,8 @@ import {
 import {
   Alert,
   Button,
+  Card,
+  CardProps,
   CopyToClipboardButton,
   Counter,
   DialogTrigger,
@@ -152,9 +152,7 @@ const spanHasException = (span: Span) => {
 const defaultCardProps: Partial<CardProps> = {
   backgroundColor: "light",
   borderColor: "light",
-  variant: "compact",
   collapsible: true,
-  bodyStyle: { padding: 0 },
 };
 
 const CONDENSED_VIEW_CONTAINER_WIDTH_THRESHOLD = 900;
@@ -702,11 +700,7 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
         collapsible
         backgroundColor="light"
         borderColor="light"
-        bodyStyle={{
-          padding: 0,
-        }}
         titleSeparator={false}
-        variant="compact"
         title={modelNameTitleEl}
       >
         <Tabs>
@@ -1035,7 +1029,6 @@ function RerankerSpanInfo(props: {
         titleExtra={<Counter>{numInputDocuments}</Counter>}
         {...defaultCardProps}
         defaultOpen={false}
-        bodyStyle={{ padding: 0 }}
       >
         {
           <ul
@@ -1065,7 +1058,6 @@ function RerankerSpanInfo(props: {
         title={"Output Documents"}
         titleExtra={<Counter>{numOutputDocuments}</Counter>}
         {...defaultCardProps}
-        bodyStyle={{ padding: 0 }}
       >
         {
           <ul
@@ -1300,9 +1292,6 @@ function DocumentItem({
       {...defaultCardProps}
       backgroundColor={backgroundColor}
       borderColor={borderColor}
-      bodyStyle={{
-        padding: 0,
-      }}
       title={
         <Flex direction="row" gap="size-50" alignItems="center">
           <Icon svg={<Icons.FileOutline />} />
@@ -1631,7 +1620,6 @@ function LLMToolSchema({
       {...defaultCardProps}
       backgroundColor="yellow-100"
       borderColor="yellow-700"
-      bodyStyle={{ padding: 0 }}
       extra={<CopyToClipboardButton text={toolSchema} />}
     >
       <CodeBlock value={toolSchema} mimeType={"json"} />

--- a/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
+++ b/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
@@ -3,11 +3,11 @@ import { Controller, useForm } from "react-hook-form";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { css } from "@emotion/react";
 
-import { Card, CardProps } from "@arizeai/components";
-
 import {
   Alert,
   Button,
+  Card,
+  CardProps,
   Dialog,
   Flex,
   Icon,
@@ -32,7 +32,6 @@ const defaultCardProps: Partial<CardProps> = {
   backgroundColor: "light",
   borderColor: "light",
   collapsible: true,
-  bodyStyle: { padding: 0 },
 };
 
 type ExampleToAdd = {

--- a/app/stories/Card.stories.tsx
+++ b/app/stories/Card.stories.tsx
@@ -103,3 +103,28 @@ WithTitleExtra.args = {
   ),
   width: "400px",
 };
+
+/**
+ * Card without title separator
+ */
+export const WithoutTitleSeparator = Template.bind({});
+
+WithoutTitleSeparator.args = {
+  title: "Card Without Separator",
+  subTitle: "This card has no separator between title and content",
+  titleSeparator: false,
+  width: "400px",
+};
+
+/**
+ * Collapsible card that starts closed
+ */
+export const DefaultClosed = Template.bind({});
+
+DefaultClosed.args = {
+  title: "Default Closed Card",
+  subTitle: "This card starts in a collapsed state",
+  collapsible: true,
+  defaultOpen: false,
+  width: "400px",
+};

--- a/app/stories/Disclosure.stories.tsx
+++ b/app/stories/Disclosure.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
 import {
+  Card,
   Disclosure,
   DisclosureGroup,
   type DisclosureGroupProps,
@@ -11,6 +10,7 @@ import {
   DisclosureTrigger,
   DisclosureTriggerProps,
   Text,
+  View,
 } from "@phoenix/components";
 
 const meta: Meta = {
@@ -24,25 +24,23 @@ const meta: Meta = {
 export default meta;
 
 const Template: StoryFn<DisclosureGroupProps> = (args) => (
-  <Card
-    title="Disclosure"
-    bodyStyle={{ padding: 0, width: "600px" }}
-    variant="compact"
-  >
-    <DisclosureGroup {...args}>
-      <Disclosure id="content">
-        <DisclosureTrigger>First Item Title</DisclosureTrigger>
-        <DisclosurePanel>
-          <Text>First Item Content</Text>
-        </DisclosurePanel>
-      </Disclosure>
-      <Disclosure id="content-2">
-        <DisclosureTrigger>Second Item Title</DisclosureTrigger>
-        <DisclosurePanel>
-          <Text>Second Item Content</Text>
-        </DisclosurePanel>
-      </Disclosure>
-    </DisclosureGroup>
+  <Card title="Disclosure">
+    <View width="600px">
+      <DisclosureGroup {...args}>
+        <Disclosure id="content">
+          <DisclosureTrigger>First Item Title</DisclosureTrigger>
+          <DisclosurePanel>
+            <Text>First Item Content</Text>
+          </DisclosurePanel>
+        </Disclosure>
+        <Disclosure id="content-2">
+          <DisclosureTrigger>Second Item Title</DisclosureTrigger>
+          <DisclosurePanel>
+            <Text>Second Item Content</Text>
+          </DisclosurePanel>
+        </Disclosure>
+      </DisclosureGroup>
+    </View>
   </Card>
 );
 
@@ -80,37 +78,35 @@ export const SingleItem: Meta<typeof SingleItemStory> = {
 };
 
 const ExtraTitleContentStory: StoryFn<DisclosureTriggerProps> = (args) => (
-  <Card
-    title="Disclosure"
-    bodyStyle={{ padding: 0, width: "600px" }}
-    variant="compact"
-  >
-    <DisclosureGroup>
-      <Disclosure id="content" {...args}>
-        <DisclosureTrigger {...args}>
-          Content Title
-          <span
-            style={{
-              color: "var(--ac-global-text-color-500)",
-              border: "1px solid var(--ac-global-text-color-500)",
-              borderRadius: "12px",
-              padding: "var(--ac-global-dimension-static-size-100)",
-              height: "8px",
-              width: "16px",
-              lineHeight: "0px",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            1
-          </span>
-        </DisclosureTrigger>
-        <DisclosurePanel>
-          <Text>Content</Text>
-        </DisclosurePanel>
-      </Disclosure>
-    </DisclosureGroup>
+  <Card title="Disclosure">
+    <View width="600px">
+      <DisclosureGroup>
+        <Disclosure id="content" {...args}>
+          <DisclosureTrigger {...args}>
+            Content Title
+            <span
+              style={{
+                color: "var(--ac-global-text-color-500)",
+                border: "1px solid var(--ac-global-text-color-500)",
+                borderRadius: "12px",
+                padding: "var(--ac-global-dimension-static-size-100)",
+                height: "8px",
+                width: "16px",
+                lineHeight: "0px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              1
+            </span>
+          </DisclosureTrigger>
+          <DisclosurePanel>
+            <Text>Content</Text>
+          </DisclosurePanel>
+        </Disclosure>
+      </DisclosureGroup>
+    </View>
   </Card>
 );
 

--- a/app/stories/RadioGroup.stories.tsx
+++ b/app/stories/RadioGroup.stories.tsx
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
 import {
+  Card,
   Icon,
   Icons,
   Radio,
   RadioGroup,
   type RadioGroupProps,
+  View,
 } from "@phoenix/components";
 
 const meta: Meta = {
@@ -21,18 +21,20 @@ const meta: Meta = {
 export default meta;
 
 const Template: StoryFn<RadioGroupProps> = (args) => (
-  <Card title="RadioGroup" bodyStyle={{ width: "600px" }} variant="compact">
-    <RadioGroup aria-label="RadioGroup" {...args}>
-      <Radio aria-label="Option 1" value="1">
-        Option 1
-      </Radio>
-      <Radio aria-label="Option 2" value="2">
-        Option 2
-      </Radio>
-      <Radio aria-label="Option 3" value="3">
-        Option 3
-      </Radio>
-    </RadioGroup>
+  <Card title="RadioGroup">
+    <View width="600px" padding="size-200">
+      <RadioGroup aria-label="RadioGroup" {...args}>
+        <Radio aria-label="Option 1" value="1">
+          Option 1
+        </Radio>
+        <Radio aria-label="Option 2" value="2">
+          Option 2
+        </Radio>
+        <Radio aria-label="Option 3" value="3">
+          Option 3
+        </Radio>
+      </RadioGroup>
+    </View>
   </Card>
 );
 
@@ -47,18 +49,20 @@ export const Default: Meta<typeof RadioGroup> = {
 };
 
 const AsIconTemplate: StoryFn<RadioGroupProps> = (args) => (
-  <Card title="RadioGroup" bodyStyle={{ width: "600px" }} variant="compact">
-    <RadioGroup aria-label="RadioGroupWithIcons" {...args}>
-      <Radio aria-label="Option 1" value="1">
-        <Icon svg={<Icons.Info />} />
-      </Radio>
-      <Radio aria-label="Option 2" value="2">
-        <Icon svg={<Icons.Info />} />
-      </Radio>
-      <Radio aria-label="Option 3" value="3">
-        <Icon svg={<Icons.Info />} />
-      </Radio>
-    </RadioGroup>
+  <Card title="RadioGroup">
+    <View width="600px" padding="size-200">
+      <RadioGroup aria-label="RadioGroupWithIcons" {...args}>
+        <Radio aria-label="Option 1" value="1">
+          <Icon svg={<Icons.Info />} />
+        </Radio>
+        <Radio aria-label="Option 2" value="2">
+          <Icon svg={<Icons.Info />} />
+        </Radio>
+        <Radio aria-label="Option 3" value="3">
+          <Icon svg={<Icons.Info />} />
+        </Radio>
+      </RadioGroup>
+    </View>
   </Card>
 );
 

--- a/app/stories/Slider.stories.tsx
+++ b/app/stories/Slider.stories.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
-import { Slider, SliderNumberField } from "@phoenix/components";
+import { Card, Slider, SliderNumberField, View } from "@phoenix/components";
 
 const meta: Meta<typeof Slider> = {
   title: "Slider",
@@ -16,8 +14,10 @@ const meta: Meta<typeof Slider> = {
 export default meta;
 
 const Template: StoryFn<typeof Slider> = (args) => (
-  <Card title="Slider" bodyStyle={{ width: "600px" }} variant="compact">
-    <Slider {...args} />
+  <Card title="Slider">
+    <View width="600px" padding="size-200">
+      <Slider {...args} />
+    </View>
   </Card>
 );
 
@@ -32,14 +32,12 @@ export const Default = {
 };
 
 const WithNumberFieldTemplate: StoryFn<typeof Slider> = (args) => (
-  <Card
-    title="Slider with Number Field"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Slider {...args}>
-      <SliderNumberField />
-    </Slider>
+  <Card title="Slider with Number Field">
+    <View width="600px" padding="size-200">
+      <Slider {...args}>
+        <SliderNumberField />
+      </Slider>
+    </View>
   </Card>
 );
 
@@ -54,10 +52,12 @@ export const WithNumberField = {
 };
 
 const SteppedSliderTemplate: StoryFn<typeof Slider> = (args) => (
-  <Card title="Stepped Slider" bodyStyle={{ width: "600px" }} variant="compact">
-    <Slider {...args}>
-      <SliderNumberField />
-    </Slider>
+  <Card title="Stepped Slider">
+    <View width="600px" padding="size-200">
+      <Slider {...args}>
+        <SliderNumberField />
+      </Slider>
+    </View>
   </Card>
 );
 
@@ -73,14 +73,12 @@ export const SteppedSlider = {
 };
 
 const FloatingPointTemplate: StoryFn<typeof Slider> = (args) => (
-  <Card
-    title="Floating Point Slider"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Slider {...args}>
-      <SliderNumberField />
-    </Slider>
+  <Card title="Floating Point Slider">
+    <View width="600px" padding="size-200">
+      <Slider {...args}>
+        <SliderNumberField />
+      </Slider>
+    </View>
   </Card>
 );
 
@@ -96,12 +94,10 @@ export const FloatingPoint = {
 };
 
 const MultiThumbTemplate: StoryFn<typeof Slider> = (args) => (
-  <Card
-    title="Multi-Thumb Slider"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Slider {...args} />
+  <Card title="Multi-Thumb Slider">
+    <View width="600px" padding="size-200">
+      <Slider {...args} />
+    </View>
   </Card>
 );
 
@@ -119,14 +115,12 @@ export const MultiThumb = {
 const ControlledTemplate: StoryFn<typeof Slider> = (args) => {
   const [value, setValue] = useState<number>(50);
   return (
-    <Card
-      title="Controlled Slider"
-      bodyStyle={{ width: "600px" }}
-      variant="compact"
-    >
-      <Slider {...args} value={value} onChange={(v) => setValue(v as number)}>
-        <SliderNumberField />
-      </Slider>
+    <Card title="Controlled Slider">
+      <View width="600px" padding="size-200">
+        <Slider {...args} value={value} onChange={(v) => setValue(v as number)}>
+          <SliderNumberField />
+        </Slider>
+      </View>
     </Card>
   );
 };

--- a/app/stories/Tabs.stories.tsx
+++ b/app/stories/Tabs.stories.tsx
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
 import {
+  Card,
   LazyTabPanel,
   Tab,
   TabList,
   TabPanel,
   Tabs,
+  View,
 } from "@phoenix/components";
 
 const meta: Meta = {
@@ -21,23 +21,25 @@ const meta: Meta = {
 export default meta;
 
 const Template: StoryFn = (args) => (
-  <Card title="Basic Tabs" bodyStyle={{ width: "600px" }} variant="compact">
-    <Tabs {...args}>
-      <TabList>
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3">Tab 3</Tab>
-      </TabList>
-      <TabPanel padded id="tab1">
-        Content for Tab 1
-      </TabPanel>
-      <TabPanel padded id="tab2">
-        Content for Tab 2
-      </TabPanel>
-      <TabPanel padded id="tab3">
-        Content for Tab 3
-      </TabPanel>
-    </Tabs>
+  <Card title="Basic Tabs">
+    <View width="600px" padding="size-200">
+      <Tabs {...args}>
+        <TabList>
+          <Tab id="tab1">Tab 1</Tab>
+          <Tab id="tab2">Tab 2</Tab>
+          <Tab id="tab3">Tab 3</Tab>
+        </TabList>
+        <TabPanel padded id="tab1">
+          Content for Tab 1
+        </TabPanel>
+        <TabPanel padded id="tab2">
+          Content for Tab 2
+        </TabPanel>
+        <TabPanel padded id="tab3">
+          Content for Tab 3
+        </TabPanel>
+      </Tabs>
+    </View>
   </Card>
 );
 
@@ -47,29 +49,27 @@ export const Default = {
 };
 
 const DisabledTemplate: StoryFn = (args) => (
-  <Card
-    title="Tabs with Disabled State"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Tabs {...args}>
-      <TabList>
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2" isDisabled>
-          Tab 2 (Disabled)
-        </Tab>
-        <Tab id="tab3">Tab 3</Tab>
-      </TabList>
-      <TabPanel padded id="tab1">
-        Content for Tab 1
-      </TabPanel>
-      <TabPanel padded id="tab2">
-        Content for Tab 2
-      </TabPanel>
-      <TabPanel padded id="tab3">
-        Content for Tab 3
-      </TabPanel>
-    </Tabs>
+  <Card title="Tabs with Disabled State">
+    <View width="600px" padding="size-200">
+      <Tabs {...args}>
+        <TabList>
+          <Tab id="tab1">Tab 1</Tab>
+          <Tab id="tab2" isDisabled>
+            Tab 2 (Disabled)
+          </Tab>
+          <Tab id="tab3">Tab 3</Tab>
+        </TabList>
+        <TabPanel padded id="tab1">
+          Content for Tab 1
+        </TabPanel>
+        <TabPanel padded id="tab2">
+          Content for Tab 2
+        </TabPanel>
+        <TabPanel padded id="tab3">
+          Content for Tab 3
+        </TabPanel>
+      </Tabs>
+    </View>
   </Card>
 );
 
@@ -79,27 +79,25 @@ export const WithDisabledTab = {
 };
 
 const LazyLoadingTemplate: StoryFn = (args) => (
-  <Card
-    title="Lazy Loading Tabs"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Tabs {...args}>
-      <TabList>
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3">Tab 3</Tab>
-      </TabList>
-      <LazyTabPanel padded id="tab1">
-        Content for Tab 1 (Lazy Loaded)
-      </LazyTabPanel>
-      <LazyTabPanel padded id="tab2">
-        Content for Tab 2 (Lazy Loaded)
-      </LazyTabPanel>
-      <LazyTabPanel padded id="tab3">
-        Content for Tab 3 (Lazy Loaded)
-      </LazyTabPanel>
-    </Tabs>
+  <Card title="Lazy Loading Tabs">
+    <View width="600px" padding="size-200">
+      <Tabs {...args}>
+        <TabList>
+          <Tab id="tab1">Tab 1</Tab>
+          <Tab id="tab2">Tab 2</Tab>
+          <Tab id="tab3">Tab 3</Tab>
+        </TabList>
+        <LazyTabPanel padded id="tab1">
+          Content for Tab 1 (Lazy Loaded)
+        </LazyTabPanel>
+        <LazyTabPanel padded id="tab2">
+          Content for Tab 2 (Lazy Loaded)
+        </LazyTabPanel>
+        <LazyTabPanel padded id="tab3">
+          Content for Tab 3 (Lazy Loaded)
+        </LazyTabPanel>
+      </Tabs>
+    </View>
   </Card>
 );
 
@@ -109,43 +107,41 @@ export const LazyLoading = {
 };
 
 const ComplexContentTemplate: StoryFn = (args) => (
-  <Card
-    title="Tabs with Complex Content"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Tabs {...args}>
-      <TabList>
-        <Tab id="details">Details</Tab>
-        <Tab id="settings">Settings</Tab>
-        <Tab id="advanced">Advanced</Tab>
-      </TabList>
-      <TabPanel id="details">
-        <h3>Product Details</h3>
-        <p>
-          This is a detailed description of the product with multiple paragraphs
-          of text.
-        </p>
-        <p>It can contain rich content and complex layouts.</p>
-      </TabPanel>
-      <TabPanel id="settings">
-        <h3>Settings Panel</h3>
-        <ul>
-          <li>Setting 1</li>
-          <li>Setting 2</li>
-          <li>Setting 3</li>
-        </ul>
-      </TabPanel>
-      <TabPanel id="advanced">
-        <h3>Advanced Options</h3>
-        <div>
-          <p>Advanced configuration options go here.</p>
-          <button onClick={() => alert("Advanced action clicked!")}>
-            Perform Action
-          </button>
-        </div>
-      </TabPanel>
-    </Tabs>
+  <Card title="Tabs with Complex Content">
+    <View width="600px" padding="size-200">
+      <Tabs {...args}>
+        <TabList>
+          <Tab id="details">Details</Tab>
+          <Tab id="settings">Settings</Tab>
+          <Tab id="advanced">Advanced</Tab>
+        </TabList>
+        <TabPanel id="details">
+          <h3>Product Details</h3>
+          <p>
+            This is a detailed description of the product with multiple
+            paragraphs of text.
+          </p>
+          <p>It can contain rich content and complex layouts.</p>
+        </TabPanel>
+        <TabPanel id="settings">
+          <h3>Settings Panel</h3>
+          <ul>
+            <li>Setting 1</li>
+            <li>Setting 2</li>
+            <li>Setting 3</li>
+          </ul>
+        </TabPanel>
+        <TabPanel id="advanced">
+          <h3>Advanced Options</h3>
+          <div>
+            <p>Advanced configuration options go here.</p>
+            <button onClick={() => alert("Advanced action clicked!")}>
+              Perform Action
+            </button>
+          </div>
+        </TabPanel>
+      </Tabs>
+    </View>
   </Card>
 );
 
@@ -155,23 +151,25 @@ export const ComplexContent = {
 };
 
 const OrientationTemplate: StoryFn = (args) => (
-  <Card title="Vertical Tabs" bodyStyle={{ width: "600px" }} variant="compact">
-    <Tabs {...args} orientation="vertical">
-      <TabList>
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3">Tab 3</Tab>
-      </TabList>
-      <TabPanel padded id="tab1">
-        Content for Tab 1
-      </TabPanel>
-      <TabPanel padded id="tab2">
-        Content for Tab 2
-      </TabPanel>
-      <TabPanel padded id="tab3">
-        Content for Tab 3
-      </TabPanel>
-    </Tabs>
+  <Card title="Vertical Tabs">
+    <View width="600px" padding="size-200">
+      <Tabs {...args} orientation="vertical">
+        <TabList>
+          <Tab id="tab1">Tab 1</Tab>
+          <Tab id="tab2">Tab 2</Tab>
+          <Tab id="tab3">Tab 3</Tab>
+        </TabList>
+        <TabPanel padded id="tab1">
+          Content for Tab 1
+        </TabPanel>
+        <TabPanel padded id="tab2">
+          Content for Tab 2
+        </TabPanel>
+        <TabPanel padded id="tab3">
+          Content for Tab 3
+        </TabPanel>
+      </Tabs>
+    </View>
   </Card>
 );
 

--- a/app/stories/TitledPanel.stories.tsx
+++ b/app/stories/TitledPanel.stories.tsx
@@ -1,9 +1,7 @@
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
-import { Text, Token, View } from "@phoenix/components";
+import { Card, Text, Token, View } from "@phoenix/components";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 
 const meta: Meta = {
@@ -19,19 +17,21 @@ const bodyStyle = { width: "600px", height: "300px" };
 export default meta;
 
 const Template: StoryFn = (args) => (
-  <Card title="TitledPanel" bodyStyle={bodyStyle} variant="compact">
-    <PanelGroup direction="vertical">
-      <TitledPanel title="Regular Panel">
-        <View padding="size-200">
-          <Text>This is a non-resizable panel with title</Text>
-        </View>
-      </TitledPanel>
-      <TitledPanel title="Basic Panel" resizable {...args}>
-        <View padding="size-200">
-          <Text>This is a basic panel with a title</Text>
-        </View>
-      </TitledPanel>
-    </PanelGroup>
+  <Card title="TitledPanel">
+    <View {...bodyStyle}>
+      <PanelGroup direction="vertical">
+        <TitledPanel title="Regular Panel">
+          <View padding="size-200">
+            <Text>This is a non-resizable panel with title</Text>
+          </View>
+        </TitledPanel>
+        <TitledPanel title="Basic Panel" resizable {...args}>
+          <View padding="size-200">
+            <Text>This is a basic panel with a title</Text>
+          </View>
+        </TitledPanel>
+      </PanelGroup>
+    </View>
   </Card>
 );
 
@@ -41,27 +41,25 @@ export const Default: Meta<typeof TitledPanel> = {
 };
 
 const WithCustomContentTemplate: StoryFn = (args) => (
-  <Card
-    title="TitledPanel with Custom Content"
-    bodyStyle={bodyStyle}
-    variant="compact"
-  >
-    <PanelGroup direction="vertical">
-      <Panel>
-        <View padding="size-200">
-          <Text>This is a regular panel with some content</Text>
-        </View>
-      </Panel>
-      <TitledPanel title="Custom Content Panel" resizable {...args}>
-        <View padding="size-200">
-          <h3>Custom Content</h3>
-          <p>
-            This panel contains custom content with different styling and
-            layout.
-          </p>
-        </View>
-      </TitledPanel>
-    </PanelGroup>
+  <Card title="TitledPanel with Custom Content">
+    <View {...bodyStyle}>
+      <PanelGroup direction="vertical">
+        <Panel>
+          <View padding="size-200">
+            <Text>This is a regular panel with some content</Text>
+          </View>
+        </Panel>
+        <TitledPanel title="Custom Content Panel" resizable {...args}>
+          <View padding="size-200">
+            <h3>Custom Content</h3>
+            <p>
+              This panel contains custom content with different styling and
+              layout.
+            </p>
+          </View>
+        </TitledPanel>
+      </PanelGroup>
+    </View>
   </Card>
 );
 
@@ -71,29 +69,31 @@ export const WithCustomContent: Meta<typeof TitledPanel> = {
 };
 
 const MultiplePanelsTemplate: StoryFn = (args) => (
-  <Card title="Multiple TitledPanels" bodyStyle={bodyStyle} variant="compact">
-    <PanelGroup direction="vertical">
-      <TitledPanel title="Regular Panel">
-        <View padding="size-200">
-          <Text>This is the main content panel</Text>
-        </View>
-      </TitledPanel>
-      <TitledPanel resizable title="First Titled Panel" {...args}>
-        <View padding="size-200">
-          <Text>This is the first titled panel</Text>
-        </View>
-      </TitledPanel>
-      <TitledPanel resizable title="Second Titled Panel" {...args}>
-        <View padding="size-200">
-          <Text>This is the second titled panel</Text>
-        </View>
-      </TitledPanel>
-      <TitledPanel resizable title="Third Titled Panel" {...args}>
-        <View padding="size-200">
-          <Text>This is the third titled panel</Text>
-        </View>
-      </TitledPanel>
-    </PanelGroup>
+  <Card title="Multiple TitledPanels">
+    <View {...bodyStyle}>
+      <PanelGroup direction="vertical">
+        <TitledPanel title="Regular Panel">
+          <View padding="size-200">
+            <Text>This is the main content panel</Text>
+          </View>
+        </TitledPanel>
+        <TitledPanel resizable title="First Titled Panel" {...args}>
+          <View padding="size-200">
+            <Text>This is the first titled panel</Text>
+          </View>
+        </TitledPanel>
+        <TitledPanel resizable title="Second Titled Panel" {...args}>
+          <View padding="size-200">
+            <Text>This is the second titled panel</Text>
+          </View>
+        </TitledPanel>
+        <TitledPanel resizable title="Third Titled Panel" {...args}>
+          <View padding="size-200">
+            <Text>This is the third titled panel</Text>
+          </View>
+        </TitledPanel>
+      </PanelGroup>
+    </View>
   </Card>
 );
 
@@ -103,37 +103,35 @@ export const MultiplePanels: Meta<typeof TitledPanel> = {
 };
 
 const WithCustomTitleTemplate: StoryFn = (args) => (
-  <Card
-    title="TitledPanel with Custom Title"
-    bodyStyle={bodyStyle}
-    variant="compact"
-  >
-    <PanelGroup direction="vertical">
-      <Panel>
-        <View padding="size-200">
-          <Text>This is the main content area</Text>
-        </View>
-      </Panel>
-      <TitledPanel
-        title={
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--ac-global-dimension-size-100)",
-            }}
-          >
-            <span>Custom Title</span>
-            <Token color="green">New</Token>
+  <Card title="TitledPanel with Custom Title">
+    <View {...bodyStyle}>
+      <PanelGroup direction="vertical">
+        <Panel>
+          <View padding="size-200">
+            <Text>This is the main content area</Text>
+          </View>
+        </Panel>
+        <TitledPanel
+          title={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--ac-global-dimension-size-100)",
+              }}
+            >
+              <span>Custom Title</span>
+              <Token color="green">New</Token>
+            </div>
+          }
+          {...args}
+        >
+          <div style={{ padding: "var(--ac-global-dimension-size-200)" }}>
+            This panel has a custom title with additional elements
           </div>
-        }
-        {...args}
-      >
-        <div style={{ padding: "var(--ac-global-dimension-size-200)" }}>
-          This panel has a custom title with additional elements
-        </div>
-      </TitledPanel>
-    </PanelGroup>
+        </TitledPanel>
+      </PanelGroup>
+    </View>
   </Card>
 );
 

--- a/app/stories/ToggleButtonGroup.stories.tsx
+++ b/app/stories/ToggleButtonGroup.stories.tsx
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
 import {
+  Card,
   Icon,
   Icons,
   ToggleButton,
   ToggleButtonGroup,
   type ToggleButtonGroupProps,
+  View,
 } from "@phoenix/components";
 
 const meta: Meta = {
@@ -21,22 +21,20 @@ const meta: Meta = {
 export default meta;
 
 const Template: StoryFn<ToggleButtonGroupProps> = (args) => (
-  <Card
-    title="ToggleButtonGroup"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <ToggleButtonGroup aria-label="ToggleButtonGroup" {...args}>
-      <ToggleButton aria-label="Option 1" id="1">
-        Option 1
-      </ToggleButton>
-      <ToggleButton aria-label="Option 2" id="2">
-        Option 2
-      </ToggleButton>
-      <ToggleButton aria-label="Option 3" id="3">
-        Option 3
-      </ToggleButton>
-    </ToggleButtonGroup>
+  <Card title="ToggleButtonGroup">
+    <View width="600px" padding="size-200">
+      <ToggleButtonGroup aria-label="ToggleButtonGroup" {...args}>
+        <ToggleButton aria-label="Option 1" id="1">
+          Option 1
+        </ToggleButton>
+        <ToggleButton aria-label="Option 2" id="2">
+          Option 2
+        </ToggleButton>
+        <ToggleButton aria-label="Option 3" id="3">
+          Option 3
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </View>
   </Card>
 );
 
@@ -59,22 +57,20 @@ export const Default: Meta<typeof ToggleButtonGroup> = {
 };
 
 const AsIconTemplate: StoryFn<ToggleButtonGroupProps> = (args) => (
-  <Card
-    title="ToggleButtonGroup"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <ToggleButtonGroup aria-label="ToggleButtonGroupWithIcons" {...args}>
-      <ToggleButton aria-label="Option 1" id="1">
-        <Icon svg={<Icons.Info />} />
-      </ToggleButton>
-      <ToggleButton aria-label="Option 2" id="2">
-        <Icon svg={<Icons.Info />} />
-      </ToggleButton>
-      <ToggleButton aria-label="Option 3" id="3">
-        <Icon svg={<Icons.Info />} />
-      </ToggleButton>
-    </ToggleButtonGroup>
+  <Card title="ToggleButtonGroup">
+    <View width="600px" padding="size-200">
+      <ToggleButtonGroup aria-label="ToggleButtonGroupWithIcons" {...args}>
+        <ToggleButton aria-label="Option 1" id="1">
+          <Icon svg={<Icons.Info />} />
+        </ToggleButton>
+        <ToggleButton aria-label="Option 2" id="2">
+          <Icon svg={<Icons.Info />} />
+        </ToggleButton>
+        <ToggleButton aria-label="Option 3" id="3">
+          <Icon svg={<Icons.Info />} />
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </View>
   </Card>
 );
 

--- a/app/stories/Token.stories.tsx
+++ b/app/stories/Token.stories.tsx
@@ -1,8 +1,14 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import { Card } from "@arizeai/components";
-
-import { Flex, Icon, Icons, Token, type TokenProps } from "@phoenix/components";
+import {
+  Card,
+  Flex,
+  Icon,
+  Icons,
+  Token,
+  type TokenProps,
+  View,
+} from "@phoenix/components";
 
 const meta: Meta = {
   title: "Token",
@@ -15,8 +21,10 @@ const meta: Meta = {
 export default meta;
 
 const Template: StoryFn<TokenProps> = (args) => (
-  <Card title="Token" bodyStyle={{ width: "600px" }} variant="compact">
-    <Token {...args}>Example Token</Token>
+  <Card title="Token">
+    <View width="600px" padding="size-200">
+      <Token {...args}>Example Token</Token>
+    </View>
   </Card>
 );
 
@@ -29,14 +37,12 @@ export const Default: Meta<typeof Token> = {
 };
 
 const InteractiveTemplate: StoryFn<TokenProps> = (args) => (
-  <Card
-    title="Interactive Token"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Token {...args} onPress={() => alert("Token clicked!")}>
-      Clickable Token
-    </Token>
+  <Card title="Interactive Token">
+    <View width="600px" padding="size-200">
+      <Token {...args} onPress={() => alert("Token clicked!")}>
+        Clickable Token
+      </Token>
+    </View>
   </Card>
 );
 
@@ -49,14 +55,12 @@ export const Interactive: Meta<typeof Token> = {
 };
 
 const RemovableTemplate: StoryFn<TokenProps> = (args) => (
-  <Card
-    title="Removable Token"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Token {...args} onRemove={() => alert("Token removed!")}>
-      Removable Token
-    </Token>
+  <Card title="Removable Token">
+    <View width="600px" padding="size-200">
+      <Token {...args} onRemove={() => alert("Token removed!")}>
+        Removable Token
+      </Token>
+    </View>
   </Card>
 );
 
@@ -69,14 +73,12 @@ export const Removable: Meta<typeof Token> = {
 };
 
 const WithLeadingVisualTemplate: StoryFn<TokenProps> = (args) => (
-  <Card
-    title="Token with Leading Visual"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Token {...args} leadingVisual={<Icon svg={<Icons.Info />} />}>
-      With Leading Visual
-    </Token>
+  <Card title="Token with Leading Visual">
+    <View width="600px" padding="size-200">
+      <Token {...args} leadingVisual={<Icon svg={<Icons.Info />} />}>
+        With Leading Visual
+      </Token>
+    </View>
   </Card>
 );
 
@@ -90,19 +92,17 @@ export const WithLeadingVisual: Meta<typeof Token> = {
 };
 
 const FullInteractiveTemplate: StoryFn<TokenProps> = (args) => (
-  <Card
-    title="Full Interactive Token"
-    bodyStyle={{ width: "600px" }}
-    variant="compact"
-  >
-    <Token
-      {...args}
-      leadingVisual={<Icon svg={<Icons.Info />} />}
-      onPress={() => alert("Token clicked!")}
-      onRemove={() => alert("Token removed!")}
-    >
-      Interactive & Removable
-    </Token>
+  <Card title="Full Interactive Token">
+    <View width="600px" padding="size-200">
+      <Token
+        {...args}
+        leadingVisual={<Icon svg={<Icons.Info />} />}
+        onPress={() => alert("Token clicked!")}
+        onRemove={() => alert("Token removed!")}
+      >
+        Interactive & Removable
+      </Token>
+    </View>
   </Card>
 );
 
@@ -115,18 +115,20 @@ export const FullInteractive: Meta<typeof Token> = {
 };
 
 const SizeTemplate: StoryFn<TokenProps> = (args) => (
-  <Card title="Token Size" bodyStyle={{ width: "600px" }} variant="compact">
-    <Flex gap="size-100" wrap>
-      <Token {...args} size="S" color="var(--ac-global-color-primary)">
-        Small Token
-      </Token>
-      <Token {...args} size="M" color="var(--ac-global-color-primary)">
-        Medium Token
-      </Token>
-      <Token {...args} size="L" color="var(--ac-global-color-primary)">
-        Large Token
-      </Token>
-    </Flex>
+  <Card title="Token Size">
+    <View width="600px" padding="size-200">
+      <Flex gap="size-100" wrap>
+        <Token {...args} size="S" color="var(--ac-global-color-primary)">
+          Small Token
+        </Token>
+        <Token {...args} size="M" color="var(--ac-global-color-primary)">
+          Medium Token
+        </Token>
+        <Token {...args} size="L" color="var(--ac-global-color-primary)">
+          Large Token
+        </Token>
+      </Flex>
+    </View>
   </Card>
 );
 
@@ -138,19 +140,21 @@ export const Size: Meta<typeof Token> = {
 };
 
 const GroupTemplate: StoryFn<TokenProps> = (args) => (
-  <Card title="Token Group" bodyStyle={{ width: "600px" }} variant="compact">
-    <Flex gap="size-100" wrap>
-      <Token {...args}>Default Token</Token>
-      <Token {...args} color="var(--ac-global-color-primary)">
-        Primary Token
-      </Token>
-      <Token {...args} color="var(--ac-global-color-danger)">
-        Danger Token
-      </Token>
-      <Token {...args} color="var(--ac-global-color-success)">
-        Success Token
-      </Token>
-    </Flex>
+  <Card title="Token Group">
+    <View width="600px" padding="size-200">
+      <Flex gap="size-100" wrap>
+        <Token {...args}>Default Token</Token>
+        <Token {...args} color="var(--ac-global-color-primary)">
+          Primary Token
+        </Token>
+        <Token {...args} color="var(--ac-global-color-danger)">
+          Danger Token
+        </Token>
+        <Token {...args} color="var(--ac-global-color-success)">
+          Success Token
+        </Token>
+      </Flex>
+    </View>
   </Card>
 );
 


### PR DESCRIPTION
This completes the migration to use the new Card component, mainly by updating cards used in the settings page, span details page, and storybook stories. This also adds `titleSeparator` and `defaultOpen` props to Card, to maintain existing layout/behavior.  I'm not sure if we want to keep these since each prop is only used once, so definitely open to alternate ideas.

LLMSpanInfo card with no title separator:
<img width="723" height="291" alt="image" src="https://github.com/user-attachments/assets/320d5237-9ca9-4a5c-814d-fd859ce3e31d" />

RerankerSpanInfo card with defaultOpen=false:
<img width="723" height="291" alt="image" src="https://github.com/user-attachments/assets/ed7addf3-27a4-481a-a3cf-4403bda8415a" />

Some other various screenshots of updated cards:

<img width="717" height="378" alt="image" src="https://github.com/user-attachments/assets/2c6a947c-b47a-4f22-a1e4-0daf60b379ed" />

<img width="860" height="772" alt="image" src="https://github.com/user-attachments/assets/0e5bb818-72d6-4e76-9232-a31f6068bd66" />

<img width="1412" height="808" alt="image" src="https://github.com/user-attachments/assets/3bcd534a-1911-4337-8016-f09980c405f5" />

<img width="1338" height="542" alt="image" src="https://github.com/user-attachments/assets/766658e2-5e68-4c4f-80a4-a7c2c9036746" />

