### PR TITLE
feat: datasets table label column

### DIFF
--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -17,7 +17,7 @@ import {
 } from "@tanstack/react-table";
 import { css } from "@emotion/react";
 
-import { Icon, Icons, Link } from "@phoenix/components";
+import { Icon, Icons, Link, Token } from "@phoenix/components";
 import { CompactJSONCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
@@ -86,6 +86,11 @@ export function DatasetsTable(props: DatasetsTableProps) {
                 createdAt
                 exampleCount
                 experimentCount
+                labels {
+                  id
+                  name
+                  color
+                }
               }
             }
           }
@@ -128,6 +133,60 @@ export function DatasetsTable(props: DatasetsTableProps) {
             ? `${row.original.id}/experiments`
             : `${row.original.id}/examples`;
           return <Link to={to}>{row.original.name}</Link>;
+        },
+      },
+      {
+        header: "labels",
+        accessorKey: "labels",
+        enableSorting: false,
+        cell: ({ row }) => {
+          return (
+            <ul
+              css={css`
+                display: flex;
+                flex-direction: row;
+                gap: var(--ac-global-dimension-size-100);
+                min-width: 0;
+                flex-wrap: wrap;
+              `}
+            >
+              {row.original.labels.map((label) => (
+                <li
+                  key={label.id}
+                  css={css`
+                    min-width: 0;
+                    max-width: 200px;
+                  `}
+                >
+                  <Token
+                    color={label.color}
+                    css={css`
+                      min-width: 0;
+                      max-width: 100%;
+                      span {
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                        min-width: 0;
+                      }
+                    `}
+                  >
+                    <span
+                      css={css`
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                        min-width: 0;
+                      `}
+                      title={label.name}
+                    >
+                      {label.name}
+                    </span>
+                  </Token>
+                </li>
+              ))}
+            </ul>
+          );
         },
       },
       {

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -151,39 +151,13 @@ export function DatasetsTable(props: DatasetsTableProps) {
               `}
             >
               {row.original.labels.map((label) => (
-                <li
-                  key={label.id}
-                  css={css`
-                    min-width: 0;
-                    max-width: 200px;
-                  `}
-                >
-                  <Token
-                    color={label.color}
-                    css={css`
-                      min-width: 0;
-                      max-width: 100%;
-                      span {
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                        min-width: 0;
-                      }
-                    `}
-                  >
-                    <span
-                      css={css`
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                        min-width: 0;
-                      `}
-                      title={label.name}
-                    >
-                      {label.name}
-                    </span>
-                  </Token>
-                </li>
+<li key={label.id}>
+  <Token color={label.color}>
+    <Truncate maxWidth={200}>
+      {label.name}
+    </Truncate>
+  </Token>
+</li>
               ))}
             </ul>
           );

--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -22,7 +22,9 @@ import { CompactJSONCell } from "@phoenix/components/table";
 import { selectableTableCSS } from "@phoenix/components/table/styles";
 import { TableEmptyWrap } from "@phoenix/components/table/TableEmptyWrap";
 import { TimestampCell } from "@phoenix/components/table/TimestampCell";
+import { Truncate } from "@phoenix/components/utility/Truncate";
 import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
 import { DatasetsTable_datasets$key } from "./__generated__/DatasetsTable_datasets.graphql";
@@ -58,6 +60,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
   const navigate = useNavigate();
   const notifySuccess = useNotifySuccess();
   const notifyError = useNotifyError();
+  const isDatasetLabelEnabled = useFeatureFlag("datasetLabel");
   const { data, loadNext, hasNext, isLoadingNext, refetch } =
     usePaginationFragment<
       DatasetsTableDatasetsQuery,
@@ -135,34 +138,40 @@ export function DatasetsTable(props: DatasetsTableProps) {
           return <Link to={to}>{row.original.name}</Link>;
         },
       },
-      {
-        header: "labels",
-        accessorKey: "labels",
-        enableSorting: false,
-        cell: ({ row }) => {
-          return (
-            <ul
-              css={css`
-                display: flex;
-                flex-direction: row;
-                gap: var(--ac-global-dimension-size-100);
-                min-width: 0;
-                flex-wrap: wrap;
-              `}
-            >
-              {row.original.labels.map((label) => (
-<li key={label.id}>
-  <Token color={label.color}>
-    <Truncate maxWidth={200}>
-      {label.name}
-    </Truncate>
-  </Token>
-</li>
-              ))}
-            </ul>
-          );
-        },
-      },
+      ...(isDatasetLabelEnabled
+        ? [
+            {
+              header: "labels",
+              accessorKey: "labels",
+              enableSorting: false,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              cell: ({ row }: any) => {
+                return (
+                  <ul
+                    css={css`
+                      display: flex;
+                      flex-direction: row;
+                      gap: var(--ac-global-dimension-size-100);
+                      min-width: 0;
+                      flex-wrap: wrap;
+                    `}
+                  >
+                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                    {row.original.labels.map((label: any) => (
+                      <li key={label.id}>
+                        <Token color={label.color}>
+                          <Truncate maxWidth={200} title={label.name}>
+                            {label.name}
+                          </Truncate>
+                        </Token>
+                      </li>
+                    ))}
+                  </ul>
+                );
+              },
+            },
+          ]
+        : []),
       {
         header: "description",
         accessorKey: "description",

--- a/app/src/pages/datasets/__generated__/DatasetsPageQuery.graphql.ts
+++ b/app/src/pages/datasets/__generated__/DatasetsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f36a42947770296e21a4591de68628f7>>
+ * @generated SignedSource<<275f7645a73151e39d530b4f1e95d9b6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,7 +34,21 @@ var v0 = [
       "dir": "desc"
     }
   }
-];
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -81,20 +95,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "id",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "name",
-                    "storageKey": null
-                  },
+                  (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -128,6 +130,26 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "experimentCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DatasetLabel",
+                    "kind": "LinkedField",
+                    "name": "labels",
+                    "plural": true,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "color",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   },
                   {
@@ -193,12 +215,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "695b221e981c4795492d79faa7d007e4",
+    "cacheID": "0bdf83ff96fd6bfc2dc513d5edbadc31",
     "id": null,
     "metadata": {},
     "name": "DatasetsPageQuery",
     "operationKind": "query",
-    "text": "query DatasetsPageQuery {\n  ...DatasetsTable_datasets\n}\n\nfragment DatasetsTable_datasets on Query {\n  datasets(first: 100, sort: {col: createdAt, dir: desc}) {\n    edges {\n      node {\n        id\n        name\n        description\n        metadata\n        createdAt\n        exampleCount\n        experimentCount\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query DatasetsPageQuery {\n  ...DatasetsTable_datasets\n}\n\nfragment DatasetsTable_datasets on Query {\n  datasets(first: 100, sort: {col: createdAt, dir: desc}) {\n    edges {\n      node {\n        id\n        name\n        description\n        metadata\n        createdAt\n        exampleCount\n        experimentCount\n        labels {\n          id\n          name\n          color\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/datasets/__generated__/DatasetsTableDatasetsQuery.graphql.ts
+++ b/app/src/pages/datasets/__generated__/DatasetsTableDatasetsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<438890125493320563fbfa4214924473>>
+ * @generated SignedSource<<5dda4bc48964078a2de9ab61f0a93709>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,7 +82,21 @@ v1 = [
     "name": "sort",
     "variableName": "sort"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -129,20 +143,8 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "id",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "name",
-                    "storageKey": null
-                  },
+                  (v2/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -176,6 +178,26 @@ return {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "experimentCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DatasetLabel",
+                    "kind": "LinkedField",
+                    "name": "labels",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "color",
+                        "storageKey": null
+                      }
+                    ],
                     "storageKey": null
                   },
                   {
@@ -241,16 +263,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "08daa0d1d804707d650c0b689bcbd156",
+    "cacheID": "3e819f41f7a6ed480c70522da77062a9",
     "id": null,
     "metadata": {},
     "name": "DatasetsTableDatasetsQuery",
     "operationKind": "query",
-    "text": "query DatasetsTableDatasetsQuery(\n  $after: String = null\n  $filter: DatasetFilter = null\n  $first: Int = 100\n  $sort: DatasetSort = {col: createdAt, dir: desc}\n) {\n  ...DatasetsTable_datasets_3JsJJ3\n}\n\nfragment DatasetsTable_datasets_3JsJJ3 on Query {\n  datasets(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      node {\n        id\n        name\n        description\n        metadata\n        createdAt\n        exampleCount\n        experimentCount\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query DatasetsTableDatasetsQuery(\n  $after: String = null\n  $filter: DatasetFilter = null\n  $first: Int = 100\n  $sort: DatasetSort = {col: createdAt, dir: desc}\n) {\n  ...DatasetsTable_datasets_3JsJJ3\n}\n\nfragment DatasetsTable_datasets_3JsJJ3 on Query {\n  datasets(first: $first, after: $after, sort: $sort, filter: $filter) {\n    edges {\n      node {\n        id\n        name\n        description\n        metadata\n        createdAt\n        exampleCount\n        experimentCount\n        labels {\n          id\n          name\n          color\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7e2060873b57927f5b7eac64411dbc94";
+(node as any).hash = "82e24aac9e40f779947bb6b87468f506";
 
 export default node;

--- a/app/src/pages/datasets/__generated__/DatasetsTable_datasets.graphql.ts
+++ b/app/src/pages/datasets/__generated__/DatasetsTable_datasets.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cb7eb84798872f704be0e5731b13ff8a>>
+ * @generated SignedSource<<77cd03b68f6d032a3a0ac98c6e58f1a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,11 @@ export type DatasetsTable_datasets$data = {
         readonly exampleCount: number;
         readonly experimentCount: number;
         readonly id: string;
+        readonly labels: ReadonlyArray<{
+          readonly color: string;
+          readonly id: string;
+          readonly name: string;
+        }>;
         readonly metadata: any;
         readonly name: string;
       };
@@ -36,7 +41,21 @@ import DatasetsTableDatasetsQuery_graphql from './DatasetsTableDatasetsQuery.gra
 const node: ReaderFragment = (function(){
 var v0 = [
   "datasets"
-];
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "argumentDefinitions": [
     {
@@ -123,20 +142,8 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "id",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
+                (v1/*: any*/),
+                (v2/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -170,6 +177,26 @@ return {
                   "args": null,
                   "kind": "ScalarField",
                   "name": "experimentCount",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "DatasetLabel",
+                  "kind": "LinkedField",
+                  "name": "labels",
+                  "plural": true,
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "color",
+                      "storageKey": null
+                    }
+                  ],
                   "storageKey": null
                 },
                 {
@@ -226,6 +253,6 @@ return {
 };
 })();
 
-(node as any).hash = "7e2060873b57927f5b7eac64411dbc94";
+(node as any).hash = "82e24aac9e40f779947bb6b87468f506";
 
 export default node;


### PR DESCRIPTION
resolves #9619 
<img width="1278" height="274" alt="Screenshot 2025-10-03 at 12 38 16 PM" src="https://github.com/user-attachments/assets/06e28780-3cdc-4977-9f4f-33443c812686" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a feature-flagged labels column to the datasets table and updates queries to fetch label data.
> 
> - **UI (Datasets Table)**:
>   - Add non-sortable `labels` column (gated by `datasetLabel` feature flag) rendering colored `Token`s with truncated names.
>   - Import and use `Token` and `Truncate` components.
> - **GraphQL/Relay**:
>   - Extend fragments/queries to include `labels { id name color }` on `Dataset` nodes across `DatasetsTable` and related generated files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34f0305c66e45b440a6a98b016429ed94cafba2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->