### PR TITLE
fix: Remove circular context exports from barrel file for more consistent HMR

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,11 +3,13 @@ import { RelayEnvironmentProvider } from "react-relay";
 
 import { Provider } from "@arizeai/components";
 
+import { NotificationProvider } from "@phoenix/contexts/NotificationContext/NotificationProvider";
+
 import { CredentialsProvider } from "./contexts/CredentialsContext";
 import { FeatureFlagsProvider } from "./contexts/FeatureFlagsContext";
 import { FunctionalityProvider } from "./contexts/FunctionalityContext";
 import { PreferencesProvider } from "./contexts/PreferencesContext";
-import { NotificationProvider, ThemeProvider, useTheme } from "./contexts";
+import { ThemeProvider, useTheme } from "./contexts";
 import { GlobalStyles } from "./GlobalStyles";
 import RelayEnvironment from "./RelayEnvironment";
 import { AppRoutes } from "./Routes";

--- a/app/src/contexts/NotificationContext/NotificationProvider.tsx
+++ b/app/src/contexts/NotificationContext/NotificationProvider.tsx
@@ -1,0 +1,41 @@
+import { PropsWithChildren, useMemo } from "react";
+import { UNSTABLE_ToastQueue as ToastQueue } from "react-aria-components";
+import { flushSync } from "react-dom";
+
+import { ToastRegion } from "@phoenix/components";
+import {
+  NotificationContext,
+  NotificationParams,
+} from "@phoenix/contexts/NotificationContext/NotificationContext";
+
+const createToastQueue = (
+  ...args: ConstructorParameters<typeof ToastQueue<NotificationParams>>
+) => new ToastQueue<NotificationParams>(...args);
+
+export const NotificationProvider = ({
+  children,
+}: PropsWithChildren): JSX.Element => {
+  const queue = useMemo(
+    () =>
+      createToastQueue({
+        // Wrap state updates in a CSS view transition.
+        wrapUpdate(fn) {
+          if ("startViewTransition" in document) {
+            // @ts-expect-error this will error until we upgrade our version of typescript
+            document?.startViewTransition(() => {
+              flushSync(fn);
+            });
+          } else {
+            fn();
+          }
+        },
+      }),
+    []
+  );
+  return (
+    <NotificationContext.Provider value={{ queue }}>
+      <ToastRegion queue={queue} />
+      {children}
+    </NotificationContext.Provider>
+  );
+};

--- a/app/src/contexts/PointCloudContext/PointCloudContext.tsx
+++ b/app/src/contexts/PointCloudContext/PointCloudContext.tsx
@@ -1,27 +1,12 @@
-import { createContext, PropsWithChildren, useContext, useState } from "react";
+import { createContext, useContext } from "react";
 import { useZustand } from "use-zustand";
 
 import {
-  createPointCloudStore,
-  PointCloudProps,
   PointCloudState,
   PointCloudStore,
 } from "@phoenix/store/pointCloudStore";
 
 export const PointCloudContext = createContext<PointCloudStore | null>(null);
-
-export function PointCloudProvider({
-  children,
-  ...props
-}: PropsWithChildren<Partial<PointCloudProps>>) {
-  const [store] = useState<PointCloudStore>(() => createPointCloudStore(props));
-
-  return (
-    <PointCloudContext.Provider value={store}>
-      {children}
-    </PointCloudContext.Provider>
-  );
-}
 
 export function usePointCloudContext<T>(
   selector: (state: PointCloudState) => T,

--- a/app/src/contexts/PointCloudContext/PointCloudProvider.tsx
+++ b/app/src/contexts/PointCloudContext/PointCloudProvider.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren, useState } from "react";
+
+import { PointCloudContext } from "@phoenix/contexts/PointCloudContext/PointCloudContext";
+import {
+  createPointCloudStore,
+  type PointCloudProps,
+  type PointCloudStore,
+} from "@phoenix/store";
+
+export function PointCloudProvider({
+  children,
+  ...props
+}: PropsWithChildren<Partial<PointCloudProps>>) {
+  const [store] = useState<PointCloudStore>(() => createPointCloudStore(props));
+
+  return (
+    <PointCloudContext.Provider value={store}>
+      {children}
+    </PointCloudContext.Provider>
+  );
+}

--- a/app/src/contexts/PointCloudContext/index.tsx
+++ b/app/src/contexts/PointCloudContext/index.tsx
@@ -1,0 +1,1 @@
+export * from "./PointCloudContext";

--- a/app/src/pages/embedding/EmbeddingPage.tsx
+++ b/app/src/pages/embedding/EmbeddingPage.tsx
@@ -50,11 +50,11 @@ import {
   resizeHandleCSS,
 } from "@phoenix/components/resize/styles";
 import {
-  PointCloudProvider,
   useInferences,
   useNotifyError,
   usePointCloudContext,
 } from "@phoenix/contexts";
+import { PointCloudProvider } from "@phoenix/contexts/PointCloudContext/PointCloudProvider";
 import { useTimeRange } from "@phoenix/contexts/TimeRangeContext";
 import {
   TimeSliceContextProvider,

--- a/app/stories/ToastRegion.stories.tsx
+++ b/app/stories/ToastRegion.stories.tsx
@@ -2,12 +2,8 @@ import { ComponentProps } from "react";
 import { Meta, StoryFn } from "@storybook/react";
 
 import { Button, Flex, ToastRegion } from "@phoenix/components";
-import {
-  NotificationProvider,
-  useNotify,
-  useNotifyError,
-  useNotifySuccess,
-} from "@phoenix/contexts";
+import { useNotify, useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { NotificationProvider } from "@phoenix/contexts/NotificationContext/NotificationProvider";
 
 /**
  * ToastRegion manages the display of one or more queued toasts


### PR DESCRIPTION
I was getting a bunch of console warnings like the following in storybook, but also in dev on the playground page in particular.

```
3:12:43 PM [vite] (client) hmr invalidate /src/contexts/PointCloudContext.tsx Could not Fast Refresh ("PointCloudContext" export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports
3:12:43 PM [vite] (client) page reload src/contexts/PointCloudContext.tsx (circular import invalidate)
```

```
3:21:11 PM [vite] (client) hmr invalidate /.storybook/preview.tsx Could not Fast Refresh ("default" export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports
```

Fixed by untangling some circular exports in our contexts. I may follow up with another PR to remove the contexts barrel file altogether. It seems that any component or page that imports useTheme and any other context file from the barrel file is subject to HMR issues.

Verified that the fix at least fixes HMR on the playground page and any toast related stuff, especially storybooks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decouples Notification and PointCloud providers from context barrels, updating imports and memoizing hooks to eliminate circular exports and improve HMR.
> 
> - **Contexts**:
>   - **NotificationContext**: Export `NotificationContext`; move provider logic to `contexts/NotificationContext/NotificationProvider.tsx`; remove in-file `ToastRegion`; wrap `useNotify` in `useCallback`.
>   - **PointCloudContext**: Extract `PointCloudProvider` to `contexts/PointCloudContext/PointCloudProvider.tsx`; keep context/selectors in `PointCloudContext.tsx`; add `index.tsx` re-export.
> - **App/Pages**:
>   - Update `App.tsx` to import `NotificationProvider` from `contexts/NotificationContext/NotificationProvider`.
>   - Update `EmbeddingPage.tsx` to import `PointCloudProvider` from `contexts/PointCloudContext/PointCloudProvider`.
> - **Stories**:
>   - Adjust `ToastRegion.stories.tsx` to use new `NotificationProvider` import path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a326126dbdf810b57de62ebe50bc5bd55b34d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->