### PR TITLE
fix(experiments): fix experiment compare list table width

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -1385,7 +1385,7 @@ function TableBody<T>({
             height: `${spacerRowHeight}px`,
             padding: 0,
           }}
-          colSpan={table.getAllColumns().length}
+          colSpan={table.getVisibleLeafColumns().length}
         />
       </tr>
     </tbody>


### PR DESCRIPTION
Resolves #9979 

Fixes an issue where the experiment compare list page sometimes won't fill up 100% of its container's width as desired. The fix is to make sure the `colSpan` passed to our spacer row accounts for column visibility state. When the repetitions column is hidden (which we do when the base experiments has only one repetition), we were setting `colSpan` to one higher than it should be, which causes the browser to reserve space for an extra column that doesn't exist.

before:

https://github.com/user-attachments/assets/4255553a-4e56-460d-b4cd-bb6bb7fb7ad3

after:

https://github.com/user-attachments/assets/9e25b357-182e-4260-ae8b-b4c8a3906bc9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust spacer row colSpan to use visible columns, fixing layout/width of the Experiment Compare List table.
> 
> - **UI (Experiment Compare List)**:
>   - Update spacer row `colSpan` to `table.getVisibleLeafColumns().length` (from `getAllColumns().length`) so width matches visible columns and avoids reserving space for hidden ones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2a50560dd1f0905c812a0cc8f9d1580bd5f9e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->