### PR TITLE
ci: remove `test_annotations.py` from `mypy` exclude list

### DIFF
--- a/tests/mypy.ini
+++ b/tests/mypy.ini
@@ -3,7 +3,6 @@ strict = true
 exclude = (?x)(
           ^integration/$ # integration tests
           | ^unit/datasets/test_experiments\.py$ # TODO: fix type errors
-          | ^unit/server/api/routers/v1/test_annotations\.py$ # TODO: fix type errors
           )
 
 [mypy-nest_asyncio.*]


### PR DESCRIPTION
Resolves: #5148 

This PR enables mypy type checking for the annotations API unit tests by removing `test_annotations.py` from the exclusion list and adding proper type annotations.

- Removed `unit/server/api/routers/v1/test_annotations.py` from mypy exclude list
- `mypy tests/unit/server/api/routers/v1/test_annotations.py` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables mypy type checking for `unit/server/api/routers/v1/test_annotations.py` by removing it from the exclude pattern in `tests/mypy.ini`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04aab3407ee3f9282f5044bd2131f43275374d96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->