### PR TITLE
fix: backslashes were not escaped in py str sanitization

### DIFF
--- a/app/src/utils/__tests__/pythonUtils.test.ts
+++ b/app/src/utils/__tests__/pythonUtils.test.ts
@@ -1,10 +1,45 @@
 import { toPythonPrimitiveStr } from "../pythonUtils";
 
 describe("toPythonPrimitiveStr", () => {
-  it("should preserve strings", () => {
-    expect(toPythonPrimitiveStr("hello")).toEqual(`"hello"`);
+  it("should convert booleans to Python format", () => {
+    expect(toPythonPrimitiveStr(true)).toEqual("True");
+    expect(toPythonPrimitiveStr(false)).toEqual("False");
+  });
+
+  it("should convert numbers to strings", () => {
+    expect(toPythonPrimitiveStr(42)).toEqual("42");
+    expect(toPythonPrimitiveStr(3.14)).toEqual("3.14");
+  });
+
+  it("should escape newlines and quotes in strings", () => {
     expect(toPythonPrimitiveStr("hello\nworld")).toEqual(`"hello\\nworld"`);
-    expect(toPythonPrimitiveStr('hello"world')).toEqual(`"hello\\"world"`);
-    expect(toPythonPrimitiveStr('hello\nworld"')).toEqual(`"hello\\nworld\\""`);
+    expect(toPythonPrimitiveStr('say "hello"')).toEqual(`"say \\"hello\\""`);
+  });
+
+  it("should escape backslashes in Windows file paths", () => {
+    const input = "C:\\Users\\Alice\\Documents\\report.pdf";
+    expect(toPythonPrimitiveStr(input)).toEqual(
+      `"C:\\\\Users\\\\Alice\\\\Documents\\\\report.pdf"`
+    );
+  });
+
+  it("should escape backslashes in regex patterns", () => {
+    const input = "\\d{3}-\\d{2}-\\d{4}";
+    expect(toPythonPrimitiveStr(input)).toEqual(`"\\\\d{3}-\\\\d{2}-\\\\d{4}"`);
+  });
+
+  it("should distinguish literal backslash-n from actual newline", () => {
+    // Actual newline character
+    expect(toPythonPrimitiveStr("line1\nline2")).toEqual(`"line1\\nline2"`);
+
+    // Literal backslash followed by 'n'
+    expect(toPythonPrimitiveStr("path\\name")).toEqual(`"path\\\\name"`);
+  });
+
+  it("should handle strings with backslashes, newlines, and quotes", () => {
+    const input = 'C:\\Users\\"test"\npath';
+    expect(toPythonPrimitiveStr(input)).toEqual(
+      `"C:\\\\Users\\\\\\"test\\"\\npath"`
+    );
   });
 });

--- a/app/src/utils/pythonUtils.ts
+++ b/app/src/utils/pythonUtils.ts
@@ -2,7 +2,12 @@
  * A function that converts it to a python friendly string
  */
 function sanitizePythonStr(value: string) {
-  return value.replaceAll("\n", "\\n").replaceAll('"', '\\"');
+  // Escape backslashes FIRST before other escape sequences
+  // Otherwise we would double-escape the backslashes we add for \n and \"
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\n", "\\n")
+    .replaceAll('"', '\\"');
 }
 
 /**


### PR DESCRIPTION
`\\` were not being escaped in the `santizePythonString` function resulting in unicode errors in frontend (for example in the match filters of spans).

This PR fixes that bug and adds a more complete suite of unit tests.

Here is an image of the failure before the fix when using the match filter on a sample windows file path

<img width="572" height="109" alt="image" src="https://github.com/user-attachments/assets/5ec386fc-e7a5-4453-9c52-2fdb00b623e1" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Escapes backslashes first in Python string sanitization and adds comprehensive tests for primitive conversion and escaping.
> 
> - **Utils**:
>   - Update `sanitizePythonStr` in `app/src/utils/pythonUtils.ts` to escape backslashes (`\\`) before newlines and quotes to prevent double-escaping.
> - **Tests**:
>   - Expand `toPythonPrimitiveStr` tests in `app/src/utils/__tests__/pythonUtils.test.ts`:
>     - Booleans converted to `True`/`False`.
>     - Numbers converted to strings.
>     - Strings: escape newlines (`\n`), quotes (`\"`), and backslashes (`\\`).
>     - Cases for Windows paths, regex patterns, literal `\n` vs newline, and mixed characters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d50effadaf849f7fbd5ffe5676d069b16db78ed9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->