### PR TITLE
fix: missing markdown block for text in multi-part messages

### DIFF
--- a/app/src/components/markdown/MarkdownBlock.tsx
+++ b/app/src/components/markdown/MarkdownBlock.tsx
@@ -27,15 +27,13 @@ export function MarkdownBlock({
         `;
 
   return mode === "markdown" ? (
-    <div css={markdownCSS} data-margin={margin}>
+    <div css={markdownCSS}>
       <Markdown remarkPlugins={[remarkGfm]} css={spacingCSS}>
         {children}
       </Markdown>
     </div>
   ) : (
-    <PrettyText preCSS={spacingCSS} data-margin={margin}>
-      {children}
-    </PrettyText>
+    <PrettyText preCSS={spacingCSS}>{children}</PrettyText>
   );
 }
 

--- a/app/src/components/markdown/MarkdownBlock.tsx
+++ b/app/src/components/markdown/MarkdownBlock.tsx
@@ -11,33 +11,45 @@ import { MarkdownDisplayMode } from "./types";
 export function MarkdownBlock({
   children,
   mode,
+  margin = "default",
 }: {
   children: string;
   mode: MarkdownDisplayMode;
+  margin?: "default" | "none";
 }) {
-  return mode === "markdown" ? (
-    <div css={markdownCSS}>
-      <Markdown
-        remarkPlugins={[remarkGfm]}
-        css={css`
+  const spacingCSS =
+    margin === "none"
+      ? css`
+          margin: 0;
+        `
+      : css`
           margin: var(--ac-global-dimension-static-size-200);
-        `}
-      >
+        `;
+
+  return mode === "markdown" ? (
+    <div css={markdownCSS} data-margin={margin}>
+      <Markdown remarkPlugins={[remarkGfm]} css={spacingCSS}>
         {children}
       </Markdown>
     </div>
   ) : (
-    <PrettyText
-      preCSS={css`
-        margin: var(--ac-global-dimension-static-size-200);
-      `}
-    >
+    <PrettyText preCSS={spacingCSS} data-margin={margin}>
       {children}
     </PrettyText>
   );
 }
 
-export function ConnectedMarkdownBlock({ children }: { children: string }) {
+export function ConnectedMarkdownBlock({
+  children,
+  margin = "default",
+}: {
+  children: string;
+  margin?: "default" | "none";
+}) {
   const { mode } = useMarkdownMode();
-  return <MarkdownBlock mode={mode}>{children}</MarkdownBlock>;
+  return (
+    <MarkdownBlock mode={mode} margin={margin}>
+      {children}
+    </MarkdownBlock>
+  );
 }

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1750,17 +1750,7 @@ function MessageContentListItem({
 
   return (
     <li css={text ? messageContentTextListItemCSS : null}>
-      {text ? (
-        <pre
-          css={css`
-            white-space: pre-wrap;
-            padding: 0;
-            margin: 0;
-          `}
-        >
-          <ConnectedMarkdownBlock>{text}</ConnectedMarkdownBlock>
-        </pre>
-      ) : null}
+      {text ? <ConnectedMarkdownBlock>{text}</ConnectedMarkdownBlock> : null}
       {imageUrl ? <SpanImage url={imageUrl} /> : null}
     </li>
   );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1750,7 +1750,9 @@ function MessageContentListItem({
 
   return (
     <li css={text ? messageContentTextListItemCSS : null}>
-      {text ? <ConnectedMarkdownBlock>{text}</ConnectedMarkdownBlock> : null}
+      {text ? (
+        <ConnectedMarkdownBlock margin="none">{text}</ConnectedMarkdownBlock>
+      ) : null}
       {imageUrl ? <SpanImage url={imageUrl} /> : null}
     </li>
   );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1758,7 +1758,7 @@ function MessageContentListItem({
             margin: 0;
           `}
         >
-          {text}
+          <ConnectedMarkdownBlock>{text}</ConnectedMarkdownBlock>
         </pre>
       ) : null}
       {imageUrl ? <SpanImage url={imageUrl} /> : null}


### PR DESCRIPTION
# Before
<img width="902" height="1178" alt="Screenshot 2025-08-04 at 1 55 29 PM" src="https://github.com/user-attachments/assets/ee3e1af5-96d1-4461-8a78-c86c3a7ae6ab" />

# After

<img width="908" height="1166" alt="Screenshot 2025-08-04 at 2 18 43 PM" src="https://github.com/user-attachments/assets/6b05875a-2a67-44e7-8c55-96c7601214b6" />
