### PR TITLE
feat: Add validation on run_evals for template <> dataframe column matches

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/classify.py
@@ -430,6 +430,21 @@ def run_evals(
             "`from phoenix.evals.legacy import LLMEvaluator`"
         )
 
+    available_columns = set(dataframe.columns)
+
+    # Validate that each evaluator has all required template fields
+    for evaluator in evaluators:
+        required_fields = set(evaluator._template.variables)
+
+        missing_fields = required_fields - available_columns
+
+        if missing_fields:
+            raise ValueError(
+                f"Evaluator '{evaluator.__class__.__name__}' requires missing columns: "
+                f"{', '.join(sorted(missing_fields))}. "
+                f"Available columns: {', '.join(sorted(available_columns))}"
+            )
+
     # use the minimum default concurrency of all the models
     if concurrency is None:
         if len(evaluators) == 0:


### PR DESCRIPTION
Resolves: #5965

This PR adds validation in run_evals to ensure that all variables in the provided template match the dataframe columns before execution. This helps avoid confusing KeyError('input') messages when columns don’t align with template variables.

- Added validation to ensure all template variables match DataFrame columns before running evaluators
- Raises descriptive ValueError when missing columns are detected, listing both missing and available columns
- Includes test case to verify validation behavior

While llm_generate and llm_classify already include similar safeguards through their map_template logic (raising descriptive errors for missing variables), run_evals lacked this validation.

llm_generate: https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-evals/src/phoenix/evals/legacy/templates.py#L257-L289

llm_classify: https://github.com/Arize-ai/phoenix/blob/main/packages/phoenix-evals/src/phoenix/evals/legacy/classify.py#L232-L245