### PR TITLE
refactor: update experiment compare list page typing

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -681,6 +681,7 @@ export function ExperimentCompareListPage() {
                           annotationSummary.minScore,
                           annotationSummary.maxScore
                         )}
+                        aria-label={`${annotationSummary.annotationName} mean score`}
                       />
                     ) : (
                       <ProgressBarPlaceholder />
@@ -732,6 +733,7 @@ export function ExperimentCompareListPage() {
                       annotationSummary.minScore,
                       annotationSummary.maxScore
                     )}
+                    aria-label={`${annotationSummary.annotationName} score`}
                   />
                 ) : (
                   <ProgressBarPlaceholder />
@@ -768,6 +770,7 @@ export function ExperimentCompareListPage() {
                           annotationSummary.minScore,
                           annotationSummary.maxScore
                         )}
+                        aria-label={`${annotationSummary.annotationName} score`}
                       />
                     ) : (
                       <ProgressBarPlaceholder />

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -63,48 +63,12 @@ const tableWrapCSS = css`
   }
 `;
 
-type Example =
-  ExperimentCompareListPage_comparisons$data["compareExperiments"]["edges"][number]["comparison"]["example"];
-
 type ExperimentRun =
   ExperimentCompareListPage_comparisons$data["compareExperiments"]["edges"][number]["comparison"]["runComparisonItems"][number]["runs"][number];
 
 type Experiment = NonNullable<
   ExperimentCompareListPage_aggregateData$data["dataset"]["experiments"]
 >["edges"][number]["experiment"];
-
-type TableRow = {
-  id: Example["id"];
-  example: Example["id"];
-  input: Example["revision"]["input"];
-  referenceOutput: Example["revision"]["referenceOutput"];
-  outputs: {
-    baseExperimentValue: ExperimentRun["output"];
-    compareExperimentValues: (ExperimentRun["output"] | undefined)[];
-  };
-  tokens: {
-    baseExperimentValue: ExperimentRun["costSummary"]["total"]["tokens"];
-    compareExperimentValues: (
-      | ExperimentRun["costSummary"]["total"]["tokens"]
-      | undefined
-    )[];
-  };
-  latencyMs: {
-    baseExperimentValue: number;
-    compareExperimentValues: (number | null | undefined)[];
-  };
-  cost: {
-    baseExperimentValue: ExperimentRun["costSummary"]["total"]["cost"];
-    compareExperimentValues: (
-      | ExperimentRun["costSummary"]["total"]["cost"]
-      | undefined
-    )[];
-  };
-  annotations: {
-    baseExperimentValue: ExperimentRun["annotations"]["edges"][number]["annotation"][];
-    compareExperimentValues: ExperimentRun["annotations"]["edges"][number]["annotation"][][];
-  };
-};
 
 export function ExperimentCompareListPage() {
   const [searchParams] = useSearchParams();
@@ -234,7 +198,7 @@ export function ExperimentCompareListPage() {
     );
   }, [aggregateData?.dataset]);
 
-  const tableData: TableRow[] = useMemo(() => {
+  const tableData = useMemo(() => {
     return (
       data?.compareExperiments.edges.map((edge) => {
         const comparison = edge.comparison;
@@ -301,6 +265,8 @@ export function ExperimentCompareListPage() {
       }) ?? []
     );
   }, [data]);
+
+  type TableRow = (typeof tableData)[number];
 
   const fetchMoreOnBottomReached = useCallback(
     (containerRefElement?: HTMLDivElement | null) => {

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -63,6 +63,9 @@ const tableWrapCSS = css`
   }
 `;
 
+type Example =
+  ExperimentCompareListPage_comparisons$data["compareExperiments"]["edges"][number]["comparison"]["example"];
+
 type ExperimentRun =
   ExperimentCompareListPage_comparisons$data["compareExperiments"]["edges"][number]["comparison"]["runComparisonItems"][number]["runs"][number];
 
@@ -71,37 +74,35 @@ type Experiment = NonNullable<
 >["edges"][number]["experiment"];
 
 type TableRow = {
-  id: string;
-  example: string;
-  input: unknown;
-  referenceOutput: unknown;
+  id: Example["id"];
+  example: Example["id"];
+  input: Example["revision"]["input"];
+  referenceOutput: Example["revision"]["referenceOutput"];
   outputs: {
-    baseExperimentValue: unknown;
-    compareExperimentValues: unknown[];
+    baseExperimentValue: ExperimentRun["output"];
+    compareExperimentValues: (ExperimentRun["output"] | undefined)[];
   };
   tokens: {
-    baseExperimentValue: number | null;
-    compareExperimentValues: (number | null | undefined)[];
+    baseExperimentValue: ExperimentRun["costSummary"]["total"]["tokens"];
+    compareExperimentValues: (
+      | ExperimentRun["costSummary"]["total"]["tokens"]
+      | undefined
+    )[];
   };
   latencyMs: {
     baseExperimentValue: number;
     compareExperimentValues: (number | null | undefined)[];
   };
   cost: {
-    baseExperimentValue: number | null;
-    compareExperimentValues: (number | null | undefined)[];
+    baseExperimentValue: ExperimentRun["costSummary"]["total"]["cost"];
+    compareExperimentValues: (
+      | ExperimentRun["costSummary"]["total"]["cost"]
+      | undefined
+    )[];
   };
   annotations: {
-    baseExperimentValue: {
-      name: string;
-      score: number | null;
-      label: string | null;
-    }[];
-    compareExperimentValues: {
-      name: string;
-      score: number | null;
-      label: string | null;
-    }[][];
+    baseExperimentValue: ExperimentRun["annotations"]["edges"][number]["annotation"][];
+    compareExperimentValues: ExperimentRun["annotations"]["edges"][number]["annotation"][][];
   };
 };
 


### PR DESCRIPTION
Follow up PR to address [this comment](https://github.com/Arize-ai/phoenix/pull/9353#discussion_r2319714199) by updating the `TableRow` type defined on the experiment compare lists page to be derived from the relay-generated types.

This also includes a small change to add aria-labels to the ProgressBar component on this page, since I just noticed console warnings related to this.

