### PR TITLE
Fix github issue 9541

### DIFF
--- a/js/packages/phoenix-client/src/utils/urlUtils.ts
+++ b/js/packages/phoenix-client/src/utils/urlUtils.ts
@@ -8,7 +8,9 @@
  * @returns The base URL for the Phoenix web UI
  */
 function getWebBaseUrl(baseUrl: string): string {
-  return new URL(baseUrl).toString();
+  const url = new URL(baseUrl).toString();
+  // Remove trailing slash to avoid double slashes when concatenating paths
+  return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
 /**
@@ -28,7 +30,7 @@ export function getExperimentUrl({
   datasetId: string;
   experimentId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/compare?experimentId=${experimentId}`;
+  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/compare?experimentId=${experimentId}`;
 }
 
 /**
@@ -45,7 +47,7 @@ export function getDatasetExperimentsUrl({
   baseUrl: string;
   datasetId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/experiments`;
+  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/experiments`;
 }
 
 /**
@@ -62,5 +64,5 @@ export function getDatasetUrl({
   baseUrl: string;
   datasetId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/examples`;
+  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/examples`;
 }

--- a/js/packages/phoenix-client/src/utils/urlUtils.ts
+++ b/js/packages/phoenix-client/src/utils/urlUtils.ts
@@ -8,9 +8,7 @@
  * @returns The base URL for the Phoenix web UI
  */
 function getWebBaseUrl(baseUrl: string): string {
-  const url = new URL(baseUrl).toString();
-  // Remove trailing slash to avoid double slashes when concatenating paths
-  return url.endsWith('/') ? url.slice(0, -1) : url;
+  return new URL(baseUrl).toString();
 }
 
 /**
@@ -30,7 +28,7 @@ export function getExperimentUrl({
   datasetId: string;
   experimentId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/compare?experimentId=${experimentId}`;
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/compare?experimentId=${experimentId}`;
 }
 
 /**
@@ -47,7 +45,7 @@ export function getDatasetExperimentsUrl({
   baseUrl: string;
   datasetId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/experiments`;
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/experiments`;
 }
 
 /**
@@ -64,5 +62,5 @@ export function getDatasetUrl({
   baseUrl: string;
   datasetId: string;
 }): string {
-  return `${getWebBaseUrl(baseUrl)}/datasets/${datasetId}/examples`;
+  return `${getWebBaseUrl(baseUrl)}datasets/${datasetId}/examples`;
 }

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -53,6 +53,7 @@ from phoenix.client.resources.experiments.types import (
 )
 from phoenix.client.utils.executors import AsyncExecutor, SyncExecutor
 from phoenix.client.utils.rate_limiters import RateLimiter
+from phoenix.client.utils.url_utils import BaseURL
 
 logger = logging.getLogger(__name__)
 
@@ -504,14 +505,14 @@ class Experiments:
 
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
-        self._base_url = str(client.base_url).rstrip('/')
+        self._base_url = BaseURL(str(client.base_url))
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._base_url}/datasets/{dataset_id}/experiments"
+        return self._base_url.join("datasets", dataset_id, "experiments")
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return f"{self._base_url.join('datasets', dataset_id, 'compare')}?experimentId={experiment_id}"
 
     def run_experiment(
         self,
@@ -1536,14 +1537,14 @@ class AsyncExperiments:
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
-        self._base_url = str(client.base_url).rstrip('/')
+        self._base_url = BaseURL(str(client.base_url))
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._base_url}/datasets/{dataset_id}/experiments"
+        return self._base_url.join("datasets", dataset_id, "experiments")
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return f"{self._base_url.join('datasets', dataset_id, 'compare')}?experimentId={experiment_id}"
 
     async def run_experiment(
         self,

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -504,16 +504,14 @@ class Experiments:
 
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
-        self._base_url = str(client.base_url)
+        self._base_url = str(client.base_url).rstrip('/')
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        base_url = str(self._client.base_url).rstrip('/')
-        return f"{base_url}/datasets/{dataset_id}/experiments"
+        return f"{self._base_url}/datasets/{dataset_id}/experiments"
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        base_url = str(self._client.base_url).rstrip('/')
-        return f"{base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return f"{self._base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
 
     def run_experiment(
         self,
@@ -1538,16 +1536,14 @@ class AsyncExperiments:
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
-        self._base_url = str(client.base_url)
+        self._base_url = str(client.base_url).rstrip('/')
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        base_url = str(self._client.base_url).rstrip('/')
-        return f"{base_url}/datasets/{dataset_id}/experiments"
+        return f"{self._base_url}/datasets/{dataset_id}/experiments"
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        base_url = str(self._client.base_url).rstrip('/')
-        return f"{base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return f"{self._base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
 
     async def run_experiment(
         self,

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -508,10 +508,12 @@ class Experiments:
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/experiments"
+        base_url = str(self._client.base_url).rstrip('/')
+        return f"{base_url}/datasets/{dataset_id}/experiments"
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        base_url = str(self._client.base_url).rstrip('/')
+        return f"{base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
 
     def run_experiment(
         self,
@@ -1540,10 +1542,12 @@ class AsyncExperiments:
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/experiments"
+        base_url = str(self._client.base_url).rstrip('/')
+        return f"{base_url}/datasets/{dataset_id}/experiments"
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        base_url = str(self._client.base_url).rstrip('/')
+        return f"{base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
 
     async def run_experiment(
         self,

--- a/packages/phoenix-client/src/phoenix/client/utils/url_utils.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/url_utils.py
@@ -1,0 +1,81 @@
+"""URL utilities for constructing clean, consistent URLs."""
+
+from urllib.parse import urljoin, urlparse
+
+
+class BaseURL:
+    """
+    A utility class for handling base URLs with consistent formatting.
+    
+    Ensures that base URLs are normalized (no trailing slash) and provides
+    methods for constructing clean URLs by joining paths.
+    """
+    
+    def __init__(self, base_url: str) -> None:
+        """
+        Initialize with a base URL, automatically normalizing it.
+        
+        Args:
+            base_url: The base URL string to normalize
+        """
+        self._normalized_url = self._normalize_base_url(base_url)
+    
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
+        """
+        Normalize a base URL by removing trailing slashes.
+        
+        Args:
+            url: The URL string to normalize
+            
+        Returns:
+            The normalized URL without trailing slashes
+            
+        Examples:
+            >>> BaseURL._normalize_base_url("http://localhost:8000/")
+            "http://localhost:8000"
+            >>> BaseURL._normalize_base_url("https://api.example.com/v1/")
+            "https://api.example.com/v1"
+        """
+        return str(url).rstrip('/')
+    
+    def join(self, *path_segments: str) -> str:
+        """
+        Join path segments to the base URL, ensuring proper URL formatting.
+        
+        Args:
+            *path_segments: Path segments to join to the base URL
+            
+        Returns:
+            A properly formatted URL with the path segments joined
+            
+        Examples:
+            >>> base = BaseURL("http://localhost:8000")
+            >>> base.join("datasets", "123", "experiments")
+            "http://localhost:8000/datasets/123/experiments"
+            >>> base.join("/datasets/", "/123/", "/experiments/")
+            "http://localhost:8000/datasets/123/experiments"
+        """
+        if not path_segments:
+            return self._normalized_url
+        
+        # Clean up path segments by removing leading/trailing slashes
+        cleaned_segments = []
+        for segment in path_segments:
+            if segment:
+                cleaned_segments.append(str(segment).strip('/'))
+        
+        if not cleaned_segments:
+            return self._normalized_url
+        
+        # Join with forward slashes
+        path = '/' + '/'.join(cleaned_segments)
+        return self._normalized_url + path
+    
+    def __str__(self) -> str:
+        """Return the normalized base URL as a string."""
+        return self._normalized_url
+    
+    def __repr__(self) -> str:
+        """Return a string representation of the BaseURL object."""
+        return f"BaseURL('{self._normalized_url}')"

--- a/packages/phoenix-client/tests/client/utils/test_url_utils.py
+++ b/packages/phoenix-client/tests/client/utils/test_url_utils.py
@@ -1,0 +1,175 @@
+"""Tests for URL utilities."""
+
+import pytest
+
+from phoenix.client.utils.url_utils import BaseURL
+
+
+class TestBaseURL:
+    """Test suite for BaseURL utility class."""
+
+    def test_normalize_base_url_removes_trailing_slash(self):
+        """Test that trailing slashes are removed during normalization."""
+        test_cases = [
+            ("http://localhost:8000/", "http://localhost:8000"),
+            ("https://example.com/", "https://example.com"),
+            ("https://api.example.com/v1/", "https://api.example.com/v1"),
+            ("http://localhost:8000/api/", "http://localhost:8000/api"),
+        ]
+        
+        for input_url, expected in test_cases:
+            assert BaseURL._normalize_base_url(input_url) == expected
+
+    def test_normalize_base_url_preserves_no_trailing_slash(self):
+        """Test that URLs without trailing slashes are preserved."""
+        test_cases = [
+            "http://localhost:8000",
+            "https://example.com",
+            "https://api.example.com/v1",
+            "http://localhost:8000/api",
+        ]
+        
+        for url in test_cases:
+            assert BaseURL._normalize_base_url(url) == url
+
+    def test_init_normalizes_base_url(self):
+        """Test that __init__ properly normalizes the base URL."""
+        base_url = BaseURL("http://localhost:8000/")
+        assert str(base_url) == "http://localhost:8000"
+
+    def test_join_single_path_segment(self):
+        """Test joining a single path segment."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join("datasets")
+        assert result == "http://localhost:8000/datasets"
+
+    def test_join_multiple_path_segments(self):
+        """Test joining multiple path segments."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join("datasets", "123", "experiments")
+        assert result == "http://localhost:8000/datasets/123/experiments"
+
+    def test_join_with_leading_trailing_slashes(self):
+        """Test that join handles path segments with leading/trailing slashes."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join("/datasets/", "/123/", "/experiments/")
+        assert result == "http://localhost:8000/datasets/123/experiments"
+
+    def test_join_with_empty_segments(self):
+        """Test that join handles empty segments gracefully."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join("datasets", "", "123", "", "experiments")
+        assert result == "http://localhost:8000/datasets/123/experiments"
+
+    def test_join_with_no_segments(self):
+        """Test that join with no segments returns the base URL."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join()
+        assert result == "http://localhost:8000"
+
+    def test_join_with_query_parameters(self):
+        """Test joining path segments and then adding query parameters manually."""
+        base_url = BaseURL("http://localhost:8000")
+        result = base_url.join("datasets", "123", "compare")
+        result_with_query = f"{result}?experimentId=456"
+        assert result_with_query == "http://localhost:8000/datasets/123/compare?experimentId=456"
+
+    def test_str_representation(self):
+        """Test string representation of BaseURL."""
+        base_url = BaseURL("http://localhost:8000/")
+        assert str(base_url) == "http://localhost:8000"
+
+    def test_repr_representation(self):
+        """Test repr representation of BaseURL."""
+        base_url = BaseURL("http://localhost:8000/")
+        assert repr(base_url) == "BaseURL('http://localhost:8000')"
+
+    @pytest.mark.parametrize("input_url,expected_normalized", [
+        ("http://localhost:8000", "http://localhost:8000"),
+        ("http://localhost:8000/", "http://localhost:8000"),
+        ("https://example.com", "https://example.com"),
+        ("https://example.com/", "https://example.com"),
+        ("https://api.example.com/v1", "https://api.example.com/v1"),
+        ("https://api.example.com/v1/", "https://api.example.com/v1"),
+        ("http://localhost:8000/api", "http://localhost:8000/api"),
+        ("http://localhost:8000/api/", "http://localhost:8000/api"),
+    ])
+    def test_various_base_url_formats(self, input_url, expected_normalized):
+        """Test BaseURL with various input formats."""
+        base_url = BaseURL(input_url)
+        assert str(base_url) == expected_normalized
+
+    def test_experiment_url_construction_scenarios(self):
+        """Test realistic experiment URL construction scenarios."""
+        test_cases = [
+            {
+                "base_url": "http://localhost:8000",
+                "dataset_id": "test-dataset",
+                "experiment_id": "test-experiment",
+                "expected_experiments_url": "http://localhost:8000/datasets/test-dataset/experiments",
+                "expected_experiment_url": "http://localhost:8000/datasets/test-dataset/compare?experimentId=test-experiment",
+            },
+            {
+                "base_url": "http://localhost:8000/",
+                "dataset_id": "test-dataset",
+                "experiment_id": "test-experiment",
+                "expected_experiments_url": "http://localhost:8000/datasets/test-dataset/experiments",
+                "expected_experiment_url": "http://localhost:8000/datasets/test-dataset/compare?experimentId=test-experiment",
+            },
+            {
+                "base_url": "https://api.example.com/phoenix",
+                "dataset_id": "my-dataset",
+                "experiment_id": "exp-123",
+                "expected_experiments_url": "https://api.example.com/phoenix/datasets/my-dataset/experiments",
+                "expected_experiment_url": "https://api.example.com/phoenix/datasets/my-dataset/compare?experimentId=exp-123",
+            },
+            {
+                "base_url": "https://api.example.com/phoenix/",
+                "dataset_id": "my-dataset",
+                "experiment_id": "exp-123",
+                "expected_experiments_url": "https://api.example.com/phoenix/datasets/my-dataset/experiments",
+                "expected_experiment_url": "https://api.example.com/phoenix/datasets/my-dataset/compare?experimentId=exp-123",
+            },
+        ]
+
+        for case in test_cases:
+            base_url = BaseURL(case["base_url"])
+            
+            # Test dataset experiments URL
+            experiments_url = base_url.join("datasets", case["dataset_id"], "experiments")
+            assert experiments_url == case["expected_experiments_url"]
+            
+            # Test experiment URL (without query params)
+            experiment_base = base_url.join("datasets", case["dataset_id"], "compare")
+            experiment_url = f"{experiment_base}?experimentId={case['experiment_id']}"
+            assert experiment_url == case["expected_experiment_url"]
+
+    def test_no_double_slashes_in_any_scenario(self):
+        """Test that no double slashes are ever generated (except in protocol)."""
+        base_urls = [
+            "http://localhost:8000",
+            "http://localhost:8000/",
+            "https://example.com",
+            "https://example.com/",
+            "https://api.example.com/v1",
+            "https://api.example.com/v1/",
+        ]
+        
+        path_combinations = [
+            ("datasets",),
+            ("datasets", "123"),
+            ("datasets", "123", "experiments"),
+            ("/datasets/",),
+            ("/datasets/", "/123/"),
+            ("/datasets/", "/123/", "/experiments/"),
+            ("", "datasets", "", "123", ""),
+        ]
+        
+        for base_url_str in base_urls:
+            base_url = BaseURL(base_url_str)
+            for paths in path_combinations:
+                if paths:  # Skip empty path combinations
+                    result = base_url.join(*paths)
+                    # Check for double slashes, excluding the protocol part
+                    url_without_protocol = result.replace("https://", "").replace("http://", "")
+                    assert "//" not in url_without_protocol, f"Double slash found in: {result}"


### PR DESCRIPTION
Fix double slashes in experiment URLs for both JavaScript and Python clients.

The issue occurred when base URLs ended with a trailing slash, causing `//` in the constructed URLs. In JavaScript, `new URL().toString()` adds a trailing slash, while in Python, `httpx.URL` string representation could end with one. This PR ensures URLs are correctly formed regardless of the base URL's trailing slash.

---
[Slack Thread](https://arize-ai.slack.com/archives/D09482U53FV/p1758167766643739?thread_ts=1758167766.643739&cid=D09482U53FV)

<a href="https://cursor.com/background-agent?bcId=bc-5ea10670-86d1-40a9-b004-714ef3e65e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ea10670-86d1-40a9-b004-714ef3e65e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

