### PR TITLE
feat: extra volumes/volume mounts in helm

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -115,6 +115,8 @@ Phoenix is an open-source AI observability platform designed for experimentation
 | resources | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource configuration |
 | securityContext.container | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"enabled":true,"privileged":false,"procMount":"Default","readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"},"seLinuxOptions":{},"windowsOptions":{}}` | Container-level security context settings. When enabled=true, the entire object (excluding 'enabled') is rendered directly as the container securityContext |
 | securityContext.pod | object | `{"enabled":true,"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"},"seLinuxOptions":{},"supplementalGroups":[],"sysctls":[],"windowsOptions":{}}` | Pod-level security context settings. When enabled=true, the entire object (excluding 'enabled') is rendered directly as the pod securityContext |
+| extraVolumes | list | `[]` | Additional volumes to add to the phoenix container |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to add to the phoenix container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
 | serviceAccount.create | bool | `false` | Create a ServiceAccount for Phoenix |
 | serviceAccount.imagePullSecrets | list | `[]` | List of image pull secrets for the ServiceAccount (if using private container registries) |

--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -118,6 +118,9 @@ spec:
             {{- end }}
             - name: data
               mountPath: {{ .Values.server.workingDir | default "/data" | quote }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 
       volumes:
         {{- if and .Values.securityContext.container.enabled .Values.securityContext.container.readOnlyRootFilesystem }}
@@ -138,6 +141,9 @@ spec:
         {{- else }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 
       {{- if .Values.serviceAccount.imagePullSecrets }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -509,7 +509,7 @@ securityContext:
     windowsOptions: {}
 
 # -- Extra Volumes configuration
-extraVolumes: {}
+extraVolumes: []
 # -- example
 #- name: config-volume
 #  configMap:
@@ -518,7 +518,7 @@ extraVolumes: {}
 #  emptyDir: {}
 
 # -- Extra Volume Mounts
-extraVolumeMounts: {}
+extraVolumeMounts: []
 # -- example
 #- name: config-volume
 #  mountPath: /etc/config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -508,6 +508,24 @@ securityContext:
       type: RuntimeDefault
     windowsOptions: {}
 
+# -- Extra Volumes configuration
+extraVolumes: {}
+# -- example
+#- name: config-volume
+#  configMap:
+#    name: my-app-config
+#- name: cache-volume
+#  emptyDir: {}
+
+# -- Extra Volume Mounts
+extraVolumeMounts: {}
+# -- example
+#- name: config-volume
+#  mountPath: /etc/config
+#  readOnly: true
+#- name: cache-volume
+#  mountPath: /app/cache
+
 # -- ServiceAccount configuration
 serviceAccount:
   # -- Create a ServiceAccount for Phoenix


### PR DESCRIPTION
This PR introduces extraVolume and extraVolumeMounts which will be rendered in chart under default. This field is provided as is, it will render whatever yaml is specified under. For instance, in the values.yaml
```
extraVolumes:
  - name: config-volume
     configMap:
       name: my-app-config
  - name: cache-volume
     emptyDir: {}
...
extraVolumeMounts:
  - name: config-volume
     mountPath: /etc/config
     readOnly: true
  - name: cache-volume
     mountPath: /app/cache
```

would be valid ways of introducing new volumes to the phoenix deployment.