### PR TITLE
fix(js): allow the passthrough of tracer providers, switch to phoenix-evals in notebooks

### DIFF
--- a/js/.changeset/hip-flowers-talk.md
+++ b/js/.changeset/hip-flowers-talk.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+pass through the tracer provider to experiments so that there is no need to configure it twice

--- a/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
+++ b/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
@@ -77,17 +77,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Phoenix client initialized. Access Phoenix UI at http://localhost:6006\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "const client = createClient();\n",
     "console.log('Phoenix client initialized. Access Phoenix UI at http://localhost:6006');"
@@ -104,18 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating dataset examples...\n",
-      "examples created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "console.log('Creating dataset examples...');\n",
     "\n",
@@ -161,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,17 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created 'contains_keyword' evaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "// 1. Code-based evaluator that checks if response contains specific keywords\n",
     "const containsKeyword = asEvaluator({\n",
@@ -232,17 +207,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created 'conciseness' evaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import { createClassificationEvaluator } from \"npm:@arizeai/phoenix-evals@latest\";\n",
     "import { openai } from \"npm:@ai-sdk/openai@latest\";\n",
@@ -272,17 +239,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created 'jaccard_similarity' evaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "// 3. Custom Jaccard similarity evaluator\n",
     "const jaccardSimilarity = asEvaluator({\n",
@@ -319,17 +278,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created 'accuracy' evaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import { createClassificationEvaluator } from \"npm:@arizeai/phoenix-evals@latest\";\n",
     "import { openai } from \"npm:@ai-sdk/openai@latest\";\n",
@@ -370,162 +321,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running initial experiment...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
-      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
-      "    at async <anonymous>:3:20\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
-      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
-      "    at async <anonymous>:3:20\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
-      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
-      "    at async <anonymous>:3:20\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "📊 View dataset: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/examples\n",
-      "📺 View dataset experiments: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/experiments\n",
-      "🔗 View this experiment: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
-      "🧪 Starting experiment \"simple-experiment\" on dataset \"RGF0YXNldDo3Mg==\" with task \"task\" and 2 evaluators and 5 concurrent runs\n",
-      "🔧 Running task \"task\" on dataset \"RGF0YXNldDo3Mg==\"\n",
-      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDM= of dataset \"RGF0YXNldDo3Mg==\"\n",
-      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDQ= of dataset \"RGF0YXNldDo3Mg==\"\n",
-      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDU= of dataset \"RGF0YXNldDo3Mg==\"\n",
-      "✅ Task runs completed\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
-      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
-      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
-      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
-      "    at eventLoopTick (ext:core/01_core.js:182:21)\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
-      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
-      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
-      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
-      "    at eventLoopTick (ext:core/01_core.js:182:21)\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
-      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
-      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
-      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
-      "    at eventLoopTick (ext:core/01_core.js:182:21)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🧠 Evaluating experiment \"RXhwZXJpbWVudDoxNDM=\" with 2 evaluators\n",
-      "🔗 View experiment evaluation: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"jaccard_similarity\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"jaccard_similarity\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"jaccard_similarity\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"accuracy\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"accuracy\"\n",
-      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
-      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
-      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" failed: Cannot convert undefined or null to object\n",
-      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" failed: Cannot convert undefined or null to object\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"accuracy\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" failed: Cannot convert undefined or null to object\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Evaluation runs completed\n",
-      "✅ Experiment RXhwZXJpbWVudDoxNDM= completed\n",
-      "🔍 View results: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
-      "Initial experiment completed with ID: RXhwZXJpbWVudDoxNDM=\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "\n",
-       "### Initial experiment results\n",
-       "\n",
-       "Experiment ID: `RXhwZXJpbWVudDoxNDM=`\n"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "console.log('Running initial experiment...');\n",
     "\n",
@@ -561,84 +359,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running additional evaluators...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at <anonymous>:3:26\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at <anonymous>:3:26\n",
-      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
-      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
-      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
-      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
-      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
-      "    at <anonymous>:3:26\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🧠 Evaluating experiment \"RXhwZXJpbWVudDoxNDM=\" with 2 evaluators\n",
-      "🔗 View experiment evaluation: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"contains_keyword\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"contains_keyword\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"contains_keyword\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"conciseness\"\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"conciseness\"\n",
-      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
-      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
-      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n",
-      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"conciseness\"\n",
-      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n",
-      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
-      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
-      "✅ Evaluation runs completed\n",
-      "Additional evaluations completed\n",
-      "Evaluation runs: undefined\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "\n",
-       "### Additional Evaluation Results\n",
-       "\n",
-       "The experiment has been evaluated with additional evaluators. View the complete results in the Phoenix UI:\n",
-       "\n",
-       "http://localhost:6006\n",
-       "\n",
-       "Experiment ID: `RXhwZXJpbWVudDoxNDM=`\n"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "console.log('Running additional evaluators...');\n",
     "\n",

--- a/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
+++ b/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
@@ -77,9 +77,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Phoenix client initialized. Access Phoenix UI at http://localhost:6006\n"
+     ]
+    }
+   ],
    "source": [
     "const client = createClient();\n",
     "console.log('Phoenix client initialized. Access Phoenix UI at http://localhost:6006');"
@@ -96,9 +104,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating dataset examples...\n",
+      "examples created\n"
+     ]
+    }
+   ],
    "source": [
     "console.log('Creating dataset examples...');\n",
     "\n",
@@ -144,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,9 +193,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 'contains_keyword' evaluator\n"
+     ]
+    }
+   ],
    "source": [
     "// 1. Code-based evaluator that checks if response contains specific keywords\n",
     "const containsKeyword = asEvaluator({\n",
@@ -207,36 +232,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 'conciseness' evaluator\n"
+     ]
+    }
+   ],
    "source": [
+    "import { createClassificationEvaluator } from \"npm:@arizeai/phoenix-evals@latest\";\n",
+    "import { openai } from \"npm:@ai-sdk/openai@latest\";\n",
+    "\n",
     "// 2. LLM-based evaluator for conciseness\n",
+    "const concisenessEval = createClassificationEvaluator({\n",
+    "    model: openai(\"gpt-4o\"),\n",
+    "    promptTemplate: \"Rate the following test as concise or verbose {{output}}\",\n",
+    "    choices: { concise: 1, verbose: 0 }\n",
+    "});\n",
+    "\n",
     "const conciseness = asEvaluator({\n",
     "  name: \"conciseness\",\n",
     "  kind: \"LLM\", \n",
     "  evaluate: async ({ output }) => {\n",
-    "    const prompt = `\n",
-    "      Rate the following text on a scale of 0.0 to 1.0 for conciseness (where 1.0 is perfectly concise).\n",
-    "      \n",
-    "      TEXT: ${output}\n",
-    "      \n",
-    "      Return only a number between 0.0 and 1.0.\n",
-    "    `;\n",
-    "    \n",
-    "    const response = await openai.chat.completions.create({\n",
-    "      model: \"gpt-4o\",\n",
-    "      messages: [{ role: \"user\", content: prompt }]\n",
-    "    });\n",
-    "    \n",
-    "    const scoreText = response.choices[0]?.message?.content?.trim() || \"0\";\n",
-    "    const score = parseFloat(scoreText);\n",
+    "    const res = await concisenessEval.evaluate({ output });\n",
     "    \n",
     "    return {\n",
-    "      score: isNaN(score) ? 0.5 : score,\n",
-    "      label: score > 0.7 ? \"concise\" : \"verbose\",\n",
+    "      ...res,\n",
     "      metadata: {},\n",
-    "      explanation: `Conciseness score: ${score}`\n",
     "    };\n",
     "  }\n",
     "});\n",
@@ -246,9 +272,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 'jaccard_similarity' evaluator\n"
+     ]
+    }
+   ],
    "source": [
     "// 3. Custom Jaccard similarity evaluator\n",
     "const jaccardSimilarity = asEvaluator({\n",
@@ -285,10 +319,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 'accuracy' evaluator\n"
+     ]
+    }
+   ],
    "source": [
+    "import { createClassificationEvaluator } from \"npm:@arizeai/phoenix-evals@latest\";\n",
+    "import { openai } from \"npm:@ai-sdk/openai@latest\";\n",
+    "\n",
+    "const accuracyEval = createClassificationEvaluator({\n",
+    "    model: openai(\"gpt-4o\"),\n",
+    "    promptTemplate: \"Given the QUESTION and REFERENCE_ANSWER, determine whether the ANSWER is accurate. <question>{{question}}</question><reference>{{referenceAnswer}}</reference><answer>{{referenceAnswer}}</answer>\"\n",
+    "});\n",
+    "\n",
     "// 4. LLM-based accuracy evaluator\n",
     "const accuracy = asEvaluator({\n",
     "  name: \"accuracy\",\n",
@@ -298,37 +348,10 @@
     "    const question = input.question || \"No question provided\";\n",
     "    const referenceAnswer = expected?.answer || \"No reference answer provided\";\n",
     "    \n",
-    "    const evalPromptTemplate = `\n",
-    "      Given the QUESTION and REFERENCE_ANSWER, determine whether the ANSWER is accurate.\n",
-    "      Output only a single word (accurate or inaccurate).\n",
-    "      \n",
-    "      QUESTION: {question}\n",
-    "      \n",
-    "      REFERENCE_ANSWER: {reference_answer}\n",
-    "      \n",
-    "      ANSWER: {answer}\n",
-    "      \n",
-    "      ACCURACY (accurate / inaccurate):\n",
-    "    `;\n",
-    "    \n",
-    "    const messageContent = evalPromptTemplate\n",
-    "      .replace('{question}', question)\n",
-    "      .replace('{reference_answer}', referenceAnswer)\n",
-    "      .replace('{answer}', String(output));\n",
-    "    \n",
-    "    const response = await openai.chat.completions.create({\n",
-    "      model: \"gpt-4o\",\n",
-    "      messages: [{ role: \"user\", content: messageContent }]\n",
-    "    });\n",
-    "    \n",
-    "    const responseContent = response.choices[0]?.message?.content?.toLowerCase().trim() || \"\";\n",
-    "    const isAccurate = responseContent === \"accurate\";\n",
-    "    \n",
+    "    const res = await accuracyEval.evaluate({ question, referenceAnswer, answer: String(output) })\n",
     "    return {\n",
-    "      score: isAccurate ? 1.0 : 0.0,\n",
-    "      label: isAccurate ? \"accurate\" : \"inaccurate\",\n",
+    "    ...res,\n",
     "      metadata: {},\n",
-    "      explanation: `LLM determined the answer is ${isAccurate ? \"accurate\" : \"inaccurate\"}`\n",
     "    };\n",
     "  }\n",
     "});\n",
@@ -347,9 +370,162 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running initial experiment...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
+      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
+      "    at async <anonymous>:3:20\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
+      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
+      "    at async <anonymous>:3:20\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:105:22)\n",
+      "    at eventLoopTick (ext:core/01_core.js:175:7)\n",
+      "    at async <anonymous>:3:20\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📊 View dataset: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/examples\n",
+      "📺 View dataset experiments: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/experiments\n",
+      "🔗 View this experiment: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
+      "🧪 Starting experiment \"simple-experiment\" on dataset \"RGF0YXNldDo3Mg==\" with task \"task\" and 2 evaluators and 5 concurrent runs\n",
+      "🔧 Running task \"task\" on dataset \"RGF0YXNldDo3Mg==\"\n",
+      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDM= of dataset \"RGF0YXNldDo3Mg==\"\n",
+      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDQ= of dataset \"RGF0YXNldDo3Mg==\"\n",
+      "🔧 Running task \"task\" on example \"RGF0YXNldEV4YW1wbGU6MjE4MDU= of dataset \"RGF0YXNldDo3Mg==\"\n",
+      "✅ Task runs completed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
+      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
+      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
+      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
+      "    at eventLoopTick (ext:core/01_core.js:182:21)\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
+      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
+      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
+      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
+      "    at eventLoopTick (ext:core/01_core.js:182:21)\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at runExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:155:38)\n",
+      "    at Object.runMicrotasks (ext:core/01_core.js:672:26)\n",
+      "    at processTicksAndRejections (ext:deno_node/_next_tick.ts:57:10)\n",
+      "    at runNextTicks (ext:deno_node/_next_tick.ts:75:3)\n",
+      "    at eventLoopTick (ext:core/01_core.js:182:21)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🧠 Evaluating experiment \"RXhwZXJpbWVudDoxNDM=\" with 2 evaluators\n",
+      "🔗 View experiment evaluation: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"jaccard_similarity\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"jaccard_similarity\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"jaccard_similarity\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"accuracy\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"accuracy\"\n",
+      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
+      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
+      "✅ Evaluator \"jaccard_similarity\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" failed: Cannot convert undefined or null to object\n",
+      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" failed: Cannot convert undefined or null to object\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"accuracy\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "❌ Evaluator \"accuracy\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" failed: Cannot convert undefined or null to object\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Evaluation runs completed\n",
+      "✅ Experiment RXhwZXJpbWVudDoxNDM= completed\n",
+      "🔍 View results: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
+      "Initial experiment completed with ID: RXhwZXJpbWVudDoxNDM=\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "### Initial experiment results\n",
+       "\n",
+       "Experiment ID: `RXhwZXJpbWVudDoxNDM=`\n"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "console.log('Running initial experiment...');\n",
     "\n",
@@ -385,9 +561,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running additional evaluators...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: trace\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at TraceAPI.setGlobalTracerProvider (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/trace.js:54:59)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:101:21)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at <anonymous>:3:26\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: context\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at ContextAPI.setGlobalContextManager (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/context.js:43:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:106:27)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at <anonymous>:3:26\n",
+      "Error: @opentelemetry/api: Attempted duplicate registration of API: propagation\n",
+      "    at registerGlobal (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/internal/global-utils.js:32:21)\n",
+      "    at PropagationAPI.setGlobalPropagator (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/api/1.9.0/build/src/api/propagation.js:52:50)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-base/1.30.1/build/src/BasicTracerProvider.js:109:31)\n",
+      "    at NodeTracerProvider.register (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@opentelemetry/sdk-trace-node/1.30.1/build/src/NodeTracerProvider.js:43:15)\n",
+      "    at evaluateExperiment (file:///Users/mikeldking/Library/Caches/deno/npm/registry.npmjs.org/@arizeai/phoenix-client/4.0.0/dist/esm/experiments/runExperiment.js:270:22)\n",
+      "    at <anonymous>:3:26\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🧠 Evaluating experiment \"RXhwZXJpbWVudDoxNDM=\" with 2 evaluators\n",
+      "🔗 View experiment evaluation: http://localhost:6006/datasets/RGF0YXNldDo3Mg==/compare?experimentId=RXhwZXJpbWVudDoxNDM=\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"contains_keyword\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"contains_keyword\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"contains_keyword\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY2\" with evaluator \"conciseness\"\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY3\" with evaluator \"conciseness\"\n",
+      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
+      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
+      "✅ Evaluator \"contains_keyword\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n",
+      "🧠 Evaluating run \"RXhwZXJpbWVudFJ1bjo0ODY4\" with evaluator \"conciseness\"\n",
+      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY4\" completed\n",
+      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY3\" completed\n",
+      "✅ Evaluator \"conciseness\" on run \"RXhwZXJpbWVudFJ1bjo0ODY2\" completed\n",
+      "✅ Evaluation runs completed\n",
+      "Additional evaluations completed\n",
+      "Evaluation runs: undefined\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "### Additional Evaluation Results\n",
+       "\n",
+       "The experiment has been evaluated with additional evaluators. View the complete results in the Phoenix UI:\n",
+       "\n",
+       "http://localhost:6006\n",
+       "\n",
+       "Experiment ID: `RXhwZXJpbWVudDoxNDM=`\n"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "console.log('Running additional evaluators...');\n",
     "\n",
@@ -436,8 +687,19 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
   "language_info": {
-   "name": "typescript"
+   "codemirror_mode": "typescript",
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nbconvert_exporter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.6.2"
   }
  },
  "nbformat": 4,

--- a/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
+++ b/js/examples/notebooks/deno_datasets_and_experiments_quickstart.ipynb
@@ -410,19 +410,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Deno",
-   "language": "typescript",
-   "name": "deno"
-  },
   "language_info": {
-   "codemirror_mode": "typescript",
-   "file_extension": ".ts",
-   "mimetype": "text/x.typescript",
-   "name": "typescript",
-   "nbconvert_exporter": "script",
-   "pygments_lexer": "typescript",
-   "version": "5.6.2"
+   "name": "typescript"
   }
  },
  "nbformat": 4,

--- a/js/packages/phoenix-client/examples/dataset_and_experiments_quickstart.ts
+++ b/js/packages/phoenix-client/examples/dataset_and_experiments_quickstart.ts
@@ -9,6 +9,8 @@ import {
 import { AnnotatorKind } from "../src/types/annotations";
 import { Example } from "../src/types/datasets";
 import { createDataset } from "../src/datasets/createDataset";
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import { openai as aiOpenAI } from "@ai-sdk/openai";
 
 // Replace with your actual OpenAI API key
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -118,9 +120,9 @@ async function main() {
     evaluate: async ({ output }) => {
       const prompt = `
         Rate the following text on a scale of 0.0 to 1.0 for conciseness (where 1.0 is perfectly concise).
-        
+
         TEXT: ${output}
-        
+
         Return only a number between 0.0 and 1.0.
       `;
 
@@ -171,6 +173,24 @@ async function main() {
     },
   });
 
+  const accuracyEval = createClassificationEvaluator({
+    model: aiOpenAI("gpt-4o"),
+    name: "accuracy",
+    promptTemplate: `
+        Given the QUESTION and REFERENCE_ANSWER, determine whether the ANSWER is accurate.
+        Output only a single word (accurate or inaccurate).
+
+        QUESTION: {{question}}
+
+        REFERENCE_ANSWER: {{referenceAnswer}}
+
+        ANSWER: {{answer}}
+      `,
+    choices: {
+      accurate: 1,
+      inaccurate: 0,
+    },
+  });
   // 4. LLM-based accuracy evaluator
   const accuracy = asEvaluator({
     name: "accuracy",
@@ -180,39 +200,16 @@ async function main() {
       const question = (input.question as string) || "No question provided";
       const referenceAnswer =
         (expected?.answer as string) || "No reference answer provided";
+      const answer = String(output);
 
-      const evalPromptTemplate = `
-        Given the QUESTION and REFERENCE_ANSWER, determine whether the ANSWER is accurate.
-        Output only a single word (accurate or inaccurate).
-        
-        QUESTION: {question}
-        
-        REFERENCE_ANSWER: {reference_answer}
-        
-        ANSWER: {answer}
-        
-        ACCURACY (accurate / inaccurate):
-      `;
-
-      const messageContent = evalPromptTemplate
-        .replace("{question}", question)
-        .replace("{reference_answer}", referenceAnswer)
-        .replace("{answer}", String(output));
-
-      const response = await openai.chat.completions.create({
-        model: "gpt-4o",
-        messages: [{ role: "user", content: messageContent }],
+      const res = await accuracyEval.evaluate({
+        question,
+        referenceAnswer,
+        answer,
       });
-
-      const responseContent =
-        response.choices[0]?.message?.content?.toLowerCase().trim() || "";
-      const isAccurate = responseContent === "accurate";
-
       return {
-        score: isAccurate ? 1.0 : 0.0,
-        label: isAccurate ? "accurate" : "inaccurate",
+        ...res,
         metadata: {},
-        explanation: `LLM determined the answer is ${isAccurate ? "accurate" : "inaccurate"}`,
       };
     },
   });

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -70,7 +70,8 @@
     "openai": "^4.77.0",
     "openapi-typescript": "^7.6.1",
     "tsx": "^4.19.3",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "@arizeai/phoenix-evals": "workspace:*"
   },
   "dependencies": {
     "@arizeai/openinference-semantic-conventions": "^1.1.0",

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -23,7 +23,7 @@ import { pluralize } from "../utils/pluralize";
 import { promisifyResult } from "../utils/promisifyResult";
 import { AnnotatorKind } from "../types/annotations";
 import { createProvider, createNoOpProvider } from "./instrumentation";
-import { SpanStatusCode, Tracer } from "@opentelemetry/api";
+import { SpanStatusCode, Tracer, trace } from "@opentelemetry/api";
 import {
   MimeType,
   OpenInferenceSpanKind,
@@ -38,7 +38,6 @@ import {
   getExperimentUrl,
 } from "../utils/urlUtils";
 import assert from "assert";
-import { trace } from "@opentelemetry/api";
 
 /**
  * Validate that a repetition is valid

--- a/js/packages/phoenix-client/src/experiments/runExperiment.ts
+++ b/js/packages/phoenix-client/src/experiments/runExperiment.ts
@@ -23,7 +23,7 @@ import { pluralize } from "../utils/pluralize";
 import { promisifyResult } from "../utils/promisifyResult";
 import { AnnotatorKind } from "../types/annotations";
 import { createProvider, createNoOpProvider } from "./instrumentation";
-import { SpanStatusCode, Tracer, TracerProvider } from "@opentelemetry/api";
+import { SpanStatusCode, Tracer } from "@opentelemetry/api";
 import {
   MimeType,
   OpenInferenceSpanKind,

--- a/js/packages/phoenix-client/src/types/experiments.ts
+++ b/js/packages/phoenix-client/src/types/experiments.ts
@@ -79,10 +79,10 @@ export type Evaluator = {
 };
 
 export type EvaluationResult = {
-  score: number | null;
-  label: string | null;
-  metadata: Record<string, unknown>;
-  explanation: string | null;
+  score?: number | null;
+  label?: string | null;
+  metadata?: Record<string, unknown>;
+  explanation?: string | null;
 };
 
 export interface ExperimentEvaluationRun extends Node {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^2.0.27
         version: 2.0.27(zod@3.25.76)
+      '@arizeai/phoenix-evals':
+        specifier: workspace:*
+        version: link:../phoenix-evals
       '@types/async':
         specifier: ^3.2.24
         version: 3.2.25


### PR DESCRIPTION
resolves #9472

This fixes it so that the global tracer provider can be passed through to the evals to avoid the global tracer getting clobbered.

<img width="540" height="321" alt="Screenshot 2025-09-15 at 5 48 18 PM" src="https://github.com/user-attachments/assets/a797b73b-d964-4334-b09b-1dd9956465a5" />
