### PR TITLE
fix(client): use batch span processor for experiments

### DIFF
--- a/js/.changeset/clear-grapes-train.md
+++ b/js/.changeset/clear-grapes-train.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+switch to batch span processor by default and make it configurable

--- a/js/packages/phoenix-client/src/experiments/instrumention.ts
+++ b/js/packages/phoenix-client/src/experiments/instrumention.ts
@@ -1,10 +1,16 @@
 import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  NodeTracerProvider,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
 import { SEMRESATTRS_PROJECT_NAME } from "@arizeai/openinference-semantic-conventions";
 import { HeadersOptions } from "openapi-fetch";
-import { OpenInferenceSimpleSpanProcessor } from "@arizeai/openinference-vercel";
+import {
+  OpenInferenceBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor,
+} from "@arizeai/openinference-vercel";
 
 /**
  * Creates a provider that exports traces to Phoenix.
@@ -13,9 +19,15 @@ export function createProvider({
   projectName,
   baseUrl,
   headers,
+  useBatchSpanProcessor = true,
 }: {
   projectName: string;
   headers: HeadersOptions;
+  /**
+   * Whether to use batching for the span processor.
+   * @default true
+   */
+  useBatchSpanProcessor: boolean;
   /**
    * The base URL of the Phoenix. Doesn't include the /v1/traces path.
    */
@@ -23,22 +35,23 @@ export function createProvider({
 }) {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
 
+  const exporter = new OTLPTraceExporter({
+    url: `${baseUrl}/v1/traces`,
+    headers: Array.isArray(headers) ? Object.fromEntries(headers) : headers,
+  });
+
+  let spanProcessor: SpanProcessor;
+  if (useBatchSpanProcessor) {
+    spanProcessor = new OpenInferenceBatchSpanProcessor({ exporter });
+  } else {
+    spanProcessor = new OpenInferenceSimpleSpanProcessor({ exporter });
+  }
+
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
       [SEMRESATTRS_PROJECT_NAME]: projectName,
     }),
-    spanProcessors: [
-      // We opt to use the OpenInferenceSimpleSpanProcessor instead of the SimpleSpanProcessor
-      // Since so many AI applications use the AI SDK
-      new OpenInferenceSimpleSpanProcessor({
-        exporter: new OTLPTraceExporter({
-          url: `${baseUrl}/v1/traces`,
-          headers: Array.isArray(headers)
-            ? Object.fromEntries(headers)
-            : headers,
-        }),
-      }),
-    ],
+    spanProcessors: [spanProcessor],
   });
 
   return provider;

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -94,6 +94,11 @@ export type RunExperimentParams = ClientFn & {
    * @default true
    */
   setGlobalTracerProvider?: boolean;
+  /**
+   * Whether to use batching for the span processor.
+   * @default true
+   */
+  useBatchSpanProcessor?: boolean;
 };
 
 /**
@@ -141,6 +146,7 @@ export async function runExperiment({
   concurrency = 5,
   dryRun = false,
   setGlobalTracerProvider = true,
+  useBatchSpanProcessor = true,
 }: RunExperimentParams): Promise<RanExperiment> {
   let provider: NodeTracerProvider | undefined;
   const isDryRun = typeof dryRun === "number" || dryRun === true;
@@ -201,6 +207,7 @@ export async function runExperiment({
       projectName,
       baseUrl,
       headers: client.config.headers ?? {},
+      useBatchSpanProcessor,
     });
     // Register the provider
     if (setGlobalTracerProvider) {
@@ -421,6 +428,7 @@ export async function evaluateExperiment({
   concurrency = 5,
   dryRun = false,
   setGlobalTracerProvider = true,
+  useBatchSpanProcessor = true,
 }: {
   /**
    * The experiment to evaluate
@@ -445,6 +453,11 @@ export async function evaluateExperiment({
    * @default true
    */
   setGlobalTracerProvider?: boolean;
+  /**
+   * Whether to use batching for the span processor.
+   * @default true
+   */
+  useBatchSpanProcessor?: boolean;
 }): Promise<RanExperiment> {
   const isDryRun = typeof dryRun === "number" || dryRun === true;
   const client = _client ?? createClient();
@@ -459,6 +472,7 @@ export async function evaluateExperiment({
       projectName: "evaluators",
       baseUrl,
       headers: client.config.headers ?? {},
+      useBatchSpanProcessor,
     });
     if (setGlobalTracerProvider) {
       provider.register();

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -283,6 +283,7 @@ export async function runExperiment({
     concurrency,
     dryRun,
     setGlobalTracerProvider,
+    useBatchSpanProcessor,
   });
   ranExperiment.evaluationRuns = evaluationRuns;
 


### PR DESCRIPTION
resolves #9263 
This switches the experiment runner in the typescript client to use batching instead as this is probably the better solution for production usage.