### PR TITLE
feat: add junction table for taking snapshots of examples for experiments

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -770,6 +770,36 @@ CREATE INDEX ix_experiment_tags_user_id ON public.experiment_tags
     USING btree (user_id);
 
 
+-- Table: experiments_dataset_examples
+-- -----------------------------------
+CREATE TABLE public.experiments_dataset_examples (
+    experiment_id BIGINT NOT NULL,
+    dataset_example_id BIGINT NOT NULL,
+    dataset_example_revision_id BIGINT NOT NULL,
+    CONSTRAINT pk_experiments_dataset_examples PRIMARY KEY (experiment_id, dataset_example_id),
+    CONSTRAINT fk_experiments_dataset_examples_dataset_example_id_data_7c5c
+        FOREIGN KEY
+        (dataset_example_id)
+        REFERENCES public.dataset_examples (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_examples_dataset_example_revisio_7f42
+        FOREIGN KEY
+        (dataset_example_revision_id)
+        REFERENCES public.dataset_example_revisions (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_experiments_dataset_examples_experiment_id_experiments
+        FOREIGN KEY
+        (experiment_id)
+        REFERENCES public.experiments (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX ix_experiments_dataset_examples_dataset_example_id ON public.experiments_dataset_examples
+    USING btree (dataset_example_id);
+CREATE INDEX ix_experiments_dataset_examples_dataset_example_revision_id ON public.experiments_dataset_examples
+    USING btree (dataset_example_revision_id);
+
+
 -- Table: experiments_dataset_splits
 -- ---------------------------------
 CREATE TABLE public.experiments_dataset_splits (

--- a/src/phoenix/db/facilitator.py
+++ b/src/phoenix/db/facilitator.py
@@ -229,7 +229,7 @@ _CHILDLESS_RECORD_DELETION_GRACE_PERIOD_DAYS = 1
 
 
 def _stmt_to_delete_expired_childless_records(
-    table: type[models.Base],
+    table: type[models.HasId],
     foreign_key: Union[InstrumentedAttribute[int], InstrumentedAttribute[Optional[int]]],
 ) -> ReturningDelete[tuple[int]]:
     """

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     select,
     util,
 )
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import QueryableAttribute
 from sqlalchemy.sql.roles import InElementRole
 from typing_extensions import assert_never
@@ -309,6 +310,19 @@ def create_experiment_examples_snapshot_insert(
             ranked_subquery.c.revision_kind != "DELETE",
         ),
     )
+
+
+async def insert_experiment_with_examples_snapshot(
+    session: AsyncSession,
+    experiment: models.Experiment,
+) -> None:
+    """
+    Insert an experiment with its snapshot of dataset examples.
+    """
+    session.add(experiment)
+    await session.flush()
+    insert_stmt = create_experiment_examples_snapshot_insert(experiment)
+    await session.execute(insert_stmt)
 
 
 _AnyTuple = TypeVar("_AnyTuple", bound=tuple[Any, ...])

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -222,26 +222,21 @@ def get_dataset_example_revisions(
 
     if split_ids is not None or split_names is not None:
         if split_names is not None:
-            stmt = stmt.join(
-                models.DatasetSplitDatasetExample,
-                models.DatasetSplitDatasetExample.dataset_example_id == models.DatasetExample.id,
-            ).join(
-                models.DatasetSplit,
-                and_(
+            split_example_ids_subquery = (
+                select(models.DatasetSplitDatasetExample.dataset_example_id)
+                .join(
+                    models.DatasetSplit,
                     models.DatasetSplit.id == models.DatasetSplitDatasetExample.dataset_split_id,
-                    models.DatasetSplit.name.in_(split_names),
-                ),
+                )
+                .where(models.DatasetSplit.name.in_(split_names))
             )
+            stmt = stmt.where(models.DatasetExample.id.in_(split_example_ids_subquery))
         else:
             assert split_ids is not None
-            stmt = stmt.join(
-                models.DatasetSplitDatasetExample,
-                and_(
-                    models.DatasetSplitDatasetExample.dataset_example_id
-                    == models.DatasetExample.id,
-                    models.DatasetSplitDatasetExample.dataset_split_id.in_(split_ids),
-                ),
-            )
+            split_example_ids_subquery = select(
+                models.DatasetSplitDatasetExample.dataset_example_id
+            ).where(models.DatasetSplitDatasetExample.dataset_split_id.in_(split_ids))
+            stmt = stmt.where(models.DatasetExample.id.in_(split_example_ids_subquery))
 
     ranked_subquery = stmt.subquery()
     return (
@@ -284,18 +279,17 @@ def create_experiment_examples_snapshot_insert(
     experiment_splits_subquery = select(models.ExperimentDatasetSplit.dataset_split_id).where(
         models.ExperimentDatasetSplit.experiment_id == experiment.id
     )
+    has_splits_condition = exists(experiment_splits_subquery)
+    split_filtered_example_ids = select(models.DatasetSplitDatasetExample.dataset_example_id).where(
+        models.DatasetSplitDatasetExample.dataset_split_id.in_(experiment_splits_subquery)
+    )
 
-    stmt = stmt.outerjoin(
-        models.DatasetSplitDatasetExample,
-        and_(
-            models.DatasetSplitDatasetExample.dataset_example_id
-            == models.DatasetExampleRevision.dataset_example_id,
-            models.DatasetSplitDatasetExample.dataset_split_id.in_(experiment_splits_subquery),
-        ),
-    ).where(
+    stmt = stmt.where(
         or_(
-            ~exists(experiment_splits_subquery),  # If no splits, include all
-            models.DatasetSplitDatasetExample.dataset_split_id.isnot(None),  # Has matching split
+            ~has_splits_condition,  # No splits = include all examples
+            models.DatasetExampleRevision.dataset_example_id.in_(
+                split_filtered_example_ids
+            ),  # Has splits = filter by splits
         )
     )
 

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -149,10 +149,7 @@ def _build_ranked_revisions_query(
             func.row_number()
             .over(
                 partition_by=models.DatasetExampleRevision.dataset_example_id,
-                order_by=[
-                    models.DatasetExampleRevision.dataset_version_id.desc(),
-                    models.DatasetExampleRevision.id.desc(),
-                ],
+                order_by=models.DatasetExampleRevision.dataset_version_id.desc(),
             )
             .label("rn"),
         )

--- a/src/phoenix/db/helpers.py
+++ b/src/phoenix/db/helpers.py
@@ -130,6 +130,7 @@ def _build_ranked_revisions_query(
     /,
     *,
     dataset_id: Optional[int] = None,
+    example_ids: Optional[Union[Sequence[int], InElementRole]] = None,
 ) -> Select[tuple[int]]:
     """
     Build a query that ranks revisions per example within a dataset version.
@@ -166,6 +167,9 @@ def _build_ranked_revisions_query(
         stmt = stmt.where(models.DatasetExample.dataset_id == version_subquery)
     else:
         stmt = stmt.where(models.DatasetExample.dataset_id == dataset_id)
+
+    if example_ids is not None:
+        stmt = stmt.where(models.DatasetExampleRevision.dataset_example_id.in_(example_ids))
 
     return stmt
 
@@ -210,13 +214,11 @@ def get_dataset_example_revisions(
     stmt = _build_ranked_revisions_query(
         dataset_version_id,
         dataset_id=dataset_id,
+        example_ids=example_ids,
     ).add_columns(
         models.DatasetExampleRevision.id,
         models.DatasetExampleRevision.revision_kind,
     )
-
-    if example_ids is not None:
-        stmt = stmt.where(models.DatasetExampleRevision.dataset_example_id.in_(example_ids))
 
     if split_ids is not None or split_names is not None:
         if split_names is not None:

--- a/src/phoenix/db/migrations/versions/deb2c81c0bb2_dataset_splits.py
+++ b/src/phoenix/db/migrations/versions/deb2c81c0bb2_dataset_splits.py
@@ -46,7 +46,7 @@ _Integer = sa.Integer().with_variant(
 
 # revision identifiers, used by Alembic.
 revision: str = "deb2c81c0bb2"
-down_revision: Union[str, None] = "58228d933c91"
+down_revision: Union[str, None] = "e76cbd66ffc3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -1,0 +1,89 @@
+"""add experiments_dataset_examples junction table
+
+Revision ID: e76cbd66ffc3
+Revises: deb2c81c0bb2
+Create Date: 2025-09-23 12:33:13.554164
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+_Integer = sa.Integer().with_variant(
+    sa.BigInteger(),
+    "postgresql",
+)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e76cbd66ffc3"
+down_revision: Union[str, None] = "deb2c81c0bb2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+BACKFILL_SQL = """\
+INSERT INTO experiments_dataset_examples (
+    experiment_id,
+    dataset_example_id,
+    dataset_example_revision_id
+)
+SELECT
+    ranked.experiment_id,
+    ranked.dataset_example_id,
+    ranked.dataset_example_revision_id
+FROM (
+    SELECT
+        e.id as experiment_id,
+        der.dataset_example_id,
+        der.id as dataset_example_revision_id,
+        der.revision_kind,
+        ROW_NUMBER() OVER (
+            PARTITION BY e.id, der.dataset_example_id
+            ORDER BY der.dataset_version_id DESC, der.id DESC
+        ) as rn
+    FROM experiments e
+        JOIN dataset_examples de ON de.dataset_id = e.dataset_id
+        JOIN dataset_example_revisions der ON der.dataset_example_id = de.id
+    WHERE der.dataset_version_id <= e.dataset_version_id
+    ) ranked
+WHERE ranked.rn = 1
+    AND ranked.revision_kind != 'DELETE'
+"""
+
+
+def upgrade() -> None:
+    op.create_table(
+        "experiments_dataset_examples",
+        sa.Column(
+            "experiment_id",
+            _Integer,
+            sa.ForeignKey("experiments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dataset_example_id",
+            _Integer,
+            sa.ForeignKey("dataset_examples.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "dataset_example_revision_id",
+            _Integer,
+            sa.ForeignKey("dataset_example_revisions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.PrimaryKeyConstraint(
+            "experiment_id",
+            "dataset_example_id",
+        ),
+    )
+    conn = op.get_bind()
+    conn.execute(sa.text(BACKFILL_SQL))
+
+
+def downgrade() -> None:
+    op.drop_table("experiments_dataset_examples")

--- a/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -16,10 +16,9 @@ _Integer = sa.Integer().with_variant(
     "postgresql",
 )
 
-
 # revision identifiers, used by Alembic.
 revision: str = "e76cbd66ffc3"
-down_revision: Union[str, None] = "deb2c81c0bb2"
+down_revision: Union[str, None] = "58228d933c91"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -46,7 +46,7 @@ FROM (
         JOIN dataset_examples de ON de.dataset_id = e.dataset_id
         JOIN dataset_example_revisions der ON der.dataset_example_id = de.id
     WHERE der.dataset_version_id <= e.dataset_version_id
-    ) ranked
+) ranked
 WHERE ranked.rn = 1
     AND ranked.revision_kind != 'DELETE'
 """

--- a/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/src/phoenix/db/migrations/versions/e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -40,7 +40,7 @@ FROM (
         der.revision_kind,
         ROW_NUMBER() OVER (
             PARTITION BY e.id, der.dataset_example_id
-            ORDER BY der.dataset_version_id DESC, der.id DESC
+            ORDER BY der.dataset_version_id DESC
         ) as rn
     FROM experiments e
         JOIN dataset_examples de ON de.dataset_id = e.dataset_id

--- a/src/phoenix/server/api/dataloaders/table_fields.py
+++ b/src/phoenix/server/api/dataloaders/table_fields.py
@@ -18,7 +18,7 @@ _AttrStrIdentifier: TypeAlias = str
 
 
 class TableFieldsDataLoader(DataLoader[Key, Result]):
-    def __init__(self, db: DbSessionFactory, table: type[models.Base]) -> None:
+    def __init__(self, db: DbSessionFactory, table: type[models.HasId]) -> None:
         super().__init__(load_fn=self._load_fn)
         self._db = db
         self._table = table
@@ -37,7 +37,7 @@ class TableFieldsDataLoader(DataLoader[Key, Result]):
 
 def _get_stmt(
     keys: Iterable[tuple[RowId, QueryableAttribute[Any]]],
-    table: type[models.Base],
+    table: type[models.HasId],
 ) -> tuple[
     Select[Any],
     dict[_ResultColumnPosition, _AttrStrIdentifier],

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -26,7 +26,10 @@ from typing_extensions import assert_never
 from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
-from phoenix.db.helpers import get_dataset_example_revisions
+from phoenix.db.helpers import (
+    create_experiment_examples_snapshot_insert,
+    get_dataset_example_revisions,
+)
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
@@ -206,6 +209,9 @@ class ChatCompletionMutationMixin:
             )
             session.add(experiment)
             await session.flush()
+
+            junction_stmt = create_experiment_examples_snapshot_insert(experiment)
+            await session.execute(junction_stmt)
 
         results: list[Union[ChatCompletionMutationPayload, BaseException]] = []
         batch_size = 3

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -27,8 +27,8 @@ from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import (
-    create_experiment_examples_snapshot_insert,
     get_dataset_example_revisions,
+    insert_experiment_with_examples_snapshot,
 )
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
@@ -207,11 +207,7 @@ class ChatCompletionMutationMixin:
                 project_name=project_name,
                 user_id=user_id,
             )
-            session.add(experiment)
-            await session.flush()
-
-            junction_stmt = create_experiment_examples_snapshot_insert(experiment)
-            await session.execute(junction_stmt)
+            await insert_experiment_with_examples_snapshot(session, experiment)
 
         results: list[Union[ChatCompletionMutationPayload, BaseException]] = []
         batch_size = 3

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException, Path, Response
 from pydantic import Field
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, insert, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from starlette.requests import Request
@@ -15,7 +15,7 @@ from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND, HTTP_422_UNPROCESS
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect
+from phoenix.db.helpers import SupportedSQLDialect, get_dataset_example_revisions
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.authorization import is_not_locked
@@ -180,6 +180,23 @@ async def create_experiment(
         )
         session.add(experiment)
         await session.flush()
+
+        junction_stmt = insert(models.ExperimentDatasetExample).from_select(
+            [
+                models.ExperimentDatasetExample.experiment_id,
+                models.ExperimentDatasetExample.dataset_example_id,
+                models.ExperimentDatasetExample.dataset_example_revision_id,
+            ],
+            get_dataset_example_revisions(
+                dataset_version_id=experiment.dataset_version_id,
+                dataset_id=experiment.dataset_id,
+            ).with_only_columns(
+                literal(experiment.id),
+                models.DatasetExampleRevision.dataset_example_id,
+                models.DatasetExampleRevision.id,
+            ),
+        )
+        await session.execute(junction_stmt)
 
         dialect = SupportedSQLDialect(session.bind.dialect.name)
         project_rowid = await session.scalar(

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -17,7 +17,7 @@ from strawberry.relay import GlobalID
 from phoenix.db import models
 from phoenix.db.helpers import (
     SupportedSQLDialect,
-    create_experiment_examples_snapshot_insert,
+    insert_experiment_with_examples_snapshot,
 )
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.server.api.types.node import from_global_id_with_expected_type
@@ -181,11 +181,7 @@ async def create_experiment(
             project_name=project_name,
             user_id=user_id,
         )
-        session.add(experiment)
-        await session.flush()
-
-        junction_stmt = create_experiment_examples_snapshot_insert(experiment)
-        await session.execute(junction_stmt)
+        await insert_experiment_with_examples_snapshot(session, experiment)
 
         dialect = SupportedSQLDialect(session.bind.dialect.name)
         project_rowid = await session.scalar(

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -26,6 +26,7 @@ from typing_extensions import TypeAlias, assert_never
 from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
+from phoenix.db.helpers import create_experiment_examples_snapshot_insert
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
@@ -317,6 +318,9 @@ class Subscription:
             )
             session.add(experiment)
             await session.flush()
+
+            junction_stmt = create_experiment_examples_snapshot_insert(experiment)
+            await session.execute(junction_stmt)
         yield ChatCompletionSubscriptionExperiment(
             experiment=to_gql_experiment(experiment)
         )  # eagerly yields experiment so it can be linked by consumers of the subscription

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -26,7 +26,7 @@ from typing_extensions import TypeAlias, assert_never
 from phoenix.config import PLAYGROUND_PROJECT_NAME
 from phoenix.datetime_utils import local_now, normalize_datetime
 from phoenix.db import models
-from phoenix.db.helpers import create_experiment_examples_snapshot_insert
+from phoenix.db.helpers import insert_experiment_with_examples_snapshot
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, CustomGraphQLError, NotFound
@@ -316,11 +316,7 @@ class Subscription:
                 project_name=project_name,
                 user_id=user_id,
             )
-            session.add(experiment)
-            await session.flush()
-
-            junction_stmt = create_experiment_examples_snapshot_insert(experiment)
-            await session.execute(junction_stmt)
+            await insert_experiment_with_examples_snapshot(session, experiment)
         yield ChatCompletionSubscriptionExperiment(
             experiment=to_gql_experiment(experiment)
         )  # eagerly yields experiment so it can be linked by consumers of the subscription

--- a/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -45,8 +45,8 @@ def test_experiments_dataset_examples_backfill_migration(
     with pytest.raises(BaseException, match="alembic_version"):
         _version_num(_engine, _schema)
 
-    # Migrate to the revision before our target migration (deb2c81c0bb2)
-    _up(_engine, _alembic_config, "deb2c81c0bb2", _schema)
+    # Migrate to the revision before our target migration
+    _up(_engine, _alembic_config, "58228d933c91", _schema)
 
     # Set up test data before migration
     test_data = _setup_test_data(_engine)
@@ -61,7 +61,7 @@ def test_experiments_dataset_examples_backfill_migration(
     _verify_post_migration_state(_engine, test_data)
 
     # Test downgrade
-    _down(_engine, _alembic_config, "deb2c81c0bb2", _schema)
+    _down(_engine, _alembic_config, "58228d933c91", _schema)
 
     # Verify table is dropped
     _verify_downgrade_state(_engine)

--- a/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -1,0 +1,368 @@
+"""
+Test for experiments_dataset_examples junction table migration with backfill.
+
+This test verifies that the migration correctly:
+1. Creates the junction table with proper schema
+2. Backfills existing experiments with appropriate dataset example revisions
+3. Handles edge cases like multiple revisions and DELETE operations
+4. Maintains data integrity throughout the migration process
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Literal
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Engine, MetaData, text
+
+from . import _down, _up, _version_num
+
+
+def test_experiments_dataset_examples_backfill_migration(
+    _engine: Engine,
+    _alembic_config: Config,
+    _db_backend: Literal["sqlite", "postgresql"],
+    _schema: str,
+) -> None:
+    """
+    Test the experiments_dataset_examples junction table migration with backfill.
+
+    This test verifies:
+    1. Junction table creation with correct schema
+    2. Backfill of existing experiments with appropriate revisions
+    3. Proper handling of multiple revisions per example
+    4. Exclusion of DELETE revisions from backfill
+    5. Correct foreign key relationships and constraints
+
+    Args:
+        _engine: Database engine fixture
+        _alembic_config: Alembic configuration fixture
+        _db_backend: Database backend type ('sqlite' or 'postgresql')
+        _schema: Database schema name fixture
+    """
+
+    # Verify clean state
+    with pytest.raises(BaseException, match="alembic_version"):
+        _version_num(_engine, _schema)
+
+    # Migrate to the revision before our target migration (deb2c81c0bb2)
+    _up(_engine, _alembic_config, "deb2c81c0bb2", _schema)
+
+    # Set up test data before migration
+    test_data = _setup_test_data(_engine)
+
+    # Verify pre-migration state
+    _verify_pre_migration_state(_engine, test_data)
+
+    # Run the target migration
+    _up(_engine, _alembic_config, "e76cbd66ffc3", _schema)
+
+    # Verify post-migration state
+    _verify_post_migration_state(_engine, test_data)
+
+    # Test downgrade
+    _down(_engine, _alembic_config, "deb2c81c0bb2", _schema)
+
+    # Verify table is dropped
+    _verify_downgrade_state(_engine)
+
+
+def _setup_test_data(_engine: Engine) -> Dict[str, Any]:
+    """Set up test data before migration."""
+
+    # Use current timestamp for cross-database compatibility
+    now = datetime.now(timezone.utc).isoformat()
+
+    with _engine.connect() as conn:
+        # Create test datasets
+        dataset1_id = conn.execute(
+            text("""
+            INSERT INTO datasets (name, description, metadata, created_at, updated_at)
+            VALUES ('test_dataset_1', 'Test Dataset 1', '{}', :now, :now)
+            RETURNING id
+        """),
+            {"now": now},
+        ).scalar()
+
+        dataset2_id = conn.execute(
+            text("""
+            INSERT INTO datasets (name, description, metadata, created_at, updated_at)
+            VALUES ('test_dataset_2', 'Test Dataset 2', '{}', :now, :now)
+            RETURNING id
+        """),
+            {"now": now},
+        ).scalar()
+
+        # Create dataset versions
+        version1_id = conn.execute(
+            text("""
+            INSERT INTO dataset_versions (dataset_id, description, metadata, created_at)
+            VALUES (:dataset_id, 'Version 1', '{}', :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "now": now},
+        ).scalar()
+
+        version2_id = conn.execute(
+            text("""
+            INSERT INTO dataset_versions (dataset_id, description, metadata, created_at)
+            VALUES (:dataset_id, 'Version 2', '{}', :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "now": now},
+        ).scalar()
+
+        version3_id = conn.execute(
+            text("""
+            INSERT INTO dataset_versions (dataset_id, description, metadata, created_at)
+            VALUES (:dataset_id, 'Version 1', '{}', :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset2_id, "now": now},
+        ).scalar()
+
+        # Create dataset examples
+        example1_id = conn.execute(
+            text("""
+            INSERT INTO dataset_examples (dataset_id, created_at)
+            VALUES (:dataset_id, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "now": now},
+        ).scalar()
+
+        example2_id = conn.execute(
+            text("""
+            INSERT INTO dataset_examples (dataset_id, created_at)
+            VALUES (:dataset_id, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "now": now},
+        ).scalar()
+
+        example3_id = conn.execute(
+            text("""
+            INSERT INTO dataset_examples (dataset_id, created_at)
+            VALUES (:dataset_id, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset2_id, "now": now},
+        ).scalar()
+
+        # Create dataset example revisions with different scenarios
+        # Example 1: Multiple revisions across versions
+        revision1_1_id = conn.execute(
+            text("""
+            INSERT INTO dataset_example_revisions
+            (dataset_example_id, dataset_version_id, input, output, metadata, revision_kind, created_at)
+            VALUES (:example_id, :version_id, '{"input": "v1"}', '{"output": "v1"}', '{}', 'CREATE', :now)
+            RETURNING id
+        """),
+            {"example_id": example1_id, "version_id": version1_id, "now": now},
+        ).scalar()
+
+        revision1_2_id = conn.execute(
+            text("""
+            INSERT INTO dataset_example_revisions
+            (dataset_example_id, dataset_version_id, input, output, metadata, revision_kind, created_at)
+            VALUES (:example_id, :version_id, '{"input": "v2"}', '{"output": "v2"}', '{}', 'PATCH', :now)
+            RETURNING id
+        """),
+            {"example_id": example1_id, "version_id": version2_id, "now": now},
+        ).scalar()
+
+        # Example 2: Single revision, then DELETE (should be excluded)
+        revision2_1_id = conn.execute(
+            text("""
+            INSERT INTO dataset_example_revisions
+            (dataset_example_id, dataset_version_id, input, output, metadata, revision_kind, created_at)
+            VALUES (:example_id, :version_id, '{"input": "v1"}', '{"output": "v1"}', '{}', 'CREATE', :now)
+            RETURNING id
+        """),
+            {"example_id": example2_id, "version_id": version1_id, "now": now},
+        ).scalar()
+
+        # DELETE revision - should be excluded from backfill
+        conn.execute(
+            text("""
+            INSERT INTO dataset_example_revisions
+            (dataset_example_id, dataset_version_id, input, output, metadata, revision_kind, created_at)
+            VALUES (:example_id, :version_id, '{"input": "deleted"}', '{"output": "deleted"}', '{}', 'DELETE', :now)
+        """),
+            {"example_id": example2_id, "version_id": version2_id, "now": now},
+        )
+
+        # Example 3: Different dataset
+        revision3_1_id = conn.execute(
+            text("""
+            INSERT INTO dataset_example_revisions
+            (dataset_example_id, dataset_version_id, input, output, metadata, revision_kind, created_at)
+            VALUES (:example_id, :version_id, '{"input": "other"}', '{"output": "other"}', '{}', 'CREATE', :now)
+            RETURNING id
+        """),
+            {"example_id": example3_id, "version_id": version3_id, "now": now},
+        ).scalar()
+
+        # Create experiments
+        experiment1_id = conn.execute(
+            text("""
+            INSERT INTO experiments
+            (dataset_id, dataset_version_id, name, description, repetitions, metadata, created_at, updated_at)
+            VALUES (:dataset_id, :version_id, 'Experiment 1', 'Test Exp 1', 1, '{}', :now, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "version_id": version1_id, "now": now},
+        ).scalar()
+
+        experiment2_id = conn.execute(
+            text("""
+            INSERT INTO experiments
+            (dataset_id, dataset_version_id, name, description, repetitions, metadata, created_at, updated_at)
+            VALUES (:dataset_id, :version_id, 'Experiment 2', 'Test Exp 2', 1, '{}', :now, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset1_id, "version_id": version2_id, "now": now},
+        ).scalar()
+
+        experiment3_id = conn.execute(
+            text("""
+            INSERT INTO experiments
+            (dataset_id, dataset_version_id, name, description, repetitions, metadata, created_at, updated_at)
+            VALUES (:dataset_id, :version_id, 'Experiment 3', 'Test Exp 3', 1, '{}', :now, :now)
+            RETURNING id
+        """),
+            {"dataset_id": dataset2_id, "version_id": version3_id, "now": now},
+        ).scalar()
+
+        conn.commit()
+
+        return {
+            "datasets": [dataset1_id, dataset2_id],
+            "versions": [version1_id, version2_id, version3_id],
+            "examples": [example1_id, example2_id, example3_id],
+            "revisions": {
+                "revision1_1": revision1_1_id,
+                "revision1_2": revision1_2_id,
+                "revision2_1": revision2_1_id,
+                "revision3_1": revision3_1_id,
+            },
+            "experiments": [experiment1_id, experiment2_id, experiment3_id],
+        }
+
+
+def _verify_pre_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> None:
+    """Verify state before migration."""
+
+    # Check junction table doesn't exist (use separate transaction for PostgreSQL)
+    with _engine.connect() as conn:
+        try:
+            conn.execute(text("SELECT 1 FROM experiments_dataset_examples LIMIT 1"))
+            assert False, "Junction table should not exist before migration"
+        except Exception:
+            # Expected - table doesn't exist (different backends raise different exceptions)
+            pass
+
+    # Verify other tables exist (separate transaction)
+    with _engine.connect() as conn:
+        # Verify experiments exist
+        result = conn.execute(text("SELECT COUNT(*) FROM experiments"))
+        assert result.scalar() == 3, "Should have 3 experiments"
+
+        # Verify examples and revisions exist
+        result = conn.execute(text("SELECT COUNT(*) FROM dataset_examples"))
+        assert result.scalar() == 3, "Should have 3 dataset examples"
+
+        result = conn.execute(text("SELECT COUNT(*) FROM dataset_example_revisions"))
+        assert result.scalar() == 5, "Should have 5 revisions (including DELETE)"
+
+
+def _verify_post_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> None:
+    """Verify state after migration and backfill."""
+
+    with _engine.connect() as conn:
+        # Verify junction table exists with correct schema
+        metadata = MetaData()
+        metadata.reflect(bind=_engine)
+
+        assert "experiments_dataset_examples" in metadata.tables, "Junction table should exist"
+
+        table = metadata.tables["experiments_dataset_examples"]
+        columns = {col.name for col in table.columns}
+        expected_columns = {"experiment_id", "dataset_example_id", "dataset_example_revision_id"}
+        assert columns == expected_columns, f"Expected columns {expected_columns}, got {columns}"
+
+        # Verify primary key constraint
+        pk_cols = {col.name for col in table.primary_key.columns}
+        expected_pk = {"experiment_id", "dataset_example_id"}
+        assert pk_cols == expected_pk, f"Expected PK {expected_pk}, got {pk_cols}"
+
+        # Verify foreign key constraints
+        fk_count = len(table.foreign_keys)
+        assert fk_count == 3, f"Expected 3 foreign keys, got {fk_count}"
+
+        # Verify backfill data
+        result = conn.execute(
+            text("""
+            SELECT experiment_id, dataset_example_id, dataset_example_revision_id
+            FROM experiments_dataset_examples
+            ORDER BY experiment_id, dataset_example_id
+        """)
+        )
+
+        backfill_data = result.fetchall()
+
+        # Expected backfill results:
+        # Experiment 1 (version 1): example1 -> revision1_1, example2 -> revision2_1
+        # Experiment 2 (version 2): example1 -> revision1_2 (example2 DELETED, excluded)
+        # Experiment 3 (dataset2): example3 -> revision3_1
+
+        assert len(backfill_data) == 4, f"Expected 4 junction records, got {len(backfill_data)}"
+
+        # Verify specific mappings
+        exp1_id, exp2_id, exp3_id = test_data["experiments"]
+        ex1_id, ex2_id, ex3_id = test_data["examples"]
+        rev1_1_id = test_data["revisions"]["revision1_1"]
+        rev1_2_id = test_data["revisions"]["revision1_2"]
+        rev2_1_id = test_data["revisions"]["revision2_1"]
+        rev3_1_id = test_data["revisions"]["revision3_1"]
+
+        expected_mappings = {
+            (exp1_id, ex1_id, rev1_1_id),  # Exp1 -> Ex1 -> latest for version 1
+            (exp1_id, ex2_id, rev2_1_id),  # Exp1 -> Ex2 -> latest for version 1
+            (exp2_id, ex1_id, rev1_2_id),  # Exp2 -> Ex1 -> latest for version 2
+            # Note: Exp2 -> Ex2 excluded because Ex2 was DELETED in version 2
+            (exp3_id, ex3_id, rev3_1_id),  # Exp3 -> Ex3 -> latest for version 1
+        }
+
+        actual_mappings = {(row[0], row[1], row[2]) for row in backfill_data}
+        assert actual_mappings == expected_mappings, (
+            f"Expected {expected_mappings}, got {actual_mappings}"
+        )
+
+        # Verify no DELETE revisions were included
+        result = conn.execute(
+            text("""
+            SELECT COUNT(*) FROM experiments_dataset_examples ede
+            JOIN dataset_example_revisions der ON ede.dataset_example_revision_id = der.id
+            WHERE der.revision_kind = 'DELETE'
+        """)
+        )
+        assert result.scalar() == 0, "No DELETE revisions should be in junction table"
+
+
+def _verify_downgrade_state(_engine: Engine) -> None:
+    """Verify state after downgrade."""
+
+    # Check junction table is dropped (use separate transaction for PostgreSQL)
+    with _engine.connect() as conn:
+        try:
+            conn.execute(text("SELECT 1 FROM experiments_dataset_examples LIMIT 1"))
+            assert False, "Junction table should be dropped after downgrade"
+        except Exception:
+            # Expected - table doesn't exist (different backends raise different exceptions)
+            pass
+
+    # Verify other tables still exist (separate transaction)
+    with _engine.connect() as conn:
+        result = conn.execute(text("SELECT COUNT(*) FROM experiments"))
+        assert result.scalar() == 3, "Experiments should still exist after downgrade"

--- a/tests/unit/_helpers.py
+++ b/tests/unit/_helpers.py
@@ -188,7 +188,7 @@ async def verify_experiment_examples_junction_table(
     ## Verification Approach
 
     When expected_examples=None, this function:
-    1. **Gets all revisions** for the experiment's dataset version
+    1. **Gets all revisions** up to and including the experiment's dataset version
     2. **Finds latest revision** for each example using simple Python logic
     3. **Filters out DELETE** revisions
     4. **Checks experiment splits** independently
@@ -225,11 +225,11 @@ async def verify_experiment_examples_junction_table(
         dataset_version_id = experiment.dataset_version_id
 
         # Independent verification logic
-        # Step 1: Get ALL revisions for this dataset version
+        # Step 1: Get ALL revisions up to and including this dataset version
         all_revisions = (
             await session.scalars(
                 select(models.DatasetExampleRevision)
-                .where(models.DatasetExampleRevision.dataset_version_id == dataset_version_id)
+                .where(models.DatasetExampleRevision.dataset_version_id <= dataset_version_id)
                 .order_by(
                     models.DatasetExampleRevision.dataset_example_id,
                     models.DatasetExampleRevision.created_at.desc(),

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -25,7 +25,9 @@ from phoenix.server.api.types.DatasetVersion import DatasetVersion
 from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.node import from_global_id
 from phoenix.server.experiments.utils import is_experiment_project_name
+from phoenix.server.types import DbSessionFactory
 from phoenix.trace.attributes import flatten, get_attribute_value
+from tests.unit._helpers import verify_experiment_examples_junction_table
 from tests.unit.graphql import AsyncGraphQLClient
 from tests.unit.vcr import CustomVCR
 
@@ -943,6 +945,7 @@ class TestChatCompletionOverDatasetSubscription:
         openai_api_key: str,
         playground_dataset_with_patch_revision: None,
         custom_vcr: CustomVCR,
+        db: DbSessionFactory,
     ) -> None:
         dataset_id = str(GlobalID(type_name=Dataset.__name__, node_id=str(1)))
         version_id = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
@@ -1034,6 +1037,9 @@ class TestChatCompletionOverDatasetSubscription:
         ] == ChatCompletionSubscriptionExperiment.__name__
         experiment = experiment_payload["experiment"]
         assert (experiment_id := experiment.pop("id"))
+
+        async with db() as session:
+            await verify_experiment_examples_junction_table(session, experiment_id)
 
         # query for the span via the node interface to ensure that the span
         # recorded in the db contains identical information as the span emitted
@@ -1321,6 +1327,7 @@ class TestChatCompletionOverDatasetSubscription:
         cities_and_countries: list[tuple[str, str]],
         playground_city_and_country_dataset: None,
         custom_vcr: CustomVCR,
+        db: DbSessionFactory,
     ) -> None:
         dataset_id = str(GlobalID(type_name=Dataset.__name__, node_id=str(1)))
         version_id = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
@@ -1405,7 +1412,11 @@ class TestChatCompletionOverDatasetSubscription:
         # check experiment payload
         assert len(payloads[None]) == 1
         assert (experiment := payloads[None].pop()["chatCompletionOverDataset"]["experiment"])
-        assert isinstance(experiment["id"], str)
+        experiment_id = experiment["id"]
+        assert isinstance(experiment_id, str)
+
+        async with db() as session:
+            await verify_experiment_examples_junction_table(session, experiment_id)
 
 
 def _request_bodies_contain_same_city(request1: VCRRequest, request2: VCRRequest) -> None:


### PR DESCRIPTION
# 🔗 Add Experiments-Dataset Examples Junction Table

## Summary
Introduces a junction table to capture which dataset examples belong to each experiment at creation time, enabling accurate historical tracking and supporting dataset splits functionality.

## Key Changes
- **New junction table**: experiments_dataset_examples with composite primary key and proper foreign key constraints
- **Smart migration**: Backfills existing experiments using ROW_NUMBER() to select correct historical revisions  
- **Dataset splits support**: Automatically filters examples based on experiment's assigned splits
- **API integration**: Populates junction records across all experiment creation endpoints
- **Comprehensive testing**: Full unit and integration test coverage

## Technical Details
- Cross-database compatible (PostgreSQL/SQLite)
- Efficient helper functions with granular, reusable components
- Proper DELETE revision handling to exclude deleted examples
- Maintains referential integrity with CASCADE delete constraints
