### PR TITLE
docs: llm ops update

### DIFF
--- a/tutorials/llm_ops_overview.ipynb
+++ b/tutorials/llm_ops_overview.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "lTormFlpkh_z"
+   },
    "source": [
     "<center>\n",
     "    <p style=\"text-align:center\">\n",
@@ -22,29 +24,22 @@
     "It has the following sections:\n",
     "\n",
     "1. Understanding LLM-powered applications\n",
-    "2. Observing the application using traces\n",
-    "3. Evaluating the application using LLM Evals\n",
-    "4. Exploring and and troubleshooting the application using UMAP projection and clustering\n",
+    "2. Observing a RAG application using spans and traces\n",
+    "3. Evaluating the RAG application using LLM Evals\n",
     "\n",
-    "⚠️ This tutorial requires an OpenAI key to run\n",
+    "⚠️ This tutorial requires an OpenAI key and a [Phoenix Cloud](https://app.phoenix.arize.com/) account to run\n",
     "\n",
     "\n",
     "## Understanding LLM powered applications\n",
     "\n",
-    "Building software with LLMs, or any machine learning model, is [fundamentally different](https://karpathy.medium.com/software-2-0-a64152b37c35). Rather than compiling source code into binary to run a series of commands, we need to navigate datasets, embeddings, prompts, and parameter weights to generate consistent accurate results. LLM outputs are probabilistic and therefore don't produce the same deterministic outcome every time.\n",
-    "\n",
-    "<img src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/blog/5_steps_of_building_llm_app.png\" width=\"1100\" />\n",
-    "\n",
-    "There's a lot that can go into building an LLM application, but let's focus on the architecture. Below is a diagram of one possible architecture. In this diagram we see that the application is built around an LLM but that there are many other components that are needed to make the application work.\n",
-    "\n",
-    "<img src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/blog/llm_app_architecture.png\" width=\"1100\" />\n",
-    "\n",
-    "The complexity that is involved in building an LLM application is why observability is so important. Observability is the ability to understand the internal state of a system by examining its inputs and outputs. Each step of the response generation process needs to be monitored, evaluated and tuned to provide the best possible experience. Not only that, certain tradeoffs might need to be made to optimize for speed, cost, or accuracy. In the context of LLM applications, we need to be able to understand the internal state of the system by examining telemetry data such as LLM Traces.\n"
+    "Building software with LLMs, or any machine learning model, is [fundamentally different](https://karpathy.medium.com/software-2-0-a64152b37c35). Rather than compiling source code into binary to run a series of commands, we need to navigate datasets, embeddings, prompts, and parameter weights to generate consistent accurate results. LLM outputs are probabilistic and therefore don't produce the same deterministic outcome every time."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "brp39fbNkh_1"
+   },
    "source": [
     "## Observing the application using traces\n",
     "\n",
@@ -59,16 +54,22 @@
     "<img src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/blog/span_kinds.png\" width=\"1100\"/>\n",
     "\n",
     "\n",
-    "By capturing the building blocks of your application while it's running, phoenix can provide a more complete picture of the inner workings of your application. To illustrate this, let's look at an example LLM application and inspect it's traces."
+    "A trace is a collection of related spans that together represent a complete workflow, such as a single request to an application or one run of an agent.\n",
+    "\n",
+    "By capturing the building blocks of your application while it's running, Phoenix can provide a more complete picture of the inner workings of your application. To illustrate this, let's look at an example LLM application and inspect it's traces."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "uHG-eqAukh_1"
+   },
    "source": [
     "### Traces and Spans in action\n",
     "\n",
-    "Let's build a relatively simple LLM-powered application that will answer questions about Arize AI. This example uses LlamaIndex for RAG and OpenAI as the LLM but you could use any LLM you would like. The details of the application are not important, but the architecture is. Let's get started."
+    "Let's build a relatively simple LLM-powered application that will answer questions about Arize AI. This example uses LlamaIndex for RAG and OpenAI as the LLM but you could use any LLM you would like. The details of the application are not important, but the architecture is.\n",
+    "\n",
+    "Let's get started. First, you will need to install dependencies and set up keys. You can get your [Phoenix Cloud](https://app.phoenix.arize.com/) keys in the Settings page of your account."
    ]
   },
   {
@@ -77,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -Uqq arize-phoenix llama-index-llms-openai llama-index-embeddings-openai \"openai>=1\" gcsfs nest_asyncio openinference-instrumentation-llama_index"
+    "%pip install -Uqq arize-phoenix llama-index-llms-openai llama-index-embeddings-openai openai gcsfs nest_asyncio openinference-instrumentation-llama_index openinference-instrumentation-openai"
    ]
   },
   {
@@ -89,10 +90,23 @@
     "import os\n",
     "from getpass import getpass\n",
     "\n",
-    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
-    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\"🔑 Enter your OpenAI API key: \")\n",
     "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+    "if \"PHOENIX_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"PHOENIX_API_KEY\"] = getpass(\"🔑 Enter your Phoenix API key: \")\n",
+    "\n",
+    "if \"PHOENIX_COLLECTOR_ENDPOINT\" not in os.environ:\n",
+    "    os.environ[\"PHOENIX_COLLECTOR_ENDPOINT\"] = getpass(\"🔑 Enter your Phoenix Collector Endpoint: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "T5xpDzOnAkmg"
+   },
+   "source": [
+    "Next, we will configure tracing using the `register` function."
    ]
   },
   {
@@ -101,23 +115,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import phoenix as px\n",
-    "\n",
-    "px.launch_app().view()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
-    "\n",
     "from phoenix.otel import register\n",
     "\n",
-    "tracer_provider = register(endpoint=\"http://127.0.0.1:6006/v1/traces\")\n",
-    "LlamaIndexInstrumentor().instrument(skip_dep_check=True, tracer_provider=tracer_provider)"
+    "tracer_provider = register(auto_instrument=True, project_name=\"llm-ops\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5BUg7yRQArG6"
+   },
+   "source": [
+    "The following block of code initializes a query engine that enables RAG by querying the indexed documents to provide context-aware answers."
    ]
   },
   {
@@ -134,8 +143,6 @@
     ")\n",
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.llms.openai import OpenAI\n",
-    "\n",
-    "import phoenix as px\n",
     "\n",
     "file_system = GCSFileSystem(project=\"public-assets-275721\")\n",
     "index_path = \"arize-phoenix-assets/datasets/unstructured/llm/llama-index/arize-docs/index/\"\n",
@@ -154,9 +161,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "XjSWOT5Ikh_2"
+   },
    "source": [
-    "Now that we have an application setup, let's take a look inside."
+    "Now that we have an application setup, let'squery it and take a look inside."
    ]
   },
   {
@@ -165,7 +174,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openinference.semconv.trace import SpanAttributes\n",
+    "from opentelemetry import trace\n",
     "from tqdm import tqdm\n",
+    "\n",
+    "tracer = trace.get_tracer(__name__)\n",
     "\n",
     "queries = [\n",
     "    \"How can I query for a monitor's status using GraphQL?\",\n",
@@ -175,180 +188,49 @@
     "]\n",
     "\n",
     "for query in tqdm(queries):\n",
-    "    response = query_engine.query(query)\n",
-    "    print(f\"Query: {query}\")\n",
-    "    print(f\"Response: {response}\")"
+    "    with tracer.start_as_current_span(\"Query\") as span:\n",
+    "        span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, \"chain\")\n",
+    "        span.set_attribute(SpanAttributes.INPUT_VALUE, query)\n",
+    "        response = query_engine.query(query)\n",
+    "        span.set_attribute(SpanAttributes.OUTPUT_VALUE, response)\n",
+    "        print(f\"Query: {query}\")\n",
+    "        print(f\"Response: {response}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "tWvY9gbMkh_2"
+   },
    "source": [
     "Now that we've run the application a few times, let's take a look at the traces in the UI"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iQm9sdjYkh_2"
+   },
    "source": [
-    "print(\"The Phoenix UI:\", px.active_session().url)"
+    "The UI will give you an interactive troubleshooting experience. You can sort, filter, and search for traces. You can also view the detail of each trace to better understand what happened during the response generation process."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "Zs5y32e2BCnd"
+   },
    "source": [
-    "The UI will give you an interactive troubleshooting experience. You can sort, filter, and search for traces. You can also view the detail of each trace to better understand what happened during the response generation process.\n",
-    "\n",
-    "<img src=\"https://storage.googleapis.com/arize-phoenix-assets/assets/images/trace_details_view.png\" width=\"1100\"/>"
+    "![RAG app trace](https://storage.googleapis.com/arize-phoenix-assets/assets/images/llm-ops-rag-app.png)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "WX4pp4ezkh_2"
+   },
    "source": [
     "In addition to being able to view the traces in the UI, you can also query for traces to use as pandas dataframes in your notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spans_df = px.Client().get_spans_dataframe()\n",
-    "spans_df[[\"name\", \"span_kind\", \"attributes.input.value\", \"attributes.retrieval.documents\"]].head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "With just a few lines of code, we have managed to gain visibility into the inner workings of our application. We can now better understand how things like retrieval, prompts, and parameter weights could be affecting our application. But what can we do with this information? Let's take a look at how to use LLM evals to evaluate our application."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    input(\"The tutorial is about to move on to the evaluation section. Continue [Y/n]?\")\n",
-    "    .lower()\n",
-    "    .startswith(\"n\")\n",
-    "):\n",
-    "    assert False, \"notebook stopped\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Evaluating the application using LLM Evals\n",
-    "\n",
-    "Evaluation should serve as the primary metric for assessing your application. It determines whether the app will produce accurate responses based on the data sources and range of queries.\n",
-    "\n",
-    "While it's beneficial to examine individual queries and responses, this approach is impractical as the volume of edge-cases and failures increases. Instead, it's more effective to establish a suite of metrics and automated evaluations. These tools can provide insights into overall system performance and can identify specific areas that may require scrutiny.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's first convert our traces into a workable datasets"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from phoenix.session.evaluation import get_qa_with_reference, get_retrieved_documents\n",
-    "\n",
-    "retrieved_documents_df = get_retrieved_documents(px.active_session())\n",
-    "queries_df = get_qa_with_reference(px.active_session())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now use Phoenix's LLM Evals to evaluate these queries. LLM Evals uses an LLM to grade your application based on different criteria. For this example we will use the evals library to see if any `hallucinations` are present and if the `Q&A Correctness` is good (whether or not the application answers the question correctly)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import nest_asyncio\n",
-    "\n",
-    "from phoenix.evals import (\n",
-    "    HALLUCINATION_PROMPT_RAILS_MAP,\n",
-    "    HALLUCINATION_PROMPT_TEMPLATE,\n",
-    "    QA_PROMPT_RAILS_MAP,\n",
-    "    QA_PROMPT_TEMPLATE,\n",
-    "    OpenAIModel,\n",
-    "    llm_classify,\n",
-    ")\n",
-    "\n",
-    "nest_asyncio.apply()  # Speeds up OpenAI API calls\n",
-    "\n",
-    "# Check if the application has any indications of hallucinations\n",
-    "hallucination_eval = llm_classify(\n",
-    "    data=queries_df,\n",
-    "    model=OpenAIModel(model=\"gpt-4o\", temperature=0.0),\n",
-    "    template=HALLUCINATION_PROMPT_TEMPLATE,\n",
-    "    rails=list(HALLUCINATION_PROMPT_RAILS_MAP.values()),\n",
-    "    provide_explanation=True,  # Makes the LLM explain its reasoning\n",
-    ")\n",
-    "hallucination_eval[\"score\"] = (\n",
-    "    hallucination_eval.label[~hallucination_eval.label.isna()] == \"factual\"\n",
-    ").astype(int)\n",
-    "\n",
-    "# Check if the application is answering questions correctly\n",
-    "qa_correctness_eval = llm_classify(\n",
-    "    data=queries_df,\n",
-    "    model=OpenAIModel(model=\"gpt-4o\", temperature=0.0),\n",
-    "    template=QA_PROMPT_TEMPLATE,\n",
-    "    rails=list(QA_PROMPT_RAILS_MAP.values()),\n",
-    "    provide_explanation=True,  # Makes the LLM explain its reasoning\n",
-    "    concurrency=4,\n",
-    ")\n",
-    "\n",
-    "qa_correctness_eval[\"score\"] = (\n",
-    "    qa_correctness_eval.label[~qa_correctness_eval.label.isna()] == \"correct\"\n",
-    ").astype(int)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hallucination_eval.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qa_correctness_eval.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As you can see from the results, one of the queries was flagged as a hallucination. Let's log these results to the phoenix server to view the hallucinations in the UI."
    ]
   },
   {
@@ -360,23 +242,7 @@
     "from phoenix.client import AsyncClient\n",
     "\n",
     "px_client = AsyncClient()\n",
-    "await px_client.spans.log_span_annotations_dataframe(\n",
-    "    dataframe=hallucination_eval,\n",
-    "    annotation_name=\"Hallucination\",\n",
-    "    annotator_kind=\"LLM\",\n",
-    ")\n",
-    "await px_client.spans.log_span_annotations_dataframe(\n",
-    "    dataframe=qa_correctness_eval,\n",
-    "    annotation_name=\"QA Correctness\",\n",
-    "    annotator_kind=\"LLM\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now that we have the hallucinations logged, let's take a look at them in the UI. You will notice that the traces that correspond to hallucinations are clearly marked in the UI and you can now query for them!"
+    "primary_df = await px_client.spans.get_spans_dataframe(project_identifier=\"llm-ops\")"
    ]
   },
   {
@@ -385,40 +251,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"The Phoenix UI:\", px.active_session().url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We've now identified that there are certain queries that are resulting in hallucinations or incorrect answers. Let's see if we can use LLM Evals to identify if these issues are caused by the retrieval process for RAG. We are going to use an LLM to grade whether or not the chunks retrieved are relevant to the query."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from phoenix.evals import (\n",
-    "    RAG_RELEVANCY_PROMPT_RAILS_MAP,\n",
-    "    RAG_RELEVANCY_PROMPT_TEMPLATE,\n",
-    "    OpenAIModel,\n",
-    "    llm_classify,\n",
-    ")\n",
-    "\n",
-    "retrieved_documents_eval = llm_classify(\n",
-    "    data=retrieved_documents_df,\n",
-    "    model=OpenAIModel(model=\"gpt-4o\", temperature=0.0),\n",
-    "    template=RAG_RELEVANCY_PROMPT_TEMPLATE,\n",
-    "    rails=list(RAG_RELEVANCY_PROMPT_RAILS_MAP.values()),\n",
-    "    provide_explanation=True,\n",
-    ")\n",
-    "\n",
-    "retrieved_documents_eval[\"score\"] = (\n",
-    "    retrieved_documents_eval.label[~retrieved_documents_eval.label.isna()] == \"relevant\"\n",
-    ").astype(int)"
+    "spans_df = primary_df[\n",
+    "    [\n",
+    "        \"name\",\n",
+    "        \"span_kind\",\n",
+    "        \"context.trace_id\",\n",
+    "        \"attributes.llm.input_messages\",\n",
+    "        \"attributes.llm.output_messages\",\n",
+    "        \"attributes.retrieval.documents\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {
@@ -427,79 +269,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retrieved_documents_eval.head()"
+    "spans_df"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "qXIarX-mkh_3"
+   },
    "source": [
-    "Looks like we are getting a lot of irrelevant chunks of text that might be polluting the prompt sent to the LLM. Let's log these evals to phoenix, at which point phoenix will automatically calculate retrieval metrics for us."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from phoenix.trace import DocumentEvaluations\n",
-    "\n",
-    "px.Client().log_evaluations(\n",
-    "    DocumentEvaluations(eval_name=\"Relevance\", dataframe=retrieved_documents_eval)\n",
-    ")"
+    "With just a few lines of code, we have managed to gain visibility into the inner workings of our application. We can now better understand how things like retrieval, prompts, and parameter weights could be affecting our application. But what can we do with this information? Let's take a look at how to use LLM evals to evaluate our application."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "ihZT429Pkh_3"
+   },
    "source": [
-    "If we once again visit the UI, we will now see that Phoenix has aggregated up retrieval metrics (`precision`, `ndcg`, and `hit`). We see that our hallucinations and incorrect answers directly correlate to bad retrieval!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"The Phoenix UI:\", px.active_session().url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://raw.githubusercontent.com/Arize-ai/phoenix-assets/main/images/screenshots/document_evals_on_traces.png\" />\n",
+    "## Evaluating the application using LLM Evals (Trace-level Evaluations)\n",
     "\n",
-    "There are many more evaluations metrics that can be used to make determinations about the quality of your application. Phoenix supports evaluating not only traces but individual spans (such as retrievers) as well as performing retrieval analysis for your document chunks. Evaluation metrics can also be customized for your specific use-case. For more details, consult the phoenix docs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    input(\"The tutorial is about to move on to the analysis section. Continue [Y/n]?\")\n",
-    "    .lower()\n",
-    "    .startswith(\"n\")\n",
-    "):\n",
-    "    assert False, \"notebook stopped\"\n",
+    "Evaluation should serve as the primary metric for assessing your application. It determines whether the app will produce accurate responses based on the data sources and range of queries.\n",
     "\n",
-    "px.close_app()  # Close the Phoenix UI"
+    "While it's beneficial to examine individual queries and responses, this approach is impractical as the volume of edge-cases and failures increases. Instead, it's more effective to establish a suite of metrics and automated evaluations. These tools can provide insights into overall system performance and can identify specific areas that may require scrutiny.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "YbMTuUQEkh_3"
+   },
    "source": [
-    "## Exploring and and troubleshooting the application using UMAP projection and clustering\n",
+    "We can now use Phoenix's LLM Evals to evaluate these queries. LLM Evals uses an LLM to grade your application based on different criteria. For this example we will use the evals library to see if any `hallucinations` are present and if the `Q&A Correctness` is good (whether or not the application answers the question correctly).\n",
     "\n",
-    "We have so far figured out how to trace our application and how to evaluate it. But what if we need to understand the application at a higher level? What if we need to understand if the application is performing badly for a certain topic or if there are any patterns in the data that we can use to improve the application? This is where UMAP projection and clustering comes in. UMAP and clustering let's you view the query embeddings of your application in a 3D space. This allows you to see patterns in the data and understand how your application is performing in various clusters (semantic groups).\n",
-    "\n",
-    "Since we only ran the application for 4 queries, we won't be able to see any patterns in the data. Let's pull in a larger dataset of queries and run the application again."
+    "We will evaluate at the trace level, meaning the evaluation will consider the entire request in full context. This differs from span-level evaluations, which focus on assessing individual steps within the workflow."
    ]
   },
   {
@@ -510,70 +313,24 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "# Pull in queries from the LLM\n",
-    "query_df = pd.read_parquet(\n",
-    "    \"http://storage.googleapis.com/arize-phoenix-assets/datasets/unstructured/llm/llama-index/arize-docs/query_data_complete3.parquet\",\n",
-    ")\n",
-    "\n",
-    "query_ds = px.Inferences.from_open_inference(query_df)\n",
-    "\n",
-    "query_ds.dataframe.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's also pull in the embeddings for our knowledge base. This will allow us to see how how document chunks are being retrieved by the application."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "\n",
-    "def storage_context_to_dataframe(storage_context: StorageContext) -> pd.DataFrame:\n",
-    "    \"\"\"Converts the storage context to a pandas dataframe.\n",
-    "\n",
-    "    Args:\n",
-    "        storage_context (StorageContext): Storage context containing the index\n",
-    "        data.\n",
-    "\n",
-    "    Returns:\n",
-    "        pd.DataFrame: The dataframe containing the index data.\n",
-    "    \"\"\"\n",
-    "    document_ids = []\n",
-    "    document_texts = []\n",
-    "    document_embeddings = []\n",
-    "    docstore = storage_context.docstore\n",
-    "    vector_store = storage_context.vector_store\n",
-    "    for node_id, node in docstore.docs.items():\n",
-    "        document_ids.append(node.hash)  # use node hash as the document ID\n",
-    "        document_texts.append(node.text)\n",
-    "        document_embeddings.append(np.array(vector_store.get(node_id)))\n",
-    "    return pd.DataFrame(\n",
+    "trace_df = (\n",
+    "    spans_df.groupby(\"context.trace_id\")\n",
+    "    .agg(\n",
     "        {\n",
-    "            \"document_id\": document_ids,\n",
-    "            \"text\": document_texts,\n",
-    "            \"text_vector\": document_embeddings,\n",
+    "            \"attributes.llm.input_messages\": lambda x: \" \".join(x.dropna().astype(str)),\n",
+    "            \"attributes.llm.output_messages\": lambda x: \" \".join(x.dropna().astype(str)),\n",
+    "            \"attributes.retrieval.documents\": lambda x: \" \".join(x.dropna().astype(str)),\n",
     "        }\n",
     "    )\n",
-    "\n",
-    "\n",
-    "database_df = storage_context_to_dataframe(storage_context)\n",
-    "database_df = database_df.drop_duplicates(subset=[\"text\"])\n",
-    "database_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's now launch Phoenix with these two datasets."
+    "    .rename(\n",
+    "        columns={\n",
+    "            \"attributes.llm.input_messages\": \"input\",\n",
+    "            \"attributes.llm.output_messages\": \"output\",\n",
+    "            \"attributes.retrieval.documents\": \"reference\",\n",
+    "        }\n",
+    "    )\n",
+    "    .reset_index()\n",
+    ")"
    ]
   },
   {
@@ -582,67 +339,324 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# get a random sample of 500 documents (including retrieved documents)\n",
-    "# this will be handled by by the application in a coming release\n",
-    "num_sampled_point = 500\n",
-    "retrieved_document_ids = set(\n",
-    "    [\n",
-    "        doc_id\n",
-    "        for doc_ids in query_df[\":feature.[str].retrieved_document_ids:prompt\"].to_list()\n",
-    "        for doc_id in doc_ids\n",
-    "    ]\n",
-    ")\n",
-    "retrieved_document_mask = database_df[\"document_id\"].isin(retrieved_document_ids)\n",
-    "num_retrieved_documents = len(retrieved_document_ids)\n",
-    "num_additional_samples = num_sampled_point - num_retrieved_documents\n",
-    "unretrieved_document_mask = ~retrieved_document_mask\n",
-    "sampled_unretrieved_document_ids = set(\n",
-    "    database_df[unretrieved_document_mask][\"document_id\"]\n",
-    "    .sample(n=num_additional_samples, random_state=0)\n",
-    "    .to_list()\n",
-    ")\n",
-    "sampled_unretrieved_document_mask = database_df[\"document_id\"].isin(\n",
-    "    sampled_unretrieved_document_ids\n",
-    ")\n",
-    "sampled_document_mask = retrieved_document_mask | sampled_unretrieved_document_mask\n",
-    "sampled_database_df = database_df[sampled_document_mask]\n",
+    "trace_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HALLUCINATION_PROMPT_TEMPLATE = \"\"\"\n",
+    "In this task, you will be presented with a query, a reference text and an answer. The answer is\n",
+    "generated to the question based on the reference text. The answer may contain false information. You\n",
+    "must use the reference text to determine if the answer to the question contains false information,\n",
+    "if the answer is a hallucination of facts. Your objective is to determine whether the answer text\n",
+    "contains factual information and is not a hallucination. A 'hallucination' refers to\n",
+    "an answer that is not based on the reference text or assumes information that is not available in\n",
+    "the reference text.\n",
     "\n",
-    "database_schema = px.Schema(\n",
-    "    prediction_id_column_name=\"document_id\",\n",
-    "    prompt_column_names=px.EmbeddingColumnNames(\n",
-    "        vector_column_name=\"text_vector\",\n",
-    "        raw_data_column_name=\"text\",\n",
-    "    ),\n",
-    ")\n",
-    "database_ds = px.Inferences(\n",
-    "    dataframe=sampled_database_df,\n",
-    "    schema=database_schema,\n",
-    "    name=\"database\",\n",
+    "    [BEGIN DATA]\n",
+    "    ************\n",
+    "    [Query]: {{input}}\n",
+    "    ************\n",
+    "    [Reference text]: {{reference}}\n",
+    "    ************\n",
+    "    [Answer]: {{output}}\n",
+    "    ************\n",
+    "    [END DATA]\n",
+    "\n",
+    "    Is the answer above factual or hallucinated based on the query and reference text?\n",
+    "\n",
+    "Please read the query, reference text and answer carefully, then write out in a step by step manner\n",
+    "an EXPLANATION to show how to determine if the answer is \"factual\" or \"hallucinated\". Avoid simply\n",
+    "stating the correct answer at the outset. Your response LABEL should be a single word: either\n",
+    "\"factual\" or \"hallucinated\", and it should not include any other text or characters. \"hallucinated\"\n",
+    "indicates that the answer provides factually inaccurate information to the query based on the\n",
+    "reference text. \"factual\" indicates that the answer to the question is correct relative to the\n",
+    "reference text, and does not contain made up information.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QA_PROMPT_TEMPLATE = \"\"\"\n",
+    "You are given a question, an answer and reference text. You must determine whether the\n",
+    "given answer correctly answers the question based on the reference text. Here is the data:\n",
+    "    [BEGIN DATA]\n",
+    "    ************\n",
+    "    [Question]: {{input}}\n",
+    "    ************\n",
+    "    [Reference]: {{reference}}\n",
+    "    ************\n",
+    "    [Answer]: {{output}}\n",
+    "    [END DATA]\n",
+    "Please read the query, reference text and answer carefully, then write out in a step by step manner\n",
+    "an EXPLANATION to show how to determine if the answer is \"correct\" or \"incorrect\". Avoid simply\n",
+    "stating the correct answer at the outset. Your response LABEL must be a single word, either\n",
+    "\"correct\" or \"incorrect\", and should not contain any text or characters aside from that word.\n",
+    "\"correct\" means that the question is correctly and fully answered by the answer.\n",
+    "\"incorrect\" means that the question is not correctly or only partially answered by the\n",
+    "answer.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openinference.instrumentation import suppress_tracing\n",
+    "\n",
+    "from phoenix.evals import create_classifier\n",
+    "from phoenix.evals.evaluators import async_evaluate_dataframe\n",
+    "from phoenix.evals.llm import LLM\n",
+    "\n",
+    "llm = LLM(provider=\"openai\", model=\"gpt-5\")\n",
+    "\n",
+    "\n",
+    "hallucination_evaluator = create_classifier(\n",
+    "    name=\"hallucination\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=HALLUCINATION_PROMPT_TEMPLATE,\n",
+    "    choices={\"factual\": 1.0, \"hallucinated\": 0.0},\n",
     ")\n",
     "\n",
-    "(session := px.launch_app(primary=query_ds, corpus=database_ds, run_in_thread=False)).View()"
+    "qa_evaluator = create_classifier(\n",
+    "    name=\"q&a\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=QA_PROMPT_TEMPLATE,\n",
+    "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
+    ")\n",
+    "\n",
+    "with suppress_tracing():\n",
+    "    results_df = await async_evaluate_dataframe(\n",
+    "        dataframe=trace_df,\n",
+    "        evaluators=[hallucination_evaluator, qa_evaluator],\n",
+    "    )\n",
+    "results_df.head()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "RYNmmXOkCgO4"
+   },
    "source": [
-    "Using Phoenix's embedding projection feature, we can now view the query embeddings in a 3D space. What you are looking at is a point-cloud where each point represents a query. When embeddings are projected into a lower dimensional space, UMAP preserves the semantic distance that the embeddings encode. This means that the points that are closer together are more similar. This allows us to see patterns in the data and understand how our application is performing in various clusters. If you click through the clusters, you will see clusters of queries that are significantly farther away from the knowledge base. This means that the knowledge base does not contain enough information to answer the user's question (In this case, the document chunks don't contain any information about pricing. Can you find this cluster?).\n",
+    "After running the evaluaton, we log our traces back to Phoenix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from phoenix.evals.utils import to_annotation_dataframe\n",
     "\n",
-    "Phoenix's embedding view also supports coloring and cluster metrics by evaluations! This means you can use it to find pockets of poor user feedback or hallucinations. Phoenix's embedding view supports embeddings for text, images, and video so a most forms of unstructured data can be analyzed.\n",
+    "root_spans = primary_df[primary_df[\"parent_id\"].isna()][[\"context.trace_id\", \"context.span_id\"]]\n",
     "\n",
-    "Last but not least, Phoenix can draw the connections between queries and the document chunks. This allows you to see which document chunks are being retrieved for each query and to visualize the semantic distance between them.\n",
+    "# Merge results with root spans to align on trace_id\n",
+    "results_with_spans = pd.merge(\n",
+    "    results_df.reset_index(), root_spans, on=\"context.trace_id\", how=\"left\"\n",
+    ").set_index(\"context.span_id\", drop=False)\n",
     "\n",
-    "<img src=\"https://github.com/Arize-ai/phoenix-assets/raw/main/gifs/corpus_search_and_retrieval.gif?raw=true\" />"
+    "# Format for Phoenix logging\n",
+    "annotation_df = to_annotation_dataframe(results_with_spans)\n",
+    "\n",
+    "hallucination_eval_results = annotation_df[\n",
+    "    annotation_df[\"annotation_name\"] == \"hallucination\"\n",
+    "].copy()\n",
+    "qa_eval_results = annotation_df[annotation_df[\"annotation_name\"] == \"q&a\"].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await px_client.annotations.log_span_annotations_dataframe(\n",
+    "    dataframe=hallucination_eval_results,\n",
+    "    annotator_kind=\"LLM\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await px_client.annotations.log_span_annotations_dataframe(\n",
+    "    dataframe=qa_eval_results,\n",
+    "    annotator_kind=\"LLM\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "zdZcFBhXkh_3"
+   },
    "source": [
-    "## Conclusion\n",
+    "Now that we have the evaluation logged, let's take a look at them in the UI. You will notice that the traces that correspond to hallucinations are clearly marked in the UI and you can now query for them!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OeKTvt4Ekh_3"
+   },
+   "source": [
+    "We can use filtering to identify if there are certain queries that are resulting in hallucinations or incorrect answers. In the next section, we will use LLM Evals to identify if these issues are caused by the retrieval process for RAG. We are going to use an LLM to grade whether or not the chunks retrieved are relevant to the query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n_88gNnRDSZC"
+   },
+   "source": [
+    "![eval results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/llm-ops-rag-app-2.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g_Fod69gD_jT"
+   },
+   "source": [
+    "# Further Evaluation on Retrieval Process (Span-level Evaluations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-N5UgQOqELGB"
+   },
+   "source": [
+    "We've now identified if there are certain queries that are resulting in hallucinations or incorrect answers. Let's see if we can use LLM Evals to identify if these issues are caused by the retrieval process for RAG. We are going to use an span-level evluations to grade whether or not the chunks retrieved are relevant to the query.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_df = primary_df[\n",
+    "    (primary_df[\"span_kind\"] == \"RETRIEVER\")\n",
+    "    & (primary_df[\"attributes.retrieval.documents\"].notnull())\n",
+    "]\n",
     "\n",
-    "Phoenix is a powerful companion for building LLM-powered applications. It allows you to observe, evaluate, and explore your application at every step of you development process. For more details, consult the [phoenix docs](https://arize.com/docs/phoenix)."
+    "filtered_df = filtered_df.rename(\n",
+    "    columns={\"attributes.input.value\": \"input\", \"attributes.retrieval.documents\": \"documents\"}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RAG_RELEVANCY_PROMPT_TEMPLATE = \"\"\"\n",
+    "You are comparing a reference text to a question and trying to determine if the reference text\n",
+    "contains information relevant to answering the question. Here is the data:\n",
+    "    [BEGIN DATA]\n",
+    "    ************\n",
+    "    [Question]: {{input}}\n",
+    "    ************\n",
+    "    [Reference text]: {{documents}}\n",
+    "    ************\n",
+    "    [END DATA]\n",
+    "Compare the Question above to the Reference text. You must determine whether the Reference text\n",
+    "contains information that can help answer the Question. First, write out in a step by step manner\n",
+    "an EXPLANATION to show how to arrive at the correct answer. Avoid simply stating the correct answer\n",
+    "at the outset. Your response LABEL must be single word, either \"relevant\" or \"unrelated\", and\n",
+    "should not contain any text or characters aside from that word. \"unrelated\" means that the\n",
+    "reference text does not help answer to the Question. \"relevant\" means the reference text directly\n",
+    "answers the question.\n",
+    "\n",
+    "Example response:\n",
+    "LABEL: \"relevant\" or \"unrelated\"\n",
+    "************\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = LLM(provider=\"openai\", model=\"gpt-5\")\n",
+    "\n",
+    "\n",
+    "relevancy_evaluator = create_classifier(\n",
+    "    name=\"RAG Relevancy\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=RAG_RELEVANCY_PROMPT_TEMPLATE,\n",
+    "    choices={\"relevant\": 1.0, \"unrelated\": 0.0},\n",
+    ")\n",
+    "\n",
+    "with suppress_tracing():\n",
+    "    results_df = await async_evaluate_dataframe(\n",
+    "        dataframe=filtered_df,\n",
+    "        evaluators=[relevancy_evaluator],\n",
+    "    )\n",
+    "results_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HuFknaEkSeSb"
+   },
+   "source": [
+    "Finally, we log our span level evaluations back to Phoenix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relevancy_eval_df = to_annotation_dataframe(results_df)\n",
+    "\n",
+    "await px_client.annotations.log_span_annotations_dataframe(\n",
+    "    dataframe=relevancy_eval_df,\n",
+    "    annotator_kind=\"LLM\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N_I1aNfeSkKo"
+   },
+   "source": [
+    "To inspect span-level evaluations, go to the Annotations tab for the span.\n",
+    "\n",
+    "This view reveals how well the retrieved documents performed in terms of quality. In this case, while the application did not hallucinate (as confirmed by the trace-level evaluation), the span-level assessment showed that the retrieved documents weren’t of high quality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BzhL3z20ShpY"
+   },
+   "source": [
+    "![Span Eval Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/llm-ops-rag-3.png)"
    ]
   }
  ],
@@ -652,5 +666,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rewrites the LLM Ops tutorial to use Phoenix Cloud with auto-instrumented tracing, async client/data APIs, and updated trace- and span-level LLM evaluation workflows.
> 
> - **Tutorial scope and prerequisites**
>   - Rename sections to focus on RAG spans/traces; require Phoenix Cloud account and keys.
> - **Tracing setup**
>   - Replace local app/manual instrumentor with `phoenix.otel.register(auto_instrument=True, project_name="llm-ops")` and add explicit OpenTelemetry span around queries.
>   - Update installs to include `openinference-instrumentation-openai`; adjust OpenAI package pinning.
>   - Prompt for and set `OPENAI_API_KEY`, `PHOENIX_API_KEY`, `PHOENIX_COLLECTOR_ENDPOINT`.
> - **Data access**
>   - Switch from `px.Client().get_spans_dataframe()` to `phoenix.client.AsyncClient().spans.get_spans_dataframe(project_identifier="llm-ops")` and select OpenInference fields.
> - **Evaluations**
>   - Introduce trace-level evals by aggregating spans into `trace_df` and evaluating with new `phoenix.evals` (`LLM`, `create_classifier`, `async_evaluate_dataframe`, custom prompt templates; `suppress_tracing`).
>   - Log evals via annotations using `to_annotation_dataframe` and map to root spans.
>   - Add span-level RAG relevancy evaluator and log annotations.
> - **Docs/UX**
>   - Remove UI URL prints; add explanatory text and updated screenshots; minor copy edits.
> - **Notebook/meta**
>   - Add cell metadata ids; update `nbformat_minor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44e8f482500d33617eb7c448673e7f7a502e45f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->