### PR TITLE
chore: update suppress-tracing.md documentation

### DIFF
--- a/docs/tracing/how-to-tracing/advanced/suppress-tracing.md
+++ b/docs/tracing/how-to-tracing/advanced/suppress-tracing.md
@@ -9,7 +9,7 @@ Tracing can be paused temporarily or disabled permanently.
 If there is a section of your code for which tracing is not desired, e.g. the document chunking process, it can be put inside the `suppress_tracing` context manager as shown below.
 
 ```python
-from phoenix.trace import suppress_tracing
+from openinference.instrumentation import suppress_tracing
 
 with suppress_tracing():
     # Code running inside this block doesn't generate traces.


### PR DESCRIPTION
While looking through the documentation, I found this outdated artifact, which was adjusted in https://github.com/Arize-ai/phoenix/pull/2700

The implementation for suppress_tracing has moved to openinference-instrumentation.