### PR TITLE
refactor(evals): make evaluator a class, add ability to parse out variables

### DIFF
--- a/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
@@ -1,6 +1,11 @@
-import { CreateClassificationEvaluatorArgs, EvaluatorFn } from "../types/evals";
+import {
+  CreateClassificationEvaluatorArgs,
+  EvaluatorFn,
+  Template,
+} from "../types";
 import { createClassifierFn } from "./createClassifierFn";
 import { LLMEvaluator } from "./LLMEvaluator";
+import { getTemplateVariables } from "../template";
 
 /**
  * An LLM evaluator that performs evaluation via classification
@@ -9,12 +14,27 @@ export class ClassificationEvaluator<
   ExampleType extends Record<string, unknown>,
 > extends LLMEvaluator<ExampleType> {
   readonly evaluatorFn: EvaluatorFn<ExampleType>;
+  readonly promptTemplate: Template;
+  private _promptTemplateVariables: string[] | undefined;
   constructor(args: CreateClassificationEvaluatorArgs) {
-    const { name } = args;
-    super({ name });
+    super(args);
+    this.promptTemplate = args.promptTemplate;
     this.evaluatorFn = createClassifierFn<ExampleType>(args);
   }
   evaluate = (example: ExampleType) => {
     return this.evaluatorFn(example);
   };
+  /**
+   * List out the prompt template variables needed to perform evaluation
+   */
+  get promptTemplateVariables(): string[] {
+    if (Array.isArray(this._promptTemplateVariables)) {
+      return this._promptTemplateVariables;
+    }
+    this._promptTemplateVariables = getTemplateVariables({
+      template: this.promptTemplate,
+    });
+    // Give a copy of the variables
+    return [...this.promptTemplateVariables];
+  }
 }

--- a/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
@@ -1,0 +1,20 @@
+import { CreateClassificationEvaluatorArgs, EvaluatorFn } from "../types/evals";
+import { createClassifierFn } from "./createClassifierFn";
+import { LLMEvaluator } from "./LLMEvaluator";
+
+/**
+ * An LLM evaluator that performs evaluation via classification
+ */
+export class ClassificationEvaluator<
+  ExampleType extends Record<string, unknown>,
+> extends LLMEvaluator<ExampleType> {
+  readonly evaluatorFn: EvaluatorFn<ExampleType>;
+  constructor(args: CreateClassificationEvaluatorArgs) {
+    const { name } = args;
+    super({ name });
+    this.evaluatorFn = createClassifierFn<ExampleType>(args);
+  }
+  evaluate = (example: ExampleType) => {
+    return this.evaluatorFn(example);
+  };
+}

--- a/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
@@ -28,12 +28,12 @@ export class ClassificationEvaluator<
    * List out the prompt template variables needed to perform evaluation
    */
   get promptTemplateVariables(): string[] {
-    if (Array.isArray(this._promptTemplateVariables)) {
-      return this._promptTemplateVariables;
+    // Use dynamic programming to see if it's computed already
+    if (!Array.isArray(this._promptTemplateVariables)) {
+      this._promptTemplateVariables = getTemplateVariables({
+        template: this.promptTemplate,
+      });
     }
-    this._promptTemplateVariables = getTemplateVariables({
-      template: this.promptTemplate,
-    });
     // Give a copy of the variables
     return [...this._promptTemplateVariables];
   }

--- a/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/ClassificationEvaluator.ts
@@ -35,6 +35,6 @@ export class ClassificationEvaluator<
       template: this.promptTemplate,
     });
     // Give a copy of the variables
-    return [...this.promptTemplateVariables];
+    return [...this._promptTemplateVariables];
   }
 }

--- a/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
@@ -1,0 +1,18 @@
+import { EvaluationResult, Evaluator, OptimizationDirection } from "../types";
+
+/**
+ * Base class for llm evaluation metrics / scores
+ */
+export class LLMEvaluator<ExampleType extends Record<string, unknown>>
+  implements Evaluator<ExampleType>
+{
+  readonly name: string;
+  readonly source = "LLM" as const;
+  readonly optimizationDirection?: OptimizationDirection;
+  constructor({ name }: { name: string }) {
+    this.name = name;
+  }
+  async evaluate(_example: ExampleType): Promise<EvaluationResult> {
+    throw new Error("evaluator.evaluate not implemented");
+  }
+}

--- a/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
@@ -8,7 +8,7 @@ import {
 /**
  * Base class for llm evaluation metrics / scores
  */
-export class LLMEvaluator<ExampleType extends Record<string, unknown>>
+export abstract class LLMEvaluator<ExampleType extends Record<string, unknown>>
   implements Evaluator<ExampleType>
 {
   readonly name: string;
@@ -18,7 +18,5 @@ export class LLMEvaluator<ExampleType extends Record<string, unknown>>
     this.name = name;
     this.optimizationDirection = optimizationDirection;
   }
-  async evaluate(_example: ExampleType): Promise<EvaluationResult> {
-    throw new Error("evaluator.evaluate not implemented");
-  }
+  abstract evaluate(_example: ExampleType): Promise<EvaluationResult>;
 }

--- a/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/LLMEvaluator.ts
@@ -1,4 +1,9 @@
-import { EvaluationResult, Evaluator, OptimizationDirection } from "../types";
+import {
+  EvaluationResult,
+  Evaluator,
+  OptimizationDirection,
+  CreateEvaluatorArgs,
+} from "../types";
 
 /**
  * Base class for llm evaluation metrics / scores
@@ -9,8 +14,9 @@ export class LLMEvaluator<ExampleType extends Record<string, unknown>>
   readonly name: string;
   readonly source = "LLM" as const;
   readonly optimizationDirection?: OptimizationDirection;
-  constructor({ name }: { name: string }) {
+  constructor({ name, optimizationDirection }: CreateEvaluatorArgs) {
     this.name = name;
+    this.optimizationDirection = optimizationDirection;
   }
   async evaluate(_example: ExampleType): Promise<EvaluationResult> {
     throw new Error("evaluator.evaluate not implemented");

--- a/js/packages/phoenix-evals/src/llm/createClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/createClassificationEvaluator.ts
@@ -1,8 +1,10 @@
-import { CreateClassificationEvaluatorArgs, Evaluator } from "../types/evals";
+import { CreateClassificationEvaluatorArgs } from "../types/evals";
 import { ClassificationEvaluator } from "./ClassificationEvaluator";
 
 export function createClassificationEvaluator<
   ExampleType extends Record<string, unknown>,
->(args: CreateClassificationEvaluatorArgs): Evaluator<ExampleType> {
+>(
+  args: CreateClassificationEvaluatorArgs
+): ClassificationEvaluator<ExampleType> {
   return new ClassificationEvaluator<ExampleType>(args);
 }

--- a/js/packages/phoenix-evals/src/llm/createClassificationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/createClassificationEvaluator.ts
@@ -1,13 +1,8 @@
 import { CreateClassificationEvaluatorArgs, Evaluator } from "../types/evals";
-import { createClassifierFn } from "./createClassifierFn";
+import { ClassificationEvaluator } from "./ClassificationEvaluator";
 
 export function createClassificationEvaluator<
   ExampleType extends Record<string, unknown>,
 >(args: CreateClassificationEvaluatorArgs): Evaluator<ExampleType> {
-  return {
-    name: args.name,
-    source: "LLM",
-    optimizationDirection: args.optimizationDirection,
-    evaluate: createClassifierFn(args),
-  };
+  return new ClassificationEvaluator<ExampleType>(args);
 }

--- a/js/packages/phoenix-evals/src/llm/createHallucinationEvaluator.ts
+++ b/js/packages/phoenix-evals/src/llm/createHallucinationEvaluator.ts
@@ -1,9 +1,10 @@
-import { CreateClassificationEvaluatorArgs, Evaluator } from "../types/evals";
+import { CreateClassificationEvaluatorArgs } from "../types/evals";
 import {
   HALLUCINATION_TEMPLATE,
   HALLUCINATION_CHOICES,
 } from "../default_templates/HALLUCINATION_TEMPLATE";
 import { createClassificationEvaluator } from "./createClassificationEvaluator";
+import { ClassificationEvaluator } from "./ClassificationEvaluator";
 
 export interface HallucinationEvaluatorArgs
   extends Omit<
@@ -33,7 +34,7 @@ export type HallucinationExample = {
  */
 export function createHallucinationEvaluator(
   args: HallucinationEvaluatorArgs
-): Evaluator<HallucinationExample> {
+): ClassificationEvaluator<HallucinationExample> {
   const {
     choices = HALLUCINATION_CHOICES,
     promptTemplate = HALLUCINATION_TEMPLATE,

--- a/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
+++ b/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
@@ -1,5 +1,5 @@
 import { Template } from "../types/templating";
-import Mustache from "mustache";
+import Mustache, { TemplateSpans } from "mustache";
 
 type GetTemplateVariableArgs = {
   template: Template;
@@ -9,11 +9,10 @@ type GetTemplateVariableArgs = {
  * @param {GetTemplateVariableArgs} args
  * @returns {string[]} a list of prompt template variables
  */
-export function getTemplateVariables(args: GetTemplateVariableArgs) {
+export function getTemplateVariables(args: GetTemplateVariableArgs): string[] {
   const { template } = args;
   const templateSpans = Mustache.parse(template);
-  return templateSpans.reduce((acc, entry) => {
-    const [, templateSpan] = entry;
+  return templateSpans.reduce((acc, templateSpan) => {
     const [spanType, value] = templateSpan;
     if (spanType === "name" && typeof value === "string") {
       acc = [...acc, value];

--- a/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
+++ b/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
@@ -1,0 +1,23 @@
+import { Template } from "../types/templating";
+import Mustache from "mustache";
+
+type GetTemplateVariableArgs = {
+  template: Template;
+};
+/**
+ * Parse out the template variables of a prompt
+ * @param {GetTemplateVariableArgs} args
+ * @returns {string[]} a list of prompt template variables
+ */
+export function getTemplateVariables(args: GetTemplateVariableArgs) {
+  const { template } = args;
+  const templateSpans = Mustache.parse(template);
+  return templateSpans.entries().reduce((acc, entry) => {
+    const [, templateSpan] = entry;
+    const [spanType, value] = templateSpan;
+    if (spanType === "name") {
+      acc = [...acc, value];
+    }
+    return acc;
+  }, [] as string[]);
+}

--- a/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
+++ b/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
@@ -12,7 +12,7 @@ type GetTemplateVariableArgs = {
 export function getTemplateVariables(args: GetTemplateVariableArgs) {
   const { template } = args;
   const templateSpans = Mustache.parse(template);
-  return templateSpans.entries().reduce((acc, entry) => {
+  return templateSpans.reduce((acc, entry) => {
     const [, templateSpan] = entry;
     const [spanType, value] = templateSpan;
     if (spanType === "name" && typeof value === "string") {

--- a/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
+++ b/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
@@ -1,5 +1,5 @@
 import { Template } from "../types/templating";
-import Mustache, { TemplateSpans } from "mustache";
+import Mustache from "mustache";
 
 type GetTemplateVariableArgs = {
   template: Template;

--- a/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
+++ b/js/packages/phoenix-evals/src/template/getTemplateVariables.ts
@@ -15,7 +15,7 @@ export function getTemplateVariables(args: GetTemplateVariableArgs) {
   return templateSpans.entries().reduce((acc, entry) => {
     const [, templateSpan] = entry;
     const [spanType, value] = templateSpan;
-    if (spanType === "name") {
+    if (spanType === "name" && typeof value === "string") {
       acc = [...acc, value];
     }
     return acc;

--- a/js/packages/phoenix-evals/src/template/index.ts
+++ b/js/packages/phoenix-evals/src/template/index.ts
@@ -1,1 +1,2 @@
 export * from "./applyTemplate";
+export * from "./getTemplateVariables";

--- a/js/packages/phoenix-evals/src/types/evals.ts
+++ b/js/packages/phoenix-evals/src/types/evals.ts
@@ -100,19 +100,18 @@ export type EvaluatorFn<ExampleType extends Record<string, unknown>> = (
 /**
  * The source of the evaluation
  */
-type EvaluationSource = "LLM" | "CODE";
+export type EvaluationSource = "LLM" | "CODE";
 
 /**
  * The direction to optimize the numeric evaluation score
  * E.x. "MAXIMIZE" means that the higher the score, the better the evaluation
  */
-type OptimizationDirection = "MAXIMIZE" | "MINIMIZE";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE";
 
 /**
- * The Base Evaluator interface
- * This is the interface that all evaluators must implement
+ * The description of an evaluator
  */
-export interface Evaluator<ExampleType extends Record<string, unknown>> {
+interface EvaluatorDescription {
   /**
    * The name of the evaluator / the metric that it measures
    */
@@ -126,6 +125,14 @@ export interface Evaluator<ExampleType extends Record<string, unknown>> {
    * E.x. "MAXIMIZE" means that the higher the score, the better the evaluation
    */
   optimizationDirection?: OptimizationDirection;
+}
+
+/**
+ * The Base Evaluator interface
+ * This is the interface that all evaluators must implement
+ */
+export interface Evaluator<ExampleType extends Record<string, unknown>>
+  extends EvaluatorDescription {
   /**
    * The function that evaluates the example
    */

--- a/js/packages/phoenix-evals/src/types/evals.ts
+++ b/js/packages/phoenix-evals/src/types/evals.ts
@@ -79,8 +79,7 @@ export interface CreateClassifierArgs extends WithTelemetry {
   promptTemplate: string;
 }
 
-export interface CreateClassificationEvaluatorArgs
-  extends CreateClassifierArgs {
+export interface CreateEvaluatorArgs {
   /**
    * The name of the metric that the evaluator produces
    * E.x. "correctness"
@@ -92,6 +91,10 @@ export interface CreateClassificationEvaluatorArgs
    */
   optimizationDirection?: OptimizationDirection;
 }
+
+export interface CreateClassificationEvaluatorArgs
+  extends CreateClassifierArgs,
+    CreateEvaluatorArgs {}
 
 export type EvaluatorFn<ExampleType extends Record<string, unknown>> = (
   args: ExampleType

--- a/js/packages/phoenix-evals/test/llm/createHallucinationEvaluator.test.ts
+++ b/js/packages/phoenix-evals/test/llm/createHallucinationEvaluator.test.ts
@@ -62,6 +62,15 @@ Is the answer hallucinated? Respond with "yes" or "no".
     );
   });
 
+  it("should advertize the variables needed", () => {
+    const hallucination = createHallucinationEvaluator({ model });
+    expect(hallucination.promptTemplateVariables).toEqual([
+      "input",
+      "reference",
+      "output",
+    ]);
+  });
+
   it("should support custom template", async () => {
     // Mock the generateClassification function
     const mockGenerateClassification = vi

--- a/js/packages/phoenix-evals/test/template/getTemplateVariables.test.ts
+++ b/js/packages/phoenix-evals/test/template/getTemplateVariables.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { getTemplateVariables } from "../../src/template/getTemplateVariables";
+
+describe("getTemplateVariables", () => {
+  it("should parse out the variables of a template", () => {
+    const variables = getTemplateVariables({ template: "{{hello}} {{world}}" });
+    expect(variables).toEqual(["hello", "world"]);
+  });
+});


### PR DESCRIPTION
precursor to #9125 

Switches evaluators to be classes so that certain computed properties like template variables can be accessed and cached via dynamic programming.
