### PR TITLE
feat(phoenix-client): paginate through runs when experiments are re-run

### DIFF
--- a/js/packages/phoenix-client/src/experiments/getExperimentRuns.ts
+++ b/js/packages/phoenix-client/src/experiments/getExperimentRuns.ts
@@ -2,35 +2,60 @@ import { createClient } from "../client";
 import invariant from "tiny-invariant";
 import { ClientFn } from "../types/core";
 import { ExperimentRun } from "../types/experiments";
+import { components } from "../__generated__/api/v1";
 
 export type GetExperimentRunsParams = ClientFn & {
   /**
    * The experiment ID.
    */
   experimentId: string;
+  /**
+   * The pagination size by which to pull runs
+   * Exposed for controlling the rate at which runs are pulled
+   * @default 100
+   */
+  pageSize?: number;
 };
 
+const DEFAULT_PAGE_SIZE = 100;
+
 /**
- * A function that gets the runs (e.g. the results) of a experiment
+ * A function that gets all the runs (e.g. the results) of a experiment
  */
 export async function getExperimentRuns({
   client: _client,
   experimentId,
+  pageSize = DEFAULT_PAGE_SIZE,
 }: GetExperimentRunsParams): Promise<{ runs: ExperimentRun[] }> {
   const client = _client || createClient();
-  const getRunsPromise = client.GET("/v1/experiments/{experiment_id}/runs", {
-    params: {
-      path: {
-        experiment_id: experimentId,
+
+  // Validate that the parameter is an integer and exit early
+  invariant(
+    Number.isInteger(pageSize) && pageSize > 0,
+    "pageSize must be a positive integer greater than 0"
+  );
+  const runs: ExperimentRun[] = [];
+  let cursor: string | null = null;
+  do {
+    const res: {
+      data?: components["schemas"]["ListExperimentRunsResponseBody"];
+    } = await client.GET("/v1/experiments/{experiment_id}/runs", {
+      params: {
+        path: {
+          experiment_id: experimentId,
+        },
+        query: {
+          cursor,
+          limit: pageSize,
+        },
       },
-    },
-  });
-  const [experimentRunResponse] = await Promise.all([getRunsPromise]);
-  const { data: { data: experimentRunsData } = {} } = experimentRunResponse;
-  invariant(experimentRunsData, "Failed to retrieve experiment runs");
-  return {
-    runs: experimentRunsData.map((run) => {
-      return {
+    });
+    // NB: older versions of phoenix simply don't respond with a cursor and fetch all
+    cursor = res.data?.next_cursor || null;
+    const data = res.data?.data;
+    invariant(data, "Failed to fetch runs");
+    runs.push(
+      ...data.map((run) => ({
         id: run.id,
         traceId: run.trace_id || null,
         experimentId: run.experiment_id,
@@ -39,7 +64,11 @@ export async function getExperimentRuns({
         endTime: new Date(run.end_time),
         output: run.output as ExperimentRun["output"],
         error: run.error || null,
-      };
-    }),
+      }))
+    );
+  } while (cursor != null);
+
+  return {
+    runs,
   };
 }

--- a/js/packages/phoenix-client/test/experiments/getExperimentRuns.test.ts
+++ b/js/packages/phoenix-client/test/experiments/getExperimentRuns.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getExperimentRuns } from "../../src/experiments";
+import { components } from "../../src/__generated__/api/v1";
+
+const mockGet = vi.fn();
+
+// Mock the fetch module
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    GET: mockGet,
+    use: () => {},
+  }),
+}));
+
+const mockExperimentRuns: components["schemas"]["ListExperimentRunsResponseBody"]["data"] =
+  [
+    {
+      id: "id",
+      experiment_id: "exp_id",
+      dataset_example_id: "example_id",
+      output: { response: "res" },
+      repetition_number: 1,
+      start_time: "2025-09-20T02:54:17.638Z",
+      end_time: "2025-09-20T02:54:17.638Z",
+    },
+  ];
+
+describe("getExperimentRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReset();
+  });
+  it("should not paginate if the API doesn't provide a next cursor", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        data: mockExperimentRuns,
+      },
+    });
+    await getExperimentRuns({ experimentId: "fake" });
+    expect(mockGet).toHaveBeenCalledOnce();
+    expect(mockGet).toHaveBeenCalledWith(
+      "/v1/experiments/{experiment_id}/runs",
+      {
+        params: {
+          path: {
+            experiment_id: "fake",
+          },
+          query: {
+            cursor: null,
+            limit: 100,
+          },
+        },
+      }
+    );
+  });
+  it("should paginate through records and fetch all", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          data: mockExperimentRuns,
+          next_cursor: "c1",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: mockExperimentRuns,
+          next_cursor: "c2",
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: mockExperimentRuns,
+          next_cursor: null,
+        },
+      });
+    const { runs } = await getExperimentRuns({ experimentId: "fake" });
+    expect(mockGet).toHaveBeenCalledTimes(3);
+    expect(runs.length).toEqual(3);
+  });
+});


### PR DESCRIPTION
resolves #9384

pulls experiment runs by page size so as to not overwhelm the server.