### PR TITLE
fix: [evals] rename and update evaluator decorator 

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
@@ -9,8 +9,8 @@ from .evaluators import (
     Score,
     SourceType,
     create_classifier,
+    evaluator_function,
     list_evaluators,
-    simple_evaluator,
 )
 
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     "SourceType",
     "create_classifier",
     "list_evaluators",
-    "simple_evaluator",
+    "evaluator_function",
     "ERROR_SCORE",
     "metrics",
     "templating",

--- a/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/__init__.py
@@ -9,7 +9,7 @@ from .evaluators import (
     Score,
     SourceType,
     create_classifier,
-    evaluator_function,
+    create_evaluator,
     list_evaluators,
 )
 
@@ -23,7 +23,7 @@ __all__ = [
     "SourceType",
     "create_classifier",
     "list_evaluators",
-    "evaluator_function",
+    "create_evaluator",
     "ERROR_SCORE",
     "metrics",
     "templating",

--- a/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
@@ -509,7 +509,7 @@ def list_evaluators() -> List[str]:
     return list(_registry.keys())
 
 
-def evaluator_function(
+def create_evaluator(
     name: str, source: SourceType = "heuristic", direction: DirectionType = "maximize"
 ) -> Callable[[Callable[..., Score]], Evaluator]:
     """

--- a/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
@@ -3,7 +3,6 @@ import inspect
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from functools import wraps
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
 from typing_extensions import Mapping
@@ -510,68 +509,64 @@ def list_evaluators() -> List[str]:
     return list(_registry.keys())
 
 
-def simple_evaluator(
-    name: str, source: SourceType, direction: DirectionType = "maximize"
-) -> Callable[
-    [Callable[..., Score]], Callable[[EvalInput, Optional[Mapping[str, str]]], List[Score]]
-]:
+def evaluator_function(
+    name: str, source: SourceType = "heuristic", direction: DirectionType = "maximize"
+) -> Callable[[Callable[..., Score]], Evaluator]:
     """
-    Decorator to register a simple heuristic evaluator function.
+    Decorator that turns a simple function into an Evaluator instance.
+
     The decorated function should accept keyword args matching its required fields and return a
-    single Score.
-    The wrapper provides:
-      - automatic required_fields inference from function signature
-      - per-call input_mapping support
-      - registration under the given name (queryable via list_evaluators)
+    single Score. The returned object is an Evaluator with full support for evaluate/aevaluate,
+    evaluate_batch/aevaluate_batch, and direct callability.
 
     Args:
         name: The name of this evaluator, used for identification and Score naming.
-        source: The source of this evaluator (human, llm, or heuristic).
+        source: The source of this evaluator (human, llm, or heuristic). Defaults to "heuristic".
         direction: The direction for score optimization ("maximize" or "minimize"). Defaults to
         "maximize".
 
-    Note:
-        The decorated function should create Score objects. The name parameter is optional
-        since the decorator will set it automatically. The wrapper will also set the source.
+    Returns:
+        An Evaluator instance.
+
+    Notes:
+    The decorated function should return Score objects. The name parameter is optional
+        since the decorator will set it automatically.
+    Also registers the evaluator's evaluate callable in the registry so list_evaluators works.
     """
 
-    def deco(
-        fn: Callable[..., Score],
-    ) -> Callable[[EvalInput, Optional[Mapping[str, str]]], List[Score]]:
+    def deco(fn: Callable[..., Score]) -> Evaluator:
         sig = inspect.signature(fn)
         required: Set[str] = set(sig.parameters.keys())
 
-        @wraps(fn)
-        def wrapper(
-            eval_input: EvalInput, input_mapping: Optional[Mapping[str, str]] = None
-        ) -> List[Score]:
-            """
-            Evaluate by extracting required fields from eval_input and calling the original
-            function.
-            """
-            remapped_input = remap_eval_input(eval_input, required, input_mapping)
-
-            score = fn(**remapped_input)
-            # Create a new Score with the correct name and source if needed
-            if score.name != name or score.source != source:
-                score = Score(
-                    score=score.score,
+        class _FunctionEvaluator(Evaluator):
+            def __init__(self) -> None:
+                super().__init__(
                     name=name,
-                    label=score.label,
-                    explanation=score.explanation,
-                    metadata=score.metadata,
                     source=source,
+                    required_fields=required,
                     direction=direction,
                 )
-            return [score]
+                self._fn = fn
 
-        # Add attributes to the wrapper function
-        wrapper.required_fields = required  # type: ignore
-        wrapper.name = name  # type: ignore
-        wrapper.source = source  # type: ignore
-        wrapper.direction = direction  # type: ignore
-        _registry[name] = wrapper
-        return wrapper
+            def _evaluate(self, eval_input: EvalInput) -> List[Score]:
+                # eval_input is already remapped by Evaluator.evaluate(...)
+                score = self._fn(**eval_input)
+                if score.name != name or score.source != source or score.direction != direction:
+                    score = Score(
+                        score=score.score,
+                        name=name,
+                        label=score.label,
+                        explanation=score.explanation,
+                        metadata=score.metadata,
+                        source=source,
+                        direction=direction,
+                    )
+                return [score]
+
+        evaluator_instance = _FunctionEvaluator()
+        # Keep registry compatibility by storing a callable with expected signature
+        _registry[name] = evaluator_instance.evaluate
+        return evaluator_instance
 
     return deco
 

--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
@@ -17,10 +17,10 @@ Example 2: (field_mapping needed to map input keys to those expected by the eval
 source='heuristic')]
 """
 
-from ..evaluators import Score, evaluator_function
+from ..evaluators import Score, create_evaluator
 
 
-@evaluator_function(name="exact_match", source="heuristic")
+@create_evaluator(name="exact_match", source="heuristic")
 def exact_match(output: str, expected: str) -> Score:
     """Return exact_match score: 1.0 if output == expected else 0.0."""
     correct = output == expected

--- a/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/metrics/exact_match.py
@@ -17,10 +17,10 @@ Example 2: (field_mapping needed to map input keys to those expected by the eval
 source='heuristic')]
 """
 
-from ..evaluators import Score, simple_evaluator
+from ..evaluators import Score, evaluator_function
 
 
-@simple_evaluator(name="exact_match", source="heuristic")
+@evaluator_function(name="exact_match", source="heuristic")
 def exact_match(output: str, expected: str) -> Score:
     """Return exact_match score: 1.0 if output == expected else 0.0."""
     correct = output == expected

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
@@ -12,9 +12,9 @@ from phoenix.evals.preview.evaluators import (
     Score,
     _validate_field_value,
     create_classifier,
+    evaluator_function,
     list_evaluators,
     remap_eval_input,
-    simple_evaluator,
     to_thread,
 )
 from phoenix.evals.preview.llm import LLM, AsyncLLM
@@ -700,10 +700,10 @@ class TestRegistryAndDecorator:
             _registry.clear()
             _registry.update(original_registry)
 
-    def test_simple_evaluator_decorator(self):
-        """Test simple_evaluator decorator."""
+    def test_evaluator_function_decorator(self):
+        """Test evaluator_function decorator."""
 
-        @simple_evaluator("test_evaluator", "heuristic", "maximize")
+        @evaluator_function("test_evaluator", "heuristic", "maximize")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8, explanation="test")
 
@@ -713,10 +713,10 @@ class TestRegistryAndDecorator:
         assert len(result) == 1
         assert result[0].name == "test_evaluator"
 
-    def test_simple_evaluator_with_mapping(self):
-        """Test simple_evaluator with input mapping."""
+    def test_evaluator_function_with_mapping(self):
+        """Test evaluator_function with input mapping."""
 
-        @simple_evaluator("test_evaluator", "heuristic")
+        @evaluator_function("test_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 
@@ -725,10 +725,10 @@ class TestRegistryAndDecorator:
         assert len(result) == 1
         assert result[0].name == "test_evaluator"
 
-    def test_simple_evaluator_registration(self):
-        """Test that simple_evaluator registers the function."""
+    def test_evaluator_function_registration(self):
+        """Test that evaluator_function registers the function."""
 
-        @simple_evaluator("registered_evaluator", "heuristic")
+        @evaluator_function("registered_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
@@ -12,7 +12,7 @@ from phoenix.evals.preview.evaluators import (
     Score,
     _validate_field_value,
     create_classifier,
-    evaluator_function,
+    create_evaluator,
     list_evaluators,
     remap_eval_input,
     to_thread,
@@ -700,10 +700,10 @@ class TestRegistryAndDecorator:
             _registry.clear()
             _registry.update(original_registry)
 
-    def test_evaluator_function_decorator(self):
-        """Test evaluator_function decorator."""
+    def test_create_evaluator_decorator(self):
+        """Test create_evaluator decorator."""
 
-        @evaluator_function("test_evaluator", "heuristic", "maximize")
+        @create_evaluator("test_evaluator", "heuristic", "maximize")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8, explanation="test")
 
@@ -713,10 +713,10 @@ class TestRegistryAndDecorator:
         assert len(result) == 1
         assert result[0].name == "test_evaluator"
 
-    def test_evaluator_function_with_mapping(self):
-        """Test evaluator_function with input mapping."""
+    def test_create_evaluator_with_mapping(self):
+        """Test create_evaluator with input mapping."""
 
-        @evaluator_function("test_evaluator", "heuristic")
+        @create_evaluator("test_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 
@@ -725,10 +725,10 @@ class TestRegistryAndDecorator:
         assert len(result) == 1
         assert result[0].name == "test_evaluator"
 
-    def test_evaluator_function_registration(self):
-        """Test that evaluator_function registers the function."""
+    def test_create_evaluator_registration(self):
+        """Test that create_evaluator registers the function."""
 
-        @evaluator_function("registered_evaluator", "heuristic")
+        @create_evaluator("registered_evaluator", "heuristic")
         def test_func(input_text: str) -> Score:
             return Score(score=0.8)
 


### PR DESCRIPTION
Renames from `simple_evaluator` -> `create_evaluator` to follow decorator naming conventions and match existing experiments behavior.
Updates decorator implementation to convert decorated functions into valid `Evaluator` instances with an `evaluate` method. 