### PR TITLE
fix(evals): switch from glom to jsonpath-ng for input mapping

### DIFF
--- a/docs/evaluation/preview/evaluators.md
+++ b/docs/evaluation/preview/evaluators.md
@@ -68,7 +68,7 @@ The preview evals library provides powerful input mapping capabilities that allo
 The `input_mapping` parameter accepts several types of mappings:
 
 1. **Simple key mapping**: `{"field": "key"}` - maps evaluator field to input key
-2. **Path mapping**: `{"field": "nested.path"}` - uses spec syntax from [glom](https://glom.readthedocs.io/en/latest/tutorial.html#access-granted)
+2. **Path mapping**: `{"field": "nested.path"}` - uses JSON path syntax from [jsonpath-ng](https://pypi.org/project/jsonpath-ng/)
 3. **Callable mapping**: `{"field": lambda x: x["key"]}` - custom extraction logic
 
 ### Path Mapping Examples
@@ -83,14 +83,13 @@ input_mapping = {
 
 # Array indexing
 input_mapping = {
-    "first_doc": "input.documents.0",
-    "last_doc": "input.documents.-1"
+    "first_doc": "input.documents[0]",
+    "last_doc": "input.documents[-1]"
 }
 
 # Combined nesting and list indexing
 input_mapping = {
-    "user_query": "data.user.messages.0.content",
-    "model_response": "data.assistant.messages.0.content"
+    "user_query": "data.user.messages[0].content",
 }
 ```
 

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "typing-extensions>=4.5, <5",
   "pystache",
   "pydantic>=2.0.0",
-  "glom",
+  "jsonpath_ng",
   "openinference-semantic-conventions>=0.1.19",
   "opentelemetry-api",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/preview/utils.py
+++ b/packages/phoenix-evals/src/phoenix/evals/preview/utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Mapping, Optional, Set, Union
 
 from jsonpath_ng import parse  # type: ignore
-from jsonpath_ng.exceptions import JsonPathParserError
+from jsonpath_ng.exceptions import JsonPathParserError  # type: ignore
 
 InputMappingType = Optional[Mapping[str, Union[str, Callable[[Mapping[str, Any]], Any]]]]
 

--- a/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/preview/test_preview_evaluators.py
@@ -286,7 +286,7 @@ class TestEvaluator:
             pytest.param(
                 {"input": "test"},
                 {"input", "output"},
-                pytest.raises(ValueError, match=r"Invalid path"),
+                pytest.raises(ValueError, match=r"Path not found"),
                 id="Missing required field raises ValueError",
             ),
             pytest.param(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,4 +7,4 @@ uvloop; platform_system != 'Windows'
 fast-hdbscan
 umap-learn
 boto3
-glom
+jsonpath-ng


### PR DESCRIPTION
`glom` uses nonstandard syntax for path spec. `jsonpath-ng` is more familiar (uses brackets to index lists, whereas glom uses dot syntax). Unlike `jmespath`, it is also possible to distinguish between nonexistent paths and paths which point to None values. 