### PR TITLE
fix: version upper bound for wrapt <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "pyarrow",
   "typing-extensions>=4.6",
   "scipy",
-  "wrapt>=1.17.2",
+  "wrapt>=1.17.2,<2",
   "protobuf>=4.25.8",
   "grpcio",
   "grpc-interceptor",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Constrain `wrapt` dependency to `<2` in `pyproject.toml`.
> 
> - **Dependencies**:
>   - Update `pyproject.toml` to constrain `wrapt` from `wrapt>=1.17.2` to `wrapt>=1.17.2,<2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f466e3a5e6f77b028697342239e7e20b372f54d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->