### PR TITLE
fix: dataset labels popover

### DIFF
--- a/app/src/components/dataset/DatasetLabelConfigButton.tsx
+++ b/app/src/components/dataset/DatasetLabelConfigButton.tsx
@@ -64,10 +64,6 @@ export function DatasetLabelConfigButton(props: DatasetLabelConfigButtonProps) {
       <Popover
         placement="bottom start"
         shouldCloseOnInteractOutside={() => true}
-        css={css`
-          min-width: 400px;
-          max-width: 500px;
-        `}
       >
         <PopoverArrow />
         <Dialog>
@@ -200,10 +196,10 @@ function DatasetLabelList({
     <>
       <View
         padding="size-100"
+        paddingTop="size-50"
         borderBottomWidth="thin"
         borderColor="dark"
         minWidth={300}
-        maxWidth={300}
       >
         <Flex direction="column" gap="size-50">
           <Flex
@@ -254,8 +250,7 @@ function DatasetLabelList({
             selectedKeys={selected}
             onSelectionChange={onSelectionChange}
             css={css`
-              min-height: 300px;
-              max-height: 300px;
+              height: 300px;
             `}
             renderEmptyState={() => "No labels found"}
           >


### PR DESCRIPTION
Fixes this:

<img width="603" height="589" alt="Screenshot 2025-11-03 at 5 25 10 PM" src="https://github.com/user-attachments/assets/00ce2afe-8ab3-41e0-aeb4-b911ec5a6fce" />
