### PR TITLE
fix: remove redundant id in annotation insertables during bulk insert

### DIFF
--- a/src/phoenix/db/insertion/document_annotation.py
+++ b/src/phoenix/db/insertion/document_annotation.py
@@ -107,7 +107,6 @@ class DocumentAnnotationQueueInserter(
                             received_at=p.received_at,
                             item=p.item.as_insertable(
                                 span_rowid=anno.span_rowid,
-                                id_=anno.id_,
                             ),
                         )
                     )

--- a/src/phoenix/db/insertion/span_annotation.py
+++ b/src/phoenix/db/insertion/span_annotation.py
@@ -100,7 +100,6 @@ class SpanAnnotationQueueInserter(
                             received_at=p.received_at,
                             item=p.item.as_insertable(
                                 span_rowid=anno.span_rowid,
-                                id_=anno.id_,
                             ),
                         )
                     )

--- a/src/phoenix/db/insertion/trace_annotation.py
+++ b/src/phoenix/db/insertion/trace_annotation.py
@@ -99,7 +99,6 @@ class TraceAnnotationQueueInserter(
                             received_at=p.received_at,
                             item=p.item.as_insertable(
                                 trace_rowid=anno.trace_rowid,
-                                id_=anno.id_,
                             ),
                         )
                     )

--- a/src/phoenix/db/insertion/types.py
+++ b/src/phoenix/db/insertion/types.py
@@ -195,13 +195,11 @@ class Precursors(ABC):
         def as_insertable(
             self,
             trace_rowid: int,
-            id_: Optional[int] = None,
         ) -> Insertables.TraceAnnotation:
             return Insertables.TraceAnnotation(
                 trace_id=self.trace_id,
                 obj=self.obj,
                 trace_rowid=trace_rowid,
-                id_=id_,
             )
 
     @dataclass(frozen=True)
@@ -213,14 +211,12 @@ class Precursors(ABC):
         def as_insertable(
             self,
             span_rowid: int,
-            id_: Optional[int] = None,
         ) -> Insertables.DocumentAnnotation:
             return Insertables.DocumentAnnotation(
                 span_id=self.span_id,
                 document_position=self.document_position,
                 obj=self.obj,
                 span_rowid=span_rowid,
-                id_=id_,
             )
 
 

--- a/src/phoenix/db/insertion/types.py
+++ b/src/phoenix/db/insertion/types.py
@@ -180,13 +180,11 @@ class Precursors(ABC):
         def as_insertable(
             self,
             span_rowid: int,
-            id_: Optional[int] = None,
         ) -> Insertables.SpanAnnotation:
             return Insertables.SpanAnnotation(
                 span_id=self.span_id,
                 obj=self.obj,
                 span_rowid=span_rowid,
-                id_=id_,
             )
 
     @dataclass(frozen=True)
@@ -231,40 +229,31 @@ class Insertables(ABC):
     class SpanAnnotation(Precursors.SpanAnnotation):
         span_rowid: int
         identifier: str = ""
-        id_: Optional[int] = None
 
         @property
         def row(self) -> models.SpanAnnotation:
             obj = copy(self.obj)
             obj.span_rowid = self.span_rowid
-            if self.id_ is not None:
-                obj.id = self.id_
             return obj
 
     @dataclass(frozen=True)
     class TraceAnnotation(Precursors.TraceAnnotation):
         trace_rowid: int
         identifier: str = ""
-        id_: Optional[int] = None
 
         @property
         def row(self) -> models.TraceAnnotation:
             obj = copy(self.obj)
             obj.trace_rowid = self.trace_rowid
-            if self.id_ is not None:
-                obj.id = self.id_
             return obj
 
     @dataclass(frozen=True)
     class DocumentAnnotation(Precursors.DocumentAnnotation):
         span_rowid: int
         identifier: str = ""
-        id_: Optional[int] = None
 
         @property
         def row(self) -> models.DocumentAnnotation:
             obj = copy(self.obj)
             obj.span_rowid = self.span_rowid
-            if self.id_ is not None:
-                obj.id = self.id_
             return obj


### PR DESCRIPTION
# Fix: Remove redundant ID field in annotation insertables

Note that the process falls back to inserting records individually when bulk insert fails.

## Problem
SQLAlchemy bulk INSERT operations were failing when mixing records with explicit ID values (UPDATE scenarios) and records without ID fields (INSERT scenarios). This caused a `CompileError` because SQLAlchemy cannot compile a single bulk statement with inconsistent column structures.

```
sqlalchemy.exc.CompileError: INSERT value for column span_annotations.id is explicitly rendered as a boundparameter in the VALUES clause; a Python-side value or SQL expression is required
```

## Solution
Removed the redundant `id_` field from insertable annotation classes:
- `SpanAnnotation`
- `TraceAnnotation` 
- `DocumentAnnotation`

The ID field was redundant because PostgreSQL's uniqueness constraints already handle record identification for upsert operations:
- `span_annotations`: `(name, span_rowid, identifier)`
- `trace_annotations`: `(name, trace_rowid, identifier)`
- `document_annotations`: `(name, span_rowid, document_position, identifier)`

SQLAlchemy's `INSERT ... ON CONFLICT UPDATE` logic uses these constraints to identify existing records for updates, while new records automatically receive auto-generated IDs from the `serial` column.