### PR TITLE
ci: fix annotation test timing to prevent out-of-order updates

### DIFF
--- a/tests/integration/client/test_annotations.py
+++ b/tests/integration/client/test_annotations.py
@@ -1042,7 +1042,10 @@ class TestSendingAnnotationsBeforeSpan:
                     ),
                 ),
             )
-            await sleep(0.01)
+            # Sleep to ensure each iteration gets a distinct updated_at timestamp.
+            # Without this, rapid updates within the same second could be out of order,
+            # causing the test to fail when looking for the last iteration's values.
+            await sleep(1.01)
 
         # Send the span and wait
         headers = {"authorization": f"Bearer {_app.admin_secret}"}


### PR DESCRIPTION
## Fix flaky annotation test timing issue

### Problem
The annotation UPSERT test was flaky because rapid updates within the same second could result in out-of-order database records due to 1-second timestamp precision.

### Changes
- Increased sleep from `0.01s` to `1.01s` between test iterations
- Added explanatory comment about timestamp ordering requirements

### Why this fixes it
The test verifies UPSERT behavior by checking the final iteration's values (`labels[-1]`, `scores[-1]`, etc.). Without distinct timestamps, the database may not preserve chronological order, causing the test to fail when looking for the expected "last" values.