### PR TITLE
feat(projects): add the ability to manually create a project

### DIFF
--- a/app/src/components/project/GradientCircle.tsx
+++ b/app/src/components/project/GradientCircle.tsx
@@ -1,0 +1,29 @@
+import { css } from "@emotion/react";
+
+export interface GradientCircleProps {
+  gradientStartColor: string;
+  gradientEndColor: string;
+  size?: number;
+}
+
+export function GradientCircle({
+  gradientStartColor,
+  gradientEndColor,
+  size = 32,
+}: GradientCircleProps) {
+  return (
+    <div
+      css={css`
+        border-radius: 50%;
+        width: ${size}px;
+        height: ${size}px;
+        background: linear-gradient(
+          136.27deg,
+          ${gradientStartColor} 14.03%,
+          ${gradientEndColor} 84.38%
+        );
+        flex-shrink: 0;
+      `}
+    />
+  );
+}

--- a/app/src/components/project/GradientCircleRadio.tsx
+++ b/app/src/components/project/GradientCircleRadio.tsx
@@ -1,0 +1,97 @@
+import {
+  Radio as AriaRadio,
+  type RadioProps as AriaRadioProps,
+} from "react-aria-components";
+import { css } from "@emotion/react";
+
+import { classNames } from "@phoenix/components";
+import { StylableProps } from "@phoenix/components/types";
+
+import { GradientCircle } from "./GradientCircle";
+
+const gradientCircleRadioCSS = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ac-global-dimension-size-50);
+  padding: var(--ac-global-dimension-size-100);
+  border: 2px solid transparent;
+  border-radius: var(--ac-global-rounding-medium);
+  cursor: pointer;
+  transition: all 200ms ease;
+  position: relative;
+  background: transparent;
+
+  /* Hover state */
+  &[data-hovered]:not([data-disabled]):not([data-selected]) {
+    border-color: var(--ac-global-color-grey-200);
+  }
+
+  /* Selected state */
+  &[data-selected] {
+    background-color: var(--ac-global-color-primary-50);
+    border-color: var(--ac-global-color-primary);
+  }
+
+  /* Pressed state */
+  &[data-pressed] {
+    transform: scale(0.98);
+  }
+
+  /* Focus visible state */
+  &[data-focus-visible] {
+    outline: 2px solid var(--ac-global-color-primary);
+    outline-offset: 2px;
+  }
+
+  /* Disabled state */
+  &[data-disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Label text styling */
+  .gradient-circle-radio__label {
+    font-size: var(--ac-global-dimension-static-font-size-75);
+    color: var(--ac-global-text-color-700);
+    text-align: center;
+    font-weight: 500;
+  }
+
+  &[data-selected] .gradient-circle-radio__label {
+    color: var(--ac-global-color-primary);
+    font-weight: 600;
+  }
+`;
+
+export interface GradientCircleRadioProps extends AriaRadioProps {
+  gradientStartColor: string;
+  gradientEndColor: string;
+  label?: string;
+  size?: number;
+}
+
+export function GradientCircleRadio({
+  gradientStartColor,
+  gradientEndColor,
+  label,
+  size = 32,
+  className,
+  css: cssProp,
+  ...props
+}: GradientCircleRadioProps & StylableProps) {
+  return (
+    <AriaRadio
+      className={classNames("gradient-circle-radio", className)}
+      css={css(gradientCircleRadioCSS, cssProp)}
+      {...props}
+    >
+      <GradientCircle
+        gradientStartColor={gradientStartColor}
+        gradientEndColor={gradientEndColor}
+        size={size}
+      />
+      {label && <span className="gradient-circle-radio__label">{label}</span>}
+    </AriaRadio>
+  );
+}

--- a/app/src/components/project/GradientCircleRadioGroup.tsx
+++ b/app/src/components/project/GradientCircleRadioGroup.tsx
@@ -1,0 +1,76 @@
+import {
+  RadioGroup as AriaRadioGroup,
+  type RadioGroupProps as AriaRadioGroupProps,
+} from "react-aria-components";
+import { css } from "@emotion/react";
+
+import { classNames } from "@phoenix/components";
+import { fieldBaseCSS } from "@phoenix/components/field/styles";
+import { StylableProps } from "@phoenix/components/types";
+
+const gradientCircleRadioGroupCSS = css`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: fit-content;
+  gap: var(--ac-global-dimension-size-100);
+  font-size: var(--ac-global-dimension-static-font-size-100);
+
+  &[data-direction="row"] {
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    .react-aria-Label {
+      flex-basis: 100%;
+      margin-bottom: var(--ac-global-dimension-size-100);
+    }
+
+    [slot="description"] {
+      flex-basis: 100%;
+      margin-top: var(--ac-global-dimension-size-50);
+    }
+  }
+
+  &[data-direction="column"] {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &[data-disabled] {
+    opacity: 0.5;
+  }
+
+  &[data-readonly] {
+    .gradient-circle-radio {
+      opacity: 0.7;
+      cursor: default;
+    }
+  }
+
+  &:has(.gradient-circle-radio[data-focus-visible]) {
+    border-radius: var(--ac-global-rounding-small);
+    outline: 1px solid var(--ac-global-color-primary);
+    outline-offset: var(--ac-global-dimension-size-50);
+  }
+`;
+
+export interface GradientCircleRadioGroupProps extends AriaRadioGroupProps {
+  direction?: "row" | "column";
+}
+
+export function GradientCircleRadioGroup({
+  css: cssProp,
+  className,
+  direction = "row",
+  ...props
+}: GradientCircleRadioGroupProps & StylableProps) {
+  return (
+    <AriaRadioGroup
+      data-direction={direction}
+      className={classNames("gradient-circle-radio-group", className)}
+      css={css(fieldBaseCSS, gradientCircleRadioGroupCSS, cssProp)}
+      {...props}
+    />
+  );
+}

--- a/app/src/components/project/index.ts
+++ b/app/src/components/project/index.ts
@@ -1,0 +1,18 @@
+export { GradientCircle } from "./GradientCircle";
+export type { GradientCircleProps } from "./GradientCircle";
+
+export { GradientCircleRadio } from "./GradientCircleRadio";
+export type { GradientCircleRadioProps } from "./GradientCircleRadio";
+
+export { GradientCircleRadioGroup } from "./GradientCircleRadioGroup";
+export type { GradientCircleRadioGroupProps } from "./GradientCircleRadioGroup";
+
+export {
+  PythonIntegrations,
+  TypeScriptIntegrations,
+  TypeScriptPlatformIntegrations,
+} from "./Integrations";
+export * from "./IntegrationIcons";
+export { PythonProjectGuide } from "./PythonProjectGuide";
+export { TypeScriptProjectGuide } from "./TypeScriptProjectGuide";
+export * from "./hosting";

--- a/app/src/pages/projects/ManualProjectGuide.tsx
+++ b/app/src/pages/projects/ManualProjectGuide.tsx
@@ -1,0 +1,81 @@
+import { useCallback } from "react";
+import { graphql, useMutation } from "react-relay";
+import { useNavigate } from "react-router";
+
+import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+
+import type { ManualProjectGuideCreateProjectMutation } from "./__generated__/ManualProjectGuideCreateProjectMutation.graphql";
+import { NewProjectForm, ProjectFormParams } from "./NewProjectForm";
+
+export function ManualProjectGuide() {
+  const navigate = useNavigate();
+  const notifySuccess = useNotifySuccess();
+  const notifyError = useNotifyError();
+
+  const [commit, isCommitting] =
+    useMutation<ManualProjectGuideCreateProjectMutation>(graphql`
+      mutation ManualProjectGuideCreateProjectMutation(
+        $input: CreateProjectInput!
+      ) {
+        createProject(input: $input) {
+          project {
+            id
+            name
+            gradientStartColor
+            gradientEndColor
+            createdAt
+          }
+          query {
+            projects(first: 50) {
+              edges {
+                node {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+  const onSubmit = useCallback(
+    (params: ProjectFormParams) => {
+      commit({
+        variables: {
+          input: {
+            name: params.name,
+            description: params.description,
+            gradientStartColor: params.gradientStartColor,
+            gradientEndColor: params.gradientEndColor,
+          },
+        },
+        onCompleted: (response) => {
+          const createdProject = response.createProject.project;
+          notifySuccess({
+            title: "Project created",
+            message: `Project "${createdProject.name}" has been successfully created.`,
+          });
+          // Navigate to the project page
+          navigate(`/projects/${createdProject.id}`);
+        },
+        onError: () => {
+          notifyError({
+            title: "Failed to create project",
+            message:
+              "This is likely due to a naming conflict. Please try a different name.",
+          });
+        },
+      });
+    },
+    [commit, notifySuccess, notifyError, navigate]
+  );
+
+  return (
+    <NewProjectForm
+      onSubmit={onSubmit}
+      isSubmitting={isCommitting}
+      submitButtonText={isCommitting ? "Creating..." : "Create Project"}
+    />
+  );
+}

--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -23,6 +23,7 @@ import {
   View,
 } from "@phoenix/components";
 import { TypeScriptProjectGuide } from "@phoenix/components/project/TypeScriptProjectGuide";
+import { ManualProjectGuide } from "@phoenix/pages/projects/ManualProjectGuide";
 
 import { PythonProjectGuide } from "../../components/project/PythonProjectGuide";
 
@@ -83,6 +84,7 @@ function NewProjectDialog() {
           <TabList>
             <Tab id="python">Python</Tab>
             <Tab id="typescript">TypeScript</Tab>
+            <Tab id="manual">Manual</Tab>
           </TabList>
           <TabPanel id="python">
             <View padding="size-200" overflow="auto">
@@ -94,6 +96,11 @@ function NewProjectDialog() {
             <View padding="size-200" overflow="auto">
               <TraceBasedProjectGuideIntro />
               <TypeScriptProjectGuide />
+            </View>
+          </TabPanel>
+          <TabPanel id="manual">
+            <View padding="size-200" overflow="auto">
+              <ManualProjectGuide />
             </View>
           </TabPanel>
         </Tabs>

--- a/app/src/pages/projects/NewProjectForm.tsx
+++ b/app/src/pages/projects/NewProjectForm.tsx
@@ -1,0 +1,286 @@
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  Button,
+  FieldError,
+  Flex,
+  Form,
+  Input,
+  Label,
+  Text,
+  TextArea,
+  TextField,
+  View,
+} from "@phoenix/components";
+import { fieldBaseCSS } from "@phoenix/components/field/styles";
+import {
+  GradientCircle,
+  GradientCircleRadio,
+  GradientCircleRadioGroup,
+} from "@phoenix/components/project";
+
+export type ProjectFormParams = {
+  name: string;
+  description: string;
+  gradientPreset: string;
+  gradientStartColor: string;
+  gradientEndColor: string;
+};
+
+// URI-safe pattern: allows letters, numbers, hyphens, underscores, and dots
+const URI_SAFE_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+// Predefined gradient options
+const GRADIENT_PRESETS = [
+  {
+    id: "blue-purple",
+    label: "Blue Purple",
+    startColor: "#3B82F6",
+    endColor: "#6366F1",
+  },
+  {
+    id: "green-cyan",
+    label: "Green Cyan",
+    startColor: "#10B981",
+    endColor: "#06B6D4",
+  },
+  {
+    id: "purple-pink",
+    label: "Purple Pink",
+    startColor: "#8B5CF6",
+    endColor: "#EC4899",
+  },
+  {
+    id: "orange-yellow",
+    label: "Orange Yellow",
+    startColor: "#F97316",
+    endColor: "#FCD34D",
+  },
+  {
+    id: "pink-red",
+    label: "Pink Red",
+    startColor: "#EC4899",
+    endColor: "#EF4444",
+  },
+  {
+    id: "cyan-blue",
+    label: "Cyan Blue",
+    startColor: "#06B6D4",
+    endColor: "#3B82F6",
+  },
+  {
+    id: "emerald-teal",
+    label: "Emerald Teal",
+    startColor: "#10B981",
+    endColor: "#14B8A6",
+  },
+  {
+    id: "violet-indigo",
+    label: "Violet Indigo",
+    startColor: "#8B5CF6",
+    endColor: "#6366F1",
+  },
+  {
+    id: "rose-pink",
+    label: "Rose Pink",
+    startColor: "#F43F5E",
+    endColor: "#EC4899",
+  },
+  {
+    id: "amber-orange",
+    label: "Amber Orange",
+    startColor: "#F59E0B",
+    endColor: "#F97316",
+  },
+  {
+    id: "lime-green",
+    label: "Lime Green",
+    startColor: "#84CC16",
+    endColor: "#10B981",
+  },
+  {
+    id: "sky-cyan",
+    label: "Sky Cyan",
+    startColor: "#0EA5E9",
+    endColor: "#06B6D4",
+  },
+] as const;
+
+export function NewProjectForm({
+  onSubmit,
+  isSubmitting,
+  submitButtonText,
+}: {
+  onSubmit: (params: ProjectFormParams) => void;
+  isSubmitting: boolean;
+  submitButtonText: string;
+}) {
+  const {
+    control,
+    handleSubmit,
+    watch,
+    formState: { isDirty },
+  } = useForm<ProjectFormParams>({
+    defaultValues: {
+      name: "",
+      description: "",
+      gradientPreset: "blue-purple",
+    },
+  });
+
+  // Watch form values for preview
+  const currentPreset = watch("gradientPreset");
+
+  // Get current gradient colors based on selection
+  const getCurrentGradientColors = () => {
+    const preset = GRADIENT_PRESETS.find((p) => p.id === currentPreset);
+    return {
+      startColor: preset?.startColor || "#3B82F6",
+      endColor: preset?.endColor || "#6366F1",
+    };
+  };
+
+  const { startColor, endColor } = getCurrentGradientColors();
+
+  const handleFormSubmit = (data: ProjectFormParams) => {
+    const { startColor: finalStartColor, endColor: finalEndColor } =
+      getCurrentGradientColors();
+    onSubmit({
+      name: data.name,
+      description: data.description,
+      gradientPreset: data.gradientPreset,
+      gradientStartColor: finalStartColor,
+      gradientEndColor: finalEndColor,
+    });
+  };
+
+  return (
+    <Form>
+      <View padding="size-200">
+        {/* Gradient Configuration Section - Moved to top */}
+        <View paddingBottom="size-200" marginBottom="size-200">
+          <Flex direction="row" gap="size-400" alignItems="center">
+            <Flex direction="column" alignItems="center" gap="size-200">
+              <GradientCircle
+                gradientStartColor={startColor}
+                gradientEndColor={endColor}
+                size={100}
+              />
+            </Flex>
+            <Controller
+              name="gradientPreset"
+              control={control}
+              render={({ field: { onChange, value } }) => (
+                <div css={fieldBaseCSS}>
+                  <Label>Project Gradient</Label>
+                  <GradientCircleRadioGroup
+                    value={value}
+                    onChange={onChange}
+                    direction="row"
+                  >
+                    {GRADIENT_PRESETS.map((preset) => (
+                      <GradientCircleRadio
+                        key={preset.id}
+                        value={preset.id}
+                        gradientStartColor={preset.startColor}
+                        gradientEndColor={preset.endColor}
+                        label={preset.label}
+                        size={48}
+                      />
+                    ))}
+                  </GradientCircleRadioGroup>
+                  <Text slot="description">
+                    Select a predefined gradient to help identify your project
+                  </Text>
+                </div>
+              )}
+            />
+          </Flex>
+        </View>
+        <Controller
+          name="name"
+          control={control}
+          rules={{
+            required: "Project name is required",
+            pattern: {
+              value: URI_SAFE_PATTERN,
+              message:
+                "Project name must be URI safe. Use only letters, numbers, hyphens, underscores, and dots. No spaces or special characters.",
+            },
+            minLength: {
+              value: 1,
+              message: "Project name must be at least 1 character long",
+            },
+            maxLength: {
+              value: 100,
+              message: "Project name must be less than 100 characters long",
+            },
+          }}
+          render={({
+            field: { onChange, onBlur, value },
+            fieldState: { invalid, error },
+          }) => (
+            <TextField
+              isInvalid={invalid}
+              onChange={onChange}
+              onBlur={onBlur}
+              value={value.toString()}
+            >
+              <Label>Project Name</Label>
+              <Input placeholder="e.x. my-ai-project" />
+              {error?.message ? (
+                <FieldError>{error.message}</FieldError>
+              ) : (
+                <Text slot="description">
+                  The name of the project. Must be URI safe (letters, numbers,
+                  hyphens, underscores, dots only).
+                </Text>
+              )}
+            </TextField>
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({
+            field: { onChange, onBlur, value },
+            fieldState: { invalid, error },
+          }) => (
+            <TextField
+              isInvalid={invalid}
+              onChange={onChange}
+              onBlur={onBlur}
+              value={value.toString()}
+            >
+              <Label>Description</Label>
+              <TextArea placeholder="e.x. A project for tracking agent performance" />
+              {error?.message ? (
+                <FieldError>{error.message}</FieldError>
+              ) : (
+                <Text slot="description">The description of the project</Text>
+              )}
+            </TextField>
+          )}
+        />
+      </View>
+      <View
+        paddingEnd="size-200"
+        paddingTop="size-100"
+        paddingBottom="size-100"
+      >
+        <Flex direction="row" justifyContent="end">
+          <Button
+            isDisabled={isSubmitting}
+            variant={isDirty ? "primary" : "default"}
+            size="M"
+            onPress={() => {
+              handleSubmit(handleFormSubmit)();
+            }}
+          >
+            {submitButtonText}
+          </Button>
+        </Flex>
+      </View>
+    </Form>
+  );
+}

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -47,6 +47,7 @@ import {
   useTimeRange,
 } from "@phoenix/components/datetime";
 import { LoadMoreButton } from "@phoenix/components/LoadMoreButton";
+import { GradientCircle } from "@phoenix/components/project/GradientCircle";
 import { tableCSS } from "@phoenix/components/table/styles";
 import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
@@ -482,29 +483,6 @@ function ProjectsGrid({
   );
 }
 
-function ProjectIcon({
-  gradientStartColor,
-  gradientEndColor,
-}: {
-  gradientStartColor: string;
-  gradientEndColor: string;
-}) {
-  return (
-    <div
-      css={css`
-        border-radius: 50%;
-        width: 32px;
-        height: 32px;
-        background: linear-gradient(
-          136.27deg,
-          ${gradientStartColor} 14.03%,
-          ${gradientEndColor} 84.38%
-        );
-        flex-shrink: 0;
-      `}
-    />
-  );
-}
 type ProjectItemProps = {
   project: ProjectsPageProjectsFragment$data["projects"]["edges"][number]["project"];
   onProjectDelete: () => void;
@@ -552,7 +530,7 @@ function ProjectItem({
     >
       <Flex direction="row" justifyContent="space-between" alignItems="start">
         <Flex direction="row" gap="size-100" alignItems="center" minWidth={0}>
-          <ProjectIcon
+          <GradientCircle
             gradientStartColor={gradientStartColor}
             gradientEndColor={gradientEndColor}
           />
@@ -737,7 +715,7 @@ function ProjectsTable({
           cell: ({ row }) => {
             return (
               <Flex direction="row" gap="size-200" alignItems="center">
-                <ProjectIcon
+                <GradientCircle
                   gradientStartColor={row.original.gradientStartColor}
                   gradientEndColor={row.original.gradientEndColor}
                 />

--- a/app/src/pages/projects/__generated__/ManualProjectGuideCreateProjectMutation.graphql.ts
+++ b/app/src/pages/projects/__generated__/ManualProjectGuideCreateProjectMutation.graphql.ts
@@ -1,0 +1,204 @@
+/**
+ * @generated SignedSource<<15bdec60adef86473284d31b8926cc62>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateProjectInput = {
+  description?: string | null;
+  gradientEndColor?: string | null;
+  gradientStartColor?: string | null;
+  name: string;
+};
+export type ManualProjectGuideCreateProjectMutation$variables = {
+  input: CreateProjectInput;
+};
+export type ManualProjectGuideCreateProjectMutation$data = {
+  readonly createProject: {
+    readonly project: {
+      readonly createdAt: string;
+      readonly gradientEndColor: string;
+      readonly gradientStartColor: string;
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly query: {
+      readonly projects: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly id: string;
+            readonly name: string;
+          };
+        }>;
+      };
+    };
+  };
+};
+export type ManualProjectGuideCreateProjectMutation = {
+  response: ManualProjectGuideCreateProjectMutation$data;
+  variables: ManualProjectGuideCreateProjectMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "ProjectMutationPayload",
+    "kind": "LinkedField",
+    "name": "createProject",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Project",
+        "kind": "LinkedField",
+        "name": "project",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "gradientStartColor",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "gradientEndColor",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Query",
+        "kind": "LinkedField",
+        "name": "query",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
+            "concreteType": "ProjectConnection",
+            "kind": "LinkedField",
+            "name": "projects",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProjectEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Project",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "projects(first:50)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ManualProjectGuideCreateProjectMutation",
+    "selections": (v3/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ManualProjectGuideCreateProjectMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "66adc44a362691c6f6552bd469443fc9",
+    "id": null,
+    "metadata": {},
+    "name": "ManualProjectGuideCreateProjectMutation",
+    "operationKind": "mutation",
+    "text": "mutation ManualProjectGuideCreateProjectMutation(\n  $input: CreateProjectInput!\n) {\n  createProject(input: $input) {\n    project {\n      id\n      name\n      gradientStartColor\n      gradientEndColor\n      createdAt\n    }\n    query {\n      projects(first: 50) {\n        edges {\n          node {\n            id\n            name\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "da1e5f68e9954a2618ba7de1fb86921c";
+
+export default node;


### PR DESCRIPTION
Add the ability to manually create projects
(e.g. to create a place to put other spans for things like transfer)
<img width="2050" height="1168" alt="Screenshot 2025-08-01 at 4 18 11 PM" src="https://github.com/user-attachments/assets/c1107aa1-5c59-4226-a60e-ce098bb07572" />
