### PR TITLE
feat: add button to enable clearing local credentials for AI provider

### DIFF
--- a/app/src/pages/settings/GenerativeProvidersCard.tsx
+++ b/app/src/pages/settings/GenerativeProvidersCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { graphql, useFragment } from "react-relay";
 import {
   ColumnDef,
@@ -7,6 +7,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { css } from "@emotion/react";
 
 import {
   Button,
@@ -238,7 +239,7 @@ function ProviderCredentialsDialog({
     <Dialog>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Configure {provider.name} Credentials</DialogTitle>
+          <DialogTitle>Configure Local {provider.name} Credentials</DialogTitle>
           <DialogTitleExtra>
             <DialogCloseButton slot="close" />
           </DialogTitleExtra>
@@ -265,6 +266,16 @@ function ProviderCredentials({ provider }: { provider: ModelProvider }) {
   const credentialsConfig = ProviderToCredentialsConfigMap[provider];
   const credentials = useCredentialsContext((state) => state[provider]);
 
+  const clearLocalCredentials = useCallback(() => {
+    credentialsConfig.forEach((credentialConfig) => {
+      setCredential({
+        provider,
+        envVarName: credentialConfig.envVarName,
+        value: "",
+      });
+    });
+  }, [provider, credentialsConfig, setCredential]);
+
   return (
     <Flex direction="column" gap="size-100">
       {credentialsConfig.map((credentialConfig) => (
@@ -284,6 +295,15 @@ function ProviderCredentials({ provider }: { provider: ModelProvider }) {
           <CredentialInput />
         </CredentialField>
       ))}
+      <Button
+        onPress={clearLocalCredentials}
+        css={css`
+          align-self: flex-start;
+          margin-top: var(--ac-global-dimension-size-100);
+        `}
+      >
+        Clear Local Credentials
+      </Button>
     </Flex>
   );
 }


### PR DESCRIPTION
Resolves #9119 

Adds a button to the AI provider credential configuration modal to enable clearing local credentials in a more intuitive way. This also edits the modal's header text for clarity.

https://github.com/user-attachments/assets/bb37b6b6-71e1-4d4b-8cb2-9cddd290c0f6


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a button to clear locally stored AI provider credentials and updates the dialog title to emphasize local configuration.
> 
> - **UI (settings)**:
>   - **Credentials dialog** (`app/src/pages/settings/GenerativeProvidersCard.tsx`):
>     - Add "Clear Local Credentials" button that wipes all local provider credential fields via `clearLocalCredentials`.
>     - Update dialog title to "Configure Local {provider} Credentials" for clarity.
>   - **Implementation details**:
>     - Use `useCallback` for the clear handler; apply minor styling with Emotion `css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f897054e6e9c930e333e403c3bd7aecc6cff5469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->