### PR TITLE
docs(evals): migrate phoenix overview to use new evals 2

### DIFF
--- a/tutorials/ai_evals_course/phoenix_overview.ipynb
+++ b/tutorials/ai_evals_course/phoenix_overview.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,18 +123,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/mikeldking/work/phoenix/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from phoenix.otel import register\n",
     "\n",
@@ -157,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,20 +170,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x11f7c58f0>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import duckdb\n",
     "from datasets import load_dataset\n",
@@ -205,26 +185,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 385687, 'title': 'Fast X', 'genres': 'Action-Crime-Thriller', 'original_language': 'en', 'overview': \"Over many missions and against impossible odds Dom Toretto and his family have outsmarted out-nerved and outdriven every foe in their path. Now they confront the most lethal opponent they've ever faced: A terrifying threat emerging from the shadows of the past who's fueled by blood revenge and who is determined to shatter this family and destroy everything—and everyone—that Dom loves forever.\", 'popularity': 6682.1, 'production_companies': 'Universal Pictures-Original Film-One Race-Perfect Storm Entertainment', 'release_date': '2023-05-17', 'budget': 340000000.0, 'revenue': 686700000.0, 'runtime': 142.0, 'status': 'Released', 'tagline': 'The end of the road begins.', 'vote_average': 7.331, 'vote_count': 1856.0, 'credits': 'Vin Diesel-Michelle Rodriguez-Tyrese Gibson-Ludacris-John Cena-Nathalie Emmanuel-Jordana Brewster-Sung Kang-Jason Momoa-Scott Eastwood-Daniela Melchior-Alan Ritchson-Helen Mirren-Brie Larson-Jason Statham-Charlize Theron-Rita Moreno-Joaquim de Almeida-Leo A. Perry-Luis Da Silva Jr.-Jaz Hutchins-Luka Hays-Alexander Capon-Pete Davidson-Shadrach Agozino-Ludmilla-Miraj Grbić-Meadow Walker Thornton-Allan-Michael Irby-Shahir Figueira-Ben-Hur Santos-Debby Ann Ryan-Josh Dun-Robert Bastens-Dwayne Johnson-Gal Gadot', 'keywords': 'sequel-revenge-racing-family-cars', 'poster_path': '/fiVW06jE7z9YnO4trhaMEdclSiC.jpg', 'backdrop_path': '/4XM8DUTQb3lhLemJC51Jx4a2EuA.jpg', 'recommendations': '19603-445954-697843-603692-781009-502356-747355-640146-569094-1070777-536437-121342-325358-667538-960033-496450-447365-1037644-298618-713704-1121116'}\n",
-      "{'id': 758323, 'title': \"The Pope's Exorcist\", 'genres': 'Horror-Mystery-Thriller', 'original_language': 'en', 'overview': \"Father Gabriele Amorth Chief Exorcist of the Vatican investigates a young boy's terrifying possession and ends up uncovering a centuries-old conspiracy the Vatican has desperately tried to keep hidden.\", 'popularity': 5953.227, 'production_companies': 'Screen Gems-2.0 Entertainment-Jesus & Mary-Worldwide Katz-Loyola Productions-FFILME.RO', 'release_date': '2023-04-05', 'budget': 18000000.0, 'revenue': 65675816.0, 'runtime': 103.0, 'status': 'Released', 'tagline': 'Inspired by the actual files of Father Gabriele Amorth, Chief Exorcist of the Vatican.', 'vote_average': 7.433, 'vote_count': 545.0, 'credits': \"Russell Crowe-Daniel Zovatto-Alex Essoe-Franco Nero-Peter DeSouza-Feighoney-Laurel Marsden-Cornell John-Ryan O'Grady-Bianca Bardoe-Santi Bayón-Paloma Bloyd-Alessandro Gruttadauria-River Hawkins-Jordi Collet-Carrie Munro-Marc Velasco-Edward Harper-Jones-Matthew Sim-Victor Solé-Tom Bonington-Andrea Dugoni-Ed White-Laila Barwick-Gennaro Diana-Pablo Raybould-Ralph Ineson-Derek Carroll-Ella Cannon\", 'keywords': 'spain-rome italy-vatican-pope-pig-possession-conspiracy-devil-exorcist-skepticism-catholic priest-1980s-supernatural horror', 'poster_path': '/9JBEPLTPSm0d1mbEcLxULjJq9Eh.jpg', 'backdrop_path': '/hiHGRbyTcbZoLsYYkO4QiCLYe34.jpg', 'recommendations': '713704-296271-502356-1076605-1084225-1008005-916224-1023313-1033219-980078-842945-943822-816904-804150-638974-649609-603692-849869-809787-776835-1104040'}\n",
-      "{'id': 640146, 'title': 'Ant-Man and the Wasp: Quantumania', 'genres': 'Action-Adventure-Science Fiction', 'original_language': 'en', 'overview': \"Super-Hero partners Scott Lang and Hope van Dyne along with with Hope's parents Janet van Dyne and Hank Pym and Scott's daughter Cassie Lang find themselves exploring the Quantum Realm interacting with strange new creatures and embarking on an adventure that will push them beyond the limits of what they thought possible.\", 'popularity': 4425.387, 'production_companies': 'Marvel Studios-Kevin Feige Productions', 'release_date': '2023-02-15', 'budget': 200000000.0, 'revenue': 475766228.0, 'runtime': 125.0, 'status': 'Released', 'tagline': 'Witness the beginning of a new dynasty.', 'vote_average': 6.507, 'vote_count': 2811.0, 'credits': \"Paul Rudd-Evangeline Lilly-Jonathan Majors-Kathryn Newton-Michelle Pfeiffer-Michael Douglas-Corey Stoll-Bill Murray-William Jackson Harper-David Dastmalchian-Jamie Andrew Cutler-Katy O'Brian-Mark Weinman-Randall Park-Ross Mullan-Tom Clark-Leon Cooke-Nathan Blees-Durassie Kiangangu-Liran Nathan-Sam Symons-Grahame Fox-Nicola Peluso-Harrison Daniels-Brahmdeo Shannon Ramana-Russell Balogh-Leonardo Taiwo-Osian Roberts-Lucas Gerstel-Mia Gerstel-Tracy Jeffrey-Dinah Jeffrey-Judy Jeffrey-John Nayagam-Greta Nayagam-Cathy Chan-Adam Sai-Jamie Sai-Jakari Fraser-Patricia Belcher-Mark Oliver Everett-Ruben Rabasa-Melanie Garcia-Gregg Turkington-Sierra Katow-Ryan Bergara-Marielle Scott-Jake Millgard-Dey Young-Briza Covarrubias-Tess Aubert-David J. Castillo-Sir Cornwell-Alan Heitz-Esther McAuley-Aisling Maria Andreica-Milton Lopes-Roger Craig Smith-Matthew Wood-Loveday Smith-John Townsend-Tom Hiddleston-Owen Wilson-Abby Ryder Fortson\", 'keywords': 'hero-ant-sequel-superhero-based on comic-family-superhero team-aftercreditsstinger-duringcreditsstinger-marvel cinematic universe (mcu)', 'poster_path': '/qnqGbB22YJ7dSs4o6M7exTpNxPz.jpg', 'backdrop_path': '/m8JTwHFwX7I7JY5fPe4SjqejWag.jpg', 'recommendations': '823999-676841-868759-734048-267805-965839-1033219-1035806-946310-811948-842942-772515-1058949-1105283-938992-1077280-76600-677179-802401-461191-980078'}\n",
-      "{'id': 677179, 'title': 'Creed III', 'genres': 'Drama-Action', 'original_language': 'en', 'overview': 'After dominating the boxing world Adonis Creed has been thriving in both his career and family life. When a childhood friend and former boxing prodigy Damien Anderson resurfaces after serving a long sentence in prison he is eager to prove that he deserves his shot in the ring. The face-off between former friends is more than just a fight. To settle the score Adonis must put his future on the line to battle Damien — a fighter who has nothing to lose.', 'popularity': 3994.342, 'production_companies': 'Metro-Goldwyn-Mayer-Proximity Media-Balboa Productions-Outlier Society Productions-Chartoff-Winkler Productions', 'release_date': '2023-03-01', 'budget': 75000000.0, 'revenue': 269000000.0, 'runtime': 116.0, 'status': 'Released', 'tagline': \"You can't run from your past.\", 'vote_average': 7.262, 'vote_count': 1129.0, 'credits': \"Michael B. Jordan-Tessa Thompson-Jonathan Majors-Wood Harris-Phylicia Rashād-Mila Davis-Kent-José Benavidez Jr.-Selenis Leyva-Florian Munteanu-Thaddeus J. Mixson-Spence Moore II-Tony Bellew-Patrice Harris-Ann Najjar-Jacob 'Stitch' Duran-Terence Crawford-Bobby Hernandez-Yahya McClain-Lamont Lankford-Corey Calliet-Kenny Bayless-Todd Grisham-Jessica McCaskill-Maya Page-Jimmy Lennon Jr.-Russell Mora-Al Bernstein-Mauro Ranallo-Brianna Valeria Gonzalez Vazquez-Shayra Medal-Kimberly Dawn Davis-David Diamante-Tony Weeks-Chris Mannix-Andreia Gibau-Soraya Yd-Stephen A. Smith-Barry Pepper-Jessica Holmes-Canelo Álvarez-Fernanda Gomez-Kehlani-Jeremy Lee Stone-Aaron D. Alexander-Brian Neal-Corey Hibbert-James Harden-Jove Edmond-Engle Files-Michael A. Jordan-Natasha Ofili-Rose Eshay-Alan Boell-Eli Joshua Adé-Butch Locsin-Stefni Valencia-Bella Dee-Anastasia Wilson-Beth Scherr-Michelle Davidson-Leah Haile-Teófimo López-Pete Penuel\", 'keywords': 'philadelphia pennsylvania-husband wife relationship-deaf-sports-sequel-orphan-former best friend-ex-con-childhood friends-juvenile detention center-boxing-prodigy', 'poster_path': '/cvsXj3I9Q2iyyIo95AecSd1tad7.jpg', 'backdrop_path': '/5i6SjyDbDWqyun8klUuCxrlFbyw.jpg', 'recommendations': '965839-267805-943822-842942-1035806-823999-1077280-1058949-772515-937278-640146-758009-536554-1011679-315162-934433-785084-631842-82856-100088-436270'}\n",
-      "{'id': 502356, 'title': 'The Super Mario Bros. Movie', 'genres': 'Animation-Family-Adventure-Fantasy-Comedy', 'original_language': 'en', 'overview': 'While working underground to fix a water main Brooklyn plumbers—and brothers—Mario and Luigi are transported down a mysterious pipe and wander into a magical new world. But when the brothers are separated Mario embarks on an epic quest to find Luigi.', 'popularity': 3859.926, 'production_companies': 'Universal Pictures-Illumination-Nintendo', 'release_date': '2023-04-05', 'budget': 100000000.0, 'revenue': 1278766975.0, 'runtime': 92.0, 'status': 'Released', 'tagline': None, 'vote_average': 7.764, 'vote_count': 4042.0, 'credits': 'Chris Pratt-Charlie Day-Anya Taylor-Joy-Jack Black-Keegan-Michael Key-Seth Rogen-Fred Armisen-Khary Payton-Sebastian Maniscalco-Charles Martinet-Kevin Michael Richardson-Juliet Jelenic-Rino Romano-John DiMaggio-Jessica DiCicco-Eric Bauza-Scott Menville-Jason Broad-Carlos Alazraqui-Ashly Burch-Rachel Butera-Cathy Cavadini-Will Collyer-Django Craig-Willow Geer-Aaron Hendry-Andy Hirsch-Phil LaMarr-Jeremy Maxwell-Daniel Mora-Eric Osmond-Noreen Reardon-Lee Shorten-Cree Summer-Nisa Ward-Nora Wyman-Barbara Harris-Kazumi Totaka', 'keywords': 'video game-gorilla-plumber-magic mushroom-anthropomorphism-based on video game-toad-aftercreditsstinger-duringcreditsstinger-damsel in distress-piano-white gloves-brother brother relationship', 'poster_path': '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg', 'backdrop_path': '/2klQ1z1fcHGgQPevbEQdkCnzyuS.jpg', 'recommendations': '713704-385687-640146-60898-758323-1008005-493529-677179-603692-594767-977177-552688-76600-385647-860867-447365-1084226-1106739-325358-868759-868985'}\n",
-      "{'id': 631842, 'title': 'Knock at the Cabin', 'genres': 'Horror-Mystery-Thriller', 'original_language': 'en', 'overview': 'While vacationing at a remote cabin a young girl and her two fathers are taken hostage by four armed strangers who demand that the family make an unthinkable choice to avert the apocalypse. With limited access to the outside world the family must decide what they believe before all is lost.', 'popularity': 3422.537, 'production_companies': 'Blinding Edge Pictures-Universal Pictures-FilmNation Entertainment-Wishmore-Perfect World Pictures', 'release_date': '2023-02-01', 'budget': 20000000.0, 'revenue': 52000000.0, 'runtime': 100.0, 'status': 'Released', 'tagline': 'Save your family or save humanity. Make the choice.', 'vote_average': 6.457, 'vote_count': 888.0, 'credits': \"Dave Bautista-Jonathan Groff-Ben Aldridge-Kristen Cui-Nikki Amuka-Bird-Rupert Grint-Abby Quinn-Clare Louise Frost-McKenna Kerrigan-Odera Adimorah-M. Night Shyamalan-Ian Merrill Peakes-Denise Nakano-Rose Luardo-Billy Vargus-Satomi Hofmann-Kelvin Leung-Lee Avant-Katy Murphy-Kittson O'Neill-Lya Yanne-Hanna Gaffney-Monica Fleurette-Saria Chen\", 'keywords': 'based on novel or book-sacrifice-cabin-faith-end of the world-apocalypse-home invasion-lgbt-aftercreditsstinger-adopted child-adopted daughter-shot on film-gay-same sex relationship-religious symbolism', 'poster_path': '/dm06L9pxDOL9jNSK4Cb6y139rrG.jpg', 'backdrop_path': '/zWDMQX0sPaW2u0N2pJaYA8bVVaJ.jpg', 'recommendations': '1058949-646389-772515-505642-143970-667216-1048522-785084-1058617-986054-640146-937278-1001500-717980-677179-935906-536554-945703-82856-100088-1003580'}\n",
-      "{'id': 603692, 'title': 'John Wick: Chapter 4', 'genres': 'Action-Thriller-Crime', 'original_language': 'en', 'overview': 'With the price on his head ever increasing John Wick uncovers a path to defeating The High Table. But before he can earn his freedom Wick must face off against a new enemy with powerful alliances across the globe and forces that turn old friends into foes.', 'popularity': 2808.342, 'production_companies': 'Thunder Road-87Eleven-Summit Entertainment-Studio Babelsberg', 'release_date': '2023-03-22', 'budget': 90000000.0, 'revenue': 431769198.0, 'runtime': 170.0, 'status': 'Released', 'tagline': 'No way back, one way out.', 'vote_average': 7.904, 'vote_count': 3039.0, 'credits': 'Keanu Reeves-Donnie Yen-Bill Skarsgård-Ian McShane-Laurence Fishburne-Lance Reddick-Clancy Brown-Hiroyuki Sanada-Rina Sawayama-Scott Adkins-Aimée Kwan-Marko Zaror-Natalia Tena-Shamier Anderson-George Georgiou-Yoshinori Tashiro-Hiroki Sumi-Daiki Suzuki-Julia Asuka Riedl-Milena Rendón-Ivy Quainoo-Irina Trifanov-Iryna Fedorova-Andrej Kaminsky-Sven Marquardt-Raicho Vasilev-Marie Pierra Kakoma-Gina Aponte-Christoph Hofmann', 'keywords': 'new york city-martial arts-hitman-sequel-organized crime-osaka japan-aftercreditsstinger-hunted-professional assassin-neo-noir-berlin', 'poster_path': '/vZloFAK7NmvMGKE7VkF5UHaz0I.jpg', 'backdrop_path': '/1inZm0xxXrpRfN0LxwE2TXzyLN6.jpg', 'recommendations': '1098239-802401-24791-502356-385687-525644-1076605-1103694-384093-203579-649336-325358-347196-1033219-1007938-493529-1084225-594767-762338-840326-804150'}\n",
-      "{'id': 840326, 'title': 'Sisu', 'genres': 'Action-War', 'original_language': 'fi', 'overview': 'Deep in the wilderness of Lapland Aatami Korpi is searching for gold but after he stumbles upon Nazi patrol a breathtaking and gold-hungry chase through the destroyed and mined Lapland wilderness begins.', 'popularity': 2634.212, 'production_companies': 'Subzero Film Entertainment-Good Chaos-Stage 6 Films', 'release_date': '2023-01-27', 'budget': 6200000.0, 'revenue': 10568631.0, 'runtime': 91.0, 'status': 'Released', 'tagline': 'Vengeance is golden.', 'vote_average': 7.393, 'vote_count': 261.0, 'credits': 'Jorma Tommila-Aksel Hennie-Jack Doolan-Mimosa Willamo-Onni Tommila-Tatu Sinisalo-Wilhelm Enckell-Vincent Willestrand-Arttu Kapulainen-Elina Saarela-Ilkka Koivula-Max Ovaska-Joel Hirvonen-Pekka Huotari-Severi Saarinen-Aamu Milonoff-Joonas Brilli-Nicholas Francett-Kevin Francett-Eemeli Franssi-Jussi Kaila-Jarkko Klemetti-Henri Koljonen-Pekka Laakso-Martti Näätä Leinonen-Joosua Oja-Pietari Paappanen-Oskari Skyttä-Tomi Lampinen-Mila Leppälä-Jasmi Mäenpää-Nora Nevia-Jenna Tyni-Anssi-Pekka Fredriksson-Jarmo Hietamäki-Wellu Mikkonen-Akseli Hakovirta-Juho-Lauri Hakovirta-Iisko Hirvasvuopio-Sakari Maliniemi-Jukka Vuorela-Ari Joki-Nikita Makkojev-Jasmin Valjas-Linnea Vilppunen-Hannu Anttila-Mario Esposito-Tarmo Hassinen-Miia Heikkinen-Kimmo Henriksson-Arto Kairajärvi-Risto Korhonen-Mirva Korvala-Steven Madlin-Julia Malmsten-Annika Moisio-Kari Parkkinen-Tommi Pelkonen-Arto Peltomäki-Leena Sormunen-Pekka Virkkunen-Jukka Virtanen-Tinwelindon Belbog', 'keywords': 'world war ii-nordic mythology-lapland-finnish mythology', 'poster_path': '/tELs0h3PPicRbsuu5cQ8UFcBQno.jpg', 'backdrop_path': '/94TIUEhuwv8PhdIADEvSuwPljS5.jpg', 'recommendations': '552688-713704-882569-296271-502356-605886-868985-758323-826753-385687-620705-916224-1079078-977223-804150-493529-878361-964980-809787-876969-447365'}\n",
-      "{'id': 646389, 'title': 'Plane', 'genres': 'Action-Adventure-Thriller', 'original_language': 'en', 'overview': 'After a heroic job of successfully landing his storm-damaged aircraft in a war zone a fearless pilot finds himself between the agendas of multiple militias planning to take the plane and its passengers hostage.', 'popularity': 2618.646, 'production_companies': 'MadRiver Pictures-Di Bonaventura Pictures-G-BASE-Olive Hill Media-Riverstone Pictures', 'release_date': '2023-01-12', 'budget': 25000000.0, 'revenue': 51000000.0, 'runtime': 107.0, 'status': 'Released', 'tagline': 'Survive together or die alone.', 'vote_average': 6.901, 'vote_count': 785.0, 'credits': 'Gerard Butler-Mike Colter-Yoson An-Tony Goldwyn-Daniella Pineda-Paul Ben-Victor-Remi Adeleke-Joey Slotnick-Evan Dane Taylor-Claro de los Reyes-Kelly Gale-Haleigh Hekking-Lilly Krug-Oliver Trevena-Tara Westwood-Mark Labella-Quinn McPherson-Kate Rachesky-Amber Rivera-Otis Winston-Modesto Lacen-Jeff Francisco-Jeffrey Holsman-Ariel Felix-Rose Eshay-Jessica Nam-Thomas A. Curran-Ricky Robles Cruz-Matthew Valeña-Natalia Román García-Ángel Fabián Rivera-Heather Seiffert-Kate Bisset', 'keywords': 'pilot-airplane-philippines-held hostage-plane crash', 'poster_path': '/qi9r5xBgcc9KTxlOLjssEbDgO0J.jpg', 'backdrop_path': '/9Rq14Eyrf7Tu1xk0Pl7VcNbNh1n.jpg', 'recommendations': '505642-758769-864692-631842-1058949-925943-758009-315162-615777-707610-922830-1013870-536554-1035806-58087-996727'}\n",
-      "{'id': 569094, 'title': 'Spider-Man: Across the Spider-Verse', 'genres': 'Action-Adventure-Animation-Science Fiction', 'original_language': 'en', 'overview': 'After reuniting with Gwen Stacy Brooklyn’s full-time friendly neighborhood Spider-Man is catapulted across the Multiverse where he encounters the Spider Society a team of Spider-People charged with protecting the Multiverse’s very existence. But when the heroes clash on how to handle a new threat Miles finds himself pitted against the other Spiders and must set out on his own to save those he loves most.', 'popularity': 2550.738, 'production_companies': 'Columbia Pictures-Sony Pictures Animation-Lord Miller-Pascal Pictures-Arad Productions', 'release_date': '2023-05-31', 'budget': 100000000.0, 'revenue': 512609552.0, 'runtime': 140.0, 'status': 'Released', 'tagline': \"It's how you wear the mask that matters\", 'vote_average': 8.64, 'vote_count': 1684.0, 'credits': \"Shameik Moore-Hailee Steinfeld-Brian Tyree Henry-Luna Lauren Velez-Jake Johnson-Oscar Isaac-Jason Schwartzman-Issa Rae-Daniel Kaluuya-Karan Soni-Shea Whigham-Greta Lee-Mahershala Ali-Amandla Stenberg-Jharrel Jerome-Andy Samberg-Jack Quaid-Rachel Dratch-Ziggy Marley-Jorma Taccone-J.K. Simmons-Donald Glover-Elizabeth Perkins-Kathryn Hahn-Ayo Edebiri-Nicole Delaney-Antonina Lentini-Atsuko Okatsuka-Peter Sohn-Melissa Sturm-Lorraine Velez-Nic Novicki-Taran Killam-Metro Boomin-Josh Keaton-Sofia Barclay-Danielle Perez-Yuri Lowenthal-Rita Rani Ahuja-Ismail Bashey-Oscar Camacho-Freddy Ferrari-Kerry Gutierrez-Kamal Khan-Angelo Sekou Kouyate-Andrew Leviton-David Michie-Sumit Naig-Juan Pacheco-Chrystee Pharris-Ben Pronsky-Al Rodrigo-Jaswant Dev Shrestha-Libby Thomas Dickey-Ruth Zalduondo-Jasper Johannes Andrews-Gredel Berrios Calladine-Natalia Castellanos-Russell Tyre Francis-Deepti Gupta-Sohm Kapila-Pradnya Kuwadekar-Ashley London-Christopher Miller-Andrea Navedo-Lakshmi Patel-Jacqueline Pinol-Eliyas Qureshi-Lashana Rodriguez-Dennis Singletary-Amanda Troop-Sitara Attaie-Mayuri Bhandari-June Christopher-Michelle Jubilee Gonzalez-Marabina Jaimes-Rez Kempton-Lex Lang-Phil Lord-Richard Miro-Doug Nicholas-Shakira Ja'nai Paye-James Pirri-Marley Ralph-Michelle Ruff-Narender Sood-Cedric L. Williams-Kimberly Bailey-Sanjay Chandani-Melanie Duke-Jorge R. Gutierrez-Miguel Jiron-Deepti Kingra-Mickelsen-Luisa Leschin-Caitlin McKenna-Richard Andrew Morgado-Arthur Ortiz-Eliana A. Perez-Juan Pope-Mike Rianda-Stan Sellers-Warren Sroka-Jason Linere-White-Kimiko Glenn-Peggy Lu-John Mulaney-Andrew Garfield-Denis Leary-Tobey Maguire-Cliff Robertson-Alfred Molina-Post Malone\", 'keywords': 'sacrifice-villain-comic book-sequel-superhero-based on comic-alternate dimension-alternate version-super power-brooklyn new york city-superhero team-spider bite-super villain-cliffhanger-teen superhero-alternate universe-female superhero-cartoon spider', 'poster_path': '/8Vt6mWEReuy4Of61Lnj5Xj704m8.jpg', 'backdrop_path': '/4HodYYKEIsGOdinkGi2Ucz6X9i0.jpg', 'recommendations': '496450-667538-385687-603692-298618-447277-976573-598331-324857-447365-462883-536437-979296-313369-537210-1106591-532408-502356-1140706-820707-462376'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "records = conn.query(\"SELECT * FROM movies LIMIT 10\").to_df().to_dict(orient=\"records\")\n",
     "\n",
@@ -246,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,17 +286,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT title FROM movies ORDER BY revenue DESC LIMIT 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = await generate_sql(\"What is the top grossing movie?\")\n",
     "print(query)"
@@ -350,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,20 +416,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'The top-grossing movie is \"Avatar.\"'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "await movie_agent(\"What is the top grossing movie?\")"
    ]
@@ -488,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,40 +455,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Question:  Which Brad Pitt movie received the highest rating?\n",
-      "Answer:  The Brad Pitt movie titled \"Voom Portraits\" received the highest rating.\n",
-      "\n",
-      "\n",
-      "Question:  What is the top grossing Marvel movie?\n",
-      "Answer:  The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
-      "\n",
-      "\n",
-      "Question:  What foreign-language fantasy movie was the most popular?\n",
-      "Answer:  The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This film, with a fantasy-drama genre, is in Spanish and follows the story of Sol, a 17-year-old who faces bullying and harassment after moving to a new town. She finds solace and protection in a mysterious and magical female dog. Despite its low vote average, its intriguing plot and fantastical elements have made it stand out in terms of popularity.\n",
-      "\n",
-      "\n",
-      "Question:  what are the best sci-fi movies of 2017?\n",
-      "Answer:  I don't know which science fiction movies from 2017 are considered the best based on the provided data.\n",
-      "\n",
-      "\n",
-      "Question:  What anime topped the box office in the 2010s?\n",
-      "Answer:  I don't know which anime topped the box office in the 2010s based on the information provided.\n",
-      "\n",
-      "\n",
-      "Question:  Recommend a romcom that stars Paul Rudd.\n",
-      "Answer:  If you're looking for a romantic comedy featuring Paul Rudd, I recommend \"Clueless.\" It's a charming blend of comedy and romance where Rudd portrays Cher's ex-stepbrother, who offers her wisdom about growing up and making meaningful connections. His presence in the film adds a delightful touch to this classic tale of teenage life and matchmaking in Beverly Hills.\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openinference.instrumentation import dangerously_using_project\n",
     "\n",
@@ -568,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,104 +503,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>annotation_name</th>\n",
-       "      <th>result.label</th>\n",
-       "      <th>attributes.input.value</th>\n",
-       "      <th>attributes.output.value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>44537d6a9d89f403</th>\n",
-       "      <td>correctness</td>\n",
-       "      <td>incorrect</td>\n",
-       "      <td>Which Brad Pitt movie received the highest rat...</td>\n",
-       "      <td>The Brad Pitt movie titled \"Voom Portraits\" re...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>768806da8b9f91ea</th>\n",
-       "      <td>correctness</td>\n",
-       "      <td>correct</td>\n",
-       "      <td>What is the top grossing Marvel movie?</td>\n",
-       "      <td>The top-grossing Marvel movie is \"Avengers: En...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9fa1caf54d143f4e</th>\n",
-       "      <td>correctness</td>\n",
-       "      <td>incorrect</td>\n",
-       "      <td>What foreign-language fantasy movie was the mo...</td>\n",
-       "      <td>The most popular foreign-language fantasy movi...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25e46043b8a52b20</th>\n",
-       "      <td>correctness</td>\n",
-       "      <td>incorrect</td>\n",
-       "      <td>what are the best sci-fi movies of 2017?</td>\n",
-       "      <td>I don't know which science fiction movies from...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7503437a6dea3233</th>\n",
-       "      <td>correctness</td>\n",
-       "      <td>incorrect</td>\n",
-       "      <td>What anime topped the box office in the 2010s?</td>\n",
-       "      <td>I don't know which anime topped the box office...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 annotation_name result.label  \\\n",
-       "44537d6a9d89f403     correctness    incorrect   \n",
-       "768806da8b9f91ea     correctness      correct   \n",
-       "9fa1caf54d143f4e     correctness    incorrect   \n",
-       "25e46043b8a52b20     correctness    incorrect   \n",
-       "7503437a6dea3233     correctness    incorrect   \n",
-       "\n",
-       "                                             attributes.input.value  \\\n",
-       "44537d6a9d89f403  Which Brad Pitt movie received the highest rat...   \n",
-       "768806da8b9f91ea             What is the top grossing Marvel movie?   \n",
-       "9fa1caf54d143f4e  What foreign-language fantasy movie was the mo...   \n",
-       "25e46043b8a52b20           what are the best sci-fi movies of 2017?   \n",
-       "7503437a6dea3233     What anime topped the box office in the 2010s?   \n",
-       "\n",
-       "                                            attributes.output.value  \n",
-       "44537d6a9d89f403  The Brad Pitt movie titled \"Voom Portraits\" re...  \n",
-       "768806da8b9f91ea  The top-grossing Marvel movie is \"Avengers: En...  \n",
-       "9fa1caf54d143f4e  The most popular foreign-language fantasy movi...  \n",
-       "25e46043b8a52b20  I don't know which science fiction movies from...  \n",
-       "7503437a6dea3233  I don't know which anime topped the box office...  "
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "examples_df = combined_df[\n",
     "    [\"annotation_name\", \"result.label\", \"attributes.input.value\", \"attributes.output.value\"]\n",
@@ -704,52 +522,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "You are an expert evaluator of question and answer pairs. You will be given a human question and an answer from an AI agent.\n",
-      "Your job is to determine if the answer is \"correct\" or \"incorrect\" and to provide a clear reason why the label should be assigned.\n",
-      "\n",
-      "Here are some examples of correct and incorrect answers:\n",
-      "<examples>\n",
-      "Question: Which Brad Pitt movie received the highest rating?\n",
-      "Answer: The Brad Pitt movie titled \"Voom Portraits\" received the highest rating.\n",
-      "Label: incorrect\n",
-      "\n",
-      "Question: What is the top grossing Marvel movie?\n",
-      "Answer: The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
-      "Label: correct\n",
-      "\n",
-      "Question: What foreign-language fantasy movie was the most popular?\n",
-      "Answer: The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This film, with a fantasy-drama genre, is in Spanish and follows the story of Sol, a 17-year-old who faces bullying and harassment after moving to a new town. She finds solace and protection in a mysterious and magical female dog. Despite its low vote average, its intriguing plot and fantastical elements have made it stand out in terms of popularity.\n",
-      "Label: incorrect\n",
-      "\n",
-      "Question: what are the best sci-fi movies of 2017?\n",
-      "Answer: I don't know which science fiction movies from 2017 are considered the best based on the provided data.\n",
-      "Label: incorrect\n",
-      "\n",
-      "Question: What anime topped the box office in the 2010s?\n",
-      "Answer: I don't know which anime topped the box office in the 2010s based on the information provided.\n",
-      "Label: incorrect\n",
-      "</examples>\n",
-      "\n",
-      "<data>\n",
-      "<question>\n",
-      "{attributes.input.value}\n",
-      "</question>\n",
-      "<answer>\n",
-      "{attributes.output.value}\n",
-      "</answer>\n",
-      "</data>\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "example_answers = \"\\n\\n\".join(\n",
     "    [\n",
@@ -781,99 +556,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>attributes.input.value</th>\n",
-       "      <th>attributes.output.value</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>context.span_id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>f361c10d05028cbb</th>\n",
-       "      <td>Recommend a romcom that stars Paul Rudd.</td>\n",
-       "      <td>If you're looking for a romantic comedy featur...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7503437a6dea3233</th>\n",
-       "      <td>What anime topped the box office in the 2010s?</td>\n",
-       "      <td>I don't know which anime topped the box office...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25e46043b8a52b20</th>\n",
-       "      <td>what are the best sci-fi movies of 2017?</td>\n",
-       "      <td>I don't know which science fiction movies from...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9fa1caf54d143f4e</th>\n",
-       "      <td>What foreign-language fantasy movie was the mo...</td>\n",
-       "      <td>The most popular foreign-language fantasy movi...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>768806da8b9f91ea</th>\n",
-       "      <td>What is the top grossing Marvel movie?</td>\n",
-       "      <td>The top-grossing Marvel movie is \"Avengers: En...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                             attributes.input.value  \\\n",
-       "context.span_id                                                       \n",
-       "f361c10d05028cbb           Recommend a romcom that stars Paul Rudd.   \n",
-       "7503437a6dea3233     What anime topped the box office in the 2010s?   \n",
-       "25e46043b8a52b20           what are the best sci-fi movies of 2017?   \n",
-       "9fa1caf54d143f4e  What foreign-language fantasy movie was the mo...   \n",
-       "768806da8b9f91ea             What is the top grossing Marvel movie?   \n",
-       "\n",
-       "                                            attributes.output.value  \n",
-       "context.span_id                                                      \n",
-       "f361c10d05028cbb  If you're looking for a romantic comedy featur...  \n",
-       "7503437a6dea3233  I don't know which anime topped the box office...  \n",
-       "25e46043b8a52b20  I don't know which science fiction movies from...  \n",
-       "9fa1caf54d143f4e  The most popular foreign-language fantasy movi...  \n",
-       "768806da8b9f91ea  The top-grossing Marvel movie is \"Avengers: En...  "
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "spans_df[[\"attributes.input.value\", \"attributes.output.value\"]].head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,32 +589,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "columns overlap but no suffix specified: Index(['name', 'span_kind', 'parent_id', 'start_time', 'end_time',\n       'status_code', 'status_message', 'events', 'context.span_id',\n       'context.trace_id', 'attributes.output.mime_type',\n       'attributes.input.mime_type', 'attributes.openinference.span.kind',\n       'attributes.input.value', 'attributes.output.value'],\n      dtype='object')",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[20]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m spans_with_evals_df = \u001b[43mspans_df\u001b[49m\u001b[43m.\u001b[49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevals_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhow\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mleft\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      3\u001b[39m spans_with_evals_df[\n\u001b[32m      4\u001b[39m     [\u001b[33m\"\u001b[39m\u001b[33mattributes.input.value\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mattributes.output.value\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mlabel\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mscore\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mexplanation\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m      5\u001b[39m ].head()\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/frame.py:10764\u001b[39m, in \u001b[36mDataFrame.join\u001b[39m\u001b[34m(self, other, on, how, lsuffix, rsuffix, sort, validate)\u001b[39m\n\u001b[32m  10754\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m how == \u001b[33m\"\u001b[39m\u001b[33mcross\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m  10755\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m merge(\n\u001b[32m  10756\u001b[39m             \u001b[38;5;28mself\u001b[39m,\n\u001b[32m  10757\u001b[39m             other,\n\u001b[32m   (...)\u001b[39m\u001b[32m  10762\u001b[39m             validate=validate,\n\u001b[32m  10763\u001b[39m         )\n\u001b[32m> \u001b[39m\u001b[32m10764\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmerge\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m  10765\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m  10766\u001b[39m \u001b[43m        \u001b[49m\u001b[43mother\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10767\u001b[39m \u001b[43m        \u001b[49m\u001b[43mleft_on\u001b[49m\u001b[43m=\u001b[49m\u001b[43mon\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10768\u001b[39m \u001b[43m        \u001b[49m\u001b[43mhow\u001b[49m\u001b[43m=\u001b[49m\u001b[43mhow\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10769\u001b[39m \u001b[43m        \u001b[49m\u001b[43mleft_index\u001b[49m\u001b[43m=\u001b[49m\u001b[43mon\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m  10770\u001b[39m \u001b[43m        \u001b[49m\u001b[43mright_index\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m  10771\u001b[39m \u001b[43m        \u001b[49m\u001b[43msuffixes\u001b[49m\u001b[43m=\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlsuffix\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrsuffix\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10772\u001b[39m \u001b[43m        \u001b[49m\u001b[43msort\u001b[49m\u001b[43m=\u001b[49m\u001b[43msort\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10773\u001b[39m \u001b[43m        \u001b[49m\u001b[43mvalidate\u001b[49m\u001b[43m=\u001b[49m\u001b[43mvalidate\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10774\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m  10775\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m  10776\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m on \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:184\u001b[39m, in \u001b[36mmerge\u001b[39m\u001b[34m(left, right, how, on, left_on, right_on, left_index, right_index, sort, suffixes, copy, indicator, validate)\u001b[39m\n\u001b[32m    169\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    170\u001b[39m     op = _MergeOperation(\n\u001b[32m    171\u001b[39m         left_df,\n\u001b[32m    172\u001b[39m         right_df,\n\u001b[32m   (...)\u001b[39m\u001b[32m    182\u001b[39m         validate=validate,\n\u001b[32m    183\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m184\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mop\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_result\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:888\u001b[39m, in \u001b[36m_MergeOperation.get_result\u001b[39m\u001b[34m(self, copy)\u001b[39m\n\u001b[32m    884\u001b[39m     \u001b[38;5;28mself\u001b[39m.left, \u001b[38;5;28mself\u001b[39m.right = \u001b[38;5;28mself\u001b[39m._indicator_pre_merge(\u001b[38;5;28mself\u001b[39m.left, \u001b[38;5;28mself\u001b[39m.right)\n\u001b[32m    886\u001b[39m join_index, left_indexer, right_indexer = \u001b[38;5;28mself\u001b[39m._get_join_info()\n\u001b[32m--> \u001b[39m\u001b[32m888\u001b[39m result = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_reindex_and_concat\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    889\u001b[39m \u001b[43m    \u001b[49m\u001b[43mjoin_index\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mleft_indexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mright_indexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcopy\u001b[49m\n\u001b[32m    890\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    891\u001b[39m result = result.__finalize__(\u001b[38;5;28mself\u001b[39m, method=\u001b[38;5;28mself\u001b[39m._merge_type)\n\u001b[32m    893\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.indicator:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:840\u001b[39m, in \u001b[36m_MergeOperation._reindex_and_concat\u001b[39m\u001b[34m(self, join_index, left_indexer, right_indexer, copy)\u001b[39m\n\u001b[32m    837\u001b[39m left = \u001b[38;5;28mself\u001b[39m.left[:]\n\u001b[32m    838\u001b[39m right = \u001b[38;5;28mself\u001b[39m.right[:]\n\u001b[32m--> \u001b[39m\u001b[32m840\u001b[39m llabels, rlabels = \u001b[43m_items_overlap_with_suffix\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    841\u001b[39m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mleft\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_info_axis\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mright\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_info_axis\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43msuffixes\u001b[49m\n\u001b[32m    842\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    844\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m left_indexer \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_range_indexer(left_indexer, \u001b[38;5;28mlen\u001b[39m(left)):\n\u001b[32m    845\u001b[39m     \u001b[38;5;66;03m# Pinning the index here (and in the right code just below) is not\u001b[39;00m\n\u001b[32m    846\u001b[39m     \u001b[38;5;66;03m#  necessary, but makes the `.take` more performant if we have e.g.\u001b[39;00m\n\u001b[32m    847\u001b[39m     \u001b[38;5;66;03m#  a MultiIndex for left.index.\u001b[39;00m\n\u001b[32m    848\u001b[39m     lmgr = left._mgr.reindex_indexer(\n\u001b[32m    849\u001b[39m         join_index,\n\u001b[32m    850\u001b[39m         left_indexer,\n\u001b[32m   (...)\u001b[39m\u001b[32m    855\u001b[39m         use_na_proxy=\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[32m    856\u001b[39m     )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:2720\u001b[39m, in \u001b[36m_items_overlap_with_suffix\u001b[39m\u001b[34m(left, right, suffixes)\u001b[39m\n\u001b[32m   2717\u001b[39m lsuffix, rsuffix = suffixes\n\u001b[32m   2719\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m lsuffix \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m rsuffix:\n\u001b[32m-> \u001b[39m\u001b[32m2720\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mcolumns overlap but no suffix specified: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mto_rename\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m   2722\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mrenamer\u001b[39m(x, suffix: \u001b[38;5;28mstr\u001b[39m | \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m   2723\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m   2724\u001b[39m \u001b[33;03m    Rename the left and right indices.\u001b[39;00m\n\u001b[32m   2725\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m   2736\u001b[39m \u001b[33;03m    x : renamed column name\u001b[39;00m\n\u001b[32m   2737\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n",
-      "\u001b[31mValueError\u001b[39m: columns overlap but no suffix specified: Index(['name', 'span_kind', 'parent_id', 'start_time', 'end_time',\n       'status_code', 'status_message', 'events', 'context.span_id',\n       'context.trace_id', 'attributes.output.mime_type',\n       'attributes.input.mime_type', 'attributes.openinference.span.kind',\n       'attributes.input.value', 'attributes.output.value'],\n      dtype='object')"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "spans_with_evals_df = spans_df.join(evals_df, how=\"left\")\n",
-    "\n",
-    "spans_with_evals_df[\n",
-    "    [\"attributes.input.value\", \"attributes.output.value\", \"label\", \"score\", \"explanation\"]\n",
-    "].head()"
+    "evals_df.head()"
    ]
   },
   {
@@ -932,12 +603,11 @@
    "outputs": [],
    "source": [
     "from phoenix.client import AsyncClient\n",
+    "from phoenix.evals.utils import to_annotation_dataframe\n",
     "\n",
     "px_client = AsyncClient()\n",
     "await px_client.spans.log_span_annotations_dataframe(\n",
-    "    dataframe=evals_df,\n",
-    "    annotation_name=\"llm_correctness\",\n",
-    "    annotator_kind=\"LLM\",\n",
+    "    dataframe=to_annotation_dataframe(evals_df),\n",
     ")"
    ]
   },
@@ -971,15 +641,15 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "# ds = await px_client.datasets.create_dataset(\n",
-    "#     name=\"movie-train\",\n",
-    "#     dataframe=pd.DataFrame([{\"question\": question} for question in questions]),\n",
-    "#     input_keys=[\"question\"],\n",
-    "#     output_keys=[],\n",
-    "# )\n",
+    "ds = await px_client.datasets.create_dataset(\n",
+    "    name=\"movie-train\",\n",
+    "    dataframe=pd.DataFrame([{\"question\": question} for question in questions]),\n",
+    "    input_keys=[\"question\"],\n",
+    "    output_keys=[],\n",
+    ")\n",
     "\n",
     "# If you have already uploaded the dataset, you can fetch it using the following line\n",
-    "ds = await px_client.datasets.get_dataset(dataset=\"movie-train\")"
+    "# ds = await px_client.datasets.get_dataset(dataset=\"movie-train\")"
    ]
   },
   {
@@ -1188,7 +858,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = run_experiment(\n",
+    "experiment = await async_run_experiment(\n",
     "    dataset=ds,\n",
     "    experiment_name=\"with examples\",\n",
     "    task=task,\n",
@@ -1210,77 +880,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
+    "from phoenix.client.experiments import async_evaluate_experiment\n",
+    "from phoenix.evals import create_classifier\n",
     "\n",
-    "from openai import OpenAI\n",
-    "\n",
-    "from phoenix.client.experiments import create_evaluator, evaluate_experiment\n",
-    "\n",
-    "# Note: EvaluationResult type may have changed in new client API\n",
-    "\n",
-    "openai_client = OpenAI()\n",
-    "\n",
-    "judge_system_prompt = \"\"\"\n",
+    "judge_prompt_template = \"\"\"\n",
     "You are a judge that determines if a given question can be answered with the SQL results.\n",
     "\n",
     "Provide the label `useful` if the SQL results contain records that help answer the question.\n",
     "Provide the label `useless` if the SQL results do not contain records that help answer the question.\n",
+    "\n",
+    "<data>\n",
+    "<question>\n",
+    "{input.question}\n",
+    "</question>\n",
+    "<results>\n",
+    "{output.results}\n",
+    "<results>\n",
+    "</data>\n",
     "\"\"\"\n",
     "\n",
-    "judge_user_prompt = \"\"\"\n",
-    "[BEGIN DATA]\n",
-    "************\n",
-    "{question}\n",
-    "{results}\n",
-    "************\n",
-    "[END DATA]\n",
-    "\"\"\"\n",
+    "usefulness = create_classifier(\n",
+    "    name=\"usefulness\",\n",
+    "    llm=LLM(model=\"gpt-4o\", provider=\"openai\"),\n",
+    "    prompt_template=judge_prompt_template,\n",
+    "    choices={ \"useful\": 1, \"useless\": 0 }\n",
+    ")\n",
     "\n",
-    "\n",
-    "@create_evaluator(name=\"usefulness\", kind=\"llm\")\n",
-    "def usefulness(input, output):\n",
-    "    question = input.get(\"question\")\n",
-    "    results = output.get(\"results\", \"\")\n",
-    "    response = openai_client.chat.completions.create(\n",
-    "        model=\"gpt-4o\",\n",
-    "        messages=[\n",
-    "            {\"role\": \"system\", \"content\": judge_system_prompt},\n",
-    "            {\n",
-    "                \"role\": \"user\",\n",
-    "                \"content\": judge_user_prompt.format(question=question, results=str(results)),\n",
-    "            },\n",
-    "        ],\n",
-    "        tool_choice=\"required\",\n",
-    "        tools=[\n",
-    "            {\n",
-    "                \"type\": \"function\",\n",
-    "                \"function\": {\n",
-    "                    \"name\": \"usefulness\",\n",
-    "                    \"description\": \"Determine if the SQL results are useful for answering the question.\",\n",
-    "                    \"parameters\": {\n",
-    "                        \"type\": \"object\",\n",
-    "                        \"properties\": {\n",
-    "                            \"explanation\": {\n",
-    "                                \"type\": \"string\",\n",
-    "                                \"description\": \"Explain why the label is useful or useless.\",\n",
-    "                            },\n",
-    "                            \"label\": {\"type\": \"string\", \"enum\": [\"useful\", \"useless\"]},\n",
-    "                        },\n",
-    "                    },\n",
-    "                },\n",
-    "            }\n",
-    "        ],\n",
-    "    )\n",
-    "    if response.choices[0].message.tool_calls is None:\n",
-    "        raise ValueError(\"No tool call found in response\")\n",
-    "    args = json.loads(response.choices[0].message.tool_calls[0].function.arguments)\n",
-    "    label = args[\"label\"]\n",
-    "    explanation = args[\"explanation\"]\n",
-    "    score = 1 if label == \"useful\" else 0\n",
-    "    return score, label, explanation\n",
-    "\n",
-    "\n",
-    "evaluate_experiment(experiment, evaluators=[usefulness])"
+    "await async_evaluate_experiment(experiment=experiment, evaluators=[usefulness])"
    ]
   },
   {
@@ -1364,24 +990,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from phoenix.evals import llm_classify\n",
-    "from phoenix.evals.models import OpenAIModel\n",
-    "from phoenix.evals.templates import PromptTemplate\n",
+    "from phoenix.evals import async_evaluate_dataframe\n",
     "\n",
-    "evals_df = llm_classify(\n",
-    "    data=spans_df,\n",
-    "    model=OpenAIModel(model=\"gpt-4o\"),\n",
-    "    rails=[\"correct\", \"incorrect\"],\n",
-    "    template=PromptTemplate(\n",
-    "        template=eval_prompt,\n",
-    "    ),\n",
-    "    exit_on_error=False,\n",
-    "    provide_explanation=True,\n",
-    ")\n",
-    "\n",
-    "## Assign 1 to correct and 0 to incorrect\n",
-    "evals_df[\"score\"] = evals_df[\"label\"].apply(lambda x: 1 if x == \"correct\" else 0)\n",
-    "evals_df[[\"label\", \"score\", \"explanation\"]].head()"
+    "evals_df = await async_evaluate_dataframe(\n",
+    "    dataframe=spans_df,\n",
+    "    evaluators=[llm_correctness]\n",
+    ")"
    ]
   },
   {
@@ -1390,11 +1004,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "evals_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phoenix.evals.utils import to_annotation_dataframe\n",
+    "\n",
     "px_client = AsyncClient()\n",
+    "\n",
     "await px_client.annotations.log_span_annotations_dataframe(\n",
-    "    dataframe=evals_df,\n",
-    "    annotation_name=\"llm_correctness\",\n",
-    "    annotator_kind=\"LLM\",\n",
+    "    dataframe=to_annotation_dataframe(evals_df),\n",
     ")"
    ]
   },

--- a/tutorials/ai_evals_course/phoenix_overview.ipynb
+++ b/tutorials/ai_evals_course/phoenix_overview.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +185,7 @@
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x124a2c5f0>"
+       "<_duckdb.DuckDBPyConnection at 0x121078d30>"
       ]
      },
      "execution_count": 3,
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -378,7 +378,7 @@
        "[{'title': 'Avatar'}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,16 +472,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The top-grossing movie is \"Avatar.\"'"
+       "'The top grossing movie is \"Avatar.\"'"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -530,27 +530,27 @@
      "output_type": "stream",
      "text": [
       "Question:  Which Brad Pitt movie received the highest rating?\n",
-      "Answer:  The Brad Pitt movie that received the highest rating is \"Voom Portraits.\"\n",
+      "Answer:  The Brad Pitt movie \"Voom Portraits\" received the highest rating.\n",
       "\n",
       "\n",
       "Question:  What is the top grossing Marvel movie?\n",
-      "Answer:  The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
+      "Answer:  The top grossing Marvel movie is \"Avengers: Endgame\".\n",
       "\n",
       "\n",
       "Question:  What foreign-language fantasy movie was the most popular?\n",
-      "Answer:  The foreign-language fantasy movie titled \"The Nights Belong to Monsters\" was the most popular. It's a Spanish-language film released on October 9, 2021. The movie blends fantasy and drama, telling the story of a 17-year-old girl named Sol who deals with bullying and harassment in a new town. She unexpectedly forms a protective bond with a mystical dog that defends her.\n",
+      "Answer:  The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This Spanish-language film is a blend of fantasy and drama, focusing on a 17-year-old girl named Sol who faces hostility, bullying, and harassment in a new town. Her situation changes when she forms a symbiotic relationship with a mysterious and magical dog that protects her. The movie is produced by Rispo Films and Tieless Media and was released on October 9, 2021. Despite its popularity, it has a low average user rating.\n",
       "\n",
       "\n",
       "Question:  what are the best sci-fi movies of 2017?\n",
-      "Answer:  I don't know.\n",
+      "Answer:  I don't know which sci-fi movies are considered the best of 2017 based on the data provided.\n",
       "\n",
       "\n",
       "Question:  What anime topped the box office in the 2010s?\n",
-      "Answer:  I don't know which anime topped the box office in the 2010s based on the provided data.\n",
+      "Answer:  I don't know which anime topped the box office in the 2010s based on the data provided.\n",
       "\n",
       "\n",
       "Question:  Recommend a romcom that stars Paul Rudd.\n",
-      "Answer:  If you are looking for a romantic comedy featuring Paul Rudd, I would recommend \"Clueless.\" It's a delightful mix of comedy and romance, set in a Beverly Hills high school, where the main character Cher, played by Alicia Silverstone, learns some important life lessons and finds unexpected love. Paul Rudd plays a key role as Cher's thoughtful and charming ex-stepbrother, making it a classic romcom worth watching.\n",
+      "Answer:  If you're looking for a romantic comedy featuring Paul Rudd, I would recommend \"Clueless.\" It's a delightful blend of comedy and romance with Paul Rudd playing alongside Alicia Silverstone in a story about a wealthy high school student who plays matchmaker. Another great choice is \"I Love You, Man,\" where Paul Rudd stars as a man searching for a best man for his wedding and ends up forming an unexpected friendship. Both films are entertaining and showcase Rudd's charm and comedic timing beautifully.\n",
       "\n",
       "\n"
      ]
@@ -579,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,22 +601,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "\"['annotation_name', 'result.label'] not in index\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[30]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m examples_df = \u001b[43mcombined_df\u001b[49m\u001b[43m[\u001b[49m\n\u001b[32m      2\u001b[39m \u001b[43m    \u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mannotation_name\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mresult.label\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mattributes.input.value\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mattributes.output.value\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[32m      3\u001b[39m \u001b[43m]\u001b[49m.head()\n\u001b[32m      4\u001b[39m examples_df\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m is_iterator(key):\n\u001b[32m   4112\u001b[39m         key = \u001b[38;5;28mlist\u001b[39m(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m     indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_get_indexer_strict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcolumns\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m[\u001b[32m1\u001b[39m]\n\u001b[32m   4115\u001b[39m \u001b[38;5;66;03m# take() does not accept boolean indexers\u001b[39;00m\n\u001b[32m   4116\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(indexer, \u001b[33m\"\u001b[39m\u001b[33mdtype\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m) == \u001b[38;5;28mbool\u001b[39m:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:6212\u001b[39m, in \u001b[36mIndex._get_indexer_strict\u001b[39m\u001b[34m(self, key, axis_name)\u001b[39m\n\u001b[32m   6209\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   6210\u001b[39m     keyarr, indexer, new_indexer = \u001b[38;5;28mself\u001b[39m._reindex_non_unique(keyarr)\n\u001b[32m-> \u001b[39m\u001b[32m6212\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_raise_if_missing\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   6214\u001b[39m keyarr = \u001b[38;5;28mself\u001b[39m.take(indexer)\n\u001b[32m   6215\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Index):\n\u001b[32m   6216\u001b[39m     \u001b[38;5;66;03m# GH 42790 - Preserve name from an Index\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:6264\u001b[39m, in \u001b[36mIndex._raise_if_missing\u001b[39m\u001b[34m(self, key, indexer, axis_name)\u001b[39m\n\u001b[32m   6261\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNone of [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m] are in the [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00maxis_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m]\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   6263\u001b[39m not_found = \u001b[38;5;28mlist\u001b[39m(ensure_index(key)[missing_mask.nonzero()[\u001b[32m0\u001b[39m]].unique())\n\u001b[32m-> \u001b[39m\u001b[32m6264\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnot_found\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m not in index\u001b[39m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"['annotation_name', 'result.label'] not in index\""
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>annotation_name</th>\n",
+       "      <th>result.label</th>\n",
+       "      <th>attributes.input.value</th>\n",
+       "      <th>attributes.output.value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4738ded59cdcd6bd</th>\n",
+       "      <td>correctness</td>\n",
+       "      <td>incorrect</td>\n",
+       "      <td>Which Brad Pitt movie received the highest rat...</td>\n",
+       "      <td>The Brad Pitt movie \"Voom Portraits\" received ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6a7a775e37b887f8</th>\n",
+       "      <td>correctness</td>\n",
+       "      <td>correct</td>\n",
+       "      <td>What is the top grossing Marvel movie?</td>\n",
+       "      <td>The top grossing Marvel movie is \"Avengers: En...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5eadf30616992035</th>\n",
+       "      <td>correctness</td>\n",
+       "      <td>incorrect</td>\n",
+       "      <td>What foreign-language fantasy movie was the mo...</td>\n",
+       "      <td>The most popular foreign-language fantasy movi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4f0f5d5ccef5a1e0</th>\n",
+       "      <td>correctness</td>\n",
+       "      <td>incorrect</td>\n",
+       "      <td>what are the best sci-fi movies of 2017?</td>\n",
+       "      <td>I don't know which sci-fi movies are considere...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6de075915169d472</th>\n",
+       "      <td>correctness</td>\n",
+       "      <td>incorrect</td>\n",
+       "      <td>What anime topped the box office in the 2010s?</td>\n",
+       "      <td>I don't know which anime topped the box office...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 annotation_name result.label  \\\n",
+       "4738ded59cdcd6bd     correctness    incorrect   \n",
+       "6a7a775e37b887f8     correctness      correct   \n",
+       "5eadf30616992035     correctness    incorrect   \n",
+       "4f0f5d5ccef5a1e0     correctness    incorrect   \n",
+       "6de075915169d472     correctness    incorrect   \n",
+       "\n",
+       "                                             attributes.input.value  \\\n",
+       "4738ded59cdcd6bd  Which Brad Pitt movie received the highest rat...   \n",
+       "6a7a775e37b887f8             What is the top grossing Marvel movie?   \n",
+       "5eadf30616992035  What foreign-language fantasy movie was the mo...   \n",
+       "4f0f5d5ccef5a1e0           what are the best sci-fi movies of 2017?   \n",
+       "6de075915169d472     What anime topped the box office in the 2010s?   \n",
+       "\n",
+       "                                            attributes.output.value  \n",
+       "4738ded59cdcd6bd  The Brad Pitt movie \"Voom Portraits\" received ...  \n",
+       "6a7a775e37b887f8  The top grossing Marvel movie is \"Avengers: En...  \n",
+       "5eadf30616992035  The most popular foreign-language fantasy movi...  \n",
+       "4f0f5d5ccef5a1e0  I don't know which sci-fi movies are considere...  \n",
+       "6de075915169d472  I don't know which anime topped the box office...  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -635,18 +715,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'examples_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[31]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m example_answers = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join(\n\u001b[32m      2\u001b[39m     [\n\u001b[32m      3\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mQuestion: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mattributes.input.value\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mAnswer: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mattributes.output.value\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mLabel: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mresult.label\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m         \u001b[38;5;28;01mfor\u001b[39;00m example \u001b[38;5;129;01min\u001b[39;00m \u001b[43mexamples_df\u001b[49m.to_dict(orient=\u001b[33m\"\u001b[39m\u001b[33mrecords\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m     ]\n\u001b[32m      6\u001b[39m )\n\u001b[32m      7\u001b[39m eval_prompt = \u001b[33mf\u001b[39m\u001b[33m\"\"\"\u001b[39m\n\u001b[32m      8\u001b[39m \u001b[33mYou are an expert evaluator of question and answer pairs. You will be given a human question and an answer from an AI agent.\u001b[39m\n\u001b[32m      9\u001b[39m \u001b[33mYour job is to determine if the answer is \u001b[39m\u001b[33m\"\u001b[39m\u001b[33mcorrect\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m or \u001b[39m\u001b[33m\"\u001b[39m\u001b[33mincorrect\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m.\u001b[39m\n\u001b[32m   (...)\u001b[39m\u001b[32m     23\u001b[39m \u001b[33mExplanation:\u001b[39m\n\u001b[32m     24\u001b[39m \u001b[33m\"\"\"\u001b[39m\n\u001b[32m     26\u001b[39m \u001b[38;5;28mprint\u001b[39m(eval_prompt)\n",
-      "\u001b[31mNameError\u001b[39m: name 'examples_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "You are an expert evaluator of question and answer pairs. You will be given a human question and an answer from an AI agent.\n",
+      "Your job is to determine if the answer is \"correct\" or \"incorrect\" and to provide a clear reason why the label should be assigned.\n",
+      "\n",
+      "Here are some examples of correct and incorrect answers:\n",
+      "<examples>\n",
+      "Question: Which Brad Pitt movie received the highest rating?\n",
+      "Answer: The Brad Pitt movie \"Voom Portraits\" received the highest rating.\n",
+      "Label: incorrect\n",
+      "\n",
+      "Question: What is the top grossing Marvel movie?\n",
+      "Answer: The top grossing Marvel movie is \"Avengers: Endgame\".\n",
+      "Label: correct\n",
+      "\n",
+      "Question: What foreign-language fantasy movie was the most popular?\n",
+      "Answer: The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This Spanish-language film is a blend of fantasy and drama, focusing on a 17-year-old girl named Sol who faces hostility, bullying, and harassment in a new town. Her situation changes when she forms a symbiotic relationship with a mysterious and magical dog that protects her. The movie is produced by Rispo Films and Tieless Media and was released on October 9, 2021. Despite its popularity, it has a low average user rating.\n",
+      "Label: incorrect\n",
+      "\n",
+      "Question: what are the best sci-fi movies of 2017?\n",
+      "Answer: I don't know which sci-fi movies are considered the best of 2017 based on the data provided.\n",
+      "Label: incorrect\n",
+      "\n",
+      "Question: What anime topped the box office in the 2010s?\n",
+      "Answer: I don't know which anime topped the box office in the 2010s based on the data provided.\n",
+      "Label: incorrect\n",
+      "</examples>\n",
+      "\n",
+      "<data>\n",
+      "<question>\n",
+      "{attributes.input.value}\n",
+      "</question>\n",
+      "<answer>\n",
+      "{attributes.output.value}\n",
+      "</answer>\n",
+      "</data>\n",
+      "\n"
      ]
     }
    ],
@@ -659,21 +770,21 @@
     ")\n",
     "eval_prompt = f\"\"\"\n",
     "You are an expert evaluator of question and answer pairs. You will be given a human question and an answer from an AI agent.\n",
-    "Your job is to determine if the answer is \"correct\" or \"incorrect\".\n",
+    "Your job is to determine if the answer is \"correct\" or \"incorrect\" and to provide a clear reason why the label should be assigned.\n",
     "\n",
     "Here are some examples of correct and incorrect answers:\n",
+    "<examples>\n",
     "{example_answers}\n",
+    "</examples>\n",
     "\n",
-    "## Evaluation\n",
-    "Provide your answer in the following format:\n",
-    "Question: <question>\n",
-    "Answer: <answer>\n",
-    "Explanation: <explanation>\n",
-    "Label: <correct|incorrect>\n",
-    "\n",
-    "Question: {{attributes.input.value}}\n",
-    "Answer: {{attributes.output.value}}\n",
-    "Explanation:\n",
+    "<data>\n",
+    "<question>\n",
+    "{{attributes.input.value}}\n",
+    "</question>\n",
+    "<answer>\n",
+    "{{attributes.output.value}}\n",
+    "</answer>\n",
+    "</data>\n",
     "\"\"\"\n",
     "\n",
     "print(eval_prompt)"
@@ -681,37 +792,188 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>attributes.input.value</th>\n",
+       "      <th>attributes.output.value</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>context.span_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>6cac14b09ccc0048</th>\n",
+       "      <td>Recommend a romcom that stars Paul Rudd.</td>\n",
+       "      <td>If you're looking for a romantic comedy featur...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6de075915169d472</th>\n",
+       "      <td>What anime topped the box office in the 2010s?</td>\n",
+       "      <td>I don't know which anime topped the box office...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4f0f5d5ccef5a1e0</th>\n",
+       "      <td>what are the best sci-fi movies of 2017?</td>\n",
+       "      <td>I don't know which sci-fi movies are considere...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5eadf30616992035</th>\n",
+       "      <td>What foreign-language fantasy movie was the mo...</td>\n",
+       "      <td>The most popular foreign-language fantasy movi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6a7a775e37b887f8</th>\n",
+       "      <td>What is the top grossing Marvel movie?</td>\n",
+       "      <td>The top grossing Marvel movie is \"Avengers: En...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                             attributes.input.value  \\\n",
+       "context.span_id                                                       \n",
+       "6cac14b09ccc0048           Recommend a romcom that stars Paul Rudd.   \n",
+       "6de075915169d472     What anime topped the box office in the 2010s?   \n",
+       "4f0f5d5ccef5a1e0           what are the best sci-fi movies of 2017?   \n",
+       "5eadf30616992035  What foreign-language fantasy movie was the mo...   \n",
+       "6a7a775e37b887f8             What is the top grossing Marvel movie?   \n",
+       "\n",
+       "                                            attributes.output.value  \n",
+       "context.span_id                                                      \n",
+       "6cac14b09ccc0048  If you're looking for a romantic comedy featur...  \n",
+       "6de075915169d472  I don't know which anime topped the box office...  \n",
+       "4f0f5d5ccef5a1e0  I don't know which sci-fi movies are considere...  \n",
+       "5eadf30616992035  The most popular foreign-language fantasy movi...  \n",
+       "6a7a775e37b887f8  The top grossing Marvel movie is \"Avengers: En...  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "spans_df[[\"attributes.input.value\", \"attributes.output.value\"]].head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from phoenix.evals import llm_classify\n",
-    "from phoenix.evals.models import OpenAIModel\n",
-    "from phoenix.evals.templates import PromptTemplate\n",
+    "from phoenix.evals.evaluators import create_classifier\n",
+    "from phoenix.evals.llm import LLM\n",
     "\n",
-    "evals_df = llm_classify(\n",
-    "    data=spans_df,\n",
-    "    model=OpenAIModel(model=\"gpt-4o\"),\n",
-    "    rails=[\"correct\", \"incorrect\"],\n",
-    "    template=PromptTemplate(\n",
-    "        template=eval_prompt,\n",
-    "    ),\n",
-    "    exit_on_error=False,\n",
-    "    provide_explanation=True,\n",
-    ")\n",
+    "# Define a classification based evaluation\n",
+    "llm_correctness = create_classifier(name=\"llm_correctness\", llm=LLM(model=\"gpt-4o\", provider=\"openai\"), prompt_template=eval_prompt, choices={ \"correct\": 1, \"incorrect\": 0 })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
+      "Requeuing...\n",
+      "Retries exhausted after 11 attempts: Path not found: attributes\n",
+      "Retries exhausted after 11 attempts: Path not found: attributes\n",
+      "Retries exhausted after 11 attempts: Path not found: attributes\n"
+     ]
+    }
+   ],
+   "source": [
+    "from phoenix.evals import async_evaluate_dataframe\n",
     "\n",
-    "## Assign 1 to correct and 0 to incorrect\n",
-    "evals_df[\"score\"] = evals_df[\"label\"].apply(lambda x: 1 if x == \"correct\" else 0)\n",
-    "evals_df[[\"label\", \"score\", \"explanation\"]].head()"
+    "evals_df = await async_evaluate_dataframe(dataframe=spans_df, evaluators=[llm_correctness])"
    ]
   },
   {

--- a/tutorials/ai_evals_course/phoenix_overview.ipynb
+++ b/tutorials/ai_evals_course/phoenix_overview.ipynb
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U \"arize-phoenix>=11.0.0\" openai 'httpx<0.28' duckdb datasets pyarrow \"pydantic>=2.0.0\" nest_asyncio \"openinference-instrumentation>=0.1.38\" openinference-instrumentation-openai --quiet"
+    "!pip install -U \"arize-phoenix-otel\" \"arize-phoenix-client>=1.20.0\" openai 'httpx<0.28' duckdb datasets pyarrow \"pydantic>=2.0.0\" nest_asyncio \"openinference-instrumentation>=0.1.38\" openinference-instrumentation-openai --quiet"
    ]
   },
   {
@@ -123,9 +123,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mikeldking/work/phoenix/.venv/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from phoenix.otel import register\n",
     "\n",
@@ -143,30 +152,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's make sure we can run async code in the notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import nest_asyncio\n",
-    "\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Lastly, let's make sure we have our OpenAI API key set up."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,9 +179,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<_duckdb.DuckDBPyConnection at 0x124a2c5f0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import duckdb\n",
     "from datasets import load_dataset\n",
@@ -203,9 +205,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id': 385687, 'title': 'Fast X', 'genres': 'Action-Crime-Thriller', 'original_language': 'en', 'overview': \"Over many missions and against impossible odds Dom Toretto and his family have outsmarted out-nerved and outdriven every foe in their path. Now they confront the most lethal opponent they've ever faced: A terrifying threat emerging from the shadows of the past who's fueled by blood revenge and who is determined to shatter this family and destroy everything—and everyone—that Dom loves forever.\", 'popularity': 6682.1, 'production_companies': 'Universal Pictures-Original Film-One Race-Perfect Storm Entertainment', 'release_date': '2023-05-17', 'budget': 340000000.0, 'revenue': 686700000.0, 'runtime': 142.0, 'status': 'Released', 'tagline': 'The end of the road begins.', 'vote_average': 7.331, 'vote_count': 1856.0, 'credits': 'Vin Diesel-Michelle Rodriguez-Tyrese Gibson-Ludacris-John Cena-Nathalie Emmanuel-Jordana Brewster-Sung Kang-Jason Momoa-Scott Eastwood-Daniela Melchior-Alan Ritchson-Helen Mirren-Brie Larson-Jason Statham-Charlize Theron-Rita Moreno-Joaquim de Almeida-Leo A. Perry-Luis Da Silva Jr.-Jaz Hutchins-Luka Hays-Alexander Capon-Pete Davidson-Shadrach Agozino-Ludmilla-Miraj Grbić-Meadow Walker Thornton-Allan-Michael Irby-Shahir Figueira-Ben-Hur Santos-Debby Ann Ryan-Josh Dun-Robert Bastens-Dwayne Johnson-Gal Gadot', 'keywords': 'sequel-revenge-racing-family-cars', 'poster_path': '/fiVW06jE7z9YnO4trhaMEdclSiC.jpg', 'backdrop_path': '/4XM8DUTQb3lhLemJC51Jx4a2EuA.jpg', 'recommendations': '19603-445954-697843-603692-781009-502356-747355-640146-569094-1070777-536437-121342-325358-667538-960033-496450-447365-1037644-298618-713704-1121116'}\n",
+      "{'id': 758323, 'title': \"The Pope's Exorcist\", 'genres': 'Horror-Mystery-Thriller', 'original_language': 'en', 'overview': \"Father Gabriele Amorth Chief Exorcist of the Vatican investigates a young boy's terrifying possession and ends up uncovering a centuries-old conspiracy the Vatican has desperately tried to keep hidden.\", 'popularity': 5953.227, 'production_companies': 'Screen Gems-2.0 Entertainment-Jesus & Mary-Worldwide Katz-Loyola Productions-FFILME.RO', 'release_date': '2023-04-05', 'budget': 18000000.0, 'revenue': 65675816.0, 'runtime': 103.0, 'status': 'Released', 'tagline': 'Inspired by the actual files of Father Gabriele Amorth, Chief Exorcist of the Vatican.', 'vote_average': 7.433, 'vote_count': 545.0, 'credits': \"Russell Crowe-Daniel Zovatto-Alex Essoe-Franco Nero-Peter DeSouza-Feighoney-Laurel Marsden-Cornell John-Ryan O'Grady-Bianca Bardoe-Santi Bayón-Paloma Bloyd-Alessandro Gruttadauria-River Hawkins-Jordi Collet-Carrie Munro-Marc Velasco-Edward Harper-Jones-Matthew Sim-Victor Solé-Tom Bonington-Andrea Dugoni-Ed White-Laila Barwick-Gennaro Diana-Pablo Raybould-Ralph Ineson-Derek Carroll-Ella Cannon\", 'keywords': 'spain-rome italy-vatican-pope-pig-possession-conspiracy-devil-exorcist-skepticism-catholic priest-1980s-supernatural horror', 'poster_path': '/9JBEPLTPSm0d1mbEcLxULjJq9Eh.jpg', 'backdrop_path': '/hiHGRbyTcbZoLsYYkO4QiCLYe34.jpg', 'recommendations': '713704-296271-502356-1076605-1084225-1008005-916224-1023313-1033219-980078-842945-943822-816904-804150-638974-649609-603692-849869-809787-776835-1104040'}\n",
+      "{'id': 640146, 'title': 'Ant-Man and the Wasp: Quantumania', 'genres': 'Action-Adventure-Science Fiction', 'original_language': 'en', 'overview': \"Super-Hero partners Scott Lang and Hope van Dyne along with with Hope's parents Janet van Dyne and Hank Pym and Scott's daughter Cassie Lang find themselves exploring the Quantum Realm interacting with strange new creatures and embarking on an adventure that will push them beyond the limits of what they thought possible.\", 'popularity': 4425.387, 'production_companies': 'Marvel Studios-Kevin Feige Productions', 'release_date': '2023-02-15', 'budget': 200000000.0, 'revenue': 475766228.0, 'runtime': 125.0, 'status': 'Released', 'tagline': 'Witness the beginning of a new dynasty.', 'vote_average': 6.507, 'vote_count': 2811.0, 'credits': \"Paul Rudd-Evangeline Lilly-Jonathan Majors-Kathryn Newton-Michelle Pfeiffer-Michael Douglas-Corey Stoll-Bill Murray-William Jackson Harper-David Dastmalchian-Jamie Andrew Cutler-Katy O'Brian-Mark Weinman-Randall Park-Ross Mullan-Tom Clark-Leon Cooke-Nathan Blees-Durassie Kiangangu-Liran Nathan-Sam Symons-Grahame Fox-Nicola Peluso-Harrison Daniels-Brahmdeo Shannon Ramana-Russell Balogh-Leonardo Taiwo-Osian Roberts-Lucas Gerstel-Mia Gerstel-Tracy Jeffrey-Dinah Jeffrey-Judy Jeffrey-John Nayagam-Greta Nayagam-Cathy Chan-Adam Sai-Jamie Sai-Jakari Fraser-Patricia Belcher-Mark Oliver Everett-Ruben Rabasa-Melanie Garcia-Gregg Turkington-Sierra Katow-Ryan Bergara-Marielle Scott-Jake Millgard-Dey Young-Briza Covarrubias-Tess Aubert-David J. Castillo-Sir Cornwell-Alan Heitz-Esther McAuley-Aisling Maria Andreica-Milton Lopes-Roger Craig Smith-Matthew Wood-Loveday Smith-John Townsend-Tom Hiddleston-Owen Wilson-Abby Ryder Fortson\", 'keywords': 'hero-ant-sequel-superhero-based on comic-family-superhero team-aftercreditsstinger-duringcreditsstinger-marvel cinematic universe (mcu)', 'poster_path': '/qnqGbB22YJ7dSs4o6M7exTpNxPz.jpg', 'backdrop_path': '/m8JTwHFwX7I7JY5fPe4SjqejWag.jpg', 'recommendations': '823999-676841-868759-734048-267805-965839-1033219-1035806-946310-811948-842942-772515-1058949-1105283-938992-1077280-76600-677179-802401-461191-980078'}\n",
+      "{'id': 677179, 'title': 'Creed III', 'genres': 'Drama-Action', 'original_language': 'en', 'overview': 'After dominating the boxing world Adonis Creed has been thriving in both his career and family life. When a childhood friend and former boxing prodigy Damien Anderson resurfaces after serving a long sentence in prison he is eager to prove that he deserves his shot in the ring. The face-off between former friends is more than just a fight. To settle the score Adonis must put his future on the line to battle Damien — a fighter who has nothing to lose.', 'popularity': 3994.342, 'production_companies': 'Metro-Goldwyn-Mayer-Proximity Media-Balboa Productions-Outlier Society Productions-Chartoff-Winkler Productions', 'release_date': '2023-03-01', 'budget': 75000000.0, 'revenue': 269000000.0, 'runtime': 116.0, 'status': 'Released', 'tagline': \"You can't run from your past.\", 'vote_average': 7.262, 'vote_count': 1129.0, 'credits': \"Michael B. Jordan-Tessa Thompson-Jonathan Majors-Wood Harris-Phylicia Rashād-Mila Davis-Kent-José Benavidez Jr.-Selenis Leyva-Florian Munteanu-Thaddeus J. Mixson-Spence Moore II-Tony Bellew-Patrice Harris-Ann Najjar-Jacob 'Stitch' Duran-Terence Crawford-Bobby Hernandez-Yahya McClain-Lamont Lankford-Corey Calliet-Kenny Bayless-Todd Grisham-Jessica McCaskill-Maya Page-Jimmy Lennon Jr.-Russell Mora-Al Bernstein-Mauro Ranallo-Brianna Valeria Gonzalez Vazquez-Shayra Medal-Kimberly Dawn Davis-David Diamante-Tony Weeks-Chris Mannix-Andreia Gibau-Soraya Yd-Stephen A. Smith-Barry Pepper-Jessica Holmes-Canelo Álvarez-Fernanda Gomez-Kehlani-Jeremy Lee Stone-Aaron D. Alexander-Brian Neal-Corey Hibbert-James Harden-Jove Edmond-Engle Files-Michael A. Jordan-Natasha Ofili-Rose Eshay-Alan Boell-Eli Joshua Adé-Butch Locsin-Stefni Valencia-Bella Dee-Anastasia Wilson-Beth Scherr-Michelle Davidson-Leah Haile-Teófimo López-Pete Penuel\", 'keywords': 'philadelphia pennsylvania-husband wife relationship-deaf-sports-sequel-orphan-former best friend-ex-con-childhood friends-juvenile detention center-boxing-prodigy', 'poster_path': '/cvsXj3I9Q2iyyIo95AecSd1tad7.jpg', 'backdrop_path': '/5i6SjyDbDWqyun8klUuCxrlFbyw.jpg', 'recommendations': '965839-267805-943822-842942-1035806-823999-1077280-1058949-772515-937278-640146-758009-536554-1011679-315162-934433-785084-631842-82856-100088-436270'}\n",
+      "{'id': 502356, 'title': 'The Super Mario Bros. Movie', 'genres': 'Animation-Family-Adventure-Fantasy-Comedy', 'original_language': 'en', 'overview': 'While working underground to fix a water main Brooklyn plumbers—and brothers—Mario and Luigi are transported down a mysterious pipe and wander into a magical new world. But when the brothers are separated Mario embarks on an epic quest to find Luigi.', 'popularity': 3859.926, 'production_companies': 'Universal Pictures-Illumination-Nintendo', 'release_date': '2023-04-05', 'budget': 100000000.0, 'revenue': 1278766975.0, 'runtime': 92.0, 'status': 'Released', 'tagline': None, 'vote_average': 7.764, 'vote_count': 4042.0, 'credits': 'Chris Pratt-Charlie Day-Anya Taylor-Joy-Jack Black-Keegan-Michael Key-Seth Rogen-Fred Armisen-Khary Payton-Sebastian Maniscalco-Charles Martinet-Kevin Michael Richardson-Juliet Jelenic-Rino Romano-John DiMaggio-Jessica DiCicco-Eric Bauza-Scott Menville-Jason Broad-Carlos Alazraqui-Ashly Burch-Rachel Butera-Cathy Cavadini-Will Collyer-Django Craig-Willow Geer-Aaron Hendry-Andy Hirsch-Phil LaMarr-Jeremy Maxwell-Daniel Mora-Eric Osmond-Noreen Reardon-Lee Shorten-Cree Summer-Nisa Ward-Nora Wyman-Barbara Harris-Kazumi Totaka', 'keywords': 'video game-gorilla-plumber-magic mushroom-anthropomorphism-based on video game-toad-aftercreditsstinger-duringcreditsstinger-damsel in distress-piano-white gloves-brother brother relationship', 'poster_path': '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg', 'backdrop_path': '/2klQ1z1fcHGgQPevbEQdkCnzyuS.jpg', 'recommendations': '713704-385687-640146-60898-758323-1008005-493529-677179-603692-594767-977177-552688-76600-385647-860867-447365-1084226-1106739-325358-868759-868985'}\n",
+      "{'id': 631842, 'title': 'Knock at the Cabin', 'genres': 'Horror-Mystery-Thriller', 'original_language': 'en', 'overview': 'While vacationing at a remote cabin a young girl and her two fathers are taken hostage by four armed strangers who demand that the family make an unthinkable choice to avert the apocalypse. With limited access to the outside world the family must decide what they believe before all is lost.', 'popularity': 3422.537, 'production_companies': 'Blinding Edge Pictures-Universal Pictures-FilmNation Entertainment-Wishmore-Perfect World Pictures', 'release_date': '2023-02-01', 'budget': 20000000.0, 'revenue': 52000000.0, 'runtime': 100.0, 'status': 'Released', 'tagline': 'Save your family or save humanity. Make the choice.', 'vote_average': 6.457, 'vote_count': 888.0, 'credits': \"Dave Bautista-Jonathan Groff-Ben Aldridge-Kristen Cui-Nikki Amuka-Bird-Rupert Grint-Abby Quinn-Clare Louise Frost-McKenna Kerrigan-Odera Adimorah-M. Night Shyamalan-Ian Merrill Peakes-Denise Nakano-Rose Luardo-Billy Vargus-Satomi Hofmann-Kelvin Leung-Lee Avant-Katy Murphy-Kittson O'Neill-Lya Yanne-Hanna Gaffney-Monica Fleurette-Saria Chen\", 'keywords': 'based on novel or book-sacrifice-cabin-faith-end of the world-apocalypse-home invasion-lgbt-aftercreditsstinger-adopted child-adopted daughter-shot on film-gay-same sex relationship-religious symbolism', 'poster_path': '/dm06L9pxDOL9jNSK4Cb6y139rrG.jpg', 'backdrop_path': '/zWDMQX0sPaW2u0N2pJaYA8bVVaJ.jpg', 'recommendations': '1058949-646389-772515-505642-143970-667216-1048522-785084-1058617-986054-640146-937278-1001500-717980-677179-935906-536554-945703-82856-100088-1003580'}\n",
+      "{'id': 603692, 'title': 'John Wick: Chapter 4', 'genres': 'Action-Thriller-Crime', 'original_language': 'en', 'overview': 'With the price on his head ever increasing John Wick uncovers a path to defeating The High Table. But before he can earn his freedom Wick must face off against a new enemy with powerful alliances across the globe and forces that turn old friends into foes.', 'popularity': 2808.342, 'production_companies': 'Thunder Road-87Eleven-Summit Entertainment-Studio Babelsberg', 'release_date': '2023-03-22', 'budget': 90000000.0, 'revenue': 431769198.0, 'runtime': 170.0, 'status': 'Released', 'tagline': 'No way back, one way out.', 'vote_average': 7.904, 'vote_count': 3039.0, 'credits': 'Keanu Reeves-Donnie Yen-Bill Skarsgård-Ian McShane-Laurence Fishburne-Lance Reddick-Clancy Brown-Hiroyuki Sanada-Rina Sawayama-Scott Adkins-Aimée Kwan-Marko Zaror-Natalia Tena-Shamier Anderson-George Georgiou-Yoshinori Tashiro-Hiroki Sumi-Daiki Suzuki-Julia Asuka Riedl-Milena Rendón-Ivy Quainoo-Irina Trifanov-Iryna Fedorova-Andrej Kaminsky-Sven Marquardt-Raicho Vasilev-Marie Pierra Kakoma-Gina Aponte-Christoph Hofmann', 'keywords': 'new york city-martial arts-hitman-sequel-organized crime-osaka japan-aftercreditsstinger-hunted-professional assassin-neo-noir-berlin', 'poster_path': '/vZloFAK7NmvMGKE7VkF5UHaz0I.jpg', 'backdrop_path': '/1inZm0xxXrpRfN0LxwE2TXzyLN6.jpg', 'recommendations': '1098239-802401-24791-502356-385687-525644-1076605-1103694-384093-203579-649336-325358-347196-1033219-1007938-493529-1084225-594767-762338-840326-804150'}\n",
+      "{'id': 840326, 'title': 'Sisu', 'genres': 'Action-War', 'original_language': 'fi', 'overview': 'Deep in the wilderness of Lapland Aatami Korpi is searching for gold but after he stumbles upon Nazi patrol a breathtaking and gold-hungry chase through the destroyed and mined Lapland wilderness begins.', 'popularity': 2634.212, 'production_companies': 'Subzero Film Entertainment-Good Chaos-Stage 6 Films', 'release_date': '2023-01-27', 'budget': 6200000.0, 'revenue': 10568631.0, 'runtime': 91.0, 'status': 'Released', 'tagline': 'Vengeance is golden.', 'vote_average': 7.393, 'vote_count': 261.0, 'credits': 'Jorma Tommila-Aksel Hennie-Jack Doolan-Mimosa Willamo-Onni Tommila-Tatu Sinisalo-Wilhelm Enckell-Vincent Willestrand-Arttu Kapulainen-Elina Saarela-Ilkka Koivula-Max Ovaska-Joel Hirvonen-Pekka Huotari-Severi Saarinen-Aamu Milonoff-Joonas Brilli-Nicholas Francett-Kevin Francett-Eemeli Franssi-Jussi Kaila-Jarkko Klemetti-Henri Koljonen-Pekka Laakso-Martti Näätä Leinonen-Joosua Oja-Pietari Paappanen-Oskari Skyttä-Tomi Lampinen-Mila Leppälä-Jasmi Mäenpää-Nora Nevia-Jenna Tyni-Anssi-Pekka Fredriksson-Jarmo Hietamäki-Wellu Mikkonen-Akseli Hakovirta-Juho-Lauri Hakovirta-Iisko Hirvasvuopio-Sakari Maliniemi-Jukka Vuorela-Ari Joki-Nikita Makkojev-Jasmin Valjas-Linnea Vilppunen-Hannu Anttila-Mario Esposito-Tarmo Hassinen-Miia Heikkinen-Kimmo Henriksson-Arto Kairajärvi-Risto Korhonen-Mirva Korvala-Steven Madlin-Julia Malmsten-Annika Moisio-Kari Parkkinen-Tommi Pelkonen-Arto Peltomäki-Leena Sormunen-Pekka Virkkunen-Jukka Virtanen-Tinwelindon Belbog', 'keywords': 'world war ii-nordic mythology-lapland-finnish mythology', 'poster_path': '/tELs0h3PPicRbsuu5cQ8UFcBQno.jpg', 'backdrop_path': '/94TIUEhuwv8PhdIADEvSuwPljS5.jpg', 'recommendations': '552688-713704-882569-296271-502356-605886-868985-758323-826753-385687-620705-916224-1079078-977223-804150-493529-878361-964980-809787-876969-447365'}\n",
+      "{'id': 646389, 'title': 'Plane', 'genres': 'Action-Adventure-Thriller', 'original_language': 'en', 'overview': 'After a heroic job of successfully landing his storm-damaged aircraft in a war zone a fearless pilot finds himself between the agendas of multiple militias planning to take the plane and its passengers hostage.', 'popularity': 2618.646, 'production_companies': 'MadRiver Pictures-Di Bonaventura Pictures-G-BASE-Olive Hill Media-Riverstone Pictures', 'release_date': '2023-01-12', 'budget': 25000000.0, 'revenue': 51000000.0, 'runtime': 107.0, 'status': 'Released', 'tagline': 'Survive together or die alone.', 'vote_average': 6.901, 'vote_count': 785.0, 'credits': 'Gerard Butler-Mike Colter-Yoson An-Tony Goldwyn-Daniella Pineda-Paul Ben-Victor-Remi Adeleke-Joey Slotnick-Evan Dane Taylor-Claro de los Reyes-Kelly Gale-Haleigh Hekking-Lilly Krug-Oliver Trevena-Tara Westwood-Mark Labella-Quinn McPherson-Kate Rachesky-Amber Rivera-Otis Winston-Modesto Lacen-Jeff Francisco-Jeffrey Holsman-Ariel Felix-Rose Eshay-Jessica Nam-Thomas A. Curran-Ricky Robles Cruz-Matthew Valeña-Natalia Román García-Ángel Fabián Rivera-Heather Seiffert-Kate Bisset', 'keywords': 'pilot-airplane-philippines-held hostage-plane crash', 'poster_path': '/qi9r5xBgcc9KTxlOLjssEbDgO0J.jpg', 'backdrop_path': '/9Rq14Eyrf7Tu1xk0Pl7VcNbNh1n.jpg', 'recommendations': '505642-758769-864692-631842-1058949-925943-758009-315162-615777-707610-922830-1013870-536554-1035806-58087-996727'}\n",
+      "{'id': 569094, 'title': 'Spider-Man: Across the Spider-Verse', 'genres': 'Action-Adventure-Animation-Science Fiction', 'original_language': 'en', 'overview': 'After reuniting with Gwen Stacy Brooklyn’s full-time friendly neighborhood Spider-Man is catapulted across the Multiverse where he encounters the Spider Society a team of Spider-People charged with protecting the Multiverse’s very existence. But when the heroes clash on how to handle a new threat Miles finds himself pitted against the other Spiders and must set out on his own to save those he loves most.', 'popularity': 2550.738, 'production_companies': 'Columbia Pictures-Sony Pictures Animation-Lord Miller-Pascal Pictures-Arad Productions', 'release_date': '2023-05-31', 'budget': 100000000.0, 'revenue': 512609552.0, 'runtime': 140.0, 'status': 'Released', 'tagline': \"It's how you wear the mask that matters\", 'vote_average': 8.64, 'vote_count': 1684.0, 'credits': \"Shameik Moore-Hailee Steinfeld-Brian Tyree Henry-Luna Lauren Velez-Jake Johnson-Oscar Isaac-Jason Schwartzman-Issa Rae-Daniel Kaluuya-Karan Soni-Shea Whigham-Greta Lee-Mahershala Ali-Amandla Stenberg-Jharrel Jerome-Andy Samberg-Jack Quaid-Rachel Dratch-Ziggy Marley-Jorma Taccone-J.K. Simmons-Donald Glover-Elizabeth Perkins-Kathryn Hahn-Ayo Edebiri-Nicole Delaney-Antonina Lentini-Atsuko Okatsuka-Peter Sohn-Melissa Sturm-Lorraine Velez-Nic Novicki-Taran Killam-Metro Boomin-Josh Keaton-Sofia Barclay-Danielle Perez-Yuri Lowenthal-Rita Rani Ahuja-Ismail Bashey-Oscar Camacho-Freddy Ferrari-Kerry Gutierrez-Kamal Khan-Angelo Sekou Kouyate-Andrew Leviton-David Michie-Sumit Naig-Juan Pacheco-Chrystee Pharris-Ben Pronsky-Al Rodrigo-Jaswant Dev Shrestha-Libby Thomas Dickey-Ruth Zalduondo-Jasper Johannes Andrews-Gredel Berrios Calladine-Natalia Castellanos-Russell Tyre Francis-Deepti Gupta-Sohm Kapila-Pradnya Kuwadekar-Ashley London-Christopher Miller-Andrea Navedo-Lakshmi Patel-Jacqueline Pinol-Eliyas Qureshi-Lashana Rodriguez-Dennis Singletary-Amanda Troop-Sitara Attaie-Mayuri Bhandari-June Christopher-Michelle Jubilee Gonzalez-Marabina Jaimes-Rez Kempton-Lex Lang-Phil Lord-Richard Miro-Doug Nicholas-Shakira Ja'nai Paye-James Pirri-Marley Ralph-Michelle Ruff-Narender Sood-Cedric L. Williams-Kimberly Bailey-Sanjay Chandani-Melanie Duke-Jorge R. Gutierrez-Miguel Jiron-Deepti Kingra-Mickelsen-Luisa Leschin-Caitlin McKenna-Richard Andrew Morgado-Arthur Ortiz-Eliana A. Perez-Juan Pope-Mike Rianda-Stan Sellers-Warren Sroka-Jason Linere-White-Kimiko Glenn-Peggy Lu-John Mulaney-Andrew Garfield-Denis Leary-Tobey Maguire-Cliff Robertson-Alfred Molina-Post Malone\", 'keywords': 'sacrifice-villain-comic book-sequel-superhero-based on comic-alternate dimension-alternate version-super power-brooklyn new york city-superhero team-spider bite-super villain-cliffhanger-teen superhero-alternate universe-female superhero-cartoon spider', 'poster_path': '/8Vt6mWEReuy4Of61Lnj5Xj704m8.jpg', 'backdrop_path': '/4HodYYKEIsGOdinkGi2Ucz6X9i0.jpg', 'recommendations': '496450-667538-385687-603692-298618-447277-976573-598331-324857-447365-462883-536437-979296-313369-537210-1106591-532408-502356-1140706-820707-462376'}\n"
+     ]
+    }
+   ],
    "source": [
     "records = conn.query(\"SELECT * FROM movies LIMIT 10\").to_df().to_dict(orient=\"records\")\n",
     "\n",
@@ -227,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,10 +254,10 @@
     "\n",
     "import openai\n",
     "\n",
-    "from phoenix.client import Client\n",
+    "from phoenix.client import AsyncClient\n",
     "from phoenix.client.types import PromptVersion\n",
     "\n",
-    "px_client = Client()\n",
+    "px_client = AsyncClient()\n",
     "client = openai.AsyncClient()\n",
     "\n",
     "columns = conn.query(\"DESCRIBE movies\").to_df().to_dict(orient=\"records\")\n",
@@ -272,7 +291,7 @@
     "[END EXAMPLES]\n",
     "\"\"\"\n",
     "\n",
-    "prompt_template = px_client.prompts.create(\n",
+    "prompt_template = await px_client.prompts.create(\n",
     "    name=\"movie-text-to-sql\",\n",
     "    version=PromptVersion(\n",
     "        [\n",
@@ -304,9 +323,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT title FROM movies ORDER BY revenue DESC LIMIT 1\n"
+     ]
+    }
+   ],
    "source": [
     "query = await generate_sql(\"What is the top grossing movie?\")\n",
     "print(query)"
@@ -323,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,9 +364,26 @@
     "@tracer.tool\n",
     "def execute_sql(query):\n",
     "    records = conn.query(query).fetchdf().to_dict(orient=\"records\")\n",
-    "    return list(map(sanitize_records, records))\n",
-    "\n",
-    "\n",
+    "    return list(map(sanitize_records, records))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'title': 'Avatar'}]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "execute_sql(query)"
    ]
   },
@@ -352,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +441,7 @@
     "Answer:\n",
     "\"\"\"\n",
     "\n",
-    "synthesis_prompt_template = px_client.prompts.create(\n",
+    "synthesis_prompt_template = await px_client.prompts.create(\n",
     "    name=\"movie-synthesis\",\n",
     "    version=PromptVersion(\n",
     "        [\n",
@@ -428,9 +472,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The top-grossing movie is \"Avatar.\"'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "await movie_agent(\"What is the top grossing movie?\")"
    ]
@@ -444,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,9 +522,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Question:  Which Brad Pitt movie received the highest rating?\n",
+      "Answer:  The Brad Pitt movie that received the highest rating is \"Voom Portraits.\"\n",
+      "\n",
+      "\n",
+      "Question:  What is the top grossing Marvel movie?\n",
+      "Answer:  The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
+      "\n",
+      "\n",
+      "Question:  What foreign-language fantasy movie was the most popular?\n",
+      "Answer:  The foreign-language fantasy movie titled \"The Nights Belong to Monsters\" was the most popular. It's a Spanish-language film released on October 9, 2021. The movie blends fantasy and drama, telling the story of a 17-year-old girl named Sol who deals with bullying and harassment in a new town. She unexpectedly forms a protective bond with a mystical dog that defends her.\n",
+      "\n",
+      "\n",
+      "Question:  what are the best sci-fi movies of 2017?\n",
+      "Answer:  I don't know.\n",
+      "\n",
+      "\n",
+      "Question:  What anime topped the box office in the 2010s?\n",
+      "Answer:  I don't know which anime topped the box office in the 2010s based on the provided data.\n",
+      "\n",
+      "\n",
+      "Question:  Recommend a romcom that stars Paul Rudd.\n",
+      "Answer:  If you are looking for a romantic comedy featuring Paul Rudd, I would recommend \"Clueless.\" It's a delightful mix of comedy and romance, set in a Beverly Hills high school, where the main character Cher, played by Alicia Silverstone, learns some important life lessons and finds unexpected love. Paul Rudd plays a key role as Cher's thoughtful and charming ex-stepbrother, making it a classic romcom worth watching.\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from openinference.instrumentation import dangerously_using_project\n",
     "\n",
@@ -493,20 +579,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from phoenix.client import Client\n",
+    "from phoenix.client import AsyncClient\n",
     "from phoenix.client.types.spans import SpanQuery\n",
     "\n",
-    "phoenix_client = Client()\n",
+    "px_client = AsyncClient()\n",
     "query = SpanQuery().where(\"name == 'movie_agent'\")\n",
     "\n",
-    "spans_df = phoenix_client.spans.get_spans_dataframe(\n",
+    "spans_df = await px_client.spans.get_spans_dataframe(\n",
     "    project_identifier=\"movie-agent-baseline\", query=query\n",
     ")\n",
-    "annotations_df = phoenix_client.spans.get_span_annotations_dataframe(\n",
+    "annotations_df = await px_client.spans.get_span_annotations_dataframe(\n",
     "    spans_dataframe=spans_df, project_identifier=\"movie-agent-baseline\"\n",
     ")\n",
     "\n",
@@ -515,9 +601,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "\"['annotation_name', 'result.label'] not in index\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[30]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m examples_df = \u001b[43mcombined_df\u001b[49m\u001b[43m[\u001b[49m\n\u001b[32m      2\u001b[39m \u001b[43m    \u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mannotation_name\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mresult.label\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mattributes.input.value\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mattributes.output.value\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[32m      3\u001b[39m \u001b[43m]\u001b[49m.head()\n\u001b[32m      4\u001b[39m examples_df\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m is_iterator(key):\n\u001b[32m   4112\u001b[39m         key = \u001b[38;5;28mlist\u001b[39m(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m     indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_get_indexer_strict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcolumns\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m[\u001b[32m1\u001b[39m]\n\u001b[32m   4115\u001b[39m \u001b[38;5;66;03m# take() does not accept boolean indexers\u001b[39;00m\n\u001b[32m   4116\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(indexer, \u001b[33m\"\u001b[39m\u001b[33mdtype\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m) == \u001b[38;5;28mbool\u001b[39m:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:6212\u001b[39m, in \u001b[36mIndex._get_indexer_strict\u001b[39m\u001b[34m(self, key, axis_name)\u001b[39m\n\u001b[32m   6209\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   6210\u001b[39m     keyarr, indexer, new_indexer = \u001b[38;5;28mself\u001b[39m._reindex_non_unique(keyarr)\n\u001b[32m-> \u001b[39m\u001b[32m6212\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_raise_if_missing\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mindexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis_name\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   6214\u001b[39m keyarr = \u001b[38;5;28mself\u001b[39m.take(indexer)\n\u001b[32m   6215\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Index):\n\u001b[32m   6216\u001b[39m     \u001b[38;5;66;03m# GH 42790 - Preserve name from an Index\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:6264\u001b[39m, in \u001b[36mIndex._raise_if_missing\u001b[39m\u001b[34m(self, key, indexer, axis_name)\u001b[39m\n\u001b[32m   6261\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNone of [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m] are in the [\u001b[39m\u001b[38;5;132;01m{\u001b[39;00maxis_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m]\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   6263\u001b[39m not_found = \u001b[38;5;28mlist\u001b[39m(ensure_index(key)[missing_mask.nonzero()[\u001b[32m0\u001b[39m]].unique())\n\u001b[32m-> \u001b[39m\u001b[32m6264\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnot_found\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m not in index\u001b[39m\u001b[33m\"\u001b[39m)\n",
+      "\u001b[31mKeyError\u001b[39m: \"['annotation_name', 'result.label'] not in index\""
+     ]
+    }
+   ],
    "source": [
     "examples_df = combined_df[\n",
     "    [\"annotation_name\", \"result.label\", \"attributes.input.value\", \"attributes.output.value\"]\n",
@@ -534,9 +635,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'examples_df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[31]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m example_answers = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join(\n\u001b[32m      2\u001b[39m     [\n\u001b[32m      3\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mQuestion: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mattributes.input.value\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mAnswer: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mattributes.output.value\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mLabel: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexample[\u001b[33m'\u001b[39m\u001b[33mresult.label\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m         \u001b[38;5;28;01mfor\u001b[39;00m example \u001b[38;5;129;01min\u001b[39;00m \u001b[43mexamples_df\u001b[49m.to_dict(orient=\u001b[33m\"\u001b[39m\u001b[33mrecords\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m     ]\n\u001b[32m      6\u001b[39m )\n\u001b[32m      7\u001b[39m eval_prompt = \u001b[33mf\u001b[39m\u001b[33m\"\"\"\u001b[39m\n\u001b[32m      8\u001b[39m \u001b[33mYou are an expert evaluator of question and answer pairs. You will be given a human question and an answer from an AI agent.\u001b[39m\n\u001b[32m      9\u001b[39m \u001b[33mYour job is to determine if the answer is \u001b[39m\u001b[33m\"\u001b[39m\u001b[33mcorrect\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m or \u001b[39m\u001b[33m\"\u001b[39m\u001b[33mincorrect\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m.\u001b[39m\n\u001b[32m   (...)\u001b[39m\u001b[32m     23\u001b[39m \u001b[33mExplanation:\u001b[39m\n\u001b[32m     24\u001b[39m \u001b[33m\"\"\"\u001b[39m\n\u001b[32m     26\u001b[39m \u001b[38;5;28mprint\u001b[39m(eval_prompt)\n",
+      "\u001b[31mNameError\u001b[39m: name 'examples_df' is not defined"
+     ]
+    }
+   ],
    "source": [
     "example_answers = \"\\n\\n\".join(\n",
     "    [\n",
@@ -616,14 +729,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'evals_df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[32]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mphoenix\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mclient\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m AsyncClient\n\u001b[32m      3\u001b[39m px_client = AsyncClient()\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m px_client.spans.log_span_annotations_dataframe(\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m     dataframe=\u001b[43mevals_df\u001b[49m,\n\u001b[32m      6\u001b[39m     annotation_name=\u001b[33m\"\u001b[39m\u001b[33mllm_correctness\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      7\u001b[39m     annotator_kind=\u001b[33m\"\u001b[39m\u001b[33mLLM\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      8\u001b[39m )\n",
+      "\u001b[31mNameError\u001b[39m: name 'evals_df' is not defined"
+     ]
+    }
+   ],
    "source": [
     "from phoenix.client import AsyncClient\n",
     "\n",
     "px_client = AsyncClient()\n",
-    "await px_client.annotations.log_span_annotations_dataframe(\n",
+    "await px_client.spans.log_span_annotations_dataframe(\n",
     "    dataframe=evals_df,\n",
     "    annotation_name=\"llm_correctness\",\n",
     "    annotator_kind=\"LLM\",\n",
@@ -654,21 +779,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
-    "ds = await px_client.datasets.create_dataset(\n",
-    "    name=\"movie-train\",\n",
-    "    dataframe=pd.DataFrame([{\"question\": question} for question in questions]),\n",
-    "    input_keys=[\"question\"],\n",
-    "    output_keys=[],\n",
-    ")\n",
+    "# ds = await px_client.datasets.create_dataset(\n",
+    "#     name=\"movie-train\",\n",
+    "#     dataframe=pd.DataFrame([{\"question\": question} for question in questions]),\n",
+    "#     input_keys=[\"question\"],\n",
+    "#     output_keys=[],\n",
+    "# )\n",
     "\n",
     "# If you have already uploaded the dataset, you can fetch it using the following line\n",
-    "# ds = await px_client.datasets.get_dataset(dataset=\"movie-train\")"
+    "ds = await px_client.datasets.get_dataset(dataset=\"movie-train\")"
    ]
   },
   {
@@ -680,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,24 +859,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🧪 Experiment started.\n",
+      "📺 View dataset experiments: http://127.0.0.1:6006/datasets/RGF0YXNldDoy/experiments\n",
+      "🔗 View this experiment: http://127.0.0.1:6006/datasets/RGF0YXNldDoy/compare?experimentId=RXhwZXJpbWVudDo1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[A\n",
+      "\u001b[A\n",
+      "\u001b[A\n",
+      "\u001b[A\n",
+      "running tasks |██████████| 18/18 (100.0%) | ⏳ 03:35<00:00 | 11.98s/it\n",
+      "/Users/mikeldking/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:5398: RuntimeWarning: coroutine 'OITracer._chain.<locals>.async_wrapper' was never awaited\n",
+      "  if is_integer(key) or is_float(key):\n",
+      "RuntimeWarning: Enable tracemalloc to get the object allocation traceback\n",
+      "running experiment evaluations |██████████| 18/18 (100.0%) | ⏳ 03:35<00:00 | 11.97s/it\n",
+      "\n",
+      "\u001b[A\n",
+      "\u001b[A\n",
+      "\u001b[A\n",
+      "running tasks |██████████| 18/18 (100.0%) | ⏳ 00:08<00:00 |  2.25it/s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Task runs completed.\n",
+      "🧠 Evaluation started.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "running experiment evaluations |██████████| 18/18 (100.0%) | ⏳ 00:02<00:00 |  8.62it/s"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment completed: 18 task runs, 1 evaluator runs, 18 evaluations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "from phoenix.client.experiments import run_experiment\n",
+    "from phoenix.client.experiments import async_run_experiment\n",
     "\n",
     "\n",
     "# Define the task to run query_db on the input question\n",
-    "def task(input):\n",
-    "    return query_db(input[\"question\"])\n",
+    "async def task(input):\n",
+    "    return await query_db(input[\"question\"])\n",
     "\n",
     "\n",
-    "experiment = run_experiment(\n",
+    "experiment = await async_run_experiment(\n",
     "    dataset=ds,\n",
     "    task=task,\n",
     "    evaluators=[has_results],\n",
     "    experiment_metadata=CONFIG,\n",
     "    experiment_name=\"baseline\",\n",
+    "    repetitions=3,\n",
     ")"
    ]
   },
@@ -785,9 +971,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'conn' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m samples = \u001b[43mconn\u001b[49m.query(\u001b[33m\"\u001b[39m\u001b[33mSELECT * FROM movies LIMIT 5\u001b[39m\u001b[33m\"\u001b[39m).to_df().to_dict(orient=\u001b[33m\"\u001b[39m\u001b[33mrecords\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      3\u001b[39m example_row = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join(\n\u001b[32m      4\u001b[39m     \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcolumn[\u001b[33m'\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m | \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcolumn[\u001b[33m'\u001b[39m\u001b[33mcolumn_type\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m | \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msamples[\u001b[32m0\u001b[39m][column[\u001b[33m'\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m'\u001b[39m]]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m      5\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m column \u001b[38;5;129;01min\u001b[39;00m columns\n\u001b[32m      6\u001b[39m )\n\u001b[32m      8\u001b[39m column_header = \u001b[33m\"\u001b[39m\u001b[33m | \u001b[39m\u001b[33m\"\u001b[39m.join(column[\u001b[33m\"\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m\"\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m column \u001b[38;5;129;01min\u001b[39;00m columns)\n",
+      "\u001b[31mNameError\u001b[39m: name 'conn' is not defined"
+     ]
+    }
+   ],
    "source": [
     "samples = conn.query(\"SELECT * FROM movies LIMIT 5\").to_df().to_dict(orient=\"records\")\n",
     "\n",
@@ -831,7 +1029,7 @@
     "- SELECT * FROM movies\n",
     "\"\"\"\n",
     "\n",
-    "prompt_template = phoenix_client.prompts.create(\n",
+    "prompt_template = await px_client.prompts.create(\n",
     "    name=\"movie-text-to-sql\",\n",
     "    version=PromptVersion(\n",
     "        [\n",
@@ -1134,7 +1332,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.13.3"
   }
  },

--- a/tutorials/ai_evals_course/phoenix_overview.ipynb
+++ b/tutorials/ai_evals_course/phoenix_overview.ipynb
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U \"arize-phoenix-otel\" \"arize-phoenix-client>=1.20.0\" openai 'httpx<0.28' duckdb datasets pyarrow \"pydantic>=2.0.0\" nest_asyncio \"openinference-instrumentation>=0.1.38\" openinference-instrumentation-openai --quiet"
+    "!pip install -U \"arize-phoenix-otel\" \"arize-phoenix-client>=1.20.0\" \"arize-phoenix-evals>=2.3.0\" openai 'httpx<0.28' duckdb datasets pyarrow \"pydantic>=2.0.0\" nest_asyncio \"openinference-instrumentation>=0.1.38\" openinference-instrumentation-openai --quiet"
    ]
   },
   {
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,16 +179,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<_duckdb.DuckDBPyConnection at 0x121078d30>"
+       "<_duckdb.DuckDBPyConnection at 0x11f7c58f0>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -369,20 +369,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'title': 'Avatar'}]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "execute_sql(query)"
    ]
@@ -396,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,16 +461,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The top grossing movie is \"Avatar.\"'"
+       "'The top-grossing movie is \"Avatar.\"'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -499,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -530,27 +519,27 @@
      "output_type": "stream",
      "text": [
       "Question:  Which Brad Pitt movie received the highest rating?\n",
-      "Answer:  The Brad Pitt movie \"Voom Portraits\" received the highest rating.\n",
+      "Answer:  The Brad Pitt movie titled \"Voom Portraits\" received the highest rating.\n",
       "\n",
       "\n",
       "Question:  What is the top grossing Marvel movie?\n",
-      "Answer:  The top grossing Marvel movie is \"Avengers: Endgame\".\n",
+      "Answer:  The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
       "\n",
       "\n",
       "Question:  What foreign-language fantasy movie was the most popular?\n",
-      "Answer:  The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This Spanish-language film is a blend of fantasy and drama, focusing on a 17-year-old girl named Sol who faces hostility, bullying, and harassment in a new town. Her situation changes when she forms a symbiotic relationship with a mysterious and magical dog that protects her. The movie is produced by Rispo Films and Tieless Media and was released on October 9, 2021. Despite its popularity, it has a low average user rating.\n",
+      "Answer:  The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This film, with a fantasy-drama genre, is in Spanish and follows the story of Sol, a 17-year-old who faces bullying and harassment after moving to a new town. She finds solace and protection in a mysterious and magical female dog. Despite its low vote average, its intriguing plot and fantastical elements have made it stand out in terms of popularity.\n",
       "\n",
       "\n",
       "Question:  what are the best sci-fi movies of 2017?\n",
-      "Answer:  I don't know which sci-fi movies are considered the best of 2017 based on the data provided.\n",
+      "Answer:  I don't know which science fiction movies from 2017 are considered the best based on the provided data.\n",
       "\n",
       "\n",
       "Question:  What anime topped the box office in the 2010s?\n",
-      "Answer:  I don't know which anime topped the box office in the 2010s based on the data provided.\n",
+      "Answer:  I don't know which anime topped the box office in the 2010s based on the information provided.\n",
       "\n",
       "\n",
       "Question:  Recommend a romcom that stars Paul Rudd.\n",
-      "Answer:  If you're looking for a romantic comedy featuring Paul Rudd, I would recommend \"Clueless.\" It's a delightful blend of comedy and romance with Paul Rudd playing alongside Alicia Silverstone in a story about a wealthy high school student who plays matchmaker. Another great choice is \"I Love You, Man,\" where Paul Rudd stars as a man searching for a best man for his wedding and ends up forming an unexpected friendship. Both films are entertaining and showcase Rudd's charm and comedic timing beautifully.\n",
+      "Answer:  If you're looking for a romantic comedy featuring Paul Rudd, I recommend \"Clueless.\" It's a charming blend of comedy and romance where Rudd portrays Cher's ex-stepbrother, who offers her wisdom about growing up and making meaningful connections. His presence in the film adds a delightful touch to this classic tale of teenage life and matchmaking in Beverly Hills.\n",
       "\n",
       "\n"
      ]
@@ -579,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -633,35 +622,35 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4738ded59cdcd6bd</th>\n",
+       "      <th>44537d6a9d89f403</th>\n",
        "      <td>correctness</td>\n",
        "      <td>incorrect</td>\n",
        "      <td>Which Brad Pitt movie received the highest rat...</td>\n",
-       "      <td>The Brad Pitt movie \"Voom Portraits\" received ...</td>\n",
+       "      <td>The Brad Pitt movie titled \"Voom Portraits\" re...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6a7a775e37b887f8</th>\n",
+       "      <th>768806da8b9f91ea</th>\n",
        "      <td>correctness</td>\n",
        "      <td>correct</td>\n",
        "      <td>What is the top grossing Marvel movie?</td>\n",
-       "      <td>The top grossing Marvel movie is \"Avengers: En...</td>\n",
+       "      <td>The top-grossing Marvel movie is \"Avengers: En...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5eadf30616992035</th>\n",
+       "      <th>9fa1caf54d143f4e</th>\n",
        "      <td>correctness</td>\n",
        "      <td>incorrect</td>\n",
        "      <td>What foreign-language fantasy movie was the mo...</td>\n",
        "      <td>The most popular foreign-language fantasy movi...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4f0f5d5ccef5a1e0</th>\n",
+       "      <th>25e46043b8a52b20</th>\n",
        "      <td>correctness</td>\n",
        "      <td>incorrect</td>\n",
        "      <td>what are the best sci-fi movies of 2017?</td>\n",
-       "      <td>I don't know which sci-fi movies are considere...</td>\n",
+       "      <td>I don't know which science fiction movies from...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6de075915169d472</th>\n",
+       "      <th>7503437a6dea3233</th>\n",
        "      <td>correctness</td>\n",
        "      <td>incorrect</td>\n",
        "      <td>What anime topped the box office in the 2010s?</td>\n",
@@ -673,28 +662,28 @@
       ],
       "text/plain": [
        "                 annotation_name result.label  \\\n",
-       "4738ded59cdcd6bd     correctness    incorrect   \n",
-       "6a7a775e37b887f8     correctness      correct   \n",
-       "5eadf30616992035     correctness    incorrect   \n",
-       "4f0f5d5ccef5a1e0     correctness    incorrect   \n",
-       "6de075915169d472     correctness    incorrect   \n",
+       "44537d6a9d89f403     correctness    incorrect   \n",
+       "768806da8b9f91ea     correctness      correct   \n",
+       "9fa1caf54d143f4e     correctness    incorrect   \n",
+       "25e46043b8a52b20     correctness    incorrect   \n",
+       "7503437a6dea3233     correctness    incorrect   \n",
        "\n",
        "                                             attributes.input.value  \\\n",
-       "4738ded59cdcd6bd  Which Brad Pitt movie received the highest rat...   \n",
-       "6a7a775e37b887f8             What is the top grossing Marvel movie?   \n",
-       "5eadf30616992035  What foreign-language fantasy movie was the mo...   \n",
-       "4f0f5d5ccef5a1e0           what are the best sci-fi movies of 2017?   \n",
-       "6de075915169d472     What anime topped the box office in the 2010s?   \n",
+       "44537d6a9d89f403  Which Brad Pitt movie received the highest rat...   \n",
+       "768806da8b9f91ea             What is the top grossing Marvel movie?   \n",
+       "9fa1caf54d143f4e  What foreign-language fantasy movie was the mo...   \n",
+       "25e46043b8a52b20           what are the best sci-fi movies of 2017?   \n",
+       "7503437a6dea3233     What anime topped the box office in the 2010s?   \n",
        "\n",
        "                                            attributes.output.value  \n",
-       "4738ded59cdcd6bd  The Brad Pitt movie \"Voom Portraits\" received ...  \n",
-       "6a7a775e37b887f8  The top grossing Marvel movie is \"Avengers: En...  \n",
-       "5eadf30616992035  The most popular foreign-language fantasy movi...  \n",
-       "4f0f5d5ccef5a1e0  I don't know which sci-fi movies are considere...  \n",
-       "6de075915169d472  I don't know which anime topped the box office...  "
+       "44537d6a9d89f403  The Brad Pitt movie titled \"Voom Portraits\" re...  \n",
+       "768806da8b9f91ea  The top-grossing Marvel movie is \"Avengers: En...  \n",
+       "9fa1caf54d143f4e  The most popular foreign-language fantasy movi...  \n",
+       "25e46043b8a52b20  I don't know which science fiction movies from...  \n",
+       "7503437a6dea3233  I don't know which anime topped the box office...  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -715,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -729,23 +718,23 @@
       "Here are some examples of correct and incorrect answers:\n",
       "<examples>\n",
       "Question: Which Brad Pitt movie received the highest rating?\n",
-      "Answer: The Brad Pitt movie \"Voom Portraits\" received the highest rating.\n",
+      "Answer: The Brad Pitt movie titled \"Voom Portraits\" received the highest rating.\n",
       "Label: incorrect\n",
       "\n",
       "Question: What is the top grossing Marvel movie?\n",
-      "Answer: The top grossing Marvel movie is \"Avengers: Endgame\".\n",
+      "Answer: The top-grossing Marvel movie is \"Avengers: Endgame.\"\n",
       "Label: correct\n",
       "\n",
       "Question: What foreign-language fantasy movie was the most popular?\n",
-      "Answer: The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This Spanish-language film is a blend of fantasy and drama, focusing on a 17-year-old girl named Sol who faces hostility, bullying, and harassment in a new town. Her situation changes when she forms a symbiotic relationship with a mysterious and magical dog that protects her. The movie is produced by Rispo Films and Tieless Media and was released on October 9, 2021. Despite its popularity, it has a low average user rating.\n",
+      "Answer: The most popular foreign-language fantasy movie is \"The Nights Belong to Monsters.\" This film, with a fantasy-drama genre, is in Spanish and follows the story of Sol, a 17-year-old who faces bullying and harassment after moving to a new town. She finds solace and protection in a mysterious and magical female dog. Despite its low vote average, its intriguing plot and fantastical elements have made it stand out in terms of popularity.\n",
       "Label: incorrect\n",
       "\n",
       "Question: what are the best sci-fi movies of 2017?\n",
-      "Answer: I don't know which sci-fi movies are considered the best of 2017 based on the data provided.\n",
+      "Answer: I don't know which science fiction movies from 2017 are considered the best based on the provided data.\n",
       "Label: incorrect\n",
       "\n",
       "Question: What anime topped the box office in the 2010s?\n",
-      "Answer: I don't know which anime topped the box office in the 2010s based on the data provided.\n",
+      "Answer: I don't know which anime topped the box office in the 2010s based on the information provided.\n",
       "Label: incorrect\n",
       "</examples>\n",
       "\n",
@@ -792,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -827,29 +816,29 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>6cac14b09ccc0048</th>\n",
+       "      <th>f361c10d05028cbb</th>\n",
        "      <td>Recommend a romcom that stars Paul Rudd.</td>\n",
        "      <td>If you're looking for a romantic comedy featur...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6de075915169d472</th>\n",
+       "      <th>7503437a6dea3233</th>\n",
        "      <td>What anime topped the box office in the 2010s?</td>\n",
        "      <td>I don't know which anime topped the box office...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4f0f5d5ccef5a1e0</th>\n",
+       "      <th>25e46043b8a52b20</th>\n",
        "      <td>what are the best sci-fi movies of 2017?</td>\n",
-       "      <td>I don't know which sci-fi movies are considere...</td>\n",
+       "      <td>I don't know which science fiction movies from...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5eadf30616992035</th>\n",
+       "      <th>9fa1caf54d143f4e</th>\n",
        "      <td>What foreign-language fantasy movie was the mo...</td>\n",
        "      <td>The most popular foreign-language fantasy movi...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6a7a775e37b887f8</th>\n",
+       "      <th>768806da8b9f91ea</th>\n",
        "      <td>What is the top grossing Marvel movie?</td>\n",
-       "      <td>The top grossing Marvel movie is \"Avengers: En...</td>\n",
+       "      <td>The top-grossing Marvel movie is \"Avengers: En...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -858,22 +847,22 @@
       "text/plain": [
        "                                             attributes.input.value  \\\n",
        "context.span_id                                                       \n",
-       "6cac14b09ccc0048           Recommend a romcom that stars Paul Rudd.   \n",
-       "6de075915169d472     What anime topped the box office in the 2010s?   \n",
-       "4f0f5d5ccef5a1e0           what are the best sci-fi movies of 2017?   \n",
-       "5eadf30616992035  What foreign-language fantasy movie was the mo...   \n",
-       "6a7a775e37b887f8             What is the top grossing Marvel movie?   \n",
+       "f361c10d05028cbb           Recommend a romcom that stars Paul Rudd.   \n",
+       "7503437a6dea3233     What anime topped the box office in the 2010s?   \n",
+       "25e46043b8a52b20           what are the best sci-fi movies of 2017?   \n",
+       "9fa1caf54d143f4e  What foreign-language fantasy movie was the mo...   \n",
+       "768806da8b9f91ea             What is the top grossing Marvel movie?   \n",
        "\n",
        "                                            attributes.output.value  \n",
        "context.span_id                                                      \n",
-       "6cac14b09ccc0048  If you're looking for a romantic comedy featur...  \n",
-       "6de075915169d472  I don't know which anime topped the box office...  \n",
-       "4f0f5d5ccef5a1e0  I don't know which sci-fi movies are considere...  \n",
-       "5eadf30616992035  The most popular foreign-language fantasy movi...  \n",
-       "6a7a775e37b887f8  The top grossing Marvel movie is \"Avengers: En...  "
+       "f361c10d05028cbb  If you're looking for a romantic comedy featur...  \n",
+       "7503437a6dea3233  I don't know which anime topped the box office...  \n",
+       "25e46043b8a52b20  I don't know which science fiction movies from...  \n",
+       "9fa1caf54d143f4e  The most popular foreign-language fantasy movi...  \n",
+       "768806da8b9f91ea  The top-grossing Marvel movie is \"Avengers: En...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -884,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,79 +886,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 1: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 2: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 3: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 4: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 5: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 6: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 7: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 8: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 9: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Exception in worker on attempt 10: raised ValueError('Path not found: attributes')\n",
-      "Requeuing...\n",
-      "Retries exhausted after 11 attempts: Path not found: attributes\n",
-      "Retries exhausted after 11 attempts: Path not found: attributes\n",
-      "Retries exhausted after 11 attempts: Path not found: attributes\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from phoenix.evals import async_evaluate_dataframe\n",
     "\n",
@@ -978,9 +897,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "columns overlap but no suffix specified: Index(['name', 'span_kind', 'parent_id', 'start_time', 'end_time',\n       'status_code', 'status_message', 'events', 'context.span_id',\n       'context.trace_id', 'attributes.output.mime_type',\n       'attributes.input.mime_type', 'attributes.openinference.span.kind',\n       'attributes.input.value', 'attributes.output.value'],\n      dtype='object')",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[20]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m spans_with_evals_df = \u001b[43mspans_df\u001b[49m\u001b[43m.\u001b[49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevals_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhow\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mleft\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      3\u001b[39m spans_with_evals_df[\n\u001b[32m      4\u001b[39m     [\u001b[33m\"\u001b[39m\u001b[33mattributes.input.value\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mattributes.output.value\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mlabel\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mscore\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mexplanation\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m      5\u001b[39m ].head()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/frame.py:10764\u001b[39m, in \u001b[36mDataFrame.join\u001b[39m\u001b[34m(self, other, on, how, lsuffix, rsuffix, sort, validate)\u001b[39m\n\u001b[32m  10754\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m how == \u001b[33m\"\u001b[39m\u001b[33mcross\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m  10755\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m merge(\n\u001b[32m  10756\u001b[39m             \u001b[38;5;28mself\u001b[39m,\n\u001b[32m  10757\u001b[39m             other,\n\u001b[32m   (...)\u001b[39m\u001b[32m  10762\u001b[39m             validate=validate,\n\u001b[32m  10763\u001b[39m         )\n\u001b[32m> \u001b[39m\u001b[32m10764\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmerge\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m  10765\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m  10766\u001b[39m \u001b[43m        \u001b[49m\u001b[43mother\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10767\u001b[39m \u001b[43m        \u001b[49m\u001b[43mleft_on\u001b[49m\u001b[43m=\u001b[49m\u001b[43mon\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10768\u001b[39m \u001b[43m        \u001b[49m\u001b[43mhow\u001b[49m\u001b[43m=\u001b[49m\u001b[43mhow\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10769\u001b[39m \u001b[43m        \u001b[49m\u001b[43mleft_index\u001b[49m\u001b[43m=\u001b[49m\u001b[43mon\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m  10770\u001b[39m \u001b[43m        \u001b[49m\u001b[43mright_index\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m  10771\u001b[39m \u001b[43m        \u001b[49m\u001b[43msuffixes\u001b[49m\u001b[43m=\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlsuffix\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrsuffix\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10772\u001b[39m \u001b[43m        \u001b[49m\u001b[43msort\u001b[49m\u001b[43m=\u001b[49m\u001b[43msort\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10773\u001b[39m \u001b[43m        \u001b[49m\u001b[43mvalidate\u001b[49m\u001b[43m=\u001b[49m\u001b[43mvalidate\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m  10774\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m  10775\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m  10776\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m on \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:184\u001b[39m, in \u001b[36mmerge\u001b[39m\u001b[34m(left, right, how, on, left_on, right_on, left_index, right_index, sort, suffixes, copy, indicator, validate)\u001b[39m\n\u001b[32m    169\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    170\u001b[39m     op = _MergeOperation(\n\u001b[32m    171\u001b[39m         left_df,\n\u001b[32m    172\u001b[39m         right_df,\n\u001b[32m   (...)\u001b[39m\u001b[32m    182\u001b[39m         validate=validate,\n\u001b[32m    183\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m184\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mop\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_result\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:888\u001b[39m, in \u001b[36m_MergeOperation.get_result\u001b[39m\u001b[34m(self, copy)\u001b[39m\n\u001b[32m    884\u001b[39m     \u001b[38;5;28mself\u001b[39m.left, \u001b[38;5;28mself\u001b[39m.right = \u001b[38;5;28mself\u001b[39m._indicator_pre_merge(\u001b[38;5;28mself\u001b[39m.left, \u001b[38;5;28mself\u001b[39m.right)\n\u001b[32m    886\u001b[39m join_index, left_indexer, right_indexer = \u001b[38;5;28mself\u001b[39m._get_join_info()\n\u001b[32m--> \u001b[39m\u001b[32m888\u001b[39m result = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_reindex_and_concat\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    889\u001b[39m \u001b[43m    \u001b[49m\u001b[43mjoin_index\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mleft_indexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mright_indexer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcopy\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcopy\u001b[49m\n\u001b[32m    890\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    891\u001b[39m result = result.__finalize__(\u001b[38;5;28mself\u001b[39m, method=\u001b[38;5;28mself\u001b[39m._merge_type)\n\u001b[32m    893\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.indicator:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:840\u001b[39m, in \u001b[36m_MergeOperation._reindex_and_concat\u001b[39m\u001b[34m(self, join_index, left_indexer, right_indexer, copy)\u001b[39m\n\u001b[32m    837\u001b[39m left = \u001b[38;5;28mself\u001b[39m.left[:]\n\u001b[32m    838\u001b[39m right = \u001b[38;5;28mself\u001b[39m.right[:]\n\u001b[32m--> \u001b[39m\u001b[32m840\u001b[39m llabels, rlabels = \u001b[43m_items_overlap_with_suffix\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    841\u001b[39m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mleft\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_info_axis\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mright\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_info_axis\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43msuffixes\u001b[49m\n\u001b[32m    842\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    844\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m left_indexer \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_range_indexer(left_indexer, \u001b[38;5;28mlen\u001b[39m(left)):\n\u001b[32m    845\u001b[39m     \u001b[38;5;66;03m# Pinning the index here (and in the right code just below) is not\u001b[39;00m\n\u001b[32m    846\u001b[39m     \u001b[38;5;66;03m#  necessary, but makes the `.take` more performant if we have e.g.\u001b[39;00m\n\u001b[32m    847\u001b[39m     \u001b[38;5;66;03m#  a MultiIndex for left.index.\u001b[39;00m\n\u001b[32m    848\u001b[39m     lmgr = left._mgr.reindex_indexer(\n\u001b[32m    849\u001b[39m         join_index,\n\u001b[32m    850\u001b[39m         left_indexer,\n\u001b[32m   (...)\u001b[39m\u001b[32m    855\u001b[39m         use_na_proxy=\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[32m    856\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/reshape/merge.py:2720\u001b[39m, in \u001b[36m_items_overlap_with_suffix\u001b[39m\u001b[34m(left, right, suffixes)\u001b[39m\n\u001b[32m   2717\u001b[39m lsuffix, rsuffix = suffixes\n\u001b[32m   2719\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m lsuffix \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m rsuffix:\n\u001b[32m-> \u001b[39m\u001b[32m2720\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mcolumns overlap but no suffix specified: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mto_rename\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m   2722\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mrenamer\u001b[39m(x, suffix: \u001b[38;5;28mstr\u001b[39m | \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m   2723\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m   2724\u001b[39m \u001b[33;03m    Rename the left and right indices.\u001b[39;00m\n\u001b[32m   2725\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m   2736\u001b[39m \u001b[33;03m    x : renamed column name\u001b[39;00m\n\u001b[32m   2737\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n",
+      "\u001b[31mValueError\u001b[39m: columns overlap but no suffix specified: Index(['name', 'span_kind', 'parent_id', 'start_time', 'end_time',\n       'status_code', 'status_message', 'events', 'context.span_id',\n       'context.trace_id', 'attributes.output.mime_type',\n       'attributes.input.mime_type', 'attributes.openinference.span.kind',\n       'attributes.input.value', 'attributes.output.value'],\n      dtype='object')"
+     ]
+    }
+   ],
    "source": [
     "spans_with_evals_df = spans_df.join(evals_df, how=\"left\")\n",
     "\n",
@@ -991,21 +927,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'evals_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[32]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mphoenix\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mclient\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m AsyncClient\n\u001b[32m      3\u001b[39m px_client = AsyncClient()\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m px_client.spans.log_span_annotations_dataframe(\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m     dataframe=\u001b[43mevals_df\u001b[49m,\n\u001b[32m      6\u001b[39m     annotation_name=\u001b[33m\"\u001b[39m\u001b[33mllm_correctness\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      7\u001b[39m     annotator_kind=\u001b[33m\"\u001b[39m\u001b[33mLLM\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      8\u001b[39m )\n",
-      "\u001b[31mNameError\u001b[39m: name 'evals_df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from phoenix.client import AsyncClient\n",
     "\n",
@@ -1041,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1083,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1101,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1121,69 +1045,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🧪 Experiment started.\n",
-      "📺 View dataset experiments: http://127.0.0.1:6006/datasets/RGF0YXNldDoy/experiments\n",
-      "🔗 View this experiment: http://127.0.0.1:6006/datasets/RGF0YXNldDoy/compare?experimentId=RXhwZXJpbWVudDo1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[A\n",
-      "\u001b[A\n",
-      "\u001b[A\n",
-      "\u001b[A\n",
-      "running tasks |██████████| 18/18 (100.0%) | ⏳ 03:35<00:00 | 11.98s/it\n",
-      "/Users/mikeldking/work/phoenix/.venv/lib/python3.13/site-packages/pandas/core/indexes/base.py:5398: RuntimeWarning: coroutine 'OITracer._chain.<locals>.async_wrapper' was never awaited\n",
-      "  if is_integer(key) or is_float(key):\n",
-      "RuntimeWarning: Enable tracemalloc to get the object allocation traceback\n",
-      "running experiment evaluations |██████████| 18/18 (100.0%) | ⏳ 03:35<00:00 | 11.97s/it\n",
-      "\n",
-      "\u001b[A\n",
-      "\u001b[A\n",
-      "\u001b[A\n",
-      "running tasks |██████████| 18/18 (100.0%) | ⏳ 00:08<00:00 |  2.25it/s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Task runs completed.\n",
-      "🧠 Evaluation started.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "running experiment evaluations |██████████| 18/18 (100.0%) | ⏳ 00:02<00:00 |  8.62it/s"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Experiment completed: 18 task runs, 1 evaluator runs, 18 evaluations\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from phoenix.client.experiments import async_run_experiment\n",
     "\n",
@@ -1233,21 +1097,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'conn' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m samples = \u001b[43mconn\u001b[49m.query(\u001b[33m\"\u001b[39m\u001b[33mSELECT * FROM movies LIMIT 5\u001b[39m\u001b[33m\"\u001b[39m).to_df().to_dict(orient=\u001b[33m\"\u001b[39m\u001b[33mrecords\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      3\u001b[39m example_row = \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m.join(\n\u001b[32m      4\u001b[39m     \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcolumn[\u001b[33m'\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m | \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcolumn[\u001b[33m'\u001b[39m\u001b[33mcolumn_type\u001b[39m\u001b[33m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m | \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msamples[\u001b[32m0\u001b[39m][column[\u001b[33m'\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m'\u001b[39m]]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m      5\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m column \u001b[38;5;129;01min\u001b[39;00m columns\n\u001b[32m      6\u001b[39m )\n\u001b[32m      8\u001b[39m column_header = \u001b[33m\"\u001b[39m\u001b[33m | \u001b[39m\u001b[33m\"\u001b[39m.join(column[\u001b[33m\"\u001b[39m\u001b[33mcolumn_name\u001b[39m\u001b[33m\"\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m column \u001b[38;5;129;01min\u001b[39;00m columns)\n",
-      "\u001b[31mNameError\u001b[39m: name 'conn' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "samples = conn.query(\"SELECT * FROM movies LIMIT 5\").to_df().to_dict(orient=\"records\")\n",
     "\n",

--- a/tutorials/ai_evals_course/phoenix_overview.ipynb
+++ b/tutorials/ai_evals_course/phoenix_overview.ipynb
@@ -573,7 +573,12 @@
     "from phoenix.evals.llm import LLM\n",
     "\n",
     "# Define a classification based evaluation\n",
-    "llm_correctness = create_classifier(name=\"llm_correctness\", llm=LLM(model=\"gpt-4o\", provider=\"openai\"), prompt_template=eval_prompt, choices={ \"correct\": 1, \"incorrect\": 0 })"
+    "llm_correctness = create_classifier(\n",
+    "    name=\"llm_correctness\",\n",
+    "    llm=LLM(model=\"gpt-4o\", provider=\"openai\"),\n",
+    "    prompt_template=eval_prompt,\n",
+    "    choices={\"correct\": 1, \"incorrect\": 0},\n",
+    ")"
    ]
   },
   {
@@ -903,7 +908,7 @@
     "    name=\"usefulness\",\n",
     "    llm=LLM(model=\"gpt-4o\", provider=\"openai\"),\n",
     "    prompt_template=judge_prompt_template,\n",
-    "    choices={ \"useful\": 1, \"useless\": 0 }\n",
+    "    choices={\"useful\": 1, \"useless\": 0},\n",
     ")\n",
     "\n",
     "await async_evaluate_experiment(experiment=experiment, evaluators=[usefulness])"
@@ -992,10 +997,7 @@
    "source": [
     "from phoenix.evals import async_evaluate_dataframe\n",
     "\n",
-    "evals_df = await async_evaluate_dataframe(\n",
-    "    dataframe=spans_df,\n",
-    "    evaluators=[llm_correctness]\n",
-    ")"
+    "evals_df = await async_evaluate_dataframe(dataframe=spans_df, evaluators=[llm_correctness])"
    ]
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes the Phoenix overview tutorial to use the new OTEL package and Async client/APIs, adds async experiment flow, and refreshes examples/outputs.
> 
> - **Tutorials**: `tutorials/ai_evals_course/phoenix_overview.ipynb`
>   - **Dependencies**: replace `arize-phoenix` with `arize-phoenix-otel` and add `arize-phoenix-client>=1.20.0`.
>   - **Client/API migration**:
>     - Switch `phoenix.client.Client` → `AsyncClient` and add `await` for prompt/spans/datasets operations.
>     - Use `openai.AsyncClient` for async chat completions.
>     - Update annotation logging to `px_client.spans.log_span_annotations_dataframe`.
>   - **Tracing**: initialize via `phoenix.otel.register` with auto-instrumentation; instrument functions with `@tracer.chain/tool/agent`.
>   - **Datasets & Experiments**:
>     - Optionally fetch existing dataset; add async experiment runner `async_run_experiment` with an async `task` and `repetitions=3`.
>   - **Content**: execute cells and display results for end-to-end flow; add prompt few-shot improvement section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a559dab65b9793e9567c19fdd21592e1b5e6e949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->