### PR TITLE
docs: updating experiments for llm ops

### DIFF
--- a/tutorials/llm_ops_overview.ipynb
+++ b/tutorials/llm_ops_overview.ipynb
@@ -26,6 +26,7 @@
     "1. Understanding LLM-powered applications\n",
     "2. Observing a RAG application using spans and traces\n",
     "3. Evaluating the RAG application using LLM Evals\n",
+    "4. Learn how to construct an experimentation and evaluation workflow\n",
     "\n",
     "⚠️ This tutorial requires an OpenAI key and a [Phoenix Cloud](https://app.phoenix.arize.com/) account to run\n",
     "\n",
@@ -658,6 +659,231 @@
    "source": [
     "![Span Eval Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/llm-ops-rag-3.png)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yiQSjIQ0obOl"
+   },
+   "source": [
+    "# Creating an experimentation workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BDU80-ofoeDb"
+   },
+   "source": [
+    "At this point, we’ve covered how to trace and evaluate your application data.\n",
+    "\n",
+    "The next step is to add these traces to a dataset. Once your traces are organized in a dataset, you can run experiments to measure how changes in your application affect the evaluation metrics. Below, we’ll walk through an example of this process."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "H18oekgWqq-S"
+   },
+   "source": [
+    "Running an experiment requires three main components: a dataset, a task to execute on that dataset, and evaluators to measure the quality of the task’s outputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qX15R3PNq2Fy"
+   },
+   "source": [
+    "### Define Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "queries = [\n",
+    "    \"How can I query for a monitor's status using GraphQL?\",\n",
+    "    \"How do I delete a model?\",\n",
+    "    \"How much does an enterprise license of Arize cost?\",\n",
+    "    \"How do I log a prediction using the python SDK?\",\n",
+    "    \"What is a trace versus a span?\",\n",
+    "    \"Does Arize AX or Arize Phoenix support TypeScript\",\n",
+    "    \"What is an experiment?\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_df = pd.DataFrame(data={\"query\": queries})\n",
+    "dataset = await px_client.datasets.create_dataset(\n",
+    "    dataframe=dataset_df,\n",
+    "    name=\"arize-questions\",\n",
+    "    input_keys=[\"query\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N_pGKbNdrk3w"
+   },
+   "source": [
+    "If you navigate to the Datasets page of your Arize Phoenix instance, you will see the dataset we just created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BxNufeW7rsDu"
+   },
+   "source": [
+    "### Define Task & Evaluator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_system(input):\n",
+    "    response = query_engine.query(input[\"query\"])\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HALLUCINATION_PROMPT_TEMPLATE = \"\"\"\n",
+    "In this task, you will be presented with a query, a reference text and an answer. The answer is\n",
+    "generated to the question based on the reference text. The answer may contain false information. You\n",
+    "must use the reference text to determine if the answer to the question contains false information,\n",
+    "if the answer is a hallucination of facts. Your objective is to determine whether the answer text\n",
+    "contains factual information and is not a hallucination. A 'hallucination' refers to\n",
+    "an answer that is not based on the reference text or assumes information that is not available in\n",
+    "the reference text.\n",
+    "\n",
+    "    [BEGIN DATA]\n",
+    "    ************\n",
+    "    [Query]: {{input}}\n",
+    "    ************\n",
+    "    [Reference text and Answer]: {{output}}\n",
+    "    ************\n",
+    "    [END DATA]\n",
+    "\n",
+    "    Is the answer above factual or hallucinated based on the query and reference text?\n",
+    "\n",
+    "Please read the query, reference text and answer carefully, then write out in a step by step manner\n",
+    "an EXPLANATION to show how to determine if the answer is \"factual\" or \"hallucinated\". Avoid simply\n",
+    "stating the correct answer at the outset. Your response LABEL should be a single word: either\n",
+    "\"factual\" or \"hallucinated\", and it should not include any other text or characters. \"hallucinated\"\n",
+    "indicates that the answer provides factually inaccurate information to the query based on the\n",
+    "reference text. \"factual\" indicates that the answer to the question is correct relative to the\n",
+    "reference text, and does not contain made up information.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "QA_PROMPT_TEMPLATE = \"\"\"\n",
+    "You are given a question, an answer and reference text. You must determine whether the\n",
+    "given answer correctly answers the question based on the reference text. Here is the data:\n",
+    "    [BEGIN DATA]\n",
+    "    ************\n",
+    "    [Question]: {{input}}\n",
+    "    ************\n",
+    "    [Reference text and Answer]: {{output}}\n",
+    "    ************\n",
+    "    [END DATA]\n",
+    "Please read the query, reference text and answer carefully, then write out in a step by step manner\n",
+    "an EXPLANATION to show how to determine if the answer is \"correct\" or \"incorrect\". Avoid simply\n",
+    "stating the correct answer at the outset. Your response LABEL must be a single word, either\n",
+    "\"correct\" or \"incorrect\", and should not contain any text or characters aside from that word.\n",
+    "\"correct\" means that the question is correctly and fully answered by the answer.\n",
+    "\"incorrect\" means that the question is not correctly or only partially answered by the\n",
+    "answer.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hallucination_evaluator = create_classifier(\n",
+    "    name=\"hallucination\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=HALLUCINATION_PROMPT_TEMPLATE,\n",
+    "    choices={\"factual\": 1.0, \"hallucinated\": 0.0},\n",
+    ")\n",
+    "\n",
+    "qa_evaluator = create_classifier(\n",
+    "    name=\"q&a\",\n",
+    "    llm=llm,\n",
+    "    prompt_template=QA_PROMPT_TEMPLATE,\n",
+    "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jPbaJwflsYHs"
+   },
+   "source": [
+    "### Run Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment = await px_client.experiments.run_experiment(\n",
+    "    dataset=dataset, task=query_system, evaluators=[hallucination_evaluator, qa_evaluator]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8TvYVkDJziva"
+   },
+   "source": [
+    "You will see your experiment and results populate in Phoenix. From here, you can make changes to the RAG application, run the same datasets of examples, and see how the evaluation metrics change!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "uTr0CVpJw71W"
+   },
+   "source": [
+    "![Experiment](https://storage.googleapis.com/arize-phoenix-assets/assets/images/llm-ops-6.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an experimentation workflow to the LLM Ops tutorial, showing how to build a dataset, define a task and LLM evaluators, and run experiments in Phoenix.
> 
> - **Tutorials**: Update `tutorials/llm_ops_overview.ipynb`
>   - **New section**: `Creating an experimentation workflow`
>     - Define dataset from sample `queries`; create via `px_client.datasets.create_dataset`.
>     - Implement task `query_system` using `query_engine.query`.
>     - Add evaluators with `create_classifier` for `hallucination` and `q&a` using custom prompt templates.
>     - Run experiment with `px_client.experiments.run_experiment(dataset, task, evaluators)` and show results image.
>   - Intro list: add item `4. Learn how to construct an experimentation and evaluation workflow`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dc280cf339801bf77ff961383efc544df234768. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->