### PR TITLE
fix(helm): remove hook annotations

### DIFF
--- a/helm/templates/phoenix/deployment.yaml
+++ b/helm/templates/phoenix/deployment.yaml
@@ -10,9 +10,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "2"
 spec:
   replicas: {{ .Values.replicaCount | default 1 }}
   {{- if .Values.deployment.strategy }}


### PR DESCRIPTION
These hooks seem to be useless and prevent successful deployment with certain tools (like Pulumi).