### PR TITLE
feat: special case sqlite:///:memory: in helm

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -83,6 +83,7 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes for the persistent volume |
 | persistence.annotations | object | `{}` | Annotations to add to the PVC |
 | persistence.enabled | bool | `false` | Enable persistent storage for Phoenix home directory |
+| persistence.inMemory | bool | `false` | Enable in-memory configuration of sqlite strategy | 
 | persistence.labels | object | `{}` | Labels to add to the PVC |
 | persistence.size | string | `"20Gi"` | Size of the persistent volume for Phoenix home directory |
 | persistence.storageClass | string | `""` | Kubernetes storage class for Phoenix home volume |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Truncate at 63 chars, kuberneteres DNS name limitation. 
+Truncate at 63 chars, kuberneteres DNS name limitation.
 */}}
 {{- define "phoenix.name" -}}
 {{- default "phoenix" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
@@ -57,7 +57,7 @@ Truncate at 63 chars, kuberneteres DNS name limitation.
   {{- printf "%s-grpc" (include "phoenix.fullname" .) -}}
 {{- end -}}
 {{- define "phoenix.grpcPort" -}}
-  {{- .Values.server.grpcPort | default 4317 }} 
+  {{- .Values.server.grpcPort | default 4317 }}
 {{- end -}}
 
 {{/*
@@ -67,13 +67,17 @@ Validate persistence configuration to prevent data storage conflicts
 {{- $persistenceEnabled := .Values.persistence.enabled | toString | eq "true" }}
 {{- $postgresqlEnabled := .Values.postgresql.enabled | toString | eq "true" }}
 {{- $databaseUrlConfigured := and .Values.database.url (ne .Values.database.url "") }}
-{{- if and $persistenceEnabled $postgresqlEnabled }}
+{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+{{- if and $isMemoryDatabase $postgresqlEnabled }}
+{{- fail "ERROR: In-memory database configuration conflict!\n\nWhen using SQLite In-memory (database.url=\"sqlite:///:memory:\"), PostgreSQL must be disabled.\n\nTo fix this:\n  - Set database.url=\"sqlite:///:memory:\"\n  - Set postgresql.enabled=false\n\nNote: In-memory mode is for demos/testing only. All data will be lost when the pod restarts." }}
+{{- end }}
+{{- if and $persistenceEnabled $postgresqlEnabled (not $isMemoryDatabase) }}
 {{- fail "ERROR: Invalid persistence configuration detected!\n\nYou cannot enable both 'persistence.enabled=true' and 'postgresql.enabled=true' simultaneously.\n\nThese options are mutually exclusive. Please choose ONE of the following:\n\n  1. SQLite with persistent storage:\n     - Set persistence.enabled=true\n     - Set postgresql.enabled=false\n     - Leave database.url empty\n\n  2. Built-in PostgreSQL:\n     - Set persistence.enabled=false\n     - Set postgresql.enabled=true\n     - Leave database.url empty\n\n  3. External database:\n     - Set persistence.enabled=false\n     - Set postgresql.enabled=false\n     - Configure database.url with your external database connection string\n\nFor more information, see the persistence configuration comments in values.yaml" }}
 {{- end }}
-{{- if and $persistenceEnabled $databaseUrlConfigured }}
+{{- if and $persistenceEnabled $databaseUrlConfigured (not $isMemoryDatabase) }}
 {{- fail "ERROR: Invalid SQLite configuration detected!\n\nWhen using SQLite with persistent storage (persistence.enabled=true), the 'database.url' must be empty.\n\nSQLite will automatically use the persistent volume at the working directory.\n\nTo fix this:\n  - Set persistence.enabled=true\n  - Set postgresql.enabled=false\n  - Set database.url to empty string\n\nIf you want to use an external database instead:\n  - Set persistence.enabled=false\n  - Set postgresql.enabled=false\n  - Configure database.url with your external database connection string" }}
 {{- end }}
-{{- if and $databaseUrlConfigured $postgresqlEnabled }}
+{{- if and $databaseUrlConfigured $postgresqlEnabled (not $isMemoryDatabase) }}
 {{- fail "ERROR: Conflicting database configuration detected!\n\nYou cannot specify both 'database.url' and enable the built-in PostgreSQL (postgresql.enabled=true).\n\nTo fix this, choose ONE option:\n\n  1. Use external database:\n     - Set postgresql.enabled=false\n     - Keep database.url configured with your external database\n\n  2. Use built-in PostgreSQL:\n     - Set postgresql.enabled=true\n     - Set database.url to empty string\n\nThe database.url setting overrides PostgreSQL settings, so having both enabled creates ambiguity." }}
 {{- end }}
 {{- end }}
@@ -105,12 +109,13 @@ Validate database URL format when provided
 {{- define "phoenix.validateDatabaseUrl" -}}
 {{- $databaseUrlConfigured := and .Values.database.url (ne .Values.database.url "") }}
 {{- $persistenceEnabled := .Values.persistence.enabled | toString | eq "true" }}
+{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
 {{- if $databaseUrlConfigured }}
 {{- $url := .Values.database.url }}
 {{- if not (or (hasPrefix "postgresql://" $url) (hasPrefix "sqlite://" $url)) }}
 {{- fail (printf "ERROR: Invalid database.url format detected!\n\nThe database.url must start with a valid scheme.\n\nProvided: %s\n\nSupported formats:\n  - PostgreSQL: postgresql://username:password@host:port/database\n  - SQLite: sqlite:///path/to/database.db\n\nExample PostgreSQL URL:\n  database.url: \"postgresql://myuser:mypass@db.example.com:5432/phoenix\"" $url) }}
 {{- end }}
-{{- if and (hasPrefix "sqlite://" $url) (not $persistenceEnabled) }}
+{{- if and (hasPrefix "sqlite://" $url) (not $persistenceEnabled) (not $isMemoryDatabase) }}
 {{- fail "ERROR: SQLite database URL provided without persistent storage!\n\nWhen using SQLite with database.url, you must enable persistent storage to prevent data loss.\n\nTo fix this:\n  - Set persistence.enabled=true\n  - Ensure the SQLite file path in database.url points to the persistent volume\n\nAlternatively, for SQLite with persistence, it's recommended to:\n  - Set persistence.enabled=true\n  - Set database.url to empty string (Phoenix will auto-configure SQLite)" }}
 {{- end }}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -118,5 +118,11 @@ Validate database URL format when provided
 {{- if and (hasPrefix "sqlite://" $url) (not $persistenceEnabled) (not $isMemoryDatabase) }}
 {{- fail "ERROR: SQLite database URL provided without persistent storage!\n\nWhen using SQLite with database.url, you must enable persistent storage to prevent data loss.\n\nTo fix this:\n  - Set persistence.enabled=true\n  - Ensure the SQLite file path in database.url points to the persistent volume\n\nAlternatively, for SQLite with persistence, it's recommended to:\n  - Set persistence.enabled=true\n  - Set database.url to empty string (Phoenix will auto-configure SQLite)" }}
 {{- end }}
+{{- if and ($persistenceEnabled) ($isMemoryDatabase) }}
+{{- fail "ERROR: cannot use in-memory and persistance at the same time" }}
+{{- end }}
+{{- if and (not (hasPrefix "sqlite://:memory:" $url)) (not $persistenceEnabled) ($isMemoryDatabase) }}
+{{- fail "ERROR: Sqlite database URL is using in-memory setting without proper `sqlite://:memory:` prefix." }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Validate persistence configuration to prevent data storage conflicts
 {{- $persistenceEnabled := .Values.persistence.enabled | toString | eq "true" }}
 {{- $postgresqlEnabled := .Values.postgresql.enabled | toString | eq "true" }}
 {{- $databaseUrlConfigured := and .Values.database.url (ne .Values.database.url "") }}
-{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+{{- $isMemoryDatabase := .Values.persistence.inMemory | toString | eq "true" }}
 {{- if and $isMemoryDatabase $postgresqlEnabled }}
 {{- fail "ERROR: In-memory database configuration conflict!\n\nWhen using SQLite In-memory (database.url=\"sqlite:///:memory:\"), PostgreSQL must be disabled.\n\nTo fix this:\n  - Set database.url=\"sqlite:///:memory:\"\n  - Set postgresql.enabled=false\n\nNote: In-memory mode is for demos/testing only. All data will be lost when the pod restarts." }}
 {{- end }}
@@ -109,7 +109,7 @@ Validate database URL format when provided
 {{- define "phoenix.validateDatabaseUrl" -}}
 {{- $databaseUrlConfigured := and .Values.database.url (ne .Values.database.url "") }}
 {{- $persistenceEnabled := .Values.persistence.enabled | toString | eq "true" }}
-{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+{{- $isMemoryDatabase := .Values.persistence.inMemory | toString | eq "true" }}
 {{- if $databaseUrlConfigured }}
 {{- $url := .Values.database.url }}
 {{- if not (or (hasPrefix "postgresql://" $url) (hasPrefix "sqlite://" $url)) }}

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -130,7 +130,7 @@ spec:
         - name: home-volume
           emptyDir: {}
         {{- end }}
-        {{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+        {{- $isMemoryDatabase := .Values.persistence.inMemory | toString | eq "true" }} 
         {{- if and (.Values.persistence.enabled | toString | eq "true") (not $isMemoryDatabase) }}
         - name: data
           persistentVolumeClaim:

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -130,7 +130,8 @@ spec:
         - name: home-volume
           emptyDir: {}
         {{- end }}
-        {{- if .Values.persistence.enabled | toString | eq "true" }}
+        {{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+        {{- if and (.Values.persistence.enabled | toString | eq "true") (not $isMemoryDatabase) }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-data-pvc

--- a/helm/templates/phoenix/pvc.yaml
+++ b/helm/templates/phoenix/pvc.yaml
@@ -1,5 +1,6 @@
 {{- include "phoenix.validatePersistence" . }}
-{{- if .Values.persistence.enabled | toString | eq "true" }}
+{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+{{- if and (.Values.persistence.enabled | toString | eq "true") (not $isMemoryDatabase) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/templates/phoenix/pvc.yaml
+++ b/helm/templates/phoenix/pvc.yaml
@@ -1,5 +1,5 @@
 {{- include "phoenix.validatePersistence" . }}
-{{- $isMemoryDatabase := eq .Values.database.url "sqlite:///:memory:" }}
+{{- $isMemoryDatabase := .Values.persistence.inMemory | toString | eq "true" }}
 {{- if and (.Values.persistence.enabled | toString | eq "true") (not $isMemoryDatabase) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -185,10 +185,13 @@ persistence:
   # NOTE: This setting is ignored when database.url="sqlite:///:memory:" (in-memory database)
   # Choose one persistence strategy:
   #   - SQLite: persistence.enabled=true, postgresql.enabled=false
-  #   - SQLite In-memory: database.url="sqlite:///:memory:", postgresql.enabled=false
+  #   - SQLite In-memory: persistence.inMemory=true , postgresql.enabled=false
   #   - PostgreSQL: persistence.enabled=false, postgresql.enabled=true
   #   - External DB: persistence.enabled=false, postgresql.enabled=false, database.url configured
   enabled: false
+
+  # -- Enable in-memory configuration of sqlite strategy
+  inMemory: false
 
   # -- Kubernetes storage class for Phoenix home volume
   storageClass: ""
@@ -227,7 +230,7 @@ persistence:
 # 4. Ensure the external database is accessible from the cluster
 #
 # Strategy 4 - SQLite In-memory (for demos/testing only - DATA WILL BE LOST ON RESTART):
-# Set database.url="sqlite:///:memory:", postgresql.enabled=false
+# Set persistence.inMemory=true, postgresql.enabled=false
 #
 database:
   # -- Storage allocation in GiB for the database persistent volume

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,9 +182,11 @@ persistence:
   # -- Enable persistent storage for Phoenix home directory
   # When enabled, Phoenix uses SQLite for local storage stored in the persistent volume
   # IMPORTANT: Cannot be enabled simultaneously with postgresql.enabled=true
+  # NOTE: This setting is ignored when database.url="sqlite:///:memory:" (in-memory database)
   # Choose one persistence strategy:
   #   - SQLite: persistence.enabled=true, postgresql.enabled=false
-  #   - PostgreSQL: persistence.enabled=false, postgresql.enabled=true  
+  #   - SQLite In-memory: database.url="sqlite:///:memory:", postgresql.enabled=false
+  #   - PostgreSQL: persistence.enabled=false, postgresql.enabled=true
   #   - External DB: persistence.enabled=false, postgresql.enabled=false, database.url configured
   enabled: false
 
@@ -214,7 +216,7 @@ persistence:
 # NOTE: SQLite database will be created at: ${PHOENIX_WORKING_DIR}/phoenix.db
 #
 # Strategy 2 - Built-in PostgreSQL (for production with managed state):
-# 1. Set persistence.enabled=false 
+# 1. Set persistence.enabled=false
 # 2. Set postgresql.enabled=true (default)
 # 3. PostgreSQL data will be stored in its own persistent volume
 #
@@ -223,6 +225,9 @@ persistence:
 # 2. Set postgresql.enabled=false to disable the built-in PostgreSQL
 # 3. Set database.url with full connection string, OR configure database.postgres settings
 # 4. Ensure the external database is accessible from the cluster
+#
+# Strategy 4 - SQLite In-memory (for demos/testing only - DATA WILL BE LOST ON RESTART):
+# Set database.url="sqlite:///:memory:", postgresql.enabled=false
 #
 database:
   # -- Storage allocation in GiB for the database persistent volume
@@ -260,7 +265,7 @@ database:
   # - When using SQLite (Strategy 1): MUST be empty - SQLite auto-uses persistent volume
   # - When using built-in PostgreSQL (Strategy 2): MUST be empty - auto-configured
   # - When using external database (Strategy 3): MUST be configured with full connection string
-  # 
+  #
   # Examples for external databases:
   # PostgreSQL: "postgresql://username:password@your-rds-endpoint.region.rds.amazonaws.com:5432/phoenix"
   # SQLite: "sqlite:///path/to/database.db" (only for external SQLite files, not recommended)
@@ -328,7 +333,7 @@ auth:
   oauth2:
     # -- Enable OAuth2/OIDC authentication
     enabled: false
-    
+
     # -- List of OAuth2 identity providers to configure
     # Each provider requires client_id, client_secret, and oidc_config_url
     # Optional settings include display_name, allow_sign_up, and auto_login


### PR DESCRIPTION
This special cases `sqlite:///:memory:` so that we don't need persistent volumes, simplifying quick starts.