### PR TITLE
fix: Fix import error on evaluator page

### DIFF
--- a/app/src/pages/evaluators/NewEvaluatorPage.tsx
+++ b/app/src/pages/evaluators/NewEvaluatorPage.tsx
@@ -39,7 +39,7 @@ import {
 import { getInstancePromptParamsFromStore } from "@phoenix/pages/playground/playgroundPromptUtils";
 import { useDerivedPlaygroundVariables } from "@phoenix/pages/playground/useDerivedPlaygroundVariables";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
-import { identifierPattern } from "@phoenix/utils/identifierUtils";
+import { validateIdentifier } from "@phoenix/utils/identifierUtils";
 
 export const NewEvaluatorPage = () => {
   return (
@@ -281,7 +281,7 @@ const NewEvaluatorPageContent = () => {
           <PanelContainer>
             <Flex
               direction="row"
-              alignItems="center"
+              alignItems="baseline"
               width="100%"
               gap="size-100"
               marginTop="size-100"
@@ -290,14 +290,7 @@ const NewEvaluatorPageContent = () => {
                 name="name"
                 control={nameControl}
                 rules={{
-                  required: "Name is required",
-                  pattern: {
-                    value: identifierPattern.value,
-                    message: identifierPattern.message.replace(
-                      "identifier",
-                      "evaluator name"
-                    ),
-                  },
+                  validate: validateIdentifier,
                 }}
                 render={({ field, fieldState: { error } }) => (
                   <TextField {...field} autoComplete="off" isInvalid={!!error}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches name field validation to `validateIdentifier` and tweaks layout alignment on `NewEvaluatorPage`.
> 
> - **Evaluators**:
>   - **Validation**:
>     - Replace `identifierPattern` with `validateIdentifier`; update `Controller` rules for `name` to use `validate`.
>   - **UI Layout**:
>     - Change `Flex` `alignItems` from `center` to `baseline` in `app/src/pages/evaluators/NewEvaluatorPage.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f7edc788d501c4318494f2871ffacf02ce204c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->