### PR TITLE
chore: migrate openai_tracing_tutorial to use new client

### DIFF
--- a/tutorials/tracing/openai_tracing_tutorial.ipynb
+++ b/tutorials/tracing/openai_tracing_tutorial.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install \"openai>=1.0.0\" arize-phoenix jsonschema openinference-instrumentation-openai 'httpx<0.28'"
+    "!pip install \"openai>=1.0.0\" arize-phoenix arize-phoenix-client jsonschema openinference-instrumentation-openai 'httpx<0.28'"
    ]
   },
   {


### PR DESCRIPTION
Updates the openai_tracing_tutorial notebook to use the new phoenix client