### PR TITLE
chore: cleanup css on experiment compare

### DIFF
--- a/app/src/components/table/IndeterminateCheckboxCell.tsx
+++ b/app/src/components/table/IndeterminateCheckboxCell.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
+import { css } from "@emotion/react";
 
 import { Checkbox, CheckboxProps } from "@phoenix/components/checkbox";
-
 /**
  * A checkbox that can be in an indeterminate state.
  * Borrowed from tanstack/react-table example code.
@@ -21,10 +21,10 @@ export function IndeterminateCheckboxCell(checkboxProps: CheckboxProps) {
       }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      style={{
-        padding: "var(--ac-global-dimension-size-100)",
-        cursor: "pointer",
-      }}
+      css={css`
+        cursor: pointer;
+        padding: var(--ac-global-dimension-size-25);
+      `}
     >
       <Checkbox inputRef={ref} isHovered={isHovered} {...checkboxProps} />
     </div>

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -79,7 +79,7 @@ export const tableCSS = css`
       height: 100%;
       &:not(:last-of-type) {
         & > td {
-          border-bottom: 1px solid var(--ac-global-border-color-default);
+          border-bottom: 1px solid var(--ac-global-color-grey-100);
         }
       }
       & > td {
@@ -97,10 +97,10 @@ export const borderedTableCSS = css`
   tbody:not(.is-empty) {
     tr {
       & > td {
-        border-bottom: 1px solid var(--ac-global-border-color-default);
+        border-bottom: 1px solid var(--ac-global-color-grey-100);
       }
       & > td:not(:last-of-type) {
-        border-right: 1px solid var(--ac-global-border-color-default);
+        border-right: 1px solid var(--ac-global-color-grey-100);
       }
     }
   }

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -3,9 +3,9 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { css } from "@emotion/react";
 
 import {
+  Button,
   Flex,
   Icon,
-  IconButton,
   Icons,
   KeyboardToken,
   Tooltip,
@@ -59,14 +59,13 @@ export const ExampleDetailsPaginator = ({
   return (
     <Flex direction="row" gap="size-50" alignItems="center">
       <TooltipTrigger delay={100}>
-        <IconButton
+        <Button
           size="S"
           aria-label="Next example"
           isDisabled={!hasNext}
           onPress={handleNext}
-        >
-          <Icon svg={<Icons.ArrowDownwardOutline />} />
-        </IconButton>
+          leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
+        ></Button>
         <Tooltip
           offset={4}
           css={css`
@@ -83,14 +82,13 @@ export const ExampleDetailsPaginator = ({
         </Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={100}>
-        <IconButton
+        <Button
           size="S"
           aria-label="Previous example"
           isDisabled={!hasPrevious}
           onPress={handlePrevious}
-        >
-          <Icon svg={<Icons.ArrowUpwardOutline />} />
-        </IconButton>
+          leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
+        ></Button>
         <Tooltip
           offset={4}
           css={css`

--- a/app/src/pages/trace/TracePage.tsx
+++ b/app/src/pages/trace/TracePage.tsx
@@ -1,7 +1,13 @@
 import { Suspense } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 
-import { Dialog, Loading, Modal, ModalOverlay } from "@phoenix/components";
+import {
+  Dialog,
+  Flex,
+  Loading,
+  Modal,
+  ModalOverlay,
+} from "@phoenix/components";
 import {
   DialogCloseButton,
   DialogContent,
@@ -44,9 +50,11 @@ export function TracePage() {
           {({ close }) => (
             <DialogContent>
               <DialogHeader>
-                <DialogTitle>Trace Details</DialogTitle>
-                <DialogTitleExtra>
+                <Flex direction="row" gap="size-200" justifyContent="center">
                   <TraceDetailsPaginator currentId={paginationSubjectId} />
+                  <DialogTitle>Trace Details</DialogTitle>
+                </Flex>
+                <DialogTitleExtra>
                   <ShareLinkButton
                     preserveSearchParams
                     buttonText="Share"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a collapsible, resizable sidebar in the experiment compare dialog, update paginator UI/placement, and tweak table/checkbox styling.
> 
> - **Experiment Compare Dialog (`ExperimentCompareDetailsDialog.tsx`)**:
>   - Replace `Flex` layout with horizontal `PanelGroup`; add collapsible sidebar (`Panel` + `IconButton` toggle) and compact `PanelResizeHandle`.
>   - Add `SIDEBAR_PANEL_DEFAULT_SIZE` and imperative sidebar resizing via `ImperativePanelHandle`.
>   - Header: change title to `Example: {id}` and add "Experiment Runs" section header.
>   - Adjust runs list layout (non-flexing list items, padding/justification) and keys.
> - **Paginators**:
>   - `ExampleDetailsPaginator`: switch from `IconButton` to `Button` with `leadingVisual` icons.
>   - `TracePage`: center paginator with title using `Flex`; move paginator from title-extra into header row.
> - **Tables/Checkbox**:
>   - `IndeterminateCheckboxCell`: migrate inline `style` to Emotion `css`; reduce padding.
>   - `table/styles`: change cell borders to `var(--ac-global-color-grey-100)` for body and bordered tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d82fb8b062ab92d734985693cd92f42ba240826. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->