### PR TITLE
feat: Dynamic concurrency

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -221,7 +221,7 @@ class AsyncExecutor(Executor):
         self.exit_on_error = exit_on_error
         self.base_priority = 0
         self.termination_signal = termination_signal
-        self.timeout: int = timeout or 120
+        self.timeout: int = timeout or 60
 
         # Dynamic concurrency controller (AIMD)
         self._concurrency_controller: Optional[ConcurrencyController] = None

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -331,6 +331,7 @@ class AsyncExecutor(Executor):
                             f"Rate limit throttle on attempt {retry_count + 1}: raised {repr(exc)}"
                         )
                         tqdm.write("Requeuing...")
+                        await queue.put((priority - 1, item))
                         if self._concurrency_controller is not None:
                             self._concurrency_controller.record_error()
                     else:

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -97,7 +97,7 @@ class ConcurrencyController:
     ) -> None:
         self._max_concurrency = max(1, int(max_concurrency))
         self._current_target = max(1, min(self._max_concurrency, int(initial_target)))
-        self._window_seconds = max(0.5, float(window_seconds))
+        self._window_seconds = float(window_seconds)
         self._increase_step = max(1, int(increase_step))
         self._decrease_ratio = float(decrease_ratio)
         self._smoothing_factor = smoothing_factor

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -89,7 +89,7 @@ class ConcurrencyController:
         self,
         *,
         max_concurrency: int,
-        initial_target: int,
+        initial_target: float,
         window_seconds: float = 5,
         increase_step: float = 0.5,
         decrease_ratio: float = 0.5,
@@ -99,7 +99,7 @@ class ConcurrencyController:
         collapse_error_threshold: int = 4,
     ) -> None:
         self._max_concurrency = max(1, int(max_concurrency))
-        self._target_concurrency = float(self._max_concurrency)
+        self._target_concurrency = float(initial_target)
         self._window_seconds = float(window_seconds)
         self._increase_step = float(increase_step)
         self._decrease_ratio = float(decrease_ratio)

--- a/packages/phoenix-evals/src/phoenix/evals/executors.py
+++ b/packages/phoenix-evals/src/phoenix/evals/executors.py
@@ -88,7 +88,7 @@ class ConcurrencyController:
         *,
         max_concurrency: int,
         initial_target: int,
-        window_seconds: float = 10,
+        window_seconds: float = 5,
         increase_step: int = 1,
         decrease_ratio: float = 0.5,
         inactive_check_interval: float = 1.0,

--- a/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/anthropic.py
@@ -106,7 +106,6 @@ class AnthropicModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=self._anthropic.RateLimitError,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/bedrock.py
@@ -109,7 +109,6 @@ class BedrockModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=self.client.exceptions.ThrottlingException,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/src/phoenix/evals/models/google_genai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/google_genai.py
@@ -132,7 +132,6 @@ class GoogleGenAIModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=GoogleRateLimitError,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/mistralai.py
@@ -92,7 +92,6 @@ class MistralAIModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=MistralRateLimitError,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -102,7 +102,7 @@ class OpenAIModel(BaseModel):
         model_kwargs (Dict[str, Any], optional): Holds any model parameters valid for `create` call
             not explicitly specified. Defaults to an empty dictionary.
         request_timeout (Optional[Union[float, Tuple[float, float]]], optional): Timeout for
-            requests to OpenAI completion API. Default is 600 seconds. Defaults to None.
+            requests to OpenAI completion API. Default is 30 seconds.
         initial_rate_limit (int, optional): The initial internal rate limit in allowed requests
             per second for making LLM calls. This limit adjusts dynamically based on rate
             limit errors. Defaults to 10.
@@ -150,7 +150,7 @@ class OpenAIModel(BaseModel):
     presence_penalty: float = 0
     n: int = 1
     model_kwargs: Dict[str, Any] = field(default_factory=dict)
-    request_timeout: Optional[Union[float, Tuple[float, float]]] = None
+    request_timeout: Optional[Union[float, Tuple[float, float]]] = 30
     initial_rate_limit: int = 10
     timeout: int = 120
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/openai.py
@@ -283,7 +283,6 @@ class OpenAIModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=self._openai.RateLimitError,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
@@ -167,7 +167,7 @@ class RateLimiter:
     def __init__(
         self,
         rate_limit_error: Optional[Type[BaseException]] = None,
-        max_rate_limit_retries: int = 3,
+        max_rate_limit_retries: int = 2,
         initial_per_second_request_rate: float = 1.0,
         maximum_per_second_request_rate: Optional[float] = None,
         enforcement_window_minutes: float = 1,

--- a/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
@@ -92,7 +92,7 @@ class AdaptiveTokenBucket:
 
         self.rate = original_rate * self.rate_reduction_factor
         printif(
-            verbose, f"Reducing rate from {original_rate} to {self.rate} after rate limit error"
+            verbose, f"Throttling from {original_rate} RPS to {self.rate} RPS after rate limit error"
         )
 
         self.rate = max(self.rate, self.minimum_rate)
@@ -167,7 +167,7 @@ class RateLimiter:
     def __init__(
         self,
         rate_limit_error: Optional[Type[BaseException]] = None,
-        max_rate_limit_retries: int = 2,
+        max_rate_limit_retries: int = 0,
         initial_per_second_request_rate: float = 1.0,
         maximum_per_second_request_rate: Optional[float] = None,
         enforcement_window_minutes: float = 1,
@@ -215,7 +215,7 @@ class RateLimiter:
                         )
                         continue
             raise RateLimitError(
-                f"Exceeded max ({self._max_rate_limit_retries}) retries",
+                f"Rate limited: throttling requests to {self._throttler.rate} RPS",
                 current_rate_tokens_per_sec=self._throttler.rate,
                 initial_rate_tokens_per_sec=self._throttler._initial_rate,
                 enforcement_window_seconds=self._throttler.enforcement_window,

--- a/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
@@ -92,7 +92,8 @@ class AdaptiveTokenBucket:
 
         self.rate = original_rate * self.rate_reduction_factor
         printif(
-            verbose, f"Throttling from {original_rate} RPS to {self.rate} RPS after rate limit error"
+            verbose,
+            f"Throttling from {original_rate} RPS to {self.rate} RPS after rate limit error",
         )
 
         self.rate = max(self.rate, self.minimum_rate)

--- a/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
@@ -273,7 +273,7 @@ class RateLimiter:
                     finally:
                         self._rate_limit_handling.set()  # allow new requests to start
             raise RateLimitError(
-                f"Exceeded max ({self._max_rate_limit_retries}) retries",
+                f"Rate limited: throttling requests to {self._throttler.rate} RPS",
                 current_rate_tokens_per_sec=self._throttler.rate,
                 initial_rate_tokens_per_sec=self._throttler._initial_rate,
                 enforcement_window_seconds=self._throttler.enforcement_window,

--- a/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/rate_limiters.py
@@ -217,7 +217,7 @@ class RateLimiter:
             raise RateLimitError(
                 f"Exceeded max ({self._max_rate_limit_retries}) retries",
                 current_rate_tokens_per_sec=self._throttler.rate,
-                initial_rate_tokens_per_sec=self._throttler._initial_rate,  # type: ignore[attr-defined]
+                initial_rate_tokens_per_sec=self._throttler._initial_rate,
                 enforcement_window_seconds=self._throttler.enforcement_window,
             )
 
@@ -275,7 +275,7 @@ class RateLimiter:
             raise RateLimitError(
                 f"Exceeded max ({self._max_rate_limit_retries}) retries",
                 current_rate_tokens_per_sec=self._throttler.rate,
-                initial_rate_tokens_per_sec=self._throttler._initial_rate,  # type: ignore[attr-defined]
+                initial_rate_tokens_per_sec=self._throttler._initial_rate,
                 enforcement_window_seconds=self._throttler.enforcement_window,
             )
 

--- a/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/models/vertex.py
@@ -120,7 +120,6 @@ class GeminiModel(BaseModel):
     def _init_rate_limiter(self) -> None:
         self._rate_limiter = RateLimiter(
             rate_limit_error=self._gcp_exceptions.ResourceExhausted,
-            max_rate_limit_retries=10,
             initial_per_second_request_rate=self.initial_rate_limit,
             enforcement_window_minutes=1,
         )

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -63,9 +63,9 @@ def running_event_loop_mock(
         "phoenix.evals.executors._running_event_loop_exists",
         lambda: running_event_loop_exists,
     )
-    assert (
-        phoenix.evals.executors._running_event_loop_exists()
-    ) is running_event_loop_exists, "mocked function should return the expected value"
+    assert (phoenix.evals.executors._running_event_loop_exists()) is running_event_loop_exists, (
+        "mocked function should return the expected value"
+    )
     return running_event_loop_exists
 
 

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_classify.py
@@ -63,9 +63,9 @@ def running_event_loop_mock(
         "phoenix.evals.executors._running_event_loop_exists",
         lambda: running_event_loop_exists,
     )
-    assert (phoenix.evals.executors._running_event_loop_exists()) is running_event_loop_exists, (
-        "mocked function should return the expected value"
-    )
+    assert (
+        phoenix.evals.executors._running_event_loop_exists()
+    ) is running_event_loop_exists, "mocked function should return the expected value"
     return running_event_loop_exists
 
 

--- a/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/functions/test_executor.py
@@ -24,7 +24,9 @@ async def test_async_executor_executes():
     async def dummy_fn(payload: int) -> int:
         return payload - 1
 
-    executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
+    executor = AsyncExecutor(
+        dummy_fn, concurrency=10, max_retries=0, enable_dynamic_concurrency=False
+    )
     inputs = [1, 2, 3, 4, 5]
     outputs, _ = await executor.execute(inputs)
     assert outputs == [0, 1, 2, 3, 4]
@@ -34,7 +36,9 @@ async def test_async_executor_executes_many_tasks():
     async def dummy_fn(payload: int) -> int:
         return payload
 
-    executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
+    executor = AsyncExecutor(
+        dummy_fn, concurrency=10, max_retries=0, enable_dynamic_concurrency=False
+    )
     inputs = [x for x in range(100)]
     outputs, _ = await executor.execute(inputs)
     assert outputs == inputs
@@ -44,7 +48,9 @@ def test_async_executor_runs_synchronously():
     async def dummy_fn(payload: int) -> int:
         return payload - 2
 
-    executor = AsyncExecutor(dummy_fn, concurrency=10, max_retries=0)
+    executor = AsyncExecutor(
+        dummy_fn, concurrency=10, max_retries=0, enable_dynamic_concurrency=False
+    )
     inputs = [1, 2, 3, 4, 5]
     outputs, _ = executor.run(inputs)
     assert outputs == [-1, 0, 1, 2, 3]
@@ -57,7 +63,12 @@ async def test_async_executor_execute_exits_early_on_error():
         return payload - 1
 
     executor = AsyncExecutor(
-        dummy_fn, concurrency=1, max_retries=0, exit_on_error=True, fallback_return_value=52
+        dummy_fn,
+        concurrency=1,
+        max_retries=0,
+        exit_on_error=True,
+        fallback_return_value=52,
+        enable_dynamic_concurrency=False,
     )
     inputs = [1, 2, 3, 4, 5]
     outputs, _ = await executor.execute(inputs)
@@ -71,7 +82,12 @@ def test_async_executor_run_exits_early_on_error():
         return payload - 1
 
     executor = AsyncExecutor(
-        dummy_fn, concurrency=1, max_retries=0, exit_on_error=True, fallback_return_value=52
+        dummy_fn,
+        concurrency=1,
+        max_retries=0,
+        exit_on_error=True,
+        fallback_return_value=52,
+        enable_dynamic_concurrency=False,
     )
     inputs = [1, 2, 3, 4, 5]
     outputs, statuses = executor.run(inputs)
@@ -102,7 +118,12 @@ async def test_async_executor_can_continue_on_error():
         return payload - 1
 
     executor = AsyncExecutor(
-        dummy_fn, concurrency=1, max_retries=1, exit_on_error=False, fallback_return_value=52
+        dummy_fn,
+        concurrency=1,
+        max_retries=1,
+        exit_on_error=False,
+        fallback_return_value=52,
+        enable_dynamic_concurrency=False,
     )
     inputs = [1, 2, 3, 4, 5]
     outputs, statuses = await executor.execute(inputs)
@@ -141,7 +162,12 @@ async def test_async_executor_marks_completed_with_retries_status():
         return payload - 1
 
     executor = AsyncExecutor(
-        dummy_fn, concurrency=1, max_retries=3, exit_on_error=False, fallback_return_value=52
+        dummy_fn,
+        concurrency=1,
+        max_retries=3,
+        exit_on_error=False,
+        fallback_return_value=52,
+        enable_dynamic_concurrency=False,
     )
     inputs = [1, 2, 3, 4, 5]
     outputs, execution_details = await executor.execute(inputs)
@@ -194,6 +220,12 @@ async def test_async_executor_sigint_handling():
         max_retries=0,
         fallback_return_value="test",
         termination_signal=signal.SIGUSR1,
+        enable_dynamic_concurrency=False,
+        dynamic_initial_target=1,
+        dynamic_window_seconds=0.1,
+        dynamic_increase_step=1,
+        dynamic_decrease_ratio=0.5,
+        dynamic_inactive_check_interval=0.01,
     )
     task = asyncio.create_task(executor.execute(InterruptingIterator(sigint_index, result_length)))
 
@@ -205,7 +237,7 @@ async def test_async_executor_sigint_handling():
 @pytest.mark.xfail(reason="Flaky test", strict=False)
 async def test_async_executor_retries():
     mock_generate = AsyncMock(side_effect=RuntimeError("Test exception"))
-    executor = AsyncExecutor(mock_generate, max_retries=3)
+    executor = AsyncExecutor(mock_generate, max_retries=3, enable_dynamic_concurrency=False)
 
     await executor.execute([1])  # by default the executor does not raise on generation errors
 
@@ -572,16 +604,20 @@ def test_executor_factory_returns_async_not_in_thread_if_async_context():
 
 class MockController:
     def __init__(self, *, current_target: int, inactive_check_interval: float = 0.01) -> None:
-        self._current_target = current_target
+        self._target_concurrency = current_target
         self._inactive_check_interval = inactive_check_interval
 
     @property
+    def target_concurrency(self) -> int:
+        return max(1, int(self._target_concurrency))
+
+    @property
     def current_target(self) -> int:
-        return self._current_target
+        return self.target_concurrency
 
     @current_target.setter
     def current_target(self, value: int) -> None:  # type: ignore[no-redef]
-        self._current_target = value
+        self._target_concurrency = value
 
     @property
     def inactive_check_interval(self) -> float:


### PR DESCRIPTION
- The `AsyncExecutor` controls how many simultaneous async tasks can be started at once, which enables local throttling of submitted tasks in the event of rate limit errors
- However, if the allowed number of tasks is throttled too much, the executor will keep on trying to pick up throttled tasks, time out, and exhaust the total number of retries per task, leading to failed tasks

This PR adds dynamic feedback to the number of workers which either decreases or increases the concurrency if a rate limit error occurs in a configurable window (default 5s). Furthermore, if more than one rate limit error occurs within a larger window (30s) the concurrency will be dropped to 1.