### PR TITLE
feat: use composite primary key for crosswalk tables

### DIFF
--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -395,12 +395,9 @@ CREATE INDEX ix_dataset_example_revisions_dataset_version_id ON public.dataset_e
 -- Table: dataset_splits_dataset_examples
 -- --------------------------------------
 CREATE TABLE public.dataset_splits_dataset_examples (
-    id bigserial NOT NULL,
     dataset_split_id BIGINT NOT NULL,
     dataset_example_id BIGINT NOT NULL,
-    CONSTRAINT pk_dataset_splits_dataset_examples PRIMARY KEY (id),
-    CONSTRAINT uq_dataset_splits_dataset_examples_dataset_split_id_dat_9586
-        UNIQUE (dataset_split_id, dataset_example_id),
+    CONSTRAINT pk_dataset_splits_dataset_examples PRIMARY KEY (dataset_split_id, dataset_example_id),
     CONSTRAINT fk_dataset_splits_dataset_examples_dataset_example_id_d_63b2
         FOREIGN KEY
         (dataset_example_id)
@@ -803,12 +800,9 @@ CREATE INDEX ix_experiments_dataset_examples_dataset_example_revision_id ON publ
 -- Table: experiments_dataset_splits
 -- ---------------------------------
 CREATE TABLE public.experiments_dataset_splits (
-    id bigserial NOT NULL,
     experiment_id BIGINT NOT NULL,
     dataset_split_id BIGINT NOT NULL,
-    CONSTRAINT pk_experiments_dataset_splits PRIMARY KEY (id),
-    CONSTRAINT uq_experiments_dataset_splits_experiment_id_dataset_split_id
-        UNIQUE (experiment_id, dataset_split_id),
+    CONSTRAINT pk_experiments_dataset_splits PRIMARY KEY (experiment_id, dataset_split_id),
     CONSTRAINT fk_experiments_dataset_splits_dataset_split_id_dataset_splits
         FOREIGN KEY
         (dataset_split_id)

--- a/src/phoenix/db/migrations/versions/deb2c81c0bb2_dataset_splits.py
+++ b/src/phoenix/db/migrations/versions/deb2c81c0bb2_dataset_splits.py
@@ -93,7 +93,6 @@ def upgrade() -> None:
     # Create crosswalk table: dataset_splits_dataset_examples
     op.create_table(
         "dataset_splits_dataset_examples",
-        sa.Column("id", _Integer, primary_key=True),
         sa.Column(
             "dataset_split_id",
             _Integer,
@@ -105,11 +104,10 @@ def upgrade() -> None:
             _Integer,
             sa.ForeignKey("dataset_examples.id", ondelete="CASCADE"),
             nullable=False,
-            # index on the second element of the unique constraint tuple is needed
-            # only the first element is sorted in the composite index behind the unique constraint
+            # index on the second element of the composite primary key
             index=True,
         ),
-        sa.UniqueConstraint(
+        sa.PrimaryKeyConstraint(
             "dataset_split_id",
             "dataset_example_id",
         ),
@@ -122,7 +120,6 @@ def upgrade() -> None:
 
     op.create_table(
         "experiments_dataset_splits",
-        sa.Column("id", _Integer, primary_key=True),
         sa.Column(
             "experiment_id",
             _Integer,
@@ -134,11 +131,10 @@ def upgrade() -> None:
             _Integer,
             sa.ForeignKey("dataset_splits.id", ondelete="CASCADE"),
             nullable=False,
-            # index on the second element of the unique constraint tuple is needed
-            # only the first element is sorted in the composite index behind the unique constraint
+            # index on the second element of the composite primary key
             index=True,
         ),
-        sa.UniqueConstraint(
+        sa.PrimaryKeyConstraint(
             "experiment_id",
             "dataset_split_id",
         ),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -1253,7 +1253,7 @@ class DatasetSplit(HasId):
     )
 
 
-class DatasetSplitDatasetExample(HasId):
+class DatasetSplitDatasetExample(Base):
     __tablename__ = "dataset_splits_dataset_examples"
     dataset_split_id: Mapped[int] = mapped_column(
         ForeignKey("dataset_splits.id", ondelete="CASCADE"),
@@ -1269,7 +1269,7 @@ class DatasetSplitDatasetExample(HasId):
         "DatasetExample", back_populates="dataset_splits_dataset_examples"
     )
     __table_args__ = (
-        UniqueConstraint(
+        PrimaryKeyConstraint(
             "dataset_split_id",
             "dataset_example_id",
         ),
@@ -1310,7 +1310,7 @@ class Experiment(HasId):
     )
 
 
-class ExperimentDatasetSplit(HasId):
+class ExperimentDatasetSplit(Base):
     __tablename__ = "experiments_dataset_splits"
     experiment_id: Mapped[int] = mapped_column(
         ForeignKey("experiments.id", ondelete="CASCADE"),
@@ -1326,7 +1326,7 @@ class ExperimentDatasetSplit(HasId):
         "DatasetSplit", back_populates="experiment_dataset_splits"
     )
     __table_args__ = (
-        UniqueConstraint(
+        PrimaryKeyConstraint(
             "experiment_id",
             "dataset_split_id",
         ),


### PR DESCRIPTION
## Summary
This PR updates the crosswalk/junction tables in the dataset splits feature to use composite primary keys instead of separate auto-incrementing `id` columns with unique constraints, following the established pattern from `experiments_dataset_examples`.

## Changes Made

### Migration (`deb2c81c0bb2_dataset_splits.py`)
- **`dataset_splits_dataset_examples`**: Removed `id` column, replaced `UniqueConstraint` with `PrimaryKeyConstraint(dataset_split_id, dataset_example_id)`
- **`experiments_dataset_splits`**: Removed `id` column, replaced `UniqueConstraint` with `PrimaryKeyConstraint(experiment_id, dataset_split_id)`

### Models (`models.py`)
- **`DatasetSplitDatasetExample`**: Changed inheritance from `HasId` to `Base`, updated `__table_args__` to use `PrimaryKeyConstraint`
- **`ExperimentDatasetSplit`**: Changed inheritance from `HasId` to `Base`, updated `__table_args__` to use `PrimaryKeyConstraint`

## Database Schema Relationships

Arrows are parent-to-child foreign key constraints.

```mermaid
graph TD
    A[experiments] --> D[experiments_dataset_splits]
    B[dataset_splits] --> D[experiments_dataset_splits]
    B[dataset_splits] --> E[dataset_splits_dataset_examples]
    C[dataset_examples] --> E[dataset_splits_dataset_examples]
       
    class D,E crosswalk
    class A,B,C regular
```