### PR TITLE
feat: Improve binding ergonomics

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import inspect
 import itertools
 import json
@@ -269,6 +270,10 @@ class Evaluator(ABC):
     def bind(self, input_mapping: InputMappingType) -> None:
         """Binds an evaluator with a fixed input mapping."""
         self._input_mapping = input_mapping
+
+    def unbind(self) -> None:
+        """Unbinds an evaluator from an input mapping."""
+        self._input_mapping = None
 
     def _get_required_fields(self, input_mapping: Optional[InputMappingType]) -> Set[str]:
         """
@@ -1053,8 +1058,9 @@ def bind_evaluator(
             }
             result = bound_evaluator.evaluate(data)
     """
-    evaluator.bind(input_mapping=input_mapping)
-    return evaluator
+    evaluator_copy = cast(Evaluator, copy.deepcopy(evaluator))
+    evaluator_copy.bind(input_mapping=input_mapping)
+    return evaluator_copy
 
 
 # --- Helper functions for dataframe evaluation ---

--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -1058,7 +1058,7 @@ def bind_evaluator(
             }
             result = bound_evaluator.evaluate(data)
     """
-    evaluator_copy = cast(Evaluator, copy.deepcopy(evaluator))
+    evaluator_copy = copy.deepcopy(evaluator)
     evaluator_copy.bind(input_mapping=input_mapping)
     return evaluator_copy
 


### PR DESCRIPTION
- Adds an `unbind` method to Evaluators to remove any associated input mapping bind
- the `bind_evaluator` function now returns a copy of the original evaluator to prevent undesired mutation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `Evaluator.unbind()` and updates `bind_evaluator` to return a deep-copied, bound evaluator instead of mutating the original.
> 
> - **Evaluators** (`packages/phoenix-evals/src/phoenix/evals/evaluators.py`):
>   - Add `Evaluator.unbind()` to clear any bound `input_mapping`.
>   - Update `bind_evaluator` to `deepcopy` the provided evaluator, bind the copy, and return it (prevents mutating the original).
>   - Import `copy` to support deep copying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c8f23e04b5d85a526b7ba6571423ee96b50803d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->