### PR TITLE
fix: custom TypeDict for Example as input

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -1411,9 +1411,9 @@ class AsyncDatasets:
             else:
                 examples_list = cast(list[Example], list(examples))
 
-            inputs = [dict(example["input"]) for example in examples_list]
-            outputs = [dict(example.get("output") or {}) for example in examples_list]
-            metadata = [dict(example.get("metadata") or {}) for example in examples_list]
+            inputs = [example["input"] for example in examples_list]
+            outputs = [example.get("output") or {} for example in examples_list]
+            metadata = [example.get("metadata") or {} for example in examples_list]
 
         if has_tabular:
             table = dataframe if dataframe is not None else csv_file_path
@@ -1517,9 +1517,9 @@ class AsyncDatasets:
             else:
                 examples_list = cast(list[Example], list(examples))
 
-            inputs = [dict(example["input"]) for example in examples_list]
-            outputs = [dict(example.get("output") or {}) for example in examples_list]
-            metadata = [dict(example.get("metadata") or {}) for example in examples_list]
+            inputs = [example["input"] for example in examples_list]
+            outputs = [example.get("output") or {} for example in examples_list]
+            metadata = [example.get("metadata") or {} for example in examples_list]
 
         if has_tabular:
             table = dataframe if dataframe is not None else csv_file_path

--- a/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
+++ b/packages/phoenix-client/tests/client/resources/datasets/test_datasets.py
@@ -16,7 +16,6 @@ from phoenix.client.resources.datasets import (
     _get_csv_column_headers,  # pyright: ignore[reportPrivateUsage]
     _infer_keys,  # pyright: ignore[reportPrivateUsage]
     _is_all_dict,  # pyright: ignore[reportPrivateUsage]
-    _is_valid_dataset_example,  # pyright: ignore[reportPrivateUsage]
     _parse_datetime,  # pyright: ignore[reportPrivateUsage]
     _prepare_csv,  # pyright: ignore[reportPrivateUsage]
     _prepare_dataframe_as_csv,  # pyright: ignore[reportPrivateUsage]
@@ -154,18 +153,6 @@ class TestHelperFunctions:
         assert _is_all_dict([{"a": 1}, {"b": 2}])
         assert not _is_all_dict([{"a": 1}, "not a dict"])
         assert _is_all_dict([])
-
-    def test_is_valid_dataset_example(self) -> None:
-        valid_example = v1.DatasetExample(
-            id="ex1",
-            input={"text": "hello"},
-            output={"response": "hi"},
-            metadata={"source": "test"},
-            updated_at="2024-01-15T10:00:00",
-        )
-        assert _is_valid_dataset_example(valid_example)
-        assert not _is_valid_dataset_example({"incomplete": "dict"})
-        assert not _is_valid_dataset_example("not a dict")
 
     def test_get_csv_column_headers(self) -> None:
         csv_content = "col1,col2,col3\nval1,val2,val3\n"


### PR DESCRIPTION
resolves #9755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces DatasetExample validation with a new Example TypedDict and TypeGuard, updates sync/async dataset APIs to accept it and handle optional fields, and removes related tests.
> 
> - **Client/Datasets**:
>   - Introduce `Example` `TypedDict` (optional `output`/`metadata`) and `_is_single_example` `TypeGuard`.
>   - Update `Datasets.create_dataset`/`add_examples_to_dataset` and async variants to accept `Example | Iterable[Example]` and extract `inputs`/`outputs`/`metadata` using defaults when absent.
>   - Simplify extraction (no `dict(...)` casting; use `.get(...)` with `{}` fallback).
>   - Add typing imports (`TypedDict`, `TypeGuard`, `NotRequired`, `cast`).
> - **Tests**:
>   - Remove `_is_valid_dataset_example` usage and its test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bd353241d97fea2f4ec9ffb549c2d4cec07e0b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->