### PR TITLE
fix: Experiment tracing should respect OITracer configs

### DIFF
--- a/packages/phoenix-client/pyproject.toml
+++ b/packages/phoenix-client/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "tqdm",
   "typing-extensions",
   "openinference-semantic-conventions",
+  "openinference-instrumentation>=0.1.20",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
 ]

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin
 import httpx
 import opentelemetry.sdk.trace as trace_sdk
 from httpx import HTTPStatusError
+from openinference.instrumentation import OITracer, TraceConfig
 from openinference.semconv.resource import ResourceAttributes
 from openinference.semconv.trace import (
     OpenInferenceMimeTypeValues,
@@ -173,7 +174,7 @@ def _get_tracer(
         span_processor = _NoOpProcessor()
 
     tracer_provider.add_span_processor(span_processor)
-    return tracer_provider.get_tracer(__name__), resource
+    return OITracer(tracer_provider.get_tracer(__name__), config=TraceConfig()), resource
 
 
 def get_tqdm_progress_bar_formatter(title: str) -> str:


### PR DESCRIPTION
resolves #9149 

Use OITracers for experiments to respect OIConfigurations