### PR TITLE
docs(evals): update BYO evaluator markdown

### DIFF
--- a/docs/evaluation/preview/templating.md
+++ b/docs/evaluation/preview/templating.md
@@ -1,19 +1,14 @@
 # Prompt Templates
 
-Lightweight utilities to render prompts and infer required fields. We plan to support multimodal prompts, but right now templates only work with text.  
+The evals library provides lightweight utilities to render prompts and infer required fields from placeholders. 
+The prompt template abstraction is designed for simple prompts, and does not currently support different roles or messages construction. 
 
-### Abstractions
-- TemplateFormat: `"mustache" | "f-string"`
-- TemplateFormatter: strategy interface implemented by Mustache and f-string formatters
-- Template: detects format, extracts variables, and renders prompts
-- detect_template_format(template: str) -> TemplateFormat
-- FormatterFactory: create formatter explicitly or via auto-detect
+**Note:** Prompt templates are text-only at this time, but we plan to support multi-modal prompts soon. 
 
 ### Template
-- Constructor: `Template(template: str, template_format: TemplateFormat | None = None)`
-- Properties: `template_format`, `variables: list[str]`
-- Methods: `render(variables: dict) -> str`
-- Auto-detects format using heuristics that handle escaped JSON in f-strings (e.g., `{{"k":1}}`).
+- [API Reference](https://arize-phoenix.readthedocs.io/projects/evals/en/latest/api/evals.html#prompt-template)
+- Auto-detects format (f-string or mustache).
+- Handles escaped JSON in f-strings (e.g., `{{"k":1}}`).
 
 ### Formatters
 - MustacheFormatter: `{{var}}` placeholders via pystache
@@ -30,7 +25,7 @@ text = template.render({"name": "Alice", "place": "Phoenix"})
 assert text == "Hello Alice, welcome to Phoenix"
 ```
 
-2) f-string basics
+2) F-string basics
 ```python
 from phoenix.evals.templating import Template, TemplateFormat
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Overhauls the BYO evaluator guide to use ClassificationEvaluator and a custom LLMEvaluator with structured output, and clarifies prompt templating usage and limitations.
> 
> - **Docs — Building Custom Evaluators (`docs/evaluation/how-to-evals/bring-your-own-evaluator.md`)**
>   - Replace older `llm_classify`/`llm_generate` flow with `ClassificationEvaluator` usage, including prompt template guidance and label `choices` (string and scored mappings; multi-class support).
>   - Add end-to-end code example initializing `ClassificationEvaluator` with `LLM` and running `evaluate`.
>   - Introduce a custom numeric-rating evaluator by subclassing `LLMEvaluator` with JSON schema, implementing `_evaluate`, and example usage.
>   - Streamline “Improving your Custom Eval” with testing guidance and links to example notebooks.
> - **Docs — Prompt Templates (`docs/evaluation/preview/templating.md`)**
>   - Clarify template purpose, auto-detection (f-string/mustache), and text-only limitation; add API reference link and minor copy edits (e.g., F-string casing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d8b7167d8fd62685a51ca4b7e0297a255c6cd94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->