### PR TITLE
fix: message role should not be required

### DIFF
--- a/app/src/openInference/tracing/__tests__/types.test.ts
+++ b/app/src/openInference/tracing/__tests__/types.test.ts
@@ -1,12 +1,7 @@
 import { isAttributeMessage } from "../types";
 
 describe("isAttributeMessage", () => {
-  it("should return true if the message conforms to an object with a role", () => {
-    expect(isAttributeMessage({ role: "system " })).toBe(true);
-  });
-
   it("should return false if the message does not conform to a reasonable shape", () => {
-    expect(isAttributeMessage({})).toBe(false);
     expect(isAttributeMessage("")).toBe(false);
     expect(isAttributeMessage(null)).toBe(false);
   });

--- a/app/src/openInference/tracing/types.ts
+++ b/app/src/openInference/tracing/types.ts
@@ -139,9 +139,5 @@ export function isAttributeMessages(
 export function isAttributeMessage(
   message: unknown
 ): message is AttributeMessage {
-  return (
-    typeof message === "object" &&
-    message !== null &&
-    MessageAttributePostfixes.role in message
-  );
+  return typeof message === "object" && message !== null;
 }


### PR DESCRIPTION
missing role gets [converted](https://github.com/Arize-ai/phoenix/blob/5e646183c11947b2e4c0e51a356db860e32cfc90/app/src/pages/trace/SpanDetails.tsx#L1420) to `unknown` anyway

# Before

Messages are not displayed at all.

<img width="436" height="253" alt="Screenshot 2025-08-03 at 11 16 52 PM" src="https://github.com/user-attachments/assets/38284b90-19c1-4656-beda-a37c71f59ade" />

# After

<img width="479" height="534" alt="Screenshot 2025-08-03 at 11 15 58 PM" src="https://github.com/user-attachments/assets/33daed6d-a20e-4746-b20e-65afe5660cf7" />



