### PR TITLE
feat: [evals] add `evaluate_dataframe` functionality

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
@@ -9,8 +9,8 @@ from .evaluators import (
     Score,
     SourceType,
     create_classifier,
+    evaluator_function,
     list_evaluators,
-    simple_evaluator,
 )
 
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     "SourceType",
     "create_classifier",
     "list_evaluators",
-    "simple_evaluator",
+    "evaluator_function",
     "ERROR_SCORE",
     "metrics",
     "templating",

--- a/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
@@ -520,6 +520,18 @@ def evaluator_function(
     single Score. The returned object is an Evaluator with full support for evaluate/aevaluate,
     batch_evaluate/abatch_evaluate, and direct callability.
 
+    Args:
+        name: The name of this evaluator, used for identification and Score naming.
+        source: The source of this evaluator (human, llm, or heuristic). Defaults to "heuristic".
+        direction: The direction for score optimization ("maximize" or "minimize"). Defaults to
+        "maximize".
+
+    Returns:
+        An Evaluator instance.
+
+    Notes:
+    The decorated function should return Score objects. The name parameter is optional
+        since the decorator will set it automatically.
     Also registers the evaluator's evaluate callable in the registry so list_evaluators works.
     """
 
@@ -599,7 +611,6 @@ def create_classifier(
     )
 
 
-# --- Standalone DataFrame evaluation ---
 def evaluate_dataframe(
     dataframe: pd.DataFrame,
     evaluators: List[Evaluator],
@@ -618,7 +629,7 @@ def evaluate_dataframe(
       present for that property across all rows. The "_details" column is created for any score
       name observed.
     - For evaluator errors (exceptions or a single ERROR Score), add a column
-      "error_{evaluator.name}" containing the error Score serialized via to_dict(). The column is
+      "{evaluator.name}_errors" containing the error Score serialized via to_dict(). The column is
       created only if any row had an error for that evaluator.
     - input_mappings: optional per-evaluator mapping from evaluator-required field -> dataframe
       column name, keyed by evaluator.name.
@@ -638,7 +649,6 @@ def evaluate_dataframe(
     label_used: Dict[str, bool] = {}
     explanation_used: Dict[str, bool] = {}
 
-    # Per-evaluator error columns
     # Pre-create error columns keyed by evaluator name
     error_cols: Dict[str, List[Optional[Dict[str, Any]]]] = {}
     error_cols_used: Dict[str, bool] = {}

--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
@@ -17,10 +17,10 @@ Example 2: (field_mapping needed to map input keys to those expected by the eval
 source='heuristic')]
 """
 
-from ..evaluators import Score, simple_evaluator
+from ..evaluators import Score, evaluator_function
 
 
-@simple_evaluator(name="exact_match", source="heuristic")
+@evaluator_function(name="exact_match", source="heuristic")
 def exact_match(output: str, expected: str) -> Score:
     """Return exact_match score: 1.0 if output == expected else 0.0."""
     correct = output == expected

--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/precision_recall.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/precision_recall.py
@@ -1,0 +1,340 @@
+"""
+Precision/Recall/F-score (F-beta) evaluator for classification tasks.
+
+- Supports binary and multi-class classification
+- Labels can be strings or integers (must be hashable)
+
+Key behaviors:
+- Binary mode: If `positive_label` is provided, or labels are exactly {0, 1} with no
+  `positive_label` provided (defaults to positive=1), computes precision/recall/F exclusively
+  for the positive class (one-vs-rest). No averaging suffix is used in metric names.
+- Multi-class mode: Computes per-class metrics one-vs-rest and aggregates using the selected
+  averaging strategy: "macro" (default), "micro", or "weighted". When average is not the default
+  "macro", a suffix (e.g., `_micro`) is appended to score names.
+
+Naming rules:
+- Defaults (beta=1.0, average="macro"): names are `precision`, `recall`, and `f1`.
+- Non-default average: e.g., `precision_micro`, `recall_weighted`, `f0_5_micro`.
+
+Zero-division handling:
+- When a denominator is zero (e.g., a class has no predicted or true instances), the metric is
+  set to `zero_division` (default 0.0), consistent with common library behavior.
+
+Examples:
+1) Multi-class (macro):
+>>> from phoenix.evals.preview.metrics.precision_recall import PrecisionRecallFScore
+>>> evaluator = PrecisionRecallFScore(beta=1.0, average="macro")
+>>> eval_input = {"y_true": ["cat", "dog", "cat", "bird"],
+...               "y_pred": ["cat", "cat", "cat", "bird"]}
+>>> scores = evaluator(eval_input)
+>>> [s.name for s in scores]
+['precision', 'recall', 'f1']
+
+2) Binary with explicit positive label:
+>>> evaluator = PrecisionRecallFScore(beta=0.5, positive_label="spam")
+>>> eval_input = {"y_true": ["spam", "ham", "spam"],
+...               "y_pred": ["spam", "spam", "ham"]}
+>>> scores = evaluator(eval_input)
+>>> [s.name for s in scores]
+['precision', 'recall', 'f0_5']
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from ..evaluators import Evaluator, Score
+
+AverageType = Literal["macro", "micro", "weighted"]
+
+
+def _format_beta_for_name(beta: float) -> str:
+    if beta <= 0:
+        # Validation will raise elsewhere; keep a safe fallback
+        return "f"
+    if float(beta).is_integer():
+        return f"f{int(beta)}"
+    text = ("%g" % beta).replace(".", "_")
+    return f"f{text}"
+
+
+@dataclass(frozen=True)
+class _ClassCounts:
+    true_positive: int = 0
+    false_positive: int = 0
+    false_negative: int = 0
+
+    @property
+    def support(self) -> int:
+        return self.true_positive + self.false_negative
+
+
+class PrecisionRecallFScore(Evaluator):
+    """
+    Heuristic evaluator that computes precision, recall, and F-score.
+
+    - Required fields: `y_true`, `y_pred` (sequences of labels)
+    - Supports labels as strings or integers
+    - Supports binary and multi-class via averaging strategies
+
+    Parameters
+    - beta: weight of recall relative to precision. Must be > 0. Defaults to 1.0 (F1).
+    - average: aggregation strategy across classes. One of {'macro','micro','weighted'}.
+               Defaults to 'macro'. Suffixes are only appended to metric names when a non-default
+               average is used.
+    - positive_label: when set, compute binary precision/recall/F exclusively for this label
+                      (one-vs-rest). If None and labels are numeric with unique set {0,1}, the
+                      positive label defaults to 1. Otherwise, multi-class averaging is used.
+    - zero_division: value to use when a metric is undefined (e.g., 0/0). Defaults to 0.0.
+
+    Inputs
+    - y_true, y_pred: sequences (e.g., list, tuple, NumPy array) of hashable labels. Passing a
+      single string (e.g., 'cat') is not supported; pass a sequence instead (e.g., ['cat']).
+    """
+
+    def __init__(
+        self,
+        beta: float = 1.0,
+        average: AverageType = "macro",
+        zero_division: float = 0.0,
+        positive_label: Optional[Hashable] = None,
+    ) -> None:
+        super().__init__(
+            name="precision_recall_fscore",
+            source="heuristic",
+            required_fields={"y_true", "y_pred"},
+            direction="maximize",
+        )
+        if beta <= 0:
+            raise ValueError("beta must be > 0")
+        if average not in ("macro", "micro", "weighted"):
+            raise ValueError("average must be one of {'macro','micro','weighted'}")
+        self.beta = float(beta)
+        self.average = average
+        self.zero_division = float(zero_division)
+        self.positive_label = positive_label
+
+    def _evaluate(self, eval_input: Mapping[str, Any]) -> List[Score]:
+        y_true_raw = eval_input["y_true"]
+        y_pred_raw = eval_input["y_pred"]
+
+        # Disallow accidental single-string inputs (strings are Sequences)
+        if isinstance(y_true_raw, (str, bytes)) or isinstance(y_pred_raw, (str, bytes)):
+            raise ValueError("y_true and y_pred must be sequences of labels, not single strings")
+
+        if not isinstance(y_true_raw, Sequence) or not isinstance(y_pred_raw, Sequence):
+            raise ValueError("y_true and y_pred must be sequences of labels")
+
+        y_true = list(y_true_raw)
+        y_pred = list(y_pred_raw)
+
+        # Ensure labels are hashable so they can be used as dict/set keys
+        self._assert_hashable_labels(y_true, "y_true")
+        self._assert_hashable_labels(y_pred, "y_pred")
+
+        if len(y_true) != len(y_pred):
+            raise ValueError(
+                f"y_true and y_pred must have the same length. Got {len(y_true)} and {len(y_pred)}"
+            )
+        if len(y_true) == 0:
+            raise ValueError("y_true and y_pred must be non-empty")
+
+        labels = self._collect_labels(y_true, y_pred)
+        counts_by_label = self._compute_counts(y_true, y_pred, labels)
+
+        # Determine if we are in binary (positive_label) mode
+        pos_label = self._resolve_positive_label(self.positive_label, labels)
+
+        if pos_label is not None:
+            class_counts = counts_by_label.get(pos_label)
+            if class_counts is None:
+                raise ValueError(
+                    f"positive_label {pos_label!r} not present in labels {list(labels)!r}"
+                )
+            precision = self._safe_div(
+                class_counts.true_positive, class_counts.true_positive + class_counts.false_positive
+            )
+            recall = self._safe_div(
+                class_counts.true_positive, class_counts.true_positive + class_counts.false_negative
+            )
+            suffix = ""
+        else:
+            precision, recall = self._aggregate_precision_recall(counts_by_label)
+            suffix = "" if self.average == "macro" else f"_{self.average}"
+
+        f_score = self._compute_f_score(precision, recall, self.beta)
+
+        beta_name = _format_beta_for_name(self.beta)
+
+        return [
+            Score(
+                name=f"precision{suffix}",
+                score=precision,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+            Score(
+                name=f"recall{suffix}",
+                score=recall,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+            Score(
+                name=f"{beta_name}{suffix}",
+                score=f_score,
+                source=self.source,
+                direction=self.direction,
+                metadata={
+                    "beta": self.beta,
+                    "average": self.average,
+                    "labels": list(labels),
+                    "positive_label": pos_label,
+                },
+            ),
+        ]
+
+    def _collect_labels(
+        self, y_true: Sequence[Hashable], y_pred: Sequence[Hashable]
+    ) -> List[Hashable]:
+        # Preserve a stable, interpretable order: first seen in y_true, then unseen from y_pred
+        seen = set()
+        ordered: List[Hashable] = []
+        for y in y_true:
+            if y not in seen:
+                seen.add(y)
+                ordered.append(y)
+        for y in y_pred:
+            if y not in seen:
+                seen.add(y)
+                ordered.append(y)
+        return ordered
+
+    def _compute_counts(
+        self, y_true: Sequence[Hashable], y_pred: Sequence[Hashable], labels: Sequence[Hashable]
+    ) -> Dict[Hashable, _ClassCounts]:
+        counts: Dict[Hashable, _ClassCounts] = {label: _ClassCounts() for label in labels}
+        for yt, yp in zip(y_true, y_pred):
+            if yt == yp:
+                tp = counts[yt].true_positive + 1
+                counts[yt] = _ClassCounts(
+                    true_positive=tp,
+                    false_positive=counts[yt].false_positive,
+                    false_negative=counts[yt].false_negative,
+                )
+            else:
+                # Predicted class receives a false positive
+                if yp in counts:
+                    c = counts[yp]
+                    counts[yp] = _ClassCounts(
+                        true_positive=c.true_positive,
+                        false_positive=c.false_positive + 1,
+                        false_negative=c.false_negative,
+                    )
+                # True class receives a false negative
+                if yt in counts:
+                    c = counts[yt]
+                    counts[yt] = _ClassCounts(
+                        true_positive=c.true_positive,
+                        false_positive=c.false_positive,
+                        false_negative=c.false_negative + 1,
+                    )
+        return counts
+
+    def _safe_div(self, numerator: float, denominator: float) -> float:
+        if denominator == 0.0:
+            return float(self.zero_division)
+        return numerator / denominator
+
+    def _aggregate_precision_recall(
+        self, counts_by_label: Mapping[Hashable, _ClassCounts]
+    ) -> Tuple[float, float]:
+        if self.average == "micro":
+            tp = sum(c.true_positive for c in counts_by_label.values())
+            fp = sum(c.false_positive for c in counts_by_label.values())
+            fn = sum(c.false_negative for c in counts_by_label.values())
+            precision = self._safe_div(tp, tp + fp)
+            recall = self._safe_div(tp, tp + fn)
+            return precision, recall
+
+        # per-class metrics
+        per_class_precision: List[float] = []
+        per_class_recall: List[float] = []
+        supports: List[int] = []
+        for c in counts_by_label.values():
+            p = self._safe_div(c.true_positive, c.true_positive + c.false_positive)
+            r = self._safe_div(c.true_positive, c.true_positive + c.false_negative)
+            per_class_precision.append(p)
+            per_class_recall.append(r)
+            supports.append(c.support)
+
+        if self.average == "macro":
+            precision = sum(per_class_precision) / len(per_class_precision)
+            recall = sum(per_class_recall) / len(per_class_recall)
+            return precision, recall
+
+        # weighted
+        total = sum(supports)
+        if total == 0:
+            return float(self.zero_division), float(self.zero_division)
+        precision = sum(p * s for p, s in zip(per_class_precision, supports)) / total
+        recall = sum(r * s for r, s in zip(per_class_recall, supports)) / total
+        return precision, recall
+
+    def _compute_f_score(self, precision: float, recall: float, beta: float) -> float:
+        if precision == 0.0 and recall == 0.0:
+            return 0.0
+        beta_sq = beta * beta
+        numerator = (1 + beta_sq) * precision * recall
+        denominator = (beta_sq * precision) + recall
+        return self._safe_div(numerator, denominator)
+
+    def _resolve_positive_label(
+        self, configured_positive: Optional[Hashable], labels: Sequence[Hashable]
+    ) -> Optional[Hashable]:
+        """
+        Decide whether to run in binary mode and which label is positive.
+
+        - If a positive label is provided, use it.
+        - Else, if labels are a binary numeric set {0, 1}, use 1 as positive.
+        - Otherwise, return None to indicate multi-class averaging mode.
+        """
+        if configured_positive is not None:
+            return configured_positive
+
+        unique = set(labels)
+        if unique.issubset({0, 1}) and len(unique) == 2:
+            return 1
+        return None
+
+    def _assert_hashable_labels(self, labels: Sequence[Any], name: str) -> None:
+        for idx, value in enumerate(labels):
+            try:
+                hash(value)
+            except TypeError as e:
+                raise ValueError(
+                    f"All labels in {name} must be hashable. "
+                    f"Found unhashable value at index {idx}: {value!r}"
+                ) from e

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
@@ -14,9 +14,9 @@ from phoenix.evals.preview.evaluators import (
     _validate_field_value,
     create_classifier,
     evaluate_dataframe,
+    evaluator_function,
     list_evaluators,
     remap_eval_input,
-    simple_evaluator,
     to_thread,
 )
 from phoenix.evals.preview.llm import LLM, AsyncLLM
@@ -901,9 +901,9 @@ class TestRegistryAndDecorator:
             _registry.update(original_registry)
 
     def test_simple_evaluator_decorator(self):
-        """Test simple_evaluator decorator."""
+        """Test evaluator_function decorator."""
 
-        @simple_evaluator("test_evaluator", "heuristic", "maximize")
+        @evaluator_function("test_evaluator", "heuristic", "maximize")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8, explanation="test")
 
@@ -914,9 +914,9 @@ class TestRegistryAndDecorator:
         assert result[0].name == "test_evaluator"
 
     def test_simple_evaluator_with_mapping(self):
-        """Test simple_evaluator with input mapping."""
+        """Test evaluator_function with input mapping."""
 
-        @simple_evaluator("test_evaluator", "heuristic")
+        @evaluator_function("test_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 
@@ -926,9 +926,9 @@ class TestRegistryAndDecorator:
         assert result[0].name == "test_evaluator"
 
     def test_simple_evaluator_registration(self):
-        """Test that simple_evaluator registers the function."""
+        """Test that evaluator_function registers the function."""
 
-        @simple_evaluator("registered_evaluator", "heuristic")
+        @evaluator_function("registered_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 


### PR DESCRIPTION
Adds an `evaluate_dataframe` function that takes a dataframe of eval inputs, a list of evaluators, and optional input mappings. 

Also updates the decorator function:
- rename from `simple_evaluator` -> `evaluator_function`
- make it return a fully functioning `Evaluator` instance for full compatibility 

Behavior of `evaluate_dataframe`: 
   - Simple, synchronous function that iterates over rows of the dataframe and evaluates one at a time. We should add concurrency and batching, etc. once all that is ready. 
   - For each produced Score (identified by Score.name), add columns:
        - "{score_name}_score" (float/int)
        - "{score_name}_label" (str)
        - "{score_name}_explanation" (str)
        - "{score_name}_details" (dict from Score.to_dict())
        - Only create the "_score", "_label", "_explanation" columns if any non-None values are
      present for that property across all rows. The "_details" column is created for any score
      name observed.
- For evaluator errors (exceptions or a single ERROR Score), add a column
      "{evaluator.name}_errors" containing the error Score serialized via to_dict(). The column is
      created only if any row had an error for that evaluator.
- input_mappings: optional per-evaluator mapping from evaluator-required field -> dataframe
      column name, keyed by evaluator.name.