### PR TITLE
feat: support more providers with LLM

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
@@ -27,6 +27,7 @@ def get_litellm_rate_limit_errors() -> list[Type[Exception]]:
 
     return [LiteLLMRateLimitError]
 
+
 @register_provider(
     provider="openai",
     client_factory=create_openai_client,

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/adapter.py
@@ -13,7 +13,10 @@ from ...types import BaseLLMAdapter, ObjectGenerationMethod
 from .client import LiteLLMClient
 from .factories import (
     create_anthropic_client,
+    create_bedrock_client,
+    create_litellm_client,
     create_openai_client,
+    create_vertex_client,
 )
 
 logger = logging.getLogger(__name__)
@@ -24,7 +27,12 @@ def get_litellm_rate_limit_errors() -> list[Type[Exception]]:
 
     return [LiteLLMRateLimitError]
 
-
+@register_provider(
+    provider="openai",
+    client_factory=create_openai_client,
+    get_rate_limit_errors=get_litellm_rate_limit_errors,
+    dependencies=["litellm"],
+)
 @register_provider(
     provider="anthropic",
     client_factory=create_anthropic_client,
@@ -32,8 +40,20 @@ def get_litellm_rate_limit_errors() -> list[Type[Exception]]:
     dependencies=["litellm"],
 )
 @register_provider(
-    provider="openai",
-    client_factory=create_openai_client,
+    provider="vertex",
+    client_factory=create_vertex_client,
+    get_rate_limit_errors=get_litellm_rate_limit_errors,
+    dependencies=["litellm"],
+)
+@register_provider(
+    provider="bedrock",
+    client_factory=create_bedrock_client,
+    get_rate_limit_errors=get_litellm_rate_limit_errors,
+    dependencies=["litellm", "boto3"],
+)
+@register_provider(
+    provider="litellm",
+    client_factory=create_litellm_client,
     get_rate_limit_errors=get_litellm_rate_limit_errors,
     dependencies=["litellm"],
 )

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/factories.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/litellm/factories.py
@@ -13,3 +13,11 @@ def create_openai_client(model: str, is_async: bool, **kwargs: Any) -> LiteLLMCl
 
 def create_litellm_client(model: str, is_async: bool, **kwargs: Any) -> LiteLLMClient:
     return LiteLLMClient(provider="litellm", model=model, **kwargs)
+
+
+def create_vertex_client(model: str, is_async: bool, **kwargs: Any) -> LiteLLMClient:
+    return LiteLLMClient(provider="vertex_ai", model=model, **kwargs)
+
+
+def create_bedrock_client(model: str, is_async: bool, **kwargs: Any) -> LiteLLMClient:
+    return LiteLLMClient(provider="bedrock", model=model, **kwargs)

--- a/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/factories.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/adapters/openai/factories.py
@@ -15,9 +15,9 @@ def create_openai_client(model: str, is_async: bool, **kwargs: Any) -> Any:
         from openai import AsyncOpenAI, OpenAI
 
         if is_async:
-            client: Union[AsyncOpenAI, OpenAI] = AsyncOpenAI(**kwargs)
+            client: Union[AsyncOpenAI, OpenAI] = AsyncOpenAI(max_retries=0, **kwargs)
         else:
-            client = OpenAI(**kwargs)
+            client = OpenAI(max_retries=0, **kwargs)
 
         return OpenAIClientWrapper(client, model)
     except ImportError:
@@ -29,9 +29,9 @@ def create_azure_openai_client(model: str, is_async: bool, **kwargs: Any) -> Any
         from openai import AsyncAzureOpenAI, AzureOpenAI
 
         if is_async:
-            client: Union[AsyncAzureOpenAI, AzureOpenAI] = AsyncAzureOpenAI(**kwargs)
+            client: Union[AsyncAzureOpenAI, AzureOpenAI] = AsyncAzureOpenAI(max_retries=0, **kwargs)
         else:
-            client = AzureOpenAI(**kwargs)
+            client = AzureOpenAI(max_retries=0, **kwargs)
         return OpenAIClientWrapper(client, model)
     except ImportError:
         raise ImportError("OpenAI package not installed. Run: pip install openai")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Vertex AI, Bedrock, and raw LiteLLM providers to the LiteLLM adapter and sets OpenAI/Azure OpenAI clients to no-retry.
> 
> - **LLM (LiteLLM adapter)**:
>   - Register additional providers: `vertex` (via `create_vertex_client`), `bedrock` (via `create_bedrock_client`), and `litellm` (via `create_litellm_client`), alongside `openai` and `anthropic`.
>   - Associate rate-limit errors and dependencies for new providers (e.g., `boto3` for `bedrock`).
> - **Factories (LiteLLM)**:
>   - Add `create_vertex_client` (`provider="vertex_ai"`) and `create_bedrock_client` (`provider="bedrock"`).
> - **Factories (OpenAI)**:
>   - Initialize `OpenAI`/`AsyncOpenAI` and `AzureOpenAI`/`AsyncAzureOpenAI` with `max_retries=0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6fbe203a245f769320cc935d79510d49214e388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->