### PR TITLE
fix: remove Popover wrapping modals

### DIFF
--- a/app/src/components/trace/SpanAnnotationActionMenu.tsx
+++ b/app/src/components/trace/SpanAnnotationActionMenu.tsx
@@ -86,6 +86,7 @@ export function SpanAnnotationActionMenu(props: SpanAnnotationActionMenuProps) {
             title: "Annotation Deleted",
             message: `Annotation ${annotationName} has been deleted.`,
           });
+          setDeleting(false);
         },
         onError: (error) => {
           onSpanAnnotationActionError(error);
@@ -143,47 +144,45 @@ export function SpanAnnotationActionMenu(props: SpanAnnotationActionMenuProps) {
 
       {/* Delete confirmation dialog */}
       <DialogTrigger isOpen={deleting} onOpenChange={setDeleting}>
-        <Popover>
-          <ModalOverlay>
-            <Modal>
-              <Dialog>
-                {({ close }) => (
-                  <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>Delete Annotation</DialogTitle>
-                    </DialogHeader>
-                    <View padding="size-200">
-                      <Text color="danger">
-                        {`Are you sure you want to delete annotation ${annotationName}? This cannot be undone.`}
-                      </Text>
-                    </View>
-                    <View
-                      paddingEnd="size-200"
-                      paddingTop="size-100"
-                      paddingBottom="size-100"
-                      borderTopColor="light"
-                      borderTopWidth="thin"
-                    >
-                      <Flex direction="row" justifyContent="end" gap="size-200">
-                        <StopPropagation>
-                          <Button onPress={close}>Cancel</Button>
-                        </StopPropagation>
-                        <Button
-                          variant="danger"
-                          onPress={() => {
-                            handleDelete();
-                          }}
-                        >
-                          Delete Annotation
-                        </Button>
-                      </Flex>
-                    </View>
-                  </DialogContent>
-                )}
-              </Dialog>
-            </Modal>
-          </ModalOverlay>
-        </Popover>
+        <ModalOverlay>
+          <Modal>
+            <Dialog>
+              {({ close }) => (
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Delete Annotation</DialogTitle>
+                  </DialogHeader>
+                  <View padding="size-200">
+                    <Text color="danger">
+                      {`Are you sure you want to delete annotation ${annotationName}? This cannot be undone.`}
+                    </Text>
+                  </View>
+                  <View
+                    paddingEnd="size-200"
+                    paddingTop="size-100"
+                    paddingBottom="size-100"
+                    borderTopColor="light"
+                    borderTopWidth="thin"
+                  >
+                    <Flex direction="row" justifyContent="end" gap="size-200">
+                      <StopPropagation>
+                        <Button onPress={close}>Cancel</Button>
+                      </StopPropagation>
+                      <Button
+                        variant="danger"
+                        onPress={() => {
+                          handleDelete();
+                        }}
+                      >
+                        Delete Annotation
+                      </Button>
+                    </Flex>
+                  </View>
+                </DialogContent>
+              )}
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
       </DialogTrigger>
     </>
   );

--- a/app/src/pages/project/SpanSelectionToolbar.tsx
+++ b/app/src/pages/project/SpanSelectionToolbar.tsx
@@ -226,49 +226,45 @@ export function SpanSelectionToolbar(props: SpanSelectionToolbarProps) {
             isOpen={isCreatingDataset}
             onOpenChange={setIsCreatingDataset}
           >
-            <Popover>
-              <ModalOverlay>
-                <Modal>
-                  <Dialog>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>New Dataset</DialogTitle>
-                        <DialogTitleExtra>
-                          <Button
-                            variant="default"
-                            size="S"
-                            onPress={() => {
-                              setIsCreatingDataset(false);
-                            }}
-                            leadingVisual={
-                              <Icon svg={<Icons.CloseOutline />} />
-                            }
-                          ></Button>
-                        </DialogTitleExtra>
-                      </DialogHeader>
-                      <CreateDatasetForm
-                        onDatasetCreateError={(error) => {
-                          const formattedError =
-                            getErrorMessagesFromRelayMutationError(error);
-                          notifyError({
-                            title: "Dataset creation failed",
-                            message: `Failed to create dataset: ${formattedError?.[0] ?? error.message}`,
-                          });
-                        }}
-                        onDatasetCreated={(dataset) => {
-                          setIsCreatingDataset(false);
-                          notifySuccess({
-                            title: "Dataset created",
-                            message: `${dataset.name} has been successfully created.`,
-                          });
-                          setIsDatasetPopoverOpen(true);
-                        }}
-                      />
-                    </DialogContent>
-                  </Dialog>
-                </Modal>
-              </ModalOverlay>
-            </Popover>
+            <ModalOverlay>
+              <Modal>
+                <Dialog>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>New Dataset</DialogTitle>
+                      <DialogTitleExtra>
+                        <Button
+                          variant="default"
+                          size="S"
+                          onPress={() => {
+                            setIsCreatingDataset(false);
+                          }}
+                          leadingVisual={<Icon svg={<Icons.CloseOutline />} />}
+                        ></Button>
+                      </DialogTitleExtra>
+                    </DialogHeader>
+                    <CreateDatasetForm
+                      onDatasetCreateError={(error) => {
+                        const formattedError =
+                          getErrorMessagesFromRelayMutationError(error);
+                        notifyError({
+                          title: "Dataset creation failed",
+                          message: `Failed to create dataset: ${formattedError?.[0] ?? error.message}`,
+                        });
+                      }}
+                      onDatasetCreated={(dataset) => {
+                        setIsCreatingDataset(false);
+                        notifySuccess({
+                          title: "Dataset created",
+                          message: `${dataset.name} has been successfully created.`,
+                        });
+                        setIsDatasetPopoverOpen(true);
+                      }}
+                    />
+                  </DialogContent>
+                </Dialog>
+              </Modal>
+            </ModalOverlay>
           </DialogTrigger>
           <Button
             size="M"


### PR DESCRIPTION
Removes Popover from two modals: the create dataset from span selection modal and the trace details delete annotation confirmation modal. 

The Popover component blocks click events from reaching the modal, making it impossible to interact with any elements within the modal. Based on react-aria-components docs ([Popover](https://react-spectrum.adobe.com/react-aria/Popover.html) and [Modal](https://react-spectrum.adobe.com/react-aria/Modal.html)) it seems these components are intended for two separate use cases and shouldn't be used together.


https://github.com/user-attachments/assets/81e43203-75e4-40a5-b893-6c1add1c50c5


https://github.com/user-attachments/assets/a8c13f7a-da72-4697-8aeb-3ddecac31472
