### PR TITLE
fix: improve error handling for OIDC

### DIFF
--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -157,10 +157,7 @@ async def create_tokens(
             error="Authentication failed. Please contact your administrator.",
         )
     if authorization_code is None:
-        logger.error(
-            "OAuth2 callback missing authorization code for IDP %s",
-            idp_name,
-        )
+        logger.error("OAuth2 callback missing authorization code for IDP %s", idp_name)
         return _redirect_to_login(
             request=request,
             error="Authentication failed. Please contact your administrator.",

--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -158,7 +158,7 @@ async def create_tokens(
         )
     if authorization_code is None:
         logger.error(
-            "OAuth2 callback missing authorization code for IDP %s (state=%s)",
+            "OAuth2 callback missing authorization code for IDP %s",
             idp_name,
         )
         return _redirect_to_login(

--- a/src/phoenix/server/oauth2.py
+++ b/src/phoenix/server/oauth2.py
@@ -83,10 +83,8 @@ class OAuth2Clients:
             self._auto_login_client = client
         self._clients[config.idp_name] = client
 
-    def get_client(self, idp_name: str) -> OAuth2Client:
-        if (client := self._clients.get(idp_name)) is None:
-            raise ValueError(f"unknown or unregistered OAuth2 client: {idp_name}")
-        return client
+    def get_client(self, idp_name: str) -> Optional[OAuth2Client]:
+        return self._clients.get(idp_name)
 
     @classmethod
     def from_configs(cls, configs: Iterable[OAuth2ClientConfig]) -> "OAuth2Clients":


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens OAuth2/OIDC login and token callbacks with explicit error handling, logging, optional code handling, and a non-throwing client lookup.
> 
> - **Backend / OAuth2 Router (`src/phoenix/server/api/routers/oauth2.py`)**:
>   - Handle unknown IDPs by checking `oauth2_clients.get_client(idp_name)` and redirecting without raising.
>   - Token callback: accept optional `code`, `error`, `error_description`; log failures; handle missing code; redirect with generic error.
>   - Add security notes about untrusted query params.
>   - Minor: import and use `logging`.
> - **Auth Client Management (`src/phoenix/server/oauth2.py`)**:
>   - Change `OAuth2Clients.get_client(idp_name)` to return `Optional[OAuth2Client]` instead of raising, aligning with new call sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fe82713280c9ebf0d6a7f583d84c3caec40515f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->