### PR TITLE
feat(experiments): enable paging experiment compare details

### DIFF
--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Flex,
   Icon,
+  IconButton,
   Icons,
   KeyboardToken,
   Tooltip,
@@ -59,14 +60,14 @@ export const ExampleDetailsPaginator = ({
   return (
     <Flex direction="row" gap="size-50" alignItems="center">
       <TooltipTrigger delay={100}>
-        <Button
+        <IconButton
           size="S"
-          id="next"
-          leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
           aria-label="Next example"
           isDisabled={!hasNext}
           onPress={handleNext}
-        />
+        >
+          <Icon svg={<Icons.ArrowDownwardOutline />} />
+        </IconButton>
         <Tooltip
           offset={4}
           css={css`
@@ -83,14 +84,14 @@ export const ExampleDetailsPaginator = ({
         </Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={100}>
-        <Button
+        <IconButton
           size="S"
-          id="previous"
-          leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
           aria-label="Previous example"
           isDisabled={!hasPrevious}
           onPress={handlePrevious}
-        />
+        >
+          <Icon svg={<Icons.ArrowUpwardOutline />} />
+        </IconButton>
         <Tooltip
           offset={4}
           css={css`

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -1,0 +1,148 @@
+import { startTransition } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { css } from "@emotion/react";
+
+import {
+  Button,
+  Flex,
+  Icon,
+  Icons,
+  KeyboardToken,
+  Tooltip,
+  TooltipTrigger,
+} from "@phoenix/components";
+
+const NEXT_EXAMPLE_HOTKEY = "j";
+const PREVIOUS_EXAMPLE_HOTKEY = "k";
+
+export const ExampleDetailsPaginator = ({
+  currentId,
+  exampleSequence,
+  onNext,
+  onPrevious,
+}: {
+  currentId: string;
+  exampleSequence: string[];
+  onNext: (nextId: string) => void;
+  onPrevious: (previousId: string) => void;
+}) => {
+  useHotkeys(NEXT_EXAMPLE_HOTKEY, () => {
+    const { nextExampleId } = getExampleNeighbors(exampleSequence, currentId);
+    if (nextExampleId) {
+      onNext(nextExampleId);
+    }
+  });
+
+  useHotkeys(PREVIOUS_EXAMPLE_HOTKEY, () => {
+    const { previousExampleId } = getExampleNeighbors(
+      exampleSequence,
+      currentId
+    );
+    if (previousExampleId) {
+      onPrevious(previousExampleId);
+    }
+  });
+
+  const { nextExampleId, previousExampleId } = getExampleNeighbors(
+    exampleSequence,
+    currentId
+  );
+  const hasPrevious = !!previousExampleId;
+  const hasNext = !!nextExampleId;
+
+  return (
+    <Flex direction="row" gap="size-50" alignItems="center">
+      <TooltipTrigger delay={100}>
+        <Button
+          size="S"
+          id="next"
+          leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
+          aria-label="Next example"
+          isDisabled={!hasNext}
+          onPress={() => {
+            startTransition(() => {
+              if (nextExampleId) {
+                onNext(nextExampleId);
+              }
+            });
+          }}
+        />
+        <Tooltip
+          offset={4}
+          css={css`
+            background-color: var(--ac-global-background-color-dark);
+            border-color: var(--ac-global-border-color-dark);
+            border-radius: var(--ac-global-rounding-medium);
+            padding: var(--ac-global-dimension-static-size-100);
+          `}
+        >
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <span>Next example</span>
+            <KeyboardToken>{NEXT_EXAMPLE_HOTKEY}</KeyboardToken>
+          </Flex>
+        </Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger delay={100}>
+        <Button
+          size="S"
+          id="previous"
+          leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
+          aria-label="Previous example"
+          isDisabled={!hasPrevious}
+          onPress={() => {
+            startTransition(() => {
+              if (previousExampleId) {
+                onPrevious(previousExampleId);
+              }
+            });
+          }}
+        />
+        <Tooltip
+          offset={4}
+          css={css`
+            background-color: var(--ac-global-background-color-dark);
+            border-color: var(--ac-global-border-color-dark);
+            border-radius: var(--ac-global-rounding-medium);
+            padding: var(--ac-global-dimension-static-size-100);
+          `}
+        >
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <span>Previous example</span>
+            <KeyboardToken>{PREVIOUS_EXAMPLE_HOTKEY}</KeyboardToken>
+          </Flex>
+        </Tooltip>
+      </TooltipTrigger>
+    </Flex>
+  );
+};
+
+const getExampleNeighbors = (exampleSequence: string[], currentId: string) => {
+  const currentIndex = exampleSequence.findIndex(
+    (exampleId) => exampleId === currentId
+  );
+
+  if (currentIndex === -1) {
+    return {
+      nextExampleId: undefined,
+      previousExampleId: undefined,
+    };
+  }
+
+  const previousIndex = currentIndex - 1;
+  const nextIndex = currentIndex + 1;
+
+  let previousExampleId;
+  let nextExampleId;
+
+  if (previousIndex >= 0) {
+    previousExampleId = exampleSequence[previousIndex];
+  }
+  if (nextIndex < exampleSequence.length) {
+    nextExampleId = exampleSequence[nextIndex];
+  }
+
+  return {
+    nextExampleId,
+    previousExampleId,
+  };
+};

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -3,7 +3,6 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { css } from "@emotion/react";
 
 import {
-  Button,
   Flex,
   Icon,
   IconButton,

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -26,29 +26,35 @@ export const ExampleDetailsPaginator = ({
   onNext: (nextId: string) => void;
   onPrevious: (previousId: string) => void;
 }) => {
-  useHotkeys(NEXT_EXAMPLE_HOTKEY, () => {
-    const { nextExampleId } = getExampleNeighbors(exampleSequence, currentId);
-    if (nextExampleId) {
-      onNext(nextExampleId);
-    }
-  });
-
-  useHotkeys(PREVIOUS_EXAMPLE_HOTKEY, () => {
-    const { previousExampleId } = getExampleNeighbors(
-      exampleSequence,
-      currentId
-    );
-    if (previousExampleId) {
-      onPrevious(previousExampleId);
-    }
-  });
-
   const { nextExampleId, previousExampleId } = getExampleNeighbors(
     exampleSequence,
     currentId
   );
   const hasPrevious = !!previousExampleId;
   const hasNext = !!nextExampleId;
+
+  const handleNext = () => {
+    if (hasNext) {
+      startTransition(() => {
+        onNext(nextExampleId);
+      });
+    }
+  };
+  const handlePrevious = () => {
+    if (hasPrevious) {
+      startTransition(() => {
+        onPrevious(previousExampleId);
+      });
+    }
+  };
+
+  useHotkeys(NEXT_EXAMPLE_HOTKEY, () => {
+    handleNext();
+  });
+
+  useHotkeys(PREVIOUS_EXAMPLE_HOTKEY, () => {
+    handlePrevious();
+  });
 
   return (
     <Flex direction="row" gap="size-50" alignItems="center">
@@ -59,13 +65,7 @@ export const ExampleDetailsPaginator = ({
           leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
           aria-label="Next example"
           isDisabled={!hasNext}
-          onPress={() => {
-            startTransition(() => {
-              if (nextExampleId) {
-                onNext(nextExampleId);
-              }
-            });
-          }}
+          onPress={handleNext}
         />
         <Tooltip
           offset={4}
@@ -89,13 +89,7 @@ export const ExampleDetailsPaginator = ({
           leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
           aria-label="Previous example"
           isDisabled={!hasPrevious}
-          onPress={() => {
-            startTransition(() => {
-              if (previousExampleId) {
-                onPrevious(previousExampleId);
-              }
-            });
-          }}
+          onPress={handlePrevious}
         />
         <Tooltip
           offset={4}

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -17,17 +17,17 @@ const PREVIOUS_EXAMPLE_HOTKEY = "k";
 
 export const ExampleDetailsPaginator = ({
   currentId,
-  exampleSequence,
+  exampleIds,
   onNext,
   onPrevious,
 }: {
   currentId: string;
-  exampleSequence: string[];
+  exampleIds: string[];
   onNext: (nextId: string) => void;
   onPrevious: (previousId: string) => void;
 }) => {
   const { nextExampleId, previousExampleId } = getExampleNeighbors(
-    exampleSequence,
+    exampleIds,
     currentId
   );
   const hasPrevious = !!previousExampleId;
@@ -110,8 +110,8 @@ export const ExampleDetailsPaginator = ({
   );
 };
 
-const getExampleNeighbors = (exampleSequence: string[], currentId: string) => {
-  const currentIndex = exampleSequence.findIndex(
+const getExampleNeighbors = (exampleIds: string[], currentId: string) => {
+  const currentIndex = exampleIds.findIndex(
     (exampleId) => exampleId === currentId
   );
 
@@ -129,10 +129,10 @@ const getExampleNeighbors = (exampleSequence: string[], currentId: string) => {
   let nextExampleId;
 
   if (previousIndex >= 0) {
-    previousExampleId = exampleSequence[previousIndex];
+    previousExampleId = exampleIds[previousIndex];
   }
-  if (nextIndex < exampleSequence.length) {
-    nextExampleId = exampleSequence[nextIndex];
+  if (nextIndex < exampleIds.length) {
+    nextExampleId = exampleIds[nextIndex];
   }
 
   return {

--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { css } from "@emotion/react";
@@ -147,101 +147,105 @@ export function ExperimentCompareDetails({
 
   return (
     <PanelGroup direction="vertical" autoSaveId="example-compare-panel-group">
-      <Panel defaultSize={35}>
-        <div
-          css={css`
-            overflow: auto;
-            height: 100%;
-          `}
-        >
-          <View overflow="hidden" padding="size-200">
-            <Flex direction="row" gap="size-200" flex="1 1 auto">
-              <View width="50%">
-                <Card
-                  title="Input"
-                  extra={<CopyToClipboardButton text={JSON.stringify(input)} />}
-                >
-                  <View maxHeight="300px" overflow="auto">
-                    <JSONBlock value={JSON.stringify(input, null, 2)} />
-                  </View>
-                </Card>
-              </View>
-              <View width="50%">
-                <Card
-                  title="Reference Output"
-                  extra={
-                    <CopyToClipboardButton
-                      text={JSON.stringify(referenceOutput)}
-                    />
-                  }
-                >
-                  <View maxHeight="300px" overflow="auto">
-                    <JSONBlock
-                      value={JSON.stringify(referenceOutput, null, 2)}
-                    />
-                  </View>
-                </Card>
-              </View>
-            </Flex>
-          </View>
-        </div>
-      </Panel>
-      <PanelResizeHandle css={resizeHandleCSS} />
-      <Panel defaultSize={65}>
-        <Flex direction="column" height="100%">
-          <View
-            paddingStart="size-200"
-            paddingEnd="size-200"
-            paddingTop="size-100"
-            paddingBottom="size-100"
-            borderBottomColor="dark"
-            borderBottomWidth="thin"
-            flex="none"
-          >
-            <Heading level={2}>Experiments</Heading>
-          </View>
+      <Suspense>
+        <Panel defaultSize={35}>
           <div
             css={css`
-              overflow-y: auto;
+              overflow: auto;
               height: 100%;
-              padding: var(--ac-global-dimension-static-size-200);
             `}
           >
-            <ul
+            <View overflow="hidden" padding="size-200">
+              <Flex direction="row" gap="size-200" flex="1 1 auto">
+                <View width="50%">
+                  <Card
+                    title="Input"
+                    extra={
+                      <CopyToClipboardButton text={JSON.stringify(input)} />
+                    }
+                  >
+                    <View maxHeight="300px" overflow="auto">
+                      <JSONBlock value={JSON.stringify(input, null, 2)} />
+                    </View>
+                  </Card>
+                </View>
+                <View width="50%">
+                  <Card
+                    title="Reference Output"
+                    extra={
+                      <CopyToClipboardButton
+                        text={JSON.stringify(referenceOutput)}
+                      />
+                    }
+                  >
+                    <View maxHeight="300px" overflow="auto">
+                      <JSONBlock
+                        value={JSON.stringify(referenceOutput, null, 2)}
+                      />
+                    </View>
+                  </Card>
+                </View>
+              </Flex>
+            </View>
+          </div>
+        </Panel>
+        <PanelResizeHandle css={resizeHandleCSS} />
+        <Panel defaultSize={65}>
+          <Flex direction="column" height="100%">
+            <View
+              paddingStart="size-200"
+              paddingEnd="size-200"
+              paddingTop="size-100"
+              paddingBottom="size-100"
+              borderBottomColor="dark"
+              borderBottomWidth="thin"
+              flex="none"
+            >
+              <Heading level={2}>Experiments</Heading>
+            </View>
+            <div
               css={css`
-                display: flex;
-                flex-direction: row;
-                flex-wrap: none;
-                gap: var(--ac-global-dimension-static-size-200);
+                overflow-y: auto;
+                height: 100%;
+                padding: var(--ac-global-dimension-static-size-200);
               `}
             >
-              {experimentIds?.map((experimentId, index) => {
-                const experiment = experimentsById?.[experimentId];
-                if (!experiment) {
-                  return null;
-                }
-                return (
-                  <li
-                    key={experimentId}
-                    css={css`
-                      // Make them all the same size
-                      flex: 1 1 0px;
-                    `}
-                  >
-                    <ExperimentItem
-                      experiment={experiment}
-                      experimentRuns={
-                        experimentRunsByExperimentId?.[experimentId] || []
-                      }
-                      index={index}
-                    />
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        </Flex>
-      </Panel>
+              <ul
+                css={css`
+                  display: flex;
+                  flex-direction: row;
+                  flex-wrap: none;
+                  gap: var(--ac-global-dimension-static-size-200);
+                `}
+              >
+                {experimentIds?.map((experimentId, index) => {
+                  const experiment = experimentsById?.[experimentId];
+                  if (!experiment) {
+                    return null;
+                  }
+                  return (
+                    <li
+                      key={experimentId}
+                      css={css`
+                        // Make them all the same size
+                        flex: 1 1 0px;
+                      `}
+                    >
+                      <ExperimentItem
+                        experiment={experiment}
+                        experimentRuns={
+                          experimentRunsByExperimentId?.[experimentId] || []
+                        }
+                        index={index}
+                      />
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </Flex>
+        </Panel>
+      </Suspense>
     </PanelGroup>
   );
 }

--- a/app/src/pages/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetails.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo } from "react";
+import { useMemo } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { css } from "@emotion/react";
@@ -147,105 +147,101 @@ export function ExperimentCompareDetails({
 
   return (
     <PanelGroup direction="vertical" autoSaveId="example-compare-panel-group">
-      <Suspense>
-        <Panel defaultSize={35}>
+      <Panel defaultSize={35}>
+        <div
+          css={css`
+            overflow: auto;
+            height: 100%;
+          `}
+        >
+          <View overflow="hidden" padding="size-200">
+            <Flex direction="row" gap="size-200" flex="1 1 auto">
+              <View width="50%">
+                <Card
+                  title="Input"
+                  extra={<CopyToClipboardButton text={JSON.stringify(input)} />}
+                >
+                  <View maxHeight="300px" overflow="auto">
+                    <JSONBlock value={JSON.stringify(input, null, 2)} />
+                  </View>
+                </Card>
+              </View>
+              <View width="50%">
+                <Card
+                  title="Reference Output"
+                  extra={
+                    <CopyToClipboardButton
+                      text={JSON.stringify(referenceOutput)}
+                    />
+                  }
+                >
+                  <View maxHeight="300px" overflow="auto">
+                    <JSONBlock
+                      value={JSON.stringify(referenceOutput, null, 2)}
+                    />
+                  </View>
+                </Card>
+              </View>
+            </Flex>
+          </View>
+        </div>
+      </Panel>
+      <PanelResizeHandle css={resizeHandleCSS} />
+      <Panel defaultSize={65}>
+        <Flex direction="column" height="100%">
+          <View
+            paddingStart="size-200"
+            paddingEnd="size-200"
+            paddingTop="size-100"
+            paddingBottom="size-100"
+            borderBottomColor="dark"
+            borderBottomWidth="thin"
+            flex="none"
+          >
+            <Heading level={2}>Experiments</Heading>
+          </View>
           <div
             css={css`
-              overflow: auto;
+              overflow-y: auto;
               height: 100%;
+              padding: var(--ac-global-dimension-static-size-200);
             `}
           >
-            <View overflow="hidden" padding="size-200">
-              <Flex direction="row" gap="size-200" flex="1 1 auto">
-                <View width="50%">
-                  <Card
-                    title="Input"
-                    extra={
-                      <CopyToClipboardButton text={JSON.stringify(input)} />
-                    }
-                  >
-                    <View maxHeight="300px" overflow="auto">
-                      <JSONBlock value={JSON.stringify(input, null, 2)} />
-                    </View>
-                  </Card>
-                </View>
-                <View width="50%">
-                  <Card
-                    title="Reference Output"
-                    extra={
-                      <CopyToClipboardButton
-                        text={JSON.stringify(referenceOutput)}
-                      />
-                    }
-                  >
-                    <View maxHeight="300px" overflow="auto">
-                      <JSONBlock
-                        value={JSON.stringify(referenceOutput, null, 2)}
-                      />
-                    </View>
-                  </Card>
-                </View>
-              </Flex>
-            </View>
-          </div>
-        </Panel>
-        <PanelResizeHandle css={resizeHandleCSS} />
-        <Panel defaultSize={65}>
-          <Flex direction="column" height="100%">
-            <View
-              paddingStart="size-200"
-              paddingEnd="size-200"
-              paddingTop="size-100"
-              paddingBottom="size-100"
-              borderBottomColor="dark"
-              borderBottomWidth="thin"
-              flex="none"
-            >
-              <Heading level={2}>Experiments</Heading>
-            </View>
-            <div
+            <ul
               css={css`
-                overflow-y: auto;
-                height: 100%;
-                padding: var(--ac-global-dimension-static-size-200);
+                display: flex;
+                flex-direction: row;
+                flex-wrap: none;
+                gap: var(--ac-global-dimension-static-size-200);
               `}
             >
-              <ul
-                css={css`
-                  display: flex;
-                  flex-direction: row;
-                  flex-wrap: none;
-                  gap: var(--ac-global-dimension-static-size-200);
-                `}
-              >
-                {experimentIds?.map((experimentId, index) => {
-                  const experiment = experimentsById?.[experimentId];
-                  if (!experiment) {
-                    return null;
-                  }
-                  return (
-                    <li
-                      key={experimentId}
-                      css={css`
-                        // Make them all the same size
-                        flex: 1 1 0px;
-                      `}
-                    >
-                      <ExperimentItem
-                        experiment={experiment}
-                        experimentRuns={
-                          experimentRunsByExperimentId?.[experimentId] || []
-                        }
-                        index={index}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          </Flex>
-        </Panel>
-      </Suspense>
+              {experimentIds?.map((experimentId, index) => {
+                const experiment = experimentsById?.[experimentId];
+                if (!experiment) {
+                  return null;
+                }
+                return (
+                  <li
+                    key={experimentId}
+                    css={css`
+                      // Make them all the same size
+                      flex: 1 1 0px;
+                    `}
+                  >
+                    <ExperimentItem
+                      experiment={experiment}
+                      experimentRuns={
+                        experimentRunsByExperimentId?.[experimentId] || []
+                      }
+                      index={index}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </Flex>
+      </Panel>
     </PanelGroup>
   );
 }

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -904,23 +904,17 @@ function SelectedExampleDialog({
   onPreviousExample: (previousId: string) => void;
 }) {
   return (
-    <Dialog>
+    <Dialog aria-label="Example Details">
       <DialogContent>
         <DialogHeader>
-          <Flex gap="size-50">
+          <Flex gap="size-150">
             <ExampleDetailsPaginator
               currentId={selectedExampleId}
               exampleSequence={exampleSequence}
               onNext={onNextExample}
               onPrevious={onPreviousExample}
             />
-            <DialogTitle
-              css={css`
-                margin-left: var(--ac-global-dimension-static-size-100);
-              `}
-            >
-              {selectedExampleId}
-            </DialogTitle>
+            <DialogTitle>{selectedExampleId}</DialogTitle>
           </Flex>
           <DialogTitleExtra>
             <LinkButton

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -427,8 +427,9 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             if (!currentRow) {
               return null;
             }
+            const nextExampleIndex = currentRow.index + 1;
             const nextExampleId =
-              table.getRowModel().rows[currentRow.index + 1]?.original.id;
+              table.getRowModel().rows[nextExampleIndex]?.original.id;
             if (nextExampleId) {
               setDialog(
                 <SelectedExampleDialog
@@ -441,6 +442,8 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                   selectPreviousExample={() =>
                     selectPreviousExample(nextExampleId)
                   }
+                  canSelectNextExample={nextExampleIndex < tableData.length - 1}
+                  canSelectPreviousExample={nextExampleIndex > 0}
                 />
               );
             }
@@ -452,8 +455,9 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
             if (!currentRow) {
               return null;
             }
+            const previousExampleIndex = currentRow.index - 1;
             const previousExampleId =
-              table.getRowModel().rows[currentRow.index - 1]?.original.id;
+              table.getRowModel().rows[previousExampleIndex]?.original.id;
             if (previousExampleId) {
               setDialog(
                 <SelectedExampleDialog
@@ -466,6 +470,10 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                   selectPreviousExample={() =>
                     selectPreviousExample(previousExampleId)
                   }
+                  canSelectNextExample={
+                    previousExampleIndex < tableData.length - 1
+                  }
+                  canSelectPreviousExample={previousExampleIndex > 0}
                 />
               );
             }
@@ -489,6 +497,8 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
               selectPreviousExample={() =>
                 selectPreviousExample(row.original.id)
               }
+              canSelectNextExample={row.index < tableData.length - 1}
+              canSelectPreviousExample={row.index > 0}
             />
           );
         },
@@ -503,6 +513,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
     experimentInfoById,
     getExperimentColor,
     baseExperiment.datasetVersionId,
+    tableData.length,
   ]);
 
   const columns = useMemo(() => {
@@ -916,6 +927,8 @@ function SelectedExampleDialog({
   compareExperimentIds,
   selectNextExample,
   selectPreviousExample,
+  canSelectNextExample,
+  canSelectPreviousExample,
 }: {
   selectedExampleId: string;
   datasetId: string;
@@ -924,16 +937,22 @@ function SelectedExampleDialog({
   compareExperimentIds: string[];
   selectNextExample: () => void;
   selectPreviousExample: () => void;
+  canSelectNextExample: boolean;
+  canSelectPreviousExample: boolean;
 }) {
   const NEXT_EXAMPLE_HOTKEY = "j";
   const PREVIOUS_EXAMPLE_HOTKEY = "k";
 
   useHotkeys(NEXT_EXAMPLE_HOTKEY, () => {
-    selectNextExample();
+    if (canSelectNextExample) {
+      selectNextExample();
+    }
   });
 
   useHotkeys(PREVIOUS_EXAMPLE_HOTKEY, () => {
-    selectPreviousExample();
+    if (canSelectPreviousExample) {
+      selectPreviousExample();
+    }
   });
   return (
     <Dialog>
@@ -946,7 +965,7 @@ function SelectedExampleDialog({
                 id="next"
                 leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
                 aria-label="Next trace"
-                // isDisabled={!hasNext}
+                isDisabled={!canSelectNextExample}
                 onPress={selectNextExample}
               />
               <Tooltip
@@ -970,7 +989,7 @@ function SelectedExampleDialog({
                 id="previous"
                 leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
                 aria-label="Previous trace"
-                // isDisabled={!hasPrevious}
+                isDisabled={!canSelectPreviousExample}
                 onPress={selectPreviousExample}
               />
               <Tooltip
@@ -1194,6 +1213,8 @@ function ExperimentRunOutputCell({
   annotationSummaries,
   selectNextExample,
   selectPreviousExample,
+  canSelectNextExample,
+  canSelectPreviousExample,
 }: {
   datasetId: string;
   datasetVersionId: string;
@@ -1207,6 +1228,8 @@ function ExperimentRunOutputCell({
   annotationSummaries: readonly AnnotationSummary[];
   selectNextExample: () => void;
   selectPreviousExample: () => void;
+  canSelectNextExample: boolean;
+  canSelectPreviousExample: boolean;
 }) {
   const [selectedRepetitionNumber, setSelectedRepetitionNumber] = useState(1);
 
@@ -1259,6 +1282,8 @@ function ExperimentRunOutputCell({
                 selectedExampleId={tableRow.id}
                 selectNextExample={selectNextExample}
                 selectPreviousExample={selectPreviousExample}
+                canSelectNextExample={canSelectNextExample}
+                canSelectPreviousExample={canSelectPreviousExample}
               />
             );
           }}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -37,6 +37,7 @@ import {
   Icon,
   IconButton,
   Icons,
+  KeyboardToken,
   LinkButton,
   Loading,
   Modal,
@@ -938,7 +939,63 @@ function SelectedExampleDialog({
     <Dialog>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{`Comparing Experiments for Example: ${selectedExampleId}`}</DialogTitle>
+          <Flex gap="size-50">
+            <TooltipTrigger delay={100}>
+              <Button
+                size="S"
+                id="next"
+                leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
+                aria-label="Next trace"
+                // isDisabled={!hasNext}
+                onPress={selectNextExample}
+              />
+              <Tooltip
+                offset={4}
+                css={css`
+                  background-color: var(--ac-global-background-color-dark);
+                  border-color: var(--ac-global-border-color-dark);
+                  border-radius: var(--ac-global-rounding-medium);
+                  padding: var(--ac-global-dimension-static-size-100);
+                `}
+              >
+                <Flex direction="row" gap="size-100" alignItems="center">
+                  <span>Next example</span>
+                  <KeyboardToken>{NEXT_EXAMPLE_HOTKEY}</KeyboardToken>
+                </Flex>
+              </Tooltip>
+            </TooltipTrigger>
+            <TooltipTrigger delay={100}>
+              <Button
+                size="S"
+                id="previous"
+                leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
+                aria-label="Previous trace"
+                // isDisabled={!hasPrevious}
+                onPress={selectPreviousExample}
+              />
+              <Tooltip
+                offset={4}
+                css={css`
+                  background-color: var(--ac-global-background-color-dark);
+                  border-color: var(--ac-global-border-color-dark);
+                  border-radius: var(--ac-global-rounding-medium);
+                  padding: var(--ac-global-dimension-static-size-100);
+                `}
+              >
+                <Flex direction="row" gap="size-100" alignItems="center">
+                  <span>Previous example</span>
+                  <KeyboardToken>{PREVIOUS_EXAMPLE_HOTKEY}</KeyboardToken>
+                </Flex>
+              </Tooltip>
+            </TooltipTrigger>
+            <DialogTitle
+              css={css`
+                margin-left: var(--ac-global-dimension-static-size-100);
+              `}
+            >
+              {selectedExampleId}
+            </DialogTitle>
+          </Flex>
           <DialogTitleExtra>
             <LinkButton
               size="S"

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -644,9 +644,6 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
       <ModalOverlay
         isOpen={!!selectedExampleId}
         onOpenChange={() => {
-          // Clear the URL search params for the span selection
-          searchParams.delete("selectedSpanNodeId");
-          setSearchParams(searchParams, { replace: true });
           setSelectedExampleId(null);
         }}
       >
@@ -679,6 +676,9 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
       <ModalOverlay
         isOpen={!!dialog}
         onOpenChange={() => {
+          // Clear the URL search params for the span selection
+          searchParams.delete("selectedSpanNodeId");
+          setSearchParams(searchParams, { replace: true });
           setDialog(null);
         }}
       >

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -1013,13 +1013,15 @@ function SelectedExampleDialog({
             <DialogCloseButton />
           </DialogTitleExtra>
         </DialogHeader>
-        <ExperimentCompareDetails
-          datasetId={datasetId}
-          datasetExampleId={selectedExampleId}
-          datasetVersionId={datasetVersionId}
-          baseExperimentId={baseExperimentId}
-          compareExperimentIds={compareExperimentIds}
-        />
+        <Suspense>
+          <ExperimentCompareDetails
+            datasetId={datasetId}
+            datasetExampleId={selectedExampleId}
+            datasetVersionId={datasetVersionId}
+            baseExperimentId={baseExperimentId}
+            compareExperimentIds={compareExperimentIds}
+          />
+        </Suspense>
       </DialogContent>
     </Dialog>
   );

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -659,7 +659,16 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
               baseExperimentId={baseExperimentId}
               compareExperimentIds={compareExperimentIds}
               exampleSequence={exampleSequence}
-              onNextExample={(nextId) => setSelectedExampleId(nextId)}
+              onNextExample={(nextId) => {
+                setSelectedExampleId(nextId);
+                if (
+                  nextId === exampleSequence[exampleSequence.length - 1] &&
+                  !isLoadingNext &&
+                  hasNext
+                ) {
+                  loadNext(PAGE_SIZE);
+                }
+              }}
               onPreviousExample={(previousId) =>
                 setSelectedExampleId(previousId)
               }

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -289,7 +289,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
     [data]
   );
 
-  const exampleSequence = useMemo(() => {
+  const exampleIds = useMemo(() => {
     return tableData.map((row) => row.id);
   }, [tableData]);
 
@@ -655,11 +655,11 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
               selectedExampleId={selectedExampleId}
               baseExperimentId={baseExperimentId}
               compareExperimentIds={compareExperimentIds}
-              exampleSequence={exampleSequence}
+              exampleIds={exampleIds}
               onNextExample={(nextId) => {
                 setSelectedExampleId(nextId);
                 if (
-                  nextId === exampleSequence[exampleSequence.length - 1] &&
+                  nextId === exampleIds[exampleIds.length - 1] &&
                   !isLoadingNext &&
                   hasNext
                 ) {
@@ -890,7 +890,7 @@ function SelectedExampleDialog({
   datasetVersionId,
   baseExperimentId,
   compareExperimentIds,
-  exampleSequence,
+  exampleIds,
   onNextExample,
   onPreviousExample,
 }: {
@@ -899,7 +899,7 @@ function SelectedExampleDialog({
   datasetVersionId: string;
   baseExperimentId: string;
   compareExperimentIds: string[];
-  exampleSequence: string[];
+  exampleIds: string[];
   onNextExample: (nextId: string) => void;
   onPreviousExample: (previousId: string) => void;
 }) {
@@ -910,7 +910,7 @@ function SelectedExampleDialog({
           <Flex gap="size-150">
             <ExampleDetailsPaginator
               currentId={selectedExampleId}
-              exampleSequence={exampleSequence}
+              exampleIds={exampleIds}
               onNext={onNextExample}
               onPrevious={onPreviousExample}
             />


### PR DESCRIPTION
Enables paging between examples from the experiment compare details slideover, either with buttons or keyboard shortcuts. The keyboard shortcuts are J + K keys, same as in the trace details slideover.



https://github.com/user-attachments/assets/e0b6bab0-79ef-4d2d-a4a1-43e69b0ef251

