### PR TITLE
docs: fix client python docs

### DIFF
--- a/packages/phoenix-client/docs/source/conf.py
+++ b/packages/phoenix-client/docs/source/conf.py
@@ -52,7 +52,6 @@ add_module_names = False
 
 # Napoleon
 napoleon_google_docstring = True
-napoleon_numpy_docstring = True
 
 # Autosummary
 autosummary_generate = True

--- a/packages/phoenix-client/docs/source/conf.py
+++ b/packages/phoenix-client/docs/source/conf.py
@@ -52,6 +52,7 @@ add_module_names = False
 
 # Napoleon
 napoleon_google_docstring = True
+napoleon_numpy_docstring = True
 
 # Autosummary
 autosummary_generate = True

--- a/packages/phoenix-client/src/phoenix/client/client.py
+++ b/packages/phoenix-client/src/phoenix/client/client.py
@@ -22,21 +22,22 @@ class Client:
         headers: Mapping[str, str] | None = None,
         http_client: httpx.Client | None = None,
     ):
-        """
-        Initializes a Client instance.
+        """Initializes a Client instance.
 
         Args:
-            base_url (Optional[str]): The base URL for the API endpoint. If not provided, it will
-                be read from the environment variables or fall back to http://localhost:6006/.
-            api_key (Optional[str]): The API key for authentication. If provided, it will be
-                included in the Authorization header as a bearer token. Defaults to None.
-            headers (Optional[Mapping[str, str]]): Additional headers to be included in the HTTP.
-                Defaults to None. This is ignored if http_client is provided. Additional headers
-                may be added from the environment variables, but won't override specified values.
-            http_client (Optional[httpx.Client]): An instance of httpx.Client to be used for
-                making HTTP requests. If not provided, a new instance will be created. Defaults
-                to None.
-        """  # noqa: E501
+            base_url (Optional[str | httpx.URL]): The base URL for the API endpoint.
+                If not provided, it will be read from the environment variables or
+                fall back to http://localhost:6006/.
+            api_key (Optional[str]): The API key for authentication. If provided, it
+                will be included in the Authorization header as a bearer token.
+            headers (Optional[Mapping[str, str]]): Additional headers to be included
+                in the HTTP requests. This is ignored if http_client is provided.
+                Additional headers may be added from the environment variables, but
+                won't override specified values.
+            http_client (Optional[httpx.Client]): An instance of httpx.Client to be
+                used for making HTTP requests. If not provided, a new instance will
+                be created.
+        """
         if http_client is None:
             base_url = base_url or get_base_url()
             self._client = _WrappedClient(
@@ -63,8 +64,7 @@ class Client:
 
     @property
     def prompts(self) -> Prompts:
-        """
-        Returns an instance of the Prompts class for interacting with prompt-related API endpoints.
+        """Returns an instance of the Prompts class for interacting with prompt-related API endpoints.
 
         Returns:
             Prompts: An instance of the Prompts class.
@@ -73,8 +73,7 @@ class Client:
 
     @property
     def projects(self) -> Projects:
-        """
-        Returns an instance of the Projects class for interacting with project-related API endpoints.
+        """Returns an instance of the Projects class for interacting with project-related API endpoints.
 
         Returns:
             Projects: An instance of the Projects class.
@@ -83,20 +82,16 @@ class Client:
 
     @property
     def spans(self) -> Spans:
-        """
-        Returns an instance of the Spans class for interacting with span-related
-        API endpoints.
+        """Returns an instance of the Spans class for interacting with span-related API endpoints.
 
         Returns:
             Spans: An instance of the Spans class.
-        """
+        """  # noqa: E501
         return self._spans
 
     @property
     def annotations(self) -> Annotations:
-        """
-        Returns an instance of the Annotations class for interacting with annotation-related
-        API endpoints.
+        """Returns an instance of the Annotations class for interacting with annotation-related API endpoints.
 
         Returns:
             Annotations: An instance of the Annotations class.
@@ -105,18 +100,20 @@ class Client:
 
     @property
     def datasets(self) -> Datasets:
-        """
-        Returns an instance of the Datasets class for interacting with dataset-related
-        API endpoints.
-        """
+        """Returns an instance of the Datasets class for interacting with dataset-related API endpoints.
+
+        Returns:
+            Datasets: An instance of the Datasets class.
+        """  # noqa: E501
         return self._datasets
 
     @property
     def experiments(self) -> Experiments:
-        """
-        Returns an instance of the Experiments class for interacting with experiment-related
-        API endpoints.
-        """
+        """Returns an instance of the Experiments class for interacting with experiment-related API endpoints.
+
+        Returns:
+            Experiments: An instance of the Experiments class.
+        """  # noqa: E501
         return self._experiments
 
 
@@ -129,21 +126,22 @@ class AsyncClient:
         headers: Mapping[str, str] | None = None,
         http_client: httpx.AsyncClient | None = None,
     ):
-        """
-        Initializes an Asynchronous Client instance.
+        """Initializes an Asynchronous Client instance.
 
         Args:
-            base_url (Optional[str]): The base URL for the API endpoint. If not provided, it will
-                be read from the environment variables or fall back to http://localhost:6006/.
-            api_key (Optional[str]): The API key for authentication. If provided, it will be
-                included in the Authorization header as a bearer token. Defaults to None.
-            headers (Optional[Mapping[str, str]]): Additional headers to be included in the HTTP.
-                Defaults to None. This is ignored if http_client is provided. Additional headers
-                may be added from the environment variables, but won't override specified values.
-            http_client (Optional[httpx.AsyncClient]): An instance of httpx.AsyncClient to be used
-                for making HTTP requests. If not provided, a new instance will be created. Defaults
-                to None.
-        """  # noqa: E501
+            base_url (Optional[str | httpx.URL]): The base URL for the API endpoint.
+                If not provided, it will be read from the environment variables or
+                fall back to http://localhost:6006/.
+            api_key (Optional[str]): The API key for authentication. If provided, it
+                will be included in the Authorization header as a bearer token.
+            headers (Optional[Mapping[str, str]]): Additional headers to be included
+                in the HTTP requests. This is ignored if http_client is provided.
+                Additional headers may be added from the environment variables, but
+                won't override specified values.
+            http_client (Optional[httpx.AsyncClient]): An instance of httpx.AsyncClient
+                to be used for making HTTP requests. If not provided, a new instance
+                will be created.
+        """
         if http_client is None:
             base_url = base_url or get_base_url()
             http_client = httpx.AsyncClient(
@@ -168,62 +166,56 @@ class AsyncClient:
 
     @property
     def prompts(self) -> AsyncPrompts:
-        """
-        Returns an instance of the Asynchronous Prompts class for interacting with prompt-related
-        API endpoints.
+        """Returns an instance of the AsyncPrompts class for interacting with prompt-related API endpoints.
 
         Returns:
-            AsyncPrompts: An instance of the Prompts class.
+            AsyncPrompts: An instance of the AsyncPrompts class.
         """  # noqa: E501
         return self._prompts
 
     @property
     def projects(self) -> AsyncProjects:
-        """
-        Returns an instance of the Asynchronous Projects class for interacting with project-related
-        API endpoints.
+        """Returns an instance of the AsyncProjects class for interacting with project-related API endpoints.
 
         Returns:
-            AsyncProjects: An instance of the Projects class.
+            AsyncProjects: An instance of the AsyncProjects class.
         """  # noqa: E501
         return self._projects
 
     @property
     def spans(self) -> AsyncSpans:
-        """
-        Returns an instance of the Asynchronous Spans class for interacting with span-related
-        API endpoints.
+        """Returns an instance of the AsyncSpans class for interacting with span-related API endpoints.
 
         Returns:
-            AsyncSpans: An instance of the Spans class.
-        """
+            AsyncSpans: An instance of the AsyncSpans class.
+        """  # noqa: E501
         return self._spans
 
     @property
     def annotations(self) -> AsyncAnnotations:
-        """
-        Returns an instance of the Asynchronous Annotations class for interacting with annotation-related
-        API endpoints.
+        """Returns an instance of the AsyncAnnotations class for interacting with annotation-related API endpoints.
 
         Returns:
-            AsyncAnnotations: An instance of the Annotations class.
+            AsyncAnnotations: An instance of the AsyncAnnotations class.
         """  # noqa: E501
         return self._annotations
 
     @property
     def datasets(self) -> AsyncDatasets:
-        """
-        Returns an instance of the Asynchronous Datasets class for interacting with dataset-related
-        API endpoints.
-        """
+        """Returns an instance of the AsyncDatasets class for interacting with dataset-related API endpoints.
+
+        Returns:
+            AsyncDatasets: An instance of the AsyncDatasets class.
+        """  # noqa: E501
         return self._datasets
 
     @property
     def experiments(self) -> AsyncExperiments:
-        """
-        Returns an instance of the Asynchronous Experiments class for interacting with
-        experiment-related API endpoints.
-        """
+        """Returns an instance of the AsyncExperiments class for interacting with experiment-related API endpoints.
+
+        Returns:
+            AsyncExperiments: An instance of the AsyncExperiments class.
+        """  # noqa: E501
         return self._experiments
 
 

--- a/packages/phoenix-client/src/phoenix/client/resources/annotations/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/annotations/__init__.py
@@ -23,8 +23,8 @@ class Annotations:
 
     This class provides synchronous methods for creating and managing span annotations.
 
-    Example:
-        ```python
+    Example::
+
         from phoenix.client import Client
 
         client = Client()
@@ -34,14 +34,13 @@ class Annotations:
             label="positive",
             score=0.9,
         )
-        ```
-    """  # noqa: E501
+    """
 
     def __init__(self, client: httpx.Client) -> None:
         """Initialize the Annotations client.
 
         Args:
-            client: The httpx client to use for making requests.
+            client (httpx.Client): The httpx client to use for making requests.
         """
         self._client = client
 
@@ -61,31 +60,36 @@ class Annotations:
         """Add a single span annotation.
 
         Args:
-            annotation_name: The name of the annotation.
-            span_id: The ID of the span to annotate.
-            annotator_kind: The kind of annotator used for the annotation. Must be one of "LLM", "CODE", or "HUMAN".
-            label: The label assigned by the annotation.
-            score: The score assigned by the annotation.
-            explanation: Explanation of the annotation result.
-            metadata: Additional metadata for the annotation.
-            identifier: An optional identifier for the annotation. Each annotation is uniquely identified by the combination
-                of name, span_id, and identifier (where a null identifier is equivalent to an empty string).
-                If an annotation with the same name, span_id, and identifier already exists, it will be updated.
-                Using a non-empty identifier allows you to have multiple annotations with the same name and span_id.
-                Most of the time, you can leave this as None - it will also update the record with identifier="" if it exists.
-            sync: If True, the request will be fulfilled synchronously and the response will contain
-                the inserted annotation ID. If False, the request will be processed asynchronously.
+            annotation_name (str): The name of the annotation.
+            span_id (str): The ID of the span to annotate.
+            annotator_kind (Literal["LLM", "CODE", "HUMAN"]): The kind of annotator used for
+                the annotation. Must be one of "LLM", "CODE", or "HUMAN". Defaults to "HUMAN".
+            label (Optional[str]): The label assigned by the annotation.
+            score (Optional[float]): The score assigned by the annotation.
+            explanation (Optional[str]): Explanation of the annotation result.
+            metadata (Optional[dict[str, Any]]): Additional metadata for the annotation.
+            identifier (Optional[str]): An optional identifier for the annotation. Each
+                annotation is uniquely identified by the combination of name, span_id, and
+                identifier (where a null identifier is equivalent to an empty string).
+                If an annotation with the same name, span_id, and identifier already exists,
+                it will be updated. Using a non-empty identifier allows you to have multiple
+                annotations with the same name and span_id. Most of the time, you can leave
+                this as None - it will also update the record with identifier="" if it exists.
+            sync (bool): If True, the request will be fulfilled synchronously and the response
+                will contain the inserted annotation ID. If False, the request will be
+                processed asynchronously. Defaults to False.
 
         Returns:
-            If sync is True, the inserted span annotation containing an ID. If sync is False, None.
+            Optional[v1.InsertedSpanAnnotation]: If sync is True, the inserted span annotation
+                containing an ID. If sync is False, None.
 
         Raises:
             httpx.HTTPError: If the request fails.
-            ValueError: If the response is invalid or if at least one of label, score, or explanation
-                is not provided.
+            ValueError: If the response is invalid or if at least one of label, score, or
+                explanation is not provided.
 
-        Example:
-            ```python
+        Example::
+
             from phoenix.client import Client
 
             client = Client()
@@ -97,7 +101,6 @@ class Annotations:
                 explanation="The text expresses a positive sentiment.",
                 sync=True,
             )
-            ```
         """  # noqa: E501
         anno = _get_span_annotation(
             span_id=span_id,
@@ -123,33 +126,40 @@ class Annotations:
     ) -> Optional[list[v1.InsertedSpanAnnotation]]:
         """Log multiple span annotations from a pandas DataFrame.
 
-        This method allows you to create multiple span annotations at once by providing the data in a pandas DataFrame.
-        The DataFrame can either include `name` or `annotation_name` columns (but not both) and `annotator_kind` column,
-        or you can specify global values for all rows. The data is processed in chunks of 100 rows for efficient batch processing.
+        This method allows you to create multiple span annotations at once by providing the data
+        in a pandas DataFrame. The DataFrame can either include `name` or `annotation_name` columns
+        (but not both) and `annotator_kind` column, or you can specify global values for all rows.
+        The data is processed in chunks of 100 rows for efficient batch processing.
 
         Args:
-            dataframe: A pandas DataFrame containing the annotation data. Must include either a "name" or "annotation_name" column
-                (but not both) or provide a global annotation_name parameter. Similarly, must include an "annotator_kind" column
-                or provide a global annotator_kind. The `span_id` can be either a column in the DataFrame or will be taken from
-                the DataFrame index. Optional columns include: "label", "score", "explanation", "metadata", and "identifier".
-            annotator_kind: Optional. The kind of annotator used for all annotations. If provided, this value will be used
-                for all rows and the DataFrame does not need to include an "annotator_kind" column.
-                Must be one of "LLM", "CODE", or "HUMAN".
-            annotation_name: Optional. The name to use for all annotations. If provided, this value will be used
-                for all rows and the DataFrame does not need to include a "name" or "annotation_name" column.
-            sync: If True, the request will be fulfilled synchronously and the response will contain
-                the inserted annotation IDs. If False, the request will be processed asynchronously.
+            dataframe (pd.DataFrame): A pandas DataFrame containing the annotation data. Must include
+                either a "name" or "annotation_name" column (but not both) or provide a global
+                annotation_name parameter. Similarly, must include an "annotator_kind" column or
+                provide a global annotator_kind. The `span_id` can be either a column in the
+                DataFrame or will be taken from the DataFrame index. Optional columns include:
+                "label", "score", "explanation", "metadata", and "identifier".
+            annotator_kind (Optional[Literal["LLM", "CODE", "HUMAN"]]): The kind of annotator used
+                for all annotations. If provided, this value will be used for all rows and the
+                DataFrame does not need to include an "annotator_kind" column. Must be one of
+                "LLM", "CODE", or "HUMAN".
+            annotation_name (Optional[str]): The name to use for all annotations. If provided, this
+                value will be used for all rows and the DataFrame does not need to include a "name"
+                or "annotation_name" column.
+            sync (bool): If True, the request will be fulfilled synchronously and the response will
+                contain the inserted annotation IDs. If False, the request will be processed
+                asynchronously. Defaults to False.
 
         Returns:
-            If sync is True, a list of all inserted span annotations. If sync is False, None.
+            Optional[list[v1.InsertedSpanAnnotation]]: If sync is True, a list of all inserted span
+                annotations. If sync is False, None.
 
         Raises:
             ImportError: If pandas is not installed.
-            ValueError: If the DataFrame is missing required columns, if both "name" and "annotation_name" columns are present,
-                or if no valid annotation data is provided.
+            ValueError: If the DataFrame is missing required columns, if both "name" and
+                "annotation_name" columns are present, or if no valid annotation data is provided.
 
-        Example:
-            ```python
+        Example::
+
             import pandas as pd
 
             # Using name and annotator_kind from DataFrame
@@ -179,7 +189,6 @@ class Annotations:
                 annotation_name="sentiment",  # applies to all rows
                 annotator_kind="HUMAN"  # applies to all rows
             )
-            ```
         """  # noqa: E501
         # Process DataFrame chunks using iterator
         all_responses: list[v1.InsertedSpanAnnotation] = []
@@ -237,8 +246,8 @@ class AsyncAnnotations:
 
     This class provides asynchronous methods for creating and managing span annotations.
 
-    Example:
-        ```python
+    Example::
+
         from phoenix.client import AsyncClient
 
         async_client = AsyncClient()
@@ -248,7 +257,6 @@ class AsyncAnnotations:
             label="positive",
             score=0.9,
         )
-        ```
     """  # noqa: E501
 
     def __init__(self, client: httpx.AsyncClient) -> None:
@@ -298,8 +306,8 @@ class AsyncAnnotations:
             ValueError: If the response is invalid or if at least one of label, score, or explanation
                 is not provided.
 
-        Example:
-            ```python
+        Example::
+
             from phoenix.client import AsyncClient
 
             async_client = AsyncClient()
@@ -311,7 +319,6 @@ class AsyncAnnotations:
                 explanation="The text expresses a positive sentiment.",
                 sync=True,
             )
-            ```
         """  # noqa: E501
         anno = _get_span_annotation(
             span_id=span_id,
@@ -361,8 +368,8 @@ class AsyncAnnotations:
             ImportError: If pandas is not installed.
             ValueError: If the DataFrame is missing required columns or if no valid annotation data is provided.
 
-        Example:
-            ```python
+        Example::
+
             import pandas as pd
 
             # Using name and annotator_kind from DataFrame
@@ -383,7 +390,6 @@ class AsyncAnnotations:
                 annotation_name="sentiment",  # applies to all rows
                 annotator_kind="HUMAN"  # applies to all rows
             )
-            ```
         """  # noqa: E501
         # Process DataFrame chunks using iterator
         all_responses: list[v1.InsertedSpanAnnotation] = []
@@ -421,8 +427,8 @@ class AsyncAnnotations:
             httpx.HTTPError: If the request fails.
             ValueError: If the response is invalid.
 
-        Example:
-            ```python
+        Example::
+
             from phoenix.client import AsyncClient
 
             async_client = AsyncClient()
@@ -454,7 +460,6 @@ class AsyncAnnotations:
             await async_client.annotations.log_span_annotations(
                 span_annotations=[annotation1, annotation2],
             )
-            ```
         """  # noqa: E501
         # Convert to list and validate input
         annotations_list: list[v1.SpanAnnotationData] = list(span_annotations)

--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -25,8 +25,13 @@ DEFAULT_TIMEOUT_IN_SECONDS = 5
 
 
 def _is_valid_dataset_example(obj: Any) -> bool:
-    """
-    Check if an object is a valid DatasetExample using the TypedDict's annotations.
+    """Check if an object is a valid DatasetExample using the TypedDict's annotations.
+
+    Args:
+        obj (Any): The object to validate.
+
+    Returns:
+        bool: True if the object is a valid DatasetExample, False otherwise.
     """
     if not isinstance(obj, dict):
         return False
@@ -39,19 +44,18 @@ def _is_valid_dataset_example(obj: Any) -> bool:
 
 
 class Dataset:
-    """
-    A dataset with its examples and version information.
+    """A dataset with its examples and version information.
 
     Attributes:
-        id: The dataset ID
-        name: The dataset name
-        description: The dataset description
-        version_id: The current version ID
-        examples: List of examples in this version
-        metadata: Additional dataset metadata
-        created_at: When the dataset was created
-        updated_at: When the dataset was last updated
-        example_count: Number of examples in this version
+        id (str): The dataset ID.
+        name (str): The dataset name.
+        description (Optional[str]): The dataset description.
+        version_id (str): The current version ID.
+        examples (list[v1.DatasetExample]): List of examples in this version.
+        metadata (dict[str, Any]): Additional dataset metadata.
+        created_at (datetime): When the dataset was created.
+        updated_at (datetime): When the dataset was last updated.
+        example_count (int): Number of examples in this version.
     """
 
     def __init__(

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -13,15 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class Prompts:
-    """
-    Provides methods for interacting with prompt resources.
+    """Provides methods for interacting with prompt resources.
 
     This class allows you to retrieve and create prompt versions.
 
-    Example:
-        Basic usage:
-            >>> from phoenix.client import Client
-            >>> Client().prompts.get(prompt_identifier="my-prompt")
+    Example::
+
+        from phoenix.client import Client
+        Client().prompts.get(prompt_identifier="my-prompt")
     """
 
     def __init__(self, client: httpx.Client) -> None:

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -23,11 +23,14 @@ _MAX_SPAN_IDS_PER_REQUEST = 100
 
 
 class Spans:
-    """
-    Provides methods for interacting with span resources.
+    """Provides methods for interacting with span resources.
 
-    Example:
-        Non-DataFrame methods:
+    This class offers both regular and DataFrame-based methods for retrieving,
+    logging, and managing spans and their annotations.
+
+    Examples:
+        Non-DataFrame methods::
+
             >>> from phoenix.client import Client
             >>> client = Client()
 
@@ -57,7 +60,8 @@ class Spans:
             ... )
             >>> print(f"Queued {result['total_queued']} spans")
 
-        DataFrame methods:
+        DataFrame methods::
+
             >>> from phoenix.client.types.spans import SpanQuery
 
             # Get spans as DataFrame
@@ -72,7 +76,6 @@ class Spans:
 
             # Delete a span
             >>> client.spans.delete(span_identifier="abc123def456")
-
     """
 
     def __init__(self, client: httpx.Client) -> None:
@@ -90,25 +93,25 @@ class Spans:
         project_name: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
-        """
-        Retrieves spans based on the provided filter conditions.
+        """Retrieves spans based on the provided filter conditions.
 
         Args:
-            query: A SpanQuery object defining the query criteria.
-            start_time: Optional start time for filtering.
-            end_time: Optional end time for filtering.
-            limit: Maximum number of spans to return.
-            root_spans_only: Whether to return only root spans.
-            project_name: Optional project name to filter by. Deprecated, use `project_identifier`
-                to also specify by the project id.
-            project_identifier: Optional project identifier (name or id) to filter by.
-            timeout: Optional request timeout in seconds.
+            query (Optional[SpanQuery]): A SpanQuery object defining the query criteria.
+            start_time (Optional[datetime]): Optional start time for filtering.
+            end_time (Optional[datetime]): Optional end time for filtering.
+            limit (int): Maximum number of spans to return. Defaults to 1000.
+            root_spans_only (Optional[bool]): Whether to return only root spans.
+            project_name (Optional[str]): Optional project name to filter by. Deprecated,
+                use `project_identifier` to also specify by the project id.
+            project_identifier (Optional[str]): Optional project identifier (name or id)
+                to filter by.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            pandas DataFrame
+            pd.DataFrame: A pandas DataFrame containing the retrieved spans.
 
         Raises:
-            ImportError: If pandas is not installed
+            ImportError: If pandas is not installed.
         """
         project_name = project_name
         query = query if query else SpanQuery()
@@ -169,31 +172,35 @@ class Spans:
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
-        """
-        Fetches span annotations and returns them as a pandas DataFrame.
+        """Fetches span annotations and returns them as a pandas DataFrame.
 
         Exactly one of *spans_dataframe*, *span_ids*, or *spans* should be provided.
 
         Args:
-            spans_dataframe: A DataFrame (typically returned by `get_spans_dataframe`) with a
-                `context.span_id` or `span_id` column.
-            span_ids: An iterable of span IDs.
-            spans: A list of Span objects (typically returned by `get_spans`).
-            project_identifier: The project identifier (name or ID) used in the API path.
-            include_annotation_names: Optional list of annotation names to include. If provided,
-                only annotations with these names will be returned.
-            exclude_annotation_names: Optional list of annotation names to exclude from results.
-                Defaults to ["note"] to exclude note annotations, which are reserved for notes
-                added via the UI.
-            limit: Maximum number of annotations returned per request page.
-            timeout: Optional request timeout in seconds.
+            spans_dataframe (Optional[pd.DataFrame]): A DataFrame (typically returned by
+                `get_spans_dataframe`) with a `context.span_id` or `span_id` column.
+            span_ids (Optional[Iterable[str]]): An iterable of span IDs.
+            spans (Optional[Iterable[v1.Span]]): A list of Span objects (typically
+                returned by `get_spans`).
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path. Defaults to "default".
+            include_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to include. If provided, only annotations with these
+                names will be returned.
+            exclude_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to exclude from results. Defaults to ["note"] to
+                exclude note annotations, which are reserved for notes added via the UI.
+            limit (int): Maximum number of annotations returned per request page.
+                Defaults to 1000.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A DataFrame where each row corresponds to a single span annotation.
+            pd.DataFrame: A DataFrame where each row corresponds to a single span annotation.
 
         Raises:
-            ValueError: If not exactly one of *spans_dataframe*, *span_ids*, or *spans* is provided,
-                or if the `context.span_id` or `span_id` column is missing from *spans_dataframe*.
+            ValueError: If not exactly one of *spans_dataframe*, *span_ids*, or *spans*
+                is provided, or if the `context.span_id` or `span_id` column is missing
+                from *spans_dataframe*.
             ImportError: If pandas is not installed.
             httpx.HTTPStatusError: If the API returns an error response.
         """
@@ -289,25 +296,28 @@ class Spans:
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
-        """
-        Fetches span annotations and returns them as a list of SpanAnnotation objects.
+        """Fetches span annotations and returns them as a list of SpanAnnotation objects.
 
         Exactly one of *span_ids* or *spans* should be provided.
 
         Args:
-            span_ids: An iterable of span IDs.
-            spans: A list of Span objects (typically returned by `get_spans`).
-            project_identifier: The project identifier (name or ID) used in the API path.
-            include_annotation_names: Optional list of annotation names to include. If provided,
-                only annotations with these names will be returned.
-            exclude_annotation_names: Optional list of annotation names to exclude from results.
-                Defaults to ["note"] to exclude note annotations, which are reserved for notes
-                added via the UI.
-            limit: Maximum number of annotations returned per request page.
-            timeout: Optional request timeout in seconds.
+            span_ids (Optional[Iterable[str]]): An iterable of span IDs.
+            spans (Optional[Iterable[v1.Span]]): A list of Span objects (typically
+                returned by `get_spans`).
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            include_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to include. If provided, only annotations with these
+                names will be returned.
+            exclude_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to exclude from results. Defaults to ["note"] to
+                exclude note annotations, which are reserved for notes added via the UI.
+            limit (int): Maximum number of annotations returned per request page.
+                Defaults to 1000.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A list of SpanAnnotation objects.
+            list[v1.SpanAnnotation]: A list of SpanAnnotation objects.
 
         Raises:
             ValueError: If not exactly one of *span_ids* or *spans* is provided.
@@ -384,18 +394,20 @@ class Spans:
         limit: int = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.Span]:
-        """
-        Retrieves spans with simple filtering options.
+        """Retrieves spans with simple filtering options.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            start_time: Optional start time for filtering (inclusive lower bound).
-            end_time: Optional end time for filtering (exclusive upper bound).
-            limit: Maximum number of spans to return (default: 100).
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            start_time (Optional[datetime]): Optional start time for filtering
+                (inclusive lower bound).
+            end_time (Optional[datetime]): Optional end time for filtering
+                (exclusive upper bound).
+            limit (int): Maximum number of spans to return. Defaults to 100.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A list of Span objects.
+            list[v1.Span]: A list of Span objects.
 
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
@@ -445,20 +457,20 @@ class Spans:
         spans: Sequence[v1.Span],
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> v1.CreateSpansResponseBody:
-        """
-        Logs spans to a project.
+        """Logs spans to a project.
 
         If any spans are invalid or duplicates, no spans will be logged and a
         SpanCreationError will be raised with details about the failed spans.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            spans: A sequence of Span objects to log.
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            spans (Sequence[v1.Span]): A sequence of Span objects to log.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A CreateSpansResponseBody with statistics about the operation. When successful,
-            total_queued will equal total_received.
+            v1.CreateSpansResponseBody: A CreateSpansResponseBody with statistics about
+                the operation. When successful, total_queued will equal total_received.
 
         Raises:
             SpanCreationError: If any spans failed validation (invalid or duplicates).
@@ -487,16 +499,26 @@ class Spans:
         spans_dataframe: "pd.DataFrame",
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> v1.CreateSpansResponseBody:
-        """
-        Logs spans to a project from a pandas DataFrame.
+        """Logs spans to a project from a pandas DataFrame.
 
         If any spans are invalid or duplicates, no spans will be logged and a
         SpanCreationError will be raised with details about the failed spans.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            spans_dataframe: A pandas DataFrame with a `context.span_id` or `span_id` column.
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            spans_dataframe (pd.DataFrame): A pandas DataFrame with a `context.span_id`
+                or `span_id` column.
+            timeout (Optional[int]): Optional request timeout in seconds.
+
+        Returns:
+            v1.CreateSpansResponseBody: A CreateSpansResponseBody with statistics about
+                the operation. When successful, total_queued will equal total_received.
+
+        Raises:
+            SpanCreationError: If any spans failed validation (invalid or duplicates).
+            httpx.HTTPStatusError: If the API returns an unexpected error response.
+            httpx.TimeoutException: If the request times out.
         """
         spans = _dataframe_to_spans(spans_dataframe)
         return self.log_spans(project_identifier=project_identifier, spans=spans, timeout=timeout)
@@ -507,24 +529,25 @@ class Spans:
         span_identifier: str,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> None:
-        """
-        Deletes a single span by identifier.
+        """Deletes a single span by identifier.
 
         **Important**: This operation deletes ONLY the specified span itself and does NOT
         delete its descendants/children. All child spans will remain in the trace and
         become orphaned (their parent_id will point to a non-existent span).
 
         Behavior:
-        - Deletes only the target span (preserves all descendant spans)
-        - If this was the last span in the trace, the trace record is also deleted
-        - If the deleted span had a parent, its cumulative metrics (error count, token counts)
-          are subtracted from all ancestor spans in the chain
+            - Deletes only the target span (preserves all descendant spans)
+            - If this was the last span in the trace, the trace record is also deleted
+            - If the deleted span had a parent, its cumulative metrics (error count, token counts)
+              are subtracted from all ancestor spans in the chain
 
-        **Note**: This operation is irreversible and may create orphaned spans.
+        Note:
+            This operation is irreversible and may create orphaned spans.
 
         Args:
-            span_identifier: The span identifier: either a relay GlobalID or OpenTelemetry span_id.
-            timeout: Optional request timeout in seconds.
+            span_identifier (str): The span identifier: either a relay GlobalID or
+                OpenTelemetry span_id.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Raises:
             httpx.HTTPStatusError: If the span is not found (404) or other API errors.
@@ -548,11 +571,14 @@ class Spans:
 
 
 class AsyncSpans:
-    """
-    Provides async methods for interacting with span resources.
+    """Provides async methods for interacting with span resources.
 
-    Example:
-        Non-DataFrame methods:
+    This class offers both regular and DataFrame-based async methods for retrieving,
+    logging, and managing spans and their annotations.
+
+    Examples:
+        Non-DataFrame methods::
+
             >>> from phoenix.client import AsyncClient
             >>> client = AsyncClient()
 
@@ -582,7 +608,8 @@ class AsyncSpans:
             ... )
             >>> print(f"Queued {result['total_queued']} spans")
 
-        DataFrame methods:
+        DataFrame methods::
+
             >>> from phoenix.client.types.spans import SpanQuery
 
             # Get spans as DataFrame
@@ -597,7 +624,6 @@ class AsyncSpans:
 
             # Delete a span
             >>> await client.spans.delete(span_identifier="abc123def456")
-
     """
 
     def __init__(self, client: httpx.AsyncClient) -> None:
@@ -615,25 +641,25 @@ class AsyncSpans:
         project_identifier: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
-        """
-        Retrieves spans based on the provided filter conditions.
+        """Retrieves spans based on the provided filter conditions.
 
         Args:
-            query: A SpanQuery object defining the query criteria.
-            start_time: Optional start time for filtering.
-            end_time: Optional end time for filtering.
-            limit: Maximum number of spans to return.
-            root_spans_only: Whether to return only root spans.
-            project_name: Optional project name to filter by. Deprecated, use `project_identifier`
-                to also specify by the project id.
-            project_identifier: Optional project identifier (name or id) to filter by.
-            timeout: Optional request timeout in seconds.
+            query (Optional[SpanQuery]): A SpanQuery object defining the query criteria.
+            start_time (Optional[datetime]): Optional start time for filtering.
+            end_time (Optional[datetime]): Optional end time for filtering.
+            limit (int): Maximum number of spans to return. Defaults to 1000.
+            root_spans_only (Optional[bool]): Whether to return only root spans.
+            project_name (Optional[str]): Optional project name to filter by. Deprecated,
+                use `project_identifier` to also specify by the project id.
+            project_identifier (Optional[str]): Optional project identifier (name or id)
+                to filter by.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            pandas DataFrame
+            pd.DataFrame: A pandas DataFrame containing the retrieved spans.
 
         Raises:
-            ImportError: If pandas is not installed
+            ImportError: If pandas is not installed.
         """
         project_name = project_name
         query = query if query else SpanQuery()
@@ -695,31 +721,35 @@ class AsyncSpans:
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> "pd.DataFrame":
-        """
-        Fetches span annotations and returns them as a pandas DataFrame.
+        """Fetches span annotations and returns them as a pandas DataFrame.
 
         Exactly one of *spans_dataframe*, *span_ids*, or *spans* should be provided.
 
         Args:
-            spans_dataframe: A DataFrame (typically returned by `get_spans_dataframe`) with a
-                `context.span_id` or `span_id` column.
-            span_ids: An iterable of span IDs.
-            spans: A list of Span objects (typically returned by `get_spans`).
-            project_identifier: The project identifier (name or ID) used in the API path.
-            include_annotation_names: Optional list of annotation names to include. If provided,
-                only annotations with these names will be returned.
-            exclude_annotation_names: Optional list of annotation names to exclude from results.
-                Defaults to ["note"] to exclude note annotations, which are reserved for notes
-                added via the UI.
-            limit: Maximum number of annotations returned per request page.
-            timeout: Optional request timeout in seconds.
+            spans_dataframe (Optional[pd.DataFrame]): A DataFrame (typically returned by
+                `get_spans_dataframe`) with a `context.span_id` or `span_id` column.
+            span_ids (Optional[Iterable[str]]): An iterable of span IDs.
+            spans (Optional[Iterable[v1.Span]]): A list of Span objects (typically
+                returned by `get_spans`).
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            include_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to include. If provided, only annotations with these
+                names will be returned.
+            exclude_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to exclude from results. Defaults to ["note"] to
+                exclude note annotations, which are reserved for notes added via the UI.
+            limit (int): Maximum number of annotations returned per request page.
+                Defaults to 1000.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A DataFrame where each row corresponds to a single span annotation.
+            pd.DataFrame: A DataFrame where each row corresponds to a single span annotation.
 
         Raises:
-            ValueError: If not exactly one of *spans_dataframe*, *span_ids*, or *spans* is provided,
-                or if the `context.span_id` or `span_id` column is missing from *spans_dataframe*.
+            ValueError: If not exactly one of *spans_dataframe*, *span_ids*, or *spans*
+                is provided, or if the `context.span_id` or `span_id` column is missing
+                from *spans_dataframe*.
             ImportError: If pandas is not installed.
             httpx.HTTPStatusError: If the API returns an error response.
         """
@@ -815,25 +845,28 @@ class AsyncSpans:
         limit: int = 1000,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.SpanAnnotation]:
-        """
-        Fetches span annotations and returns them as a list of SpanAnnotation objects.
+        """Fetches span annotations and returns them as a list of SpanAnnotation objects.
 
         Exactly one of *span_ids* or *spans* should be provided.
 
         Args:
-            span_ids: An iterable of span IDs.
-            spans: A list of Span objects (typically returned by `get_spans`).
-            project_identifier: The project identifier (name or ID) used in the API path.
-            include_annotation_names: Optional list of annotation names to include. If provided,
-                only annotations with these names will be returned.
-            exclude_annotation_names: Optional list of annotation names to exclude from results.
-                Defaults to ["note"] to exclude note annotations, which are reserved for notes
-                added via the UI.
-            limit: Maximum number of annotations returned per request page.
-            timeout: Optional request timeout in seconds.
+            span_ids (Optional[Iterable[str]]): An iterable of span IDs.
+            spans (Optional[Iterable[v1.Span]]): A list of Span objects (typically
+                returned by `get_spans`).
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            include_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to include. If provided, only annotations with these
+                names will be returned.
+            exclude_annotation_names (Optional[Sequence[str]]): Optional list of
+                annotation names to exclude from results. Defaults to ["note"] to
+                exclude note annotations, which are reserved for notes added via the UI.
+            limit (int): Maximum number of annotations returned per request page.
+                Defaults to 1000.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A list of SpanAnnotation objects.
+            list[v1.SpanAnnotation]: A list of SpanAnnotation objects.
 
         Raises:
             ValueError: If not exactly one of *span_ids* or *spans* is provided.
@@ -910,18 +943,20 @@ class AsyncSpans:
         limit: int = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.Span]:
-        """
-        Retrieves spans with simple filtering options.
+        """Retrieves spans with simple filtering options.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            start_time: Optional start time for filtering (inclusive lower bound).
-            end_time: Optional end time for filtering (exclusive upper bound).
-            limit: Maximum number of spans to return (default: 100).
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            start_time (Optional[datetime]): Optional start time for filtering
+                (inclusive lower bound).
+            end_time (Optional[datetime]): Optional end time for filtering
+                (exclusive upper bound).
+            limit (int): Maximum number of spans to return. Defaults to 100.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A list of Span objects.
+            list[v1.Span]: A list of Span objects.
 
         Raises:
             httpx.HTTPStatusError: If the API returns an error response.
@@ -971,20 +1006,20 @@ class AsyncSpans:
         spans: Sequence[v1.Span],
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> v1.CreateSpansResponseBody:
-        """
-        Logs spans to a project.
+        """Logs spans to a project.
 
         If any spans are invalid or duplicates, no spans will be logged and a
         SpanCreationError will be raised with details about the failed spans.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            spans: A sequence of Span objects to log.
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            spans (Sequence[v1.Span]): A sequence of Span objects to log.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A CreateSpansResponseBody with statistics about the operation. When successful,
-            total_queued will equal total_received.
+            v1.CreateSpansResponseBody: A CreateSpansResponseBody with statistics about
+                the operation. When successful, total_queued will equal total_received.
 
         Raises:
             SpanCreationError: If any spans failed validation (invalid or duplicates).
@@ -1012,20 +1047,26 @@ class AsyncSpans:
         spans_dataframe: "pd.DataFrame",
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> v1.CreateSpansResponseBody:
-        """
-        Logs spans to a project from a pandas DataFrame.
+        """Logs spans to a project from a pandas DataFrame.
 
         If any spans are invalid or duplicates, no spans will be logged and a
         SpanCreationError will be raised with details about the failed spans.
 
         Args:
-            project_identifier: The project identifier (name or ID) used in the API path.
-            spans_dataframe: A pandas DataFrame with a `context.span_id` or `span_id` column.
-            timeout: Optional request timeout in seconds.
+            project_identifier (str): The project identifier (name or ID) used in the
+                API path.
+            spans_dataframe (pd.DataFrame): A pandas DataFrame with a `context.span_id`
+                or `span_id` column.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Returns:
-            A CreateSpansResponseBody with statistics about the operation. When successful,
-            total_queued will equal total_received.
+            v1.CreateSpansResponseBody: A CreateSpansResponseBody with statistics about
+                the operation. When successful, total_queued will equal total_received.
+
+        Raises:
+            SpanCreationError: If any spans failed validation (invalid or duplicates).
+            httpx.HTTPStatusError: If the API returns an unexpected error response.
+            httpx.TimeoutException: If the request times out.
         """
 
         spans = _dataframe_to_spans(spans_dataframe)
@@ -1039,24 +1080,25 @@ class AsyncSpans:
         span_identifier: str,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> None:
-        """
-        Deletes a single span by identifier.
+        """Deletes a single span by identifier.
 
         **Important**: This operation deletes ONLY the specified span itself and does NOT
         delete its descendants/children. All child spans will remain in the trace and
         become orphaned (their parent_id will point to a non-existent span).
 
         Behavior:
-        - Deletes only the target span (preserves all descendant spans)
-        - If this was the last span in the trace, the trace record is also deleted
-        - If the deleted span had a parent, its cumulative metrics (error count, token counts)
-          are subtracted from all ancestor spans in the chain
+            - Deletes only the target span (preserves all descendant spans)
+            - If this was the last span in the trace, the trace record is also deleted
+            - If the deleted span had a parent, its cumulative metrics (error count, token counts)
+              are subtracted from all ancestor spans in the chain
 
-        **Note**: This operation is irreversible and may create orphaned spans.
+        Note:
+            This operation is irreversible and may create orphaned spans.
 
         Args:
-            span_identifier: The span identifier: either a relay GlobalID or OpenTelemetry span_id.
-            timeout: Optional request timeout in seconds.
+            span_identifier (str): The span identifier: either a relay GlobalID or
+                OpenTelemetry span_id.
+            timeout (Optional[int]): Optional request timeout in seconds.
 
         Raises:
             httpx.HTTPStatusError: If the span is not found (404) or other API errors.
@@ -1080,10 +1122,26 @@ class AsyncSpans:
 
 
 def _to_iso_format(value: Optional[datetime]) -> Optional[str]:
+    """Convert a datetime to ISO format string.
+
+    Args:
+        value (Optional[datetime]): The datetime value to convert.
+
+    Returns:
+        Optional[str]: ISO format string if value is provided, None otherwise.
+    """
     return value.isoformat() if value else None
 
 
 def _decode_df_from_json_string(obj: str) -> "pd.DataFrame":
+    """Decode a JSON string into a pandas DataFrame using table schema.
+
+    Args:
+        obj (str): JSON string containing DataFrame data in table schema format.
+
+    Returns:
+        pd.DataFrame: The decoded pandas DataFrame with cleaned index and column names.
+    """
     import pandas as pd
     from pandas.io.json._table_schema import parse_table_schema  # type: ignore
 
@@ -1096,9 +1154,18 @@ def _normalize_datetime(
     dt: Optional[datetime],
     tz: Optional[tzinfo] = None,
 ) -> Optional[datetime]:
-    """
+    """Normalize a datetime to UTC timezone.
+
     If the input datetime is timezone-naive, it is localized as local timezone
     unless tzinfo is specified.
+
+    Args:
+        dt (Optional[datetime]): The datetime to normalize.
+        tz (Optional[tzinfo]): Optional timezone to use for naive datetimes.
+            Defaults to local timezone if not provided.
+
+    Returns:
+        Optional[datetime]: The normalized datetime in UTC, or None if input is None.
     """
     if not isinstance(dt, datetime):
         return None
@@ -1108,7 +1175,17 @@ def _normalize_datetime(
 
 
 def _process_span_dataframe(response: httpx.Response) -> "pd.DataFrame":
-    """Processes the httpx response to extract a pandas DataFrame, handling multipart responses."""
+    """Processes the httpx response to extract a pandas DataFrame, handling multipart responses.
+
+    Args:
+        response (httpx.Response): The HTTP response containing DataFrame data.
+
+    Returns:
+        pd.DataFrame: The extracted pandas DataFrame, or empty DataFrame if no data.
+
+    Raises:
+        ValueError: If boundary not found in Content-Type header for multipart response.
+    """
     import pandas as pd
 
     content_type = response.headers.get("Content-Type")
@@ -1139,6 +1216,15 @@ def _process_span_dataframe(response: httpx.Response) -> "pd.DataFrame":
 
 
 def _flatten_nested_column(df: "pd.DataFrame", column_name: str) -> "pd.DataFrame":
+    """Flatten a nested dictionary column in a DataFrame.
+
+    Args:
+        df (pd.DataFrame): The DataFrame containing the nested column.
+        column_name (str): The name of the column to flatten.
+
+    Returns:
+        pd.DataFrame: DataFrame with the nested column flattened and prefixed.
+    """
     import pandas as pd
 
     if column_name in df.columns:
@@ -1158,6 +1244,17 @@ def _format_log_spans_error_message(
     invalid_spans: Sequence[InvalidSpanInfo],
     duplicate_spans: Sequence[DuplicateSpanInfo],
 ) -> str:
+    """Format error message for span logging failures.
+
+    Args:
+        total_invalid (int): Total number of invalid spans.
+        total_duplicates (int): Total number of duplicate spans.
+        invalid_spans (Sequence[InvalidSpanInfo]): List of invalid span information.
+        duplicate_spans (Sequence[DuplicateSpanInfo]): List of duplicate span information.
+
+    Returns:
+        str: Formatted error message describing the failures.
+    """
     MAX_ERRORS_TO_SHOW = 5
     error_parts: list[str] = []
 
@@ -1191,7 +1288,18 @@ def _parse_log_spans_response(
     response: httpx.Response,
     spans: Sequence[v1.Span],
 ) -> v1.CreateSpansResponseBody:
-    """Parse the response from log spans request."""
+    """Parse the response from log spans request.
+
+    Args:
+        response (httpx.Response): The HTTP response from the log spans request.
+        spans (Sequence[v1.Span]): The original spans that were sent in the request.
+
+    Returns:
+        v1.CreateSpansResponseBody: Parsed response body with span creation statistics.
+
+    Raises:
+        SpanCreationError: If the response indicates validation errors or duplicates.
+    """
     response_data = response.json()
 
     if response.status_code == 422 and "detail" in response_data:
@@ -1215,7 +1323,15 @@ def _parse_log_spans_validation_error(
     response_data: dict[str, Any],
     spans: Sequence[v1.Span],
 ) -> v1.CreateSpansResponseBody:
-    """Convert FastAPI validation errors to our expected format."""
+    """Convert FastAPI validation errors to our expected format.
+
+    Args:
+        response_data (dict[str, Any]): The response data containing validation errors.
+        spans (Sequence[v1.Span]): The original spans that were sent in the request.
+
+    Returns:
+        v1.CreateSpansResponseBody: Formatted response body with invalid span information.
+    """
     invalid_spans: list[InvalidSpanInfo] = []
 
     for error in response_data.get("detail", []):
@@ -1240,7 +1356,15 @@ def _extract_invalid_span_from_log_spans_error(
     error: dict[str, Any],
     spans: Sequence[v1.Span],
 ) -> Optional[InvalidSpanInfo]:
-    """Extract invalid span info from a validation error."""
+    """Extract invalid span info from a validation error.
+
+    Args:
+        error (dict[str, Any]): The validation error dictionary.
+        spans (Sequence[v1.Span]): The original spans that were sent in the request.
+
+    Returns:
+        Optional[InvalidSpanInfo]: Invalid span information if extractable, None otherwise.
+    """
     loc_raw = error.get("loc", [])
     if not isinstance(loc_raw, list):
         return None
@@ -1265,7 +1389,15 @@ def _extract_invalid_span_from_log_spans_error(
 def _raise_log_spans_error(
     error_data: Union[dict[str, Any], v1.CreateSpansResponseBody],
 ) -> None:
-    """Raise SpanCreationError from error response data."""
+    """Raise SpanCreationError from error response data.
+
+    Args:
+        error_data (Union[dict[str, Any], v1.CreateSpansResponseBody]): Error data
+            from the API response.
+
+    Raises:
+        SpanCreationError: Always raised with details about the span creation failures.
+    """
     total_received = error_data.get("total_received", 0)
     total_queued = error_data.get("total_queued", 0)
     total_invalid = cast(int, error_data.get("total_invalid", 0))

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -31,51 +31,51 @@ class Spans:
     Examples:
         Non-DataFrame methods::
 
-            >>> from phoenix.client import Client
-            >>> client = Client()
+        >>> from phoenix.client import Client
+        >>> client = Client()
 
-            # Get spans as list
-            >>> spans = client.spans.get_spans(
-            ...     project_identifier="my-project",
-            ...     limit=100
-            ... )
+        # Get spans as list
+        >>> spans = client.spans.get_spans(
+        ...     project_identifier="my-project",
+        ...     limit=100
+        ... )
 
-            # Get span annotations as list
-            >>> annotations = client.spans.get_span_annotations(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+        # Get span annotations as list
+        >>> annotations = client.spans.get_span_annotations(
+        ...     span_ids=["span1", "span2"],
+        ...     project_identifier="my-project"
+        ... )
 
-            # Log spans
-            >>> spans = [
-            ...     {
-            ...         "id": "1",
-            ...         "name": "test",
-            ...         "context": {"trace_id": "123", "span_id": "456"},
-            ...     }
-            ... ]
-            >>> result = client.spans.log_spans(
-            ...     project_identifier="my-project",
-            ...     spans=spans
-            ... )
-            >>> print(f"Queued {result['total_queued']} spans")
+        # Log spans
+        >>> spans = [
+        ...     {
+        ...         "id": "1",
+        ...         "name": "test",
+        ...         "context": {"trace_id": "123", "span_id": "456"},
+        ...     }
+        ... ]
+        >>> result = client.spans.log_spans(
+        ...     project_identifier="my-project",
+        ...     spans=spans
+        ... )
+        >>> print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-            >>> from phoenix.client.types.spans import SpanQuery
+        >>> from phoenix.client.types.spans import SpanQuery
 
-            # Get spans as DataFrame
-            >>> query = SpanQuery().select(annotations["relevance"])
-            >>> df = client.spans.get_spans_dataframe(query=query)
+        # Get spans as DataFrame
+        >>> query = SpanQuery().select(annotations["relevance"])
+        >>> df = client.spans.get_spans_dataframe(query=query)
 
-            # Get span annotations as DataFrame
-            >>> annotations_df = client.spans.get_span_annotations_dataframe(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+        # Get span annotations as DataFrame
+        >>> annotations_df = client.spans.get_span_annotations_dataframe(
+        ...     span_ids=["span1", "span2"],
+        ...     project_identifier="my-project"
+        ... )
 
-            # Delete a span
-            >>> client.spans.delete(span_identifier="abc123def456")
+        # Delete a span
+        >>> client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.Client) -> None:
@@ -554,14 +554,14 @@ class Spans:
             httpx.TimeoutException: If the request times out.
 
         Example:
-            >>> from phoenix.client import Client
-            >>> client = Client()
+        >>> from phoenix.client import Client
+        >>> client = Client()
 
-            # Delete by OpenTelemetry span_id
-            >>> client.spans.delete_span(span_identifier="051581bf3cb55c13")
+        # Delete by OpenTelemetry span_id
+        >>> client.spans.delete_span(span_identifier="051581bf3cb55c13")
 
-            # Delete by Phoenix Global ID
-            >>> client.spans.delete(span_identifier="U3BhbjoxMjM=")
+        # Delete by Phoenix Global ID
+        >>> client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = self._client.delete(
             url=f"v1/spans/{span_identifier}",
@@ -579,51 +579,51 @@ class AsyncSpans:
     Examples:
         Non-DataFrame methods::
 
-            >>> from phoenix.client import AsyncClient
-            >>> client = AsyncClient()
+        >>> from phoenix.client import AsyncClient
+        >>> client = AsyncClient()
 
-            # Get spans as list
-            >>> spans = await client.spans.get_spans(
-            ...     project_identifier="my-project",
-            ...     limit=100
-            ... )
+        # Get spans as list
+        >>> spans = await client.spans.get_spans(
+        ...     project_identifier="my-project",
+        ...     limit=100
+        ... )
 
-            # Get span annotations as list
-            >>> annotations = await client.spans.get_span_annotations(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+        # Get span annotations as list
+        >>> annotations = await client.spans.get_span_annotations(
+        ...     span_ids=["span1", "span2"],
+        ...     project_identifier="my-project"
+        ... )
 
-            # Log spans
-            >>> spans = [
-            ...     {
-            ...         "id": "1",
-            ...         "name": "test",
-            ...         "context": {"trace_id": "123", "span_id": "456"},
-            ...     }
-            ... ]
-            >>> result = await client.spans.log_spans(
-            ...     project_identifier="my-project",
-            ...     spans=spans
-            ... )
-            >>> print(f"Queued {result['total_queued']} spans")
+        # Log spans
+        >>> spans = [
+        ...     {
+        ...         "id": "1",
+        ...         "name": "test",
+        ...         "context": {"trace_id": "123", "span_id": "456"},
+        ...     }
+        ... ]
+        >>> result = await client.spans.log_spans(
+        ...     project_identifier="my-project",
+        ...     spans=spans
+        ... )
+        >>> print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-            >>> from phoenix.client.types.spans import SpanQuery
+        >>> from phoenix.client.types.spans import SpanQuery
 
-            # Get spans as DataFrame
-            >>> query = SpanQuery().select(annotations["relevance"])
-            >>> df = await client.spans.get_spans_dataframe(query=query)
+        # Get spans as DataFrame
+        >>> query = SpanQuery().select(annotations["relevance"])
+        >>> df = await client.spans.get_spans_dataframe(query=query)
 
-            # Get span annotations as DataFrame
-            >>> annotations_df = await client.spans.get_span_annotations_dataframe(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+        # Get span annotations as DataFrame
+        >>> annotations_df = await client.spans.get_span_annotations_dataframe(
+        ...     span_ids=["span1", "span2"],
+        ...     project_identifier="my-project"
+        ... )
 
-            # Delete a span
-            >>> await client.spans.delete(span_identifier="abc123def456")
+        # Delete a span
+        >>> await client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.AsyncClient) -> None:
@@ -1105,14 +1105,14 @@ class AsyncSpans:
             httpx.TimeoutException: If the request times out.
 
         Example:
-            >>> from phoenix.client import AsyncClient
-            >>> client = AsyncClient()
+        >>> from phoenix.client import AsyncClient
+        >>> client = AsyncClient()
 
-            # Delete by OpenTelemetry span_id
-            >>> await client.spans.delete(span_identifier="abc123def456")
+        # Delete by OpenTelemetry span_id
+        >>> await client.spans.delete(span_identifier="abc123def456")
 
-            # Delete by Phoenix Global ID
-            >>> await client.spans.delete(span_identifier="U3BhbjoxMjM=")
+        # Delete by Phoenix Global ID
+        >>> await client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = await self._client.delete(
             url=f"v1/spans/{span_identifier}",

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -31,51 +31,51 @@ class Spans:
     Examples:
         Non-DataFrame methods::
 
-            >>> from phoenix.client import Client
-            >>> client = Client()
+            from phoenix.client import Client
+            client = Client()
 
             # Get spans as list
-            >>> spans = client.spans.get_spans(
-            ...     project_identifier="my-project",
-            ...     limit=100
-            ... )
+            spans = client.spans.get_spans(
+                project_identifier="my-project",
+                limit=100
+            )
 
             # Get span annotations as list
-            >>> annotations = client.spans.get_span_annotations(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+            annotations = client.spans.get_span_annotations(
+                span_ids=["span1", "span2"],
+                project_identifier="my-project"
+            )
 
             # Log spans
-            >>> spans = [
-            ...     {
-            ...         "id": "1",
-            ...         "name": "test",
-            ...         "context": {"trace_id": "123", "span_id": "456"},
-            ...     }
-            ... ]
-            >>> result = client.spans.log_spans(
-            ...     project_identifier="my-project",
-            ...     spans=spans
-            ... )
-            >>> print(f"Queued {result['total_queued']} spans")
+            spans = [
+                {
+                    "id": "1",
+                    "name": "test",
+                    "context": {"trace_id": "123", "span_id": "456"},
+                }
+            ]
+            result = client.spans.log_spans(
+                project_identifier="my-project",
+                spans=spans
+            )
+            print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-            >>> from phoenix.client.types.spans import SpanQuery
+            from phoenix.client.types.spans import SpanQuery
 
             # Get spans as DataFrame
-            >>> query = SpanQuery().select(annotations["relevance"])
-            >>> df = client.spans.get_spans_dataframe(query=query)
+            query = SpanQuery().select(annotations["relevance"])
+            df = client.spans.get_spans_dataframe(query=query)
 
             # Get span annotations as DataFrame
-            >>> annotations_df = client.spans.get_span_annotations_dataframe(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+            annotations_df = client.spans.get_span_annotations_dataframe(
+                span_ids=["span1", "span2"],
+                project_identifier="my-project"
+            )
 
             # Delete a span
-            >>> client.spans.delete(span_identifier="abc123def456")
+            client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.Client) -> None:
@@ -553,15 +553,16 @@ class Spans:
             httpx.HTTPStatusError: If the span is not found (404) or other API errors.
             httpx.TimeoutException: If the request times out.
 
-        Example:
-            >>> from phoenix.client import Client
-            >>> client = Client()
+        Example::
+
+            from phoenix.client import Client
+            client = Client()
 
             # Delete by OpenTelemetry span_id
-            >>> client.spans.delete_span(span_identifier="051581bf3cb55c13")
+            client.spans.delete_span(span_identifier="051581bf3cb55c13")
 
             # Delete by Phoenix Global ID
-            >>> client.spans.delete(span_identifier="U3BhbjoxMjM=")
+            client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = self._client.delete(
             url=f"v1/spans/{span_identifier}",
@@ -579,51 +580,51 @@ class AsyncSpans:
     Examples:
         Non-DataFrame methods::
 
-            >>> from phoenix.client import AsyncClient
-            >>> client = AsyncClient()
+            from phoenix.client import AsyncClient
+            client = AsyncClient()
 
             # Get spans as list
-            >>> spans = await client.spans.get_spans(
-            ...     project_identifier="my-project",
-            ...     limit=100
-            ... )
+            spans = await client.spans.get_spans(
+                project_identifier="my-project",
+                limit=100
+            )
 
             # Get span annotations as list
-            >>> annotations = await client.spans.get_span_annotations(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+            annotations = await client.spans.get_span_annotations(
+                span_ids=["span1", "span2"],
+                project_identifier="my-project"
+            )
 
             # Log spans
-            >>> spans = [
-            ...     {
-            ...         "id": "1",
-            ...         "name": "test",
-            ...         "context": {"trace_id": "123", "span_id": "456"},
-            ...     }
-            ... ]
-            >>> result = await client.spans.log_spans(
-            ...     project_identifier="my-project",
-            ...     spans=spans
-            ... )
-            >>> print(f"Queued {result['total_queued']} spans")
+            spans = [
+                {
+                    "id": "1",
+                    "name": "test",
+                    "context": {"trace_id": "123", "span_id": "456"},
+                }
+            ]
+            result = await client.spans.log_spans(
+                project_identifier="my-project",
+                spans=spans
+            )
+            print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-            >>> from phoenix.client.types.spans import SpanQuery
+            from phoenix.client.types.spans import SpanQuery
 
             # Get spans as DataFrame
-            >>> query = SpanQuery().select(annotations["relevance"])
-            >>> df = await client.spans.get_spans_dataframe(query=query)
+            query = SpanQuery().select(annotations["relevance"])
+            df = await client.spans.get_spans_dataframe(query=query)
 
             # Get span annotations as DataFrame
-            >>> annotations_df = await client.spans.get_span_annotations_dataframe(
-            ...     span_ids=["span1", "span2"],
-            ...     project_identifier="my-project"
-            ... )
+            annotations_df = await client.spans.get_span_annotations_dataframe(
+                span_ids=["span1", "span2"],
+                project_identifier="my-project"
+            )
 
             # Delete a span
-            >>> await client.spans.delete(span_identifier="abc123def456")
+            await client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.AsyncClient) -> None:
@@ -1104,15 +1105,16 @@ class AsyncSpans:
             httpx.HTTPStatusError: If the span is not found (404) or other API errors.
             httpx.TimeoutException: If the request times out.
 
-        Example:
-            >>> from phoenix.client import AsyncClient
-            >>> client = AsyncClient()
+        Examples::
+
+            from phoenix.client import AsyncClient
+            client = AsyncClient()
 
             # Delete by OpenTelemetry span_id
-            >>> await client.spans.delete(span_identifier="abc123def456")
+            await client.spans.delete(span_identifier="abc123def456")
 
             # Delete by Phoenix Global ID
-            >>> await client.spans.delete(span_identifier="U3BhbjoxMjM=")
+            await client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = await self._client.delete(
             url=f"v1/spans/{span_identifier}",

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -31,51 +31,51 @@ class Spans:
     Examples:
         Non-DataFrame methods::
 
-        >>> from phoenix.client import Client
-        >>> client = Client()
+            >>> from phoenix.client import Client
+            >>> client = Client()
 
-        # Get spans as list
-        >>> spans = client.spans.get_spans(
-        ...     project_identifier="my-project",
-        ...     limit=100
-        ... )
+            # Get spans as list
+            >>> spans = client.spans.get_spans(
+            ...     project_identifier="my-project",
+            ...     limit=100
+            ... )
 
-        # Get span annotations as list
-        >>> annotations = client.spans.get_span_annotations(
-        ...     span_ids=["span1", "span2"],
-        ...     project_identifier="my-project"
-        ... )
+            # Get span annotations as list
+            >>> annotations = client.spans.get_span_annotations(
+            ...     span_ids=["span1", "span2"],
+            ...     project_identifier="my-project"
+            ... )
 
-        # Log spans
-        >>> spans = [
-        ...     {
-        ...         "id": "1",
-        ...         "name": "test",
-        ...         "context": {"trace_id": "123", "span_id": "456"},
-        ...     }
-        ... ]
-        >>> result = client.spans.log_spans(
-        ...     project_identifier="my-project",
-        ...     spans=spans
-        ... )
-        >>> print(f"Queued {result['total_queued']} spans")
+            # Log spans
+            >>> spans = [
+            ...     {
+            ...         "id": "1",
+            ...         "name": "test",
+            ...         "context": {"trace_id": "123", "span_id": "456"},
+            ...     }
+            ... ]
+            >>> result = client.spans.log_spans(
+            ...     project_identifier="my-project",
+            ...     spans=spans
+            ... )
+            >>> print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-        >>> from phoenix.client.types.spans import SpanQuery
+            >>> from phoenix.client.types.spans import SpanQuery
 
-        # Get spans as DataFrame
-        >>> query = SpanQuery().select(annotations["relevance"])
-        >>> df = client.spans.get_spans_dataframe(query=query)
+            # Get spans as DataFrame
+            >>> query = SpanQuery().select(annotations["relevance"])
+            >>> df = client.spans.get_spans_dataframe(query=query)
 
-        # Get span annotations as DataFrame
-        >>> annotations_df = client.spans.get_span_annotations_dataframe(
-        ...     span_ids=["span1", "span2"],
-        ...     project_identifier="my-project"
-        ... )
+            # Get span annotations as DataFrame
+            >>> annotations_df = client.spans.get_span_annotations_dataframe(
+            ...     span_ids=["span1", "span2"],
+            ...     project_identifier="my-project"
+            ... )
 
-        # Delete a span
-        >>> client.spans.delete(span_identifier="abc123def456")
+            # Delete a span
+            >>> client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.Client) -> None:
@@ -554,14 +554,14 @@ class Spans:
             httpx.TimeoutException: If the request times out.
 
         Example:
-        >>> from phoenix.client import Client
-        >>> client = Client()
+            >>> from phoenix.client import Client
+            >>> client = Client()
 
-        # Delete by OpenTelemetry span_id
-        >>> client.spans.delete_span(span_identifier="051581bf3cb55c13")
+            # Delete by OpenTelemetry span_id
+            >>> client.spans.delete_span(span_identifier="051581bf3cb55c13")
 
-        # Delete by Phoenix Global ID
-        >>> client.spans.delete(span_identifier="U3BhbjoxMjM=")
+            # Delete by Phoenix Global ID
+            >>> client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = self._client.delete(
             url=f"v1/spans/{span_identifier}",
@@ -579,51 +579,51 @@ class AsyncSpans:
     Examples:
         Non-DataFrame methods::
 
-        >>> from phoenix.client import AsyncClient
-        >>> client = AsyncClient()
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
 
-        # Get spans as list
-        >>> spans = await client.spans.get_spans(
-        ...     project_identifier="my-project",
-        ...     limit=100
-        ... )
+            # Get spans as list
+            >>> spans = await client.spans.get_spans(
+            ...     project_identifier="my-project",
+            ...     limit=100
+            ... )
 
-        # Get span annotations as list
-        >>> annotations = await client.spans.get_span_annotations(
-        ...     span_ids=["span1", "span2"],
-        ...     project_identifier="my-project"
-        ... )
+            # Get span annotations as list
+            >>> annotations = await client.spans.get_span_annotations(
+            ...     span_ids=["span1", "span2"],
+            ...     project_identifier="my-project"
+            ... )
 
-        # Log spans
-        >>> spans = [
-        ...     {
-        ...         "id": "1",
-        ...         "name": "test",
-        ...         "context": {"trace_id": "123", "span_id": "456"},
-        ...     }
-        ... ]
-        >>> result = await client.spans.log_spans(
-        ...     project_identifier="my-project",
-        ...     spans=spans
-        ... )
-        >>> print(f"Queued {result['total_queued']} spans")
+            # Log spans
+            >>> spans = [
+            ...     {
+            ...         "id": "1",
+            ...         "name": "test",
+            ...         "context": {"trace_id": "123", "span_id": "456"},
+            ...     }
+            ... ]
+            >>> result = await client.spans.log_spans(
+            ...     project_identifier="my-project",
+            ...     spans=spans
+            ... )
+            >>> print(f"Queued {result['total_queued']} spans")
 
         DataFrame methods::
 
-        >>> from phoenix.client.types.spans import SpanQuery
+            >>> from phoenix.client.types.spans import SpanQuery
 
-        # Get spans as DataFrame
-        >>> query = SpanQuery().select(annotations["relevance"])
-        >>> df = await client.spans.get_spans_dataframe(query=query)
+            # Get spans as DataFrame
+            >>> query = SpanQuery().select(annotations["relevance"])
+            >>> df = await client.spans.get_spans_dataframe(query=query)
 
-        # Get span annotations as DataFrame
-        >>> annotations_df = await client.spans.get_span_annotations_dataframe(
-        ...     span_ids=["span1", "span2"],
-        ...     project_identifier="my-project"
-        ... )
+            # Get span annotations as DataFrame
+            >>> annotations_df = await client.spans.get_span_annotations_dataframe(
+            ...     span_ids=["span1", "span2"],
+            ...     project_identifier="my-project"
+            ... )
 
-        # Delete a span
-        >>> await client.spans.delete(span_identifier="abc123def456")
+            # Delete a span
+            >>> await client.spans.delete(span_identifier="abc123def456")
     """
 
     def __init__(self, client: httpx.AsyncClient) -> None:
@@ -1105,14 +1105,14 @@ class AsyncSpans:
             httpx.TimeoutException: If the request times out.
 
         Example:
-        >>> from phoenix.client import AsyncClient
-        >>> client = AsyncClient()
+            >>> from phoenix.client import AsyncClient
+            >>> client = AsyncClient()
 
-        # Delete by OpenTelemetry span_id
-        >>> await client.spans.delete(span_identifier="abc123def456")
+            # Delete by OpenTelemetry span_id
+            >>> await client.spans.delete(span_identifier="abc123def456")
 
-        # Delete by Phoenix Global ID
-        >>> await client.spans.delete(span_identifier="U3BhbjoxMjM=")
+            # Delete by Phoenix Global ID
+            >>> await client.spans.delete(span_identifier="U3BhbjoxMjM=")
         """
         response = await self._client.delete(
             url=f"v1/spans/{span_identifier}",


### PR DESCRIPTION
This makes all python client docs conform to google spec. Otherwise it renders badly via napoleon https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html