### PR TITLE
fix: Clear error message for non-existent prompts instead of HTTP 404

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -118,7 +118,7 @@ class Prompts:
             prompt_response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+                raise ValueError(f"Prompt not found: {prompt_version_id or prompt_identifier}")
             raise
         return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 
@@ -389,7 +389,7 @@ class AsyncPrompts:
             prompt_response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+                raise ValueError(f"Prompt not found: {prompt_version_id or prompt_identifier}")
             raise
         return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 


### PR DESCRIPTION
Resolves: #6746

- Catch HTTP 404 responses in the prompt retrieval method
- Raise a descriptive `ValueError` with a clear message indicating the prompt wasn't found
- Maintain all other HTTP error behavior unchanged

Minimal code to reproduce
```py
from phoenix.client import Client

px_client = Client()

prompt_name = "non existant prompt"
px_client.prompts.get(prompt_identifier=prompt_name)
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert 404s from prompt retrieval into a clear ValueError in both sync and async clients, updating imports and docs accordingly.
> 
> - **Client prompts API (`packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py`)**
>   - Handle 404s in `Prompts.get` and `AsyncPrompts.get`: catch `httpx.HTTPStatusError` with status 404 and raise `ValueError("Prompt not found: ...")` instead; preserve other HTTP errors.
>   - Add `HTTPStatusError` import and update docstrings to document `ValueError` on missing prompts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16336f7423e12c1db4ac0f24e279f98d2c72a1ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->