### PR TITLE
feat: Collect all json path segments when flattening example keys

### DIFF
--- a/app/src/pages/evaluators/EvaluatorInputMapping.tsx
+++ b/app/src/pages/evaluators/EvaluatorInputMapping.tsx
@@ -114,7 +114,10 @@ const EvaluatorInputMappingControls = ({
     if (!data.example?.revision) {
       return [];
     }
-    const flat = flattenObject(data.example.revision);
+    const flat = flattenObject({
+      obj: data.example.revision,
+      keepNonTerminalValues: true,
+    });
     return [
       ...Object.keys(flat).map((key) => ({
         id: key,

--- a/app/src/utils/jsonUtils.ts
+++ b/app/src/utils/jsonUtils.ts
@@ -60,18 +60,35 @@ export function safelyStringifyJSON(
 /**
  * Flattens an object into a single-level object.
  */
-export function flattenObject(
-  obj: object,
-  parentKey: string = "",
-  separator: string = "."
-): Record<string, string | boolean | number> {
+export function flattenObject({
+  obj,
+  parentKey = "",
+  separator = ".",
+  keepNonTerminalValues = false,
+}: {
+  obj: object;
+  parentKey?: string;
+  separator?: string;
+  keepNonTerminalValues?: boolean;
+}) {
   const result: Record<string, string | boolean | number> = {};
 
   for (const [key, value] of Object.entries(obj)) {
     const newKey = parentKey ? `${parentKey}${separator}${key}` : key;
 
     if (value && typeof value === "object") {
-      Object.assign(result, flattenObject(value, newKey, separator));
+      if (keepNonTerminalValues) {
+        result[newKey] = value;
+      }
+      Object.assign(
+        result,
+        flattenObject({
+          obj: value,
+          parentKey: newKey,
+          separator,
+          keepNonTerminalValues,
+        })
+      );
     } else {
       result[newKey] = value;
     }
@@ -94,7 +111,7 @@ export function jsonStringToFlatObject(
       return {};
     }
     // Flatten the parsed object
-    return flattenObject(parsedObj, "", separator);
+    return flattenObject({ obj: parsedObj, separator });
   } catch (e) {
     // The parsing failed, do nothing
   }


### PR DESCRIPTION
<img width="624" height="988" alt="image" src="https://github.com/user-attachments/assets/9f555d30-1375-4c80-b4b9-8592e7b8ff0c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an option to include non-terminal path segments in flattened objects and updates evaluator input mapping and JSON flatten helper to use the new API.
> 
> - **Utils**:
>   - `flattenObject` now accepts an options object with `keepNonTerminalValues` to include non-terminal path segments as keys.
>   - Update `jsonStringToFlatObject` to use the new `flattenObject` signature.
> - **UI (Evaluators)**:
>   - `EvaluatorInputMapping` uses `flattenObject({ obj, keepNonTerminalValues: true })` to expose all JSON path segments for mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13e9f528aacf3b55ae3f6019cc9500ba2a0852e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->