### PR TITLE
fix: change rails to choices in notebook 

### DIFF
--- a/tutorials/evals/session_level_evals.ipynb
+++ b/tutorials/evals/session_level_evals.ipynb
@@ -16,7 +16,7 @@
     "        |\n",
     "        <a href=\"https://join.slack.com/t/arize-ai/shared_invite/zt-1px8dcmlf-fmThhDFD_V_48oU7ALan4Q\">Community</a>\n",
     "    </p>\n",
-    "</center>"
+    "</center>\n"
    ]
   },
   {
@@ -25,7 +25,7 @@
     "id": "luyELn4GGIG4"
    },
    "source": [
-    "# Session Level Evals for an AI Tutor"
+    "# Session Level Evals for an AI Tutor\n"
    ]
   },
   {
@@ -37,13 +37,14 @@
     "This tutorial demonstrates how to run session-level evaluations on conversations with an AI tutor. You'll log the results back to Phoenix for further monitoring and analysis. Session-level evaluations are valuable because they provide a holistic view of the entire interaction, enabling you to assess broader patterns and answer high-level questions about user experience and system performance.\n",
     "\n",
     "In this tutorial, you will:\n",
+    "\n",
     "- Trace and aggregate multi-turn interactions into structured sessions\n",
     "- Evaluate sessions across multiple dimensions such as Correctness, Goal Completion, and Frustration\n",
     "- Format the evaluation outputs to match the Phoenix schema and log them to the platform\n",
     "\n",
     "By the end, you’ll have a robust evaluation pipeline for analyzing and comparing session-level performance.\n",
     "\n",
-    "✅ You’ll need a free [Phoenix Cloud account](https://app.arize.com/auth/phoenix/login) and an Anthropic API key to run this notebook."
+    "✅ You’ll need a free [Phoenix Cloud account](https://app.arize.com/auth/phoenix/login) and an Anthropic API key to run this notebook.\n"
    ]
   },
   {
@@ -52,7 +53,7 @@
     "id": "kBepM2asGIG5"
    },
    "source": [
-    "# Set up Dependencies & Keys"
+    "# Set up Dependencies & Keys\n"
    ]
   },
   {
@@ -100,7 +101,7 @@
     "id": "2hZF50xAGIG6"
    },
    "source": [
-    "# Configure Tracing"
+    "# Configure Tracing\n"
    ]
   },
   {
@@ -123,7 +124,7 @@
     "id": "TWBoBKyVGIG6"
    },
    "source": [
-    "# Build and Run AI Tutor"
+    "# Build and Run AI Tutor\n"
    ]
   },
   {
@@ -132,7 +133,7 @@
     "id": "xiFsdf88GIG7"
    },
    "source": [
-    "In this example, we demonstrate how to evaluate AI tutor sessions. The tutor begins by receiving a user ID, topic, and question. It then explains the topic to the student and engages them with follow-up questions in a multi-turn conversation, continuing until the student ends the session. Our goal is to assess the overall quality of this interaction from start to finish."
+    "In this example, we demonstrate how to evaluate AI tutor sessions. The tutor begins by receiving a user ID, topic, and question. It then explains the topic to the student and engages them with follow-up questions in a multi-turn conversation, continuing until the student ends the session. Our goal is to assess the overall quality of this interaction from start to finish.\n"
    ]
   },
   {
@@ -214,7 +215,7 @@
     "id": "SY-O-94iGIG7"
    },
    "source": [
-    "# Prepare Spans for Session-Level Evaluation"
+    "# Prepare Spans for Session-Level Evaluation\n"
    ]
   },
   {
@@ -225,7 +226,7 @@
    "source": [
     "These following cells prepare the data for session-level evaluation. We start by loading all spans into a DataFrame, then sort them chronologically and group them by session ID. You can also group the spans by user ID.\n",
     "\n",
-    "Next, we separate user inputs from AI responses, and finally, store the structured results in a dataframe. We will use this dataframe to run our evaluations."
+    "Next, we separate user inputs from AI responses, and finally, store the structured results in a dataframe. We will use this dataframe to run our evaluations.\n"
    ]
   },
   {
@@ -248,7 +249,7 @@
     "id": "F3WKlr0XGIG7"
    },
    "source": [
-    "Here, we group our spans together to make a session dataframe. We also include logic to truncate part of the sesssion messages if token limits are exceeded. This prevents context window issues for longer sessions."
+    "Here, we group our spans together to make a session dataframe. We also include logic to truncate part of the sesssion messages if token limits are exceeded. This prevents context window issues for longer sessions.\n"
    ]
   },
   {
@@ -363,7 +364,7 @@
     "id": "CqZ1dUUPGIG8"
    },
    "source": [
-    "# Session Correctness Eval"
+    "# Session Correctness Eval\n"
    ]
   },
   {
@@ -372,7 +373,7 @@
     "id": "xeeP6qaSGIG8"
    },
    "source": [
-    "We are ready to begin running our evals. Let's start with an eval that ensures the AI tutor is giving the student factual information:"
+    "We are ready to begin running our evals. Let's start with an eval that ensures the AI tutor is giving the student factual information:\n"
    ]
   },
   {
@@ -432,13 +433,13 @@
     "    model=\"claude-3-7-sonnet-latest\",\n",
     ")\n",
     "\n",
-    "rails = [\"correct\", \"incorrect\"]\n",
+    "choices = [\"correct\", \"incorrect\"]\n",
     "\n",
     "correctness_evaluator = create_classifier(\n",
     "    name=\"correctness\",\n",
     "    llm=model,\n",
     "    prompt_template=SESSION_CORRECTNESS_PROMPT,\n",
-    "    rails=rails,\n",
+    "    choices=choices,\n",
     ")\n",
     "\n",
     "# Run the evaluation\n",
@@ -456,7 +457,7 @@
     "id": "hTgm3EIsGIG8"
    },
    "source": [
-    "# Session Frustration Prompt"
+    "# Session Frustration Prompt\n"
    ]
   },
   {
@@ -465,7 +466,7 @@
     "id": "iZkTcbr3GIG8"
    },
    "source": [
-    "This evaluation is used to make sure the student isn't getting frustrated with the tutor:"
+    "This evaluation is used to make sure the student isn't getting frustrated with the tutor:\n"
    ]
   },
   {
@@ -516,13 +517,13 @@
    "outputs": [],
    "source": [
     "# Run the evaluation\n",
-    "rails = [\"frustrated\", \"not_frustrated\"]\n",
+    "choices = [\"frustrated\", \"not_frustrated\"]\n",
     "\n",
     "frustration_evaluator = create_classifier(\n",
     "    name=\"frustration\",\n",
     "    llm=model,\n",
     "    prompt_template=SESSION_FRUSTRATION_PROMPT,\n",
-    "    rails=rails,\n",
+    "    choices=choices,\n",
     ")\n",
     "\n",
     "# Run the evaluation\n",
@@ -540,7 +541,7 @@
     "id": "2tnQB0FjGIG8"
    },
    "source": [
-    "# Session Goal Achievement Eval"
+    "# Session Goal Achievement Eval\n"
    ]
   },
   {
@@ -549,7 +550,7 @@
     "id": "4e_CHDlOGIG8"
    },
    "source": [
-    "Finally, we evaluate to ensure the tutor helped the student reach their learning goals:"
+    "Finally, we evaluate to ensure the tutor helped the student reach their learning goals:\n"
    ]
   },
   {
@@ -595,13 +596,13 @@
    },
    "outputs": [],
    "source": [
-    "rails = [\"achieved\", \"not_achieved\"]\n",
+    "choices = [\"achieved\", \"not_achieved\"]\n",
     "\n",
     "goal_achievement_evaluator = create_classifier(\n",
     "    name=\"goal_achievement\",\n",
     "    llm=model,\n",
     "    prompt_template=SESSION_GOAL_ACHIEVEMENT_PROMPT,\n",
-    "    rails=rails,\n",
+    "    choices=choices,\n",
     ")\n",
     "\n",
     "# Run the evaluation\n",
@@ -619,7 +620,7 @@
     "id": "uUqxH3noGIG8"
    },
    "source": [
-    "# Log Evaluations Back to Phoenix"
+    "# Log Evaluations Back to Phoenix\n"
    ]
   },
   {
@@ -628,7 +629,7 @@
     "id": "PMYOgvMGGIG8"
    },
    "source": [
-    "Finally, we can log the evaluation results back to Phoenix. In the sessions, tab of your project, you will see the evaluation results populate for each session."
+    "Finally, we can log the evaluation results back to Phoenix. In the sessions, tab of your project, you will see the evaluation results populate for each session.\n"
    ]
   },
   {
@@ -719,7 +720,7 @@
     "id": "LE61B1VpGIG9"
    },
    "source": [
-    "![Session Eval Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-session-level-evals.png)"
+    "![Session Eval Results](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-session-level-evals.png)\n"
    ]
   }
  ],


### PR DESCRIPTION
Changes rails to choices for creating classification evaluators in the session evals tutorial notebook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the session-level evals notebook to use the `choices` parameter (instead of `rails`) when creating classification evaluators for correctness, frustration, and goal achievement.
> 
> - **Tutorials**:
>   - `tutorials/evals/session_level_evals.ipynb`
>     - **Evaluations**:
>       - Update `create_classifier` calls to use `choices` instead of `rails` for:
>         - `correctness_evaluator` (`["correct", "incorrect"]`)
>         - `frustration_evaluator` (`["frustrated", "not_frustrated"]`)
>         - `goal_achievement_evaluator` (`["achieved", "not_achieved"]`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f5456155202a2c2d54c5dfce8ec5a143113a02b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->