### PR TITLE
chore: allow client port for vite

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -19,6 +19,9 @@ export default defineConfig(() => {
       port: 6006,
     },
     server: {
+      hmr: process.env.VITE_HMR_CLIENT_PORT
+        ? { clientPort: parseInt(process.env.VITE_HMR_CLIENT_PORT) }
+        : true,
       open: "http://localhost:6006",
     },
     resolve: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional `server.hmr.clientPort` in `app/vite.config.mts` driven by `VITE_HMR_CLIENT_PORT` env var.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9958ced2ff39e322e5cc7e20cd58877b24440d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->