### PR TITLE
fix: include basename in link generated by ShareLinkButton

### DIFF
--- a/app/src/components/ShareLinkButton.tsx
+++ b/app/src/components/ShareLinkButton.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router";
 
 import { Button, Icon, Icons, Text, View } from "@phoenix/components";
 import { useNotifySuccess } from "@phoenix/contexts";
+import { prependBasename } from "@phoenix/utils/routingUtils";
 
 export const ShareLinkButton = ({
   buttonText,
@@ -23,7 +24,10 @@ export const ShareLinkButton = ({
         size="S"
         leadingVisual={<Icon svg={<Icons.ShareOutline />} />}
         onPress={() => {
-          const url = new URL(location.pathname, window.location.origin);
+          const url = new URL(
+            prependBasename(location.pathname),
+            window.location.origin
+          );
           if (preserveSearchParams) {
             url.search = location.search;
           }


### PR DESCRIPTION
Adds basename to links generated by ShareLinkButton. This fixes an issue where links are broken when Phoenix is running behind a reverse proxy with a custom root path.