### PR TITLE
fix: add composite index to traces

### DIFF
--- a/src/phoenix/db/migrations/versions/272b66ff50f8_drop_indices_from_traces.py
+++ b/src/phoenix/db/migrations/versions/272b66ff50f8_drop_indices_from_traces.py
@@ -1,0 +1,27 @@
+"""drop indices from traces
+
+Revision ID: 272b66ff50f8
+Revises: a20694b15f82
+Create Date: 2025-08-11 20:37:46.941940
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "272b66ff50f8"
+down_revision: Union[str, None] = "a20694b15f82"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_traces_project_rowid", table_name="traces")
+    op.drop_index("ix_traces_start_time", table_name="traces")
+
+
+def downgrade() -> None:
+    op.create_index("ix_traces_project_rowid", "traces", ["project_rowid"])
+    op.create_index("ix_traces_start_time", "traces", ["start_time"])

--- a/src/phoenix/db/migrations/versions/735d3d93c33e_add_index_to_traces.py
+++ b/src/phoenix/db/migrations/versions/735d3d93c33e_add_index_to_traces.py
@@ -1,0 +1,29 @@
+"""add index to traces
+
+Revision ID: 735d3d93c33e
+Revises: 272b66ff50f8
+Create Date: 2025-08-11 20:52:47.477712
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "735d3d93c33e"
+down_revision: Union[str, None] = "272b66ff50f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_traces_project_rowid_start_time",
+        "traces",
+        ["project_rowid", "start_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_traces_project_rowid_start_time", table_name="traces")

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -319,3 +319,13 @@ def test_up_and_down_migrations(
         _up(_engine, _alembic_config, "a20694b15f82", _schema)
         _down(_engine, _alembic_config, "6a88424799fe", _schema)
     _up(_engine, _alembic_config, "a20694b15f82", _schema)
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "272b66ff50f8", _schema)
+        _down(_engine, _alembic_config, "a20694b15f82", _schema)
+    _up(_engine, _alembic_config, "272b66ff50f8", _schema)
+
+    for _ in range(2):
+        _up(_engine, _alembic_config, "735d3d93c33e", _schema)
+        _down(_engine, _alembic_config, "272b66ff50f8", _schema)
+    _up(_engine, _alembic_config, "735d3d93c33e", _schema)


### PR DESCRIPTION
## Fix: Add composite index to traces table

Replaces separate indexes on `project_rowid` and `start_time` with a single composite index on `(project_rowid, start_time)`.

**Why composite is better:**
- **Reduced storage overhead**: One index instead of two saves disk space and memory
- **Improved query performance**: Queries filtering by both `project_rowid` AND `start_time` can use a single index lookup instead of intersecting two separate indexes
- **Better cache efficiency**: Single index means better utilization of database buffer cache
- **Optimized for common query patterns**: Most trace queries likely filter by project first, then by time range, which perfectly matches the composite index column order

The composite index can efficiently serve queries on:
- Both columns together (most efficient)
- Just `project_rowid` (uses index prefix)
- Range queries on `start_time` within a specific project