### PR TITLE
feat: [evals] add precision recall fscore metric 

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/__init__.py
@@ -1,7 +1,9 @@
 from .exact_match import exact_match
 from .hallucination import HallucinationEvaluator
+from .precision_recall import PrecisionRecallFScore
 
 __all__ = [
     "exact_match",
     "HallucinationEvaluator",
+    "PrecisionRecallFScore",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/precision_recall.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/precision_recall.py
@@ -1,0 +1,341 @@
+"""
+Precision/Recall/F-score (F-beta) evaluator for single-label classification.
+
+- Supports binary and multi-class problems
+- Labels can be strings or integers (must be hashable)
+- No external dependencies
+
+Key behaviors:
+- Binary mode: If `positive_label` is provided, or labels are exactly {0, 1} with no
+  `positive_label` provided (defaults to positive=1), computes precision/recall/F exclusively
+  for the positive class (one-vs-rest). No averaging suffix is used in metric names.
+- Multi-class mode: Computes per-class metrics one-vs-rest and aggregates using the selected
+  averaging strategy: "macro" (default), "micro", or "weighted". When average is not the default
+  "macro", a suffix (e.g., `_micro`) is appended to metric names.
+
+Naming rules:
+- Defaults (beta=1.0, average="macro"): names are `precision`, `recall`, and `f1`.
+- Non-default average: e.g., `precision_micro`, `recall_weighted`, `f0_5_micro`.
+
+Zero-division handling:
+- When a denominator is zero (e.g., a class has no predicted or true instances), the metric is
+  set to `zero_division` (default 0.0), consistent with common library behavior.
+
+Examples:
+1) Multi-class (macro):
+>>> from phoenix.evals.preview.metrics.precision_recall import PrecisionRecallFScore
+>>> evaluator = PrecisionRecallFScore(beta=1.0, average="macro")
+>>> eval_input = {"y_true": ["cat", "dog", "cat", "bird"],
+...               "y_pred": ["cat", "cat", "cat", "bird"]}
+>>> scores = evaluator(eval_input)
+>>> [s.name for s in scores]
+['precision', 'recall', 'f1']
+
+2) Binary with explicit positive label:
+>>> evaluator = PrecisionRecallFScore(beta=0.5, positive_label="spam")
+>>> eval_input = {"y_true": ["spam", "ham", "spam"],
+...               "y_pred": ["spam", "spam", "ham"]}
+>>> scores = evaluator(eval_input)
+>>> [s.name for s in scores]
+['precision', 'recall', 'f0_5']
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from ..evaluators import Evaluator, Score
+
+AverageType = Literal["macro", "micro", "weighted"]
+
+
+def _format_beta_for_name(beta: float) -> str:
+    if beta <= 0:
+        # Validation will raise elsewhere; keep a safe fallback
+        return "f"
+    if float(beta).is_integer():
+        return f"f{int(beta)}"
+    text = ("%g" % beta).replace(".", "_")
+    return f"f{text}"
+
+
+@dataclass(frozen=True)
+class _ClassCounts:
+    true_positive: int = 0
+    false_positive: int = 0
+    false_negative: int = 0
+
+    @property
+    def support(self) -> int:
+        return self.true_positive + self.false_negative
+
+
+class PrecisionRecallFScore(Evaluator):
+    """
+    Heuristic evaluator that computes precision, recall, and F-score.
+
+    - Required fields: `y_true`, `y_pred` (sequences of labels)
+    - Supports labels as strings or integers
+    - Supports binary and multi-class via averaging strategies
+
+    Parameters
+    - beta: weight of recall relative to precision. Must be > 0. Defaults to 1.0 (F1).
+    - average: aggregation strategy across classes. One of {'macro','micro','weighted'}.
+               Defaults to 'macro'. Suffixes are only appended to metric names when a non-default
+               average is used.
+    - positive_label: when set, compute binary precision/recall/F exclusively for this label
+                      (one-vs-rest). If None and labels are numeric with unique set {0,1}, the
+                      positive label defaults to 1. Otherwise, multi-class averaging is used.
+    - zero_division: value to use when a metric is undefined (e.g., 0/0). Defaults to 0.0.
+
+    Inputs
+    - y_true, y_pred: sequences (e.g., list, tuple, NumPy array) of hashable labels. Passing a
+      single string (e.g., 'cat') is not supported; pass a sequence instead (e.g., ['cat']).
+    """
+
+    def __init__(
+        self,
+        beta: float = 1.0,
+        average: AverageType = "macro",
+        zero_division: float = 0.0,
+        positive_label: Optional[Hashable] = None,
+    ) -> None:
+        super().__init__(
+            name="precision_recall_fscore",
+            source="heuristic",
+            required_fields={"y_true", "y_pred"},
+            direction="maximize",
+        )
+        if beta <= 0:
+            raise ValueError("beta must be > 0")
+        if average not in ("macro", "micro", "weighted"):
+            raise ValueError("average must be one of {'macro','micro','weighted'}")
+        self.beta = float(beta)
+        self.average = average
+        self.zero_division = float(zero_division)
+        self.positive_label = positive_label
+
+    def _evaluate(self, eval_input: Mapping[str, Any]) -> List[Score]:
+        y_true_raw = eval_input["y_true"]
+        y_pred_raw = eval_input["y_pred"]
+
+        # Disallow accidental single-string inputs (strings are Sequences)
+        if isinstance(y_true_raw, (str, bytes)) or isinstance(y_pred_raw, (str, bytes)):
+            raise ValueError("y_true and y_pred must be sequences of labels, not single strings")
+
+        if not isinstance(y_true_raw, Sequence) or not isinstance(y_pred_raw, Sequence):
+            raise ValueError("y_true and y_pred must be sequences of labels")
+
+        y_true = list(y_true_raw)
+        y_pred = list(y_pred_raw)
+
+        # Ensure labels are hashable so they can be used as dict/set keys
+        self._assert_hashable_labels(y_true, "y_true")
+        self._assert_hashable_labels(y_pred, "y_pred")
+
+        if len(y_true) != len(y_pred):
+            raise ValueError(
+                f"y_true and y_pred must have the same length. Got {len(y_true)} and {len(y_pred)}"
+            )
+        if len(y_true) == 0:
+            raise ValueError("y_true and y_pred must be non-empty")
+
+        labels = self._collect_labels(y_true, y_pred)
+        counts_by_label = self._compute_counts(y_true, y_pred, labels)
+
+        # Determine if we are in binary (positive_label) mode
+        pos_label = self._resolve_positive_label(self.positive_label, labels)
+
+        if pos_label is not None:
+            class_counts = counts_by_label.get(pos_label)
+            if class_counts is None:
+                raise ValueError(
+                    f"positive_label {pos_label!r} not present in labels {list(labels)!r}"
+                )
+            precision = self._safe_div(
+                class_counts.true_positive, class_counts.true_positive + class_counts.false_positive
+            )
+            recall = self._safe_div(
+                class_counts.true_positive, class_counts.true_positive + class_counts.false_negative
+            )
+            suffix = ""
+        else:
+            precision, recall = self._aggregate_precision_recall(counts_by_label)
+            suffix = "" if self.average == "macro" else f"_{self.average}"
+
+        f_score = self._compute_f_score(precision, recall, self.beta)
+
+        beta_name = _format_beta_for_name(self.beta)
+
+        return [
+            Score(
+                name=f"precision{suffix}",
+                score=precision,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+            Score(
+                name=f"recall{suffix}",
+                score=recall,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+            Score(
+                name=f"{beta_name}{suffix}",
+                score=f_score,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+        ]
+
+    def _collect_labels(
+        self, y_true: Sequence[Hashable], y_pred: Sequence[Hashable]
+    ) -> List[Hashable]:
+        # Preserve a stable, interpretable order: first seen in y_true, then unseen from y_pred
+        seen = set()
+        ordered: List[Hashable] = []
+        for y in y_true:
+            if y not in seen:
+                seen.add(y)
+                ordered.append(y)
+        for y in y_pred:
+            if y not in seen:
+                seen.add(y)
+                ordered.append(y)
+        return ordered
+
+    def _compute_counts(
+        self, y_true: Sequence[Hashable], y_pred: Sequence[Hashable], labels: Sequence[Hashable]
+    ) -> Dict[Hashable, _ClassCounts]:
+        counts: Dict[Hashable, _ClassCounts] = {label: _ClassCounts() for label in labels}
+        for yt, yp in zip(y_true, y_pred):
+            if yt == yp:
+                tp = counts[yt].true_positive + 1
+                counts[yt] = _ClassCounts(
+                    true_positive=tp,
+                    false_positive=counts[yt].false_positive,
+                    false_negative=counts[yt].false_negative,
+                )
+            else:
+                # Predicted class receives a false positive
+                if yp in counts:
+                    c = counts[yp]
+                    counts[yp] = _ClassCounts(
+                        true_positive=c.true_positive,
+                        false_positive=c.false_positive + 1,
+                        false_negative=c.false_negative,
+                    )
+                # True class receives a false negative
+                if yt in counts:
+                    c = counts[yt]
+                    counts[yt] = _ClassCounts(
+                        true_positive=c.true_positive,
+                        false_positive=c.false_positive,
+                        false_negative=c.false_negative + 1,
+                    )
+        return counts
+
+    def _safe_div(self, numerator: float, denominator: float) -> float:
+        if denominator == 0.0:
+            return float(self.zero_division)
+        return numerator / denominator
+
+    def _aggregate_precision_recall(
+        self, counts_by_label: Mapping[Hashable, _ClassCounts]
+    ) -> Tuple[float, float]:
+        if self.average == "micro":
+            tp = sum(c.true_positive for c in counts_by_label.values())
+            fp = sum(c.false_positive for c in counts_by_label.values())
+            fn = sum(c.false_negative for c in counts_by_label.values())
+            precision = self._safe_div(tp, tp + fp)
+            recall = self._safe_div(tp, tp + fn)
+            return precision, recall
+
+        # per-class metrics
+        per_class_precision: List[float] = []
+        per_class_recall: List[float] = []
+        supports: List[int] = []
+        for c in counts_by_label.values():
+            p = self._safe_div(c.true_positive, c.true_positive + c.false_positive)
+            r = self._safe_div(c.true_positive, c.true_positive + c.false_negative)
+            per_class_precision.append(p)
+            per_class_recall.append(r)
+            supports.append(c.support)
+
+        if self.average == "macro":
+            precision = sum(per_class_precision) / len(per_class_precision)
+            recall = sum(per_class_recall) / len(per_class_recall)
+            return precision, recall
+
+        # weighted
+        total = sum(supports)
+        if total == 0:
+            return float(self.zero_division), float(self.zero_division)
+        precision = sum(p * s for p, s in zip(per_class_precision, supports)) / total
+        recall = sum(r * s for r, s in zip(per_class_recall, supports)) / total
+        return precision, recall
+
+    def _compute_f_score(self, precision: float, recall: float, beta: float) -> float:
+        if precision == 0.0 and recall == 0.0:
+            return 0.0
+        beta_sq = beta * beta
+        numerator = (1 + beta_sq) * precision * recall
+        denominator = (beta_sq * precision) + recall
+        return self._safe_div(numerator, denominator)
+
+    def _resolve_positive_label(
+        self, configured_positive: Optional[Hashable], labels: Sequence[Hashable]
+    ) -> Optional[Hashable]:
+        """
+        Decide whether to run in binary mode and which label is positive.
+
+        - If a positive label is provided, use it.
+        - Else, if labels are a binary numeric set {0, 1}, use 1 as positive.
+        - Otherwise, return None to indicate multi-class averaging mode.
+        """
+        if configured_positive is not None:
+            return configured_positive
+
+        unique = set(labels)
+        if unique.issubset({0, 1}) and len(unique) == 2:
+            return 1
+        return None
+
+    def _assert_hashable_labels(self, labels: Sequence[Any], name: str) -> None:
+        for idx, value in enumerate(labels):
+            try:
+                hash(value)
+            except TypeError as e:
+                raise ValueError(
+                    f"All labels in {name} must be hashable. "
+                    f"Found unhashable value at index {idx}: {value!r}"
+                ) from e

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/metrics/test_precision_recall.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/metrics/test_precision_recall.py
@@ -1,0 +1,171 @@
+from typing import Any, Dict, List
+
+import pytest
+
+from phoenix.evals.preview.metrics import PrecisionRecallFScore
+
+
+def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
+    return {s.name: s.score for s in scores}
+
+
+@pytest.mark.parametrize(
+    "description, kwargs, y_true, y_pred, expected_names, expected_scores, expects_exception",
+    [
+        pytest.param(
+            "binary ints default positive=1",
+            dict(beta=1.0),
+            [0, 1, 1, 0, 1],
+            [0, 1, 0, 0, 1],
+            ["precision", "recall", "f1"],
+            dict(precision=1.0, recall=2 / 3, f1=0.8),
+            False,
+            id="binary-default-positive",
+        ),
+        pytest.param(
+            "binary strings with explicit positive label and beta=0.5",
+            dict(beta=0.5, positive_label="spam"),
+            ["spam", "ham", "spam", "ham"],
+            ["spam", "spam", "ham", "ham"],
+            ["precision", "recall", "f0_5"],
+            dict(precision=0.5, recall=0.5, f0_5=0.5),
+            False,
+            id="binary-explicit-positive",
+        ),
+        pytest.param(
+            "multiclass macro averaging (default names)",
+            dict(beta=1.0, average="macro"),
+            ["a", "b", "a", "c"],
+            ["a", "a", "a", "c"],
+            ["precision", "recall", "f1"],
+            dict(precision=5 / 9, recall=2 / 3, f1=60 / 99),
+            False,
+            id="multiclass-macro",
+        ),
+        pytest.param(
+            "multiclass micro averaging (suffix names)",
+            dict(beta=1.0, average="micro"),
+            ["a", "b", "a", "c"],
+            ["a", "a", "a", "c"],
+            ["precision_micro", "recall_micro", "f1_micro"],
+            dict(precision_micro=0.75, recall_micro=0.75, f1_micro=0.75),
+            False,
+            id="multiclass-micro",
+        ),
+        pytest.param(
+            "multiclass weighted averaging (suffix names)",
+            dict(beta=1.0, average="weighted"),
+            ["a", "b", "a", "c"],
+            ["a", "a", "a", "c"],
+            ["precision_weighted", "recall_weighted", "f1_weighted"],
+            dict(precision_weighted=7 / 12, recall_weighted=3 / 4, f1_weighted=21 / 32),
+            False,
+            id="multiclass-weighted",
+        ),
+        pytest.param(
+            "zero_division set to 1.0 affects undefined precision",
+            dict(beta=1.0, average="macro", zero_division=1.0),
+            ["a", "b"],
+            ["a", "a"],
+            ["precision", "recall", "f1"],
+            # For class 'b': precision undefined -> 1.0, recall = 0.0
+            # Per-class precision: a=0.5? Here a: TP=1, FP=1 -> 1/(1+1)=0.5; b: 1.0
+            # Macro P=(0.5+1.0)/2=0.75; Macro R=(1.0+0.0)/2=0.5; F1 from aggregated P,R: 2*0.75*0.5/(0.75+0.5)=0.6
+            dict(precision=0.75, recall=0.5, f1=0.6),
+            False,
+            id="zero-division-custom",
+        ),
+        pytest.param(
+            "beta=2 naming and values (micro)",
+            dict(beta=2.0, average="micro"),
+            ["x", "y", "z"],
+            ["x", "y", "x"],
+            ["precision_micro", "recall_micro", "f2_micro"],
+            # accuracy = 2/3; precision_micro=recall_micro=2/3; f2 = (1+4)*(2/3)*(2/3)/(4*(2/3)+(2/3)) = 5*(4/9)/(10/3) = (20/9)*(3/10)=2/3
+            dict(precision_micro=2 / 3, recall_micro=2 / 3, f2_micro=2 / 3),
+            False,
+            id="beta-2-micro-naming",
+        ),
+    ],
+)
+def test_precision_recall_fscore_success(
+    description: str,
+    kwargs: Dict[str, Any],
+    y_true: List[Any],
+    y_pred: List[Any],
+    expected_names: List[str],
+    expected_scores: Dict[str, float],
+    expects_exception: bool,
+) -> None:
+    evaluator = PrecisionRecallFScore(**kwargs)
+    scores = evaluator({"y_true": y_true, "y_pred": y_pred})
+    names = [s.name for s in scores]
+    assert names == expected_names
+    by_name = _scores_by_name(scores)
+    for key, expected in expected_scores.items():
+        assert by_name[key] == pytest.approx(expected, rel=1e-6, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "description, kwargs, y_true, y_pred, expects_exception",
+    [
+        pytest.param(
+            "single string input should error",
+            dict(),
+            "cat",
+            ["cat"],
+            False,
+            id="error-single-string",
+        ),
+        pytest.param(
+            "unhashable label should error",
+            dict(),
+            [[1], [0]],
+            [[1], [1]],
+            False,
+            id="error-unhashable-label",
+        ),
+        pytest.param(
+            "length mismatch",
+            dict(),
+            [1, 0, 1],
+            [1, 0],
+            False,
+            id="error-length-mismatch",
+        ),
+        pytest.param(
+            "empty inputs",
+            dict(),
+            [],
+            [],
+            True,
+            id="error-empty",
+        ),
+        pytest.param(
+            "positive_label not present",
+            dict(positive_label="pos"),
+            ["a", "a"],
+            ["a", "a"],
+            False,
+            id="error-positive-not-present",
+        ),
+    ],
+)
+def test_precision_recall_fscore_errors(
+    description: str,
+    kwargs: Dict[str, Any],
+    y_true: Any,
+    y_pred: Any,
+    expects_exception: bool,
+) -> None:
+    evaluator = PrecisionRecallFScore(**kwargs)
+    if expects_exception:
+        with pytest.raises(ValueError):
+            _ = evaluator({"y_true": y_true, "y_pred": y_pred})
+    else:
+        scores = evaluator({"y_true": y_true, "y_pred": y_pred})
+        # Evaluators return an ERROR score instead of raising
+        assert len(scores) == 1
+        err = scores[0]
+        assert err.name == "ERROR"
+        assert isinstance(err.explanation, str) and err.explanation


### PR DESCRIPTION
Adds a combined precision, recall, fscore metric for evaluating classification tasks. 

Supports both binary and multi-class, numeric or string labels. 

Returns 3 separate `Score` objects, one for each of precision, recall, f score. 

Configuration parameters: 

- beta: weight of recall relative to precision, defaults to 1 
- average: aggregation strategy across classes (macro, micro, weighted) defaults to macro. 
- pos_label: when set, compute binary precision/recall/F exclusively for this label. If None and labels are numeric with unique set {0,1}, the positive label defaults to 1. Otherwise, multi-class averaging is used.