### PR TITLE
chore: Fix dev scripts on linux

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -131,7 +131,7 @@
     "dev:offline": "pnpm run dev:server:offline & pnpm run build:static && pnpm run build:relay && vite",
     "dev:embeddings": "pnpm run dev:server:embeddings & pnpm run build:static && pnpm run build:relay && vite",
     "dev:ui": "pnpm run build:static && pnpm run build:relay && vite",
-    "dev:server": "source .env && uv run --compile --with-requirements=../requirements/dev.txt phoenix --dev serve",
+    "dev:server": "source ./.env && uv run --compile --with-requirements=../requirements/dev.txt phoenix --dev serve",
     "dev:server:offline": "python -m phoenix.server.main --dev serve",
     "dev:server:embeddings": "pnpm dev:server --with-fixture=fashion_mnist",
     "dev:server:test": "node ./tests/utils/testServer.mjs",
@@ -147,7 +147,7 @@
     "prettier:check": "prettier --check './src/**/*'",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build",
-    "chromatic": "source .env && npx chromatic"
+    "chromatic": "source ./.env && npx chromatic"
   },
   "engines": {
     "node": ">=22"

--- a/js/packages/phoenix-mcp/package.json
+++ b/js/packages/phoenix-mcp/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && chmod 755 build/index.js",
-    "dev": "source .env && tsx src/index.ts -- --apiKey $PHOENIX_API_KEY --baseUrl $PHOENIX_BASE_URL",
+    "dev": "source ./.env && tsx src/index.ts -- --apiKey $PHOENIX_API_KEY --baseUrl $PHOENIX_BASE_URL",
     "typecheck": "tsc --noEmit",
     "inspect": "pnpm run build && npx -y @modelcontextprotocol/inspector -- node build/index.js"
   },


### PR DESCRIPTION
Some linux terminals/PATHs do not support `source .env`, they need to have the current directory pre-pended like `source ./.env` or else the .env file cannot be found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefix `.env` with `./.env` in dev/chromatic scripts for `app` and `phoenix-mcp` packages.
> 
> - **Scripts**:
>   - `app/package.json`:
>     - Update `dev:server` and `chromatic` to `source ./.env`.
>   - `js/packages/phoenix-mcp/package.json`:
>     - Update `dev` to `source ./.env`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b80703e75d6d68ebdfecf0ea2d6135b9e8e8d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->