### PR TITLE
feat(experiments): eval / annotation quick filters

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -46,6 +46,7 @@ import {
   ModalOverlay,
   Popover,
   PopoverArrow,
+  Separator,
   Text,
   View,
   ViewSummaryAside,
@@ -84,6 +85,7 @@ import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { ExampleDetailsDialog } from "@phoenix/pages/example/ExampleDetailsDialog";
 import { ExperimentNameWithColorSwatch } from "@phoenix/pages/experiment/ExperimentNameWithColorSwatch";
+import { ExperimentRunAnnotationFiltersList } from "@phoenix/pages/experiment/ExperimentRunAnnotationFiltersList";
 import { assertUnreachable } from "@phoenix/typeUtils";
 import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
@@ -1326,7 +1328,18 @@ export function ExperimentRunCellAnnotationsList(
                 <PopoverArrow />
                 <Dialog style={{ width: 400 }}>
                   <View padding="size-200">
-                    <AnnotationDetailsContent annotation={annotation} />
+                    <Flex direction="column" gap="size-50">
+                      <AnnotationDetailsContent annotation={annotation} />
+                      <Separator />
+                      <section>
+                        <Heading level={4} weight="heavy">
+                          Filters
+                        </Heading>
+                        <ExperimentRunAnnotationFiltersList
+                          annotation={annotation}
+                        />
+                      </section>
+                    </Flex>
                   </View>
                 </Dialog>
               </Popover>

--- a/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
+++ b/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
@@ -43,7 +43,7 @@ export function ExperimentRunAnnotationFiltersList({
           condition: `evals['${name}'].label == '${label}'`,
         },
         {
-          text: `${name} does't equal ${label}`,
+          text: `${name} doesn't equal ${label}`,
           condition: `evals['${name}'].label != '${label}'`,
         },
       ];

--- a/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
+++ b/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
@@ -28,7 +28,7 @@ export function ExperimentRunAnnotationFiltersList({
         },
         {
           text: `${name} is greater than ${formatFloat(score)}`,
-          condition: `evals['${name}'].score < ${score}`,
+          condition: `evals['${name}'].score > ${score}`,
         },
         {
           text: `${name} is less than ${formatFloat(score)}`,

--- a/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
+++ b/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+
+import { ListBox, ListBoxItem } from "@phoenix/components";
+import { Annotation } from "@phoenix/components/annotation";
+import { useExperimentRunFilterCondition } from "@phoenix/pages/experiment/ExperimentRunFilterConditionContext";
+import { formatFloat } from "@phoenix/utils/numberFormatUtils";
+
+type AnnotationFilter = {
+  text: string;
+  condition: string;
+};
+/**
+ * Given a specific set of annotations, shows a set of quick filters to apply to the view
+ */
+export function ExperimentRunAnnotationFiltersList({
+  annotation,
+}: {
+  annotation: Annotation;
+}) {
+  const { appendFilterCondition } = useExperimentRunFilterCondition();
+  const { name, score, label } = annotation;
+  const filters = useMemo<AnnotationFilter[]>(() => {
+    if (typeof score === "number") {
+      return [
+        {
+          text: `${name} is ${formatFloat(score)}`,
+          condition: `evals['${name}'].score == ${score}`,
+        },
+        {
+          text: `${name} is greater than ${formatFloat(score)}`,
+          condition: `evals['${name}'].score < ${score}`,
+        },
+        {
+          text: `${name} is less than ${formatFloat(score)}`,
+          condition: `evals['${name}'].score > ${score}`,
+        },
+      ];
+    }
+    if (typeof label === "string" && label) {
+      return [
+        {
+          text: `${name} matches ${label}`,
+          condition: `evals['${name}'].label == '${label}'`,
+        },
+        {
+          text: `${name} does't equal ${label}`,
+          condition: `evals['${name}'].label != '${label}'`,
+        },
+      ];
+    }
+    return [];
+  }, [name, label, score]);
+  return (
+    <ListBox
+      items={filters}
+      aria-label="experiment filters"
+      selectionMode="single"
+      onSelectionChange={(selection) => {
+        if (selection === "all") {
+          return;
+        }
+        const condition = selection.keys().next().value;
+        if (condition) {
+          appendFilterCondition(String(condition));
+        }
+      }}
+    >
+      {(filter) => (
+        <ListBoxItem key={filter.condition} id={filter.condition}>
+          {filter.text}
+        </ListBoxItem>
+      )}
+    </ListBox>
+  );
+}

--- a/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
+++ b/app/src/pages/experiment/ExperimentRunAnnotationFiltersList.tsx
@@ -32,7 +32,7 @@ export function ExperimentRunAnnotationFiltersList({
         },
         {
           text: `${name} is less than ${formatFloat(score)}`,
-          condition: `evals['${name}'].score > ${score}`,
+          condition: `evals['${name}'].score < ${score}`,
         },
       ];
     }


### PR DESCRIPTION
resolves #8774 

Adds the ability to filter by eval / annotation values
<img width="2056" height="1172" alt="Screenshot 2025-08-21 at 1 16 01 PM" src="https://github.com/user-attachments/assets/3580025a-83d0-48f7-97c5-3331baf221db" />
