### PR TITLE
fix: Add OpenAI timeout to playground client

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -546,7 +546,6 @@ class DeepSeekStreamingClient(OpenAIBaseStreamingClient):
         client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url or "https://api.deepseek.com",
-            timeout=30,
         )
         super().__init__(client=client, model=model, credentials=credentials)
         # DeepSeek uses OpenAI-compatible API but we'll track it as a separate provider
@@ -585,7 +584,10 @@ class XAIStreamingClient(OpenAIBaseStreamingClient):
                 raise BadRequest("An API key is required for xAI models")
             api_key = "sk-fake-api-key"
 
-        client = AsyncOpenAI(api_key=api_key, base_url=base_url or "https://api.x.ai/v1")
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url or "https://api.x.ai/v1",
+        )
         super().__init__(client=client, model=model, credentials=credentials)
         # xAI uses OpenAI-compatible API but we'll track it as a separate provider
         # Adding a custom "xai" provider value to make it distinguishable in traces
@@ -1138,7 +1140,7 @@ class OpenAIStreamingClient(OpenAIBaseStreamingClient):
                 raise BadRequest("An API key is required for OpenAI models")
             api_key = "sk-fake-api-key"
 
-        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=30)
         super().__init__(client=client, model=model, credentials=credentials)
         self._attributes[LLM_PROVIDER] = OpenInferenceLLMProviderValues.OPENAI.value
         self._attributes[LLM_SYSTEM] = OpenInferenceLLMSystemValues.OPENAI.value

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -543,7 +543,11 @@ class DeepSeekStreamingClient(OpenAIBaseStreamingClient):
                 raise BadRequest("An API key is required for DeepSeek models")
             api_key = "sk-fake-api-key"
 
-        client = AsyncOpenAI(api_key=api_key, base_url=base_url or "https://api.deepseek.com")
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url or "https://api.deepseek.com",
+            timeout=30,
+        )
         super().__init__(client=client, model=model, credentials=credentials)
         # DeepSeek uses OpenAI-compatible API but we'll track it as a separate provider
         # Adding a custom "deepseek" provider value to make it distinguishable in traces


### PR DESCRIPTION
- Adds explicit timeout to OpenAI SDK for playground
- This improves the stability as the OpenAI client will occasionally hang on some CloudFlare errors