### PR TITLE
fix: Ensure latest user api keys are fetched on profile page

### DIFF
--- a/app/src/contexts/ViewerContext.tsx
+++ b/app/src/contexts/ViewerContext.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition } from "react";
+import React, { startTransition, useCallback } from "react";
 import { graphql, useRefetchableFragment } from "react-relay";
 
 import {
@@ -62,7 +62,7 @@ export function ViewerProvider({
     `,
     query
   );
-  const refetchViewer = () => {
+  const refetchViewer = useCallback(() => {
     startTransition(() => {
       _refetch(
         {},
@@ -71,7 +71,7 @@ export function ViewerProvider({
         }
       );
     });
-  };
+  }, [_refetch]);
   return (
     <ViewerContext.Provider value={{ viewer: data.viewer, refetchViewer }}>
       {children}

--- a/app/src/pages/profile/APIKeysTable.tsx
+++ b/app/src/pages/profile/APIKeysTable.tsx
@@ -44,10 +44,10 @@ export function APIKeysTable({ query }: { query: APIKeysTableFragment$key }) {
   const [commit] = useMutation(graphql`
     mutation APIKeysTableDeleteAPIKeyMutation($input: DeleteApiKeyInput!) {
       deleteUserApiKey(input: $input) {
-        __typename
-        apiKeyId
         query {
-          ...UserAPIKeysTableFragment
+          viewer {
+            ...APIKeysTableFragment
+          }
         }
       }
     }
@@ -69,7 +69,7 @@ export function APIKeysTable({ query }: { query: APIKeysTableFragment$key }) {
             refetch(
               {},
               {
-                fetchPolicy: "network-only",
+                fetchPolicy: "store-and-network",
               }
             );
           });
@@ -80,7 +80,9 @@ export function APIKeysTable({ query }: { query: APIKeysTableFragment$key }) {
   );
 
   const tableData = useMemo(() => {
-    return [...data.apiKeys];
+    // ensure we don't have any undefined values in the array
+    // there is some hard to reproduce bug where the apiKeys array is not always populated
+    return data.apiKeys.filter(Boolean);
   }, [data]);
 
   type TableRow = (typeof tableData)[number];

--- a/app/src/pages/profile/ProfilePage.tsx
+++ b/app/src/pages/profile/ProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { css } from "@emotion/react";
 
 import { Flex } from "@phoenix/components";
@@ -21,7 +22,12 @@ const profilePageInnerCSS = css`
 `;
 
 export function ProfilePage() {
-  const { viewer } = useViewer();
+  const { viewer, refetchViewer } = useViewer();
+
+  useEffect(() => {
+    refetchViewer();
+  }, [refetchViewer]);
+
   if (!viewer) {
     return null;
   }

--- a/app/src/pages/profile/__generated__/APIKeysTableDeleteAPIKeyMutation.graphql.ts
+++ b/app/src/pages/profile/__generated__/APIKeysTableDeleteAPIKeyMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<49f60807e5523a753f297c524a001147>>
+ * @generated SignedSource<<1649555d3c8fbb8e67132fd53fdd3403>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,10 +18,10 @@ export type APIKeysTableDeleteAPIKeyMutation$variables = {
 };
 export type APIKeysTableDeleteAPIKeyMutation$data = {
   readonly deleteUserApiKey: {
-    readonly __typename: "DeleteApiKeyMutationPayload";
-    readonly apiKeyId: string;
     readonly query: {
-      readonly " $fragmentSpreads": FragmentRefs<"UserAPIKeysTableFragment">;
+      readonly viewer: {
+        readonly " $fragmentSpreads": FragmentRefs<"APIKeysTableFragment">;
+      } | null;
     };
   };
 };
@@ -49,20 +49,6 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "apiKeyId",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 };
@@ -81,8 +67,6 @@ return {
         "name": "deleteUserApiKey",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -92,9 +76,20 @@ return {
             "plural": false,
             "selections": [
               {
+                "alias": null,
                 "args": null,
-                "kind": "FragmentSpread",
-                "name": "UserAPIKeysTableFragment"
+                "concreteType": "User",
+                "kind": "LinkedField",
+                "name": "viewer",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "APIKeysTableFragment"
+                  }
+                ],
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -120,8 +115,6 @@ return {
         "name": "deleteUserApiKey",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -133,59 +126,52 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "UserApiKey",
+                "concreteType": "User",
                 "kind": "LinkedField",
-                "name": "userApiKeys",
-                "plural": true,
+                "name": "viewer",
+                "plural": false,
                 "selections": [
-                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "name",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "description",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "createdAt",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "expiresAt",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "User",
+                    "concreteType": "UserApiKey",
                     "kind": "LinkedField",
-                    "name": "user",
-                    "plural": false,
+                    "name": "apiKeys",
+                    "plural": true,
                     "selections": [
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "email",
+                        "name": "name",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "description",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "expiresAt",
+                        "storageKey": null
+                      }
                     ],
                     "storageKey": null
-                  }
+                  },
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -198,16 +184,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "510641f5bceb5958f37618a9f54095c3",
+    "cacheID": "4bdd87573f4445b94a5d22dca4c9da3b",
     "id": null,
     "metadata": {},
     "name": "APIKeysTableDeleteAPIKeyMutation",
     "operationKind": "mutation",
-    "text": "mutation APIKeysTableDeleteAPIKeyMutation(\n  $input: DeleteApiKeyInput!\n) {\n  deleteUserApiKey(input: $input) {\n    __typename\n    apiKeyId\n    query {\n      ...UserAPIKeysTableFragment\n    }\n  }\n}\n\nfragment UserAPIKeysTableFragment on Query {\n  userApiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n    user {\n      email\n      id\n    }\n  }\n}\n"
+    "text": "mutation APIKeysTableDeleteAPIKeyMutation(\n  $input: DeleteApiKeyInput!\n) {\n  deleteUserApiKey(input: $input) {\n    query {\n      viewer {\n        ...APIKeysTableFragment\n        id\n      }\n    }\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3a505d9d13944798a57fc873ddf0992d";
+(node as any).hash = "8d26517ce1b7bca6482fbd3dcdd320e3";
 
 export default node;


### PR DESCRIPTION
Also guard against cases where api key edge members may be undefined. This happens in hard to reproduce edge-cases.

Resolves #9848

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Profile now refetches the viewer to get up-to-date API keys; mutation returns `viewer` and table filters undefined entries.
> 
> - **Profile/Viewer**:
>   - Call `refetchViewer()` on mount in `pages/profile/ProfilePage.tsx` to fetch latest `viewer`/API keys.
>   - Stabilize `refetchViewer` in `contexts/ViewerContext.tsx` with `useCallback`.
> - **API Keys Table**:
>   - Update delete mutation to return `query.viewer { ...APIKeysTableFragment }` and align generated Relay types.
>   - Change post-delete refetch policy to `store-and-network`.
>   - Guard table data by filtering `data.apiKeys` to remove undefined entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82858be14d3c8c6555d427e784ed9f3a8ba82586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->