### PR TITLE
fix(client): make sure printed url work for proxied urls

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/client.py
+++ b/packages/phoenix-client/src/phoenix/client/client.py
@@ -27,7 +27,7 @@ class Client:
         Args:
             base_url (Optional[str | httpx.URL]): The base URL for the API endpoint.
                 If not provided, it will be read from the environment variables or
-                fall back to http://localhost:6006/.
+                fall back to http://localhost:6006.
             api_key (Optional[str]): The API key for authentication. If provided, it
                 will be included in the Authorization header as a bearer token.
             headers (Optional[Mapping[str, str]]): Additional headers to be included
@@ -131,7 +131,7 @@ class AsyncClient:
         Args:
             base_url (Optional[str | httpx.URL]): The base URL for the API endpoint.
                 If not provided, it will be read from the environment variables or
-                fall back to http://localhost:6006/.
+                fall back to http://localhost:6006.
             api_key (Optional[str]): The API key for authentication. If provided, it
                 will be included in the Authorization header as a bearer token.
             headers (Optional[Mapping[str, str]]): Additional headers to be included

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -508,10 +508,13 @@ class Experiments:
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/experiments"
+        return urljoin(str(self._client.base_url), f"datasets/{dataset_id}/experiments")
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return urljoin(
+            str(self._client._base_url),  # pyright: ignore[reportPrivateUsage]
+            f"datasets/{dataset_id}/compare?experimentId={experiment_id}",
+        )
 
     def run_experiment(
         self,
@@ -1540,10 +1543,13 @@ class AsyncExperiments:
         self._headers = dict(client.headers)
 
     def get_dataset_experiments_url(self, dataset_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/experiments"
+        return urljoin(str(self._client.base_url), f"datasets/{dataset_id}/experiments")
 
     def get_experiment_url(self, dataset_id: str, experiment_id: str) -> str:
-        return f"{self._client.base_url}/datasets/{dataset_id}/compare?experimentId={experiment_id}"
+        return urljoin(
+            str(self._client.base_url),
+            f"datasets/{dataset_id}/compare?experimentId={experiment_id}",
+        )
 
     async def run_experiment(
         self,

--- a/packages/phoenix-client/tests/client/resources/experiments/test_experiment_urls.py
+++ b/packages/phoenix-client/tests/client/resources/experiments/test_experiment_urls.py
@@ -1,0 +1,28 @@
+import httpx
+import pytest
+
+from phoenix.client.resources.experiments import Experiments
+
+
+@pytest.mark.parametrize(
+    "base_url, dataset_id, experiment_id, expected_experiment_url",
+    [
+        (
+            "http://localhost:6006",
+            "12345",
+            "78910",
+            "http://localhost:6006/datasets/12345/compare?experimentId=78910",
+        ),
+        (
+            "https://app.phoenix.arize.com/s/me",
+            "12345",
+            "78910",
+            "https://app.phoenix.arize.com/s/me/datasets/12345/compare?experimentId=78910",
+        ),
+    ],
+)
+def test_get_experiment_url(
+    base_url: str, dataset_id: str, experiment_id: str, expected_experiment_url: str
+) -> None:
+    experiments = Experiments(client=httpx.Client(base_url=base_url))
+    assert experiments.get_experiment_url(dataset_id, experiment_id) == expected_experiment_url

--- a/packages/phoenix-client/tests/client/test_client.py
+++ b/packages/phoenix-client/tests/client/test_client.py
@@ -1,0 +1,20 @@
+import pytest
+
+from phoenix.client import Client
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("https://app.phoenix.arize.com/s/me", "https://app.phoenix.arize.com/s/me/"),
+        ("http://localhost:6006/", "http://localhost:6006"),
+        ("http://localhost:6006", "http://localhost:6006"),
+    ],
+)
+def test_url_sanitization(input: str, expected: str) -> None:
+    """
+    This test exists mainly to show the diverging behavior within httpx where a
+    trailing / is added to URLs that contain slugs.
+    """
+    client = Client(base_url=input)
+    assert str(client._client.base_url) == expected  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
resolves #9541 

There is an inconsistency in the URLs for httpx. For any URL with a slug, it appends a trailing `/` so this was constructing invalid urls. This fixes this by using urljoin. The behavior is documented in the test.