### PR TITLE
fix: erroneous dedup key for annotations

### DIFF
--- a/src/phoenix/db/insertion/document_annotation.py
+++ b/src/phoenix/db/insertion/document_annotation.py
@@ -181,7 +181,7 @@ def _key(p: Received[Precursors.DocumentAnnotation]) -> _Key:
 
 
 def _unique_by(p: Received[Insertables.DocumentAnnotation]) -> _UniqueBy:
-    return p.item.obj.name, p.item.span_rowid, p.item.document_position, p.item.identifier
+    return p.item.obj.name, p.item.span_rowid, p.item.document_position, p.item.obj.identifier
 
 
 def _time(p: Received[Any]) -> datetime:

--- a/src/phoenix/db/insertion/session_annotation.py
+++ b/src/phoenix/db/insertion/session_annotation.py
@@ -73,6 +73,7 @@ class SessionAnnotationQueueInserter(
         list[Postponed[Precursors.SessionAnnotation]],
         list[Received[Precursors.SessionAnnotation]],
     ]:
+        print("parcels", len(parcels))
         to_insert: list[Received[Insertables.SessionAnnotation]] = []
         to_postpone: list[Postponed[Precursors.SessionAnnotation]] = []
         to_discard: list[Received[Precursors.SessionAnnotation]] = []
@@ -169,7 +170,7 @@ def _key(p: Received[Precursors.SessionAnnotation]) -> _Key:
 
 
 def _unique_by(p: Received[Insertables.SessionAnnotation]) -> _UniqueBy:
-    return p.item.obj.name, p.item.project_session_rowid, p.item.identifier
+    return p.item.obj.name, p.item.project_session_rowid, p.item.obj.identifier
 
 
 def _time(p: Received[Any]) -> datetime:

--- a/src/phoenix/db/insertion/session_annotation.py
+++ b/src/phoenix/db/insertion/session_annotation.py
@@ -73,7 +73,6 @@ class SessionAnnotationQueueInserter(
         list[Postponed[Precursors.SessionAnnotation]],
         list[Received[Precursors.SessionAnnotation]],
     ]:
-        print("parcels", len(parcels))
         to_insert: list[Received[Insertables.SessionAnnotation]] = []
         to_postpone: list[Postponed[Precursors.SessionAnnotation]] = []
         to_discard: list[Received[Precursors.SessionAnnotation]] = []

--- a/src/phoenix/db/insertion/span_annotation.py
+++ b/src/phoenix/db/insertion/span_annotation.py
@@ -167,7 +167,7 @@ def _key(p: Received[Precursors.SpanAnnotation]) -> _Key:
 
 
 def _unique_by(p: Received[Insertables.SpanAnnotation]) -> _UniqueBy:
-    return p.item.obj.name, p.item.span_rowid, p.item.identifier
+    return p.item.obj.name, p.item.span_rowid, p.item.obj.identifier
 
 
 def _time(p: Received[Any]) -> datetime:

--- a/src/phoenix/db/insertion/trace_annotation.py
+++ b/src/phoenix/db/insertion/trace_annotation.py
@@ -166,7 +166,7 @@ def _key(p: Received[Precursors.TraceAnnotation]) -> _Key:
 
 
 def _unique_by(p: Received[Insertables.TraceAnnotation]) -> _UniqueBy:
-    return p.item.obj.name, p.item.trace_rowid, p.item.identifier
+    return p.item.obj.name, p.item.trace_rowid, p.item.obj.identifier
 
 
 def _time(p: Received[Any]) -> datetime:

--- a/src/phoenix/db/insertion/types.py
+++ b/src/phoenix/db/insertion/types.py
@@ -248,7 +248,6 @@ class Insertables(ABC):
     class SpanAnnotation(Precursors.SpanAnnotation):
         updated_at: datetime
         span_rowid: int
-        identifier: str = ""
 
         @property
         def row(self) -> models.SpanAnnotation:
@@ -261,7 +260,6 @@ class Insertables(ABC):
     class TraceAnnotation(Precursors.TraceAnnotation):
         updated_at: datetime
         trace_rowid: int
-        identifier: str = ""
 
         @property
         def row(self) -> models.TraceAnnotation:
@@ -274,7 +272,6 @@ class Insertables(ABC):
     class DocumentAnnotation(Precursors.DocumentAnnotation):
         updated_at: datetime
         span_rowid: int
-        identifier: str = ""
 
         @property
         def row(self) -> models.DocumentAnnotation:
@@ -287,7 +284,6 @@ class Insertables(ABC):
     class SessionAnnotation(Precursors.SessionAnnotation):
         updated_at: datetime
         project_session_rowid: int
-        identifier: str = ""
 
         @property
         def row(self) -> models.ProjectSessionAnnotation:

--- a/tests/integration/client/test_annotations.py
+++ b/tests/integration/client/test_annotations.py
@@ -2899,7 +2899,9 @@ class TestClientForSessionAnnotations:
         ]
 
         # Send all annotations in a burst
-        task = AsyncClient(base_url=_app.base_url, api_key=api_key).sessions.log_session_annotations(
+        task = AsyncClient(
+            base_url=_app.base_url, api_key=api_key
+        ).sessions.log_session_annotations(
             session_annotations=session_annotations * 2,
             sync=False,
         )


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/9753

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates annotations by using the object's `identifier` across inserters and adds integration tests validating burst inserts with unique identifiers.
> 
> - **Backend (DB insertion)**:
>   - Dedup keys updated to use `obj.identifier` in `src/phoenix/db/insertion/{span,trace,session,document}_annotation.py` (`_unique_by` now references `p.item.obj.identifier`).
>   - `Insertables` cleanup in `src/phoenix/db/insertion/types.py` (remove per-insertable `identifier` field reliance).
> - **Tests**:
>   - Add burst/concurrency tests ensuring multiple annotations with same `name` but different `identifier` are inserted and deduped correctly for `span`, `trace`, and `session`.
>   - Import `asyncio.gather` to run parallel logging tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a933e24017d709e6ccc51971523fc81985eed53f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->