### PR TITLE
docs: add session api docs

### DIFF
--- a/packages/phoenix-client/docs/source/api/sessions.rst
+++ b/packages/phoenix-client/docs/source/api/sessions.rst
@@ -1,0 +1,10 @@
+Sessions
+========
+
+.. autoclass:: client.resources.sessions.Sessions
+   :members:
+   :show-inheritance:
+
+.. autoclass:: client.resources.sessions.AsyncSessions
+   :members:
+   :show-inheritance:

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -484,7 +484,7 @@ api/datasets
 api/experiments
 api/prompts
 api/spans
-api/annotations
+api/sessions
 api/projects
 api/helpers
 api/utils

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -484,6 +484,7 @@ api/datasets
 api/experiments
 api/prompts
 api/spans
+api/annotations
 api/sessions
 api/projects
 api/helpers

--- a/packages/phoenix-client/docs/source/index.md
+++ b/packages/phoenix-client/docs/source/index.md
@@ -7,6 +7,7 @@ Welcome to the Phoenix Client documentation. This lightweight Python client prov
 - **[Prompts](api/prompts)** - Manage prompt templates and versions
 - **[Spans](api/spans)** - Access and analyze traces and spans
 - **[Annotations](api/annotations)** - Add annotations, evals, and feedback to spans
+- **[Sessions](api/sessions)** - Add session annotations to multi-turn conversations and threads
 - **[Projects](api/projects)** - Organize your work with project management
 
 ## Installation


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Sessions API docs and links them in the index navigation and toctree.
> 
> - **Docs**:
>   - **New Sessions API reference**: Add `docs/source/api/sessions.rst` with autodoc for `client.resources.sessions.Sessions` and `client.resources.sessions.AsyncSessions`.
>   - **Index updates**: Link Sessions in `docs/source/index.md` navigation list and include `api/sessions` in the toctree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966d8ed73128fcf61f50b90532698db07c437147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->