### PR TITLE
fix(experiments): optimize compare experiments query

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -562,7 +562,7 @@ type Dataset implements Node {
   Number of experiments for a specific version if version is specified, or for all versions if version is not specified.
   """
   experimentCount(datasetVersionId: ID): Int!
-  experiments(first: Int = 50, last: Int, after: String, before: String, filterCondition: String): ExperimentConnection!
+  experiments(first: Int = 50, last: Int, after: String, before: String, filterCondition: String, filterIds: [ID!]): ExperimentConnection!
   experimentAnnotationSummaries: [ExperimentAnnotationSummary!]!
   lastUpdatedAt: DateTime
 }

--- a/app/src/pages/experiment/ExperimentCompareMetricsPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareMetricsPage.tsx
@@ -99,13 +99,14 @@ export function ExperimentCompareMetricsPage() {
     graphql`
       fragment ExperimentCompareMetricsPage_experiments on Query
       @argumentDefinitions(
+        datasetId: { type: "ID!" }
         baseExperimentId: { type: "ID!" }
         compareExperimentIds: { type: "[ID!]!" }
-        datasetId: { type: "ID!" }
+        experimentIds: { type: "[ID!]!" }
       ) {
         dataset: node(id: $datasetId) {
           ... on Dataset {
-            experiments {
+            experiments(filterIds: $experimentIds) {
               edges {
                 experiment: node {
                   id

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -169,6 +169,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
           after: { type: "String", defaultValue: null }
           baseExperimentId: { type: "ID!" }
           compareExperimentIds: { type: "[ID!]!" }
+          experimentIds: { type: "[ID!]!" }
           datasetId: { type: "ID!" }
           filterCondition: { type: "String", defaultValue: null }
         ) {
@@ -230,7 +231,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
           dataset: node(id: $datasetId) {
             id
             ... on Dataset {
-              experiments {
+              experiments(filterIds: $experimentIds) {
                 edges {
                   experiment: node {
                     id

--- a/app/src/pages/experiment/ExperimentMultiSelector.tsx
+++ b/app/src/pages/experiment/ExperimentMultiSelector.tsx
@@ -42,13 +42,17 @@ export function ExperimentMultiSelector(props: {
   const data = useFragment(
     graphql`
       fragment ExperimentMultiSelector__data on Query
-      @argumentDefinitions(hasBaseExperiment: { type: "Boolean!" }) {
+      @argumentDefinitions(
+        datasetId: { type: "ID!" }
+        experimentIds: { type: "[ID!]!" }
+        hasBaseExperiment: { type: "Boolean!" }
+      ) {
         dataset: node(id: $datasetId) {
           id
           ... on Dataset {
             id
             name
-            experiments {
+            experiments(filterIds: $experimentIds) {
               edges {
                 experiment: node {
                   id

--- a/app/src/pages/experiment/__generated__/ExperimentCompareMetricsPage_experiments.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareMetricsPage_experiments.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b99ba60c1cb4011a2c241c10d689bbd>>
+ * @generated SignedSource<<5770e16659b194dd41394395fef2c9c8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -144,6 +144,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "datasetId"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "experimentIds"
     }
   ],
   "kind": "Fragment",
@@ -169,7 +174,13 @@ return {
           "selections": [
             {
               "alias": null,
-              "args": null,
+              "args": [
+                {
+                  "kind": "Variable",
+                  "name": "filterIds",
+                  "variableName": "experimentIds"
+                }
+              ],
               "concreteType": "ExperimentConnection",
               "kind": "LinkedField",
               "name": "experiments",
@@ -373,6 +384,6 @@ return {
 };
 })();
 
-(node as any).hash = "e11be301f1cc94b71e2491e092528ddc";
+(node as any).hash = "e6231b9a95bfe0a54cfa4dc81db7ed75";
 
 export default node;

--- a/app/src/pages/experiment/__generated__/ExperimentCompareTableQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<90d24f99b384546e302435d8636f3e3b>>
+ * @generated SignedSource<<e3231ad0bc9b564c9b85f7a72864560b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type ExperimentCompareTableQuery$variables = {
   baseExperimentId: string;
   compareExperimentIds: ReadonlyArray<string>;
   datasetId: string;
+  experimentIds: ReadonlyArray<string>;
   filterCondition?: string | null;
   first?: number | null;
 };
@@ -47,6 +48,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "datasetId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "experimentIds"
   },
   {
     "defaultValue": null,
@@ -168,6 +174,11 @@ return {
             "kind": "Variable",
             "name": "datasetId",
             "variableName": "datasetId"
+          },
+          {
+            "kind": "Variable",
+            "name": "experimentIds",
+            "variableName": "experimentIds"
           },
           (v4/*: any*/),
           (v5/*: any*/)
@@ -482,7 +493,13 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "filterIds",
+                    "variableName": "experimentIds"
+                  }
+                ],
                 "concreteType": "ExperimentConnection",
                 "kind": "LinkedField",
                 "name": "experiments",
@@ -589,16 +606,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e297f14c2b5a36bb39a1b21a32019595",
+    "cacheID": "41fb0ab21c1e06cf77779ceeba86054d",
     "id": null,
     "metadata": {},
     "name": "ExperimentCompareTableQuery",
     "operationKind": "query",
-    "text": "query ExperimentCompareTableQuery(\n  $after: String = null\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $datasetId: ID!\n  $filterCondition: String = null\n  $first: Int = 50\n) {\n  ...ExperimentCompareTable_comparisons_2x9tCD\n}\n\nfragment ExperimentCompareTable_comparisons_2x9tCD on Query {\n  compareExperiments(first: $first, after: $after, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds, filterCondition: $filterCondition) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        runComparisonItems {\n          experimentId\n          runs {\n            id\n            output\n            error\n            startTime\n            endTime\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ExperimentCompareTableQuery(\n  $after: String = null\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $datasetId: ID!\n  $experimentIds: [ID!]!\n  $filterCondition: String = null\n  $first: Int = 50\n) {\n  ...ExperimentCompareTable_comparisons_Gjac5\n}\n\nfragment ExperimentCompareTable_comparisons_Gjac5 on Query {\n  compareExperiments(first: $first, after: $after, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds, filterCondition: $filterCondition) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        runComparisonItems {\n          experimentId\n          runs {\n            id\n            output\n            error\n            startTime\n            endTime\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7e6469e562a19c73a57fbff90a036030";
+(node as any).hash = "d94346bf96bd527ddb757879eded860a";
 
 export default node;

--- a/app/src/pages/experiment/__generated__/ExperimentCompareTable_comparisons.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareTable_comparisons.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ce4f00b15379c5e3a552f5414d5c868>>
+ * @generated SignedSource<<36aab213bb1e425b1b59e337e7c6a6c9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -172,6 +172,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "datasetId"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "experimentIds"
     },
     {
       "defaultValue": null,
@@ -512,7 +517,13 @@ return {
           "selections": [
             {
               "alias": null,
-              "args": null,
+              "args": [
+                {
+                  "kind": "Variable",
+                  "name": "filterIds",
+                  "variableName": "experimentIds"
+                }
+              ],
               "concreteType": "ExperimentConnection",
               "kind": "LinkedField",
               "name": "experiments",
@@ -622,6 +633,6 @@ return {
 };
 })();
 
-(node as any).hash = "7e6469e562a19c73a57fbff90a036030";
+(node as any).hash = "d94346bf96bd527ddb757879eded860a";
 
 export default node;

--- a/app/src/pages/experiment/__generated__/ExperimentMultiSelector__data.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentMultiSelector__data.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<65cd286872627cedfd704160cf1e3b58>>
+ * @generated SignedSource<<851cded43af7e48d5304b7e09f76bd8e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,8 +58,14 @@ return {
       "name": "baseExperimentId"
     },
     {
-      "kind": "RootArgument",
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "datasetId"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "experimentIds"
     },
     {
       "defaultValue": null,
@@ -92,7 +98,13 @@ return {
             (v1/*: any*/),
             {
               "alias": null,
-              "args": null,
+              "args": [
+                {
+                  "kind": "Variable",
+                  "name": "filterIds",
+                  "variableName": "experimentIds"
+                }
+              ],
               "concreteType": "ExperimentConnection",
               "kind": "LinkedField",
               "name": "experiments",
@@ -185,6 +197,6 @@ return {
 };
 })();
 
-(node as any).hash = "5cf14c739bf8fcef57b5b3a8dc324e1f";
+(node as any).hash = "6a2f2f212665a259ccc6138563f96b55";
 
 export default node;

--- a/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f21ba7c66e68afa8ff61ae3f7da5264a>>
+ * @generated SignedSource<<9256a65e177555b0ebf769955d99c081>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type experimentCompareLoaderQuery$variables = {
   baseExperimentId: string;
   compareExperimentIds: ReadonlyArray<string>;
   datasetId: string;
+  experimentIds: ReadonlyArray<string>;
   hasBaseExperiment: boolean;
   includeGridView: boolean;
   includeMetricsView: boolean;
@@ -45,75 +46,94 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "hasBaseExperiment"
+  "name": "experimentIds"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeGridView"
+  "name": "hasBaseExperiment"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeMetricsView"
+  "name": "includeGridView"
 },
 v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "includeMetricsView"
+},
+v7 = {
   "kind": "Variable",
   "name": "baseExperimentId",
   "variableName": "baseExperimentId"
 },
-v7 = {
+v8 = {
   "kind": "Variable",
   "name": "compareExperimentIds",
   "variableName": "compareExperimentIds"
 },
-v8 = [
-  (v6/*: any*/),
+v9 = {
+  "kind": "Variable",
+  "name": "datasetId",
+  "variableName": "datasetId"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "experimentIds",
+  "variableName": "experimentIds"
+},
+v11 = [
   (v7/*: any*/),
-  {
-    "kind": "Variable",
-    "name": "datasetId",
-    "variableName": "datasetId"
-  }
+  (v8/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/)
 ],
-v9 = [
+v12 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "datasetId"
   }
 ],
-v10 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v11 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v13 = [
-  (v6/*: any*/),
+v16 = [
+  {
+    "kind": "Variable",
+    "name": "filterIds",
+    "variableName": "experimentIds"
+  }
+],
+v17 = [
   (v7/*: any*/),
+  (v8/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 50
   }
 ],
-v14 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "Trace",
@@ -135,25 +155,25 @@ v14 = {
       "name": "projectId",
       "storageKey": null
     },
-    (v11/*: any*/)
+    (v14/*: any*/)
   ],
   "storageKey": null
 },
-v15 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tokens",
   "storageKey": null
 },
-v16 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cost",
   "storageKey": null
 },
-v17 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "CostBreakdown",
@@ -161,56 +181,56 @@ v17 = {
   "name": "total",
   "plural": false,
   "selections": [
-    (v15/*: any*/),
-    (v16/*: any*/)
+    (v19/*: any*/),
+    (v20/*: any*/)
   ],
   "storageKey": null
 },
-v18 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "averageRunLatencyMs",
   "storageKey": null
 },
-v19 = [
-  (v15/*: any*/)
+v23 = [
+  (v19/*: any*/)
 ],
-v20 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "annotationName",
   "storageKey": null
 },
-v21 = [
-  (v6/*: any*/),
-  (v7/*: any*/)
+v25 = [
+  (v7/*: any*/),
+  (v8/*: any*/)
 ],
-v22 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "compareExperimentId",
   "storageKey": null
 },
-v23 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "numIncreases",
   "storageKey": null
 },
-v24 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "numDecreases",
   "storageKey": null
 },
-v25 = [
-  (v23/*: any*/),
-  (v24/*: any*/)
+v29 = [
+  (v27/*: any*/),
+  (v28/*: any*/)
 ];
 return {
   "fragment": {
@@ -220,7 +240,8 @@ return {
       (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -232,7 +253,7 @@ return {
         "passingValue": true,
         "selections": [
           {
-            "args": (v8/*: any*/),
+            "args": (v11/*: any*/),
             "kind": "FragmentSpread",
             "name": "ExperimentCompareTable_comparisons"
           }
@@ -240,6 +261,8 @@ return {
       },
       {
         "args": [
+          (v9/*: any*/),
+          (v10/*: any*/),
           {
             "kind": "Variable",
             "name": "hasBaseExperiment",
@@ -255,7 +278,7 @@ return {
         "passingValue": true,
         "selections": [
           {
-            "args": (v8/*: any*/),
+            "args": (v11/*: any*/),
             "kind": "FragmentSpread",
             "name": "ExperimentCompareMetricsPage_experiments"
           }
@@ -273,28 +296,29 @@ return {
       (v1/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Operation",
     "name": "experimentCompareLoaderQuery",
     "selections": [
       {
         "alias": "dataset",
-        "args": (v9/*: any*/),
+        "args": (v12/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v10/*: any*/),
-          (v11/*: any*/),
+          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v12/*: any*/),
+              (v15/*: any*/),
               {
                 "alias": null,
-                "args": null,
+                "args": (v16/*: any*/),
                 "concreteType": "ExperimentConnection",
                 "kind": "LinkedField",
                 "name": "experiments",
@@ -316,8 +340,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/),
-                          (v12/*: any*/),
+                          (v14/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -355,7 +379,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v17/*: any*/),
             "concreteType": "ExperimentComparisonConnection",
             "kind": "LinkedField",
             "name": "compareExperiments",
@@ -385,7 +409,7 @@ return {
                         "name": "example",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -437,7 +461,7 @@ return {
                             "name": "runs",
                             "plural": true,
                             "selections": [
-                              (v11/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -466,7 +490,7 @@ return {
                                 "name": "endTime",
                                 "storageKey": null
                               },
-                              (v14/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -475,7 +499,7 @@ return {
                                 "name": "costSummary",
                                 "plural": false,
                                 "selections": [
-                                  (v17/*: any*/)
+                                  (v21/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -503,8 +527,8 @@ return {
                                         "name": "node",
                                         "plural": false,
                                         "selections": [
-                                          (v11/*: any*/),
-                                          (v12/*: any*/),
+                                          (v14/*: any*/),
+                                          (v15/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -533,7 +557,7 @@ return {
                                             "name": "explanation",
                                             "storageKey": null
                                           },
-                                          (v14/*: any*/)
+                                          (v18/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -549,7 +573,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v11/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -568,8 +592,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/),
-                      (v11/*: any*/)
+                      (v13/*: any*/),
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -606,7 +630,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v17/*: any*/),
             "filters": [
               "baseExperimentId",
               "compareExperimentIds",
@@ -619,7 +643,7 @@ return {
           },
           {
             "alias": "dataset",
-            "args": (v9/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": null,
             "kind": "LinkedField",
             "name": "node",
@@ -630,7 +654,7 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
+                    "args": (v16/*: any*/),
                     "concreteType": "ExperimentConnection",
                     "kind": "LinkedField",
                     "name": "experiments",
@@ -667,7 +691,7 @@ return {
                                 "name": "project",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/)
+                                  (v14/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -687,15 +711,15 @@ return {
                                     "name": "total",
                                     "plural": false,
                                     "selections": [
-                                      (v16/*: any*/),
-                                      (v15/*: any*/)
+                                      (v20/*: any*/),
+                                      (v19/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
                                 ],
                                 "storageKey": null
                               },
-                              (v18/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -740,12 +764,12 @@ return {
             "name": "node",
             "plural": false,
             "selections": [
-              (v10/*: any*/),
-              (v11/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v12/*: any*/)
+                  (v15/*: any*/)
                 ],
                 "type": "Experiment",
                 "abstractKey": null
@@ -762,7 +786,7 @@ return {
         "selections": [
           {
             "alias": "dataset",
-            "args": (v9/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": null,
             "kind": "LinkedField",
             "name": "node",
@@ -773,7 +797,7 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": null,
+                    "args": (v16/*: any*/),
                     "concreteType": "ExperimentConnection",
                     "kind": "LinkedField",
                     "name": "experiments",
@@ -795,7 +819,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -804,7 +828,7 @@ return {
                                 "name": "costSummary",
                                 "plural": false,
                                 "selections": [
-                                  (v17/*: any*/),
+                                  (v21/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -812,7 +836,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "prompt",
                                     "plural": false,
-                                    "selections": (v19/*: any*/),
+                                    "selections": (v23/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -822,7 +846,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "completion",
                                     "plural": false,
-                                    "selections": (v19/*: any*/),
+                                    "selections": (v23/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -836,7 +860,7 @@ return {
                                 "name": "annotationSummaries",
                                 "plural": true,
                                 "selections": [
-                                  (v20/*: any*/),
+                                  (v24/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -865,13 +889,13 @@ return {
           },
           {
             "alias": null,
-            "args": (v21/*: any*/),
+            "args": (v25/*: any*/),
             "concreteType": "CompareExperimentRunMetricCounts",
             "kind": "LinkedField",
             "name": "compareExperimentRunMetricCounts",
             "plural": true,
             "selections": [
-              (v22/*: any*/),
+              (v26/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -879,7 +903,7 @@ return {
                 "kind": "LinkedField",
                 "name": "latency",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v29/*: any*/),
                 "storageKey": null
               },
               {
@@ -889,7 +913,7 @@ return {
                 "kind": "LinkedField",
                 "name": "promptTokenCount",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v29/*: any*/),
                 "storageKey": null
               },
               {
@@ -899,7 +923,7 @@ return {
                 "kind": "LinkedField",
                 "name": "completionTokenCount",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v29/*: any*/),
                 "storageKey": null
               },
               {
@@ -909,7 +933,7 @@ return {
                 "kind": "LinkedField",
                 "name": "totalTokenCount",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v29/*: any*/),
                 "storageKey": null
               },
               {
@@ -919,7 +943,7 @@ return {
                 "kind": "LinkedField",
                 "name": "totalCost",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v29/*: any*/),
                 "storageKey": null
               }
             ],
@@ -927,16 +951,16 @@ return {
           },
           {
             "alias": null,
-            "args": (v21/*: any*/),
+            "args": (v25/*: any*/),
             "concreteType": "CompareExperimentRunAnnotationMetricCounts",
             "kind": "LinkedField",
             "name": "compareExperimentRunAnnotationMetricCounts",
             "plural": true,
             "selections": [
-              (v20/*: any*/),
-              (v22/*: any*/),
-              (v23/*: any*/),
-              (v24/*: any*/)
+              (v24/*: any*/),
+              (v26/*: any*/),
+              (v27/*: any*/),
+              (v28/*: any*/)
             ],
             "storageKey": null
           }
@@ -945,16 +969,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2039ccab3875c03fe26f9416829a5e29",
+    "cacheID": "b039d831b187fe852c9cee69de3405e1",
     "id": null,
     "metadata": {},
     "name": "experimentCompareLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentCompareLoaderQuery(\n  $datasetId: ID!\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $hasBaseExperiment: Boolean!\n  $includeGridView: Boolean!\n  $includeMetricsView: Boolean!\n) {\n  ...ExperimentCompareTable_comparisons_hJmED @include(if: $includeGridView)\n  ...ExperimentMultiSelector__data_3PEhJA\n  ...ExperimentCompareMetricsPage_experiments_hJmED @include(if: $includeMetricsView)\n}\n\nfragment ExperimentCompareMetricsPage_experiments_hJmED on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments {\n        edges {\n          experiment: node {\n            id\n            averageRunLatencyMs\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n              prompt {\n                tokens\n              }\n              completion {\n                tokens\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  compareExperimentRunMetricCounts(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    compareExperimentId\n    latency {\n      numIncreases\n      numDecreases\n    }\n    promptTokenCount {\n      numIncreases\n      numDecreases\n    }\n    completionTokenCount {\n      numIncreases\n      numDecreases\n    }\n    totalTokenCount {\n      numIncreases\n      numDecreases\n    }\n    totalCost {\n      numIncreases\n      numDecreases\n    }\n  }\n  compareExperimentRunAnnotationMetricCounts(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    annotationName\n    compareExperimentId\n    numIncreases\n    numDecreases\n  }\n}\n\nfragment ExperimentCompareTable_comparisons_hJmED on Query {\n  compareExperiments(first: 50, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        runComparisonItems {\n          experimentId\n          runs {\n            id\n            output\n            error\n            startTime\n            endTime\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentMultiSelector__data_3PEhJA on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n      experiments {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            createdAt\n          }\n        }\n      }\n    }\n  }\n  baseExperiment: node(id: $baseExperimentId) @include(if: $hasBaseExperiment) {\n    __typename\n    ... on Experiment {\n      id\n      name\n    }\n    id\n  }\n}\n"
+    "text": "query experimentCompareLoaderQuery(\n  $datasetId: ID!\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $experimentIds: [ID!]!\n  $hasBaseExperiment: Boolean!\n  $includeGridView: Boolean!\n  $includeMetricsView: Boolean!\n) {\n  ...ExperimentCompareTable_comparisons_4mFQqw @include(if: $includeGridView)\n  ...ExperimentMultiSelector__data_3oaxwQ\n  ...ExperimentCompareMetricsPage_experiments_4mFQqw @include(if: $includeMetricsView)\n}\n\nfragment ExperimentCompareMetricsPage_experiments_4mFQqw on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            averageRunLatencyMs\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n              prompt {\n                tokens\n              }\n              completion {\n                tokens\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  compareExperimentRunMetricCounts(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    compareExperimentId\n    latency {\n      numIncreases\n      numDecreases\n    }\n    promptTokenCount {\n      numIncreases\n      numDecreases\n    }\n    completionTokenCount {\n      numIncreases\n      numDecreases\n    }\n    totalTokenCount {\n      numIncreases\n      numDecreases\n    }\n    totalCost {\n      numIncreases\n      numDecreases\n    }\n  }\n  compareExperimentRunAnnotationMetricCounts(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    annotationName\n    compareExperimentId\n    numIncreases\n    numDecreases\n  }\n}\n\nfragment ExperimentCompareTable_comparisons_4mFQqw on Query {\n  compareExperiments(first: 50, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        runComparisonItems {\n          experimentId\n          runs {\n            id\n            output\n            error\n            startTime\n            endTime\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentMultiSelector__data_3oaxwQ on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            createdAt\n          }\n        }\n      }\n    }\n  }\n  baseExperiment: node(id: $baseExperimentId) @include(if: $hasBaseExperiment) {\n    __typename\n    ... on Experiment {\n      id\n      name\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a9d72437f4b596cec44d86f4e7e3eaf9";
+(node as any).hash = "957512ec0be352bf9ae4099a7d6cb597";
 
 export default node;

--- a/app/src/pages/experiment/experimentCompareLoader.ts
+++ b/app/src/pages/experiment/experimentCompareLoader.ts
@@ -34,6 +34,7 @@ export async function experimentCompareLoader(
         $datasetId: ID!
         $baseExperimentId: ID!
         $compareExperimentIds: [ID!]!
+        $experimentIds: [ID!]!
         $hasBaseExperiment: Boolean!
         $includeGridView: Boolean!
         $includeMetricsView: Boolean!
@@ -41,18 +42,24 @@ export async function experimentCompareLoader(
         ...ExperimentCompareTable_comparisons
           @include(if: $includeGridView)
           @arguments(
+            datasetId: $datasetId
             baseExperimentId: $baseExperimentId
             compareExperimentIds: $compareExperimentIds
-            datasetId: $datasetId
+            experimentIds: $experimentIds
           )
         ...ExperimentMultiSelector__data
-          @arguments(hasBaseExperiment: $hasBaseExperiment)
+          @arguments(
+            datasetId: $datasetId
+            experimentIds: $experimentIds
+            hasBaseExperiment: $hasBaseExperiment
+          )
         ...ExperimentCompareMetricsPage_experiments
           @include(if: $includeMetricsView)
           @arguments(
+            datasetId: $datasetId
             baseExperimentId: $baseExperimentId
             compareExperimentIds: $compareExperimentIds
-            datasetId: $datasetId
+            experimentIds: $experimentIds
           )
       }
     `,
@@ -60,6 +67,10 @@ export async function experimentCompareLoader(
       datasetId,
       baseExperimentId: baseExperimentId ?? "",
       compareExperimentIds,
+      experimentIds: [
+        ...(baseExperimentId ? [baseExperimentId] : []),
+        ...compareExperimentIds,
+      ],
       hasBaseExperiment: baseExperimentId != null,
       includeGridView: view === "grid" && baseExperimentId != null,
       includeMetricsView: view === "metrics" && baseExperimentId != null,


### PR DESCRIPTION
Needed since we are now computing aggregate statistics for each experiment for the grid view column headers. We're currently computing those statistics for every experiment. Will eventually do this via the query DSL once implemented.