### PR TITLE
refactor(experiments): place annotations at the bottom

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1053,6 +1053,9 @@ export const derivedCSS = (theme: ThemeContextType["theme"]) => css`
     // Style for cards
     --ac-global-card-header-height: 46px;
 
+    // Style for popovers
+    --ac-global-popover-background-color: var(--ac-global-color-grey-50);
+
     --ac-global-rounding-xsmall: var(--ac-global-dimension-static-size-25);
     --ac-global-rounding-small: var(--ac-global-dimension-static-size-50);
     --ac-global-rounding-medium: var(--ac-global-dimension-static-size-100);

--- a/app/src/components/annotation/AnnotationDetailsContent.tsx
+++ b/app/src/components/annotation/AnnotationDetailsContent.tsx
@@ -4,7 +4,10 @@ import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import type { Annotation } from "./types";
 
-export function AnnotationTooltipContent({
+/**
+ * A component that displays the details of a particular annotatio
+ */
+export function AnnotationDetailsContent({
   annotation,
 }: {
   annotation: Annotation;
@@ -33,7 +36,9 @@ export function AnnotationTooltipContent({
             <Text weight="heavy" color="inherit">
               score
             </Text>
-            <Text color="inherit">{floatFormatter(annotation.score)}</Text>
+            <Text color="inherit" fontFamily="mono">
+              {floatFormatter(annotation.score)}
+            </Text>
           </Flex>
           {annotation.annotatorKind ? (
             <Flex direction="row" justifyContent="space-between">

--- a/app/src/components/annotation/AnnotationDetailsContent.tsx
+++ b/app/src/components/annotation/AnnotationDetailsContent.tsx
@@ -1,4 +1,5 @@
 import { Flex, Text, View } from "@phoenix/components";
+import { AnnotationColorSwatch } from "@phoenix/components/annotation/AnnotationColorSwatch";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
 
@@ -20,9 +21,12 @@ export function AnnotationDetailsContent({
       justifyContent="space-between"
     >
       <View>
-        <Text weight="heavy" color="inherit" size="L" elementType="h3">
-          {annotation.name}
-        </Text>
+        <Flex direction="row" gap="size-100" alignItems="center">
+          <AnnotationColorSwatch annotationName={annotation.name} />
+          <Text weight="heavy" color="inherit" size="L" elementType="h3">
+            {annotation.name}
+          </Text>
+        </Flex>
         <View paddingTop="size-100" minWidth="150px">
           <Flex direction="row" justifyContent="space-between">
             <Text weight="heavy" color="inherit">

--- a/app/src/components/annotation/AnnotationLabel.tsx
+++ b/app/src/components/annotation/AnnotationLabel.tsx
@@ -1,14 +1,9 @@
 import { PropsWithChildren } from "react";
 import { css } from "@emotion/react";
 
-import { Flex, Icon, Icons, Text } from "@phoenix/components";
-import { assertUnreachable } from "@phoenix/typeUtils";
-import { formatFloat } from "@phoenix/utils/numberFormatUtils";
+import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
 
-import { AnnotationColorSwatch } from "./AnnotationColorSwatch";
-import { Annotation } from "./types";
-
-type AnnotationDisplayPreference = "label" | "score" | "none";
+import { Annotation, AnnotationDisplayPreference } from "./types";
 
 export const baseAnnotationLabelCSS = css`
   border-radius: var(--ac-global-dimension-size-50);
@@ -16,55 +11,19 @@ export const baseAnnotationLabelCSS = css`
   padding: var(--ac-global-dimension-size-50)
     var(--ac-global-dimension-size-100);
   transition: background-color 0.2s;
+  display: flex;
+  flex-direction: row;
+  gap: var(--ac-global-dimension-size-50);
   &[data-clickable="true"] {
     cursor: pointer;
     &:hover {
       background-color: var(--ac-global-color-grey-300);
     }
   }
-
   .ac-icon-wrap {
     font-size: 12px;
   }
 `;
-
-const textCSS = css`
-  display: flex;
-  align-items: center;
-  .ac-text {
-    display: inline-block;
-    max-width: 9rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-`;
-
-const getAnnotationDisplayValue = (
-  annotation: Annotation,
-  displayPreference: AnnotationDisplayPreference
-) => {
-  switch (displayPreference) {
-    case "label":
-      return (
-        annotation.label ||
-        (typeof annotation.score == "number" &&
-          formatFloat(annotation.score)) ||
-        "n/a"
-      );
-    case "score":
-      return (
-        (typeof annotation.score == "number" &&
-          formatFloat(annotation.score)) ||
-        annotation.label ||
-        "n/a"
-      );
-    case "none":
-      return "";
-    default:
-      assertUnreachable(displayPreference);
-  }
-};
 
 export function AnnotationLabel({
   annotation,
@@ -73,7 +32,6 @@ export function AnnotationLabel({
   className,
   children,
   clickable: _clickable,
-  showClickableIcon = true,
 }: PropsWithChildren<{
   annotation: Annotation;
   /**
@@ -82,11 +40,6 @@ export function AnnotationLabel({
    * clickable element (e.g. a dialog trigger, a link, etc).
    */
   clickable?: boolean;
-  /**
-   * When an annotation is clickable, this prop controls whether to show the click affordance icon.
-   * @default true
-   */
-  showClickableIcon?: boolean;
   onClick?: () => void;
   /**
    * The preferred value to display in the annotation label.
@@ -100,11 +53,6 @@ export function AnnotationLabel({
   className?: string;
 }>) {
   const clickable = _clickable ?? typeof onClick == "function";
-  const labelValue = getAnnotationDisplayValue(
-    annotation,
-    annotationDisplayPreference
-  );
-
   return (
     <div
       role={clickable ? "button" : undefined}
@@ -124,30 +72,11 @@ export function AnnotationLabel({
         }
       }}
     >
-      <Flex direction="row" gap="size-100" alignItems="center">
-        <AnnotationColorSwatch annotationName={annotation.name} />
-        <div css={textCSS}>
-          <Text weight="heavy" size="XS" color="inherit">
-            {annotation.name}
-          </Text>
-        </div>
-        {labelValue && (
-          <div
-            css={css(
-              textCSS,
-              css`
-                margin-left: var(--ac-global-dimension-100);
-              `
-            )}
-          >
-            <Text size="XS">{labelValue}</Text>
-          </div>
-        )}
-        {children}
-        {clickable && showClickableIcon ? (
-          <Icon svg={<Icons.ArrowIosForwardOutline />} />
-        ) : null}
-      </Flex>
+      <AnnotationNameAndValue
+        annotation={annotation}
+        displayPreference={annotationDisplayPreference}
+      />
+      {children}
     </div>
   );
 }

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -6,7 +6,7 @@ import { assertUnreachable } from "@phoenix/typeUtils";
 import { formatFloat } from "@phoenix/utils/numberFormatUtils";
 
 import { AnnotationColorSwatch } from "./AnnotationColorSwatch";
-import { Annotation } from "./types";
+import type { Annotation, AnnotationDisplayPreference } from "./types";
 
 const textCSS = css`
   display: flex;
@@ -19,8 +19,6 @@ const textCSS = css`
     text-overflow: ellipsis;
   }
 `;
-
-type AnnotationDisplayPreference = "label" | "score" | "none";
 
 const getAnnotationDisplayValue = ({
   annotation,
@@ -86,9 +84,7 @@ export function AnnotationNameAndValue({
             `
           )}
         >
-          <Text size={size} fontFamily="mono">
-            {labelValue}
-          </Text>
+          <Text fontFamily="mono">{labelValue}</Text>
         </div>
       )}
     </Flex>

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -70,7 +70,7 @@ export function AnnotationNameAndValue({
       className="annotation-name-and-value"
     >
       <AnnotationColorSwatch annotationName={annotation.name} />
-      <div css={textCSS}>
+      <div css={css(textCSS, { minWidth: "5rem" })}>
         <Text weight="heavy" size={size} color="inherit">
           {annotation.name}
         </Text>

--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -1,0 +1,96 @@
+import { css } from "@emotion/react";
+
+import { Flex, Text } from "@phoenix/components";
+import { SizingProps } from "@phoenix/components/types";
+import { assertUnreachable } from "@phoenix/typeUtils";
+import { formatFloat } from "@phoenix/utils/numberFormatUtils";
+
+import { AnnotationColorSwatch } from "./AnnotationColorSwatch";
+import { Annotation } from "./types";
+
+const textCSS = css`
+  display: flex;
+  align-items: center;
+  .ac-text {
+    display: inline-block;
+    max-width: 9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+
+type AnnotationDisplayPreference = "label" | "score" | "none";
+
+const getAnnotationDisplayValue = ({
+  annotation,
+  displayPreference,
+}: {
+  annotation: Annotation;
+  displayPreference: AnnotationDisplayPreference;
+}) => {
+  switch (displayPreference) {
+    case "label":
+      return (
+        annotation.label ||
+        (typeof annotation.score == "number" &&
+          formatFloat(annotation.score)) ||
+        "n/a"
+      );
+    case "score":
+      return (
+        (typeof annotation.score == "number" &&
+          formatFloat(annotation.score)) ||
+        annotation.label ||
+        "n/a"
+      );
+    case "none":
+      return "";
+    default:
+      assertUnreachable(displayPreference);
+  }
+};
+
+interface AnnotationNameAndValueProps extends SizingProps {
+  annotation: Annotation;
+  displayPreference: AnnotationDisplayPreference;
+}
+export function AnnotationNameAndValue({
+  annotation,
+  displayPreference,
+  size,
+}: AnnotationNameAndValueProps) {
+  const labelValue = getAnnotationDisplayValue({
+    annotation,
+    displayPreference,
+  });
+  return (
+    <Flex
+      direction="row"
+      gap="size-100"
+      alignItems="center"
+      className="annotation-name-and-value"
+    >
+      <AnnotationColorSwatch annotationName={annotation.name} />
+      <div css={textCSS}>
+        <Text weight="heavy" size={size} color="inherit">
+          {annotation.name}
+        </Text>
+      </div>
+      {labelValue && (
+        <div
+          css={css(
+            textCSS,
+            css`
+              margin-left: var(--ac-global-dimension-100);
+            `
+          )}
+        >
+          <Text size={size} fontFamily="mono">
+            {labelValue}
+          </Text>
+        </div>
+      )}
+    </Flex>
+  );
+}

--- a/app/src/components/annotation/AnnotationSummaryGroup.tsx
+++ b/app/src/components/annotation/AnnotationSummaryGroup.tsx
@@ -167,7 +167,6 @@ export const AnnotationSummaryGroupTokens = ({
               annotationDisplayPreference="none"
               css={annotationLabelCSS}
               clickable
-              showClickableIcon={false}
             >
               {meanScore != null ? (
                 <SummaryValuePreview

--- a/app/src/components/annotation/AnnotationTooltip.tsx
+++ b/app/src/components/annotation/AnnotationTooltip.tsx
@@ -1,16 +1,8 @@
 import { ReactNode } from "react";
 
-import {
-  Flex,
-  RichTooltip,
-  Text,
-  TooltipTrigger,
-  TriggerWrap,
-  View,
-} from "@phoenix/components";
-import { Truncate } from "@phoenix/components/utility/Truncate";
-import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
+import { RichTooltip, TooltipTrigger, TriggerWrap } from "@phoenix/components";
 
+import { AnnotationTooltipContent } from "./AnnotationTooltipContent";
 import { Annotation } from "./types";
 
 /**
@@ -19,97 +11,17 @@ import { Annotation } from "./types";
 export function AnnotationTooltip({
   annotation,
   children,
-  extra,
-  layout = "vertical",
-  leadingExtra,
 }: {
   leadingExtra?: ReactNode;
   annotation: Annotation;
   children: ReactNode;
-  layout?: "horizontal" | "vertical";
   extra?: ReactNode;
 }) {
   return (
     <TooltipTrigger delay={500}>
       <TriggerWrap>{children}</TriggerWrap>
       <RichTooltip offset={3}>
-        <Flex
-          direction={layout === "horizontal" ? "row" : "column"}
-          alignItems="start"
-        >
-          <Flex
-            direction="column"
-            gap="size-100"
-            height="100%"
-            justifyContent="space-between"
-          >
-            {leadingExtra}
-            <View>
-              <Text weight="heavy" color="inherit" size="L" elementType="h3">
-                {annotation.name}
-              </Text>
-              <View paddingTop="size-100" minWidth="150px">
-                <Flex direction="row" justifyContent="space-between">
-                  <Text weight="heavy" color="inherit">
-                    label
-                  </Text>
-                  <Text color="inherit" title={annotation.label ?? undefined}>
-                    <Truncate maxWidth="200px">
-                      {annotation.label || "--"}
-                    </Truncate>
-                  </Text>
-                </Flex>
-                <Flex direction="row" justifyContent="space-between">
-                  <Text weight="heavy" color="inherit">
-                    score
-                  </Text>
-                  <Text color="inherit">
-                    {floatFormatter(annotation.score)}
-                  </Text>
-                </Flex>
-                {annotation.annotatorKind ? (
-                  <Flex direction="row" justifyContent="space-between">
-                    <Text weight="heavy" color="inherit">
-                      annotator kind
-                    </Text>
-                    <Text color="inherit">{annotation.annotatorKind}</Text>
-                  </Flex>
-                ) : null}
-              </View>
-              {annotation.explanation ? (
-                <View paddingTop="size-50">
-                  <Flex direction="column">
-                    <Text weight="heavy" color="inherit">
-                      explanation
-                    </Text>
-                    <View maxHeight="300px" overflow="auto">
-                      <Text color="inherit">{annotation.explanation}</Text>
-                    </View>
-                  </Flex>
-                </View>
-              ) : null}
-              {annotation.createdAt ? (
-                <Flex
-                  direction="row"
-                  justifyContent="space-between"
-                  wrap="wrap"
-                  gap="size-100"
-                >
-                  <Text weight="heavy" color="inherit">
-                    created at
-                  </Text>
-                  <Text color="inherit">
-                    {new Date(annotation.createdAt)
-                      .toLocaleString()
-                      .split(",")
-                      .join(",\n")}
-                  </Text>
-                </Flex>
-              ) : null}
-            </View>
-          </Flex>
-          {extra}
-        </Flex>
+        <AnnotationTooltipContent annotation={annotation} />
       </RichTooltip>
     </TooltipTrigger>
   );

--- a/app/src/components/annotation/AnnotationTooltip.tsx
+++ b/app/src/components/annotation/AnnotationTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 import { RichTooltip, TooltipTrigger, TriggerWrap } from "@phoenix/components";
 
-import { AnnotationTooltipContent } from "./AnnotationTooltipContent";
+import { AnnotationTooltipContent } from "./AnnotationDetailsContent";
 import { Annotation } from "./types";
 
 /**

--- a/app/src/components/annotation/AnnotationTooltip.tsx
+++ b/app/src/components/annotation/AnnotationTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 import { RichTooltip, TooltipTrigger, TriggerWrap } from "@phoenix/components";
 
-import { AnnotationTooltipContent } from "./AnnotationDetailsContent";
+import { AnnotationDetailsContent } from "./AnnotationDetailsContent";
 import { Annotation } from "./types";
 
 /**
@@ -21,7 +21,7 @@ export function AnnotationTooltip({
     <TooltipTrigger delay={500}>
       <TriggerWrap>{children}</TriggerWrap>
       <RichTooltip offset={3}>
-        <AnnotationTooltipContent annotation={annotation} />
+        <AnnotationDetailsContent annotation={annotation} />
       </RichTooltip>
     </TooltipTrigger>
   );

--- a/app/src/components/annotation/AnnotationTooltipContent.tsx
+++ b/app/src/components/annotation/AnnotationTooltipContent.tsx
@@ -1,0 +1,80 @@
+import { Flex, Text, View } from "@phoenix/components";
+import { Truncate } from "@phoenix/components/utility/Truncate";
+import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
+
+import type { Annotation } from "./types";
+
+export function AnnotationTooltipContent({
+  annotation,
+}: {
+  annotation: Annotation;
+}) {
+  return (
+    <Flex
+      direction="column"
+      gap="size-100"
+      height="100%"
+      justifyContent="space-between"
+    >
+      <View>
+        <Text weight="heavy" color="inherit" size="L" elementType="h3">
+          {annotation.name}
+        </Text>
+        <View paddingTop="size-100" minWidth="150px">
+          <Flex direction="row" justifyContent="space-between">
+            <Text weight="heavy" color="inherit">
+              label
+            </Text>
+            <Text color="inherit" title={annotation.label ?? undefined}>
+              <Truncate maxWidth="200px">{annotation.label || "--"}</Truncate>
+            </Text>
+          </Flex>
+          <Flex direction="row" justifyContent="space-between">
+            <Text weight="heavy" color="inherit">
+              score
+            </Text>
+            <Text color="inherit">{floatFormatter(annotation.score)}</Text>
+          </Flex>
+          {annotation.annotatorKind ? (
+            <Flex direction="row" justifyContent="space-between">
+              <Text weight="heavy" color="inherit">
+                annotator kind
+              </Text>
+              <Text color="inherit">{annotation.annotatorKind}</Text>
+            </Flex>
+          ) : null}
+        </View>
+        {annotation.explanation ? (
+          <View paddingTop="size-50">
+            <Flex direction="column">
+              <Text weight="heavy" color="inherit">
+                explanation
+              </Text>
+              <View maxHeight="300px" overflow="auto">
+                <Text color="inherit">{annotation.explanation}</Text>
+              </View>
+            </Flex>
+          </View>
+        ) : null}
+        {annotation.createdAt ? (
+          <Flex
+            direction="row"
+            justifyContent="space-between"
+            wrap="wrap"
+            gap="size-100"
+          >
+            <Text weight="heavy" color="inherit">
+              created at
+            </Text>
+            <Text color="inherit">
+              {new Date(annotation.createdAt)
+                .toLocaleString()
+                .split(",")
+                .join(",\n")}
+            </Text>
+          </Flex>
+        ) : null}
+      </View>
+    </Flex>
+  );
+}

--- a/app/src/components/annotation/types.ts
+++ b/app/src/components/annotation/types.ts
@@ -26,3 +26,5 @@ export type AnnotationInputPropsBase<T extends AnnotationConfig> = {
   annotationConfig: T;
   onSubmitExplanation?: (explanation: string) => void;
 };
+
+export type AnnotationDisplayPreference = "label" | "score" | "none";

--- a/app/src/components/overlay/Popover.tsx
+++ b/app/src/components/overlay/Popover.tsx
@@ -20,7 +20,7 @@ const popoverSlideKeyframes = keyframes`
 
 const popoverCSS = css`
   box-sizing: border-box;
-  --background-color: var(--ac-global-background-color-light);
+  --background-color: var(--ac-global-popover-background-color);
   transition:
     transform 200ms,
     opacity 200ms;
@@ -39,7 +39,7 @@ const popoverCSS = css`
 
   .react-aria-OverlayArrow svg {
     display: block;
-    fill: var(--ac-global-background-color-light);
+    fill: var(--background-color);
     stroke: var(--ac-global-border-color-light);
     stroke-width: 1px;
   }

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -483,13 +483,11 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
               <CellTop extra={runControls}>
                 <ExperimentRunMetadata {...run} />
               </CellTop>
-              <PaddedCell>
-                <ExperimentRunOutput
-                  {...run}
-                  displayFullText={displayFullText}
-                  setDialog={setDialog}
-                />
-              </PaddedCell>
+              <ExperimentRunOutput
+                {...run}
+                displayFullText={displayFullText}
+                setDialog={setDialog}
+              />
             </>
           ) : (
             <PaddedCell>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { Pressable } from "react-aria-components";
 import { graphql, usePaginationFragment } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useNavigate, useSearchParams } from "react-router";
@@ -44,14 +45,13 @@ import {
   Modal,
   ModalOverlay,
   Popover,
+  PopoverArrow,
   Text,
   View,
   ViewSummaryAside,
 } from "@phoenix/components";
-import {
-  AnnotationLabel,
-  AnnotationTooltip,
-} from "@phoenix/components/annotation";
+import { AnnotationLabel } from "@phoenix/components/annotation";
+import { AnnotationTooltipContent } from "@phoenix/components/annotation/AnnotationDetailsContent";
 import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
 import { JSONBlock } from "@phoenix/components/code";
 import { JSONText } from "@phoenix/components/code/JSONText";
@@ -1278,9 +1278,10 @@ export function ExperimentRunCellAnnotationsList(
       css={css`
         display: flex;
         flex-direction: column;
-        gap: var(--ac-global-dimension-static-size-100);
         flex: none;
-        padding: var(--ac-global-dimension-static-size-100);
+        padding: 0 var(--ac-global-dimension-static-size-100)
+          var(--ac-global-dimension-static-size-100)
+          var(--ac-global-dimension-static-size-100);
       `}
     >
       {annotations.map((annotation) => {
@@ -1298,25 +1299,37 @@ export function ExperimentRunCellAnnotationsList(
               gap: var(--ac-global-dimension-static-size-50);
             `}
           >
-            <AnnotationTooltip annotation={annotation}>
-              <button
-                className="button--reset"
-                css={css`
-                  background-color: lightblue;
-                  padding: var(--ac-global-dimension-size-50);
-                  flex: 1 1 auto;
-                  width: 100%;
-                  &:hover {
-                    background-color: var(--ac-global-color-grey-200);
-                  }
-                `}
-              >
-                <AnnotationNameAndValue
-                  annotation={annotation}
-                  displayPreference={"score"}
-                />
-              </button>
-            </AnnotationTooltip>
+            <DialogTrigger>
+              <Pressable>
+                <button
+                  className="button--reset"
+                  css={css`
+                    cursor: pointer;
+                    padding: var(--ac-global-dimension-size-50)
+                      var(--ac-global-dimension-size-100);
+                    flex: 1 1 auto;
+                    border-radius: var(--ac-global-rounding-small);
+                    width: 100%;
+                    &:hover {
+                      background-color: var(--ac-global-color-grey-200);
+                    }
+                  `}
+                >
+                  <AnnotationNameAndValue
+                    annotation={annotation}
+                    displayPreference="score"
+                  />
+                </button>
+              </Pressable>
+              <Popover placement="top left">
+                <PopoverArrow />
+                <Dialog style={{ width: 400 }}>
+                  <View padding="size-200">
+                    <AnnotationTooltipContent annotation={annotation} />
+                  </View>
+                </Dialog>
+              </Popover>
+            </DialogTrigger>
             <TooltipTrigger>
               <IconButton
                 size="S"

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -51,7 +51,7 @@ import {
   ViewSummaryAside,
 } from "@phoenix/components";
 import { AnnotationLabel } from "@phoenix/components/annotation";
-import { AnnotationTooltipContent } from "@phoenix/components/annotation/AnnotationDetailsContent";
+import { AnnotationDetailsContent } from "@phoenix/components/annotation/AnnotationDetailsContent";
 import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
 import { JSONBlock } from "@phoenix/components/code";
 import { JSONText } from "@phoenix/components/code/JSONText";
@@ -295,7 +295,13 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
         enableSorting: false,
         cell: ({ row }) => {
           return (
-            <>
+            <Flex
+              direction="column"
+              height="100%"
+              css={css`
+                overflow: hidden;
+              `}
+            >
               <CellTop
                 extra={
                   <TooltipTrigger>
@@ -333,7 +339,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                   />
                 </LargeTextWrap>
               </PaddedCell>
-            </>
+            </Flex>
           );
         },
       },
@@ -480,7 +486,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
           );
 
           return run ? (
-            <>
+            <Flex direction="column" height="100%">
               <CellTop extra={runControls}>
                 <ExperimentRunMetadata {...run} />
               </CellTop>
@@ -489,7 +495,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                 displayFullText={displayFullText}
                 setDialog={setDialog}
               />
-            </>
+            </Flex>
           ) : (
             <PaddedCell>
               <NotRunText />
@@ -1321,11 +1327,11 @@ export function ExperimentRunCellAnnotationsList(
                   />
                 </button>
               </Pressable>
-              <Popover placement="top left">
+              <Popover placement="top">
                 <PopoverArrow />
                 <Dialog style={{ width: 400 }}>
                   <View padding="size-200">
-                    <AnnotationTooltipContent annotation={annotation} />
+                    <AnnotationDetailsContent annotation={annotation} />
                   </View>
                 </Dialog>
               </Popover>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -941,12 +941,7 @@ function ExperimentRunOutput(
     : [];
 
   return (
-    <Flex
-      direction="column"
-      gap="size-100"
-      height="100%"
-      justifyContent="space-between"
-    >
+    <Flex direction="column" height="100%" justifyContent="space-between">
       <View padding="size-200" flex="1 1 auto">
         <LargeTextWrap>
           <JSONText

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -52,6 +52,7 @@ import {
   AnnotationLabel,
   AnnotationTooltip,
 } from "@phoenix/components/annotation";
+import { AnnotationNameAndValue } from "@phoenix/components/annotation/AnnotationNameAndValue";
 import { JSONBlock } from "@phoenix/components/code";
 import { JSONText } from "@phoenix/components/code/JSONText";
 import {
@@ -1280,10 +1281,6 @@ export function ExperimentRunCellAnnotationsList(
         gap: var(--ac-global-dimension-static-size-100);
         flex: none;
         padding: var(--ac-global-dimension-static-size-100);
-        li:hover {
-          background-color: var(--ac-global-color-grey-100);
-          cursor: pointer;
-        }
       `}
     >
       {annotations.map((annotation) => {
@@ -1302,33 +1299,44 @@ export function ExperimentRunCellAnnotationsList(
             `}
           >
             <AnnotationTooltip annotation={annotation}>
-              <AnnotationLabel annotation={annotation} />
+              <button
+                className="button--reset"
+                css={css`
+                  background-color: lightblue;
+                  padding: var(--ac-global-dimension-size-50);
+                  flex: 1 1 auto;
+                  width: 100%;
+                  &:hover {
+                    background-color: var(--ac-global-color-grey-200);
+                  }
+                `}
+              >
+                <AnnotationNameAndValue
+                  annotation={annotation}
+                  displayPreference={"score"}
+                />
+              </button>
             </AnnotationTooltip>
-            <Flex direction="row" gap="size-100">
-              <IconButton size="S">
-                <Icon svg={<Icons.InfoOutline />} />
+            <TooltipTrigger>
+              <IconButton
+                size="S"
+                onPress={() => {
+                  if (hasTrace) {
+                    onTraceClick({
+                      annotationName: annotation.name,
+                      traceId,
+                      projectId,
+                    });
+                  }
+                }}
+              >
+                <Icon svg={<Icons.Trace />} />
               </IconButton>
-              <TooltipTrigger>
-                <IconButton
-                  size="S"
-                  onPress={() => {
-                    if (hasTrace) {
-                      onTraceClick({
-                        annotationName: annotation.name,
-                        traceId,
-                        projectId,
-                      });
-                    }
-                  }}
-                >
-                  <Icon svg={<Icons.Trace />} />
-                </IconButton>
-                <Tooltip>
-                  <TooltipArrow />
-                  View evaluation trace
-                </Tooltip>
-              </TooltipTrigger>
-            </Flex>
+              <Tooltip>
+                <TooltipArrow />
+                View evaluation trace
+              </Tooltip>
+            </TooltipTrigger>
           </li>
         );
       })}


### PR DESCRIPTION
this is a pre-cursor to #8774 

This moves us towards being able to consistently displaying filters on the bottom. There are some cases that are not covered. Notably:

- Consolidate on the background color of dialogs vs tooltips (think they probably need to converge)
- Missing annotations on one grid view vs the other
- Button styling
- Padding on content vs bottom metrics

<img width="1920" height="936" alt="Screenshot 2025-08-19 at 2 04 47 PM" src="https://github.com/user-attachments/assets/83b6c923-4d72-4a9f-8cf1-61d64719fccb" />

