### PR TITLE
feat: Add GPT-5 support to Azure OpenAI models

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/models/openai.py
@@ -560,7 +560,7 @@ def _get_token_param_str(is_azure: bool, model: str) -> str:
     However, Azure OpenAI models currently do not support
     max_completion_tokens unless it's an o1 or o3 model.
     """
-    azure_reasoning_models = ("o1", "o3", "o4")
+    azure_reasoning_models = ("o1", "o3", "o4", "gpt-5")
     if is_azure and not model.startswith(azure_reasoning_models):
         return "max_tokens"
     return "max_completion_tokens"


### PR DESCRIPTION
GPT-5 is considered an Azure "reasoning model" and uses the `max_completion_tokens` parameter

https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning?tabs=gpt-5%2Cpython%2Cpy