### PR TITLE
feat: use es2022 for typescript

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
-    "lib": ["ES2021", "DOM"],
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "module": "ES6",


### PR DESCRIPTION
I think 3 years is enough for evergreen. Also I would like to list timezones like so https://github.com/microsoft/TypeScript/issues/49231