### PR TITLE
feat: Improve rendering of dataset evals on playground

### DIFF
--- a/app/src/components/annotation/AnnotationNameAndValue.tsx
+++ b/app/src/components/annotation/AnnotationNameAndValue.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import { css } from "@emotion/react";
 
 import { Flex, Text } from "@phoenix/components";
@@ -52,11 +53,13 @@ const getAnnotationDisplayValue = ({
 interface AnnotationNameAndValueProps extends SizingProps {
   annotation: Annotation;
   displayPreference: AnnotationDisplayPreference;
+  minWidth?: CSSProperties["minWidth"];
 }
 export function AnnotationNameAndValue({
   annotation,
   displayPreference,
   size,
+  minWidth = "5rem",
 }: AnnotationNameAndValueProps) {
   const labelValue = getAnnotationDisplayValue({
     annotation,
@@ -70,7 +73,7 @@ export function AnnotationNameAndValue({
       className="annotation-name-and-value"
     >
       <AnnotationColorSwatch annotationName={annotation.name} />
-      <div css={css(textCSS, { minWidth: "5rem" })}>
+      <div css={css(textCSS, { minWidth })} title={annotation.name}>
         <Text weight="heavy" size={size} color="inherit">
           {annotation.name}
         </Text>

--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -10,12 +10,11 @@ import {
   Token,
   View,
 } from "@phoenix/components";
+import { AnnotationNameAndValue } from "@phoenix/components/annotation";
 import { DatasetSplits } from "@phoenix/components/datasetSplit/DatasetSplits";
 import { EvaluatorSelect } from "@phoenix/components/evaluators/EvaluatorSelect";
-import { useTheme } from "@phoenix/contexts";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { Mutable } from "@phoenix/typeUtils";
-import { getWordColor } from "@phoenix/utils/colorUtils";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 import { PlaygroundDatasetSectionQuery } from "./__generated__/PlaygroundDatasetSectionQuery.graphql";
@@ -30,7 +29,6 @@ export function PlaygroundDatasetSection({
   splitIds?: string[];
 }) {
   const instances = usePlaygroundContext((state) => state.instances);
-  const { theme } = useTheme();
   const isRunning = instances.some((instance) => instance.activeRunId != null);
   const experimentIds = useMemo(() => {
     return instances
@@ -130,14 +128,23 @@ export function PlaygroundDatasetSection({
             <Flex direction="row" gap="size-100" alignItems="center">
               {evaluators
                 .filter((e) => selectedEvaluatorIds.includes(e.id))
-                .map((e) => (
-                  <Token
+                .slice(0, 3)
+                .flatMap((e, index, array) => [
+                  <AnnotationNameAndValue
                     key={e.id}
-                    color={getWordColor({ word: e.name, theme })}
-                  >
-                    {e.name}
-                  </Token>
-                ))}
+                    annotation={e}
+                    displayPreference="none"
+                    minWidth="auto"
+                  />,
+                  ...(index === array.length - 1 &&
+                  selectedEvaluatorIds.length > 3
+                    ? [
+                        <Token key={`more`}>
+                          <Text>+ {selectedEvaluatorIds.length - 3} more</Text>
+                        </Token>,
+                      ]
+                    : []),
+                ])}
             </Flex>
             <EvaluatorSelect
               evaluators={evaluators as Mutable<(typeof evaluators)[number]>[]}


### PR DESCRIPTION
<img width="1443" height="156" alt="image" src="https://github.com/user-attachments/assets/77e7c3c4-0bde-4b4a-8aae-eabe4c5933bd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `AnnotationNameAndValue` to render selected evaluators (capped at 3 with a “+ N more” token) and add a `minWidth` prop and tooltip to the annotation component.
> 
> - **Playground**:
>   - Replace evaluator tokens with `AnnotationNameAndValue`; show up to 3 selected evaluators and append a `+ N more` token when exceeded.
> - **Annotation**:
>   - Add optional `minWidth` prop (default `"5rem"`) to `AnnotationNameAndValue` and use it in styles; add `title` tooltip with `annotation.name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b8aa2b69964465415d8cf32e26fe8e5ee7c69e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->