### PR TITLE
feat(design): add geist mono for values

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1279,6 +1279,17 @@ const chartCSS = css`
   }
 `;
 
+const fontFamilyCSS = css`
+  .font-default {
+    font-family: "Geist", sans-serif;
+    font-optical-sizing: auto;
+  }
+  .font-mono {
+    font-family: "Geist Mono", monospace;
+    font-optical-sizing: auto;
+  }
+`;
+
 export function GlobalStyles() {
   const { theme = "dark" } = useProvider();
   const themeCSS = theme === "dark" ? darkThemeCSS : lightThemeCSS;
@@ -1294,7 +1305,8 @@ export function GlobalStyles() {
         appGlobalStylesCSS,
         codeMirrorOverridesCSS,
         ReactGridLayoutCSS,
-        chartCSS
+        chartCSS,
+        fontFamilyCSS
       )}
     />
   );

--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1284,7 +1284,8 @@ const fontFamilyCSS = css`
     font-family: "Geist", sans-serif;
     font-optical-sizing: auto;
   }
-  .font-mono {
+  .font-mono,
+  pre {
     font-family: "Geist Mono", monospace;
     font-optical-sizing: auto;
   }

--- a/app/src/components/annotation/MeanScore.tsx
+++ b/app/src/components/annotation/MeanScore.tsx
@@ -12,12 +12,16 @@ export const MeanScore = ({
   fallback?: React.ReactNode;
 } & Omit<TextProps, "children">) => {
   if (value == null || typeof value !== "number" || isNaN(value)) {
-    return <Text {...props}>{fallback}</Text>;
+    return (
+      <Text {...props} fontFamily="mono">
+        {fallback}
+      </Text>
+    );
   }
   return (
     <Text {...props}>
       <span aria-label="mean score">μ&nbsp;</span>
-      {`${formatFloat(value)}`}
+      <span className="font-mono">{`${formatFloat(value)}`}</span>
     </Text>
   );
 };

--- a/app/src/components/code/JSONText.tsx
+++ b/app/src/components/code/JSONText.tsx
@@ -52,7 +52,11 @@ export function JSONText({
     // Just show text and log a warning
     // eslint-disable-next-line no-console
     console.warn("JSONText component received a non-object value", json);
-    return <span title={title}>{String(json)}</span>;
+    return (
+      <span title={title} className="font-mono">
+        {String(json)}
+      </span>
+    );
   }
   const obj = json as Record<string, unknown>;
   if (Object.keys(obj).length === 0) {
@@ -66,7 +70,11 @@ export function JSONText({
       const singleValueStr: string = hasMaxLength
         ? formatText(singleValue, maxLength)
         : singleValue;
-      return <span title={title}>{singleValueStr}</span>;
+      return (
+        <span title={title} className="font-mono">
+          {singleValueStr}
+        </span>
+      );
     }
   }
   const textValue = hasMaxLength ? formatText(fullValue, maxLength) : fullValue;

--- a/app/src/components/content/Text.tsx
+++ b/app/src/components/content/Text.tsx
@@ -5,6 +5,8 @@ import {
 } from "react-aria-components";
 import { css } from "@emotion/react";
 
+import { classNames } from "@arizeai/components";
+
 import {
   ColorValue,
   DOMProps,
@@ -49,6 +51,11 @@ export interface TextProps extends AriaTextProps, DOMProps, StyleProps {
    */
   fontStyle?: CSSProperties["fontStyle"];
   /**
+   * The font family
+   * @default 'default'
+   */
+  fontFamily?: "default" | "mono";
+  /**
    * The disabled state of the text
    */
   isDisabled?: boolean;
@@ -84,13 +91,14 @@ function Text(props: TextProps, ref: Ref<HTMLElement>) {
     size = "S",
     weight = "normal",
     fontStyle = "normal",
+    fontFamily = "default",
     ...otherProps
   } = props;
   const { styleProps } = useStyleProps(otherProps);
 
   return (
     <AriaText
-      className="ac-text"
+      className={classNames("ac-text", `font-${fontFamily}`)}
       {...otherProps}
       {...styleProps}
       css={css`

--- a/app/src/components/table/FloatCell.tsx
+++ b/app/src/components/table/FloatCell.tsx
@@ -1,7 +1,12 @@
 import { CellContext } from "@tanstack/react-table";
+import { css } from "@emotion/react";
 
 import { isNumberOrNull } from "@phoenix/typeUtils";
 import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
+
+const floatRightCSS = css`
+  float: right;
+`;
 
 /**
  * A table cell that nicely formats the value of a float.
@@ -14,7 +19,11 @@ export function FloatCell<TData extends object, TValue>({
     throw new Error("IntCell only supports number or null values.");
   }
   return (
-    <span title={value != null ? String(value) : ""}>
+    <span
+      title={value != null ? String(value) : ""}
+      className="font-mono"
+      css={floatRightCSS}
+    >
       {floatFormatter(value)}
     </span>
   );

--- a/app/src/components/table/IntCell.tsx
+++ b/app/src/components/table/IntCell.tsx
@@ -18,7 +18,11 @@ export function IntCell<TData extends object, TValue>({
     throw new Error("IntCell only supports number or null values.");
   }
   return (
-    <span title={value != null ? String(value) : ""} css={floatRightCSS}>
+    <span
+      title={value != null ? String(value) : ""}
+      className="font-mono"
+      css={floatRightCSS}
+    >
       {intFormatter(value)}
     </span>
   );

--- a/app/src/components/trace/LatencyText.tsx
+++ b/app/src/components/trace/LatencyText.tsx
@@ -51,7 +51,7 @@ export function LatencyText({
           />
         </Text>
       ) : null}
-      <Text color={color} size={size}>
+      <Text color={color} size={size} fontFamily="mono">
         {latencyText}
       </Text>
     </Flex>

--- a/app/src/components/trace/TokenCosts.tsx
+++ b/app/src/components/trace/TokenCosts.tsx
@@ -41,7 +41,9 @@ function TokenCosts(props: TokenCostsProps, ref: Ref<HTMLDivElement>) {
           color: var(--ac-global-text-color-900);
         `}
       />
-      <Text size={props.size}>{text}</Text>
+      <Text size={props.size} fontFamily="mono">
+        {text}
+      </Text>
     </div>
   );
 }

--- a/app/src/components/trace/TokenCount.tsx
+++ b/app/src/components/trace/TokenCount.tsx
@@ -41,7 +41,9 @@ function TokenCount(props: TokenCountProps, ref: Ref<HTMLDivElement>) {
           color: var(--ac-global-text-color-900);
         `}
       />
-      <Text size={props.size}>{text}</Text>
+      <Text size={props.size} fontFamily="mono">
+        {text}
+      </Text>
     </div>
   );
 }

--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -136,7 +136,9 @@ export function ProjectPageHeader(props: {
               <Text elementType="h3" size="S" color="text-700">
                 Total Traces
               </Text>
-              <Text size="L">{intFormatter(data?.traceCount)}</Text>
+              <Text size="L" fontFamily="mono">
+                {intFormatter(data?.traceCount)}
+              </Text>
             </Flex>
             <Flex direction="column" flex="none">
               <Text elementType="h3" size="S" color="text-700">
@@ -144,7 +146,7 @@ export function ProjectPageHeader(props: {
               </Text>
               <TooltipTrigger delay={0}>
                 <Focusable>
-                  <Text size="L" role="button">
+                  <Text size="L" role="button" fontFamily="mono">
                     {costFormatter(data?.costSummary?.total?.cost ?? 0)}
                   </Text>
                 </Focusable>

--- a/app/src/pages/projects/ProjectsPage.tsx
+++ b/app/src/pages/projects/ProjectsPage.tsx
@@ -673,7 +673,9 @@ function ProjectMetricsRow({
         <Text elementType="h3" size="S" color="text-700">
           Total Traces
         </Text>
-        <Text size="L">{intFormatter(traceCount)}</Text>
+        <Text size="L" fontFamily="mono">
+          {intFormatter(traceCount)}
+        </Text>
       </Flex>
       <Flex direction="column">
         <Text elementType="h3" size="S" color="text-700">

--- a/app/stories/Text.stories.tsx
+++ b/app/stories/Text.stories.tsx
@@ -29,6 +29,8 @@ const colors: TextProps["color"][] = [
   ...GLOBAL_COLORS,
 ];
 
+const fontFamilies: TextProps["fontFamily"][] = ["default", "mono"];
+
 /**
  * A gallery of all the variants
  */
@@ -89,6 +91,26 @@ function GalleryComponent() {
           return (
             <Text key={color} size="L" color={color} weight="heavy">
               {`I will not waste chalk`}
+            </Text>
+          );
+        })}
+      </p>
+      <p
+        css={css`
+          .ac-text {
+            display: block;
+          }
+        `}
+      >
+        {fontFamilies.map((fontFamily) => {
+          return (
+            <Text
+              key={fontFamily}
+              size="L"
+              fontFamily={fontFamily}
+              weight="heavy"
+            >
+              {`I will not waste chalk (${fontFamily})`}
             </Text>
           );
         })}

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -58,7 +58,7 @@
     {% if allow_external_resources %}
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
     {% endif %}
     {% if not is_development -%}
       {% set _ = collect_assets('index.tsx') -%}


### PR DESCRIPTION
Add a mono font for showing values (e.x. numerics)
<img width="641" height="405" alt="Screenshot 2025-08-11 at 3 00 45 PM" src="https://github.com/user-attachments/assets/67e7f0dd-2624-4a0d-b16a-eddfd32b660f" />
