### PR TITLE
fix(experiments): fix copy button cutoff in slideover run cards

### DIFF
--- a/app/src/components/experiment/ExperimentCompareDetails.tsx
+++ b/app/src/components/experiment/ExperimentCompareDetails.tsx
@@ -577,9 +577,11 @@ export function ExperimentItem({
       : getExperimentColor(experimentIndex - 1);
 
   const hasExperimentResult = experimentRun !== undefined;
-  const experimentRunOutputStr = experimentRun
-    ? JSON.stringify(experimentRun.output, null, 2)
-    : undefined;
+  const experimentRunOutputStr = useMemo(
+    () =>
+      experimentRun ? JSON.stringify(experimentRun.output, null, 2) : undefined,
+    [experimentRun]
+  );
   return (
     <div css={experimentItemCSS}>
       <Flex direction="column">
@@ -609,7 +611,7 @@ export function ExperimentItem({
                 </Heading>
               </>
             )}
-            {experimentRunOutputStr && (
+            {experimentRunOutputStr && !experimentRun?.error && (
               <div
                 css={css`
                   margin-left: auto;
@@ -648,9 +650,7 @@ export function ExperimentItem({
               {experimentRun.error ? (
                 <View padding="size-200">{experimentRun.error}</View>
               ) : (
-                <JSONBlock
-                  value={JSON.stringify(experimentRun.output, null, 2)}
-                />
+                <JSONBlock value={experimentRunOutputStr} />
               )}
             </View>
           </>


### PR DESCRIPTION
Partially addresses https://github.com/Arize-ai/phoenix/issues/9796 by moving the copy button in the experiment run cards to the header to ensure there will always be room for it. This is also more consistent with how the input + reference output cards look in the top panel:

<img width="1185" height="638" alt="image" src="https://github.com/user-attachments/assets/47af5cd5-d3d7-46e6-922d-4d2309dd0c56" />


before
<img width="508" height="149" alt="image" src="https://github.com/user-attachments/assets/2ff953fa-15ba-4b64-b5f3-2b492e339a65" />


after
<img width="508" height="149" alt="image" src="https://github.com/user-attachments/assets/2cf3611e-f558-4abb-b626-76e535e2a8a7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the experiment run output copy button to the card header, memoizes stringified output, switches to `JSONBlock` with a precomputed string, and removes `JSONBlockWithCopy`.
> 
> - **UI – Experiment compare details (`app/src/components/experiment/ExperimentCompareDetails.tsx`)**:
>   - **ExperimentItem**:
>     - Add header copy button for run output (`CopyToClipboardButton`) when output exists and no error.
>     - Memoize stringified `experimentRun.output` via `useMemo` for reuse.
>     - Replace `JSONBlockWithCopy` with `JSONBlock` using the precomputed JSON string.
>   - Remove `JSONBlockWithCopy` component and its hover-based copy control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f818f0984a0b9e5e90bf769c7bf4ada7133239ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->