### PR TITLE
docs: evals on traces

### DIFF
--- a/docs/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces.md
@@ -181,7 +181,7 @@ Joke: {joke}
 """
 
 nerdy_evaluator = ClassificationEvaluator(
-    name="nerdiness_evaluator",
+    name="nerdiness",
     llm=LLM(provider="openai", model="gpt-4o-mini"),
     prompt_template=prompt_template,
     choices=["nerdy", "not nerdy"], # you could map these labels to scores, but we refrain from judgement here

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces.md
@@ -11,7 +11,7 @@ This process is similar to the [evaluation quickstart guide](https://arize.com/d
 ### Install dependencies & Set environment variables
 
 ```bash
-pip install -q "arize-phoenix>=4.29.0"
+pip install -q arize-phoenix
 pip install -q openai 'httpx<0.28'
 ```
 
@@ -97,9 +97,9 @@ print(f"Generated {len(jokes)} jokes and tracked them in Phoenix.")
 ### Download trace dataset from Phoenix
 
 ```python
-import phoenix as px
+from phoenix.client import Client
 
-spans_df = px.Client().get_spans_dataframe(project_name="evaluating_traces_quickstart")
+spans_df = Client().spans.get_spans_dataframe(project_name="evaluating_traces_quickstart")
 spans_df.head()
 ```
 
@@ -110,12 +110,12 @@ Now that we have our trace dataset, we can generate evaluations for each trace. 
 You can generate evaluations using:
 
 * Plain code
-* Phoenix's [built-in LLM as a Judge evaluators](https://arize.com/docs/phoenix/evaluation/how-to-evals/running-pre-tested-evals)
-* Your own [custom LLM as a Judge evaluator](https://arize.com/docs/phoenix/evaluation/how-to-evals/bring-your-own-evaluator)
+* The [Phoenix evals](https://arize.com/docs/phoenix/evaluation/llm-evals) library, which supports both built-in and custom evaluators.  
 * Other evaluation packages
 
 As long as you format your evaluation results properly, you can upload them to Phoenix and visualize them in the UI.
 
+### Code Eval Example
 Let's start with a simple example of generating evaluations using plain code. OpenAI has a habit of repeating jokes, so we'll generate evaluations to label whether a joke is a repeat of a previous joke.
 
 ```python
@@ -142,6 +142,8 @@ eval_df["label"] = eval_df["attributes.llm.output_messages"].apply(is_duplicate)
 
 # Convert boolean to integer (0 for False, 1 for True)
 eval_df["label"] = eval_df["label"]
+eval_df["score"] = eval_df["label"].astype(int)
+eval_df["label"] = eval_df["label"].astype(str)
 
 # Reset unique_jokes list to ensure correct results if the cell is run multiple times
 unique_jokes.clear()
@@ -153,18 +155,59 @@ We now have a DataFrame with a column for whether each joke is a repeat of a pre
 
 Our evals\_df has a column for the span\_id and a column for the evaluation result. The span\_id is what allows us to connect the evaluation to the correct trace in Phoenix. Phoenix will also automatically look for columns named "label" and "score" to display in the UI.
 
-```python
-eval_df["score"] = eval_df["score"].astype(int)
-eval_df["label"] = eval_df["label"].astype(str)
-```
 
 ```python
-from phoenix.trace import SpanEvaluations
+from phoenix.client import Client
 
-px.Client().log_evaluations(SpanEvaluations(eval_name="Duplicate", dataframe=eval_df))
+Client().spans.log_span_annotations_dataframe(dataframe=eval_df, annotation_name="duplicate", annotator_kind="CODE")
 ```
 
 You should now see evaluations in the Phoenix UI!
+
+### LLM Eval Example 
+
+Let's use the [Phoenix Evals](https://arize.com/docs/phoenix/evaluation/evals) library to define an LLM-as-a-judge evaluator that classifies jokes as either 
+"nerdy" or "not nerdy." 
+
+```python
+from phoenix.evals import ClassificationEvaluator
+from phoenix.evals.llm import LLM
+
+prompt_template = """
+Determine whether the following joke can be classified as "nerdy" or "not nerdy".
+A nerdy joke is defined as a joke that is related to science, math, or technology.
+
+Joke: {joke}
+"""
+
+nerdy_evaluator = ClassificationEvaluator(
+    name="nerdiness_evaluator",
+    llm=LLM(provider="openai", model="gpt-4o-mini"),
+    prompt_template=prompt_template,
+    choices=["nerdy", "not nerdy"], # you could map these labels to scores, but we refrain from judgement here
+)
+```
+
+Let's run this evaluator on our dataset of traces. 
+
+```python
+from phoenix.evals import async_evaluate_dataframe
+
+# isolate the joke content in its own column  
+eval_df["joke"] = eval_df["attributes.llm.output_messages"].apply(lambda x: x[0]["message.content"])
+
+results_df = await async_evaluate_dataframe(eval_df, evaluators=[nerdy_evaluator])
+```
+
+And then upload the results to Phoenix as annotations. 
+
+```python
+from phoenix.client import Client
+from phoenix.evals.utils import to_annotation_dataframe
+
+annotation_df = to_annotation_dataframe(results_df)
+Client().spans.log_span_annotations_dataframe(dataframe=annotation_df)
+```
 
 From here you can continue collecting and evaluating traces, or move on to one of these other guides:
 

--- a/docs/tracing/how-to-tracing/feedback-and-annotations/llm-evaluations.md
+++ b/docs/tracing/how-to-tracing/feedback-and-annotations/llm-evaluations.md
@@ -6,7 +6,9 @@ description: >-
 
 # Log Evaluation Results
 
-An evaluation must have a `name` (e.g. "Q\&A Correctness") and its DataFrame must contain identifiers for the subject of evaluation, e.g. a span or a document (more on that below), and values under either the `score`, `label`, or `explanation` columns. See [Evaluations](broken-reference) for more information.
+Evaluations, which can be considered a form of automated annotation, are logged as annotations inside of Phoenix. 
+Instead of coming from a "HUMAN" source, they are either "CODE" (aka heuristic) or "LLM" types. 
+An evaluation must have a name (e.g. "Q\&A Correctness") and its DataFrame must contain identifiers for the subject of evaluation, e.g. a span or a document (more on that below), and values under either the `score`, `label`, or `explanation` columns. An optional `metadata` column can also be provided.
 
 ## Connect to Phoenix
 
@@ -29,13 +31,17 @@ A dataframe of span evaluations would look similar to the table below. It must c
 
 <table><thead><tr><th>span_id</th><th>label</th><th data-type="number">score</th><th>explanation</th></tr></thead><tbody><tr><td>5B8EF798A381</td><td>correct</td><td>1</td><td>"this is correct ..."</td></tr><tr><td>E19B7EC3GG02</td><td>incorrect</td><td>0</td><td>"this is incorrect ..."</td></tr></tbody></table>
 
-The evaluations dataframe can be sent to Phoenix as follows. Note that the name of the evaluation must be supplied through the `annotation_name=` parameter. In this case we name it "Q\&A Correctness".
+The evaluations dataframe can be sent to Phoenix as follows. 
+
+Note that the name and source of the evaluation can be supplied through the `annotation_name` `annotator_kind` parameters, or as columns with the same names in the dataframe.
 
 ```python
-client.spans.log_span_annotations_dataframe(
+from phoenix.client import Client()
+
+Client().log_span_annotations(
     dataframe=qa_correctness_eval_df,
-    annotation_name="Q&A Correctness",
-    annotator_kind="LLM",
+    annotation_name="QA Correctness",
+    annotator_kind="LLM"
 )
 ```
 
@@ -45,10 +51,12 @@ A dataframe of document evaluations would look something like the table below. I
 
 <table><thead><tr><th>span_id</th><th data-type="number">document_position</th><th width="109">label</th><th width="82" data-type="number">score</th><th>explanation</th></tr></thead><tbody><tr><td>5B8EF798A381</td><td>0</td><td>relevant</td><td>1</td><td>"this is ..."</td></tr><tr><td>5B8EF798A381</td><td>1</td><td>irrelevant</td><td>0</td><td>"this is ..."</td></tr><tr><td>E19B7EC3GG02</td><td>0</td><td>relevant</td><td>1</td><td>"this is ..."</td></tr></tbody></table>
 
-The evaluations dataframe can be sent to Phoenix as follows. Note that the name of the evaluation must be supplied through the `annotation_name=` parameter. In this case we name it "Relevance".
+The evaluations dataframe can be sent to Phoenix as follows. In this case we name it "Relevance".
 
 ```python
-client.spans.log_document_annotations_dataframe(
+from phoenix.client import Client
+
+Client().spans.log_document_annotations_dataframe(
     dataframe=document_relevance_eval_df,
     annotation_name="Relevance",
     annotator_kind="LLM",
@@ -76,4 +84,20 @@ client.spans.log_span_annotations_dataframe(
     annotator_kind="LLM",
 )
 # ... continue with additional evaluations as needed
+```
+
+Or, if you specify the `annotation_name` and  `annotator_kind` as columns, you can vertically concatenate the dataframes and upload them all at once. 
+
+```python
+import pandas as pd 
+
+qa_correctness_eval_df["annotation_name"] = "QA Correctness"
+qa_correctness_eval_df["annotator_kind"] = "LLM"
+
+hallucination_eval_df["annotation_name"] = "Hallucination"
+hallucination_eval_df["annotator_kind"] = "LLM"
+
+annotations_df = pd.concat([qa_correctness_eval_df, hallucination_eval_df], ignore_index=True)
+
+px_client.spans.log_span_annotations_dataframe(dataframe=annotations_df)
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refreshes evals documentation to use new Client-based annotation APIs, adds CODE and LLM eval examples, and documents batching uploads.
> 
> - **Docs**:
>   - **Evaluating Phoenix Traces** (`docs/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces.md`):
>     - Switch to `phoenix.client.Client` APIs (`spans.get_spans_dataframe`, `spans.log_span_annotations_dataframe`) and remove legacy `px.Client().log_evaluations`/`SpanEvaluations` usage.
>     - Add explicit code example for heuristic (CODE) evals with proper `label`/`score` typing and logging via annotations.
>     - Add end-to-end LLM-eval example using `phoenix.evals` (`ClassificationEvaluator`, `async_evaluate_dataframe`, `to_annotation_dataframe`).
>     - Minor dependency/install tweaks.
>   - **LLM Evaluations** (`docs/tracing/how-to-tracing/feedback-and-annotations/llm-evaluations.md`):
>     - Clarify that evaluations are logged as annotations with `annotation_name` and `annotator_kind` (CODE/LLM), with optional `metadata`.
>     - Update examples to use `Client()` annotation logging APIs for spans/documents.
>     - Add pattern for batching multiple eval DataFrames by concatenation with per-row `annotation_name`/`annotator_kind`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c497e48f161c8464a34398174b1afafbc414bf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->