### PR TITLE
fix: client config for run_experiment docstring

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/experiments/__init__.py
@@ -118,7 +118,7 @@ def run_experiment(
             ...     dataset=dataset,
             ...     task=my_task,
             ...     experiment_name="greeting-experiment"
-            ... ) 
+            ... )
 
         With evaluators:
             >>> def accuracy_evaluator(output, expected):


### PR DESCRIPTION
With client configuration:
            >>> experiment = run_experiment(
            ...     base_url="https://app.phoenix.arize.com",
            ...     api_key="your-api-key",
            ...     dataset=dataset,
            ...     task=my_task,
            ...     experiment_name="greeting-experiment"
            ... )

i see this in the run_experiment docstring. This seems wrong, as the run_experiment function signature has no base_url or api_key attributes, instead a client attribute to pass in Client object. 

Changing to this:

With client configuration:
>>> from phoenix.client import Client
>>> client = Client()
>>> experiment = run_experiment(
            ...     client = client,
            ...     dataset=dataset,
            ...     task=my_task,
            ...     experiment_name="greeting-experiment"
            ... ) 