### PR TITLE
fix: support `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variable

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/settings.py
+++ b/packages/phoenix-otel/src/phoenix/otel/settings.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 ENV_OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
+ENV_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 
 # Phoenix environment variables
 ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
@@ -31,7 +32,11 @@ def get_env_collector_endpoint() -> Optional[str]:
     Returns:
         Optional[str]: The collector endpoint URL if found, None otherwise.
     """
-    return os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT) or os.getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
+    return (
+        os.getenv(ENV_PHOENIX_COLLECTOR_ENDPOINT)
+        or os.getenv(ENV_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+        or os.getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
+    )
 
 
 def get_env_project_name() -> str:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Support resolving collector endpoint from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, falling back after `PHOENIX_COLLECTOR_ENDPOINT` and before `OTEL_EXPORTER_OTLP_ENDPOINT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea970cc326e98016424e30763ae21729e7092595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->