### PR TITLE
chore: tox for docker devops script

### DIFF
--- a/scripts/docker/devops/docker-compose.yml
+++ b/scripts/docker/devops/docker-compose.yml
@@ -249,7 +249,7 @@ services:
   # ==========================================================================
   
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.1.0
     profiles: ["grafana"]
     restart: always
     expose:
@@ -271,7 +271,7 @@ services:
       - "network.simulation=false"
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.4.0
     profiles: ["grafana"]
     restart: always
     expose:
@@ -331,7 +331,7 @@ services:
       - "network.simulation=false"
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.16.0
     profiles: ["grafana"]
     restart: always
     environment:
@@ -348,7 +348,7 @@ services:
       - "network.simulation=false"
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.51.0
     profiles: ["grafana"]
     restart: always
     expose:
@@ -379,7 +379,7 @@ services:
   # ==========================================================================
   
   toxiproxy:
-    image: ghcr.io/shopify/toxiproxy:latest
+    image: ghcr.io/shopify/toxiproxy:2.11.0
     profiles: ["toxiproxy"]
     restart: unless-stopped
     expose:
@@ -395,7 +395,7 @@ services:
       - "network.simulation=proxy"
 
   toxiproxy-init:
-    image: curlimages/curl:latest
+    image: curlimages/curl:8.11.1
     profiles: ["toxiproxy"]
     depends_on:
       - toxiproxy

--- a/tox.ini
+++ b/tox.ini
@@ -412,3 +412,11 @@ commands =
   uv pip list -v
   ty check generate_ddl_postgresql.py
   python generate_ddl_postgresql.py {posargs}
+
+[testenv:docker_devops]
+description = Run Docker devops environment
+changedir = scripts/docker/devops
+allowlist_externals =
+  bash
+commands =
+  bash dev.sh {posargs:up}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add prune/clean commands to dev.sh, pin Grafana/Prometheus-related images, and introduce a tox env to run the Docker devops stack.
> 
> - **DevOps Script (`scripts/docker/devops/dev.sh`)**
>   - `up`: remove `--build` to use existing images by default.
>   - New commands: `prune` (clean Docker build cache) and `clean` (full Docker system cleanup).
>   - Help text updated with new commands and examples.
> - **Docker Compose (`scripts/docker/devops/docker-compose.yml`)**
>   - Pin images with explicit versions for monitoring and tooling services:
>     - `prometheus` → `prom/prometheus:v3.1.0`
>     - `grafana` → `grafana/grafana:11.4.0`
>     - `postgres-exporter` → `prometheuscommunity/postgres-exporter:v0.16.0`
>     - `cadvisor` → `gcr.io/cadvisor/cadvisor:v0.51.0`
>     - `toxiproxy` → `ghcr.io/shopify/toxiproxy:2.11.0`
>     - `toxiproxy-init` → `curlimages/curl:8.11.1`
> - **Tox (`tox.ini`)**
>   - Add `[testenv:docker_devops]` to run the Docker devops environment (`bash dev.sh {posargs:up}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0992b8ebd858f852295c3eda05f851ec4ab6db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->