### PR TITLE
feat(experiments): add experiment compare details slideover to list view

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -30,6 +30,8 @@ import { useExperimentColors } from "@phoenix/components/experiment";
 import { borderedTableCSS, tableCSS } from "@phoenix/components/table/styles";
 import {
   RichTooltip,
+  Tooltip,
+  TooltipArrow,
   TooltipTrigger,
   TriggerWrap,
 } from "@phoenix/components/tooltip";
@@ -342,18 +344,24 @@ export function ExperimentCompareListPage() {
           return (
             <Flex direction="row" gap="size-100" alignItems="center">
               <TextOverflow>{exampleId}</TextOverflow>
-              <IconButton
-                size="S"
-                aria-label="View experiment run details"
-                onPress={() => {
-                  setSelectedExampleId(exampleId);
-                }}
-                css={css`
-                  flex: none;
-                `}
-              >
-                <Icon svg={<Icons.ExpandOutline />} />
-              </IconButton>
+              <TooltipTrigger>
+                <IconButton
+                  size="S"
+                  aria-label="View experiment run details"
+                  onPress={() => {
+                    setSelectedExampleId(exampleId);
+                  }}
+                  css={css`
+                    flex: none;
+                  `}
+                >
+                  <Icon svg={<Icons.ExpandOutline />} />
+                </IconButton>
+                <Tooltip>
+                  <TooltipArrow />
+                  view experiment runs
+                </Tooltip>
+              </TooltipTrigger>
             </Flex>
           );
         },

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -949,9 +949,9 @@ export function ExperimentCompareListPage() {
           {selectedExampleId && datasetId && (
             <ExperimentCompareDetailsDialog
               datasetId={datasetId}
-              datasetVersionId={baseExperiment.datasetVersionId}
+              datasetVersionId={baseExperiment?.datasetVersionId}
               selectedExampleId={selectedExampleId}
-              baseExperimentId={baseExperiment.id}
+              baseExperimentId={baseExperiment?.id}
               compareExperimentIds={compareExperimentIds}
             />
           )}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -36,7 +36,6 @@ import {
   Icon,
   IconButton,
   Icons,
-  LinkButton,
   Loading,
   Modal,
   ModalOverlay,
@@ -70,6 +69,7 @@ import { TableEmpty } from "@phoenix/components/table/TableEmpty";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { ExampleDetailsDialog } from "@phoenix/pages/example/ExampleDetailsDialog";
+import { ExperimentCompareDetailsDialog } from "@phoenix/pages/experiment/ExperimentCompareDetailsDialog";
 import { ExperimentNameWithColorSwatch } from "@phoenix/pages/experiment/ExperimentNameWithColorSwatch";
 import { ExperimentRunAnnotationFiltersList } from "@phoenix/pages/experiment/ExperimentRunAnnotationFiltersList";
 import { floatFormatter } from "@phoenix/utils/numberFormatUtils";
@@ -82,9 +82,7 @@ import type {
   ExperimentCompareTable_comparisons$key,
 } from "./__generated__/ExperimentCompareTable_comparisons.graphql";
 import type { ExperimentCompareTableQuery } from "./__generated__/ExperimentCompareTableQuery.graphql";
-import { ExampleDetailsPaginator } from "./ExampleDetailsPaginator";
 import { ExperimentAnnotationButton } from "./ExperimentAnnotationButton";
-import { ExperimentCompareDetails } from "./ExperimentCompareDetails";
 import { ExperimentRepeatedRunGroupMetadata } from "./ExperimentRepeatedRunGroupMetadata";
 import { ExperimentRunFilterConditionField } from "./ExperimentRunFilterConditionField";
 
@@ -649,7 +647,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
       >
         <Modal variant="slideover" size="fullscreen">
           {selectedExampleId && (
-            <SelectedExampleDialog
+            <ExperimentCompareDetailsDialog
               datasetId={datasetId}
               datasetVersionId={baseExperiment.datasetVersionId}
               selectedExampleId={selectedExampleId}
@@ -881,62 +879,6 @@ function LargeTextWrap({ children }: { children: ReactNode }) {
     >
       {children}
     </div>
-  );
-}
-
-function SelectedExampleDialog({
-  selectedExampleId,
-  datasetId,
-  datasetVersionId,
-  baseExperimentId,
-  compareExperimentIds,
-  exampleIds,
-  onNextExample,
-  onPreviousExample,
-}: {
-  selectedExampleId: string;
-  datasetId: string;
-  datasetVersionId: string;
-  baseExperimentId: string;
-  compareExperimentIds: string[];
-  exampleIds: string[];
-  onNextExample: (nextId: string) => void;
-  onPreviousExample: (previousId: string) => void;
-}) {
-  return (
-    <Dialog aria-label="Example Details">
-      <DialogContent>
-        <DialogHeader>
-          <Flex gap="size-150">
-            <ExampleDetailsPaginator
-              currentId={selectedExampleId}
-              exampleIds={exampleIds}
-              onNext={onNextExample}
-              onPrevious={onPreviousExample}
-            />
-            <DialogTitle>{selectedExampleId}</DialogTitle>
-          </Flex>
-          <DialogTitleExtra>
-            <LinkButton
-              size="S"
-              to={`/datasets/${datasetId}/examples/${selectedExampleId}`}
-            >
-              View Example
-            </LinkButton>
-            <DialogCloseButton />
-          </DialogTitleExtra>
-        </DialogHeader>
-        <Suspense>
-          <ExperimentCompareDetails
-            datasetId={datasetId}
-            datasetExampleId={selectedExampleId}
-            datasetVersionId={datasetVersionId}
-            baseExperimentId={baseExperimentId}
-            compareExperimentIds={compareExperimentIds}
-          />
-        </Suspense>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/app/src/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql.ts
@@ -1,0 +1,462 @@
+/**
+ * @generated SignedSource<<992f41d5e051d799f3a6dc6e0642235d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ExperimentCompareDetailsDialogQuery$variables = {
+  datasetExampleId: string;
+  datasetId: string;
+  datasetVersionId: string;
+  experimentIds: ReadonlyArray<string>;
+};
+export type ExperimentCompareDetailsDialogQuery$data = {
+  readonly dataset: {
+    readonly experiments?: {
+      readonly edges: ReadonlyArray<{
+        readonly experiment: {
+          readonly id: string;
+          readonly name: string;
+        };
+      }>;
+    };
+  };
+  readonly example: {
+    readonly experimentRuns?: {
+      readonly edges: ReadonlyArray<{
+        readonly run: {
+          readonly annotations: {
+            readonly edges: ReadonlyArray<{
+              readonly annotation: {
+                readonly id: string;
+                readonly label: string | null;
+                readonly name: string;
+                readonly score: number | null;
+              };
+            }>;
+          };
+          readonly costSummary: {
+            readonly total: {
+              readonly cost: number | null;
+              readonly tokens: number | null;
+            };
+          };
+          readonly error: string | null;
+          readonly experimentId: string;
+          readonly id: string;
+          readonly latencyMs: number;
+          readonly output: any | null;
+        };
+      }>;
+    };
+    readonly revision?: {
+      readonly input: any;
+      readonly referenceOutput: any;
+    };
+  };
+};
+export type ExperimentCompareDetailsDialogQuery = {
+  response: ExperimentCompareDetailsDialogQuery$data;
+  variables: ExperimentCompareDetailsDialogQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "datasetExampleId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "datasetId"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "datasetVersionId"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "experimentIds"
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "datasetExampleId"
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "datasetVersionId",
+          "variableName": "datasetVersionId"
+        }
+      ],
+      "concreteType": "DatasetExampleRevision",
+      "kind": "LinkedField",
+      "name": "revision",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "input",
+          "storageKey": null
+        },
+        {
+          "alias": "referenceOutput",
+          "args": null,
+          "kind": "ScalarField",
+          "name": "output",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "experimentIds",
+          "variableName": "experimentIds"
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 120
+        }
+      ],
+      "concreteType": "ExperimentRunConnection",
+      "kind": "LinkedField",
+      "name": "experimentRuns",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ExperimentRunEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "run",
+              "args": null,
+              "concreteType": "ExperimentRun",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v5/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "latencyMs",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "experimentId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "output",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "error",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SpanCostSummary",
+                  "kind": "LinkedField",
+                  "name": "costSummary",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CostBreakdown",
+                      "kind": "LinkedField",
+                      "name": "total",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "cost",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "tokens",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ExperimentRunAnnotationConnection",
+                  "kind": "LinkedField",
+                  "name": "annotations",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "ExperimentRunAnnotationEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": "annotation",
+                          "args": null,
+                          "concreteType": "ExperimentRunAnnotation",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            (v5/*: any*/),
+                            (v6/*: any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "label",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "score",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "DatasetExample",
+  "abstractKey": null
+},
+v8 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "datasetId"
+  }
+],
+v9 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "filterIds",
+          "variableName": "experimentIds"
+        }
+      ],
+      "concreteType": "ExperimentConnection",
+      "kind": "LinkedField",
+      "name": "experiments",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ExperimentEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": "experiment",
+              "args": null,
+              "concreteType": "Experiment",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v5/*: any*/),
+                (v6/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Dataset",
+  "abstractKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ExperimentCompareDetailsDialogQuery",
+    "selections": [
+      {
+        "alias": "example",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v7/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "dataset",
+        "args": (v8/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v9/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ExperimentCompareDetailsDialogQuery",
+    "selections": [
+      {
+        "alias": "example",
+        "args": (v4/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v10/*: any*/),
+          (v7/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "dataset",
+        "args": (v8/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v10/*: any*/),
+          (v9/*: any*/),
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8d153bdb5091007864545cda77e2c21b",
+    "id": null,
+    "metadata": {},
+    "name": "ExperimentCompareDetailsDialogQuery",
+    "operationKind": "query",
+    "text": "query ExperimentCompareDetailsDialogQuery(\n  $datasetId: ID!\n  $datasetExampleId: ID!\n  $datasetVersionId: ID!\n  $experimentIds: [ID!]!\n) {\n  example: node(id: $datasetExampleId) {\n    __typename\n    ... on DatasetExample {\n      revision(datasetVersionId: $datasetVersionId) {\n        input\n        referenceOutput: output\n      }\n      experimentRuns(experimentIds: $experimentIds, first: 120) {\n        edges {\n          run: node {\n            id\n            latencyMs\n            experimentId\n            output\n            error\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  label\n                  score\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ed726080d362170763a9a9c1128be008";
+
+export default node;

--- a/app/src/pages/experiment/__generated__/ExperimentCompareListPage_aggregateData.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareListPage_aggregateData.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c7cb065ff6de092e21c747221cecda8>>
+ * @generated SignedSource<<d9d70392c9f2d8f47e45c1cca4c7cdb9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,11 +31,13 @@ export type ExperimentCompareListPage_aggregateData$data = {
               readonly tokens: number | null;
             };
           };
+          readonly datasetVersionId: string;
           readonly id: string;
           readonly runCount: number;
         };
       }>;
     };
+    readonly id?: string;
   };
   readonly " $fragmentType": "ExperimentCompareListPage_aggregateData";
 };
@@ -46,6 +48,13 @@ export type ExperimentCompareListPage_aggregateData$key = {
 
 const node: ReaderFragment = (function(){
 var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -86,6 +95,7 @@ return {
         {
           "kind": "InlineFragment",
           "selections": [
+            (v0/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -94,7 +104,7 @@ return {
               "name": "experimentAnnotationSummaries",
               "plural": true,
               "selections": [
-                (v0/*: any*/),
+                (v1/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -142,11 +152,12 @@ return {
                       "name": "node",
                       "plural": false,
                       "selections": [
+                        (v0/*: any*/),
                         {
                           "alias": null,
                           "args": null,
                           "kind": "ScalarField",
-                          "name": "id",
+                          "name": "datasetVersionId",
                           "storageKey": null
                         },
                         {
@@ -207,7 +218,7 @@ return {
                           "name": "annotationSummaries",
                           "plural": true,
                           "selections": [
-                            (v0/*: any*/),
+                            (v1/*: any*/),
                             {
                               "alias": null,
                               "args": null,
@@ -240,6 +251,6 @@ return {
 };
 })();
 
-(node as any).hash = "f1246fb93cb4a81bcfa7df072d69bea7";
+(node as any).hash = "fc91dd988055b0f691ffd85326f71915";
 
 export default node;

--- a/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/experimentCompareLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9afa606a7f2e9be611f7c89a31f5ab26>>
+ * @generated SignedSource<<7847ca1675813f411594db91c20f289a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -338,34 +338,41 @@ v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "averageRunLatencyMs",
+  "name": "datasetVersionId",
   "storageKey": null
 },
 v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "averageRunLatencyMs",
+  "storageKey": null
+},
+v42 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "runCount",
   "storageKey": null
 },
-v42 = [
+v43 = [
   (v22/*: any*/)
 ],
-v43 = {
+v44 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startTime",
   "storageKey": null
 },
-v44 = {
+v45 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endTime",
   "storageKey": null
 },
-v45 = {
+v46 = {
   "alias": null,
   "args": null,
   "concreteType": "ExperimentRunAnnotationConnection",
@@ -402,7 +409,7 @@ v45 = {
   ],
   "storageKey": null
 },
-v46 = {
+v47 = {
   "alias": null,
   "args": null,
   "concreteType": "ExperimentAnnotationSummary",
@@ -412,7 +419,7 @@ v46 = {
   "selections": (v31/*: any*/),
   "storageKey": null
 },
-v47 = [
+v48 = [
   {
     "alias": null,
     "args": null,
@@ -911,13 +918,7 @@ return {
                                 "name": "metadata",
                                 "storageKey": null
                               },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "datasetVersionId",
-                                "storageKey": null
-                              },
+                              (v40/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -954,8 +955,8 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v40/*: any*/),
                               (v41/*: any*/),
+                              (v42/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1001,7 +1002,7 @@ return {
                 "selections": [
                   {
                     "alias": null,
-                    "args": (v42/*: any*/),
+                    "args": (v43/*: any*/),
                     "concreteType": "ExperimentRunConnection",
                     "kind": "LinkedField",
                     "name": "runs",
@@ -1025,10 +1026,10 @@ return {
                             "selections": [
                               (v17/*: any*/),
                               (v33/*: any*/),
-                              (v43/*: any*/),
                               (v44/*: any*/),
-                              (v29/*: any*/),
                               (v45/*: any*/),
+                              (v29/*: any*/),
+                              (v46/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1064,10 +1065,10 @@ return {
                                         "selections": [
                                           (v17/*: any*/),
                                           (v33/*: any*/),
-                                          (v43/*: any*/),
                                           (v44/*: any*/),
+                                          (v45/*: any*/),
                                           (v29/*: any*/),
-                                          (v45/*: any*/)
+                                          (v46/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -1101,7 +1102,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v42/*: any*/),
+                    "args": (v43/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "ExperimentCompareListPage_runs",
@@ -1178,8 +1179,9 @@ return {
                             "selections": [
                               (v40/*: any*/),
                               (v41/*: any*/),
+                              (v42/*: any*/),
                               (v29/*: any*/),
-                              (v46/*: any*/)
+                              (v47/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1238,7 +1240,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v40/*: any*/),
+                              (v41/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1271,7 +1273,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v46/*: any*/)
+                              (v47/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1308,7 +1310,7 @@ return {
                     "kind": "LinkedField",
                     "name": "latency",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1318,7 +1320,7 @@ return {
                     "kind": "LinkedField",
                     "name": "totalTokenCount",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1328,7 +1330,7 @@ return {
                     "kind": "LinkedField",
                     "name": "promptTokenCount",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1338,7 +1340,7 @@ return {
                     "kind": "LinkedField",
                     "name": "completionTokenCount",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1348,7 +1350,7 @@ return {
                     "kind": "LinkedField",
                     "name": "totalCost",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1358,7 +1360,7 @@ return {
                     "kind": "LinkedField",
                     "name": "promptCost",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1368,7 +1370,7 @@ return {
                     "kind": "LinkedField",
                     "name": "completionCost",
                     "plural": false,
-                    "selections": (v47/*: any*/),
+                    "selections": (v48/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1381,12 +1383,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bca4b8d44d0c820ca5214d2618c30f67",
+    "cacheID": "c3ef638bd82587421aaf10956f43edc0",
     "id": null,
     "metadata": {},
     "name": "experimentCompareLoaderQuery",
     "operationKind": "query",
-    "text": "query experimentCompareLoaderQuery(\n  $datasetId: ID!\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $experimentIds: [ID!]!\n  $hasBaseExperiment: Boolean!\n  $hasCompareExperiments: Boolean!\n  $includeGridView: Boolean!\n  $includeListView: Boolean!\n  $includeMetricsView: Boolean!\n) {\n  ...ExperimentMultiSelector__data_4t6es6\n  ...ExperimentComparePage_selectedCompareExperiments_3xL6z4\n  ...ExperimentCompareTable_comparisons_4mFQqw @include(if: $includeGridView)\n  ...ExperimentCompareListPage_comparisons_2bWqNi @include(if: $includeListView)\n  ...ExperimentCompareListPage_aggregateData_3xL6z4 @include(if: $includeListView)\n  ...ExperimentCompareMetricsPage_experiments_4DSN89 @include(if: $includeMetricsView)\n}\n\nfragment ExperimentCompareListPage_aggregateData_3xL6z4 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experimentAnnotationSummaries {\n        annotationName\n        minScore\n        maxScore\n      }\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            averageRunLatencyMs\n            runCount\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareListPage_comparisons_2bWqNi on Query {\n  experiment: node(id: $baseExperimentId) {\n    __typename\n    ... on Experiment {\n      id\n      runs(first: 50) {\n        edges {\n          run: node {\n            id\n            output\n            startTime\n            endTime\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  name\n                  score\n                  label\n                  id\n                }\n              }\n            }\n            example {\n              id\n              revision {\n                input\n                referenceOutput: output\n              }\n              experimentRepeatedRunGroups(experimentIds: $compareExperimentIds) {\n                experimentId\n                runs {\n                  id\n                  output\n                  startTime\n                  endTime\n                  costSummary {\n                    total {\n                      tokens\n                      cost\n                    }\n                  }\n                  annotations {\n                    edges {\n                      annotation: node {\n                        name\n                        score\n                        label\n                        id\n                      }\n                    }\n                  }\n                }\n                id\n              }\n            }\n          }\n          cursor\n          node {\n            __typename\n            id\n          }\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareMetricsPage_experiments_4DSN89 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            averageRunLatencyMs\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n              prompt {\n                tokens\n                cost\n              }\n              completion {\n                tokens\n                cost\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  experimentRunMetricComparisons(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) @include(if: $hasCompareExperiments) {\n    latency {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    totalTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    promptTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    completionTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    totalCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    promptCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    completionCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n  }\n}\n\nfragment ExperimentComparePage_selectedCompareExperiments_3xL6z4 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            sequenceNumber\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareTable_comparisons_4mFQqw on Query {\n  compareExperiments(first: 50, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        repeatedRunGroups {\n          ...ExperimentRepeatedRunGroupMetadataFragment\n          annotationSummaries {\n            annotationName\n            meanScore\n          }\n          experimentId\n          runs {\n            id\n            latencyMs\n            repetitionNumber\n            output\n            error\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n          id\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            datasetVersionId\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n            repetitionCount\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentMultiSelector__data_4t6es6 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n      allExperiments: experiments {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            createdAt\n          }\n        }\n      }\n    }\n  }\n  baseExperiment: node(id: $baseExperimentId) @include(if: $hasBaseExperiment) {\n    __typename\n    ... on Experiment {\n      id\n      name\n    }\n    id\n  }\n}\n\nfragment ExperimentRepeatedRunGroupMetadataFragment on ExperimentRepeatedRunGroup {\n  id\n  averageLatencyMs\n  costSummary {\n    total {\n      tokens\n      cost\n    }\n  }\n}\n"
+    "text": "query experimentCompareLoaderQuery(\n  $datasetId: ID!\n  $baseExperimentId: ID!\n  $compareExperimentIds: [ID!]!\n  $experimentIds: [ID!]!\n  $hasBaseExperiment: Boolean!\n  $hasCompareExperiments: Boolean!\n  $includeGridView: Boolean!\n  $includeListView: Boolean!\n  $includeMetricsView: Boolean!\n) {\n  ...ExperimentMultiSelector__data_4t6es6\n  ...ExperimentComparePage_selectedCompareExperiments_3xL6z4\n  ...ExperimentCompareTable_comparisons_4mFQqw @include(if: $includeGridView)\n  ...ExperimentCompareListPage_comparisons_2bWqNi @include(if: $includeListView)\n  ...ExperimentCompareListPage_aggregateData_3xL6z4 @include(if: $includeListView)\n  ...ExperimentCompareMetricsPage_experiments_4DSN89 @include(if: $includeMetricsView)\n}\n\nfragment ExperimentCompareListPage_aggregateData_3xL6z4 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      id\n      experimentAnnotationSummaries {\n        annotationName\n        minScore\n        maxScore\n      }\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            datasetVersionId\n            averageRunLatencyMs\n            runCount\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareListPage_comparisons_2bWqNi on Query {\n  experiment: node(id: $baseExperimentId) {\n    __typename\n    ... on Experiment {\n      id\n      runs(first: 50) {\n        edges {\n          run: node {\n            id\n            output\n            startTime\n            endTime\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  name\n                  score\n                  label\n                  id\n                }\n              }\n            }\n            example {\n              id\n              revision {\n                input\n                referenceOutput: output\n              }\n              experimentRepeatedRunGroups(experimentIds: $compareExperimentIds) {\n                experimentId\n                runs {\n                  id\n                  output\n                  startTime\n                  endTime\n                  costSummary {\n                    total {\n                      tokens\n                      cost\n                    }\n                  }\n                  annotations {\n                    edges {\n                      annotation: node {\n                        name\n                        score\n                        label\n                        id\n                      }\n                    }\n                  }\n                }\n                id\n              }\n            }\n          }\n          cursor\n          node {\n            __typename\n            id\n          }\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareMetricsPage_experiments_4DSN89 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            averageRunLatencyMs\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n              prompt {\n                tokens\n                cost\n              }\n              completion {\n                tokens\n                cost\n              }\n            }\n            annotationSummaries {\n              annotationName\n              meanScore\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  experimentRunMetricComparisons(baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) @include(if: $hasCompareExperiments) {\n    latency {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    totalTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    promptTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    completionTokenCount {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    totalCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    promptCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n    completionCost {\n      numRunsImproved\n      numRunsRegressed\n      numRunsEqual\n    }\n  }\n}\n\nfragment ExperimentComparePage_selectedCompareExperiments_3xL6z4 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            sequenceNumber\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentCompareTable_comparisons_4mFQqw on Query {\n  compareExperiments(first: 50, baseExperimentId: $baseExperimentId, compareExperimentIds: $compareExperimentIds) {\n    edges {\n      comparison: node {\n        example {\n          id\n          revision {\n            input\n            referenceOutput: output\n          }\n        }\n        repeatedRunGroups {\n          ...ExperimentRepeatedRunGroupMetadataFragment\n          annotationSummaries {\n            annotationName\n            meanScore\n          }\n          experimentId\n          runs {\n            id\n            latencyMs\n            repetitionNumber\n            output\n            error\n            trace {\n              traceId\n              projectId\n              id\n            }\n            costSummary {\n              total {\n                tokens\n                cost\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  score\n                  label\n                  annotatorKind\n                  explanation\n                  trace {\n                    traceId\n                    projectId\n                    id\n                  }\n                }\n              }\n            }\n          }\n          id\n        }\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            metadata\n            datasetVersionId\n            project {\n              id\n            }\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            averageRunLatencyMs\n            runCount\n            repetitionCount\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment ExperimentMultiSelector__data_4t6es6 on Query {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      id\n      name\n      allExperiments: experiments {\n        edges {\n          experiment: node {\n            id\n            name\n            sequenceNumber\n            createdAt\n          }\n        }\n      }\n    }\n  }\n  baseExperiment: node(id: $baseExperimentId) @include(if: $hasBaseExperiment) {\n    __typename\n    ... on Experiment {\n      id\n      name\n    }\n    id\n  }\n}\n\nfragment ExperimentRepeatedRunGroupMetadataFragment on ExperimentRepeatedRunGroup {\n  id\n  averageLatencyMs\n  costSummary {\n    total {\n      tokens\n      cost\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This adds the experiment compare details slideover to the experiments list view, so that as we continue working on it, we can make sure it works in both spots.

This also makes pagination optional in the slideover and disables pagination when opened from the list view. This is because as currently implemented, pagination relies on a sequence of unique example IDs, which we can't guarantee anymore from the list view since we may have multiple rows for the same example ID if it has multiple repetitions. Rather than put too much thought into solving it now, it seemed better to just disable it and revisit when we have a better idea of how we want pagination to work on the list page.



https://github.com/user-attachments/assets/b7ab09ce-2fc6-4e55-8685-7c393e145505



