### PR TITLE
fix: record end time after span ends

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -1003,14 +1003,14 @@ class Experiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, CHAIN)
             span.set_status(status)
 
-            # Handle potential None values in span timing
-            if span.start_time is not None:
-                start_time = _decode_unix_nano(span.start_time)
-            if span.end_time is not None:
-                end_time = _decode_unix_nano(span.end_time)
-            span_context = span.get_span_context()  # type: ignore[no-untyped-call]
-            if span_context is not None and span_context.trace_id != 0:
-                trace_id = _str_trace_id(span_context.trace_id)
+        # Handle potential None values in span timing
+        if span.start_time is not None:
+            start_time = _decode_unix_nano(span.start_time)
+        if span.end_time is not None:
+            end_time = _decode_unix_nano(span.end_time)
+        span_context = span.get_span_context()  # type: ignore[no-untyped-call]
+        if span_context is not None and span_context.trace_id != 0:
+            trace_id = _str_trace_id(span_context.trace_id)
 
         exp_run: ExperimentRun = {
             "dataset_example_id": example["id"],
@@ -1162,14 +1162,14 @@ class Experiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, EVALUATOR)
             span.set_status(status)
 
-            # Handle potential None values in span timing
-            if span.start_time is not None:
-                start_time = _decode_unix_nano(span.start_time)
-            if span.end_time is not None:
-                end_time = _decode_unix_nano(span.end_time)
-            span_context = span.get_span_context()  # type: ignore[no-untyped-call]
-            if span_context is not None and span_context.trace_id != 0:
-                trace_id = _str_trace_id(span_context.trace_id)
+        # Handle potential None values in span timing
+        if span.start_time is not None:
+            start_time = _decode_unix_nano(span.start_time)
+        if span.end_time is not None:
+            end_time = _decode_unix_nano(span.end_time)
+        span_context = span.get_span_context()  # type: ignore[no-untyped-call]
+        if span_context is not None and span_context.trace_id != 0:
+            trace_id = _str_trace_id(span_context.trace_id)
 
         eval_run = ExperimentEvaluationRun(
             experiment_run_id=experiment_run["id"],
@@ -1899,14 +1899,14 @@ class AsyncExperiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, CHAIN)
             span.set_status(status)
 
-            # Handle potential None values in span timing
-            if span.start_time is not None:
-                start_time = _decode_unix_nano(span.start_time)
-            if span.end_time is not None:
-                end_time = _decode_unix_nano(span.end_time)
-            span_context = span.get_span_context()  # type: ignore[no-untyped-call]
-            if span_context is not None and span_context.trace_id != 0:
-                trace_id = _str_trace_id(span_context.trace_id)
+        # Handle potential None values in span timing
+        if span.start_time is not None:
+            start_time = _decode_unix_nano(span.start_time)
+        if span.end_time is not None:
+            end_time = _decode_unix_nano(span.end_time)
+        span_context = span.get_span_context()  # type: ignore[no-untyped-call]
+        if span_context is not None and span_context.trace_id != 0:
+            trace_id = _str_trace_id(span_context.trace_id)
 
         exp_run: ExperimentRun = {
             "dataset_example_id": example["id"],
@@ -2060,14 +2060,14 @@ class AsyncExperiments:
             span.set_attribute(OPENINFERENCE_SPAN_KIND, EVALUATOR)
             span.set_status(status)
 
-            # Handle potential None values in span timing
-            if span.start_time is not None:
-                start_time = _decode_unix_nano(span.start_time)
-            if span.end_time is not None:
-                end_time = _decode_unix_nano(span.end_time)
-            span_context = span.get_span_context()  # type: ignore[no-untyped-call]
-            if span_context is not None and span_context.trace_id != 0:
-                trace_id = _str_trace_id(span_context.trace_id)
+        # Handle potential None values in span timing
+        if span.start_time is not None:
+            start_time = _decode_unix_nano(span.start_time)
+        if span.end_time is not None:
+            end_time = _decode_unix_nano(span.end_time)
+        span_context = span.get_span_context()  # type: ignore[no-untyped-call]
+        if span_context is not None and span_context.trace_id != 0:
+            trace_id = _str_trace_id(span_context.trace_id)
 
         eval_run = ExperimentEvaluationRun(
             experiment_run_id=experiment_run["id"],


### PR DESCRIPTION
resolves #9068 

## Fix span timing collection in experiments

**Problem:**
Span timing information was being captured while still inside the span context (`with ExitStack()` block), causing:
- `end_time` to be `None` or set to an early preliminary value before the span actually completed
- Inaccurate timing measurements since the span operations hadn't finished

**Solution:**
Move span timing collection (`start_time`, `end_time`, `trace_id`) outside the span context so it's captured after the span has fully completed and all timing information is finalized.
