### PR TITLE
feat(evaluators): evaluators resolver on `Query`

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2457,6 +2457,7 @@ type Query {
   promptLabels(first: Int = 50, last: Int, after: String, before: String): PromptLabelConnection!
   datasetLabels(first: Int = 50, last: Int, after: String, before: String): DatasetLabelConnection!
   datasetSplits(first: Int = 50, last: Int, after: String, before: String): DatasetSplitConnection!
+  evaluators(first: Int = 50, last: Int, after: String, before: String): EvaluatorConnection!
   annotationConfigs(first: Int = 50, last: Int = null, after: String = null, before: String = null): AnnotationConfigConnection!
   clusters(clusters: [ClusterInput!]!): [Cluster!]!
   hdbscanClustering(

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -60,7 +60,7 @@ from phoenix.server.api.types.EmbeddingDimension import (
     DEFAULT_MIN_SAMPLES,
     to_gql_embedding_dimension,
 )
-from phoenix.server.api.types.Evaluator import LLMEvaluator
+from phoenix.server.api.types.Evaluator import Evaluator, LLMEvaluator
 from phoenix.server.api.types.Event import create_event_id, unpack_event_id
 from phoenix.server.api.types.Experiment import Experiment, to_gql_experiment
 from phoenix.server.api.types.ExperimentComparison import (
@@ -1207,6 +1207,30 @@ class Query:
                 data=data,
                 args=args,
             )
+
+    @strawberry.field
+    async def evaluators(
+        self,
+        info: Info[Context, None],
+        first: Optional[int] = 50,
+        last: Optional[int] = UNSET,
+        after: Optional[CursorString] = UNSET,
+        before: Optional[CursorString] = UNSET,
+    ) -> Connection[Evaluator]:
+        args = ConnectionArgs(
+            first=first,
+            after=after if isinstance(after, CursorString) else None,
+            last=last,
+            before=before if isinstance(before, CursorString) else None,
+        )
+        async with info.context.db() as session:
+            evaluators = await session.scalars(
+                select(models.Evaluator).order_by(models.Evaluator.name.asc())
+            )
+        return connection_from_list(
+            data=[Evaluator(id=evaluator.id, db_record=evaluator) for evaluator in evaluators],
+            args=args,
+        )
 
     @strawberry.field
     async def annotation_configs(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces Evaluators (LLM) with DB tables/models and GraphQL types/mutations/queries linked to Datasets, plus raises minimum Python to 3.10 and updates CI/tests/docs.
> 
> - **Backend/DB**:
>   - Add `evaluators`, `llm_evaluators`, and `dataset_evaluators` tables with migration `02463bd83119`.
>   - Implement SQLAlchemy models: `Evaluator`, `LLMEvaluator`, `DatasetEvaluator`; wire relations to `Dataset`, `Prompt`, `PromptVersionTag`.
> - **GraphQL API**:
>   - Add `Evaluator` interface, `LLMEvaluator` type, connections, and resolvers.
>   - New mutation `createDatasetLlmEvaluator` with input `CreateDatasetLLMEvaluatorInput`.
>   - Extend `Dataset` with `evaluators` field; add root `evaluators` query; update `node` resolver for `LLMEvaluator`.
>   - Refactor `Prompt`, `PromptVersionTag`, `User`, and annotation types to use field loaders; add prompt/prompt tag/user/evaluator field dataloaders.
> - **Tests**:
>   - Add unit tests for evaluator models, GraphQL types, and mutation.
>   - Update integration/unit configs (e.g., `pyrightconfig.json`) for Python 3.10.
> - **CI/Build**:
>   - Update GitHub workflows to include `version-13` branch and switch matrices to Python "3.10" (replacing 3.9);
>   - Adjust tox tasks to Python 3.10 targets.
> - **Project config/docs**:
>   - Raise minimum Python to `>=3.10` in `pyproject.toml`; remove 3.9 classifier.
>   - Update `DEVELOPMENT.md` guidance to Python 3.10.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ac0bbe2bfdd1ecb204a17dbb29895410f30e2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->