### PR TITLE
fix: fix adding span to empty dataset

### DIFF
--- a/app/src/components/dataset/DatasetSelect.tsx
+++ b/app/src/components/dataset/DatasetSelect.tsx
@@ -86,13 +86,8 @@ export function DatasetSelect(props: DatasetSelectProps) {
           `}
         >
           {data.datasets.edges.map(({ dataset }) => {
-            const isDisabled = dataset.exampleCount === 0;
             return (
-              <SelectItem
-                key={dataset.id}
-                id={dataset.id}
-                isDisabled={isDisabled}
-              >
+              <SelectItem key={dataset.id} id={dataset.id}>
                 <Flex direction="column" gap="size-100" width="100%">
                   <Flex
                     direction="row"
@@ -100,11 +95,6 @@ export function DatasetSelect(props: DatasetSelectProps) {
                     gap="size-200"
                     justifyContent="space-between"
                     width="100%"
-                    css={css`
-                      opacity: ${isDisabled
-                        ? "var(--ac-global-opacity-disabled)"
-                        : 1};
-                    `}
                   >
                     <Text>{dataset.name}</Text>
                     <Text color="text-700" size="XS">


### PR DESCRIPTION
Fixes bug where empty datasets were disabled in the dataset selector, preventing users from adding a span to an empty dataset. The disabled states were added to prevent users selecting an empty dataset from the playground, but now that the playground page uses a different component (DatasetSelectWithSplits), we can remove them from DatasetSelect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes disabled state and opacity styling so empty datasets can be selected in `DatasetSelect`.
> 
> - **Dataset selector (`app/src/components/dataset/DatasetSelect.tsx`)**:
>   - Remove disabled logic (`isDisabled`) for datasets with `exampleCount === 0`.
>   - Drop opacity styling tied to disabled state.
>   - `SelectItem` no longer passes `isDisabled`, enabling selection of empty datasets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a990180caedb43f209f94c580c14c891ecfa05a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->