### PR TITLE
ui(projects): add explicit 'No Tracing' project creation path

### DIFF
--- a/app/src/pages/projects/NewProjectButton.tsx
+++ b/app/src/pages/projects/NewProjectButton.tsx
@@ -84,7 +84,7 @@ function NewProjectDialog() {
           <TabList>
             <Tab id="python">Python</Tab>
             <Tab id="typescript">TypeScript</Tab>
-            <Tab id="manual">Manual</Tab>
+            <Tab id="manual">No Tracing</Tab>
           </TabList>
           <TabPanel id="python">
             <View padding="size-200" overflow="auto">
@@ -100,6 +100,7 @@ function NewProjectDialog() {
           </TabPanel>
           <TabPanel id="manual">
             <View padding="size-200" overflow="auto">
+              <Text>Create a project without setting up tracing. You can add traces later.</Text>
               <ManualProjectGuide />
             </View>
           </TabPanel>


### PR DESCRIPTION
## Summary
- Clarifies manual project creation as a "No Tracing" path and adds brief contextual help.
- Addresses #8728 by making it obvious users can create a project without setting up tracing.

## Test plan
- Open Projects page and click New Project.
- Verify tab label reads "No Tracing" and help text appears.
- Create a project to ensure mutation succeeds and project appears in list.

🤖 Generated with [opencode](https://opencode.ai)