### PR TITLE
feat(experiments): minimal refactoring of experiment compare details

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -1,0 +1,144 @@
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { css } from "@emotion/react";
+
+import {
+  Card,
+  CopyToClipboardButton,
+  Flex,
+  Heading,
+  View,
+  ViewSummaryAside,
+} from "@phoenix/components";
+import { AnnotationLabel } from "@phoenix/components/annotation";
+import { JSONBlock } from "@phoenix/components/code";
+import { SequenceNumberToken } from "@phoenix/components/experiment";
+import { resizeHandleCSS } from "@phoenix/components/resize";
+type ExperimentCompareDetailsProps = { datasetId: string };
+export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
+  return (
+    <PanelGroup direction="vertical" autoSaveId="example-compare-panel-group">
+      <Panel defaultSize={35}>
+        <div
+          css={css`
+            overflow-y: auto;
+            height: 100%;
+          `}
+        >
+          <View overflow="hidden" padding="size-200">
+            <Flex direction="row" gap="size-200" flex="1 1 auto">
+              <View width="50%">
+                <Card
+                  title="Input"
+                  extra={<CopyToClipboardButton text={JSON.stringify({})} />}
+                >
+                  <View maxHeight="300px" overflow="auto">
+                    <JSONBlock value={JSON.stringify({})} />
+                  </View>
+                </Card>
+              </View>
+              <View width="50%">
+                <Card
+                  title="Reference Output"
+                  extra={<CopyToClipboardButton text={JSON.stringify({})} />}
+                >
+                  <View maxHeight="300px" overflow="auto">
+                    <JSONBlock value={JSON.stringify({}, null, 2)} />
+                  </View>
+                </Card>
+              </View>
+            </Flex>
+          </View>
+        </div>
+      </Panel>
+      <PanelResizeHandle css={resizeHandleCSS} />
+      <Panel defaultSize={65}>
+        {/* <Flex direction="column" height="100%">
+          <View
+            paddingStart="size-200"
+            paddingEnd="size-200"
+            paddingTop="size-100"
+            paddingBottom="size-100"
+            borderBottomColor="dark"
+            borderBottomWidth="thin"
+            flex="none"
+          >
+            <Heading level={2}>Experiments</Heading>
+          </View>
+          <div
+            css={css`
+              overflow-y: auto;
+              height: 100%;
+              padding: var(--ac-global-dimension-static-size-200);
+            `}
+          >
+            <ul
+              css={css`
+                display: flex;
+                flex-direction: column;
+                gap: var(--ac-global-dimension-static-size-200);
+              `}
+            >
+              {selectedExample.runComparisonItems.map((runItem) => {
+                const experiment = experimentInfoById[runItem.experimentId];
+                return (
+                  <li key={runItem.experimentId}>
+                    <Card
+                      title={experiment?.name ?? ""}
+                      titleExtra={
+                        <SequenceNumberToken
+                          sequenceNumber={experiment?.sequenceNumber ?? 0}
+                        />
+                      }
+                    >
+                      <ul>
+                        {runItem.runs.map((run, index) => (
+                          <li key={index}>
+                            <Flex direction="row">
+                              <View flex>
+                                {run.error ? (
+                                  <View padding="size-200">{run.error}</View>
+                                ) : (
+                                  <JSONBlock
+                                    value={JSON.stringify(run.output, null, 2)}
+                                  />
+                                )}
+                              </View>
+                              <ViewSummaryAside width="size-3000">
+                                <ul
+                                  css={css`
+                                    margin-top: var(
+                                      --ac-global-dimension-static-size-100
+                                    );
+                                    display: flex;
+                                    flex-direction: column;
+                                    justify-content: flex-start;
+                                    align-items: flex-end;
+                                    gap: var(
+                                      --ac-global-dimension-static-size-100
+                                    );
+                                  `}
+                                >
+                                  {run.annotations?.edges.map((edge) => (
+                                    <li key={edge.annotation.id}>
+                                      <AnnotationLabel
+                                        annotation={edge.annotation}
+                                      />
+                                    </li>
+                                  ))}
+                                </ul>
+                              </ViewSummaryAside>
+                            </Flex>
+                          </li>
+                        ))}
+                      </ul>
+                    </Card>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </Flex> */}
+      </Panel>
+    </PanelGroup>
+  );
+}

--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -13,14 +13,26 @@ import { AnnotationLabel } from "@phoenix/components/annotation";
 import { JSONBlock } from "@phoenix/components/code";
 import { SequenceNumberToken } from "@phoenix/components/experiment";
 import { resizeHandleCSS } from "@phoenix/components/resize";
-type ExperimentCompareDetailsProps = { datasetId: string };
-export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
+
+import type { ExperimentInfoMap, TableRow } from "./ExperimentCompareTable";
+
+// TODO: this is an anti-pattern but right now the components are coupled.
+// This will be re-factored to encapsulated.
+type ExperimentCompareDetailsProps = {
+  selectedExample: TableRow;
+  experimentInfoById: ExperimentInfoMap;
+};
+
+export function ExperimentCompareDetails({
+  selectedExample,
+  experimentInfoById,
+}: ExperimentCompareDetailsProps) {
   return (
     <PanelGroup direction="vertical" autoSaveId="example-compare-panel-group">
       <Panel defaultSize={35}>
         <div
           css={css`
-            overflow-y: auto;
+            overflow: auto;
             height: 100%;
           `}
         >
@@ -52,7 +64,7 @@ export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
       </Panel>
       <PanelResizeHandle css={resizeHandleCSS} />
       <Panel defaultSize={65}>
-        {/* <Flex direction="column" height="100%">
+        <Flex direction="column" height="100%">
           <View
             paddingStart="size-200"
             paddingEnd="size-200"
@@ -74,7 +86,8 @@ export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
             <ul
               css={css`
                 display: flex;
-                flex-direction: column;
+                flex-direction: row;
+                flex-wrap: none;
                 gap: var(--ac-global-dimension-static-size-200);
               `}
             >
@@ -82,14 +95,17 @@ export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
                 const experiment = experimentInfoById[runItem.experimentId];
                 return (
                   <li key={runItem.experimentId}>
-                    <Card
-                      title={experiment?.name ?? ""}
-                      titleExtra={
+                    <View
+                      borderWidth="thin"
+                      borderColor="light"
+                      borderRadius="medium"
+                    >
+                      <Flex direction="row" gap="size-100">
+                        <Heading>{experiment?.name ?? ""}</Heading>{" "}
                         <SequenceNumberToken
                           sequenceNumber={experiment?.sequenceNumber ?? 0}
                         />
-                      }
-                    >
+                      </Flex>
                       <ul>
                         {runItem.runs.map((run, index) => (
                           <li key={index}>
@@ -131,13 +147,13 @@ export function ExperimentCompareDetails(args: ExperimentCompareDetailsProps) {
                           </li>
                         ))}
                       </ul>
-                    </Card>
+                    </View>
                   </li>
                 );
               })}
             </ul>
           </div>
-        </Flex> */}
+        </Flex>
       </Panel>
     </PanelGroup>
   );

--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -16,6 +16,7 @@ import { useExperimentColors } from "@phoenix/components/experiment";
 import { resizeHandleCSS } from "@phoenix/components/resize";
 
 import type { ExperimentInfoMap, TableRow } from "./ExperimentCompareTable";
+import { ExperimentRunMetadata } from "./ExperimentRunMetadata";
 
 // TODO: this is an anti-pattern but right now the components are coupled.
 // This will be re-factored to encapsulated.
@@ -180,23 +181,30 @@ function ExperimentItem({
       <ul>
         {runItem.runs.map((run, index) => (
           <li key={index}>
-            <ul
+            <div
               css={css`
-                padding: var(--ac-global-dimension-size-100)
+                padding: var(--ac-global-dimension-size-50)
+                  var(--ac-global-dimension-size-200)
+                  var(--ac-global-dimension-size-100)
                   var(--ac-global-dimension-size-200);
                 border-bottom: 1px solid var(--ac-global-border-color-default);
+                display: flex;
+                flex-direction: column;
+                gap: var(--ac-global-dimension-size-100);
               `}
             >
-              {run.annotations?.edges.map((edge) => (
-                <li key={edge.annotation.id}>
-                  <AnnotationNameAndValue
-                    annotation={edge.annotation}
-                    displayPreference="score"
-                  />
-                </li>
-              ))}
-            </ul>
-
+              <ExperimentRunMetadata {...run} />
+              <ul>
+                {run.annotations?.edges.map((edge) => (
+                  <li key={edge.annotation.id}>
+                    <AnnotationNameAndValue
+                      annotation={edge.annotation}
+                      displayPreference="score"
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
             <View>
               {run.error ? (
                 <View padding="size-200">{run.error}</View>

--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   ColorSwatch,
   CopyToClipboardButton,
+  Empty,
   Flex,
   Heading,
   View,
@@ -144,9 +145,13 @@ export function ExperimentCompareDetails({
 const experimentItemCSS = css`
   border: 1px solid var(--ac-global-border-color-dark);
   border-radius: var(--ac-global-rounding-small);
-  box-shadow: 0px 8px 16px rgba(0 0 0 / 0.1);
+  box-shadow: 0px 8px 8px rgba(0 0 0 / 0.05);
   min-width: 500px;
 `;
+
+/**
+ * Shows a single experiment's output and annotations
+ */
 function ExperimentItem({
   experiment,
   runItem,
@@ -159,14 +164,19 @@ function ExperimentItem({
   const { baseExperimentColor, getExperimentColor } = useExperimentColors();
   const color =
     index === 0 ? baseExperimentColor : getExperimentColor(index - 1);
+
+  const hasExperimentResult = runItem.runs.length > 0;
   return (
     <div css={experimentItemCSS}>
       <View paddingX="size-200" paddingTop="size-200">
         <Flex direction="row" gap="size-100" alignItems="center">
           <ColorSwatch color={color} shape="circle" />
-          <Heading level={3}>{experiment?.name ?? ""}</Heading>{" "}
+          <Heading weight="heavy" level={3}>
+            {experiment?.name ?? ""}
+          </Heading>{" "}
         </Flex>
       </View>
+      {!hasExperimentResult ? <Empty message="No Run" /> : null}
       <ul>
         {runItem.runs.map((run, index) => (
           <li key={index}>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -35,8 +35,7 @@ import {
   Icon,
   IconButton,
   Icons,
-  ListBox,
-  ListBoxItem,
+  LinkButton,
   Loading,
   Modal,
   ModalOverlay,
@@ -77,7 +76,6 @@ import { Truncate } from "@phoenix/components/utility/Truncate";
 import { ExampleDetailsDialog } from "@phoenix/pages/example/ExampleDetailsDialog";
 import { ExperimentNameWithColorSwatch } from "@phoenix/pages/experiment/ExperimentNameWithColorSwatch";
 import { ExperimentRunAnnotationFiltersList } from "@phoenix/pages/experiment/ExperimentRunAnnotationFiltersList";
-import { assertUnreachable } from "@phoenix/typeUtils";
 import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
 import { TraceDetails } from "../trace";
@@ -785,74 +783,6 @@ export const MemoizedTableBody = React.memo(
   (prev, next) => prev.table.options.data === next.table.options.data
 ) as typeof TableBody;
 
-enum ExperimentRowAction {
-  GO_TO_EXAMPLE = "gotoExample",
-}
-function ExperimentRowActionMenu(props: {
-  datasetId: string;
-  exampleId: string;
-}) {
-  const { datasetId, exampleId } = props;
-  const navigate = useNavigate();
-  return (
-    <div
-      // TODO: add this logic to the ActionMenu component
-      onClick={(e) => {
-        // prevent parent anchor link from being followed
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-    >
-      <DialogTrigger>
-        <TooltipTrigger>
-          <Button
-            size="S"
-            leadingVisual={<Icon svg={<Icons.MoreHorizontalOutline />} />}
-          />
-          <Tooltip>
-            <TooltipArrow />
-            More actions
-          </Tooltip>
-        </TooltipTrigger>
-        <Popover>
-          <Dialog>
-            {({ close }) => (
-              <ListBox
-                style={{ minHeight: "auto" }}
-                onAction={(firedAction) => {
-                  const action = firedAction as ExperimentRowAction;
-                  switch (action) {
-                    case ExperimentRowAction.GO_TO_EXAMPLE: {
-                      navigate(`/datasets/${datasetId}/examples/${exampleId}`);
-                      break;
-                    }
-                    default: {
-                      assertUnreachable(action);
-                    }
-                  }
-                  close();
-                }}
-              >
-                <ListBoxItem id={ExperimentRowAction.GO_TO_EXAMPLE}>
-                  <Flex
-                    direction="row"
-                    gap="size-75"
-                    justifyContent="start"
-                    alignItems="center"
-                  >
-                    <Icon svg={<Icons.ExternalLinkOutline />} />
-                    <Text>Go to example</Text>
-                  </Flex>
-                </ListBoxItem>
-              </ListBox>
-            )}
-          </Dialog>
-        </Popover>
-      </DialogTrigger>
-    </div>
-  );
-}
-
 function ExperimentMetadata(props: { experiment: Experiment }) {
   const { experiment } = props;
   const averageRunLatencyMs = experiment.averageRunLatencyMs;
@@ -1034,10 +964,12 @@ function SelectedExampleDialog({
         <DialogHeader>
           <DialogTitle>{`Comparing Experiments for Example: ${selectedExample.id}`}</DialogTitle>
           <DialogTitleExtra>
-            <ExperimentRowActionMenu
-              datasetId={datasetId}
-              exampleId={selectedExample.id}
-            />
+            <LinkButton
+              size="S"
+              to={`/datasets/${datasetId}/examples/${selectedExample.id}`}
+            >
+              View Example
+            </LinkButton>
             <DialogCloseButton />
           </DialogTitleExtra>
         </DialogHeader>

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -30,6 +30,7 @@ import {
   Dialog,
   DialogCloseButton,
   DialogTrigger,
+  Empty,
   Flex,
   Heading,
   Icon,
@@ -56,8 +57,6 @@ import {
 } from "@phoenix/components/dialog";
 import {
   ExperimentAverageRunTokenCosts,
-  ExperimentRunTokenCosts,
-  ExperimentRunTokenCount,
   useExperimentColors,
 } from "@phoenix/components/experiment";
 import { ExperimentActionMenu } from "@phoenix/components/experiment/ExperimentActionMenu";
@@ -71,7 +70,6 @@ import {
   TooltipTrigger,
 } from "@phoenix/components/tooltip";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
-import { TokenCount } from "@phoenix/components/trace/TokenCount";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { ExampleDetailsDialog } from "@phoenix/pages/example/ExampleDetailsDialog";
 import { ExperimentNameWithColorSwatch } from "@phoenix/pages/experiment/ExperimentNameWithColorSwatch";
@@ -87,6 +85,7 @@ import type {
 import type { ExperimentCompareTableQuery } from "./__generated__/ExperimentCompareTableQuery.graphql";
 import { ExperimentCompareDetails } from "./ExperimentCompareDetails";
 import { ExperimentRunFilterConditionField } from "./ExperimentRunFilterConditionField";
+import { ExperimentRunMetadata } from "./ExperimentRunMetadata";
 
 type ExampleCompareTableProps = {
   query: ExperimentCompareTable_comparisons$key;
@@ -114,7 +113,8 @@ export type TableRow =
     >;
   };
 
-type ExperimentRun =
+// TODO - switch to a fragment and don't export
+export type ExperimentRun =
   ExperimentCompareTable_comparisons$data["compareExperiments"]["edges"][number]["comparison"]["runComparisonItems"][number]["runs"][number];
 
 const tableWrapCSS = css`
@@ -406,7 +406,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
           if (numRuns === 0) {
             return (
               <PaddedCell>
-                <NotRunText />
+                <Empty message="No Run" />
               </PaddedCell>
             );
           } else if (numRuns > 1) {
@@ -486,7 +486,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             </Flex>
           ) : (
             <PaddedCell>
-              <NotRunText />
+              <Empty message="No Run" />
             </PaddedCell>
           );
         },
@@ -817,32 +817,6 @@ function ExperimentMetadata(props: { experiment: Experiment }) {
   );
 }
 
-function ExperimentRunMetadata(props: ExperimentRun) {
-  const { id, startTime, endTime, costSummary } = props;
-  const tokenCountTotal = costSummary.total.tokens;
-  const costTotal = costSummary.total.cost;
-  return (
-    <Flex direction="row" gap="size-100">
-      <RunLatency startTime={startTime} endTime={endTime} />
-      {tokenCountTotal != null && id ? (
-        <ExperimentRunTokenCount
-          tokenCountTotal={tokenCountTotal}
-          experimentRunId={id}
-          size="S"
-        />
-      ) : (
-        <TokenCount size="S">{tokenCountTotal}</TokenCount>
-      )}
-      {costTotal != null && id ? (
-        <ExperimentRunTokenCosts
-          costTotal={costTotal}
-          experimentRunId={id}
-          size="S"
-        />
-      ) : null}
-    </Flex>
-  );
-}
 /**
  * Display the output of an experiment run.
  */
@@ -892,34 +866,6 @@ function RunError({ error }: { error: string }) {
     <Flex direction="row" gap="size-50" alignItems="center">
       <Icon svg={<Icons.AlertCircleOutline />} color="danger" />
       <Text color="danger">{error}</Text>
-    </Flex>
-  );
-}
-
-function RunLatency({
-  startTime,
-  endTime,
-}: {
-  startTime: string;
-  endTime: string;
-}) {
-  const latencyMs = useMemo(() => {
-    let latencyMs: number | null = null;
-    if (startTime && endTime) {
-      latencyMs = new Date(endTime).getTime() - new Date(startTime).getTime();
-    }
-    return latencyMs;
-  }, [startTime, endTime]);
-  if (latencyMs === null) {
-    return null;
-  }
-  return <LatencyText size="S" latencyMs={latencyMs} />;
-}
-function NotRunText() {
-  return (
-    <Flex direction="row" gap="size-50">
-      <Icon svg={<Icons.MinusCircleOutline />} color="grey-800" />
-      <Text color="text-700">not run</Text>
     </Flex>
   );
 }

--- a/app/src/pages/experiment/ExperimentRunLatency.tsx
+++ b/app/src/pages/experiment/ExperimentRunLatency.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+
+import { LatencyText } from "@phoenix/components/trace/LatencyText";
+
+export function ExperimentRunLatency({
+  startTime,
+  endTime,
+}: {
+  startTime: string;
+  endTime: string;
+}) {
+  const latencyMs = useMemo(() => {
+    let latencyMs: number | null = null;
+    if (startTime && endTime) {
+      latencyMs = new Date(endTime).getTime() - new Date(startTime).getTime();
+    }
+    return latencyMs;
+  }, [startTime, endTime]);
+  if (latencyMs === null) {
+    return null;
+  }
+  return <LatencyText size="S" latencyMs={latencyMs} />;
+}

--- a/app/src/pages/experiment/ExperimentRunMetadata.tsx
+++ b/app/src/pages/experiment/ExperimentRunMetadata.tsx
@@ -1,0 +1,35 @@
+import { Flex } from "@phoenix/components";
+import {
+  ExperimentRunTokenCosts,
+  ExperimentRunTokenCount,
+} from "@phoenix/components/experiment";
+import { TokenCount } from "@phoenix/components/trace";
+
+import { ExperimentRun } from "./ExperimentCompareTable";
+import { ExperimentRunLatency } from "./ExperimentRunLatency";
+export function ExperimentRunMetadata(props: ExperimentRun) {
+  const { id, startTime, endTime, costSummary } = props;
+  const tokenCountTotal = costSummary.total.tokens;
+  const costTotal = costSummary.total.cost;
+  return (
+    <Flex direction="row" gap="size-100">
+      <ExperimentRunLatency startTime={startTime} endTime={endTime} />
+      {tokenCountTotal != null && id ? (
+        <ExperimentRunTokenCount
+          tokenCountTotal={tokenCountTotal}
+          experimentRunId={id}
+          size="S"
+        />
+      ) : (
+        <TokenCount size="S">{tokenCountTotal}</TokenCount>
+      )}
+      {costTotal != null && id ? (
+        <ExperimentRunTokenCosts
+          costTotal={costTotal}
+          experimentRunId={id}
+          size="S"
+        />
+      ) : null}
+    </Flex>
+  );
+}

--- a/app/stories/ExperimentTable.stories.tsx
+++ b/app/stories/ExperimentTable.stories.tsx
@@ -614,14 +614,14 @@ const meta: Meta<typeof SimpleExperimentTable> = {
         component: `
 A realistic experiment table showing SQL generation experiment results:
 - **CellTop Components**: Structured cell headers with controls and metadata
-- **TokenCount Component**: Display token usage with proper formatting  
+- **TokenCount Component**: Display token usage with proper formatting
 - **TokenCosts Component**: Show experiment costs with price formatting
 - **Column Resizing**: Drag column borders to adjust widths
 - **Real Experiment Data**: Uses actual text-to-SQL generation experiment results
 - **Annotation Display**: Show evaluation scores (has_results, qa_correctness) with explanations
 - **SQL Query Rendering**: Display input questions and generated SQL queries with results
 
-This table demonstrates realistic experiment tracking for LLM-based SQL generation tasks, 
+This table demonstrates realistic experiment tracking for LLM-based SQL generation tasks,
 including performance metrics, cost tracking, and quality annotations.
         `,
       },


### PR DESCRIPTION
resolves #9286 

This minimally refactors the dialog contents and makes the run outputs to be viewable side-by-side.

<img width="2056" height="1171" alt="Screenshot 2025-09-04 at 7 33 15 PM" src="https://github.com/user-attachments/assets/bb341f92-d925-4080-9202-8886842f9797" />
