### PR TITLE
fix: datasets table feature flag typing

### DIFF
--- a/app/src/pages/datasets/DatasetsTable.tsx
+++ b/app/src/pages/datasets/DatasetsTable.tsx
@@ -9,6 +9,7 @@ import {
 import { graphql, usePaginationFragment } from "react-relay";
 import { useNavigate } from "react-router";
 import {
+  CellContext,
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
@@ -144,8 +145,9 @@ export function DatasetsTable(props: DatasetsTableProps) {
               header: "labels",
               accessorKey: "labels",
               enableSorting: false,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              cell: ({ row }: any) => {
+              cell: ({
+                row,
+              }: CellContext<(typeof tableData)[number], unknown>) => {
                 return (
                   <ul
                     css={css`
@@ -156,8 +158,7 @@ export function DatasetsTable(props: DatasetsTableProps) {
                       flex-wrap: wrap;
                     `}
                   >
-                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                    {row.original.labels.map((label: any) => (
+                    {row.original.labels.map((label) => (
                       <li key={label.id}>
                         <Token color={label.color}>
                           <Truncate maxWidth={200} title={label.name}>


### PR DESCRIPTION
#9619 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the labels column cell typing using CellContext and removes any-based typings in DatasetsTable.
> 
> - **DatasetsTable (`app/src/pages/datasets/DatasetsTable.tsx`)**:
>   - **Typing**: Import and use `CellContext` from `@tanstack/react-table` for the `labels` column cell.
>     - Replace `any`-typed `cell` and label mapping with strongly typed generics.
>     - Remove related ESLint disable comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59977453439fccf0419ba6ab41b8162628499503. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->