### PR TITLE
feat(experiments): break out repetitions in experiments compare slideover

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -348,6 +348,7 @@ function ExperimentRunOutputs({
           if (!experiment) {
             return null;
           }
+          const experimentRuns = experimentRunsByExperimentId[experimentId];
           return (
             <Fragment key={experimentId}>
               <label>
@@ -365,26 +366,28 @@ function ExperimentRunOutputs({
                   {experiment.name}
                 </Flex>
               </label>
-              <View paddingStart="size-200">
-                {experimentRunsByExperimentId[experimentId]?.map((run) => (
-                  <label key={run.id}>
-                    <Flex direction="row" alignItems="center" gap="size-100">
-                      <input
-                        type="checkbox"
-                        checked={
-                          selectedExperimentRuns.find(
-                            (runSelection) => runSelection.runId === run.id
-                          )?.selected
-                        }
-                        onChange={(e) =>
-                          updateRepetitionSelection(run.id, e.target.checked)
-                        }
-                      />
-                      repetition {run.repetitionNumber}
-                    </Flex>
-                  </label>
-                ))}
-              </View>
+              {experimentRuns?.length > 1 && (
+                <View paddingStart="size-200">
+                  {experimentRuns.map((run) => (
+                    <label key={run.id}>
+                      <Flex direction="row" alignItems="center" gap="size-100">
+                        <input
+                          type="checkbox"
+                          checked={
+                            selectedExperimentRuns.find(
+                              (runSelection) => runSelection.runId === run.id
+                            )?.selected
+                          }
+                          onChange={(e) =>
+                            updateRepetitionSelection(run.id, e.target.checked)
+                          }
+                        />
+                        repetition {run.repetitionNumber}
+                      </Flex>
+                    </label>
+                  ))}
+                </View>
+              )}
             </Fragment>
           );
         })}
@@ -504,7 +507,7 @@ function ExperimentItem({
           >
             <Truncate maxWidth="100%">{experiment?.name ?? ""}</Truncate>
           </Heading>
-          {repetitionCount && experimentRun && (
+          {repetitionCount && repetitionCount > 1 && experimentRun && (
             <>
               <Icon svg={<Icons.ChevronRight />} />
               <Heading weight="heavy" level={3}>

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -33,7 +33,6 @@ import {
   ExperimentCompareDetailsDialogQuery,
   ExperimentCompareDetailsDialogQuery$data,
 } from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql";
-
 import { ExampleDetailsPaginator } from "@phoenix/pages/experiment/ExampleDetailsPaginator";
 
 import { ExperimentAnnotationButton } from "./ExperimentAnnotationButton";
@@ -198,7 +197,7 @@ export function ExperimentCompareDetails({
         acc[edge.experiment.id] = edge.experiment;
         return acc;
       },
-      {} as Record<string, Experiment>
+      {} as Record<string, Experiment | undefined>
     );
   }, [experiments]);
 
@@ -211,7 +210,7 @@ export function ExperimentCompareDetails({
         ];
         return acc;
       },
-      {} as Record<string, ExperimentRun[]>
+      {} as Record<string, ExperimentRun[] | undefined>
     );
   }, [experimentRuns]);
 
@@ -294,8 +293,8 @@ function ExperimentRunOutputs({
 }: {
   baseExperimentId: string;
   compareExperimentIds: string[];
-  experimentsById: Record<string, Experiment>;
-  experimentRunsByExperimentId: Record<string, ExperimentRun[]>;
+  experimentsById: Record<string, Experiment | undefined>;
+  experimentRunsByExperimentId: Record<string, ExperimentRun[] | undefined>;
 }) {
   const experimentIds = [baseExperimentId, ...compareExperimentIds];
 
@@ -366,7 +365,7 @@ function ExperimentRunOutputs({
                   {experiment.name}
                 </Flex>
               </label>
-              {experimentRuns?.length > 1 && (
+              {experimentRuns && experimentRuns.length > 1 && (
                 <View paddingStart="size-200">
                   {experimentRuns.map((run) => (
                     <label key={run.id}>
@@ -437,7 +436,7 @@ function ExperimentRunOutputs({
             );
           }
 
-          return experimentRunsToDisplay.map((run, repetitionIndex) => (
+          return experimentRunsToDisplay.map((run) => (
             <li
               key={run.id}
               css={css`
@@ -597,7 +596,7 @@ function JSONBlockWithCopy({ value }: { value: unknown }) {
 
 function initializeSelectionState(
   experimentIds: string[],
-  experimentRunsByExperimentId: Record<string, ExperimentRun[]>
+  experimentRunsByExperimentId: Record<string, ExperimentRun[] | undefined>
 ): ExperimentRunSelectionState[] {
   return experimentIds.flatMap((experimentId) => {
     const runs = experimentRunsByExperimentId[experimentId];
@@ -627,7 +626,7 @@ function areAllExperimentRunsSelected(
 function getSelectedExperimentRuns(
   experimentId: string,
   selectedExperimentRuns: ExperimentRunSelectionState[],
-  experimentRunsByExperimentId: Record<string, ExperimentRun[]>
+  experimentRunsByExperimentId: Record<string, ExperimentRun[] | undefined>
 ): ExperimentRun[] {
   const experimentRuns = experimentRunsByExperimentId[experimentId] || [];
   return selectedExperimentRuns

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -337,61 +337,14 @@ function ExperimentRunOutputs({
 
   return (
     <Flex gap="size-200">
-      <div
-        css={css`
-          width: 340px;
-          flex: none;
-        `}
-      >
-        {experimentIds.map((experimentId) => {
-          const experiment = experimentsById[experimentId];
-          if (!experiment) {
-            return null;
-          }
-          const experimentRuns = experimentRunsByExperimentId[experimentId];
-          return (
-            <Fragment key={experimentId}>
-              <label>
-                <Flex direction="row" alignItems="center" gap="size-100">
-                  <input
-                    type="checkbox"
-                    checked={areAllExperimentRunsSelected(
-                      experimentId,
-                      selectedExperimentRuns
-                    )}
-                    onChange={(e) =>
-                      updateExperimentSelection(experimentId, e.target.checked)
-                    }
-                  />
-                  {experiment.name}
-                </Flex>
-              </label>
-              {experimentRuns && experimentRuns.length > 1 && (
-                <View paddingStart="size-200">
-                  {experimentRuns.map((run) => (
-                    <label key={run.id}>
-                      <Flex direction="row" alignItems="center" gap="size-100">
-                        <input
-                          type="checkbox"
-                          checked={
-                            selectedExperimentRuns.find(
-                              (runSelection) => runSelection.runId === run.id
-                            )?.selected
-                          }
-                          onChange={(e) =>
-                            updateRepetitionSelection(run.id, e.target.checked)
-                          }
-                        />
-                        repetition {run.repetitionNumber}
-                      </Flex>
-                    </label>
-                  ))}
-                </View>
-              )}
-            </Fragment>
-          );
-        })}
-      </div>
+      <ExperimentRunOutputsSidebar
+        experimentIds={experimentIds}
+        experimentsById={experimentsById}
+        experimentRunsByExperimentId={experimentRunsByExperimentId}
+        selectedExperimentRuns={selectedExperimentRuns}
+        updateExperimentSelection={updateExperimentSelection}
+        updateRepetitionSelection={updateRepetitionSelection}
+      />
       <ul
         css={css`
           display: flex;
@@ -456,6 +409,109 @@ function ExperimentRunOutputs({
         })}
       </ul>
     </Flex>
+  );
+}
+
+function ExperimentRunOutputsSidebar({
+  experimentIds,
+  experimentsById,
+  experimentRunsByExperimentId,
+  selectedExperimentRuns,
+  updateExperimentSelection,
+  updateRepetitionSelection,
+}: {
+  experimentIds: string[];
+  experimentsById: Record<string, Experiment | undefined>;
+  experimentRunsByExperimentId: Record<string, ExperimentRun[] | undefined>;
+  selectedExperimentRuns: ExperimentRunSelectionState[];
+  updateExperimentSelection: (experimentId: string, checked: boolean) => void;
+  updateRepetitionSelection: (runId: string, checked: boolean) => void;
+}) {
+  const { baseExperimentColor, getExperimentColor } = useExperimentColors();
+
+  return (
+    <div
+      css={css`
+        width: 340px;
+        flex: none;
+        font-size: var(--ac-global-dimension-static-font-size-100);
+        color: var(--ac-global-color-grey-700);
+      `}
+    >
+      <Flex direction="column" gap="size-200">
+        {experimentIds.map((experimentId, experimentIndex) => {
+          const experiment = experimentsById[experimentId];
+          if (!experiment) {
+            return null;
+          }
+          const experimentRuns = experimentRunsByExperimentId[experimentId];
+          return (
+            <Fragment key={experimentId}>
+              <label>
+                <Flex direction="row" alignItems="center" gap="size-100">
+                  <input
+                    type="checkbox"
+                    checked={areAllExperimentRunsSelected(
+                      experimentId,
+                      selectedExperimentRuns
+                    )}
+                    onChange={(e) =>
+                      updateExperimentSelection(experimentId, e.target.checked)
+                    }
+                  />
+                  <span
+                    css={css`
+                      flex: none;
+                    `}
+                  >
+                    <ColorSwatch
+                      color={
+                        experimentIndex === 0
+                          ? baseExperimentColor
+                          : getExperimentColor(experimentIndex - 1)
+                      }
+                      shape="circle"
+                    />
+                  </span>
+                  {experiment.name}
+                </Flex>
+              </label>
+              {experimentRuns && experimentRuns.length > 1 && (
+                <View paddingStart="size-500">
+                  <Flex direction="column" gap="size-200">
+                    {experimentRuns.map((run) => (
+                      <label key={run.id}>
+                        <Flex
+                          direction="row"
+                          alignItems="center"
+                          gap="size-100"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={
+                              selectedExperimentRuns.find(
+                                (runSelection) => runSelection.runId === run.id
+                              )?.selected
+                            }
+                            onChange={(e) =>
+                              updateRepetitionSelection(
+                                run.id,
+                                e.target.checked
+                              )
+                            }
+                          />
+                          repetition {run.repetitionNumber}
+                        </Flex>
+                      </label>
+                    ))}
+                  </Flex>
+                </View>
+              )}
+            </Fragment>
+          );
+        })}
+      </Flex>
+    </div>
   );
 }
 

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -29,8 +29,11 @@ import { JSONBlock } from "@phoenix/components/code";
 import { useExperimentColors } from "@phoenix/components/experiment";
 import { resizeHandleCSS } from "@phoenix/components/resize";
 import { Truncate } from "@phoenix/components/utility/Truncate";
-import { ExperimentCompareDetailsDialogQuery } from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql";
-import { ExperimentCompareDetailsQuery$data } from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsQuery.graphql";
+import {
+  ExperimentCompareDetailsDialogQuery,
+  ExperimentCompareDetailsDialogQuery$data,
+} from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql";
+
 import { ExampleDetailsPaginator } from "@phoenix/pages/experiment/ExampleDetailsPaginator";
 
 import { ExperimentAnnotationButton } from "./ExperimentAnnotationButton";
@@ -45,11 +48,11 @@ type ExperimentCompareDetailsProps = {
 };
 
 type Experiment = NonNullable<
-  ExperimentCompareDetailsQuery$data["dataset"]["experiments"]
+  ExperimentCompareDetailsDialogQuery$data["dataset"]["experiments"]
 >["edges"][number]["experiment"];
 
 type ExperimentRun = NonNullable<
-  ExperimentCompareDetailsQuery$data["example"]["experimentRuns"]
+  ExperimentCompareDetailsDialogQuery$data["example"]["experimentRuns"]
 >["edges"][number]["run"];
 
 export function ExperimentCompareDetailsDialog({
@@ -136,6 +139,7 @@ export function ExperimentCompareDetails({
               edges {
                 run: node {
                   id
+                  repetitionNumber
                   latencyMs
                   experimentId
                   output
@@ -362,26 +366,24 @@ function ExperimentRunOutputs({
                 </Flex>
               </label>
               <View paddingStart="size-200">
-                {experimentRunsByExperimentId[experimentId]?.map(
-                  (run, repetitionIndex) => (
-                    <label key={run.id}>
-                      <Flex direction="row" alignItems="center" gap="size-100">
-                        <input
-                          type="checkbox"
-                          checked={
-                            selectedExperimentRuns.find(
-                              (runSelection) => runSelection.runId === run.id
-                            )?.selected
-                          }
-                          onChange={(e) =>
-                            updateRepetitionSelection(run.id, e.target.checked)
-                          }
-                        />
-                        repetition {repetitionIndex + 1}
-                      </Flex>
-                    </label>
-                  )
-                )}
+                {experimentRunsByExperimentId[experimentId]?.map((run) => (
+                  <label key={run.id}>
+                    <Flex direction="row" alignItems="center" gap="size-100">
+                      <input
+                        type="checkbox"
+                        checked={
+                          selectedExperimentRuns.find(
+                            (runSelection) => runSelection.runId === run.id
+                          )?.selected
+                        }
+                        onChange={(e) =>
+                          updateRepetitionSelection(run.id, e.target.checked)
+                        }
+                      />
+                      repetition {run.repetitionNumber}
+                    </Flex>
+                  </label>
+                ))}
               </View>
             </Fragment>
           );
@@ -444,7 +446,6 @@ function ExperimentRunOutputs({
                 experiment={experiment}
                 experimentRun={run}
                 experimentIndex={experimentIndex}
-                repetitionIndex={repetitionIndex}
                 repetitionCount={experimentRuns.length}
               />
             </li>
@@ -469,13 +470,11 @@ function ExperimentItem({
   experiment,
   experimentRun,
   experimentIndex,
-  repetitionIndex,
   repetitionCount,
 }: {
   experiment: Experiment;
   experimentRun?: ExperimentRun;
   experimentIndex: number;
-  repetitionIndex?: number;
   repetitionCount?: number;
 }) {
   const { baseExperimentColor, getExperimentColor } = useExperimentColors();
@@ -505,11 +504,11 @@ function ExperimentItem({
           >
             <Truncate maxWidth="100%">{experiment?.name ?? ""}</Truncate>
           </Heading>
-          {repetitionCount && repetitionIndex !== undefined && (
+          {repetitionCount && experimentRun && (
             <>
               <Icon svg={<Icons.ChevronRight />} />
               <Heading weight="heavy" level={3}>
-                repetition&nbsp;{repetitionIndex + 1}
+                repetition&nbsp;{experimentRun.repetitionNumber}
               </Heading>
             </>
           )}

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -28,6 +28,7 @@ import { AnnotationDetailsContent } from "@phoenix/components/annotation/Annotat
 import { JSONBlock } from "@phoenix/components/code";
 import { useExperimentColors } from "@phoenix/components/experiment";
 import { resizeHandleCSS } from "@phoenix/components/resize";
+import { Truncate } from "@phoenix/components/utility/Truncate";
 import { ExperimentCompareDetailsDialogQuery } from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql";
 import { ExperimentCompareDetailsQuery$data } from "@phoenix/pages/experiment/__generated__/ExperimentCompareDetailsQuery.graphql";
 import { ExampleDetailsPaginator } from "@phoenix/pages/experiment/ExampleDetailsPaginator";
@@ -332,7 +333,7 @@ const experimentItemCSS = css`
   border: 1px solid var(--ac-global-border-color-dark);
   border-radius: var(--ac-global-rounding-small);
   box-shadow: 0px 8px 8px rgba(0 0 0 / 0.05);
-  min-width: 500px;
+  width: 474px;
 `;
 
 /**
@@ -362,15 +363,27 @@ function ExperimentItem({
     <div css={experimentItemCSS}>
       <View paddingX="size-200" paddingTop="size-200">
         <Flex direction="row" gap="size-100" alignItems="center">
-          <ColorSwatch color={color} shape="circle" />
-          <Heading weight="heavy" level={3}>
-            {experiment?.name ?? ""}
+          <span
+            css={css`
+              flex: none;
+            `}
+          >
+            <ColorSwatch color={color} shape="circle" />
+          </span>
+          <Heading
+            weight="heavy"
+            level={3}
+            css={css`
+              min-width: 0;
+            `}
+          >
+            <Truncate maxWidth="100%">{experiment?.name ?? ""}</Truncate>
           </Heading>
           {repetitionCount && repetitionIndex !== undefined && (
             <>
               <Icon svg={<Icons.ChevronRight />} />
               <Heading weight="heavy" level={3}>
-                repetition {repetitionIndex + 1}
+                repetition&nbsp;{repetitionIndex + 1}
               </Heading>
             </>
           )}

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -261,6 +261,7 @@ export function ExperimentCompareDetails({
           css={css`
             overflow-y: auto;
             height: 100%;
+            box-sizing: border-box;
             padding: var(--ac-global-dimension-static-size-200);
           `}
         >

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -17,6 +17,8 @@ import {
   Empty,
   Flex,
   Heading,
+  Icon,
+  Icons,
   LinkButton,
   Popover,
   PopoverArrow,
@@ -286,9 +288,9 @@ export function ExperimentCompareDetails({
                 const experimentRuns =
                   experimentRunsByExperimentId?.[experimentId] || [];
                 return experimentRuns.length > 0 ? (
-                  experimentRuns.map((run, runIndex) => (
+                  experimentRuns.map((run, repetitionIndex) => (
                     <li
-                      key={`${experimentId}-${runIndex}`}
+                      key={`${experimentId}-${repetitionIndex}`}
                       css={css`
                         // Make them all the same size
                         flex: 1 1 0px;
@@ -297,7 +299,9 @@ export function ExperimentCompareDetails({
                       <ExperimentItem
                         experiment={experiment}
                         experimentRun={run}
-                        index={experimentIndex}
+                        experimentIndex={experimentIndex}
+                        repetitionIndex={repetitionIndex}
+                        repetitionCount={experimentRuns.length}
                       />
                     </li>
                   ))
@@ -311,7 +315,7 @@ export function ExperimentCompareDetails({
                   >
                     <ExperimentItem
                       experiment={experiment}
-                      index={experimentIndex}
+                      experimentIndex={experimentIndex}
                     />
                   </li>
                 );
@@ -337,15 +341,21 @@ const experimentItemCSS = css`
 function ExperimentItem({
   experiment,
   experimentRun,
-  index,
+  experimentIndex,
+  repetitionIndex,
+  repetitionCount,
 }: {
   experiment: Experiment;
   experimentRun?: ExperimentRun;
-  index: number;
+  experimentIndex: number;
+  repetitionIndex?: number;
+  repetitionCount?: number;
 }) {
   const { baseExperimentColor, getExperimentColor } = useExperimentColors();
   const color =
-    index === 0 ? baseExperimentColor : getExperimentColor(index - 1);
+    experimentIndex === 0
+      ? baseExperimentColor
+      : getExperimentColor(experimentIndex - 1);
 
   const hasExperimentResult = experimentRun !== undefined;
   return (
@@ -355,7 +365,15 @@ function ExperimentItem({
           <ColorSwatch color={color} shape="circle" />
           <Heading weight="heavy" level={3}>
             {experiment?.name ?? ""}
-          </Heading>{" "}
+          </Heading>
+          {repetitionCount && repetitionIndex !== undefined && (
+            <>
+              <Icon svg={<Icons.ChevronRight />} />
+              <Heading weight="heavy" level={3}>
+                repetition {repetitionIndex + 1}
+              </Heading>
+            </>
+          )}
         </Flex>
       </View>
       {!hasExperimentResult ? (

--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -335,6 +335,8 @@ function ExperimentRunOutputs({
     []
   );
 
+  const noRunsSelected = selectedExperimentRuns.every((run) => !run.selected);
+
   return (
     <Flex gap="size-200">
       <ExperimentRunOutputsSidebar
@@ -345,6 +347,7 @@ function ExperimentRunOutputs({
         updateExperimentSelection={updateExperimentSelection}
         updateRepetitionSelection={updateRepetitionSelection}
       />
+      {noRunsSelected && <Empty message="No runs selected" />}
       <ul
         css={css`
           display: flex;

--- a/app/src/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql.ts
+++ b/app/src/pages/experiment/__generated__/ExperimentCompareDetailsDialogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<992f41d5e051d799f3a6dc6e0642235d>>
+ * @generated SignedSource<<0b10c176519047c5c4aa2d1ed26bafe8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,6 +51,7 @@ export type ExperimentCompareDetailsDialogQuery$data = {
           readonly id: string;
           readonly latencyMs: number;
           readonly output: any | null;
+          readonly repetitionNumber: number;
         };
       }>;
     };
@@ -177,6 +178,13 @@ v7 = {
               "plural": false,
               "selections": [
                 (v5/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "repetitionNumber",
+                  "storageKey": null
+                },
                 {
                   "alias": null,
                   "args": null,
@@ -447,16 +455,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8d153bdb5091007864545cda77e2c21b",
+    "cacheID": "ac768811f510041f3c1f95eed7781e09",
     "id": null,
     "metadata": {},
     "name": "ExperimentCompareDetailsDialogQuery",
     "operationKind": "query",
-    "text": "query ExperimentCompareDetailsDialogQuery(\n  $datasetId: ID!\n  $datasetExampleId: ID!\n  $datasetVersionId: ID!\n  $experimentIds: [ID!]!\n) {\n  example: node(id: $datasetExampleId) {\n    __typename\n    ... on DatasetExample {\n      revision(datasetVersionId: $datasetVersionId) {\n        input\n        referenceOutput: output\n      }\n      experimentRuns(experimentIds: $experimentIds, first: 120) {\n        edges {\n          run: node {\n            id\n            latencyMs\n            experimentId\n            output\n            error\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  label\n                  score\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ExperimentCompareDetailsDialogQuery(\n  $datasetId: ID!\n  $datasetExampleId: ID!\n  $datasetVersionId: ID!\n  $experimentIds: [ID!]!\n) {\n  example: node(id: $datasetExampleId) {\n    __typename\n    ... on DatasetExample {\n      revision(datasetVersionId: $datasetVersionId) {\n        input\n        referenceOutput: output\n      }\n      experimentRuns(experimentIds: $experimentIds, first: 120) {\n        edges {\n          run: node {\n            id\n            repetitionNumber\n            latencyMs\n            experimentId\n            output\n            error\n            costSummary {\n              total {\n                cost\n                tokens\n              }\n            }\n            annotations {\n              edges {\n                annotation: node {\n                  id\n                  name\n                  label\n                  score\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      experiments(filterIds: $experimentIds) {\n        edges {\n          experiment: node {\n            id\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ed726080d362170763a9a9c1128be008";
+(node as any).hash = "8941dc977ef78eaf25e036cdb5b356c1";
 
 export default node;


### PR DESCRIPTION
This updates the experiment compare slideover so that repetitions are broken out into their own cards. This also adds a sidebar where the visibility of each repetition can be toggled.

With repetitions:

https://github.com/user-attachments/assets/42138812-1133-4e48-84f9-4ff712fec24b

Without repetitions:

https://github.com/user-attachments/assets/9e2d21f7-2241-4a15-9f15-4b53e48802b6

