### PR TITLE
feat: support Claude Sonnet 4.5

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1677,6 +1677,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
 @register_llm_client(
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
+        "claude-sonnet-4-5",
         "claude-sonnet-4-0",
         "claude-sonnet-4-20250514",
         "claude-opus-4-1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `claude-sonnet-4-5` to the Anthropic reasoning client model registry for playground support.
> 
> - **Backend – Anthropic**:
>   - Register `claude-sonnet-4-5` in `src/phoenix/server/api/helpers/playground_clients.py` under the Anthropic reasoning client `model_names`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c4cf6e27317a7fd2899e4e311245ccb8a03894b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->