### PR TITLE
refactor: update quickstart link in empty datasets page

### DIFF
--- a/app/src/pages/datasets/DatasetsEmpty.tsx
+++ b/app/src/pages/datasets/DatasetsEmpty.tsx
@@ -38,7 +38,7 @@ export function DatasetsEmpty() {
                 Documentation
               </ExternalLinkButton>
               <ExternalLinkButton
-                href="https://colab.research.google.com/github/arize-ai/phoenix/blob/main/tutorials/experiments/datasets_and_experiments_quickstart.ipynb"
+                href="https://arize.com/docs/phoenix/get-started/get-started-datasets-and-experiments"
                 target="_blank"
                 leadingVisual={<Icon svg={<Icons.Rocket />} />}
               >


### PR DESCRIPTION
https://github.com/Arize-ai/phoenix/issues/9925 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the Quickstart button in `DatasetsEmpty.tsx` to point to the new docs URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5995f4f37d29b91d293535d2c8df18b3cb3310d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->