### PR TITLE
fix(datasets): disable playground button for versionless dataset

### DIFF
--- a/app/src/pages/dataset/DatasetPage.tsx
+++ b/app/src/pages/dataset/DatasetPage.tsx
@@ -175,6 +175,10 @@ function DatasetPageContent({
     },
     [navigate, datasetId]
   );
+  const datasetHasVersions = useMemo(
+    () => (dataset.latestVersions?.edges.length ?? 0) > 0,
+    [dataset.latestVersions]
+  );
 
   // Set the initial tab
   const location = useLocation();
@@ -288,6 +292,7 @@ function DatasetPageContent({
             />
             <DatasetLabelConfigButton datasetId={dataset.id} />
             <Button
+              isDisabled={!datasetHasVersions}
               size="S"
               variant="primary"
               leadingVisual={<Icon svg={<Icons.PlayCircleOutline />} />}


### PR DESCRIPTION
resolves #10104

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable the Dataset page Playground button when the dataset has no versions, using a memoized version check.
> 
> - **Frontend (`app/src/pages/dataset/DatasetPage.tsx`)**:
>   - Add `datasetHasVersions` via `useMemo` from `dataset.latestVersions`.
>   - Set `Playground` button `isDisabled` when `!datasetHasVersions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8b1fb8500e784b1c69ed0c03f387bc9fdf4389b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->