### PR TITLE
chore: add in helm nodeselector tolerations and affinity

### DIFF
--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -145,3 +145,16 @@ spec:
         - name: {{ . | quote }}
         {{- end }}
       {{- end }}
+
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,12 @@ deployment:
       maxUnavailable: "25%"
       maxSurge: "25%"
 
+  # -- Tolerations, nodeSelector and affinity
+  # For Pod scheduling strategy on the nodes
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
+
 # ADDONS
 # - Ingress
 # - Postgres


### PR DESCRIPTION
Add nodeselector tolerations and affinity parameters for pod scheduling strategy.

Useful when working with nodes that have taints in order to accept some specific workloads.