### PR TITLE
feat: Plumb kwargs through to evaluate and evaluate_dataframe

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -283,7 +283,6 @@ class LLM:
             )
             {"label": "yes"}
         """
-        # Generate schema from labels
         schema = generate_classification_schema(labels, include_explanation, description)
         result: Dict[str, Any] = self.generate_object(prompt, schema, **kwargs)
         return result
@@ -371,7 +370,6 @@ class LLM:
         Returns:
             Dict[str, Any]: The generated classification.
         """
-        # Generate schema from labels
         schema = generate_classification_schema(labels, include_explanation, description)
         result: Dict[str, Any] = await self.async_generate_object(prompt, schema, **kwargs)
         return result


### PR DESCRIPTION
- allows passing arbitrary kwargs into evaluator's `evaluate` and `async_evaluate` methods
- when appropriate, these are passed onto LLM.generate_classification as invocation parameters
- per-evaluator kwargs can be passed into `evaluate_dataframe` with `eval_kwargs`, a mapping from evaluator names to kwarg dictionaries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds **kwargs passthrough to evaluator evaluate/async methods and dataframe evaluators (with per-evaluator eval_kwargs), forwarding them to LLM classification calls.
> 
> - **Evaluators**:
>   - `Evaluator.evaluate`/`async_evaluate` now accept `**kwargs` and forward to `_evaluate`/`_async_evaluate` (including thread-wrapper path).
>   - `_evaluate`/`_async_evaluate` signatures updated across base, LLM, and decorator-generated evaluators to accept `**kwargs`.
> - **LLM Evaluation**:
>   - `ClassificationEvaluator` forwards `**kwargs` to `LLM.generate_classification`/`async_generate_classification`.
> - **DataFrame Runners**:
>   - `evaluate_dataframe` and `async_evaluate_dataframe` accept `eval_kwargs` (per-evaluator) and `**kwargs` (global); merged and passed to each evaluator during task execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d1dd9769acd41691bbb0d135b98355a2a614e8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->