### PR TITLE
fix: token count component on trace tree should select span when clicked

### DIFF
--- a/app/src/components/trace/SpanTokenCount.tsx
+++ b/app/src/components/trace/SpanTokenCount.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Pressable } from "react-aria";
+import { Pressable, PressProps } from "react-aria";
 
 import {
   Loading,
@@ -20,29 +20,34 @@ type SpanTokenCountProps = {
   /**
    * The id of the node (span, trace, session, etc.)
    */
-
   nodeId: string;
   /**
    * The size of the icon and text
    */
   size?: TextProps["size"];
-};
+  /**
+   * Click handler for the token count
+   */
+  onPress?: PressProps["onPress"];
+} & Omit<PressProps, "children">;
 
 /**
  * Displays the number of tokens in the prompt and completion
  */
 export function SpanTokenCount(props: SpanTokenCountProps) {
+  const { tokenCountTotal, nodeId, size, onPress, ...pressableProps } = props;
+
   return (
     <TooltipTrigger>
-      <Pressable>
-        <TokenCount size={props.size} role="button">
-          {props.tokenCountTotal}
+      <Pressable onPress={onPress} {...pressableProps}>
+        <TokenCount size={size} role="button">
+          {tokenCountTotal}
         </TokenCount>
       </Pressable>
       <RichTooltip>
         <TooltipArrow />
         <Suspense fallback={<Loading />}>
-          <SpanTokenCountDetails spanNodeId={props.nodeId} />
+          <SpanTokenCountDetails spanNodeId={nodeId} />
         </Suspense>
       </RichTooltip>
     </TooltipTrigger>

--- a/app/src/components/trace/TraceTree.tsx
+++ b/app/src/components/trace/TraceTree.tsx
@@ -298,6 +298,9 @@ function SpanTreeItem<TSpan extends ISpanItem>(
               <SpanTokenCount
                 tokenCountTotal={tokenCountTotal}
                 nodeId={node.span.id}
+                onPress={() => {
+                  onSpanClick && onSpanClick(node.span);
+                }}
               />
             ) : null}
             {latencyMs != null && showMetricsInTraceTree ? (


### PR DESCRIPTION
Recording below shows the issue: the aria component does not bubble the click event to its parent.

https://github.com/user-attachments/assets/88c54782-2393-49a6-8816-f451d40c52ae

