### PR TITLE
chore: run alembic via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -431,3 +431,7 @@ commands_pre =
   uv pip install -q --strict --reinstall-package arize-phoenix {toxinidir}
 commands =
   alembic {posargs:--help}
+  # View migration history (shows available versions to upgrade/downgrade to): tox -e alembic -- history
+  # Backward migrations: tox -e alembic -- downgrade -1
+  # Forward migrations: tox -e alembic -- upgrade head
+  # View current version: tox -e alembic -- current


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new `tox -e alembic` env to run Alembic migrations with DB env vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90400794666795bd83e124674364e5f060ae255e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->