### PR TITLE
feat: Add Azure provider support

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/adapter.py
@@ -10,7 +10,7 @@ from phoenix.evals.utils import SUPPORTED_AUDIO_FORMATS, get_audio_format_from_b
 
 from ...registries import register_adapter, register_provider
 from ...types import BaseLLMAdapter, ObjectGenerationMethod
-from .factories import OpenAIClientWrapper, create_openai_client
+from .factories import OpenAIClientWrapper, create_azure_openai_client, create_openai_client
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,12 @@ def get_openai_rate_limit_errors() -> list[Type[Exception]]:
 @register_provider(
     provider="openai",
     client_factory=create_openai_client,
+    get_rate_limit_errors=get_openai_rate_limit_errors,
+    dependencies=["openai"],
+)
+@register_provider(
+    provider="azure",
+    client_factory=create_azure_openai_client,
     get_rate_limit_errors=get_openai_rate_limit_errors,
     dependencies=["openai"],
 )

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/factories.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/factories.py
@@ -22,3 +22,16 @@ def create_openai_client(model: str, is_async: bool, **kwargs: Any) -> Any:
         return OpenAIClientWrapper(client, model)
     except ImportError:
         raise ImportError("OpenAI package not installed. Run: pip install openai")
+
+
+def create_azure_openai_client(model: str, is_async: bool, **kwargs: Any) -> Any:
+    try:
+        from openai import AsyncAzureOpenAI, AzureOpenAI
+
+        if is_async:
+            client: Union[AsyncAzureOpenAI, AzureOpenAI] = AsyncAzureOpenAI(**kwargs)
+        else:
+            client = AzureOpenAI(**kwargs)
+        return OpenAIClientWrapper(client, model)
+    except ImportError:
+        raise ImportError("OpenAI package not installed. Run: pip install openai")

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -112,6 +112,17 @@ class LLM:
             **kwargs (Any): Additional keyword arguments forwarded to the underlying SDK client
                 constructor(s) if applicable. Use this to pass provider/client-specific options
                 such as API keys, timeouts, base URLs, etc.
+
+        Example::
+
+            from phoenix.evals.llm import LLM
+            llm = LLM(
+                provider="azure",
+                model="gpt-5o",
+                api_key="your-api-key",
+                api_version="api-version",
+                base_url="base-url",
+            )
         """
         self.provider = provider
         self.model = model

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -98,6 +98,7 @@ class LLM:
         model: Optional[str] = None,
         client: Optional[str] = None,
         initial_per_second_request_rate: Optional[float] = None,
+        **kwargs: Any,
     ):
         """Initialize the LLM wrapper.
 
@@ -108,6 +109,9 @@ class LLM:
                 first available client for the provider will be used.
             initial_per_second_request_rate (Optional[float]): Optionally, the initial per-second
                 request rate. If not specified, the default rate limit will be used.
+            **kwargs (Any): Additional keyword arguments forwarded to the underlying SDK client
+                constructor(s) if applicable. Use this to pass provider/client-specific options
+                such as API keys, timeouts, base URLs, etc.
         """
         self.provider = provider
         self.model = model
@@ -140,8 +144,8 @@ class LLM:
                 registration = provider_registrations[0]
 
             try:
-                sync_client = registration.client_factory(model=model, is_async=False)
-                async_client = registration.client_factory(model=model, is_async=True)
+                sync_client = registration.client_factory(model=model, is_async=False, **kwargs)
+                async_client = registration.client_factory(model=model, is_async=True, **kwargs)
                 rate_limit_errors = (
                     registration.get_rate_limit_errors()
                     if registration.get_rate_limit_errors


### PR DESCRIPTION
resolves #9567 

- Adds support for an `azure` provider
- kwargs passed into the `LLM` constructor are fowarded to client construction when applicable