### PR TITLE
fix: split `ENV_PHOENIX_POSTGRES_HOST` only if matched (legacy) pattern

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1134,7 +1134,7 @@ def get_env_postgres_connection_str() -> Optional[str]:
     pg_port = getenv(ENV_PHOENIX_POSTGRES_PORT)
     pg_db = getenv(ENV_PHOENIX_POSTGRES_DB)
 
-    if pg_host and _HOST_PORT_REGEX.match(pg_host):  # maintain backwards compatibility
+    if _HOST_PORT_REGEX.match(pg_host):  # maintain backwards compatibility
         pg_host, parsed_port = pg_host.split(":")
         pg_port = pg_port or parsed_port  # use the explicitly set port if provided
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1123,60 +1123,15 @@ class DirectoryError(Exception):
         super().__init__(message)
 
 
-# Regex for LEGACY backward compatibility: matches ONLY simple host:port patterns.
-# While this parsing was designed to be convenient, it has limitations when used with
-# complex host strings (IPv6 addresses, URLs with schemes, file paths, etc.).
-#
-# LEGACY SUPPORT: This host:port parsing is maintained for backward compatibility
-# with existing Phoenix deployments. For new deployments, we recommend setting
-# PHOENIX_POSTGRES_HOST and PHOENIX_POSTGRES_PORT as separate environment variables.
-#
-# Pattern: ^[^:]+:\d{1,5}$
-#   ^[^:]+    - one or more non-colon characters from start (host part)
-#   :         - exactly one colon separator
-#   \d{1,5}$  - 1-5 digits at end (port number)
-#
-# Examples:
-#   ✓ Matches:    "localhost:5432", "db.example.com:5432", "192.168.1.1:5432"
-#   ✗ Rejects:    "/path/to/socket:resource", "2001:db8::1", "http://localhost"
+# LEGACY: Regex for backward compatibility with host:port parsing in PHOENIX_POSTGRES_HOST
 _HOST_PORT_REGEX = re.compile(r"^[^:]+:\d{1,5}$")
 
 
 def get_env_postgres_connection_str() -> Optional[str]:
     """
-    Build a PostgreSQL connection string from environment variables.
+    Build PostgreSQL connection string from environment variables.
 
-    Required environment variables:
-        PHOENIX_POSTGRES_HOST: Database host
-            Examples: 'localhost', '192.168.1.100'
-        PHOENIX_POSTGRES_USER: Database username
-        PHOENIX_POSTGRES_PASSWORD: Database password (automatically URL-encoded)
-
-    Optional environment variables:
-        PHOENIX_POSTGRES_PORT: Database port (if not specified, no port is added to connection string)
-        PHOENIX_POSTGRES_DB: Database name
-
-    RECOMMENDED USAGE:
-        Set host and port as separate variables for clarity and compatibility:
-            PHOENIX_POSTGRES_HOST="localhost"
-            PHOENIX_POSTGRES_PORT="5432"
-            PHOENIX_POSTGRES_USER="myuser"
-            PHOENIX_POSTGRES_PASSWORD="mypass"
-
-    LEGACY BEHAVIOR:
-        Phoenix previously attempted to be helpful by automatically parsing host:port
-        combinations from PHOENIX_POSTGRES_HOST (e.g., "localhost:5432"). While this was
-        designed for convenience, it has limitations with complex host strings like
-        file paths, IPv6 addresses, and URLs. This parsing is maintained for
-        backward compatibility with existing deployments. For new deployments, we recommend
-        using separate host and port variables as shown above.
-
-    Returns:
-        PostgreSQL connection string in one of these formats:
-        - postgresql://user:password@host (no port specified)
-        - postgresql://user:password@host:port
-        - postgresql://user:password@host:port/database
-        Returns None if any required environment variable is missing.
+    LEGACY: Supports host:port parsing in PHOENIX_POSTGRES_HOST for backward compatibility.
     """  # noqa: E501
     if not (
         (pg_host := getenv(ENV_PHOENIX_POSTGRES_HOST, "").rstrip("/"))

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1125,7 +1125,7 @@ class DirectoryError(Exception):
 
 # Regex for LEGACY backward compatibility: matches ONLY simple host:port patterns.
 # While this parsing was designed to be convenient, it has limitations when used with
-# complex host strings (Cloud SQL mount paths, IPv6 addresses, URLs with schemes, etc.).
+# complex host strings (IPv6 addresses, URLs with schemes, file paths, etc.).
 #
 # LEGACY SUPPORT: This host:port parsing is maintained for backward compatibility
 # with existing Phoenix deployments. For new deployments, we recommend setting
@@ -1138,7 +1138,7 @@ class DirectoryError(Exception):
 #
 # Examples:
 #   ✓ Matches:    "localhost:5432", "db.example.com:5432", "192.168.1.1:5432"
-#   ✗ Rejects:    "/cloudsql/proj:region:inst", "2001:db8::1", "http://localhost"
+#   ✗ Rejects:    "/path/to/socket:resource", "2001:db8::1", "http://localhost"
 _HOST_PORT_REGEX = re.compile(r"^[^:]+:\d{1,5}$")
 
 
@@ -1148,7 +1148,7 @@ def get_env_postgres_connection_str() -> Optional[str]:
 
     Required environment variables:
         PHOENIX_POSTGRES_HOST: Database host
-            Examples: 'localhost', '192.168.1.100', '/cloudsql/project:region:instance'
+            Examples: 'localhost', '192.168.1.100'
         PHOENIX_POSTGRES_USER: Database username
         PHOENIX_POSTGRES_PASSWORD: Database password (automatically URL-encoded)
 
@@ -1167,7 +1167,7 @@ def get_env_postgres_connection_str() -> Optional[str]:
         Phoenix previously attempted to be helpful by automatically parsing host:port
         combinations from PHOENIX_POSTGRES_HOST (e.g., "localhost:5432"). While this was
         designed for convenience, it has limitations with complex host strings like
-        Cloud SQL mount paths, IPv6 addresses, and URLs. This parsing is maintained for
+        file paths, IPv6 addresses, and URLs. This parsing is maintained for
         backward compatibility with existing deployments. For new deployments, we recommend
         using separate host and port variables as shown above.
 

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1127,10 +1127,12 @@ _HOST_PORT_REGEX = re.compile(r"^[^:]+:\d{1,5}$")
 
 
 def get_env_postgres_connection_str() -> Optional[str]:
-    if not (pg_host := getenv(ENV_PHOENIX_POSTGRES_HOST, "").rstrip("/")):
+    if not (
+        (pg_host := getenv(ENV_PHOENIX_POSTGRES_HOST, "").rstrip("/"))
+        and (pg_user := getenv(ENV_PHOENIX_POSTGRES_USER))
+        and (pg_password := getenv(ENV_PHOENIX_POSTGRES_PASSWORD))
+    ):
         return None
-    pg_user = getenv(ENV_PHOENIX_POSTGRES_USER)
-    pg_password = getenv(ENV_PHOENIX_POSTGRES_PASSWORD)
     pg_port = getenv(ENV_PHOENIX_POSTGRES_PORT)
     pg_db = getenv(ENV_PHOENIX_POSTGRES_DB)
 
@@ -1138,16 +1140,14 @@ def get_env_postgres_connection_str() -> Optional[str]:
         pg_host, parsed_port = pg_host.split(":")
         pg_port = pg_port or parsed_port  # use the explicitly set port if provided
 
-    if pg_host and pg_user and pg_password:
-        encoded_password = quote_plus(pg_password)
-        connection_str = f"postgresql://{pg_user}:{encoded_password}@{pg_host}"
-        if pg_port:
-            connection_str = f"{connection_str}:{pg_port}"
-        if pg_db:
-            connection_str = f"{connection_str}/{pg_db}"
+    encoded_password = quote_plus(pg_password)
+    connection_str = f"postgresql://{pg_user}:{encoded_password}@{pg_host}"
+    if pg_port:
+        connection_str = f"{connection_str}:{pg_port}"
+    if pg_db:
+        connection_str = f"{connection_str}/{pg_db}"
 
-        return connection_str
-    return None
+    return connection_str
 
 
 def _no_local_storage() -> bool:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -10,7 +10,7 @@ from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union, cast, overload
-from urllib.parse import quote_plus, urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import wrapt
 from email_validator import EmailNotValidError, validate_email
@@ -1146,8 +1146,9 @@ def get_env_postgres_connection_str() -> Optional[str]:
         pg_host, parsed_port = pg_host.split(":")
         pg_port = pg_port or parsed_port  # use the explicitly set port if provided
 
-    encoded_password = quote_plus(pg_password)
-    connection_str = f"postgresql://{pg_user}:{encoded_password}@{pg_host}"
+    encoded_user = quote(pg_user)
+    encoded_password = quote(pg_password)
+    connection_str = f"postgresql://{encoded_user}:{encoded_password}@{pg_host}"
     if pg_port:
         connection_str = f"{connection_str}:{pg_port}"
     if pg_db:

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -1123,14 +1123,18 @@ class DirectoryError(Exception):
         super().__init__(message)
 
 
-def get_env_postgres_connection_str() -> Optional[str]:
-    pg_user = os.getenv(ENV_PHOENIX_POSTGRES_USER)
-    pg_password = os.getenv(ENV_PHOENIX_POSTGRES_PASSWORD)
-    pg_host = os.getenv(ENV_PHOENIX_POSTGRES_HOST)
-    pg_port = os.getenv(ENV_PHOENIX_POSTGRES_PORT)
-    pg_db = os.getenv(ENV_PHOENIX_POSTGRES_DB)
+_HOST_PORT_REGEX = re.compile(r"^[^:]+:\d{1,5}$")
 
-    if pg_host and ":" in pg_host:
+
+def get_env_postgres_connection_str() -> Optional[str]:
+    if not (pg_host := getenv(ENV_PHOENIX_POSTGRES_HOST, "").rstrip("/")):
+        return None
+    pg_user = getenv(ENV_PHOENIX_POSTGRES_USER)
+    pg_password = getenv(ENV_PHOENIX_POSTGRES_PASSWORD)
+    pg_port = getenv(ENV_PHOENIX_POSTGRES_PORT)
+    pg_db = getenv(ENV_PHOENIX_POSTGRES_DB)
+
+    if pg_host and _HOST_PORT_REGEX.match(pg_host):  # maintain backwards compatibility
         pg_host, parsed_port = pg_host.split(":")
         pg_port = pg_port or parsed_port  # use the explicitly set port if provided
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -101,6 +101,76 @@ def test_with_all_params_and_special_chars(monkeypatch: pytest.MonkeyPatch) -> N
     assert get_env_postgres_connection_str() == expected
 
 
+def test_cloud_sql_mount_path_not_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that Cloud SQL mount paths with colons are not incorrectly parsed as host:port."""
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # Cloud SQL mount path - should NOT be split as host:port
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "/cloudsql/project:region:instance-id")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "5432")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    # The entire path should be treated as the host, with the explicit port
+    expected = f"postgresql://user:{quote_plus('pass')}@/cloudsql/project:region:instance-id:5432"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_ipv6_address_not_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that IPv6 addresses with multiple colons are not incorrectly parsed."""
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # IPv6 address - should NOT be split as host:port
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "2001:db8::1")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "5432")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    # The entire IPv6 address should be treated as the host
+    expected = f"postgresql://user:{quote_plus('pass')}@2001:db8::1:5432"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_malformed_host_port_not_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that malformed host:port strings are not incorrectly parsed."""
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # Malformed - has colon but not valid port number
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:notaport")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "5432")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    # Should not be split, use explicit port
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost:notaport:5432"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_host_port_with_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that host:port with trailing slash is correctly parsed."""
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # Host with port and trailing slash - should be split and slash stripped
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "localhost:5432/")
+    monkeypatch.delenv("PHOENIX_POSTGRES_PORT", raising=False)
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    # Should extract port correctly, ignoring trailing slash
+    expected = f"postgresql://user:{quote_plus('pass')}@localhost:5432"
+    assert get_env_postgres_connection_str() == expected
+
+
+def test_cloud_sql_mount_with_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that Cloud SQL mount paths with trailing slash are handled correctly."""
+    monkeypatch.setenv("PHOENIX_POSTGRES_USER", "user")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PASSWORD", "pass")
+    # Cloud SQL mount path with trailing slash - should be stripped but not split
+    monkeypatch.setenv("PHOENIX_POSTGRES_HOST", "/cloudsql/project:region:instance-id/")
+    monkeypatch.setenv("PHOENIX_POSTGRES_PORT", "5432")
+    monkeypatch.delenv("PHOENIX_POSTGRES_DB", raising=False)
+
+    # The trailing slash should be stripped, but path should not be split as host:port
+    expected = f"postgresql://user:{quote_plus('pass')}@/cloudsql/project:region:instance-id:5432"
+    assert get_env_postgres_connection_str() == expected
+
+
 class TestGetEnvStartupAdmins:
     @pytest.mark.parametrize(
         "env_value, expected_result",


### PR DESCRIPTION
resolves #9058 

# Fix PostgreSQL host parsing for complex host strings

## Problem

Phoenix was automatically parsing **any** host string containing a colon as a `host:port` combination. While this was designed to be helpful, it broke complex host strings like Cloud SQL mount paths (`/cloudsql/project:region:instance-id`) and IPv6 addresses (`2001:db8::1`) that contain colons but are not `host:port` patterns.

## Solution
Added a strict regex (`^[^:]+:\d{1,5}$`) that only matches simple host:port patterns, ensuring complex host strings are treated as complete host identifiers:

✅ Still works: localhost:5432 → parsed as host=localhost, port=5432
✅ Now works: /cloudsql/project:region:instance-id → treated as complete host
✅ Protected: IPv6 addresses, URLs with schemes, other complex paths

## Backward Compatibility
Existing deployments using simple host:port patterns continue to work unchanged. However, the recommendation is now to use separate PHOENIX_POSTGRES_HOST and PHOENIX_POSTGRES_PORT environment variables for clarity and reliability.

## Impact
Enables Cloud SQL deployments while maintaining full backward compatibility for existing users.