### PR TITLE
fix(dataset): correct Python code for dataset retrieval

### DIFF
--- a/app/src/pages/dataset/DatasetCodeButton.tsx
+++ b/app/src/pages/dataset/DatasetCodeButton.tsx
@@ -50,10 +50,10 @@ function DatasetCodeDialogContent() {
 
   const pythonCode = useMemo(() => {
     return (
-      `import phoenix as px\n\n` +
-      `client = px.Client()\n` +
+      `from phoenix.client import Client\n\n` +
+      `client = Client()\n` +
       `# Get the current dataset version\n` +
-      `dataset = client.get_dataset(id="${datasetId}"${version ? `, version_id="${version.id}"` : ""})`
+      `dataset = client.datasets.get_dataset(dataset="${datasetId}"${version ? `, version_id="${version.id}"` : ""})`
     );
   }, [datasetId, version]);
 


### PR DESCRIPTION
fixes #9835

Fixed the component that display the code snippet to reflect latest version of using the ```Client```