### PR TITLE
fix: Ensure correct id is used when clicking sessions table row

### DIFF
--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -79,7 +79,7 @@ const TableBody = <T extends { id: string }>({
         return (
           <tr
             key={row.id}
-            onClick={() => navigate(`${encodeURIComponent(row.id)}`)}
+            onClick={() => navigate(`${encodeURIComponent(row.original.id)}`)}
           >
             {row.getVisibleCells().map((cell) => {
               return (


### PR DESCRIPTION
resolves #9894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Row click in `SessionsTable` now navigates to the encoded `row.original.id` instead of `row.id` to use the correct session identifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d07f0b526e5852c3fdf03f4bf95805f728817d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->