### PR TITLE
fix: only 50 users were displayed in admin view

### DIFF
--- a/app/src/pages/settings/UsersTable.tsx
+++ b/app/src/pages/settings/UsersTable.tsx
@@ -58,8 +58,13 @@ export function UsersTable({ query }: { query: UsersTable_users$key }) {
   >(
     graphql`
       fragment UsersTable_users on Query
-      @refetchable(queryName: "UsersTableQuery") {
-        users {
+      @refetchable(queryName: "UsersTableQuery")
+      @argumentDefinitions(
+        after: { type: "String", defaultValue: null }
+        first: { type: "Int", defaultValue: 10000 }
+      ) {
+        users(first: $first, after: $after)
+          @connection(key: "UsersTable_users") {
           edges {
             user: node {
               id
@@ -72,6 +77,13 @@ export function UsersTable({ query }: { query: UsersTable_users$key }) {
                 name
               }
             }
+            cursor
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+            hasPreviousPage
+            startCursor
           }
         }
       }

--- a/app/src/pages/settings/__generated__/UsersCardQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/UsersCardQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66f41fe5219700b7bc6153992c2f5afa>>
+ * @generated SignedSource<<c08aaa76bfc0fe76299abade273bc391>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,14 @@ export type UsersCardQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10000
+  }
+],
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -51,7 +58,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v0/*: any*/),
         "concreteType": "UserConnection",
         "kind": "LinkedField",
         "name": "users",
@@ -73,7 +80,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -124,28 +131,102 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v1/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "User",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v1/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasPreviousPage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startCursor",
                 "storageKey": null
               }
             ],
             "storageKey": null
           }
         ],
-        "storageKey": null
+        "storageKey": "users(first:10000)"
+      },
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "UsersTable_users",
+        "kind": "LinkedHandle",
+        "name": "users"
       }
     ]
   },
   "params": {
-    "cacheID": "7198a3944688637f02a72e35643511d0",
+    "cacheID": "2a97503989992621edd870655aac3543",
     "id": null,
     "metadata": {},
     "name": "UsersCardQuery",
     "operationKind": "query",
-    "text": "query UsersCardQuery {\n  ...UsersTable_users\n}\n\nfragment UsersTable_users on Query {\n  users {\n    edges {\n      user: node {\n        id\n        email\n        username\n        createdAt\n        authMethod\n        profilePictureUrl\n        role {\n          name\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query UsersCardQuery {\n  ...UsersTable_users\n}\n\nfragment UsersTable_users on Query {\n  users(first: 10000) {\n    edges {\n      user: node {\n        id\n        email\n        username\n        createdAt\n        authMethod\n        profilePictureUrl\n        role {\n          name\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/settings/__generated__/UsersTableQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/UsersTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<747cbed49d4e0b39454f07e4e45ac69e>>
+ * @generated SignedSource<<a56d1e31263ae11b6404e34560af7d4d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,10 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type UsersTableQuery$variables = Record<PropertyKey, never>;
+export type UsersTableQuery$variables = {
+  after?: string | null;
+  first?: number | null;
+};
 export type UsersTableQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"UsersTable_users">;
 };
@@ -20,7 +23,31 @@ export type UsersTableQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 10000,
+    "kind": "LocalArgument",
+    "name": "first"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -29,13 +56,13 @@ var v0 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "UsersTableQuery",
     "selections": [
       {
-        "args": null,
+        "args": (v1/*: any*/),
         "kind": "FragmentSpread",
         "name": "UsersTable_users"
       }
@@ -45,13 +72,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "UsersTableQuery",
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v1/*: any*/),
         "concreteType": "UserConnection",
         "kind": "LinkedField",
         "name": "users",
@@ -73,7 +100,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v0/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -124,11 +151,76 @@ return {
                         "name": "name",
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "User",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasPreviousPage",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "startCursor",
                 "storageKey": null
               }
             ],
@@ -136,20 +228,29 @@ return {
           }
         ],
         "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "filters": null,
+        "handle": "connection",
+        "key": "UsersTable_users",
+        "kind": "LinkedHandle",
+        "name": "users"
       }
     ]
   },
   "params": {
-    "cacheID": "e5a1fa2cfeca95ac9f22b2c65d3a4548",
+    "cacheID": "9f66551e6985769af4135c93313953ca",
     "id": null,
     "metadata": {},
     "name": "UsersTableQuery",
     "operationKind": "query",
-    "text": "query UsersTableQuery {\n  ...UsersTable_users\n}\n\nfragment UsersTable_users on Query {\n  users {\n    edges {\n      user: node {\n        id\n        email\n        username\n        createdAt\n        authMethod\n        profilePictureUrl\n        role {\n          name\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query UsersTableQuery(\n  $after: String = null\n  $first: Int = 10000\n) {\n  ...UsersTable_users_2HEEH6\n}\n\nfragment UsersTable_users_2HEEH6 on Query {\n  users(first: $first, after: $after) {\n    edges {\n      user: node {\n        id\n        email\n        username\n        createdAt\n        authMethod\n        profilePictureUrl\n        role {\n          name\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "acd5e44c43deb927fea733697593c97d";
+(node as any).hash = "d6e2e9ebf1ce3189d71149199a6e7c6c";
 
 export default node;

--- a/app/src/pages/settings/__generated__/UsersTable_users.graphql.ts
+++ b/app/src/pages/settings/__generated__/UsersTable_users.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d6fd217ea6bf4df9220f59dcc472356e>>
+ * @generated SignedSource<<85a064b84ed0ee92989369da9b475952>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ import { FragmentRefs } from "relay-runtime";
 export type UsersTable_users$data = {
   readonly users: {
     readonly edges: ReadonlyArray<{
+      readonly cursor: string;
       readonly user: {
         readonly authMethod: AuthMethod;
         readonly createdAt: string;
@@ -26,6 +27,12 @@ export type UsersTable_users$data = {
         readonly username: string;
       };
     }>;
+    readonly pageInfo: {
+      readonly endCursor: string | null;
+      readonly hasNextPage: boolean;
+      readonly hasPreviousPage: boolean;
+      readonly startCursor: string | null;
+    };
   };
   readonly " $fragmentType": "UsersTable_users";
 };
@@ -36,12 +43,42 @@ export type UsersTable_users$key = {
 
 import UsersTableQuery_graphql from './UsersTableQuery.graphql';
 
-const node: ReaderFragment = {
-  "argumentDefinitions": [],
+const node: ReaderFragment = (function(){
+var v0 = [
+  "users"
+];
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 10000,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
   "kind": "Fragment",
   "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
     "refetch": {
-      "connection": null,
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
       "fragmentPathInResult": [],
       "operation": UsersTableQuery_graphql
     }
@@ -49,11 +86,11 @@ const node: ReaderFragment = {
   "name": "UsersTable_users",
   "selections": [
     {
-      "alias": null,
+      "alias": "users",
       "args": null,
       "concreteType": "UserConnection",
       "kind": "LinkedField",
-      "name": "users",
+      "name": "__UsersTable_users_connection",
       "plural": false,
       "selections": [
         {
@@ -134,6 +171,70 @@ const node: ReaderFragment = {
                 }
               ],
               "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasPreviousPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "startCursor",
+              "storageKey": null
             }
           ],
           "storageKey": null
@@ -145,7 +246,8 @@ const node: ReaderFragment = {
   "type": "Query",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "acd5e44c43deb927fea733697593c97d";
+(node as any).hash = "d6e2e9ebf1ce3189d71149199a6e7c6c";
 
 export default node;


### PR DESCRIPTION
There was no cursor implementation in the graphql query for users. This meant that the users displayed were limited to 50 users.

This PR, adds the cursor, and generates the types. I've also added a screenshot with a local test showing >50 users.


<img width="750" height="2027" alt="Screenshot_20251109_214550" src="https://github.com/user-attachments/assets/c6fe1208-32bf-41e7-97db-ae7f4c24f50a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch users query to a Relay connection with cursor-based pagination (first/after) and regenerate GraphQL artifacts.
> 
> - **UsersTable** (`app/src/pages/settings/UsersTable.tsx`):
>   - Convert `users` to a Relay `@connection` with `first`/`after` args and defaults (`first: 10000`).
>   - Add `edges.cursor` and `pageInfo` (`endCursor`, `hasNextPage`, `hasPreviousPage`, `startCursor`).
>   - Enable refetchable fragment with pagination variables.
> - **Generated Relay artifacts**:
>   - Update queries/fragments to include pagination variables, connection handles (`key: "UsersTable_users"`), cursors, and `pageInfo`.
>   - Adjust variable types and storage keys (e.g., `users(first:10000)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0835a25bc0acf65f50da982afd172e89271bac07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->