### PR TITLE
fix: channel error propagation

### DIFF
--- a/js/.changeset/goofy-eyes-matter.md
+++ b/js/.changeset/goofy-eyes-matter.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+fix bug with channel error


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates ChannelError and wraps fetch failures with semantic errors (with version-compat checks) in resumeExperiment/resumeEvaluation.
> 
> - **phoenix-client (experiments)**:
>   - `resumeEvaluation`:
>     - Refine fetch error handling: route through `handleEvaluationFetchError` (version-compat check) and wrap as `EvaluationFetchError`.
>     - Let `ChannelError` from blocked `send()` bubble up; keep other unexpected errors wrapped.
>   - `resumeExperiment`:
>     - Refine fetch error handling: route through `handleFetchError` and wrap as `TaskFetchError`.
>     - Allow `ChannelError` to bubble up; wrap other unexpected channel errors.
> - **Release**:
>   - Changeset: patch for `@arizeai/phoenix-client`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 651a5f3ebb2ca5efe5ad60551f7012e746da560c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->