### PR TITLE
fix(playground): use more verbose name for save prompt button

### DIFF
--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -193,7 +193,7 @@ function SaveButton({ instanceId, dirty }: SaveButtonProps) {
     <DialogTrigger>
       <TooltipTrigger delay={100}>
         <Button variant={dirty ? "primary" : undefined} size="S">
-          Save
+          Save Prompt
         </Button>
         <Tooltip placement="top">
           <TooltipArrow />


### PR DESCRIPTION
<img width="1723" height="677" alt="Screenshot 2025-10-21 at 6 15 31 PM" src="https://github.com/user-attachments/assets/0e445b50-11df-4424-9aee-e054edda498f" />
