### PR TITLE
feat: Create evaluator mutations with optional dataset_id

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -472,7 +472,7 @@ input CreateChatPromptVersionInput {
 }
 
 input CreateCodeEvaluatorInput {
-  datasetId: ID!
+  datasetId: ID
   name: Identifier!
   description: String
 }
@@ -481,13 +481,6 @@ input CreateDatasetInput {
   name: String!
   description: String
   metadata: JSON
-}
-
-input CreateDatasetLLMEvaluatorInput {
-  datasetId: ID!
-  name: Identifier!
-  description: String
-  promptVersion: ChatPromptVersionInput!
 }
 
 input CreateDatasetLabelInput {
@@ -515,6 +508,13 @@ input CreateDatasetSplitWithExamplesInput {
   color: String!
   metadata: JSON
   exampleIds: [ID!]!
+}
+
+input CreateLLMEvaluatorInput {
+  datasetId: ID
+  name: Identifier!
+  description: String
+  promptVersion: ChatPromptVersionInput!
 }
 
 input CreateModelMutationInput {
@@ -1926,8 +1926,8 @@ type Mutation {
   addDatasetExamplesToDatasetSplits(input: AddDatasetExamplesToDatasetSplitsInput!): AddDatasetExamplesToDatasetSplitsMutationPayload!
   removeDatasetExamplesFromDatasetSplits(input: RemoveDatasetExamplesFromDatasetSplitsInput!): RemoveDatasetExamplesFromDatasetSplitsMutationPayload!
   createDatasetSplitWithExamples(input: CreateDatasetSplitWithExamplesInput!): DatasetSplitMutationPayloadWithExamples!
-  createDatasetCodeEvaluator(input: CreateCodeEvaluatorInput!): CodeEvaluatorMutationPayload!
-  createDatasetLlmEvaluator(input: CreateDatasetLLMEvaluatorInput!): LLMEvaluatorMutationPayload!
+  createCodeEvaluator(input: CreateCodeEvaluatorInput!): CodeEvaluatorMutationPayload!
+  createLlmEvaluator(input: CreateLLMEvaluatorInput!): LLMEvaluatorMutationPayload!
   assignEvaluatorToDataset(input: AssignEvaluatorToDatasetInput!): EvaluatorMutationPayload!
   unassignEvaluatorFromDataset(input: UnassignEvaluatorFromDatasetInput!): EvaluatorMutationPayload!
   deleteExperiments(input: DeleteExperimentsInput!): ExperimentMutationPayload!

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -47,8 +47,8 @@ def _parse_evaluator_id(global_id: GlobalID) -> tuple[int, EvaluatorKind]:
 
 
 @strawberry.input
-class CreateDatasetLLMEvaluatorInput:
-    dataset_id: GlobalID
+class CreateLLMEvaluatorInput:
+    dataset_id: Optional[GlobalID] = UNSET
     name: Identifier
     description: Optional[str] = UNSET
     prompt_version: ChatPromptVersionInput
@@ -56,7 +56,7 @@ class CreateDatasetLLMEvaluatorInput:
 
 @strawberry.input
 class CreateCodeEvaluatorInput:
-    dataset_id: GlobalID
+    dataset_id: Optional[GlobalID] = UNSET
     name: Identifier
     description: Optional[str] = UNSET
 
@@ -96,12 +96,14 @@ class UnassignEvaluatorFromDatasetInput:
 @strawberry.type
 class EvaluatorMutationMixin:
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
-    async def create_dataset_code_evaluator(
+    async def create_code_evaluator(
         self, info: Info[Context, None], input: CreateCodeEvaluatorInput
     ) -> CodeEvaluatorMutationPayload:
-        dataset_id = from_global_id_with_expected_type(
-            global_id=input.dataset_id, expected_type_name=Dataset.__name__
-        )
+        dataset_id: Optional[int] = None
+        if input.dataset_id is not UNSET and input.dataset_id is not None:
+            dataset_id = from_global_id_with_expected_type(
+                global_id=input.dataset_id, expected_type_name=Dataset.__name__
+            )
         user_id: Optional[int] = None
         assert isinstance(request := info.context.request, Request)
         if "user" in request.scope:
@@ -121,7 +123,10 @@ class EvaluatorMutationMixin:
                     dataset_id=dataset_id,
                     input_config={},
                 )
-            ],
+            ]
+            # only add dataset relationship if dataset_id is provided
+            if dataset_id is not None
+            else [],
         )
         try:
             async with info.context.db() as session:
@@ -136,12 +141,14 @@ class EvaluatorMutationMixin:
         )
 
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
-    async def create_dataset_llm_evaluator(
-        self, info: Info[Context, None], input: CreateDatasetLLMEvaluatorInput
+    async def create_llm_evaluator(
+        self, info: Info[Context, None], input: CreateLLMEvaluatorInput
     ) -> LLMEvaluatorMutationPayload:
-        dataset_id = from_global_id_with_expected_type(
-            global_id=input.dataset_id, expected_type_name=Dataset.__name__
-        )
+        dataset_id: Optional[int] = None
+        if input.dataset_id is not UNSET and input.dataset_id is not None:
+            dataset_id = from_global_id_with_expected_type(
+                global_id=input.dataset_id, expected_type_name=Dataset.__name__
+            )
         user_id: Optional[int] = None
         assert isinstance(request := info.context.request, Request)
         if "user" in request.scope:
@@ -173,7 +180,10 @@ class EvaluatorMutationMixin:
                     dataset_id=dataset_id,
                     input_config={},
                 )
-            ],
+            ]
+            # only add dataset relationship if dataset_id is provided
+            if dataset_id is not None
+            else [],
         )
         try:
             async with info.context.db() as session:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allow creating code/LLM evaluators without a dataset and rename evaluator creation mutations; update schema, resolvers, and tests accordingly.
> 
> - **GraphQL schema**:
>   - Make `datasetId` optional in `CreateCodeEvaluatorInput`.
>   - Replace `CreateDatasetLLMEvaluatorInput` with `CreateLLMEvaluatorInput`.
>   - Rename mutations from `createDatasetCodeEvaluator`/`createDatasetLlmEvaluator` to `createCodeEvaluator`/`createLlmEvaluator`.
> - **Server mutations**:
>   - Update input types and resolvers to accept optional `dataset_id`.
>   - Create evaluator without dataset relation when `dataset_id` is omitted.
> - **Tests**:
>   - Update mutation names/usages.
>   - Add tests verifying evaluators can be created without dataset relations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de71384c14b102ef8d65d3c6f43629b1443d0bfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->