### PR TITLE
feat: custom headers for playground

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1350,6 +1350,7 @@ input GenerativeModelInput {
   endpoint: String
   apiVersion: String
   region: String
+  customHeaders: JSON
 }
 
 enum GenerativeModelKind {

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76fde2199b541df2fec45b82c19dccff>>
+ * @generated SignedSource<<553e94657e1ecb9e079e9485072939b3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,6 +36,7 @@ export type ChatCompletionMessageInput = {
 export type GenerativeModelInput = {
   apiVersion?: string | null;
   baseUrl?: string | null;
+  customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
   providerKey: GenerativeProviderKey;

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<510c3911fb9ca78f67f92fb4d166d28c>>
+ * @generated SignedSource<<92e4dc07b4b8f3ace9dc3887f83ce4ba>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,6 +36,7 @@ export type ChatCompletionMessageInput = {
 export type GenerativeModelInput = {
   apiVersion?: string | null;
   baseUrl?: string | null;
+  customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
   providerKey: GenerativeProviderKey;

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e704eb92080f007fe1fd6397c131e6c1>>
+ * @generated SignedSource<<f732438fc354ddf0e6246232b0644f75>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type ChatCompletionMessageInput = {
 export type GenerativeModelInput = {
   apiVersion?: string | null;
   baseUrl?: string | null;
+  customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
   providerKey: GenerativeProviderKey;

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<67cd023376630a1e6268f8bb911475a4>>
+ * @generated SignedSource<<083cc3ac4db305bf0c5d1c8a8842b7bf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type ChatCompletionMessageInput = {
 export type GenerativeModelInput = {
   apiVersion?: string | null;
   baseUrl?: string | null;
+  customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
   providerKey: GenerativeProviderKey;

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1158,6 +1158,7 @@ const getBaseChatCompletionInput = ({
       providerKey: instance.model.provider,
       name: instance.model.modelName || "",
       baseUrl: instance.model.baseUrl,
+      customHeaders: instance.model.customHeaders,
       ...azureModelParams,
       ...awsModelParams,
     },

--- a/app/src/schemas/httpHeadersSchema.ts
+++ b/app/src/schemas/httpHeadersSchema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import zodToJsonSchema from "zod-to-json-schema";
+
+/**
+ * HTTP header name validation following RFC 7230
+ * Header names are case-insensitive and consist of ASCII letters, digits, and certain special characters
+ */
+const httpHeaderNameSchema = z
+  .string()
+  .min(1, "Header name cannot be empty")
+  .regex(
+    /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/,
+    "Header name must only contain valid HTTP header characters (letters, numbers, and !#$%&'*+-.^_`|~)"
+  );
+
+/**
+ * HTTP header value validation following RFC 7230
+ * Header values can contain any visible ASCII characters and spaces/tabs
+ */
+const httpHeaderValueSchema = z
+  .string()
+  .refine(
+    (value) => /^[\x20-\x7E\t]*$/.test(value),
+    "Header value must only contain visible ASCII characters"
+  );
+
+/**
+ * Schema for HTTP headers as a key-value object
+ */
+export const httpHeadersSchema = z
+  .record(httpHeaderNameSchema, httpHeaderValueSchema)
+  .describe("HTTP headers as key-value pairs")
+  .refine((headers) => {
+    // Check for duplicate header names (case-insensitive)
+    const names = Object.keys(headers);
+    const lowerNames = names.map((name) => name.toLowerCase());
+    const uniqueNames = new Set(lowerNames);
+    return uniqueNames.size === names.length;
+  }, "Duplicate header names are not allowed (header names are case-insensitive)");
+
+/**
+ * The type of HTTP headers
+ */
+export type HttpHeaders = z.infer<typeof httpHeadersSchema>;
+
+/**
+ * JSON Schema for HTTP headers (for JSONEditor validation)
+ */
+export const httpHeadersJSONSchema = zodToJsonSchema(httpHeadersSchema, {
+  name: "HttpHeaders",
+  definitions: {},
+});

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -437,6 +437,7 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
               apiVersion: null,
               endpoint: null,
               region: null,
+              customHeaders: null,
               provider,
             },
         toolChoice:

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -74,6 +74,10 @@ export type ModelConfig = {
    * The region of the deployment (e.x. us-east-1 for AWS Bedrock)
    */
   region?: string | null;
+  /**
+   * Custom headers to be sent with requests to the LLM provider
+   */
+  customHeaders?: Record<string, string> | null;
   invocationParameters: InvocationParameterInput[];
   supportedInvocationParameters: InvocationParameter[];
 };

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -4,6 +4,7 @@ grpcio
 litellm>=1.0.3
 openai>=1.0.0
 boto3
+mypy-boto3-bedrock-runtime
 opentelemetry-exporter-otlp
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-grpc

--- a/src/phoenix/server/api/input_types/GenerativeModelInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelInput.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import strawberry
 from strawberry import UNSET
+from strawberry.scalars import JSON
 
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 
@@ -19,3 +20,5 @@ class GenerativeModelInput:
     """ The API version to use for the model. """
     region: Optional[str] = UNSET
     """ The region to use for the model. """
+    custom_headers: Optional[JSON] = UNSET
+    """ Custom headers to use for the model. """


### PR DESCRIPTION
resolves #9423 

# Add Custom Headers Support to Playground

## Summary
Adds custom HTTP headers configuration to playground requests. Users can now set provider-specific headers (auth tokens, request IDs, etc.) via a JSON editor in the model config panel.

## Implementation
- **Frontend**: New JSON editor component in `ModelConfigButton.tsx` with Zod validation and provider-segregated storage
- **Backend**: Header injection via `default_headers` for OpenAI/Anthropic/Azure clients and boto3 event system for Bedrock
- **Coverage**: All providers except Google (SDK limitation)

## Changes
- Extended `GenerativeModelInput` schema with `customHeaders` field
- Added RFC 7230 compliant validation 
- Headers stored per-provider in user preferences
- Hidden for Google provider until supported