### PR TITLE
fix: conditionally render prompt template and variables

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -750,38 +750,42 @@ function LLMSpanInfo(props: { span: Span; spanAttributes: AttributeObject }) {
             <LazyTabPanel id="prompt-template">
               <View padding="size-200">
                 <Flex direction="column" gap="size-100">
-                  <View
-                    borderRadius="medium"
-                    borderColor="light"
-                    backgroundColor="light"
-                    borderWidth="thin"
-                    padding="size-200"
-                  >
-                    <CopyToClipboard text={promptTemplateObject.template}>
-                      <Text color="text-700" fontStyle="italic">
-                        prompt template
-                      </Text>
-                      <PreBlock>{promptTemplateObject.template}</PreBlock>
-                    </CopyToClipboard>
-                  </View>
-                  <View
-                    borderRadius="medium"
-                    borderColor="light"
-                    backgroundColor="light"
-                    borderWidth="thin"
-                    padding="size-200"
-                  >
-                    <CopyToClipboard
-                      text={JSON.stringify(promptTemplateObject.variables)}
+                  {promptTemplateObject.template != null && (
+                    <View
+                      borderRadius="medium"
+                      borderColor="light"
+                      backgroundColor="light"
+                      borderWidth="thin"
+                      padding="size-200"
                     >
-                      <Text color="text-700" fontStyle="italic">
-                        template variables
-                      </Text>
-                      <JSONBlock>
-                        {JSON.stringify(promptTemplateObject.variables)}
-                      </JSONBlock>
-                    </CopyToClipboard>
-                  </View>
+                      <CopyToClipboard text={promptTemplateObject.template}>
+                        <Text color="text-700" fontStyle="italic">
+                          prompt template
+                        </Text>
+                        <PreBlock>{promptTemplateObject.template}</PreBlock>
+                      </CopyToClipboard>
+                    </View>
+                  )}
+                  {promptTemplateObject.variables != null && (
+                    <View
+                      borderRadius="medium"
+                      borderColor="light"
+                      backgroundColor="light"
+                      borderWidth="thin"
+                      padding="size-200"
+                    >
+                      <CopyToClipboard
+                        text={JSON.stringify(promptTemplateObject.variables)}
+                      >
+                        <Text color="text-700" fontStyle="italic">
+                          template variables
+                        </Text>
+                        <JSONBlock>
+                          {JSON.stringify(promptTemplateObject.variables)}
+                        </JSONBlock>
+                      </CopyToClipboard>
+                    </View>
+                  )}
                 </Flex>
               </View>
             </LazyTabPanel>


### PR DESCRIPTION
Fixes this:

<img width="1721" height="812" alt="Screenshot 2025-10-27 at 2 10 05 PM" src="https://github.com/user-attachments/assets/b945183d-61bd-4012-845f-782bd1c892df" />
