### PR TITLE
fix(metrics): handle null scores in span annotation times series resolver

### DIFF
--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -1287,6 +1287,8 @@ class Project(Node):
                 name,
                 average_score,
             ) in await session.stream(stmt):
+                if average_score is None:
+                    continue
                 timestamp = _as_datetime(t)
                 if timestamp not in scores:
                     scores[timestamp] = {}


### PR DESCRIPTION
I believe this bug occurs when a user annotates their spans with only labels, no scores.

resolves #9118
