### PR TITLE
feat: Add extra body param

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1235,6 +1235,10 @@ class OpenAIReasoningReasoningModelsMixin:
                 label="Response Format",
                 canonical_name=CanonicalParameterName.RESPONSE_FORMAT,
             ),
+            JSONInvocationParameter(
+                invocation_name="extra_body",
+                label="Extra Body",
+            ),
         ]
 
 


### PR DESCRIPTION
resolves #9821 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for an `extra_body` invocation parameter in OpenAI streaming and reasoning clients.
> 
> - **LLM playground clients**:
>   - OpenAI-compatible clients now accept `extra_body` via `supported_invocation_parameters`:
>     - `OpenAIBaseStreamingClient`
>     - `OpenAIReasoningReasoningModelsMixin` (affecting OpenAI reasoning/non-streaming variants)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit affcb70800a5a6bf4e4ba55baa530e3668258304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->