### PR TITLE
feat: dataset label gql update

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1714,6 +1714,7 @@ type Mutation {
   chatCompletionOverDataset(input: ChatCompletionOverDatasetInput!): ChatCompletionOverDatasetMutationPayload!
   chatCompletion(input: ChatCompletionInput!): ChatCompletionMutationPayload!
   createDatasetLabel(input: CreateDatasetLabelInput!): CreateDatasetLabelMutationPayload!
+  updateDatasetLabel(input: UpdateDatasetLabelInput!): UpdateDatasetLabelMutationPayload!
   deleteDatasetLabels(input: DeleteDatasetLabelsInput!): DeleteDatasetLabelsMutationPayload!
   createDataset(input: CreateDatasetInput!): DatasetMutationPayload!
   patchDataset(input: PatchDatasetInput!): DatasetMutationPayload!
@@ -3096,6 +3097,17 @@ input UpdateAnnotationInput {
   explanation: String = null
   metadata: JSON! = {}
   source: AnnotationSource! = APP
+}
+
+input UpdateDatasetLabelInput {
+  datasetLabelId: ID!
+  name: String!
+  description: String = null
+  color: String!
+}
+
+type UpdateDatasetLabelMutationPayload {
+  datasetLabel: DatasetLabel!
 }
 
 input UpdateModelMutationInput {

--- a/src/phoenix/server/api/mutations/dataset_label_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_label_mutations.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import strawberry
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from strawberry import UNSET
 from strawberry.relay.types import GlobalID
 from strawberry.types import Info
@@ -9,7 +10,7 @@ from strawberry.types import Info
 from phoenix.db import models
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import BadRequest, NotFound
+from phoenix.server.api.exceptions import BadRequest, Conflict, NotFound
 from phoenix.server.api.types.DatasetLabel import DatasetLabel, to_gql_dataset_label
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 
@@ -36,6 +37,19 @@ class DeleteDatasetLabelsMutationPayload:
     dataset_labels: list[DatasetLabel]
 
 
+@strawberry.input
+class UpdateDatasetLabelInput:
+    dataset_label_id: GlobalID
+    name: str  # Required field for update pattern
+    description: Optional[str] = None  # Can be null but must be provided
+    color: str  # Required field for update pattern
+
+
+@strawberry.type
+class UpdateDatasetLabelMutationPayload:
+    dataset_label: DatasetLabel
+
+
 @strawberry.type
 class DatasetLabelMutationMixin:
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsLocked])  # type: ignore
@@ -52,6 +66,43 @@ class DatasetLabelMutationMixin:
             session.add(dataset_label_orm)
             await session.commit()
         return CreateDatasetLabelMutationPayload(
+            dataset_label=to_gql_dataset_label(dataset_label_orm)
+        )
+
+    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsLocked])  # type: ignore
+    async def update_dataset_label(
+        self, info: Info[Context, None], input: UpdateDatasetLabelInput
+    ) -> UpdateDatasetLabelMutationPayload:
+        if not input.name or not input.name.strip():
+            raise BadRequest("Dataset label name cannot be empty")
+
+        if not input.color or not input.color.strip():
+            raise BadRequest("Dataset label color cannot be empty")
+
+        if not input.color.startswith("#") or len(input.color) != 7:
+            raise BadRequest("Color must be in hex format (e.g., #FF5733)")
+
+        try:
+            dataset_label_id = from_global_id_with_expected_type(
+                input.dataset_label_id, DatasetLabel.__name__
+            )
+        except ValueError:
+            raise BadRequest(f"Invalid dataset label ID: {input.dataset_label_id}")
+
+        async with info.context.db() as session:
+            dataset_label_orm = await session.get(models.DatasetLabel, dataset_label_id)
+            if not dataset_label_orm:
+                raise NotFound(f"DatasetLabel with ID {input.dataset_label_id} not found")
+
+            dataset_label_orm.name = input.name.strip()
+            dataset_label_orm.description = input.description
+            dataset_label_orm.color = input.color.strip()
+
+            try:
+                await session.commit()
+            except IntegrityError:
+                raise Conflict(f"A dataset label named '{input.name}' already exists")
+        return UpdateDatasetLabelMutationPayload(
             dataset_label=to_gql_dataset_label(dataset_label_orm)
         )
 

--- a/src/phoenix/server/api/mutations/dataset_label_mutations.py
+++ b/src/phoenix/server/api/mutations/dataset_label_mutations.py
@@ -40,9 +40,9 @@ class DeleteDatasetLabelsMutationPayload:
 @strawberry.input
 class UpdateDatasetLabelInput:
     dataset_label_id: GlobalID
-    name: str  # Required field for update pattern
-    description: Optional[str] = None  # Can be null but must be provided
-    color: str  # Required field for update pattern
+    name: str
+    description: Optional[str] = None
+    color: str
 
 
 @strawberry.type


### PR DESCRIPTION
test plan:

```
mutation UpdateDatasetLabel($input: UpdateDatasetLabelInput!) {
    updateDatasetLabel(input: $input) {
        datasetLabel {
            name
        }
    }
}
```

sample payload:
```
{
    "input": {
        "datasetLabelId": "RGF0YXNldExhYmVsOjE=",
        "name": "update1",
        "description": "updated",
        "color": "#ABCDEF"
    }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `updateDatasetLabel` GraphQL mutation and implements server-side update with input validation and unique-name conflict handling; create now also returns conflict on duplicate names.
> 
> - **GraphQL Schema**:
>   - Add `updateDatasetLabel(input: UpdateDatasetLabelInput!): UpdateDatasetLabelMutationPayload!`.
>   - New types: `UpdateDatasetLabelInput` (fields: `datasetLabelId`, `name`, `description`, `color`) and `UpdateDatasetLabelMutationPayload`.
> - **API (server)**:
>   - Implement `update_dataset_label` in `src/phoenix/server/api/mutations/dataset_label_mutations.py` with:
>     - ID decoding via `from_global_id_with_expected_type` and NotFound handling.
>     - Validation for non-empty `name`, hex `color`.
>     - Unique-name conflict handling (Postgres/SQLite `IntegrityError` -> `Conflict`).
>   - Enhance `create_dataset_label` to surface unique-name `Conflict` on duplicate names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86a818632373c21698c35a8bf1400dd84fac72a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->