### PR TITLE
feat: Add Menu component from react-aria

### DIFF
--- a/app/src/components/index.tsx
+++ b/app/src/components/index.tsx
@@ -65,3 +65,4 @@ export * from "./toolbar";
 export * from "./card";
 export * from "./checkbox";
 export * from "./switch";
+export * from "./menu";

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -1,0 +1,100 @@
+import {
+  Menu as AriaMenu,
+  MenuItem as AriaMenuItem,
+  type MenuItemProps as AriaMenuItemProps,
+  type MenuProps as AriaMenuProps,
+  MenuTrigger as AriaMenuTrigger,
+} from "react-aria-components";
+import { css } from "@emotion/react";
+
+import { classNames, Icon, Icons } from "@phoenix/components";
+
+export const MenuTrigger = AriaMenuTrigger;
+
+export const Menu = <T extends object>({
+  className,
+  ...props
+}: AriaMenuProps<T>) => {
+  return (
+    <AriaMenu className={classNames("react-aria-Menu", className)} {...props} />
+  );
+};
+
+const menuItemCss = css`
+  margin: var(--ac-global-dimension-static-size-100);
+  padding: var(--ac-global-dimension-static-size-100) var(--ac-global-dimension-static-size-200);
+  border-radius: var(--ac-global-rounding-small);
+  outline: none;
+  cursor: default;
+  color: var(--ac-global-text-color-900);
+  position: relative;
+  display: flex;
+  gap: var(--ac-global-dimension-static-size-100);
+  align-items: center;
+
+  &[data-selected] {
+    i {
+      color: var(--ac-global-color-primary);
+    }
+  }
+
+  &[data-focused],
+  &[data-hovered] {
+    background-color: var(--ac-global-menu-item-background-color-hover);
+  }
+
+  &[data-disabled] {
+    cursor: not-allowed;
+    color: var(--ac-global-color-text-30);
+  }
+
+  &[data-focus-visible] {
+    outline: none;
+  }
+
+ & svg {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+  }
+}
+
+@media (forced-colors: active) {
+  &[data-focused] {
+    forced-color-adjust: none;
+    background: Highlight;
+    color: HighlightText;
+  }
+`;
+
+export const MenuItem = <T extends object>({
+  className,
+  ...props
+}: AriaMenuItemProps<T>) => {
+  const textValue =
+    props.textValue ||
+    (typeof props.children === "string" ? props.children : undefined);
+  return (
+    <AriaMenuItem
+      {...props}
+      css={menuItemCss}
+      className={classNames("react-aria-MenuItem", className)}
+      textValue={textValue}
+    >
+      {({ hasSubmenu }) => {
+        return (
+          <>
+            {props.children}
+            {hasSubmenu && <Icon svg={<Icons.ChevronRight />} />}
+          </>
+        );
+      }}
+    </AriaMenuItem>
+  );
+};

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -10,6 +10,12 @@ import { css } from "@emotion/react";
 import { classNames, Icon, Icons } from "@phoenix/components";
 
 const menuCss = css`
+  padding: var(--ac-global-dimension-static-size-50);
+  &:focus-visible {
+    border-radius: var(--ac-global-rounding-small);
+    outline: 2px solid var(--ac-global-color-primary);
+    outline-offset: 0px;
+  }
   &[data-empty] {
     align-items: center;
     justify-content: center;
@@ -44,6 +50,7 @@ const menuItemCss = css`
   display: flex;
   gap: var(--ac-global-dimension-static-size-100);
   align-items: center;
+  justify-content: space-between;
 
   &[data-selected] {
     background-color: var(--ac-highlight-background);
@@ -66,18 +73,6 @@ const menuItemCss = css`
 
   &[data-focus-visible] {
     outline: none;
-  }
-
- & svg {
-    fill: none;
-    stroke: currentColor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: 2;
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: 100%;
   }
 }
 

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -9,6 +9,15 @@ import { css } from "@emotion/react";
 
 import { classNames, Icon, Icons } from "@phoenix/components";
 
+const menuCss = css`
+  &[data-empty] {
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    padding: var(--ac-global-dimension-static-size-100);
+  }
+`;
+
 export const MenuTrigger = AriaMenuTrigger;
 
 export const Menu = <T extends object>({
@@ -16,7 +25,11 @@ export const Menu = <T extends object>({
   ...props
 }: AriaMenuProps<T>) => {
   return (
-    <AriaMenu className={classNames("react-aria-Menu", className)} {...props} />
+    <AriaMenu
+      className={classNames("react-aria-Menu", className)}
+      css={menuCss}
+      {...props}
+    />
   );
 };
 
@@ -33,11 +46,14 @@ const menuItemCss = css`
   align-items: center;
 
   &[data-selected] {
+    background-color: var(--ac-highlight-background);
+    color: var(--ac-highlight-foreground);
     i {
       color: var(--ac-global-color-primary);
     }
   }
 
+  &[data-open],
   &[data-focused],
   &[data-hovered] {
     background-color: var(--ac-global-menu-item-background-color-hover);
@@ -45,7 +61,7 @@ const menuItemCss = css`
 
   &[data-disabled] {
     cursor: not-allowed;
-    color: var(--ac-global-color-text-30);
+    color: var(--ac-global-color-text-300);
   }
 
   &[data-focus-visible] {
@@ -87,10 +103,11 @@ export const MenuItem = <T extends object>({
       className={classNames("react-aria-MenuItem", className)}
       textValue={textValue}
     >
-      {({ hasSubmenu }) => {
+      {({ hasSubmenu, isSelected }) => {
         return (
           <>
             {props.children}
+            {isSelected && <Icon svg={<Icons.Checkmark />} />}
             {hasSubmenu && <Icon svg={<Icons.ChevronRight />} />}
           </>
         );

--- a/app/src/components/menu/index.tsx
+++ b/app/src/components/menu/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Menu";

--- a/app/stories/Menu.stories.tsx
+++ b/app/stories/Menu.stories.tsx
@@ -1,6 +1,10 @@
+import { useMemo } from "react";
 import {
   Autocomplete,
+  Collection,
+  Header,
   Input,
+  MenuSection,
   SubmenuTrigger,
   useFilter,
 } from "react-aria-components";
@@ -16,6 +20,7 @@ import {
   MenuTrigger,
   Popover,
   SearchField,
+  Separator,
   Text,
   View,
 } from "@phoenix/components";
@@ -33,7 +38,7 @@ export default meta;
 const NESTED_MENU_ITEMS = [
   {
     id: "1",
-    name: "Item 1",
+    name: "Item 1 Group",
     children: [
       {
         id: "1.1",
@@ -43,11 +48,11 @@ const NESTED_MENU_ITEMS = [
   },
   {
     id: "2",
-    name: "Item 2",
+    name: "Item 2 Group",
   },
   {
     id: "3",
-    name: "Item 3",
+    name: "Item 3 Group",
     children: [
       {
         id: "3.1",
@@ -59,7 +64,7 @@ const NESTED_MENU_ITEMS = [
       },
       {
         id: "3.3",
-        name: "Item 3.3",
+        name: "Item 3.3 Group",
         children: [
           {
             id: "3.3.1",
@@ -72,6 +77,23 @@ const NESTED_MENU_ITEMS = [
 ];
 
 export const Template = () => {
+  return (
+    <MenuTrigger>
+      <Button>Open Menu</Button>
+      <Popover>
+        <Menu>
+          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Item 2</MenuItem>
+          <MenuItem>Item 3</MenuItem>
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+};
+
+Template.args = {};
+
+export const DynamicSearchableMenu = () => {
   const { contains } = useFilter({ sensitivity: "base" });
   return (
     <Flex direction="column" gap="size-200">
@@ -128,4 +150,49 @@ export const Template = () => {
   );
 };
 
-Template.args = {};
+export const SectionedMenu = () => {
+  const lastSection = useMemo(() => {
+    return NESTED_MENU_ITEMS[NESTED_MENU_ITEMS.length - 1];
+  }, []);
+  return (
+    <Flex direction="column" gap="size-200">
+      <Text>View the storybook for comments on implementation</Text>
+      <MenuTrigger>
+        <div>
+          <Button>Menu with Sections</Button>
+        </div>
+        <Popover>
+          <Menu
+            items={NESTED_MENU_ITEMS}
+            renderEmptyState={() => "No Items in Section"}
+          >
+            {/* You could support nested section rendering by naming this render function
+                and calling it recursively. For now, this example just renders sections one level deep */}
+            {(section) => {
+              // do not render empty sections, it is difficult to add an empty state to them
+              // you could possibly add a menu item that links to the place to add data that would populate this section
+              if (!section.children) return <></>;
+              return (
+                <>
+                  <MenuSection>
+                    <Header>
+                      <Flex justifyContent="space-between" alignItems="center">
+                        <Text weight="heavy">{section.name}</Text>
+                        <Text size="S">({section.children.length})</Text>
+                      </Flex>
+                    </Header>
+                    <Collection items={section.children}>
+                      {(item) => <MenuItem key={item.id}>{item.name}</MenuItem>}
+                    </Collection>
+                  </MenuSection>
+                  {/* Only render a separator if this is not the last section, otherwise it looks ugly */}
+                  {section.name !== lastSection.name && <Separator />}
+                </>
+              );
+            }}
+          </Menu>
+        </Popover>
+      </MenuTrigger>
+    </Flex>
+  );
+};

--- a/app/stories/Menu.stories.tsx
+++ b/app/stories/Menu.stories.tsx
@@ -1,0 +1,131 @@
+import {
+  Autocomplete,
+  Input,
+  SubmenuTrigger,
+  useFilter,
+} from "react-aria-components";
+import { Meta } from "@storybook/react";
+
+import {
+  Button,
+  Flex,
+  Icon,
+  Icons,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  SearchField,
+  Text,
+  View,
+} from "@phoenix/components";
+
+const meta: Meta<typeof Menu> = {
+  title: "Menu",
+  component: Menu,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+const NESTED_MENU_ITEMS = [
+  {
+    id: "1",
+    name: "Item 1",
+    children: [
+      {
+        id: "1.1",
+        name: "Item 1.1",
+      },
+    ],
+  },
+  {
+    id: "2",
+    name: "Item 2",
+  },
+  {
+    id: "3",
+    name: "Item 3",
+    children: [
+      {
+        id: "3.1",
+        name: "Item 3.1",
+      },
+      {
+        id: "3.2",
+        name: "Item 3.2",
+      },
+      {
+        id: "3.3",
+        name: "Item 3.3",
+        children: [
+          {
+            id: "3.3.1",
+            name: "Item 3.3.1",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const Template = () => {
+  const { contains } = useFilter({ sensitivity: "base" });
+  return (
+    <Flex direction="column" gap="size-200">
+      <Text>View the storybook for comments on implementation</Text>
+      <MenuTrigger>
+        <div>
+          <Button leadingVisual={<Icon svg={<Icons.Search />} />}>
+            Searchable Menu
+          </Button>
+        </div>
+        <Popover>
+          {/* Wrap the menu in an Autocomplete component */}
+          <Autocomplete filter={contains}>
+            {/* Nest a SearchField as child, it will automatically filter the sibling menu items */}
+            <View paddingX="size-100" marginTop="size-100">
+              <SearchField aria-label="Search" autoFocus>
+                <Input placeholder="Search..." />
+              </SearchField>
+            </View>
+            {/* Provide the items as a prop to menu, instantiating a react-aria collection */}
+            <Menu items={NESTED_MENU_ITEMS}>
+              {function renderMenuItem({ id, name, children }) {
+                // handle items with children to generate submenus
+                if (children) {
+                  return (
+                    <SubmenuTrigger>
+                      <MenuItem key={id}>{name}</MenuItem>
+                      <Popover>
+                        {/* You can nest another Autocomplete here */}
+                        <Autocomplete filter={contains}>
+                          <View paddingX="size-100" marginTop="size-100">
+                            {/* This will find the nearest autocomplete and menu items */}
+                            <SearchField aria-label="Search">
+                              <Input placeholder="Search..." />
+                            </SearchField>
+                          </View>
+                          <Menu items={children}>
+                            {/* recursively call the render fn to render submenu item children */}
+                            {(item) => renderMenuItem(item)}
+                          </Menu>
+                        </Autocomplete>
+                      </Popover>
+                    </SubmenuTrigger>
+                  );
+                }
+                // handle items with no children
+                return <MenuItem key={id}>{name}</MenuItem>;
+              }}
+            </Menu>
+          </Autocomplete>
+        </Popover>
+      </MenuTrigger>
+    </Flex>
+  );
+};
+
+Template.args = {};


### PR DESCRIPTION
<img width="505" height="354" alt="image" src="https://github.com/user-attachments/assets/bd8f257f-d523-497f-b6e6-b3129d0194f4" />

Resolves #9564 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a styled Menu component suite (Menu, MenuItem, MenuTrigger) and exports, with Storybook demos including searchable/nested and sectioned menus.
> 
> - **Components**:
>   - Introduces `Menu`, `MenuItem`, and `MenuTrigger` in `app/src/components/menu/Menu.tsx` with styling, selection checkmark, and submenu chevron.
>   - Adds barrel export `app/src/components/menu/index.tsx` and re-exports `./menu` from `app/src/components/index.tsx`.
> - **Storybook**:
>   - Adds `app/stories/Menu.stories.tsx` with:
>     - Basic menu example.
>     - Searchable, nested submenu example using `Autocomplete` and `SearchField`.
>     - Sectioned menu using `MenuSection`, `Header`, `Collection`, and `Separator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ca923022090eba435993804bf748dbe929540a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->