### PR TITLE
feat: Add repetitions parameter to runExperiment of the javascript client

### DIFF
--- a/js/packages/phoenix-client/test/experiments/runExperiment.test.ts
+++ b/js/packages/phoenix-client/test/experiments/runExperiment.test.ts
@@ -119,4 +119,60 @@ describe("runExperiment (dryRun)", () => {
       expect(experiment.evaluationRuns.length).toBe(1);
     }
   });
+
+  it("runs experiments with repetitions", async () => {
+    const task = (example: Example) => `Hi, ${example.input.name}`;
+    const evaluator = asEvaluator({
+      name: "dummy",
+      kind: "CODE",
+      evaluate: async () => ({
+        label: "ok",
+        score: 1,
+        explanation: "",
+        metadata: {},
+      }),
+    });
+
+    const experiment = await runExperiment({
+      dataset: { datasetId: mockDataset.id },
+      task,
+      evaluators: [evaluator],
+      dryRun: true,
+      repetitions: 3,
+    });
+
+    // Should have 2 examples * 3 repetitions = 6 runs
+    expect(Object.keys(experiment.runs)).toHaveLength(6);
+    if (experiment.evaluationRuns) {
+      // Should have 6 runs * 1 evaluator = 6 evaluation runs
+      expect(experiment.evaluationRuns.length).toBe(6);
+    }
+  });
+
+  it("defaults to 1 repetition when not specified", async () => {
+    const task = (example: Example) => `Hi, ${example.input.name}`;
+    const evaluator = asEvaluator({
+      name: "dummy",
+      kind: "CODE",
+      evaluate: async () => ({
+        label: "ok",
+        score: 1,
+        explanation: "",
+        metadata: {},
+      }),
+    });
+
+    const experiment = await runExperiment({
+      dataset: { datasetId: mockDataset.id },
+      task,
+      evaluators: [evaluator],
+      dryRun: true,
+    });
+
+    // Should have 2 examples * 1 repetition = 2 runs
+    expect(Object.keys(experiment.runs)).toHaveLength(2);
+    if (experiment.evaluationRuns) {
+      expect(experiment.evaluationRuns.length).toBe(2);
+    }
+  });
 });


### PR DESCRIPTION
Add repetitions parameter to runExperiment in order to observer dataset examples more than once in the experiment run.

Details:
- 

Testing:
- Added unit tests
- Tested using `phoenix-experiment-runner`. Confirming I'm seeing multiple runs of the experiment:
<img width="1283" height="679" alt="image" src="https://github.com/user-attachments/assets/4e218f15-33c0-4b94-97e9-81b7068eadd5" />
- Pending testing in my downstream consumer

Note:
- First PR for me here 👋🏻  - I took it as an opportunity to familiarise myself with Phoenix codebase and contribute to a potential feature gap. I currently need repetitions to work, so I thought I'd attempt upstream before hacking my way into it.
- This was an eager PR - I want to do a bit more testing and read up on the available issues to make sure I'm assigning folks the right thing to review.



