### PR TITLE
feat(evals): pass function doc strings through decorator

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -610,6 +610,8 @@ def create_evaluator(
 
     def deco(fn: Callable[..., Any]) -> Evaluator:
         sig = inspect.signature(fn)
+        # Preserve the docstring from the original function
+        original_docstring = fn.__doc__
 
         class _FunctionEvaluator(Evaluator):
             def __init__(self) -> None:
@@ -638,6 +640,8 @@ def create_evaluator(
                     ),
                 )
                 self._fn = fn
+                # Store the original docstring
+                self._docstring = original_docstring
 
             def _evaluate(self, eval_input: EvalInput) -> List[Score]:
                 # eval_input is already remapped by Evaluator.evaluate(...)
@@ -647,6 +651,9 @@ def create_evaluator(
 
             def __call__(self, *args: Any, **kwargs: Any) -> Any:
                 return self._fn(*args, **kwargs)
+
+        # Set the docstring on the class itself
+        _FunctionEvaluator.__doc__ = original_docstring
 
         evaluator_instance = _FunctionEvaluator()
         # Keep registry compatibility by storing a callable with expected signature


### PR DESCRIPTION
Makes it so that metrics built using `create_evaluator` get their doc strings passed on and detected for the API reference. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves and exposes original function docstrings on evaluators created via `create_evaluator` by capturing the function `__doc__`, storing it, and assigning it to the generated class.
> 
> - **Evaluators**:
>   - `create_evaluator` now preserves function docstrings:
>     - Captures `fn.__doc__` and stores it on the evaluator instance (`_docstring`).
>     - Sets the generated evaluator class `__doc__` to the original function docstring for documentation discovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07d04399d1e614670182e7db88494d2ee5e3ca10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->