### PR TITLE
docs: fix graphite main page

### DIFF
--- a/docs/section-integrations/python/graphite/README.md
+++ b/docs/section-integrations/python/graphite/README.md
@@ -1,15 +1,16 @@
-# Graphite
-
 ---
 description: >-
-  Graphite is an open-source Python framework for building and orchestrating
-  multi-agent LLM systems with visual workflow design, enabling complex AI
-  applications through intuitive node-based composition
+  Graphite is an open-source Python framework for designing and orchestrating
+  multi-agent LLM workflows with a visual builder and node-based composition.
 ---
 
-**Documentation:** [https://binome-dev.github.io/graphite/](https://binome-dev.github.io/graphite/)
+# Graphite
 
-**Integration:** [arize-integration.md](arize-integration.md)
+**Website:** [https://binome-dev.github.io/graphite/](https://binome-dev.github.io/graphite/)
 
+Graphite combines a drag-and-drop workflow canvas with Python tooling so teams
+can prototype, orchestrate, and monitor complex multi-agent applications. The
+Phoenix integration streams Graphite's OpenTelemetry traces into Phoenix or
+Arize for observability across development and production environments.
 
----
+<table data-card-size="large" data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><a href="arize-integration.md"><strong>Graphite Integration Guide</strong></a></td><td><a href="arize-integration.md">arize-integration.md</a></td></tr></tbody></table>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates tutorial notebooks to use keyword args for `to_annotation_dataframe` and bumps `fastmcp` in MCP tracing tutorial requirements.
> 
> - **Tutorials**:
>   - **Notebooks**: Switch calls from `to_annotation_dataframe(...)` to `to_annotation_dataframe(dataframe=...)` in `tutorials/evals/trace_level_evals.ipynb` and `tutorials/llm_ops_overview.ipynb`.
>   - **Dependencies**: Update `fastmcp` from `2.2.3` to `2.13.0` in `tutorials/mcp/tracing_between_mcp_client_and_server/requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2900e99fee9b17fb6a6fc16d14f0e83ed7f40e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->