### PR TITLE
feat: Add support to get of list prompt versions and prompt version details

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -157,7 +157,7 @@ class Prompts:
     def get_prompt_versions(
         self,
         *,
-        prompt_identifier: Optional[str] = None,
+        prompt_identifier: str,
         limit: Optional[int] = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.PromptVersion]:
@@ -169,8 +169,7 @@ class Prompts:
         prompt configuration including template, model settings, and invocation parameters.
 
         Args:
-            prompt_identifier: The unique identifier for the prompt. If not provided,
-                uses the prompt identifier from the current object context.
+            prompt_identifier: The unique identifier for the prompt.
             limit: Maximum number of versions to return, starting from the most recent.
                 Defaults to 100.
             timeout: Optional request timeout in seconds. Uses the default timeout
@@ -206,7 +205,7 @@ class Prompts:
             if "created_at" in record:
                 record["created_at"] = _parse_datetime(record["created_at"])
 
-        return records
+        return records  # type: ignore[no-any-return]
 
 
 class PromptVersionTags:
@@ -476,7 +475,7 @@ class AsyncPrompts:
     async def get_prompt_versions(
         self,
         *,
-        prompt_identifier: Optional[str] = None,
+        prompt_identifier: str,
         limit: Optional[int] = 100,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> list[v1.PromptVersion]:
@@ -488,8 +487,7 @@ class AsyncPrompts:
         prompt configuration including template, model settings, and invocation parameters.
 
         Args:
-            prompt_identifier: The unique identifier for the prompt. If not provided,
-                uses the prompt identifier from the current object context.
+            prompt_identifier: The unique identifier for the prompt.
             limit: Maximum number of versions to return, starting from the most recent.
                 Defaults to 100.
             timeout: Optional request timeout in seconds. Uses the default timeout
@@ -525,7 +523,7 @@ class AsyncPrompts:
             if "created_at" in record:
                 record["created_at"] = _parse_datetime(record["created_at"])
 
-        return records
+        return records  # type: ignore[no-any-return]
 
 
 class AsyncPromptVersionTags:


### PR DESCRIPTION
Resolves: #6747

Currently, users who want to inspect a PromptVersion object (e.g., view its message JSON or prompt variables) must navigate through the UI. There’s no straightforward way to fetch prompt details directly from the Python client.

This PR introduces support for listing all available prompt versions for a given prompt identifier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `get_prompt_versions` (sync/async) to fetch prompt version lists with limit/timeout and normalized `created_at` timestamps.
> 
> - **Client Prompts API (`packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py`)**:
>   - **New methods**:
>     - `Prompts.get_prompt_versions(...)`: fetches versions for a `prompt_identifier` with `limit` and `timeout`.
>     - `AsyncPrompts.get_prompt_versions(...)`: async counterpart.
>   - **Behavior**:
>     - Parses `created_at` ISO strings to `datetime` via `_parse_datetime`.
>     - Uses `DEFAULT_TIMEOUT_IN_SECONDS` for request timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d9755a6405c34bdde2532f4d2919f325ffd9544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->