### PR TITLE
feat: Wire new evaluator save button to mutation

### DIFF
--- a/app/src/pages/evaluators/__generated__/NewEvaluatorPageContentMutation.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/NewEvaluatorPageContentMutation.graphql.ts
@@ -1,0 +1,162 @@
+/**
+ * @generated SignedSource<<d56abc06fcf805863c4dcb7796af6505>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ModelProvider = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
+export type CreateLLMEvaluatorInput = {
+  datasetId?: string | null;
+  description?: string | null;
+  name: string;
+  promptVersion: ChatPromptVersionInput;
+};
+export type ChatPromptVersionInput = {
+  description?: string | null;
+  invocationParameters?: any;
+  modelName: string;
+  modelProvider: ModelProvider;
+  responseFormat?: ResponseFormatInput | null;
+  template: PromptChatTemplateInput;
+  templateFormat: PromptTemplateFormat;
+  tools?: ReadonlyArray<ToolDefinitionInput>;
+};
+export type PromptChatTemplateInput = {
+  messages: ReadonlyArray<PromptMessageInput>;
+};
+export type PromptMessageInput = {
+  content: ReadonlyArray<ContentPartInput>;
+  role: string;
+};
+export type ContentPartInput = {
+  text?: TextContentValueInput | null;
+  toolCall?: ToolCallContentValueInput | null;
+  toolResult?: ToolResultContentValueInput | null;
+};
+export type TextContentValueInput = {
+  text: string;
+};
+export type ToolCallContentValueInput = {
+  toolCall: ToolCallFunctionInput;
+  toolCallId: string;
+};
+export type ToolCallFunctionInput = {
+  arguments: string;
+  name: string;
+  type?: string | null;
+};
+export type ToolResultContentValueInput = {
+  result: any;
+  toolCallId: string;
+};
+export type ToolDefinitionInput = {
+  definition: any;
+};
+export type ResponseFormatInput = {
+  definition: any;
+};
+export type NewEvaluatorPageContentMutation$variables = {
+  input: CreateLLMEvaluatorInput;
+};
+export type NewEvaluatorPageContentMutation$data = {
+  readonly createLlmEvaluator: {
+    readonly evaluator: {
+      readonly id: string;
+      readonly name: string;
+    };
+  };
+};
+export type NewEvaluatorPageContentMutation = {
+  response: NewEvaluatorPageContentMutation$data;
+  variables: NewEvaluatorPageContentMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "LLMEvaluatorMutationPayload",
+    "kind": "LinkedField",
+    "name": "createLlmEvaluator",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "LLMEvaluator",
+        "kind": "LinkedField",
+        "name": "evaluator",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewEvaluatorPageContentMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NewEvaluatorPageContentMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "c2bbb90f883fbd1fb6f437ab01e163f3",
+    "id": null,
+    "metadata": {},
+    "name": "NewEvaluatorPageContentMutation",
+    "operationKind": "mutation",
+    "text": "mutation NewEvaluatorPageContentMutation(\n  $input: CreateLLMEvaluatorInput!\n) {\n  createLlmEvaluator(input: $input) {\n    evaluator {\n      id\n      name\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a1728c3a803bc7949c1c88b051cf64a8";
+
+export default node;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Connects the New Evaluator page’s Save action to a Relay mutation with proper payload, notifications, validation, and loading state, adding the generated GraphQL artifacts.
> 
> - **Evaluators UI**:
>   - Wire `Save` in `NewEvaluatorPage` to Relay `createLlmEvaluator` mutation, building payload from playground instance (`promptVersion`, dynamic name from `ChoiceConfig`).
>   - Add success/error notifications and parse mutation errors via `getErrorMessagesFromRelayMutationError`.
>   - Validate presence of a playground instance before submit; show error if missing.
>   - Update `Save` button with pending state (`isPending`) and dynamic label ("Creating..."/"Save").
> - **GraphQL**:
>   - Add generated mutation artifacts `__generated__/NewEvaluatorPageContentMutation.graphql.ts` for `CreateLLMEvaluatorInput` and response fields (`evaluator { id, name }`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64bcba96827315ec2832b721d2feeb17fe493db3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->