### PR TITLE
fix(experiments): fix panel resizing

### DIFF
--- a/app/src/components/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/components/experiment/ExperimentCompareDetails.tsx
@@ -296,6 +296,8 @@ function ExperimentRunOutputs({
           defaultSize={SIDEBAR_PANEL_DEFAULT_SIZE}
           ref={sidebarPanelRef}
           collapsible
+          id="sidebar-panel"
+          order={1}
           onCollapse={() => setIsSideBarOpen(false)}
         >
           <ExperimentRunOutputsSidebar
@@ -312,7 +314,7 @@ function ExperimentRunOutputs({
       {isSideBarOpen ? (
         <PanelResizeHandle css={compactResizeHandleCSS} />
       ) : null}
-      <Panel>
+      <Panel id="main-panel" order={2}>
         <View
           paddingX="size-200"
           paddingY="size-100"
@@ -431,7 +433,6 @@ function ExperimentRunOutputsSidebar({
   return (
     <div
       css={css`
-        width: 340px;
         flex: none;
         font-size: var(--ac-global-dimension-static-font-size-100);
         color: var(--ac-global-color-grey-700);


### PR DESCRIPTION
Fixes a bug where panel resizing breaks after collapsing/re-expanding the sidebar within the experiment compare details dialog. This adds `order` and `id` props to help react-resizeable-panels keep track of which panel is which across re-mounts. ([relevant docs](https://github.com/bvaughn/react-resizable-panels/tree/main/packages/react-resizable-panels#how-can-i-fix-layoutsizing-problems-with-conditionally-rendered-panels))