### PR TITLE
refactor: use numeric http status code to avoid deprecation warnings

### DIFF
--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -19,7 +19,6 @@ from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore
 from starlette.datastructures import URL, Secret, URLPath
 from starlette.responses import RedirectResponse
 from starlette.routing import Router
-from starlette.status import HTTP_302_FOUND
 from typing_extensions import Annotated, NotRequired, TypeGuard
 
 from phoenix.auth import (
@@ -117,7 +116,7 @@ async def login(
     assert isinstance(authorization_url := authorization_url_data.get("url"), str)
     assert isinstance(state := authorization_url_data.get("state"), str)
     assert isinstance(nonce := authorization_url_data.get("nonce"), str)
-    response = RedirectResponse(url=authorization_url, status_code=HTTP_302_FOUND)
+    response = RedirectResponse(url=authorization_url, status_code=302)
     response = set_oauth2_state_cookie(
         response=response,
         state=state,
@@ -217,7 +216,7 @@ async def create_tokens(
     redirect_path = prepend_root_path(request.scope, return_url or "/")
     response = RedirectResponse(
         url=redirect_path,
-        status_code=HTTP_302_FOUND,
+        status_code=302,
     )
     response = set_access_token_cookie(
         response=response, access_token=access_token, max_age=access_token_expiry

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.security import APIKeyHeader
-from starlette.status import HTTP_403_FORBIDDEN
 
 from phoenix.server.bearer_auth import is_authenticated
 
@@ -30,7 +29,7 @@ async def prevent_access_in_read_only_mode(request: Request) -> None:
     if request.app.state.read_only:
         raise HTTPException(
             detail="The Phoenix REST API is disabled in read-only mode.",
-            status_code=HTTP_403_FORBIDDEN,
+            status_code=403,
         )
 
 
@@ -57,7 +56,7 @@ def create_v1_router(authentication_enabled: bool) -> APIRouter:
         dependencies=dependencies,
         responses=add_errors_to_responses(
             [
-                HTTP_403_FORBIDDEN  # adds a 403 response to routes in the generated OpenAPI schema
+                403  # adds a 403 response to routes in the generated OpenAPI schema
             ]
         ),
     )

--- a/src/phoenix/server/api/routers/v1/annotations.py
+++ b/src/phoenix/server/api/routers/v1/annotations.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, HTTPException, Path, Query
 from pydantic import Field
 from sqlalchemy import exists, select
 from starlette.requests import Request
-from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -198,11 +197,11 @@ class SessionAnnotationsResponseBody(PaginatedResponseBody[SessionAnnotation]):
     "/projects/{project_identifier}/span_annotations",
     operation_id="listSpanAnnotationsBySpanIds",
     summary="Get span annotations for a list of span_ids.",
-    status_code=HTTP_200_OK,
+    status_code=200,
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_404_NOT_FOUND, "description": "Project or spans not found"},
-            {"status_code": HTTP_422_UNPROCESSABLE_ENTITY, "description": "Invalid parameters"},
+            {"status_code": 404, "description": "Project or spans not found"},
+            {"status_code": 422, "description": "Invalid parameters"},
         ]
     ),
 )
@@ -240,7 +239,7 @@ async def list_span_annotations(
     span_ids = list({*span_ids})
     if len(span_ids) > MAX_SPAN_IDS:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=422,
             detail=f"Too many span_ids supplied: {len(span_ids)} (max {MAX_SPAN_IDS})",
         )
 
@@ -248,7 +247,7 @@ async def list_span_annotations(
         project = await _get_project_by_identifier(session, project_identifier)
         if not project:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
 
@@ -280,7 +279,7 @@ async def list_span_annotations(
                 cursor_id = int(GlobalID.from_id(cursor).node_id)
             except ValueError:
                 raise HTTPException(
-                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=422,
                     detail="Invalid cursor value",
                 )
             stmt = stmt.where(models.SpanAnnotation.id <= cursor_id)
@@ -310,7 +309,7 @@ async def list_span_annotations(
             if not spans_exist:
                 raise HTTPException(
                     detail="None of the supplied span_ids exist in this project",
-                    status_code=HTTP_404_NOT_FOUND,
+                    status_code=404,
                 )
 
             return SpanAnnotationsResponseBody(data=[], next_cursor=None)
@@ -343,11 +342,11 @@ async def list_span_annotations(
     "/projects/{project_identifier}/trace_annotations",
     operation_id="listTraceAnnotationsByTraceIds",
     summary="Get trace annotations for a list of trace_ids.",
-    status_code=HTTP_200_OK,
+    status_code=200,
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_404_NOT_FOUND, "description": "Project or traces not found"},
-            {"status_code": HTTP_422_UNPROCESSABLE_ENTITY, "description": "Invalid parameters"},
+            {"status_code": 404, "description": "Project or traces not found"},
+            {"status_code": 422, "description": "Invalid parameters"},
         ]
     ),
 )
@@ -385,7 +384,7 @@ async def list_trace_annotations(
     trace_ids = list({*trace_ids})
     if len(trace_ids) > MAX_TRACE_IDS:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=422,
             detail=f"Too many trace_ids supplied: {len(trace_ids)} (max {MAX_TRACE_IDS})",
         )
 
@@ -393,7 +392,7 @@ async def list_trace_annotations(
         project = await _get_project_by_identifier(session, project_identifier)
         if not project:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
 
@@ -424,7 +423,7 @@ async def list_trace_annotations(
                 cursor_id = int(GlobalID.from_id(cursor).node_id)
             except ValueError:
                 raise HTTPException(
-                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=422,
                     detail="Invalid cursor value",
                 )
             stmt = stmt.where(models.TraceAnnotation.id <= cursor_id)
@@ -450,7 +449,7 @@ async def list_trace_annotations(
             if not traces_exist:
                 raise HTTPException(
                     detail="None of the supplied trace_ids exist in this project",
-                    status_code=HTTP_404_NOT_FOUND,
+                    status_code=404,
                 )
 
             return TraceAnnotationsResponseBody(data=[], next_cursor=None)
@@ -483,11 +482,11 @@ async def list_trace_annotations(
     "/projects/{project_identifier}/session_annotations",
     operation_id="listSessionAnnotationsBySessionIds",
     summary="Get session annotations for a list of session_ids.",
-    status_code=HTTP_200_OK,
+    status_code=200,
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_404_NOT_FOUND, "description": "Project or sessions not found"},
-            {"status_code": HTTP_422_UNPROCESSABLE_ENTITY, "description": "Invalid parameters"},
+            {"status_code": 404, "description": "Project or sessions not found"},
+            {"status_code": 422, "description": "Invalid parameters"},
         ]
     ),
 )
@@ -525,7 +524,7 @@ async def list_session_annotations(
     session_ids = list({*session_ids})
     if len(session_ids) > MAX_SESSION_IDS:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=422,
             detail=f"Too many session_ids supplied: {len(session_ids)} (max {MAX_SESSION_IDS})",
         )
 
@@ -533,7 +532,7 @@ async def list_session_annotations(
         project = await _get_project_by_identifier(session, project_identifier)
         if not project:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=f"Project with identifier {project_identifier} not found",
             )
 
@@ -571,7 +570,7 @@ async def list_session_annotations(
                 cursor_id = int(GlobalID.from_id(cursor).node_id)
             except ValueError:
                 raise HTTPException(
-                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=422,
                     detail="Invalid cursor value",
                 )
             stmt = stmt.where(models.ProjectSessionAnnotation.id <= cursor_id)
@@ -597,7 +596,7 @@ async def list_session_annotations(
             if not sessions_exist:
                 raise HTTPException(
                     detail="None of the supplied session_ids exist in this project",
-                    status_code=HTTP_404_NOT_FOUND,
+                    status_code=404,
                 )
 
             return SessionAnnotationsResponseBody(data=[], next_cursor=None)

--- a/src/phoenix/server/api/routers/v1/documents.py
+++ b/src/phoenix/server/api/routers/v1/documents.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import Field
 from sqlalchemy import select
 from starlette.requests import Request
-from starlette.status import HTTP_404_NOT_FOUND
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -42,7 +41,7 @@ class AnnotateSpanDocumentsResponseBody(ResponseBody[list[InsertedSpanDocumentAn
     responses=add_errors_to_responses(
         [
             {
-                "status_code": HTTP_404_NOT_FOUND,
+                "status_code": 404,
                 "description": "Span not found",
             },
             {
@@ -102,7 +101,7 @@ async def annotate_span_documents(
         if missing_span_ids:
             raise HTTPException(
                 detail=f"Spans with IDs {', '.join(missing_span_ids)} do not exist.",
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
             )
 
         # Validate that document positions are within bounds

--- a/src/phoenix/server/api/routers/v1/experiment_evaluations.py
+++ b/src/phoenix/server/api/routers/v1/experiment_evaluations.py
@@ -5,7 +5,6 @@ from dateutil.parser import isoparse
 from fastapi import APIRouter, HTTPException
 from pydantic import Field, model_validator
 from starlette.requests import Request
-from starlette.status import HTTP_404_NOT_FOUND
 from strawberry.relay import GlobalID
 from typing_extensions import Self
 
@@ -72,7 +71,7 @@ class UpsertExperimentEvaluationResponseBody(
     operation_id="upsertExperimentEvaluation",
     summary="Create or update evaluation for an experiment run",
     responses=add_errors_to_responses(
-        [{"status_code": HTTP_404_NOT_FOUND, "description": "Experiment run not found"}]
+        [{"status_code": 404, "description": "Experiment run not found"}]
     ),
 )
 async def upsert_experiment_evaluation(
@@ -85,7 +84,7 @@ async def upsert_experiment_evaluation(
     except ValueError:
         raise HTTPException(
             detail=f"ExperimentRun with ID {experiment_run_gid} does not exist",
-            status_code=HTTP_404_NOT_FOUND,
+            status_code=404,
         )
     name = request_body.name
     annotator_kind = request_body.annotator_kind

--- a/src/phoenix/server/api/routers/v1/experiment_runs.py
+++ b/src/phoenix/server/api/routers/v1/experiment_runs.py
@@ -7,7 +7,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.requests import Request
-from starlette.status import HTTP_404_NOT_FOUND, HTTP_409_CONFLICT, HTTP_422_UNPROCESSABLE_ENTITY
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
@@ -60,11 +59,11 @@ class CreateExperimentRunResponseBody(ResponseBody[CreateExperimentRunResponseBo
     responses=add_errors_to_responses(
         [
             {
-                "status_code": HTTP_404_NOT_FOUND,
+                "status_code": 404,
                 "description": "Experiment or dataset example not found",
             },
             {
-                "status_code": HTTP_409_CONFLICT,
+                "status_code": 409,
                 "description": "This experiment run has already been submitted",
             },
         ]
@@ -79,7 +78,7 @@ async def create_experiment_run(
     except ValueError:
         raise HTTPException(
             detail=f"Experiment with ID {experiment_gid} does not exist",
-            status_code=HTTP_404_NOT_FOUND,
+            status_code=404,
         )
 
     example_gid = GlobalID.from_id(request_body.dataset_example_id)
@@ -88,7 +87,7 @@ async def create_experiment_run(
     except ValueError:
         raise HTTPException(
             detail=f"DatasetExample with ID {example_gid} does not exist",
-            status_code=HTTP_404_NOT_FOUND,
+            status_code=404,
         )
 
     trace_id = request_body.trace_id
@@ -115,7 +114,7 @@ async def create_experiment_run(
         except (PostgreSQLIntegrityError, SQLiteIntegrityError):
             raise HTTPException(
                 detail="This experiment run has already been submitted",
-                status_code=HTTP_409_CONFLICT,
+                status_code=409,
             )
     request.state.event_queue.put(ExperimentRunInsertEvent((exp_run.id,)))
     run_gid = GlobalID("ExperimentRun", str(exp_run.id))
@@ -141,8 +140,8 @@ class ListExperimentRunsResponseBody(PaginatedResponseBody[ExperimentRunResponse
     response_description="Experiment runs retrieved successfully",
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_404_NOT_FOUND, "description": "Experiment not found"},
-            {"status_code": HTTP_422_UNPROCESSABLE_ENTITY, "description": "Invalid cursor format"},
+            {"status_code": 404, "description": "Experiment not found"},
+            {"status_code": 422, "description": "Invalid cursor format"},
         ]
     ),
 )
@@ -166,7 +165,7 @@ async def list_experiment_runs(
     except ValueError:
         raise HTTPException(
             detail=f"Experiment with ID {experiment_gid} does not exist",
-            status_code=HTTP_404_NOT_FOUND,
+            status_code=404,
         )
 
     stmt = (
@@ -182,7 +181,7 @@ async def list_experiment_runs(
         except ValueError:
             raise HTTPException(
                 detail=f"Invalid cursor format: {cursor}",
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=422,
             )
 
     # Apply limit only if specified for pagination

--- a/src/phoenix/server/api/routers/v1/projects.py
+++ b/src/phoenix/server/api/routers/v1/projects.py
@@ -4,12 +4,6 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import Field
 from sqlalchemy import select
 from starlette.requests import Request
-from starlette.status import (
-    HTTP_204_NO_CONTENT,
-    HTTP_403_FORBIDDEN,
-    HTTP_404_NOT_FOUND,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
 from strawberry.relay import GlobalID
 
 from phoenix.config import DEFAULT_PROJECT_NAME
@@ -70,7 +64,7 @@ class UpdateProjectResponseBody(ResponseBody[Project]):
     response_description="A list of projects with pagination information",  # noqa: E501
     responses=add_errors_to_responses(
         [
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            422,
         ]
     ),
 )
@@ -115,7 +109,7 @@ async def get_projects(
             except ValueError:
                 raise HTTPException(
                     detail=f"Invalid cursor format: {cursor}",
-                    status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                    status_code=422,
                 )
 
         stmt = stmt.limit(limit + 1)
@@ -142,8 +136,8 @@ async def get_projects(
     response_description="The requested project",  # noqa: E501
     responses=add_errors_to_responses(
         [
-            HTTP_404_NOT_FOUND,
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            404,
+            422,
         ]
     ),
 )
@@ -182,7 +176,7 @@ async def get_project(
     response_description="The newly created project",  # noqa: E501
     responses=add_errors_to_responses(
         [
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            422,
         ]
     ),
 )
@@ -223,9 +217,9 @@ async def create_project(
     response_description="The updated project",  # noqa: E501
     responses=add_errors_to_responses(
         [
-            HTTP_403_FORBIDDEN,
-            HTTP_404_NOT_FOUND,
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            403,
+            404,
+            422,
         ]
     ),
 )
@@ -262,7 +256,7 @@ async def update_project(
             role_name: UserRoleName = await session.scalar(stmt)
         if role_name != "ADMIN" and role_name != "SYSTEM":
             raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
+                status_code=403,
                 detail="Only admins can update projects",
             )
     async with request.app.state.db() as session:
@@ -282,12 +276,12 @@ async def update_project(
     summary="Delete a project by ID or name",  # noqa: E501
     description="Delete an existing project and all its associated data. The project identifier is either project ID or project name. The default project cannot be deleted. Note: When using a project name as the identifier, it cannot contain slash (/), question mark (?), or pound sign (#) characters.",  # noqa: E501
     response_description="No content returned on successful deletion",  # noqa: E501
-    status_code=HTTP_204_NO_CONTENT,
+    status_code=204,
     responses=add_errors_to_responses(
         [
-            HTTP_403_FORBIDDEN,
-            HTTP_404_NOT_FOUND,
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            403,
+            404,
+            422,
         ]
     ),
 )
@@ -322,7 +316,7 @@ async def delete_project(
             role_name: UserRoleName = await session.scalar(stmt)
         if role_name != "ADMIN" and role_name != "SYSTEM":
             raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
+                status_code=403,
                 detail="Only admins can delete projects",
             )
     async with request.app.state.db() as session:
@@ -331,7 +325,7 @@ async def delete_project(
         # The default project must not be deleted - it's forbidden
         if project.name == DEFAULT_PROJECT_NAME:
             raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
+                status_code=403,
                 detail="The default project cannot be deleted",
             )
 

--- a/src/phoenix/server/api/routers/v1/sessions.py
+++ b/src/phoenix/server/api/routers/v1/sessions.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import Field
 from sqlalchemy import select
 from starlette.requests import Request
-from starlette.status import HTTP_404_NOT_FOUND
 
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
@@ -39,9 +38,7 @@ class AnnotateSessionsResponseBody(ResponseBody[list[InsertedSessionAnnotation]]
     dependencies=[Depends(is_not_locked)],
     operation_id="annotateSessions",
     summary="Create session annotations",
-    responses=add_errors_to_responses(
-        [{"status_code": HTTP_404_NOT_FOUND, "description": "Session not found"}]
-    ),
+    responses=add_errors_to_responses([{"status_code": 404, "description": "Session not found"}]),
     response_description="Session annotations inserted successfully",
     include_in_schema=True,
 )
@@ -88,7 +85,7 @@ async def annotate_sessions(
     if missing_session_ids:
         raise HTTPException(
             detail=f"Sessions with IDs {', '.join(missing_session_ids)} do not exist.",
-            status_code=HTTP_404_NOT_FOUND,
+            status_code=404,
         )
 
     async with request.app.state.db() as session:

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -14,12 +14,6 @@ from pydantic import BaseModel, Field
 from sqlalchemy import exists, select, update
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from starlette.status import (
-    HTTP_202_ACCEPTED,
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
 from strawberry.relay import GlobalID
 
 from phoenix.config import DEFAULT_PROJECT_NAME
@@ -440,7 +434,7 @@ class SpansResponseBody(PaginatedResponseBody[Span]):
     "/spans",
     operation_id="querySpans",
     summary="Query spans with query DSL",
-    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY]),
+    responses=add_errors_to_responses([404, 422]),
     include_in_schema=False,
 )
 async def query_spans_handler(
@@ -467,7 +461,7 @@ async def query_spans_handler(
     except Exception as e:
         raise HTTPException(
             detail=f"Invalid query: {e}",
-            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=422,
         )
 
     async with request.app.state.db() as session:
@@ -490,7 +484,7 @@ async def query_spans_handler(
             )
             results.append(df)
     if not results:
-        raise HTTPException(status_code=HTTP_404_NOT_FOUND)
+        raise HTTPException(status_code=404)
 
     if accept == "application/json":
         boundary_token = token_urlsafe(64)
@@ -574,7 +568,7 @@ def _to_any_value(value: Any) -> OtlpAnyValue:
     summary="Search spans with simple filters (no DSL)",
     description="Return spans within a project filtered by time range. "
     "Supports cursor-based pagination.",
-    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY]),
+    responses=add_errors_to_responses([404, 422]),
 )
 async def span_search_otlpv1(
     request: Request,
@@ -617,7 +611,7 @@ async def span_search_otlpv1(
             cursor_rowid = int(GlobalID.from_id(cursor).node_id)
             stmt = stmt.where(models.Span.id <= cursor_rowid)
         except Exception:
-            raise HTTPException(status_code=HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor")
+            raise HTTPException(status_code=422, detail="Invalid cursor")
 
     stmt = stmt.limit(limit + 1)
 
@@ -711,7 +705,7 @@ async def span_search_otlpv1(
     summary="List spans with simple filters (no DSL)",
     description="Return spans within a project filtered by time range. "
     "Supports cursor-based pagination.",
-    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY]),
+    responses=add_errors_to_responses([404, 422]),
 )
 async def span_search(
     request: Request,
@@ -751,7 +745,7 @@ async def span_search(
         try:
             cursor_rowid = int(GlobalID.from_id(cursor).node_id)
         except Exception:
-            raise HTTPException(status_code=HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor")
+            raise HTTPException(status_code=422, detail="Invalid cursor")
         stmt = stmt.where(models.Span.id <= cursor_rowid)
 
     stmt = stmt.limit(limit + 1)
@@ -867,9 +861,7 @@ class AnnotateSpansResponseBody(ResponseBody[list[InsertedSpanAnnotation]]):
     dependencies=[Depends(is_not_locked)],
     operation_id="annotateSpans",
     summary="Create span annotations",
-    responses=add_errors_to_responses(
-        [{"status_code": HTTP_404_NOT_FOUND, "description": "Span not found"}]
-    ),
+    responses=add_errors_to_responses([{"status_code": 404, "description": "Span not found"}]),
     response_description="Span annotations inserted successfully",
     include_in_schema=True,
 )
@@ -915,7 +907,7 @@ async def annotate_spans(
         if missing_span_ids:
             raise HTTPException(
                 detail=f"Spans with IDs {', '.join(missing_span_ids)} do not exist.",
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
             )
         inserted_ids = []
         dialect = SupportedSQLDialect(session.bind.dialect.name)
@@ -957,8 +949,8 @@ class CreateSpansResponseBody(V1RoutesBaseModel):
         "Submit spans to be inserted into a project. If any spans are invalid or "
         "duplicates, no spans will be inserted."
     ),
-    responses=add_errors_to_responses([HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST]),
-    status_code=HTTP_202_ACCEPTED,
+    responses=add_errors_to_responses([404, 400]),
+    status_code=202,
 )
 async def create_spans(
     request: Request,
@@ -1066,7 +1058,7 @@ async def create_spans(
             "invalid_spans": invalid_spans,
         }
         raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
+            status_code=400,
             detail=json.dumps(error_detail),
         )
 
@@ -1102,7 +1094,7 @@ async def create_spans(
         **Note**: This operation is irreversible and may create orphaned spans.
         """
     ),
-    responses=add_errors_to_responses([HTTP_404_NOT_FOUND]),
+    responses=add_errors_to_responses([404]),
     status_code=204,  # No Content for successful deletion
 )
 async def delete_span(
@@ -1154,7 +1146,7 @@ async def delete_span(
 
         if target_span is None:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=error_detail,
             )
 

--- a/src/phoenix/server/api/routers/v1/users.py
+++ b/src/phoenix/server/api/routers/v1/users.py
@@ -12,15 +12,6 @@ from sqlalchemy.exc import IntegrityError as PostgreSQLIntegrityError
 from sqlalchemy.orm import joinedload
 from sqlean.dbapi2 import IntegrityError as SQLiteIntegrityError  # type: ignore[import-untyped]
 from starlette.datastructures import Secret
-from starlette.status import (
-    HTTP_201_CREATED,
-    HTTP_204_NO_CONTENT,
-    HTTP_400_BAD_REQUEST,
-    HTTP_403_FORBIDDEN,
-    HTTP_404_NOT_FOUND,
-    HTTP_409_CONFLICT,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
 from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias, assert_never
 
@@ -113,7 +104,7 @@ DEFAULT_PAGINATION_PAGE_LIMIT = 100
     response_description="A list of users.",
     responses=add_errors_to_responses(
         [
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            422,
         ],
     ),
     dependencies=[Depends(require_admin)],
@@ -187,12 +178,12 @@ async def list_users(
     summary="Create a new user",
     description="Create a new user with the specified configuration.",
     response_description="The newly created user.",
-    status_code=HTTP_201_CREATED,
+    status_code=201,
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_400_BAD_REQUEST, "description": "Role not found."},
-            {"status_code": HTTP_409_CONFLICT, "description": "Username or email already exists."},
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            {"status_code": 400, "description": "Role not found."},
+            {"status_code": 409, "description": "Username or email already exists."},
+            422,
         ]
     ),
     dependencies=[Depends(require_admin), Depends(is_not_locked)],
@@ -213,14 +204,14 @@ async def create_user(
     # Prevent creation of SYSTEM users
     if role == "SYSTEM":
         raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
+            status_code=400,
             detail="Cannot create users with SYSTEM role",
         )
 
     # TODO: Implement VIEWER role
     if role == "VIEWER":
         raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
+            status_code=400,
             detail="VIEWER role not yet implemented",
         )
 
@@ -259,12 +250,12 @@ async def create_user(
             session.add(user)
     except (PostgreSQLIntegrityError, SQLiteIntegrityError) as e:
         if "users.username" in str(e):
-            raise HTTPException(status_code=HTTP_409_CONFLICT, detail="Username already exists")
+            raise HTTPException(status_code=409, detail="Username already exists")
         elif "users.email" in str(e):
-            raise HTTPException(status_code=HTTP_409_CONFLICT, detail="Email already exists")
+            raise HTTPException(status_code=409, detail="Email already exists")
         else:
             raise HTTPException(
-                status_code=HTTP_409_CONFLICT,
+                status_code=409,
                 detail="Failed to create user due to a conflict with existing data",
             )
     id_ = str(GlobalID("User", str(user.id)))
@@ -314,13 +305,13 @@ async def create_user(
     summary="Delete a user by ID",
     description="Delete an existing user by their unique GlobalID.",
     response_description="No content returned on successful deletion.",
-    status_code=HTTP_204_NO_CONTENT,
+    status_code=204,
     responses=add_errors_to_responses(
         [
-            {"status_code": HTTP_404_NOT_FOUND, "description": "User not found."},
-            HTTP_422_UNPROCESSABLE_ENTITY,
+            {"status_code": 404, "description": "User not found."},
+            422,
             {
-                "status_code": HTTP_403_FORBIDDEN,
+                "status_code": 403,
                 "description": "Cannot delete the default admin or system user",
             },
         ]

--- a/src/phoenix/server/api/routers/v1/utils.py
+++ b/src/phoenix/server/api/routers/v1/utils.py
@@ -3,10 +3,6 @@ from typing import Any, Generic, Optional, TypedDict, TypeVar, Union
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.status import (
-    HTTP_404_NOT_FOUND,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
 from strawberry.relay import GlobalID
 from typing_extensions import TypeAlias, assert_never
 
@@ -135,21 +131,21 @@ async def _get_project_by_identifier(
             name = project_identifier
         except HTTPException:
             raise HTTPException(
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=422,
                 detail=f"Invalid project identifier format: {project_identifier}",
             )
         stmt = select(models.Project).filter_by(name=name)
         project = await session.scalar(stmt)
         if project is None:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=f"Project with name {name} not found",
             )
     else:
         project = await session.get(models.Project, id_)
         if project is None:
             raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
+                status_code=404,
                 detail=f"Project with ID {project_identifier} not found",
             )
     return project

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -45,7 +45,6 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse, Response
 from starlette.staticfiles import StaticFiles
-from starlette.status import HTTP_401_UNAUTHORIZED
 from starlette.templating import Jinja2Templates
 from starlette.types import Scope, StatefulLifespan
 from strawberry.extensions import SchemaExtension
@@ -352,7 +351,7 @@ class RequestOriginHostnameValidator(BaseHTTPMiddleware):
             if not (url := headers.get(key)):
                 continue
             if urlparse(url).hostname not in self._trusted_hostnames:
-                return Response(f"untrusted {key}", status_code=HTTP_401_UNAUTHORIZED)
+                return Response(f"untrusted {key}", status_code=401)
         return await call_next(request)
 
 

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -23,7 +23,6 @@ Usage:
 """
 
 from fastapi import HTTPException, Request
-from fastapi import status as fastapi_status
 
 from phoenix.config import get_env_support_email
 from phoenix.server.bearer_auth import PhoenixUser
@@ -49,7 +48,7 @@ def require_admin(request: Request) -> None:
     # System users have all privileges
     if not (isinstance(user, PhoenixUser) and user.is_admin):
         raise HTTPException(
-            status_code=fastapi_status.HTTP_403_FORBIDDEN,
+            status_code=403,
             detail="Only admin or system users can perform this action.",
         )
 
@@ -82,6 +81,6 @@ def is_not_locked(request: Request) -> None:
         if support_email := get_env_support_email():
             detail += f" Need help? Contact us at {support_email}"
         raise HTTPException(
-            status_code=fastapi_status.HTTP_507_INSUFFICIENT_STORAGE,
+            status_code=507,
             detail=detail,
         )

--- a/src/phoenix/server/bearer_auth.py
+++ b/src/phoenix/server/bearer_auth.py
@@ -9,7 +9,6 @@ from fastapi import HTTPException, Request, WebSocket, WebSocketException
 from grpc_interceptor import AsyncServerInterceptor
 from starlette.authentication import AuthCredentials, AuthenticationBackend, BaseUser
 from starlette.requests import HTTPConnection
-from starlette.status import HTTP_401_UNAUTHORIZED
 from typing_extensions import override
 
 from phoenix import config
@@ -144,16 +143,16 @@ async def is_authenticated(
     """
     assert request or websocket
     if request and not isinstance((user := request.user), PhoenixUser):
-        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token")
     if websocket and not isinstance((user := websocket.user), PhoenixUser):
-        raise WebSocketException(code=HTTP_401_UNAUTHORIZED, reason="Invalid token")
+        raise WebSocketException(code=401, reason="Invalid token")
     if isinstance(user, PhoenixSystemUser):
         return
     claims = user.claims
     if claims.status is ClaimSetStatus.EXPIRED:
-        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Expired token")
+        raise HTTPException(status_code=401, detail="Expired token")
     if claims.status is not ClaimSetStatus.VALID:
-        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(status_code=401, detail="Invalid token")
 
 
 async def create_access_and_refresh_tokens(

--- a/tests/unit/server/test_authorization.py
+++ b/tests/unit/server/test_authorization.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request
 
 from phoenix.server.authorization import require_admin
 from phoenix.server.bearer_auth import PhoenixSystemUser, PhoenixUser
@@ -40,7 +40,7 @@ def test_require_admin_denies_non_admin() -> None:
     req.user = PhoenixUser(user_id, claims)
     with pytest.raises(HTTPException) as exc_info:
         require_admin(req)
-    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.status_code == 403
     assert "Only admin or system users" in str(exc_info.value.detail)
 
 
@@ -49,4 +49,4 @@ def test_require_admin_denies_no_user() -> None:
     req.user = None
     with pytest.raises(HTTPException) as exc_info:
         require_admin(req)
-    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
> DeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.