### PR TITLE
revert: "chore: update phoenix version to 12.1.0 in kustomize and helm"

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -42,13 +42,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "12.1.0"
+appVersion: "12.0.0"
 icon: https://phoenix.arize.com/wp-content/uploads/2025/04/logo-with-arize.svg
 maintainers:
   - name: arize

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -484,7 +484,7 @@ image:
   repository: "arizephoenix/phoenix"
 
   # -- Docker image tag/version to deploy
-  tag: version-12.1.0-nonroot
+  tag: version-12.0.0-nonroot
 
 # -- Resource configuration
 resources:

--- a/kustomize/base/phoenix.yaml
+++ b/kustomize/base/phoenix.yaml
@@ -30,7 +30,7 @@ spec:
                         value: "6006"
                       - name: PHOENIX_SQL_DATABASE_URL
                         value: "postgresql://postgres:postgres123@postgres:5432/postgres"
-                  image: arizephoenix/phoenix:version-12.1.0
+                  image: arizephoenix/phoenix:version-12.0.0
                   name: phoenix
                   ports:
                       - containerPort: 6006


### PR DESCRIPTION
Reverts Arize-ai/phoenix#9712

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts Phoenix to 12.0.0 (chart 3.0.0) and updates Helm/Kustomize image tags accordingly.
> 
> - **Helm**:
>   - Downgrade `helm/Chart.yaml` `version` to `3.0.0` and `appVersion` to `"12.0.0"`.
>   - Update `helm/values.yaml` image `tag` to `version-12.0.0-nonroot`.
> - **Kustomize**:
>   - Update `kustomize/base/phoenix.yaml` container image to `arizephoenix/phoenix:version-12.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5621739903b59d882a908e05e5eac71bad1d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->