### PR TITLE
fix(evaluators): return annotation name in output config resolver

### DIFF
--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -255,16 +255,15 @@ class LLMEvaluator(Evaluator, Node):
         if self.db_record:
             assert isinstance(self.db_record.output_config, CategoricalAnnotationConfigModel)
             config = self.db_record.output_config
-            annotation_name = self.db_record.name.root
+            annotation_name = self.db_record.annotation_name
         else:
             results = await info.context.data_loaders.llm_evaluator_fields.load_many(
                 [
                     (self.id, models.LLMEvaluator.output_config),
-                    (self.id, models.LLMEvaluator.name),
+                    (self.id, models.LLMEvaluator.annotation_name),
                 ]
             )
-            config, annotation_name_identifier = results
-            annotation_name = annotation_name_identifier.root
+            config, annotation_name = results
         return _to_gql_categorical_annotation_config(config=config, annotation_name=annotation_name)
 
     @strawberry.field


### PR DESCRIPTION
Fixes:

> for example, if the mutation to create an evaluator has
> "name": "correctness",
> in its outputConfig field, then when I fetch that evaluator afterwards I get:
> "name": "root='correctness'",

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `LLMEvaluator.output_config` to read `annotation_name` (not `name.root`) from both DB record and dataloader, ensuring the correct annotation name is returned.
> 
> - **GraphQL API**:
>   - **LLMEvaluator**:
>     - `output_config` now sources `annotation_name` instead of `name.root`.
>     - Updates dataloader fields to fetch `models.LLMEvaluator.annotation_name` alongside `output_config`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f16eece5f5832e3ec9fc07dc5689dbd3badd0f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->