### PR TITLE
fix: show custom provider in models table

### DIFF
--- a/app/src/pages/settings/ModelsTable.tsx
+++ b/app/src/pages/settings/ModelsTable.tsx
@@ -215,7 +215,8 @@ export function ModelsTable({
         accessorKey: "namePattern",
         cell: ({ row }) => {
           const namePattern = row.original.namePattern;
-          const provider = row.original.providerKey;
+          const provider = row.original.provider;
+          const providerKey = row.original.providerKey;
           return (
             <Flex direction="row" gap="size-100" alignItems="center">
               <span>
@@ -231,18 +232,24 @@ export function ModelsTable({
                       color="var(--ac-global-color-grey-300)"
                     >
                       <Flex direction="row" gap="size-100" alignItems="center">
-                        <GenerativeProviderIcon
-                          provider={provider}
-                          height={18}
-                        />
-                        <span>{getProviderName(provider)}</span>
+                        {providerKey ? (
+                          <>
+                            <GenerativeProviderIcon
+                              provider={providerKey}
+                              height={18}
+                            />
+                            <span>{getProviderName(providerKey)}</span>
+                          </>
+                        ) : (
+                          <span>{provider}</span>
+                        )}
                       </Flex>
                     </Token>
                   </Focusable>
                   <Tooltip>
                     <TooltipArrow />
                     The preceding name pattern match will only be applied on
-                    incoming traces with {getProviderName(provider)} set as the
+                    incoming traces with &quot;{provider}&quot; set as the
                     provider.
                   </Tooltip>
                 </TooltipTrigger>


### PR DESCRIPTION
# Before
<img width="442" height="222" alt="Screenshot 2025-08-14 at 5 20 12 PM" src="https://github.com/user-attachments/assets/b218976f-3dbf-4d04-aaa6-5369ecb34828" />

# After
<img width="426" height="211" alt="Screenshot 2025-08-14 at 5 21 45 PM" src="https://github.com/user-attachments/assets/9c7c250a-d078-4dec-936e-b0680b7eb5a2" />
