### PR TITLE
chore: add deprecation warning for using_project from inside phoenix.trace

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,28 @@
 # Migrations
 
+## v11.0.0 to v12.0.0 (upcoming)
+
+Instrumentation helpers are being moved to `openinference-instrumentation`.
+
+Before:
+
+```python
+from phoenix.trace import using_project
+
+with using_project(project_name="change-project"):
+    ...
+```
+
+After:
+
+```python
+# openinference-instrumentation>=0.1.38
+from openinference.instrumentation import dangerously_using_project
+
+with dangerously_using_project(project_name="change-project"):
+    ...
+```
+
 ## v10.0.0 to v11.0.0
 
 This release is entirely encapsulated in a set of new tables. Have a nice release!

--- a/packages/phoenix-otel/pyproject.toml
+++ b/packages/phoenix-otel/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-sdk",
   "openinference-semantic-conventions>=0.1.17",
-  "openinference-instrumentation>=0.1.37",
+  "openinference-instrumentation>=0.1.38",
   "typing-extensions>=4.5, <5",
   "wrapt",
 ]

--- a/src/phoenix/trace/projects.py
+++ b/src/phoenix/trace/projects.py
@@ -7,6 +7,8 @@ from opentelemetry.sdk import trace
 from opentelemetry.sdk.resources import Resource
 from wrapt import wrap_function_wrapper
 
+from phoenix.utilities.deprecation import deprecated
+
 
 def project_override_wrapper(project_name: str) -> Callable[..., None]:
     def wrapper(
@@ -27,6 +29,10 @@ def project_override_wrapper(project_name: str) -> Callable[..., None]:
     return wrapper
 
 
+@deprecated(
+    "This decorator has been moved to openinference-instrumentation via dangerously_using_project"
+    " in version 0.1.28 and will be removed in an upcoming major release"
+)
 class using_project:
     """
     A context manager that switches the project for all spans created within the context.

--- a/src/phoenix/trace/projects.py
+++ b/src/phoenix/trace/projects.py
@@ -31,7 +31,7 @@ def project_override_wrapper(project_name: str) -> Callable[..., None]:
 
 @deprecated(
     "This decorator has been moved to openinference-instrumentation via dangerously_using_project"
-    " in version 0.1.28 and will be removed in an upcoming major release"
+    " in version 0.1.38 and will be removed in an upcoming major release"
 )
 class using_project:
     """


### PR DESCRIPTION
Start moving utilities outside of phoenix core package.