### PR TITLE
docs: Use the built-in instrumentor from google-adk

### DIFF
--- a/docs/section-integrations/python/google-adk/google-adk-tracing.md
+++ b/docs/section-integrations/python/google-adk/google-adk-tracing.md
@@ -148,8 +148,7 @@ remote_agent = agent_engines.create(
         "NO_PROXY": "app.phoenix.arize.com",
         "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.phoenix.arize.com/s/your-space",
         "OTEL_EXPORTER_OTLP_TIMEOUT": "60000",  # 60 seconds,
-        "ARIZE_API_KEY": "YOUR_ARIZE_API_KEY",
-        "ARIZE_SPACE_ID": "YOUR_ARIZE_SPACE_ID",
+        "PHOENIX_API_KEY": "YOUR_PHOENIX_API_KEY",
     }
 )
 ```


### PR DESCRIPTION
The Vertex AI `google-adk` package now includes a `build_instrumentor()` method. 
Updated the documentation to use this official implementation instead of the AgentModule solution (which is not well-documented in vertex).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps Google ADK tracing docs for Vertex AI Agent Engine to use `AdkApp` with `instrumentor_builder`, updates env vars, and simplifies the agent module example.
> 
> - **Docs (Google ADK Tracing)**:
>   - **Agent Engine deployment**:
>     - Replace `ModuleAgent` approach with `vertexai.agent_engines.AdkApp` using `enable_tracing=True` and `instrumentor_builder` (`build_instrumentor`).
>     - Update remote deployment snippet to pass `agent_engine=app` and revised `env_vars` (Phoenix endpoint, API key, logging, timeout, NO_PROXY).
>     - Simplify agent module (`adk_agent.py`) to only define `root_agent`; move instrumentation to the main app via builder.
>   - **Resources**: Add link to VertexAI ADK template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a612e4334938c0864b89d0e1022642fc332647d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->