### PR TITLE
fix(experiments): handle missing experiments while loading

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -102,7 +102,7 @@ type Experiment = NonNullable<
   ExperimentCompareTable_comparisons$data["dataset"]["experiments"]
 >["edges"][number]["experiment"];
 
-type ExperimentInfoMap = Record<string, Experiment>;
+type ExperimentInfoMap = Partial<Record<string, Experiment>>;
 
 type ExperimentComparison =
   ExperimentCompareTable_comparisons$data["compareExperiments"]["edges"][number]["comparison"];
@@ -325,7 +325,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
                         setDialog(
                           <ExampleDetailsDialog
                             exampleId={row.original.example.id}
-                            datasetVersionId={baseExperiment.datasetVersionId}
+                            datasetVersionId={baseExperiment?.datasetVersionId}
                           />
                         );
                       }}
@@ -376,7 +376,7 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
         ),
       },
     ];
-  }, [baseExperiment.datasetVersionId, displayFullText, setDialog]);
+  }, [baseExperiment?.datasetVersionId, displayFullText, setDialog]);
 
   const experimentColumns: ColumnDef<TableRow>[] = useMemo(() => {
     return [baseExperimentId, ...compareExperimentIds].map(
@@ -663,7 +663,8 @@ export function ExperimentCompareTable(props: ExampleCompareTableProps) {
       >
         <Modal variant="slideover" size="fullscreen">
           {selectedExampleIndex !== null &&
-            exampleIds[selectedExampleIndex] && (
+            exampleIds[selectedExampleIndex] &&
+            baseExperiment && (
               <ExperimentCompareDetailsDialog
                 datasetId={datasetId}
                 datasetVersionId={baseExperiment.datasetVersionId}


### PR DESCRIPTION
Fixes runtime error that sometimes occurs when switching between different base experiments on the experiment compare grid page.

<img width="622" height="365" alt="image" src="https://github.com/user-attachments/assets/a7e794a7-67c5-434c-895c-56189a8a5fa7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds null-safety around `baseExperiment` and relaxes `ExperimentInfoMap` typing to prevent crashes while compare data loads.
> 
> - **Experiment Compare Table (`app/src/pages/experiment/ExperimentCompareTable.tsx`)**
>   - Handle possibly missing `baseExperiment`:
>     - Use optional chaining when reading `baseExperiment?.datasetVersionId`.
>     - Guard rendering of `ExperimentCompareDetailsDialog` until `baseExperiment` exists.
>     - Update `useMemo` deps to reference `baseExperiment?.datasetVersionId`.
>   - Typing: change `ExperimentInfoMap` to `Partial<Record<string, Experiment>>` to allow absent entries during loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33621d1767077a00703003fcff410b2ab93795ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->