### PR TITLE
fix: don't display untrusted query parameters

### DIFF
--- a/app/src/pages/auth/LoggedOutPage.tsx
+++ b/app/src/pages/auth/LoggedOutPage.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 
 import { Alert, Flex, LinkButton, View } from "@phoenix/components";
 
+import { getAuthErrorMessage } from "./authErrors";
 import { AuthLayout } from "./AuthLayout";
 import { OAuth2Login } from "./OAuth2Login";
 import { PhoenixLogo } from "./PhoenixLogo";
@@ -21,7 +22,9 @@ export function LoggedOutPage() {
   const [searchParams] = useSearchParams();
   const returnUrl = searchParams.get("returnUrl");
   const showBacktoLogin = !window.Config.basicAuthDisabled;
-  const error = searchParams.get("error");
+  const errorCode = searchParams.get("error");
+  // Validate and get safe error message (prevents XSS/phishing via query params)
+  const errorMessage = getAuthErrorMessage(errorCode);
   return (
     <AuthLayout>
       <Flex direction="column" gap="size-200" alignItems="center">
@@ -30,8 +33,8 @@ export function LoggedOutPage() {
         </View>
       </Flex>
       <View paddingBottom="size-100">
-        <Alert variant={error ? "danger" : "success"}>
-          {error || "You have been logged out"}
+        <Alert variant={errorMessage ? "danger" : "success"}>
+          {errorMessage || "You have been logged out"}
         </Alert>
       </View>
       {showBacktoLogin && (

--- a/app/src/pages/auth/LoginPage.tsx
+++ b/app/src/pages/auth/LoginPage.tsx
@@ -4,6 +4,7 @@ import { css } from "@emotion/react";
 
 import { Alert, Flex, View } from "@phoenix/components";
 
+import { getAuthErrorMessage, getAuthSuccessMessage } from "./authErrors";
 import { AuthLayout } from "./AuthLayout";
 import { LoginForm } from "./LoginForm";
 import { OAuth2Login } from "./OAuth2Login";
@@ -30,7 +31,11 @@ export function LoginPage() {
   const hasOAuth2Idps = oAuth2Idps.length > 0;
   const [searchParams, setSearchParams] = useSearchParams();
   const returnUrl = searchParams.get("returnUrl");
-  const message = searchParams.get("message");
+  const successCode = searchParams.get("message");
+  const errorCode = searchParams.get("error");
+  // Validate and get safe messages (prevents XSS/phishing via query params)
+  const successMessage = getAuthSuccessMessage(successCode);
+  const errorMessage = getAuthErrorMessage(errorCode);
   // The name of the idp to trigger
   const triggerIdp = searchParams.get("trigger");
 
@@ -56,14 +61,14 @@ export function LoginPage() {
           <PhoenixLogo />
         </View>
       </Flex>
-      {message && (
+      {successMessage && (
         <View paddingBottom="size-100">
-          <Alert variant="success">{message}</Alert>
+          <Alert variant="success">{successMessage}</Alert>
         </View>
       )}
       {showLoginForm && (
         <LoginForm
-          initialError={searchParams.get("error")}
+          initialError={errorMessage}
           onSubmit={() => {
             setSearchParams((prevSearchParams) => {
               // Clear message and error

--- a/app/src/pages/auth/ResetPasswordForm.tsx
+++ b/app/src/pages/auth/ResetPasswordForm.tsx
@@ -71,7 +71,7 @@ export function ResetPasswordForm(props: {
         onCompleted: () => {
           const to = createRedirectUrlWithReturn({
             path: "/login",
-            searchParams: { message: "Password has been reset." },
+            searchParams: { message: "password_reset" },
           });
           navigate(to);
         },

--- a/app/src/pages/auth/ResetPasswordWithTokenForm.tsx
+++ b/app/src/pages/auth/ResetPasswordWithTokenForm.tsx
@@ -60,9 +60,8 @@ export function ResetPasswordWithTokenForm({
       } finally {
         setIsLoading(() => false);
       }
-      navigate(
-        `/login?message=${encodeURIComponent("Password has been reset.")}`
-      );
+      // Use success code instead of raw message to prevent phishing attacks
+      navigate("/login?message=password_reset");
     },
     [setError, navigate]
   );

--- a/app/src/pages/auth/authErrors.ts
+++ b/app/src/pages/auth/authErrors.ts
@@ -1,0 +1,30 @@
+/**
+ * Authentication message handling utilities.
+ *
+ * SECURITY: Only displays messages for codes in the allowed lists.
+ * This prevents social engineering attacks via manipulated query parameters.
+ */
+
+const AUTH_SUCCESS_MESSAGES: Record<string, string> = {
+  password_reset: "Password has been reset.",
+};
+
+/**
+ * Returns a safe error message for the given code, or null if invalid.
+ * Error messages are provided by the backend via window.Config.
+ */
+export function getAuthErrorMessage(errorCode: string | null): string | null {
+  return errorCode
+    ? (window.Config.authErrorMessages?.[errorCode] ?? null)
+    : null;
+}
+
+/**
+ * Returns a safe success message for the given code, or null if invalid.
+ * Success messages are frontend-only.
+ */
+export function getAuthSuccessMessage(
+  successCode: string | null
+): string | null {
+  return successCode ? (AUTH_SUCCESS_MESSAGES[successCode] ?? null) : null;
+}

--- a/app/src/window.d.ts
+++ b/app/src/window.d.ts
@@ -25,6 +25,11 @@ declare global {
       managementUrl?: string | null;
       supportEmail?: string | null;
       hasDbThreshold: boolean;
+      /**
+       * Mapping of auth error codes to user-friendly messages.
+       * Passed from the backend to ensure single source of truth.
+       */
+      authErrorMessages: Record<string, string>;
     };
   }
 }

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -4,6 +4,7 @@ export const baseWindowConfig = {
   authenticationEnabled: true,
   basename: "/",
   platformVersion: "1.0.0",
+  authErrorMessages: {},
 };
 Object.defineProperty(window, "Config", {
   value: baseWindowConfig,

--- a/src/phoenix/server/api/auth_messages.py
+++ b/src/phoenix/server/api/auth_messages.py
@@ -1,0 +1,46 @@
+# ruff: noqa: E501
+"""
+Authentication error and success message codes.
+
+These codes are used in authentication flows to safely communicate status
+to users via query parameters. Using codes instead of raw messages prevents
+social engineering and phishing attacks.
+
+The messages are passed to the frontend via window.Config to ensure a single
+source of truth between backend and frontend.
+"""
+
+from types import MappingProxyType
+from typing import Literal, Mapping, get_args
+
+# Error code type - used for type hints in redirect functions
+AuthErrorCode = Literal[
+    "unknown_idp",
+    "auth_failed",
+    "invalid_state",
+    "unsafe_return_url",
+    "oauth_error",
+    "no_oidc_support",
+    "missing_email_scope",
+    "email_in_use",
+    "sign_in_not_allowed",
+]
+
+# Error messages - passed to frontend via window.Config.authErrorMessages
+# Backend generates these codes when redirecting users after OAuth errors
+AUTH_ERROR_MESSAGES: Mapping[AuthErrorCode, str] = MappingProxyType(
+    {
+        "unknown_idp": "Unknown identity provider.",
+        "auth_failed": "Authentication failed. Please contact your administrator.",
+        "invalid_state": "Invalid authentication state. Please try again.",
+        "unsafe_return_url": "Invalid return URL. Please try again.",
+        "oauth_error": "Authentication failed. Please try again.",
+        "no_oidc_support": "Your identity provider does not appear to support OpenID Connect. Please contact your administrator.",
+        "missing_email_scope": "Please ensure your identity provider is configured to use the 'email' scope.",
+        "email_in_use": "An account with this email already exists.",
+        "sign_in_not_allowed": "Sign in is not allowed. Please contact your administrator.",
+    }
+)
+
+# Runtime assertion to ensure AUTH_ERROR_MESSAGES keys match AuthErrorCode Literal values
+assert set(AUTH_ERROR_MESSAGES.keys()) == set(get_args(AuthErrorCode))

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -81,6 +81,7 @@ from phoenix.db.facilitator import Facilitator
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.exceptions import PhoenixMigrationError
 from phoenix.pointcloud.umap_parameters import UMAPParameters
+from phoenix.server.api.auth_messages import AUTH_ERROR_MESSAGES, AuthErrorCode
 from phoenix.server.api.context import Context, DataLoaders
 from phoenix.server.api.dataloaders import (
     AnnotationConfigsByProjectDataLoader,
@@ -250,6 +251,8 @@ class AppConfig(NamedTuple):
     web_manifest_path: Path
     authentication_enabled: bool
     """ Whether authentication is enabled """
+    auth_error_messages: dict[AuthErrorCode, str]
+    """ Mapping of auth error codes to user-friendly messages """
     oauth2_idps: Sequence[OAuth2Idp]
     basic_auth_disabled: bool = False
     auto_login_idp_name: Optional[str] = None
@@ -326,6 +329,7 @@ class Static(StaticFiles):
                     "support_email": self._app_config.support_email,
                     "has_db_threshold": self._app_config.has_db_threshold,
                     "allow_external_resources": self._app_config.allow_external_resources,
+                    "auth_error_messages": self._app_config.auth_error_messages,
                 },
             )
         except Exception as e:
@@ -1146,6 +1150,7 @@ def create_app(
                         and get_env_database_usage_insertion_blocking_threshold_percentage()
                     ),
                     allow_external_resources=get_env_allow_external_resources(),
+                    auth_error_messages=dict(AUTH_ERROR_MESSAGES) if authentication_enabled else {},
                 ),
             ),
             name="static",

--- a/src/phoenix/server/templates/index.html
+++ b/src/phoenix/server/templates/index.html
@@ -114,6 +114,7 @@
               supportEmail: {{support_email | tojson}},
               hasDbThreshold: Boolean("{{has_db_threshold}}" == "True"),
               allowExternalResources: Boolean("{{allow_external_resources}}" == "True"),
+              authErrorMessages: {{auth_error_messages | tojson}},
           }),
           writable: false
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch auth flows to use validated message/error codes (not raw query params) with backend-supplied error message mapping passed to the frontend.
> 
> - **Frontend**:
>   - Introduce `authErrors` helpers (`getAuthErrorMessage`, `getAuthSuccessMessage`) and use them in `LoginPage` and `LoggedOutPage` to render only validated messages.
>   - Update `ResetPasswordForm` and `ResetPasswordWithTokenForm` to redirect with `message=password_reset` code.
>   - Extend `window.d.ts` with `authErrorMessages`; initialize in `vitest.setup.ts`.
> - **Backend**:
>   - Add `auth_messages.py` defining `AuthErrorCode` and `AUTH_ERROR_MESSAGES`.
>   - Update `oauth2.py` to redirect with standardized error codes (e.g., `unknown_idp`, `auth_failed`, `invalid_state`, etc.) and type `error: AuthErrorCode`.
>   - Pass `auth_error_messages` through `AppConfig`, inject into `window.Config`, and include in `index.html` template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2eb3c491024d34dfcf51b0ff243b2530b6416e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->