### PR TITLE
feat: UI cleanup - reduce re-renders

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -17,6 +17,7 @@ input AddDatasetExamplesToDatasetSplitsInput {
 
 type AddDatasetExamplesToDatasetSplitsMutationPayload {
   query: Query!
+  examples: [DatasetExample!]!
 }
 
 input AddExamplesToDatasetInput {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -740,6 +740,12 @@ type DatasetSplitMutationPayload {
   query: Query!
 }
 
+type DatasetSplitMutationPayloadWithExamples {
+  datasetSplit: DatasetSplit!
+  query: Query!
+  examples: [DatasetExample!]!
+}
+
 type DatasetValues {
   primaryValue: Float
   referenceValue: Float
@@ -1682,7 +1688,7 @@ type Mutation {
   deleteDatasetSplits(input: DeleteDatasetSplitInput!): DeleteDatasetSplitsMutationPayload!
   addDatasetExamplesToDatasetSplits(input: AddDatasetExamplesToDatasetSplitsInput!): AddDatasetExamplesToDatasetSplitsMutationPayload!
   removeDatasetExamplesFromDatasetSplits(input: RemoveDatasetExamplesFromDatasetSplitsInput!): RemoveDatasetExamplesFromDatasetSplitsMutationPayload!
-  createDatasetSplitWithExamples(input: CreateDatasetSplitWithExamplesInput!): DatasetSplitMutationPayload!
+  createDatasetSplitWithExamples(input: CreateDatasetSplitWithExamplesInput!): DatasetSplitMutationPayloadWithExamples!
   deleteExperiments(input: DeleteExperimentsInput!): ExperimentMutationPayload!
 
   """
@@ -2361,6 +2367,7 @@ input RemoveDatasetExamplesFromDatasetSplitsInput {
 
 type RemoveDatasetExamplesFromDatasetSplitsMutationPayload {
   query: Query!
+  examples: [DatasetExample!]!
 }
 
 type ResponseFormat {

--- a/app/src/components/dataset/NewDatasetSplitDialog.tsx
+++ b/app/src/components/dataset/NewDatasetSplitDialog.tsx
@@ -1,4 +1,4 @@
-import { graphql, useMutation } from "react-relay";
+import { ConnectionHandler, graphql, useMutation } from "react-relay";
 
 import { Dialog, Modal } from "@phoenix/components";
 import {
@@ -16,23 +16,57 @@ import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import type { NewDatasetSplitDialogCreateSplitMutation } from "./__generated__/NewDatasetSplitDialogCreateSplitMutation.graphql";
+import type { NewDatasetSplitDialogCreateSplitWithExamplesMutation } from "./__generated__/NewDatasetSplitDialogCreateSplitWithExamplesMutation.graphql";
 
 type NewDatasetSplitDialogProps = {
   onCompleted?: () => void;
+  exampleIds?: string[];
 };
 
 export function NewDatasetSplitDialog(props: NewDatasetSplitDialogProps) {
-  const { onCompleted } = props;
+  const { onCompleted, exampleIds } = props;
   const notifySuccess = useNotifySuccess();
   const notifyError = useNotifyError();
+
+  const [commitWithExamples, isInFlightWithExamples] =
+    useMutation<NewDatasetSplitDialogCreateSplitWithExamplesMutation>(graphql`
+      mutation NewDatasetSplitDialogCreateSplitWithExamplesMutation(
+        $input: CreateDatasetSplitWithExamplesInput!
+        $connections: [ID!]!
+      ) {
+        createDatasetSplitWithExamples(input: $input) {
+          datasetSplit
+            @prependNode(
+              connections: $connections
+              edgeTypeName: "DatasetSplitEdge"
+            ) {
+            id
+            name
+          }
+          examples {
+            id
+            datasetSplits {
+              id
+              name
+              color
+            }
+          }
+        }
+      }
+    `);
 
   const [commit, isInFlight] =
     useMutation<NewDatasetSplitDialogCreateSplitMutation>(graphql`
       mutation NewDatasetSplitDialogCreateSplitMutation(
         $input: CreateDatasetSplitInput!
+        $connections: [ID!]!
       ) {
         createDatasetSplit(input: $input) {
-          datasetSplit {
+          datasetSplit
+            @prependNode(
+              connections: $connections
+              edgeTypeName: "DatasetSplitEdge"
+            ) {
             id
             name
           }
@@ -42,32 +76,56 @@ export function NewDatasetSplitDialog(props: NewDatasetSplitDialogProps) {
 
   const onSubmit = (params: DatasetSplitParams) => {
     const trimmed = params.name.trim();
+    const connections = [
+      ConnectionHandler.getConnectionID(
+        "client:root",
+        "ManageDatasetSplitsDialog_datasetSplits"
+      ),
+    ];
+
     // TODO: Validate params
     if (!trimmed) return;
-    commit({
-      variables: {
-        input: {
-          name: trimmed,
-          description: params.description || null,
-          color: params.color,
-          metadata: null,
+
+    if (exampleIds) {
+      commitWithExamples({
+        variables: {
+          connections,
+          input: {
+            name: trimmed,
+            description: params.description || null,
+            color: params.color,
+            metadata: null,
+            exampleIds,
+          },
         },
-      },
-      onCompleted: () => {
-        notifySuccess({
-          title: "Split created",
-          message: `Created split "${trimmed}"`,
-        });
-        onCompleted?.();
-      },
-      onError: (error) => {
-        const formattedError = getErrorMessagesFromRelayMutationError(error);
-        notifyError({
-          title: "Failed to create split",
-          message: formattedError?.[0] ?? error.message,
-        });
-      },
-    });
+      });
+    } else {
+      commit({
+        variables: {
+          connections,
+          input: {
+            name: trimmed,
+            description: params.description || null,
+            color: params.color,
+            metadata: null,
+          },
+        },
+        onCompleted: () => {
+          notifySuccess({
+            title: "Split created",
+            message: `Created split "${trimmed}"`,
+          });
+          onCompleted?.();
+        },
+        onError: (error) => {
+          const formattedError = getErrorMessagesFromRelayMutationError(error);
+          notifyError({
+            title: "Failed to create split",
+            message: formattedError?.[0] ?? error.message,
+          });
+        },
+      });
+    }
   };
 
   return (
@@ -80,7 +138,10 @@ export function NewDatasetSplitDialog(props: NewDatasetSplitDialogProps) {
               <DialogCloseButton />
             </DialogTitleExtra>
           </DialogHeader>
-          <NewDatasetSplitForm onSubmit={onSubmit} isSubmitting={isInFlight} />
+          <NewDatasetSplitForm
+            onSubmit={onSubmit}
+            isSubmitting={isInFlight || isInFlightWithExamples}
+          />
         </DialogContent>
       </Dialog>
     </Modal>

--- a/app/src/components/dataset/__generated__/NewDatasetSplitDialogCreateSplitMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/NewDatasetSplitDialogCreateSplitMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c24085b0b6801826bcb1564d76b8ea1b>>
+ * @generated SignedSource<<235a0714d66b251a9d626a9a5ef9bec1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type CreateDatasetSplitInput = {
   name: string;
 };
 export type NewDatasetSplitDialogCreateSplitMutation$variables = {
+  connections: ReadonlyArray<string>;
   input: CreateDatasetSplitInput;
 };
 export type NewDatasetSplitDialogCreateSplitMutation$data = {
@@ -32,73 +33,117 @@ export type NewDatasetSplitDialogCreateSplitMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
 ],
-v1 = [
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetSplit",
+  "kind": "LinkedField",
+  "name": "datasetSplit",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
     ],
-    "concreteType": "DatasetSplitMutationPayload",
-    "kind": "LinkedField",
-    "name": "createDatasetSplit",
-    "plural": false,
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewDatasetSplitDialogCreateSplitMutation",
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "concreteType": "DatasetSplit",
+        "args": (v2/*: any*/),
+        "concreteType": "DatasetSplitMutationPayload",
         "kind": "LinkedField",
-        "name": "datasetSplit",
+        "name": "createDatasetSplit",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          }
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ],
-    "storageKey": null
-  }
-];
-return {
-  "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "NewDatasetSplitDialogCreateSplitMutation",
-    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "NewDatasetSplitDialogCreateSplitMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DatasetSplitMutationPayload",
+        "kind": "LinkedField",
+        "name": "createDatasetSplit",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "datasetSplit",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "DatasetSplitEdge"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
     "cacheID": "e2f2d371c2b1017d3aecc2d6a77a14ce",
@@ -111,6 +156,6 @@ return {
 };
 })();
 
-(node as any).hash = "f38f781f7a16295d3feda764d406d41c";
+(node as any).hash = "a30073b8a498e1a9472dc42cb57be358";
 
 export default node;

--- a/app/src/components/dataset/__generated__/NewDatasetSplitDialogCreateSplitWithExamplesMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/NewDatasetSplitDialogCreateSplitWithExamplesMutation.graphql.ts
@@ -1,0 +1,206 @@
+/**
+ * @generated SignedSource<<e5f508624b531d7a94697606fa5aa033>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateDatasetSplitWithExamplesInput = {
+  color: string;
+  description?: string | null;
+  exampleIds: ReadonlyArray<string>;
+  metadata?: any | null;
+  name: string;
+};
+export type NewDatasetSplitDialogCreateSplitWithExamplesMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateDatasetSplitWithExamplesInput;
+};
+export type NewDatasetSplitDialogCreateSplitWithExamplesMutation$data = {
+  readonly createDatasetSplitWithExamples: {
+    readonly datasetSplit: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly examples: ReadonlyArray<{
+      readonly datasetSplits: ReadonlyArray<{
+        readonly color: string;
+        readonly id: string;
+        readonly name: string;
+      }>;
+      readonly id: string;
+    }>;
+  };
+};
+export type NewDatasetSplitDialogCreateSplitWithExamplesMutation = {
+  response: NewDatasetSplitDialogCreateSplitWithExamplesMutation$data;
+  variables: NewDatasetSplitDialogCreateSplitWithExamplesMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetSplit",
+  "kind": "LinkedField",
+  "name": "datasetSplit",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/)
+  ],
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetExample",
+  "kind": "LinkedField",
+  "name": "examples",
+  "plural": true,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DatasetSplit",
+      "kind": "LinkedField",
+      "name": "datasetSplits",
+      "plural": true,
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "color",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewDatasetSplitDialogCreateSplitWithExamplesMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DatasetSplitMutationPayloadWithExamples",
+        "kind": "LinkedField",
+        "name": "createDatasetSplitWithExamples",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "NewDatasetSplitDialogCreateSplitWithExamplesMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DatasetSplitMutationPayloadWithExamples",
+        "kind": "LinkedField",
+        "name": "createDatasetSplitWithExamples",
+        "plural": false,
+        "selections": [
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "datasetSplit",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "DatasetSplitEdge"
+              }
+            ]
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e746e6264dc039ea0a907e8381a3e8d7",
+    "id": null,
+    "metadata": {},
+    "name": "NewDatasetSplitDialogCreateSplitWithExamplesMutation",
+    "operationKind": "mutation",
+    "text": "mutation NewDatasetSplitDialogCreateSplitWithExamplesMutation(\n  $input: CreateDatasetSplitWithExamplesInput!\n) {\n  createDatasetSplitWithExamples(input: $input) {\n    datasetSplit {\n      id\n      name\n    }\n    examples {\n      id\n      datasetSplits {\n        id\n        name\n        color\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "eb1ee991af123fd14dfe9b42b78728f3";
+
+export default node;

--- a/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
+++ b/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
@@ -1,4 +1,4 @@
-import { Suspense, memo, useMemo, useState } from "react";
+import { memo, Suspense, useMemo, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
@@ -94,6 +94,7 @@ function ManageDatasetSplitsDialogComponent(
                   key={`${Number(isOpen)}-${JSON.stringify(sharedSplitIds)}`}
                   sharedSplitIds={sharedSplitIds}
                   partialSplitIds={partialSplitIds}
+                  selectedExamples={selectedExamples}
                   onConfirm={onConfirm}
                 />
               ) : null}
@@ -108,9 +109,11 @@ function ManageDatasetSplitsDialogComponent(
 function ManageDatasetSplitsDialogContent(props: {
   sharedSplitIds: string[];
   partialSplitIds: string[];
+  selectedExamples: SelectedExample[];
   onConfirm: (ids: string[]) => void;
 }) {
-  const { sharedSplitIds, partialSplitIds, onConfirm } = props;
+  const { sharedSplitIds, partialSplitIds, onConfirm, selectedExamples } =
+    props;
   const [search, setSearch] = useState("");
   const [isCreateSplitOpen, setIsCreateSplitOpen] = useState(false);
   const [selectedSplitIds, setSelectedSplitIds] = useState<Set<string>>(
@@ -231,6 +234,7 @@ function ManageDatasetSplitsDialogContent(props: {
       >
         <NewDatasetSplitDialog
           onCompleted={() => setIsCreateSplitOpen(false)}
+          exampleIds={selectedExamples.map((example) => example.id)}
         />
       </ModalOverlay>
     </Autocomplete>

--- a/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
+++ b/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
@@ -1,4 +1,4 @@
-import { memo, Suspense, useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
@@ -45,7 +45,7 @@ type ManageDatasetSplitsDialogProps = {
   selectedExamples: SelectedExample[];
 };
 
-function ManageDatasetSplitsDialogComponent(
+export function ManageDatasetSplitsDialog(
   props: ManageDatasetSplitsDialogProps
 ) {
   const { isOpen, onOpenChange, onConfirm, selectedExamples } = props;
@@ -89,6 +89,8 @@ function ManageDatasetSplitsDialogComponent(
               </DialogTitleExtra>
             </DialogHeader>
             <Suspense fallback={<Loading />}>
+              {/* isOpen && is being used to reduce flickering of the dialog
+      , however it is a code smell */}
               {isOpen ? (
                 <ManageDatasetSplitsDialogContent
                   key={`${Number(isOpen)}-${JSON.stringify(sharedSplitIds)}`}
@@ -240,63 +242,3 @@ function ManageDatasetSplitsDialogContent(props: {
     </Autocomplete>
   );
 }
-
-function areManageDatasetSplitsDialogPropsEqual(
-  prevProps: ManageDatasetSplitsDialogProps,
-  nextProps: ManageDatasetSplitsDialogProps
-) {
-  if (prevProps.isOpen !== nextProps.isOpen) {
-    return false;
-  }
-
-  if (prevProps.onOpenChange !== nextProps.onOpenChange) {
-    return false;
-  }
-
-  if (prevProps.onConfirm !== nextProps.onConfirm) {
-    return false;
-  }
-
-  const prevExamples = prevProps.selectedExamples;
-  const nextExamples = nextProps.selectedExamples;
-
-  if (prevExamples.length !== nextExamples.length) {
-    return false;
-  }
-
-  for (let i = 0; i < prevExamples.length; i += 1) {
-    const prevExample = prevExamples[i];
-    const nextExample = nextExamples[i];
-
-    if (prevExample.id !== nextExample.id) {
-      return false;
-    }
-
-    const prevSplits = prevExample.splits;
-    const nextSplits = nextExample.splits;
-
-    if (prevSplits.length !== nextSplits.length) {
-      return false;
-    }
-
-    for (let j = 0; j < prevSplits.length; j += 1) {
-      const prevSplit = prevSplits[j];
-      const nextSplit = nextSplits[j];
-
-      if (
-        prevSplit?.id !== nextSplit?.id ||
-        prevSplit?.color !== nextSplit?.color ||
-        prevSplit?.name !== nextSplit?.name
-      ) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-export const ManageDatasetSplitsDialog = memo(
-  ManageDatasetSplitsDialogComponent,
-  areManageDatasetSplitsDialogPropsEqual
-);

--- a/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
+++ b/app/src/components/datasetSplit/ManageDatasetSplitsDialog.tsx
@@ -1,9 +1,10 @@
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, memo, useMemo, useState } from "react";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import { css } from "@emotion/react";
 
 import {
   Autocomplete,
+  Button,
   Dialog,
   Flex,
   Label,
@@ -13,6 +14,7 @@ import {
   View,
 } from "@phoenix/components";
 import { Checkbox } from "@phoenix/components/checkbox";
+import { NewDatasetSplitDialog } from "@phoenix/components/dataset/NewDatasetSplitDialog";
 import {
   DialogCloseButton,
   DialogContent,
@@ -27,30 +29,47 @@ import type {
   ManageDatasetSplitsDialogQuery$data,
 } from "./__generated__/ManageDatasetSplitsDialogQuery.graphql";
 
+interface SelectedExample {
+  id: string;
+  splits: readonly {
+    readonly id: string;
+    readonly color: string;
+    readonly name: string;
+  }[];
+}
+
 type ManageDatasetSplitsDialogProps = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: (selectedIds: string[]) => void;
-  sharedSplitIds: string[];
-  partialSplitIds: string[];
+  selectedExamples: SelectedExample[];
 };
 
-export function ManageDatasetSplitsDialog(
+function ManageDatasetSplitsDialogComponent(
   props: ManageDatasetSplitsDialogProps
 ) {
-  const { isOpen, onOpenChange, onConfirm, sharedSplitIds, partialSplitIds } =
-    props;
-  const [selectedSplitIds, setSelectedSplitIds] = useState<Set<string>>(
-    new Set(sharedSplitIds)
-  );
+  const { isOpen, onOpenChange, onConfirm, selectedExamples } = props;
 
-  // TODO: this is a code smell
-  // TODO: unnecessary state change, should be tracked in this component
-  useEffect(() => {
-    if (isOpen) {
-      setSelectedSplitIds(new Set(sharedSplitIds));
-    }
-  }, [isOpen, sharedSplitIds]);
+  // Calculate shared split IDs (splits that all selected examples have)
+  const sharedSplitIds = useMemo<string[]>(() => {
+    if (selectedExamples.length === 0) return [];
+    const splitIdArrays = selectedExamples.map(
+      (ex) => ex.splits.map((s) => s.id) ?? []
+    );
+    const intersection = splitIdArrays.reduce((acc, curr) =>
+      acc.filter((id) => curr.includes(id))
+    );
+    return intersection;
+  }, [selectedExamples]);
+
+  // Calculate partial split IDs (splits that at least one selected example has)
+  const partialSplitIds = useMemo<string[]>(() => {
+    if (selectedExamples.length === 0) return [];
+    const splitIdArrays = selectedExamples
+      .map((ex) => ex.splits.map((s) => s.id) ?? [])
+      .reduce((acc, curr) => acc.concat(curr), []);
+    return [...new Set(splitIdArrays)];
+  }, [selectedExamples]);
 
   return (
     <ModalOverlay
@@ -60,7 +79,7 @@ export function ManageDatasetSplitsDialog(
       }}
       isDismissable
     >
-      <Modal>
+      <Modal size="S">
         <Dialog aria-label="Manage Splits">
           <DialogContent>
             <DialogHeader>
@@ -70,12 +89,14 @@ export function ManageDatasetSplitsDialog(
               </DialogTitleExtra>
             </DialogHeader>
             <Suspense fallback={<Loading />}>
-              <ManageDatasetSplitsDialogContent
-                selectedSplitIds={selectedSplitIds}
-                setSelectedSplitIds={(s) => setSelectedSplitIds(new Set(s))}
-                partialSplitIds={partialSplitIds}
-                onConfirm={onConfirm}
-              />
+              {isOpen ? (
+                <ManageDatasetSplitsDialogContent
+                  key={`${Number(isOpen)}-${JSON.stringify(sharedSplitIds)}`}
+                  sharedSplitIds={sharedSplitIds}
+                  partialSplitIds={partialSplitIds}
+                  onConfirm={onConfirm}
+                />
+              ) : null}
             </Suspense>
           </DialogContent>
         </Dialog>
@@ -85,14 +106,16 @@ export function ManageDatasetSplitsDialog(
 }
 
 function ManageDatasetSplitsDialogContent(props: {
-  selectedSplitIds: Set<string>;
-  setSelectedSplitIds: (s: Set<string>) => void;
-  onConfirm: (ids: string[]) => void;
+  sharedSplitIds: string[];
   partialSplitIds: string[];
+  onConfirm: (ids: string[]) => void;
 }) {
-  const { selectedSplitIds, setSelectedSplitIds, onConfirm, partialSplitIds } =
-    props;
+  const { sharedSplitIds, partialSplitIds, onConfirm } = props;
   const [search, setSearch] = useState("");
+  const [isCreateSplitOpen, setIsCreateSplitOpen] = useState(false);
+  const [selectedSplitIds, setSelectedSplitIds] = useState<Set<string>>(
+    () => new Set(sharedSplitIds)
+  );
   const query = useLazyLoadQuery<ManageDatasetSplitsDialogQuery>(
     graphql`
       query ManageDatasetSplitsDialogQuery {
@@ -190,6 +213,86 @@ function ManageDatasetSplitsDialogContent(props: {
           })}
         </div>
       </View>
+      <View padding="size-100" borderTopColor="dark" borderTopWidth="thin">
+        <Button
+          variant="quiet"
+          size="S"
+          style={{ width: "100%" }}
+          onPress={() => setIsCreateSplitOpen(true)}
+        >
+          Create Split
+        </Button>
+      </View>
+      <ModalOverlay
+        isOpen={isCreateSplitOpen}
+        onOpenChange={(open) => {
+          if (!open) setIsCreateSplitOpen(false);
+        }}
+      >
+        <NewDatasetSplitDialog
+          onCompleted={() => setIsCreateSplitOpen(false)}
+        />
+      </ModalOverlay>
     </Autocomplete>
   );
 }
+
+function areManageDatasetSplitsDialogPropsEqual(
+  prevProps: ManageDatasetSplitsDialogProps,
+  nextProps: ManageDatasetSplitsDialogProps
+) {
+  if (prevProps.isOpen !== nextProps.isOpen) {
+    return false;
+  }
+
+  if (prevProps.onOpenChange !== nextProps.onOpenChange) {
+    return false;
+  }
+
+  if (prevProps.onConfirm !== nextProps.onConfirm) {
+    return false;
+  }
+
+  const prevExamples = prevProps.selectedExamples;
+  const nextExamples = nextProps.selectedExamples;
+
+  if (prevExamples.length !== nextExamples.length) {
+    return false;
+  }
+
+  for (let i = 0; i < prevExamples.length; i += 1) {
+    const prevExample = prevExamples[i];
+    const nextExample = nextExamples[i];
+
+    if (prevExample.id !== nextExample.id) {
+      return false;
+    }
+
+    const prevSplits = prevExample.splits;
+    const nextSplits = nextExample.splits;
+
+    if (prevSplits.length !== nextSplits.length) {
+      return false;
+    }
+
+    for (let j = 0; j < prevSplits.length; j += 1) {
+      const prevSplit = prevSplits[j];
+      const nextSplit = nextSplits[j];
+
+      if (
+        prevSplit?.id !== nextSplit?.id ||
+        prevSplit?.color !== nextSplit?.color ||
+        prevSplit?.name !== nextSplit?.name
+      ) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+export const ManageDatasetSplitsDialog = memo(
+  ManageDatasetSplitsDialogComponent,
+  areManageDatasetSplitsDialogPropsEqual
+);

--- a/app/src/pages/examples/ExampleSelectionToolbar.tsx
+++ b/app/src/pages/examples/ExampleSelectionToolbar.tsx
@@ -88,8 +88,13 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
       $input: AddDatasetExamplesToDatasetSplitsInput!
     ) {
       addDatasetExamplesToDatasetSplits(input: $input) {
-        query {
-          __typename
+        examples {
+          id
+          datasetSplits {
+            id
+            name
+            color
+          }
         }
       }
     }

--- a/app/src/pages/examples/ExampleSelectionToolbar.tsx
+++ b/app/src/pages/examples/ExampleSelectionToolbar.tsx
@@ -272,6 +272,8 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
           {isDeletingExamples ? "Deleting..." : "Delete"}
         </Button>
       </Toolbar>
+      {/* isManageSplitsOpen && is being used to reduce flickering of the dialog
+      , however it is a code smell */}
       {isManageSplitsOpen && (
         <ManageDatasetSplitsDialog
           selectedExamples={selectedExamples}

--- a/app/src/pages/examples/ExampleSelectionToolbar.tsx
+++ b/app/src/pages/examples/ExampleSelectionToolbar.tsx
@@ -167,7 +167,7 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
             },
           },
           onCompleted: () => {
-            refreshLatestVersion();
+            // refreshLatestVersion();
           },
           onError: (error) => {
             const formattedError =
@@ -189,7 +189,7 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
             },
           },
           onCompleted: () => {
-            refreshLatestVersion();
+            // refreshLatestVersion();
           },
           onError: (error) => {
             const formattedError =
@@ -262,13 +262,13 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
           {isDeletingExamples ? "Deleting..." : "Delete"}
         </Button>
       </Toolbar>
-      <ManageDatasetSplitsDialog
+      {isManageSplitsOpen && <ManageDatasetSplitsDialog
         selectedExamples={selectedExamples}
         isOpen={isManageSplitsOpen}
         onOpenChange={setIsManageSplitsOpen}
         onConfirm={handleManageSplitsConfirm}
-      />
-      <ModalOverlay
+      /> }
+     <ModalOverlay
         isOpen={isDeleteConfirmationDialogOpen}
         onOpenChange={(isOpen) => {
           if (!isOpen) {
@@ -320,7 +320,7 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
               </View>
             </DialogContent>
           </Dialog>
-        </Modal>
+        </Modal> 
       </ModalOverlay>
     </FloatingToolbarContainer>
   );

--- a/app/src/pages/examples/ExampleSelectionToolbar.tsx
+++ b/app/src/pages/examples/ExampleSelectionToolbar.tsx
@@ -106,7 +106,14 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
         $input: RemoveDatasetExamplesFromDatasetSplitsInput!
       ) {
         removeDatasetExamplesFromDatasetSplits(input: $input) {
-          __typename
+          examples {
+            id
+            datasetSplits {
+              id
+              name
+              color
+            }
+          }
         }
       }
     `
@@ -208,11 +215,9 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
     },
     [
       addExamplesToSplits,
-      getErrorMessagesFromRelayMutationError,
       isAddingExamplesToSplits,
       isRemovingExamplesFromSplit,
       notifyError,
-      refreshLatestVersion,
       removeExamplesFromSplit,
       selectedExamples,
       sharedSplitIds,
@@ -267,13 +272,15 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
           {isDeletingExamples ? "Deleting..." : "Delete"}
         </Button>
       </Toolbar>
-      {isManageSplitsOpen && <ManageDatasetSplitsDialog
-        selectedExamples={selectedExamples}
-        isOpen={isManageSplitsOpen}
-        onOpenChange={setIsManageSplitsOpen}
-        onConfirm={handleManageSplitsConfirm}
-      /> }
-     <ModalOverlay
+      {isManageSplitsOpen && (
+        <ManageDatasetSplitsDialog
+          selectedExamples={selectedExamples}
+          isOpen={isManageSplitsOpen}
+          onOpenChange={setIsManageSplitsOpen}
+          onConfirm={handleManageSplitsConfirm}
+        />
+      )}
+      <ModalOverlay
         isOpen={isDeleteConfirmationDialogOpen}
         onOpenChange={(isOpen) => {
           if (!isOpen) {
@@ -325,7 +332,7 @@ export function ExampleSelectionToolbar(props: ExampleSelectionToolbarProps) {
               </View>
             </DialogContent>
           </Dialog>
-        </Modal> 
+        </Modal>
       </ModalOverlay>
     </FloatingToolbarContainer>
   );

--- a/app/src/pages/examples/__generated__/ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation.graphql.ts
+++ b/app/src/pages/examples/__generated__/ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2774c04fd2b27271bf38a8056c893e14>>
+ * @generated SignedSource<<2f4adecfdc38685bab2887f41767c39f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,9 +18,14 @@ export type ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation$var
 };
 export type ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation$data = {
   readonly addDatasetExamplesToDatasetSplits: {
-    readonly query: {
-      readonly __typename: "Query";
-    };
+    readonly examples: ReadonlyArray<{
+      readonly datasetSplits: ReadonlyArray<{
+        readonly color: string;
+        readonly id: string;
+        readonly name: string;
+      }>;
+      readonly id: string;
+    }>;
   };
 };
 export type ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation = {
@@ -36,7 +41,14 @@ var v0 = [
     "name": "input"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
   {
     "alias": null,
     "args": [
@@ -54,16 +66,36 @@ v1 = [
       {
         "alias": null,
         "args": null,
-        "concreteType": "Query",
+        "concreteType": "DatasetExample",
         "kind": "LinkedField",
-        "name": "query",
-        "plural": false,
+        "name": "examples",
+        "plural": true,
         "selections": [
+          (v1/*: any*/),
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
+            "concreteType": "DatasetSplit",
+            "kind": "LinkedField",
+            "name": "datasetSplits",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "color",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           }
         ],
@@ -79,7 +111,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation",
-    "selections": (v1/*: any*/),
+    "selections": (v2/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -88,19 +120,19 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation",
-    "selections": (v1/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "f4edd66fbe9c27175dcd7f6d6fe94957",
+    "cacheID": "06b9f49cd0904e598f87797547513590",
     "id": null,
     "metadata": {},
     "name": "ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation",
     "operationKind": "mutation",
-    "text": "mutation ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation(\n  $input: AddDatasetExamplesToDatasetSplitsInput!\n) {\n  addDatasetExamplesToDatasetSplits(input: $input) {\n    query {\n      __typename\n    }\n  }\n}\n"
+    "text": "mutation ExampleSelectionToolbarAddDatasetExamplesToDatasetSplitsMutation(\n  $input: AddDatasetExamplesToDatasetSplitsInput!\n) {\n  addDatasetExamplesToDatasetSplits(input: $input) {\n    examples {\n      id\n      datasetSplits {\n        id\n        name\n        color\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dd657896cf3c272a32f0b1959bb38217";
+(node as any).hash = "df6fafc7bc7158da6290c64761474286";
 
 export default node;

--- a/app/src/pages/examples/__generated__/ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation.graphql.ts
+++ b/app/src/pages/examples/__generated__/ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<89b851cfcc5de8da0d2fecd3525e0ad6>>
+ * @generated SignedSource<<fc5fe968020002631f297d81423d62c2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,14 @@ export type ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation
 };
 export type ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation$data = {
   readonly removeDatasetExamplesFromDatasetSplits: {
-    readonly __typename: "RemoveDatasetExamplesFromDatasetSplitsMutationPayload";
+    readonly examples: ReadonlyArray<{
+      readonly datasetSplits: ReadonlyArray<{
+        readonly color: string;
+        readonly id: string;
+        readonly name: string;
+      }>;
+      readonly id: string;
+    }>;
   };
 };
 export type ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation = {
@@ -34,7 +41,14 @@ var v0 = [
     "name": "input"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
   {
     "alias": null,
     "args": [
@@ -52,8 +66,39 @@ v1 = [
       {
         "alias": null,
         "args": null,
-        "kind": "ScalarField",
-        "name": "__typename",
+        "concreteType": "DatasetExample",
+        "kind": "LinkedField",
+        "name": "examples",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetSplit",
+            "kind": "LinkedField",
+            "name": "datasetSplits",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "color",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
         "storageKey": null
       }
     ],
@@ -66,7 +111,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation",
-    "selections": (v1/*: any*/),
+    "selections": (v2/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -75,19 +120,19 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation",
-    "selections": (v1/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "930aebc5f7aa89f05a44c5649504d3ee",
+    "cacheID": "d0e1a90c1fd3a68738c02aac6f1cdb51",
     "id": null,
     "metadata": {},
     "name": "ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation",
     "operationKind": "mutation",
-    "text": "mutation ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation(\n  $input: RemoveDatasetExamplesFromDatasetSplitsInput!\n) {\n  removeDatasetExamplesFromDatasetSplits(input: $input) {\n    __typename\n  }\n}\n"
+    "text": "mutation ExampleSelectionToolbarRemoveDatasetExamplesFromDatasetSplitMutation(\n  $input: RemoveDatasetExamplesFromDatasetSplitsInput!\n) {\n  removeDatasetExamplesFromDatasetSplits(input: $input) {\n    examples {\n      id\n      datasetSplits {\n        id\n        name\n        color\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1d1b29fe57ee50492d414a6675e27516";
+(node as any).hash = "3adeb4422875b23cadabba5b3fa2c5eb";
 
 export default node;

--- a/src/phoenix/server/api/mutations/dataset_split_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_split_mutations.py
@@ -272,11 +272,13 @@ class DatasetSplitMutationMixin:
                 except (PostgreSQLIntegrityError, SQLiteIntegrityError) as e:
                     raise Conflict("Failed to add examples to dataset splits.") from e
 
-        examples = (
-            await session.scalars(
-                select(models.DatasetExample).where(models.DatasetExample.id.in_(example_rowids))
-            )
-        ).all()
+            examples = (
+                await session.scalars(
+                    select(models.DatasetExample).where(
+                        models.DatasetExample.id.in_(example_rowids)
+                    )
+                )
+            ).all()
         return AddDatasetExamplesToDatasetSplitsMutationPayload(
             query=Query(),
             examples=[to_gql_dataset_example(example) for example in examples],
@@ -330,11 +332,13 @@ class DatasetSplitMutationMixin:
 
             await session.execute(stmt)
 
-        examples = (
-            await session.scalars(
-                select(models.DatasetExample).where(models.DatasetExample.id.in_(example_rowids))
-            )
-        ).all()
+            examples = (
+                await session.scalars(
+                    select(models.DatasetExample).where(
+                        models.DatasetExample.id.in_(example_rowids)
+                    )
+                )
+            ).all()
 
         return RemoveDatasetExamplesFromDatasetSplitsMutationPayload(
             query=Query(),
@@ -397,11 +401,13 @@ class DatasetSplitMutationMixin:
                         "Failed to associate examples with the new dataset split."
                     ) from e
 
-        examples = (
-            await session.scalars(
-                select(models.DatasetExample).where(models.DatasetExample.id.in_(example_rowids))
-            )
-        ).all()
+            examples = (
+                await session.scalars(
+                    select(models.DatasetExample).where(
+                        models.DatasetExample.id.in_(example_rowids)
+                    )
+                )
+            ).all()
 
         return DatasetSplitMutationPayloadWithExamples(
             dataset_split=to_gql_dataset_split(dataset_split_orm),

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -142,3 +142,9 @@ class DatasetExample(Node):
             to_gql_dataset_split(split)
             for split in await info.context.data_loaders.dataset_example_splits.load(self.id_attr)
         ]
+
+def to_gql_dataset_example(example: models.DatasetExample) -> DatasetExample:
+    return DatasetExample(
+        id_attr=example.id,
+        created_at=example.created_at,
+    )

--- a/src/phoenix/server/api/types/DatasetExample.py
+++ b/src/phoenix/server/api/types/DatasetExample.py
@@ -143,6 +143,7 @@ class DatasetExample(Node):
             for split in await info.context.data_loaders.dataset_example_splits.load(self.id_attr)
         ]
 
+
 def to_gql_dataset_example(example: models.DatasetExample) -> DatasetExample:
     return DatasetExample(
         id_attr=example.id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable creating dataset splits with selected examples and return affected examples from split add/remove mutations; update UI and Relay to use new payloads and prepend newly created splits.
> 
> - **GraphQL Schema**:
>   - Add `examples: [DatasetExample!]!` to `AddDatasetExamplesToDatasetSplitsMutationPayload` and `RemoveDatasetExamplesFromDatasetSplitsMutationPayload`.
>   - Introduce `DatasetSplitMutationPayloadWithExamples` and update `createDatasetSplitWithExamples` to return it.
> - **Backend (Python)**:
>   - Mutations `add_dataset_examples_to_dataset_splits` and `remove_dataset_examples_from_dataset_splits` now load and return updated `examples`.
>   - `create_dataset_split_with_examples` returns new split plus associated `examples`.
>   - Add `to_gql_dataset_example` helper.
> - **Frontend (React/Relay)**:
>   - NewDatasetSplitDialog:
>     - Support creating a split with `exampleIds`; prepend new split to `ManageDatasetSplitsDialog_datasetSplits` connection; request returned `examples`.
>   - ManageDatasetSplitsDialog:
>     - Accept `selectedExamples`; compute `sharedSplitIds`/`partialSplitIds` internally.
>     - Add “Create Split” action opening `NewDatasetSplitDialog` with selected example IDs.
>   - ExampleSelectionToolbar:
>     - Pass `selectedExamples` to dialog; simplify shared/partial split logic; extract confirm handler.
>     - Update mutations to request returned `examples`.
>   - Update generated Relay artifacts accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9edff8fc434c86b26dc9ee0df9edfc8afa380d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->