### PR TITLE
fix: column selector dropdown overflow for CSV datasets with many columns

### DIFF
--- a/app/src/pages/datasets/DatasetFromCSVForm.tsx
+++ b/app/src/pages/datasets/DatasetFromCSVForm.tsx
@@ -345,6 +345,7 @@ function ColumnMultiSelector(
               onChange(Array.from(keys) as string[]);
             }}
             selectedKeys={new Set(selectedColumns)}
+            style={{ maxHeight: "40vh", overflowY: "auto" }}
           >
             {columns.map((column) => (
               <Item key={column}>{column}</Item>


### PR DESCRIPTION
resolves: #7942

### Changes
- Added scrolling functionality to the ColumnMultiSelector dropdown
- Applied responsive max-height constraint (40vh) with vertical overflow scroll

### Problem
When uploading CSV datasets with a large number of columns (10+), the column selector dropdown would overflow beyond the viewport, making it inconvenient to select columns that appeared below the fold.

### Solution
Applied a max-height constraint using viewport-relative units (40% of viewport height) and vertical scrolling to the ListBox component

<img width="1440" height="810" alt="Screenshot 2025-10-02 at 10 40 30 PM" src="https://github.com/user-attachments/assets/752cbf07-6830-4b6c-b300-94d41b0a1913" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain the `ListBox` in `DatasetFromCSVForm` column selector to 40vh with vertical scrolling to prevent dropdown overflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3553abaabd42897cebf2d1c510ec241bafde0c0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->