### PR TITLE
feat: dataset label tab in setting page

### DIFF
--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -363,6 +363,13 @@ const router = createBrowserRouter(
               }}
             />
             <Route
+              path="datasets"
+              element={<SettingsDatasetsPage />}
+              handle={{
+                crumb: () => "Datasets",
+              }}
+            />
+            <Route
               path="annotations"
               loader={settingsAnnotationsPageLoader}
               element={<SettingsAnnotationsPage />}
@@ -383,13 +390,6 @@ const router = createBrowserRouter(
               element={<SettingsPromptsPage />}
               handle={{
                 crumb: () => "Prompts",
-              }}
-            />
-            <Route
-              path="datasets"
-              element={<SettingsDatasetsPage />}
-              handle={{
-                crumb: () => "Datasets",
               }}
             />
           </Route>

--- a/app/src/Routes.tsx
+++ b/app/src/Routes.tsx
@@ -85,6 +85,7 @@ import {
   ResetPasswordPage,
   ResetPasswordWithTokenPage,
   SessionPage,
+  SettingsDatasetsPage,
   settingsGeneralPageLoader,
   SettingsPage,
   SettingsPromptsPage,
@@ -382,6 +383,13 @@ const router = createBrowserRouter(
               element={<SettingsPromptsPage />}
               handle={{
                 crumb: () => "Prompts",
+              }}
+            />
+            <Route
+              path="datasets"
+              element={<SettingsDatasetsPage />}
+              handle={{
+                crumb: () => "Datasets",
               }}
             />
           </Route>

--- a/app/src/components/dataset/NewDatasetLabelButton.tsx
+++ b/app/src/components/dataset/NewDatasetLabelButton.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+import { Button, DialogTrigger, Icon, Icons } from "@phoenix/components";
+import { Modal, ModalOverlay } from "@phoenix/components/overlay";
+
+import { NewDatasetLabelDialog } from "./NewDatasetLabelDialog";
+
+export function NewDatasetLabelButton() {
+  const [showNewDatasetLabelDialog, setShowNewDatasetLabelDialog] =
+    useState(false);
+  return (
+    <DialogTrigger>
+      <Button
+        size="S"
+        variant="primary"
+        leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
+        onPress={() => setShowNewDatasetLabelDialog(true)}
+      >
+        New Label
+      </Button>
+      <ModalOverlay
+        isOpen={showNewDatasetLabelDialog}
+        onOpenChange={setShowNewDatasetLabelDialog}
+      >
+        <Modal size="S">
+          <NewDatasetLabelDialog
+            onCompleted={() => setShowNewDatasetLabelDialog(false)}
+          />
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+}

--- a/app/src/components/dataset/NewDatasetLabelDialog.tsx
+++ b/app/src/components/dataset/NewDatasetLabelDialog.tsx
@@ -41,6 +41,26 @@ export function NewDatasetLabelDialog(props: NewDatasetLabelDialogProps) {
     `
   );
   const onSubmit = (label: LabelParams) => {
+    // Convert RGBA to hex format for backend
+    const convertToHex = (color: string): string => {
+      if (color.startsWith("#")) return color;
+
+      const rgba = color.match(
+        /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/
+      );
+      if (rgba) {
+        const [, r, g, b] = rgba;
+        const hex =
+          "#" +
+          [r, g, b]
+            .map((x) => parseInt(x).toString(16).padStart(2, "0"))
+            .join("");
+        return hex;
+      }
+
+      return color; // fallback to original color
+    };
+
     const connections = [
       ConnectionHandler.getConnectionID(
         "client:root",
@@ -48,7 +68,13 @@ export function NewDatasetLabelDialog(props: NewDatasetLabelDialogProps) {
       ),
     ];
     addLabel({
-      variables: { label, connections },
+      variables: {
+        label: {
+          ...label,
+          color: convertToHex(label.color),
+        },
+        connections,
+      },
       onCompleted,
       onError: (error) => {
         const formattedError = getErrorMessagesFromRelayMutationError(error);

--- a/app/src/components/dataset/NewDatasetLabelDialog.tsx
+++ b/app/src/components/dataset/NewDatasetLabelDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { LabelParams, NewLabelForm } from "@phoenix/components/label";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
-import { NewDatasetLabelDialogMutation } from "./__generated__/NewDatasetLabelDialogMutation.graphql";
+import type { NewDatasetLabelDialogMutation } from "./__generated__/NewDatasetLabelDialogMutation.graphql";
 
 type NewDatasetLabelDialogProps = {
   onCompleted: () => void;

--- a/app/src/components/dataset/NewDatasetLabelDialog.tsx
+++ b/app/src/components/dataset/NewDatasetLabelDialog.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { ConnectionHandler, graphql, useMutation } from "react-relay";
+
+import {
+  Alert,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@phoenix/components";
+import { LabelParams, NewLabelForm } from "@phoenix/components/label";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+import { NewDatasetLabelDialogMutation } from "./__generated__/NewDatasetLabelDialogMutation.graphql";
+
+type NewDatasetLabelDialogProps = {
+  onCompleted: () => void;
+};
+export function NewDatasetLabelDialog(props: NewDatasetLabelDialogProps) {
+  const [error, setError] = useState("");
+  const { onCompleted } = props;
+  const [addLabel, isSubmitting] = useMutation<NewDatasetLabelDialogMutation>(
+    graphql`
+      mutation NewDatasetLabelDialogMutation(
+        $label: CreateDatasetLabelInput!
+        $connections: [ID!]!
+      ) {
+        createDatasetLabel(input: $label) {
+          datasetLabel
+            @prependNode(
+              connections: $connections
+              edgeTypeName: "DatasetLabelEdge"
+            ) {
+            id
+            name
+            color
+          }
+        }
+      }
+    `
+  );
+  const onSubmit = (label: LabelParams) => {
+    const connections = [
+      ConnectionHandler.getConnectionID(
+        "client:root",
+        "DatasetLabelsTable__datasetLabels"
+      ),
+    ];
+    addLabel({
+      variables: { label, connections },
+      onCompleted,
+      onError: (error) => {
+        const formattedError = getErrorMessagesFromRelayMutationError(error);
+        setError(formattedError?.[0] ?? error.message);
+      },
+    });
+  };
+  return (
+    <Dialog>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Dataset Label</DialogTitle>
+          <DialogCloseButton />
+        </DialogHeader>
+        {error ? (
+          <Alert banner variant="danger">
+            {error}
+          </Alert>
+        ) : null}
+        <NewLabelForm onSubmit={onSubmit} isSubmitting={isSubmitting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/dataset/__generated__/NewDatasetLabelDialogMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/NewDatasetLabelDialogMutation.graphql.ts
@@ -1,0 +1,168 @@
+/**
+ * @generated SignedSource<<a0ee5848b68d88ba19ef147f49a11a07>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateDatasetLabelInput = {
+  color: string;
+  description?: string | null;
+  name: string;
+};
+export type NewDatasetLabelDialogMutation$variables = {
+  connections: ReadonlyArray<string>;
+  label: CreateDatasetLabelInput;
+};
+export type NewDatasetLabelDialogMutation$data = {
+  readonly createDatasetLabel: {
+    readonly datasetLabel: {
+      readonly color: string;
+      readonly id: string;
+      readonly name: string;
+    };
+  };
+};
+export type NewDatasetLabelDialogMutation = {
+  response: NewDatasetLabelDialogMutation$data;
+  variables: NewDatasetLabelDialogMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "label"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "label"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetLabel",
+  "kind": "LinkedField",
+  "name": "datasetLabel",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "color",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewDatasetLabelDialogMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateDatasetLabelMutationPayload",
+        "kind": "LinkedField",
+        "name": "createDatasetLabel",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "NewDatasetLabelDialogMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateDatasetLabelMutationPayload",
+        "kind": "LinkedField",
+        "name": "createDatasetLabel",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "datasetLabel",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "DatasetLabelEdge"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b3ed9cd14a2af6a7956957541826d23c",
+    "id": null,
+    "metadata": {},
+    "name": "NewDatasetLabelDialogMutation",
+    "operationKind": "mutation",
+    "text": "mutation NewDatasetLabelDialogMutation(\n  $label: CreateDatasetLabelInput!\n) {\n  createDatasetLabel(input: $label) {\n    datasetLabel {\n      id\n      name\n      color\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d7e0eff0307dd56a8cf8aa1a22bdd6d5";
+
+export default node;

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -45,6 +45,7 @@ export function SettingsPage() {
             <Tab id="models">Models</Tab>
             <Tab id="annotations">Annotations</Tab>
             <Tab id="prompts">Prompts</Tab>
+            <Tab id="datasets">Datasets</Tab>
             <Tab id="data">Data Retention</Tab>
           </TabList>
           <LazyTabPanel id="general" padded>
@@ -60,6 +61,9 @@ export function SettingsPage() {
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel id="prompts" padded>
+            <Outlet />
+          </LazyTabPanel>
+          <LazyTabPanel id="datasets" padded>
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel id="data" padded>

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -45,9 +45,9 @@ export function SettingsPage() {
             <Tab id="general">General</Tab>
             <Tab id="providers">AI Providers</Tab>
             <Tab id="models">Models</Tab>
+            {isDatasetLabelEnabled && <Tab id="datasets">Datasets</Tab>}
             <Tab id="annotations">Annotations</Tab>
             <Tab id="prompts">Prompts</Tab>
-            {isDatasetLabelEnabled && <Tab id="datasets">Datasets</Tab>}
             <Tab id="data">Data Retention</Tab>
           </TabList>
           <LazyTabPanel id="general" padded>
@@ -59,17 +59,17 @@ export function SettingsPage() {
           <LazyTabPanel id="models" padded>
             <Outlet />
           </LazyTabPanel>
+          {isDatasetLabelEnabled && (
+            <LazyTabPanel id="datasets" padded>
+              <Outlet />
+            </LazyTabPanel>
+          )}
           <LazyTabPanel id="annotations" padded>
             <Outlet />
           </LazyTabPanel>
           <LazyTabPanel id="prompts" padded>
             <Outlet />
           </LazyTabPanel>
-          {isDatasetLabelEnabled && (
-            <LazyTabPanel id="datasets" padded>
-              <Outlet />
-            </LazyTabPanel>
-          )}
           <LazyTabPanel id="data" padded>
             <Outlet />
           </LazyTabPanel>

--- a/app/src/pages/settings/SettingsPage.tsx
+++ b/app/src/pages/settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Navigate, Outlet, useLocation, useNavigate } from "react-router";
 import { css } from "@emotion/react";
 
 import { LazyTabPanel, Tab, TabList, Tabs } from "@phoenix/components";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 
 const settingsPageCSS = css`
   overflow-y: auto;
@@ -23,6 +24,7 @@ const settingsPageInnerCSS = css`
 export function SettingsPage() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const isDatasetLabelEnabled = useFeatureFlag("datasetLabel");
   const tab = pathname.split("/settings")[1].replace("/", "");
   const onChangeTab = useCallback(
     (tab: Key) => {
@@ -45,7 +47,7 @@ export function SettingsPage() {
             <Tab id="models">Models</Tab>
             <Tab id="annotations">Annotations</Tab>
             <Tab id="prompts">Prompts</Tab>
-            <Tab id="datasets">Datasets</Tab>
+            {isDatasetLabelEnabled && <Tab id="datasets">Datasets</Tab>}
             <Tab id="data">Data Retention</Tab>
           </TabList>
           <LazyTabPanel id="general" padded>
@@ -63,9 +65,11 @@ export function SettingsPage() {
           <LazyTabPanel id="prompts" padded>
             <Outlet />
           </LazyTabPanel>
-          <LazyTabPanel id="datasets" padded>
-            <Outlet />
-          </LazyTabPanel>
+          {isDatasetLabelEnabled && (
+            <LazyTabPanel id="datasets" padded>
+              <Outlet />
+            </LazyTabPanel>
+          )}
           <LazyTabPanel id="data" padded>
             <Outlet />
           </LazyTabPanel>

--- a/app/src/pages/settings/datasets/DatasetLabelsSettingsCard.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsSettingsCard.tsx
@@ -1,0 +1,28 @@
+import { graphql, useFragment } from "react-relay";
+
+import { Card } from "@phoenix/components";
+import { NewDatasetLabelButton } from "@phoenix/components/dataset/NewDatasetLabelButton";
+
+import { DatasetLabelsSettingsCardFragment$key } from "./__generated__/DatasetLabelsSettingsCardFragment.graphql";
+import { DatasetLabelsTable } from "./DatasetLabelsTable";
+
+export function DatasetLabelsSettingsCard({
+  query,
+}: {
+  query: DatasetLabelsSettingsCardFragment$key;
+}) {
+  const data = useFragment<DatasetLabelsSettingsCardFragment$key>(
+    graphql`
+      fragment DatasetLabelsSettingsCardFragment on Query {
+        ...DatasetLabelsTableFragment
+      }
+    `,
+    query
+  );
+
+  return (
+    <Card title="Dataset Labels" extra={<NewDatasetLabelButton />}>
+      <DatasetLabelsTable query={data} />
+    </Card>
+  );
+}

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 import {
   flexRender,
@@ -37,7 +38,10 @@ export function DatasetLabelsTable({
     `,
     query
   );
-  const tableData = data.datasetLabels.edges.map((edge) => edge.node);
+  const tableData = useMemo(
+    () => data.datasetLabels.edges.map((edge) => edge.node),
+    [data.datasetLabels.edges]
+  );
 
   const table = useReactTable<(typeof tableData)[number]>({
     columns: [

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -1,0 +1,115 @@
+import { graphql, useFragment } from "react-relay";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import { Flex, Token } from "@phoenix/components";
+import { TableEmpty } from "@phoenix/components/table";
+import { tableCSS } from "@phoenix/components/table/styles";
+import { DeleteDatasetLabelButton } from "@phoenix/pages/settings/datasets/DeleteDatasetLabelButton";
+
+import { DatasetLabelsTableFragment$key } from "./__generated__/DatasetLabelsTableFragment.graphql";
+
+export function DatasetLabelsTable({
+  query,
+}: {
+  query: DatasetLabelsTableFragment$key;
+}) {
+  const data = useFragment<DatasetLabelsTableFragment$key>(
+    graphql`
+      fragment DatasetLabelsTableFragment on Query
+      @argumentDefinitions(first: { type: "Int", defaultValue: 100 }) {
+        datasetLabels(first: $first)
+          @connection(key: "DatasetLabelsTable__datasetLabels") {
+          edges {
+            node {
+              id
+              name
+              description
+              color
+            }
+          }
+        }
+      }
+    `,
+    query
+  );
+  const tableData = data.datasetLabels.edges.map((edge) => edge.node);
+
+  const table = useReactTable<(typeof tableData)[number]>({
+    columns: [
+      {
+        header: "label",
+        accessorKey: "name",
+        cell: ({ row }) => {
+          return <Token color={row.original.color}>{row.original.name}</Token>;
+        },
+      },
+      {
+        header: "description",
+        accessorKey: "description",
+      },
+      {
+        header: "",
+        id: "actions",
+        cell: ({ row }) => {
+          return (
+            <Flex width="100%" alignItems="end" justifyContent="end">
+              <DeleteDatasetLabelButton datasetLabelId={row.original.id} />
+            </Flex>
+          );
+        },
+      },
+    ],
+    data: tableData,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  const rows = table.getRowModel().rows;
+  const hasContent = rows.length > 0;
+  const body = hasContent ? (
+    <tbody>
+      {rows.map((row) => {
+        return (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => {
+              return (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              );
+            })}
+          </tr>
+        );
+      })}
+    </tbody>
+  ) : (
+    <TableEmpty />
+  );
+  return (
+    <table css={tableCSS}>
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th colSpan={header.colSpan} key={header.id}>
+                {header.isPlaceholder ? null : (
+                  <div>
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext()
+                    )}
+                  </div>
+                )}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      {body}
+    </table>
+  );
+}

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -11,7 +11,7 @@ import { Flex, Token } from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
 import { tableCSS } from "@phoenix/components/table/styles";
 
-import { DatasetLabelsTableFragment$key } from "./__generated__/DatasetLabelsTableFragment.graphql";
+import type { DatasetLabelsTableFragment$key } from "./__generated__/DatasetLabelsTableFragment.graphql";
 import { DeleteDatasetLabelButton } from "./DeleteDatasetLabelButton";
 
 export function DatasetLabelsTable({

--- a/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
+++ b/app/src/pages/settings/datasets/DatasetLabelsTable.tsx
@@ -9,9 +9,9 @@ import {
 import { Flex, Token } from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
 import { tableCSS } from "@phoenix/components/table/styles";
-import { DeleteDatasetLabelButton } from "@phoenix/pages/settings/datasets/DeleteDatasetLabelButton";
 
 import { DatasetLabelsTableFragment$key } from "./__generated__/DatasetLabelsTableFragment.graphql";
+import { DeleteDatasetLabelButton } from "./DeleteDatasetLabelButton";
 
 export function DatasetLabelsTable({
   query,

--- a/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
+++ b/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { ModalOverlay } from "react-aria-components";
+import { ConnectionHandler, graphql, useMutation } from "react-relay";
+
+import {
+  Button,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+  DialogTrigger,
+  Flex,
+  Icon,
+  Icons,
+  Modal,
+  Text,
+  View,
+} from "@phoenix/components";
+import { useNotifySuccess } from "@phoenix/contexts";
+
+import { DeleteDatasetLabelButtonMutation } from "./__generated__/DeleteDatasetLabelButtonMutation.graphql";
+
+export type DeleteDatasetLabelButtonProps = {
+  datasetLabelId: string;
+};
+
+export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
+  const { datasetLabelId } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const notifySuccess = useNotifySuccess();
+  const [deleteLabel, isDeleting] =
+    useMutation<DeleteDatasetLabelButtonMutation>(graphql`
+      mutation DeleteDatasetLabelButtonMutation(
+        $input: DeleteDatasetLabelsInput!
+        $connections: [ID!]!
+      ) {
+        deleteDatasetLabels(input: $input) {
+          datasetLabels @deleteEdge(connections: $connections) {
+            id
+          }
+        }
+      }
+    `);
+  return (
+    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button
+        size="S"
+        leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+        aria-label="Delete Dataset Label"
+        isDisabled={isDeleting}
+      />
+      <ModalOverlay>
+        <Modal size="S">
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Delete Dataset Label</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <DialogContent>
+                <View padding="size-200">
+                  <Text color="danger">
+                    Are you sure you want to delete this label? It will be
+                    removed from all datasets if you do so.
+                  </Text>
+                  <View paddingTop="size-100">
+                    <Flex direction="row" justifyContent="end">
+                      <Button
+                        variant="danger"
+                        size="S"
+                        isDisabled={isDeleting}
+                        onPress={() => {
+                          deleteLabel({
+                            variables: {
+                              input: { datasetLabelIds: [datasetLabelId] },
+                              connections: [
+                                ConnectionHandler.getConnectionID(
+                                  "client:root",
+                                  "DatasetLabelsTable__datasetLabels"
+                                ),
+                              ],
+                            },
+                            onCompleted: () => {
+                              notifySuccess({
+                                title: "Label Deleted",
+                                message: "Successfully deleted dataset label",
+                              });
+                              setIsOpen(false);
+                            },
+                            onError: () => {
+                              alert(
+                                "Failed to delete dataset label. Please try again"
+                              );
+                            },
+                            // Intentionally omitting error until we have migrated to toast
+                          });
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </Flex>
+                  </View>
+                </View>
+              </DialogContent>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+}

--- a/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
+++ b/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
@@ -34,10 +34,9 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
     useMutation<DeleteDatasetLabelButtonMutation>(graphql`
       mutation DeleteDatasetLabelButtonMutation(
         $input: DeleteDatasetLabelsInput!
-        $connections: [ID!]!
       ) {
         deleteDatasetLabels(input: $input) {
-          datasetLabels @deleteEdge(connections: $connections) {
+          datasetLabels {
             id
           }
         }
@@ -77,12 +76,21 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
                           deleteLabel({
                             variables: {
                               input: { datasetLabelIds: [datasetLabelId] },
-                              connections: [
+                            },
+                            updater: (store) => {
+                              // Manually remove the deleted item from the connection
+                              const connectionId =
                                 ConnectionHandler.getConnectionID(
                                   "client:root",
                                   "DatasetLabelsTable__datasetLabels"
-                                ),
-                              ],
+                                );
+                              const connection = store.get(connectionId);
+                              if (connection) {
+                                ConnectionHandler.deleteNode(
+                                  connection,
+                                  datasetLabelId
+                                );
+                              }
                             },
                             onCompleted: () => {
                               notifySuccess({

--- a/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
+++ b/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
@@ -103,7 +103,8 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
                             onError: () => {
                               notifyError({
                                 title: "Failed to delete label",
-                                message: "Failed to delete dataset label. Please try again.",
+                                message:
+                                  "Failed to delete dataset label. Please try again.",
                               });
                             },
                           });

--- a/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
+++ b/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
@@ -35,10 +35,11 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
     useMutation<DeleteDatasetLabelButtonMutation>(graphql`
       mutation DeleteDatasetLabelButtonMutation(
         $input: DeleteDatasetLabelsInput!
+        $connections: [ID!]!
       ) {
         deleteDatasetLabels(input: $input) {
           datasetLabels {
-            id
+            id @deleteEdge(connections: $connections)
           }
         }
       }
@@ -77,21 +78,12 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
                           deleteLabel({
                             variables: {
                               input: { datasetLabelIds: [datasetLabelId] },
-                            },
-                            updater: (store) => {
-                              // Manually remove the deleted item from the connection
-                              const connectionId =
+                              connections: [
                                 ConnectionHandler.getConnectionID(
                                   "client:root",
                                   "DatasetLabelsTable__datasetLabels"
-                                );
-                              const connection = store.get(connectionId);
-                              if (connection) {
-                                ConnectionHandler.deleteNode(
-                                  connection,
-                                  datasetLabelId
-                                );
-                              }
+                                ),
+                              ],
                             },
                             onCompleted: () => {
                               notifySuccess({

--- a/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
+++ b/app/src/pages/settings/datasets/DeleteDatasetLabelButton.tsx
@@ -18,7 +18,7 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { useNotifySuccess } from "@phoenix/contexts";
+import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
 
 import { DeleteDatasetLabelButtonMutation } from "./__generated__/DeleteDatasetLabelButtonMutation.graphql";
 
@@ -30,6 +30,7 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
   const { datasetLabelId } = props;
   const [isOpen, setIsOpen] = useState(false);
   const notifySuccess = useNotifySuccess();
+  const notifyError = useNotifyError();
   const [deleteLabel, isDeleting] =
     useMutation<DeleteDatasetLabelButtonMutation>(graphql`
       mutation DeleteDatasetLabelButtonMutation(
@@ -100,11 +101,11 @@ export function DeleteDatasetLabelButton(props: DeleteDatasetLabelButtonProps) {
                               setIsOpen(false);
                             },
                             onError: () => {
-                              alert(
-                                "Failed to delete dataset label. Please try again"
-                              );
+                              notifyError({
+                                title: "Failed to delete label",
+                                message: "Failed to delete dataset label. Please try again.",
+                              });
                             },
-                            // Intentionally omitting error until we have migrated to toast
                           });
                         }}
                       >

--- a/app/src/pages/settings/datasets/SettingsDatasetsPage.tsx
+++ b/app/src/pages/settings/datasets/SettingsDatasetsPage.tsx
@@ -1,6 +1,6 @@
 import { graphql, useLazyLoadQuery } from "react-relay";
 
-import { SettingsDatasetsPageQuery } from "@phoenix/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql";
+import type { SettingsDatasetsPageQuery } from "@phoenix/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql";
 
 import { DatasetLabelsSettingsCard } from "./DatasetLabelsSettingsCard";
 

--- a/app/src/pages/settings/datasets/SettingsDatasetsPage.tsx
+++ b/app/src/pages/settings/datasets/SettingsDatasetsPage.tsx
@@ -1,0 +1,22 @@
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import { SettingsDatasetsPageQuery } from "@phoenix/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql";
+
+import { DatasetLabelsSettingsCard } from "./DatasetLabelsSettingsCard";
+
+export function SettingsDatasetsPage() {
+  const query = useLazyLoadQuery<SettingsDatasetsPageQuery>(
+    graphql`
+      query SettingsDatasetsPageQuery {
+        ...DatasetLabelsSettingsCardFragment
+      }
+    `,
+    {},
+    { fetchPolicy: "network-only" }
+  );
+  return (
+    <main>
+      <DatasetLabelsSettingsCard query={query} />
+    </main>
+  );
+}

--- a/app/src/pages/settings/datasets/__generated__/DatasetLabelsSettingsCardFragment.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DatasetLabelsSettingsCardFragment.graphql.ts
@@ -1,0 +1,40 @@
+/**
+ * @generated SignedSource<<b50d829613433d74aa41e1a672dc47fe>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetLabelsSettingsCardFragment$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetLabelsTableFragment">;
+  readonly " $fragmentType": "DatasetLabelsSettingsCardFragment";
+};
+export type DatasetLabelsSettingsCardFragment$key = {
+  readonly " $data"?: DatasetLabelsSettingsCardFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetLabelsSettingsCardFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "DatasetLabelsSettingsCardFragment",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "DatasetLabelsTableFragment"
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "3922211daa123323e1c2ac97b642ab76";
+
+export default node;

--- a/app/src/pages/settings/datasets/__generated__/DatasetLabelsTableFragment.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DatasetLabelsTableFragment.graphql.ts
@@ -1,0 +1,161 @@
+/**
+ * @generated SignedSource<<9d6564468f6e301bfc3869ec1a338f33>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetLabelsTableFragment$data = {
+  readonly datasetLabels: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly color: string;
+        readonly description: string | null;
+        readonly id: string;
+        readonly name: string;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "DatasetLabelsTableFragment";
+};
+export type DatasetLabelsTableFragment$key = {
+  readonly " $data"?: DatasetLabelsTableFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetLabelsTableFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": 100,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": null,
+        "direction": "forward",
+        "path": [
+          "datasetLabels"
+        ]
+      }
+    ]
+  },
+  "name": "DatasetLabelsTableFragment",
+  "selections": [
+    {
+      "alias": "datasetLabels",
+      "args": null,
+      "concreteType": "DatasetLabelConnection",
+      "kind": "LinkedField",
+      "name": "__DatasetLabelsTable__datasetLabels_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DatasetLabelEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "DatasetLabel",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "color",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "e22f9050d93574e15367cc63e355f3ce";
+
+export default node;

--- a/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d27a12eacf525578977f1699ad7a2696>>
+ * @generated SignedSource<<85442ebe33ba401aa450498d51463d3a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ export type DeleteDatasetLabelsInput = {
   datasetLabelIds: ReadonlyArray<string>;
 };
 export type DeleteDatasetLabelButtonMutation$variables = {
-  connections: ReadonlyArray<string>;
   input: DeleteDatasetLabelsInput;
 };
 export type DeleteDatasetLabelButtonMutation$data = {
@@ -29,17 +28,14 @@ export type DeleteDatasetLabelButtonMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "connections"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
   {
     "alias": null,
     "args": [
@@ -78,26 +74,20 @@ v2 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "DeleteDatasetLabelButtonMutation",
-    "selections": (v2/*: any*/),
+    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "DeleteDatasetLabelButtonMutation",
-    "selections": (v2/*: any*/)
+    "selections": (v1/*: any*/)
   },
   "params": {
     "cacheID": "b8a0548c9df74137476118cf38dfcc9c",
@@ -110,6 +100,6 @@ return {
 };
 })();
 
-(node as any).hash = "519ffcac85d00b2af31ebfc4df91abfd";
+(node as any).hash = "865e34a2a79804aaaef98cc9590b1021";
 
 export default node;

--- a/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
@@ -1,0 +1,115 @@
+/**
+ * @generated SignedSource<<d27a12eacf525578977f1699ad7a2696>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteDatasetLabelsInput = {
+  datasetLabelIds: ReadonlyArray<string>;
+};
+export type DeleteDatasetLabelButtonMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteDatasetLabelsInput;
+};
+export type DeleteDatasetLabelButtonMutation$data = {
+  readonly deleteDatasetLabels: {
+    readonly datasetLabels: ReadonlyArray<{
+      readonly id: string;
+    }>;
+  };
+};
+export type DeleteDatasetLabelButtonMutation = {
+  response: DeleteDatasetLabelButtonMutation$data;
+  variables: DeleteDatasetLabelButtonMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DeleteDatasetLabelsMutationPayload",
+    "kind": "LinkedField",
+    "name": "deleteDatasetLabels",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "DatasetLabel",
+        "kind": "LinkedField",
+        "name": "datasetLabels",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DeleteDatasetLabelButtonMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "DeleteDatasetLabelButtonMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "b8a0548c9df74137476118cf38dfcc9c",
+    "id": null,
+    "metadata": {},
+    "name": "DeleteDatasetLabelButtonMutation",
+    "operationKind": "mutation",
+    "text": "mutation DeleteDatasetLabelButtonMutation(\n  $input: DeleteDatasetLabelsInput!\n) {\n  deleteDatasetLabels(input: $input) {\n    datasetLabels {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "519ffcac85d00b2af31ebfc4df91abfd";
+
+export default node;

--- a/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/DeleteDatasetLabelButtonMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85442ebe33ba401aa450498d51463d3a>>
+ * @generated SignedSource<<7c229594bc1ab64fc1359da102053b55>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type DeleteDatasetLabelsInput = {
   datasetLabelIds: ReadonlyArray<string>;
 };
 export type DeleteDatasetLabelButtonMutation$variables = {
+  connections: ReadonlyArray<string>;
   input: DeleteDatasetLabelsInput;
 };
 export type DeleteDatasetLabelButtonMutation$data = {
@@ -28,66 +29,116 @@ export type DeleteDatasetLabelButtonMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
 ],
-v1 = [
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
     ],
-    "concreteType": "DeleteDatasetLabelsMutationPayload",
-    "kind": "LinkedField",
-    "name": "deleteDatasetLabels",
-    "plural": false,
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DeleteDatasetLabelButtonMutation",
     "selections": [
       {
         "alias": null,
-        "args": null,
-        "concreteType": "DatasetLabel",
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteDatasetLabelsMutationPayload",
         "kind": "LinkedField",
-        "name": "datasetLabels",
-        "plural": true,
+        "name": "deleteDatasetLabels",
+        "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "id",
+            "concreteType": "DatasetLabel",
+            "kind": "LinkedField",
+            "name": "datasetLabels",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/)
+            ],
             "storageKey": null
           }
         ],
         "storageKey": null
       }
     ],
-    "storageKey": null
-  }
-];
-return {
-  "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
-    "kind": "Fragment",
-    "metadata": null,
-    "name": "DeleteDatasetLabelButtonMutation",
-    "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "DeleteDatasetLabelButtonMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteDatasetLabelsMutationPayload",
+        "kind": "LinkedField",
+        "name": "deleteDatasetLabels",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetLabel",
+            "kind": "LinkedField",
+            "name": "datasetLabels",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "filters": null,
+                "handle": "deleteEdge",
+                "key": "",
+                "kind": "ScalarHandle",
+                "name": "id",
+                "handleArgs": [
+                  {
+                    "kind": "Variable",
+                    "name": "connections",
+                    "variableName": "connections"
+                  }
+                ]
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
     "cacheID": "b8a0548c9df74137476118cf38dfcc9c",
@@ -100,6 +151,6 @@ return {
 };
 })();
 
-(node as any).hash = "865e34a2a79804aaaef98cc9590b1021";
+(node as any).hash = "e84ccde3a71540e1e768694c2a6adb56";
 
 export default node;

--- a/app/src/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql.ts
+++ b/app/src/pages/settings/datasets/__generated__/SettingsDatasetsPageQuery.graphql.ts
@@ -1,0 +1,176 @@
+/**
+ * @generated SignedSource<<9495fa6128f97a99735e3e5d3c3ddca1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SettingsDatasetsPageQuery$variables = Record<PropertyKey, never>;
+export type SettingsDatasetsPageQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetLabelsSettingsCardFragment">;
+};
+export type SettingsDatasetsPageQuery = {
+  response: SettingsDatasetsPageQuery$data;
+  variables: SettingsDatasetsPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsDatasetsPageQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "DatasetLabelsSettingsCardFragment"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SettingsDatasetsPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "DatasetLabelConnection",
+        "kind": "LinkedField",
+        "name": "datasetLabels",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetLabelEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "DatasetLabel",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "description",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "color",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "datasetLabels(first:100)"
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "DatasetLabelsTable__datasetLabels",
+        "kind": "LinkedHandle",
+        "name": "datasetLabels"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d644286d0a3b1a6e827bb334d3435e5f",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsDatasetsPageQuery",
+    "operationKind": "query",
+    "text": "query SettingsDatasetsPageQuery {\n  ...DatasetLabelsSettingsCardFragment\n}\n\nfragment DatasetLabelsSettingsCardFragment on Query {\n  ...DatasetLabelsTableFragment\n}\n\nfragment DatasetLabelsTableFragment on Query {\n  datasetLabels(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        color\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5d2bdd09afe1ca6b4411604bf97e8f79";
+
+export default node;

--- a/app/src/pages/settings/datasets/index.tsx
+++ b/app/src/pages/settings/datasets/index.tsx
@@ -1,0 +1,1 @@
+export * from "./SettingsDatasetsPage";

--- a/app/src/pages/settings/index.tsx
+++ b/app/src/pages/settings/index.tsx
@@ -3,3 +3,4 @@ export * from "./settingsGeneralPageLoader";
 export * from "./settingsAIProvidersPageLoader";
 export * from "./SettingsDataPage";
 export * from "./prompts";
+export * from "./datasets";

--- a/app/src/pages/settings/prompts/PromptLabelsTable.tsx
+++ b/app/src/pages/settings/prompts/PromptLabelsTable.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 import {
   flexRender,
@@ -37,7 +38,10 @@ export function PromptLabelsTable({
     `,
     query
   );
-  const tableData = data.promptLabels.edges.map((edge) => edge.node);
+  const tableData = useMemo(
+    () => data.promptLabels.edges.map((edge) => edge.node),
+    [data.promptLabels.edges]
+  );
 
   const table = useReactTable<(typeof tableData)[number]>({
     columns: [


### PR DESCRIPTION
resolves #9628 
<img width="1244" height="443" alt="Screenshot 2025-10-02 at 10 06 56 AM" src="https://github.com/user-attachments/assets/713c09de-7b7e-4ad3-93a2-0684e568f3fc" />
<img width="630" height="493" alt="Screenshot 2025-10-02 at 10 07 07 AM" src="https://github.com/user-attachments/assets/ba7fb763-d933-4f3e-8dce-19d0e4cb02f4" />
<img width="534" height="212" alt="Screenshot 2025-10-02 at 10 07 19 AM" src="https://github.com/user-attachments/assets/31890638-3e85-4fba-832e-ed777373e698" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a feature-flagged Settings > Datasets tab to list, create, and delete dataset labels, plus a minor optimization in prompt labels table.
> 
> - **Settings UI**:
>   - **Datasets tab (feature-flagged `datasetLabel`)**: New `SettingsDatasetsPage` with `DatasetLabelsSettingsCard` and `DatasetLabelsTable` to list labels.
>   - **Create/Delete Labels**:
>     - Add `NewDatasetLabelButton` and `NewDatasetLabelDialog` with Relay mutation `createDatasetLabel` (prepend to `DatasetLabelsTable__datasetLabels`).
>     - Add `DeleteDatasetLabelButton` with Relay mutation `deleteDatasetLabels` (deleteEdge from `DatasetLabelsTable__datasetLabels`).
> - **Routing**:
>   - Add route `settings/datasets` and breadcrumb "Datasets" in `app/src/Routes.tsx`.
> - **Misc**:
>   - Optimize `PromptLabelsTable` by memoizing `tableData` with `useMemo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b85f4d218c5d1136e5e21d7121182d6f274b9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->