### PR TITLE
fix: [evals] drop batch evaluation methods

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/evaluators.py
@@ -149,8 +149,7 @@ class Evaluator(ABC):
     """
     Core abstraction for evaluators.
     Instances are callable: `scores = evaluator(eval_input)` (sync or async via `aevaluate`).
-    Supports single-record (`evaluate`) and batch (`batch_evaluate`) modes,
-    with optional per-call field_mapping.
+    Supports single-record (`evaluate`) mode with optional per-call field_mapping.
     """
 
     def __init__(
@@ -266,22 +265,6 @@ class Evaluator(ABC):
     __call__ = evaluate
     # ensure the callable inherits evaluate's docs for IDE support
     __call__.__doc__ = evaluate.__doc__
-
-    def batch_evaluate(
-        self, eval_inputs: List[EvalInput], input_mapping: Optional[Mapping[str, str]] = None
-    ) -> List[List[Score]]:
-        """
-        Apply `evaluate` to a list of `eval_input` mappings, reusing the same `input_mapping`.
-        """
-        return [self.evaluate(inp, input_mapping=input_mapping) for inp in eval_inputs]
-
-    async def abatch_evaluate(
-        self, eval_inputs: List[EvalInput], input_mapping: Optional[Mapping[str, str]] = None
-    ) -> List[List[Score]]:
-        """
-        Apply `aevaluate` to a list of `eval_input` mappings, reusing the same `input_mapping`.
-        """
-        return [await self.aevaluate(inp, input_mapping=input_mapping) for inp in eval_inputs]
 
 
 # --- LLM Evaluator base ---
@@ -516,8 +499,8 @@ def create_evaluator(
     Decorator that turns a simple function into an Evaluator instance.
 
     The decorated function should accept keyword args matching its required fields and return a
-    single Score. The returned object is an Evaluator with full support for evaluate/aevaluate,
-    evaluate_batch/aevaluate_batch, and direct callability.
+    single Score. The returned object is an Evaluator with full support for evaluate/aevaluate
+    and direct callability.
 
     Args:
         name: The name of this evaluator, used for identification and Score naming.

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
@@ -1,4 +1,5 @@
 # type: ignore
+import asyncio
 from contextlib import nullcontext as does_not_raise
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
@@ -461,13 +462,14 @@ class TestEvaluator:
         assert len(result) == 1
         assert result[0].name == "test_evaluator"
 
-    def test_evaluator_batch_evaluate(self):
-        """Test batch evaluation."""
+    def test_evaluator_manual_batching(self):
+        """Test applying evaluate across a list of inputs (external batching)."""
         evaluator = self.MockEvaluator(
             name="test_evaluator", source="llm", required_fields={"input"}
         )
 
-        results = evaluator.batch_evaluate([{"input": "test1"}, {"input": "test2"}])
+        inputs = [{"input": "test1"}, {"input": "test2"}]
+        results = [evaluator.evaluate(inp) for inp in inputs]
 
         assert len(results) == 2
         assert len(results[0]) == 1
@@ -486,13 +488,14 @@ class TestEvaluator:
         assert result[0].name == "test_evaluator"
 
     @pytest.mark.asyncio
-    async def test_evaluator_abatch_evaluate(self):
-        """Test async batch evaluation."""
+    async def test_evaluator_manual_async_batching(self):
+        """Test applying aevaluate across a list of inputs with gather (external batching)."""
         evaluator = self.MockEvaluator(
             name="test_evaluator", source="llm", required_fields={"input"}
         )
 
-        results = await evaluator.abatch_evaluate([{"input": "test1"}, {"input": "test2"}])
+        inputs = [{"input": "test1"}, {"input": "test2"}]
+        results = await asyncio.gather(*[evaluator.aevaluate(inp) for inp in inputs])
 
         assert len(results) == 2
         assert len(results[0]) == 1


### PR DESCRIPTION
We decided to drop batch evaluation methods from the new `Evaluator` class for the following reasons:
1. Simplicity 
2. Executors assume single record operations
3. Tracing is only possible on individual requests right now. 

We may at some point want to support separate batch methods for cost reasons since batch API calls tend to be cheaper. For now, we will keep things simple. 

