### PR TITLE
fix: Add missing typescript dep to phoenix-client

### DIFF
--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -70,6 +70,7 @@
     "openai": "^4.77.0",
     "openapi-typescript": "^7.6.1",
     "tsx": "^4.19.3",
+    "typescript": "^5.8.2",
     "vitest": "^2.1.9",
     "@arizeai/phoenix-evals": "workspace:*"
   },

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       tsx:
         specifier: ^4.19.3
         version: 4.20.4
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.2
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.11)


### PR DESCRIPTION
This missing dependency was preventing me from building in a clean dev environment. I am not sure how this is passing CI without this to be honest, it shouldn't be.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add TypeScript as a devDependency for `@arizeai/phoenix-client` and update the lockfile.
> 
> - **Tooling**:
>   - Add `typescript` to `devDependencies` in `js/packages/phoenix-client/package.json`.
>   - Update `pnpm-lock.yaml` to include `typescript` resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6106f959d0e226c65d444a6fc5e7aa58a02f858e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->