### PR TITLE
fix: render tool messages with undefined outputs

### DIFF
--- a/app/src/components/disclosure/Disclosure.tsx
+++ b/app/src/components/disclosure/Disclosure.tsx
@@ -83,7 +83,7 @@ export const DisclosurePanel = ({
 };
 
 export type DisclosureTriggerProps = PropsWithChildren<{
-  arrowPosition?: "start" | "end";
+  arrowPosition?: "start" | "end" | "none";
   justifyContent?: FlexStyleProps["justifyContent"];
   asHeading?: boolean;
   width?: CSSProperties["width"];
@@ -115,7 +115,9 @@ export const DisclosureTrigger = ({
         >
           {children}
         </Flex>
-        <Icon svg={<Icons.ArrowIosForwardOutline />} />
+        {arrowPosition !== "none" ? (
+          <Icon svg={<Icons.ArrowIosForwardOutline />} />
+        ) : null}
       </Button>
     </Heading>
   );

--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1483,7 +1483,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
             {role.toLowerCase() === "tool" ? (
               <Disclosure id="tool-content">
                 <DisclosureTrigger
-                  arrowPosition="start"
+                  arrowPosition={messageContent ? "start" : "none"}
                   justifyContent="space-between"
                 >
                   <Text>


### PR DESCRIPTION
Previously we would just render an awkwardly empty card. Now we at least show the related tool call.

<img width="1391" height="312" alt="image" src="https://github.com/user-attachments/assets/38bd98d9-a52f-4150-88dd-12f6fde39f4b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render tool-role messages without content by showing a header-only disclosure and add `arrowPosition="none"` support to hide the arrow icon.
> 
> - **Trace UI (SpanDetails)**:
>   - Always render the Tool Result disclosure for tool-role messages; conditionally show content only when present and hide the arrow when empty (`arrowPosition="none"`).
> - **Components (Disclosure)**:
>   - Extend `DisclosureTrigger` `arrowPosition` to include `"none"` and omit the arrow icon when set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f227270b82f20626f1fa22e2196d849fa21f44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->