### PR TITLE
feat: add metadata to evaluator db table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -401,7 +401,7 @@ type CodeEvaluator implements Evaluator & Node {
   id: ID!
   name: Identifier!
   description: String
-  metadata: JSON
+  metadata: JSON!
   kind: EvaluatorKind!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -1289,7 +1289,7 @@ interface Evaluator implements Node {
   id: ID!
   name: Identifier!
   description: String
-  metadata: JSON
+  metadata: JSON!
   kind: EvaluatorKind!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -1884,7 +1884,7 @@ type LLMEvaluator implements Evaluator & Node {
   id: ID!
   name: Identifier!
   description: String
-  metadata: JSON
+  metadata: JSON!
   kind: EvaluatorKind!
   createdAt: DateTime!
   updatedAt: DateTime!

--- a/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
+++ b/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
@@ -56,7 +56,7 @@ def upgrade() -> None:
         sa.Column("id", _Integer, primary_key=True),
         sa.Column("name", sa.String, nullable=False, unique=True),
         sa.Column("description", sa.String),
-        sa.Column("metadata", JSON_),
+        sa.Column("metadata", JSON_, nullable=False),
         sa.Column(
             "kind",
             sa.String,

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -190,10 +190,8 @@ class JsonDict(TypeDecorator[dict[str, Any]]):
     cache_ok = True
     impl = JSON_
 
-    def process_bind_param(
-        self, value: Optional[dict[str, Any]], _: Dialect
-    ) -> Optional[dict[str, Any]]:
-        return value if isinstance(value, dict) else None
+    def process_bind_param(self, value: Optional[dict[str, Any]], _: Dialect) -> dict[str, Any]:
+        return value if isinstance(value, dict) else {}
 
     def process_result_value(self, value: Optional[Any], _: Dialect) -> Optional[dict[str, Any]]:
         return orjson.loads(orjson.dumps(value)) if isinstance(value, dict) and value else value
@@ -2065,7 +2063,7 @@ class Evaluator(HasId):
     )
     name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False, unique=True)
     description: Mapped[Optional[str]]
-    metadata_: Mapped[Optional[dict[str, Any]]] = mapped_column("metadata")
+    metadata_: Mapped[dict[str, Any]] = mapped_column("metadata")
     user_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -48,7 +48,7 @@ class Evaluator(Node):
         raise NotImplementedError
 
     @strawberry.field
-    async def metadata(self) -> Optional[JSON]:
+    async def metadata(self) -> JSON:
         raise NotImplementedError
 
     @strawberry.field
@@ -125,7 +125,7 @@ class CodeEvaluator(Evaluator, Node):
     async def metadata(
         self,
         info: Info[Context, None],
-    ) -> Optional[JSON]:
+    ) -> JSON:
         if self.db_record:
             val = self.db_record.metadata_
         else:
@@ -223,7 +223,7 @@ class LLMEvaluator(Evaluator, Node):
     async def metadata(
         self,
         info: Info[Context, None],
-    ) -> Optional[JSON]:
+    ) -> JSON:
         if self.db_record:
             val = self.db_record.metadata_
         else:

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -146,7 +146,7 @@ class TestEvaluatorFields:
         )
         assert not resp.errors and resp.data
         node = resp.data["node"]
-        assert node["metadata"] is None
+        assert node["metadata"] == {}
         assert node["promptVersionTag"]["id"] == str(
             GlobalID("PromptVersionTag", str(_test_data["tag"]))
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a JSON `metadata` field to Evaluators (DB/models) and exposes it on `Evaluator`, `LLMEvaluator`, and `CodeEvaluator` GraphQL types, with tests validating behavior.
> 
> - **GraphQL Schema**:
>   - Add non-null `metadata: JSON!` to `Evaluator`, `LLMEvaluator`, and `CodeEvaluator` in `app/schema.graphql`.
> - **DB/Models**:
>   - Migration: add non-null `metadata` JSON column to `evaluators` table.
>   - ORM: add `metadata_` to `models.Evaluator` (mapped to `metadata`).
> - **API Resolvers**:
>   - Expose `metadata` field on `Evaluator` interface and implement in `LLMEvaluator` and `CodeEvaluator` resolvers, returning stored JSON (default `{}` when null-like).
> - **Tests**:
>   - Update `test_Evaluator.py` to assert `metadata` is returned (populated for untagged; `{}` for tagged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b6d821c19545f2d3de15ea9202154bd5fb27b8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->