### PR TITLE
fix: default sqlite usage when postgresql.enabled false

### DIFF
--- a/helm/templates/phoenix/configmap.yaml
+++ b/helm/templates/phoenix/configmap.yaml
@@ -47,12 +47,15 @@ data:
   PHOENIX_ALLOW_EXTERNAL_RESOURCES: {{ .Values.server.allowExternalResources | quote }}
 
   # Database configuration
+  {{- if .Values.database.url }}
   PHOENIX_SQL_DATABASE_URL: {{ .Values.database.url | quote }}
+  {{- else if .Values.postgresql.enabled }}
   PHOENIX_POSTGRES_HOST: {{ .Values.database.postgres.host | quote }}
   PHOENIX_POSTGRES_PORT: {{ .Values.database.postgres.port | quote }}
   PHOENIX_POSTGRES_USER: {{ .Values.database.postgres.user | quote }}
   PHOENIX_POSTGRES_DB: {{ .Values.database.postgres.db | quote }}
   PHOENIX_SQL_DATABASE_SCHEMA: {{ .Values.database.postgres.schema | quote }}
+  {{- end }}
   PHOENIX_DATABASE_ALLOCATED_STORAGE_CAPACITY_GIBIBYTES: {{ .Values.database.allocatedStorageGiB | quote }}
   PHOENIX_DEFAULT_RETENTION_POLICY_DAYS: {{ .Values.database.defaultRetentionPolicyDays | quote }}
 

--- a/helm/templates/phoenix/configmap.yaml
+++ b/helm/templates/phoenix/configmap.yaml
@@ -54,8 +54,8 @@ data:
   PHOENIX_POSTGRES_PORT: {{ .Values.database.postgres.port | quote }}
   PHOENIX_POSTGRES_USER: {{ .Values.database.postgres.user | quote }}
   PHOENIX_POSTGRES_DB: {{ .Values.database.postgres.db | quote }}
-  PHOENIX_SQL_DATABASE_SCHEMA: {{ .Values.database.postgres.schema | quote }}
   {{- end }}
+  PHOENIX_SQL_DATABASE_SCHEMA: {{ .Values.database.postgres.schema | quote }}
   PHOENIX_DATABASE_ALLOCATED_STORAGE_CAPACITY_GIBIBYTES: {{ .Values.database.allocatedStorageGiB | quote }}
   PHOENIX_DEFAULT_RETENTION_POLICY_DAYS: {{ .Values.database.defaultRetentionPolicyDays | quote }}
 


### PR DESCRIPTION
# Fix: PostgreSQL environment variables incorrectly set when postgresql.enabled=false
## Problem

The Helm chart currently sets PostgreSQL environment variables unconditionally in the ConfigMap, even when postgresql.enabled: false. This causes Phoenix to attempt connecting to the non-existent "phoenix-postgresql" service instead of falling back to SQLite as documented.

### Current behavior:

- When postgresql.enabled: false is set (Strategy 1 - SQLite mode)
- PostgreSQL environment variables are still set in the ConfigMap:
    - PHOENIX_POSTGRES_HOST: "phoenix-postgresql"
    - PHOENIX_POSTGRES_PORT, PHOENIX_POSTGRES_USER, etc.
- Phoenix tries to connect to PostgreSQL instead of using SQLite
- Results in connection failures and prevents proper SQLite fallback

## Root Cause

In `helm/templates/phoenix/configmap.yaml` lines 50-55, PostgreSQL environment variables are set unconditionally without checking if PostgreSQL is actually enabled:
YAML

### Database configuration
```
PHOENIX_SQL_DATABASE_URL: {{ .Values.database.url | quote }}
PHOENIX_POSTGRES_HOST: {{ .Values.database.postgres.host | quote }}
PHOENIX_POSTGRES_PORT: {{ .Values.database.postgres.port | quote }}
PHOENIX_POSTGRES_USER: {{ .Values.database.postgres.user | quote }}
PHOENIX_POSTGRES_DB: {{ .Values.database.postgres.db | quote }}
PHOENIX_SQL_DATABASE_SCHEMA: {{ .Values.database.postgres.schema | quote }}
```

## Solution

Added conditional logic to the ConfigMap template to only set database environment variables when they are actually needed:

- SQLite mode (postgresql.enabled: false, database.url: "") → No database env vars set → Phoenix uses SQLite
- Built-in PostgreSQL (postgresql.enabled: true) → PostgreSQL env vars set → Phoenix uses built-in PostgreSQL
- External database (database.url provided) → Only database URL set → Phoenix uses external database

## Changes Made

- Modified helm/templates/phoenix/configmap.yaml to wrap database environment variables with conditional Helm template logic
- Ensures PostgreSQL env vars are only set when PostgreSQL is actually enabled or external database URL is provided
- Allows proper SQLite fallback when using Strategy 1 (SQLite + persistence)

## Testing

Verified the fix works correctly for all three database strategies:
```bash

# Strategy 1 (SQLite) - No PostgreSQL env vars should be set
helm template phoenix ./helm --set postgresql.enabled=false --set persistence.enabled=true

# Strategy 2 (Built-in PostgreSQL) - PostgreSQL env vars should be set
helm template phoenix ./helm --set postgresql.enabled=true

# Strategy 3 (External database) - Only database URL should be set  
helm template phoenix ./helm --set postgresql.enabled=false --set database.url="postgresql://user:pass@host:5432/db"
```

Checklist:

- [x] Tested with all three database strategies
- [x] Maintains backward compatibility
- [x] Follows existing Helm template patterns
- [x] Addresses the root cause of the configuration issue
