### PR TITLE
fix: fix dataset creation form next to dataset picker

### DIFF
--- a/app/src/components/dataset/CreateDatasetForm.tsx
+++ b/app/src/components/dataset/CreateDatasetForm.tsx
@@ -29,11 +29,7 @@ export function CreateDatasetForm(props: CreateDatasetFormProps) {
         dataset {
           id
           name
-          description
-          metadata
-          createdAt
-          exampleCount
-          experimentCount
+          ...DatasetSelect_dataset
         }
       }
     }

--- a/app/src/components/dataset/__generated__/CreateDatasetFormMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/CreateDatasetFormMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8dc5f83d19ba609a2104e1732839e016>>
+ * @generated SignedSource<<0a2ddfcbb816054402a5bdb642bec1a7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type CreateDatasetFormMutation$variables = {
   description?: string | null;
   metadata?: any | null;
@@ -17,13 +18,9 @@ export type CreateDatasetFormMutation$variables = {
 export type CreateDatasetFormMutation$data = {
   readonly createDataset: {
     readonly dataset: {
-      readonly createdAt: string;
-      readonly description: string | null;
-      readonly exampleCount: number;
-      readonly experimentCount: number;
       readonly id: string;
-      readonly metadata: any;
       readonly name: string;
+      readonly " $fragmentSpreads": FragmentRefs<"DatasetSelect_dataset">;
     };
   };
 };
@@ -50,93 +47,66 @@ v2 = {
 },
 v3 = [
   {
-    "alias": null,
-    "args": [
+    "fields": [
       {
-        "fields": [
-          {
-            "kind": "Variable",
-            "name": "description",
-            "variableName": "description"
-          },
-          {
-            "kind": "Variable",
-            "name": "metadata",
-            "variableName": "metadata"
-          },
-          {
-            "kind": "Variable",
-            "name": "name",
-            "variableName": "name"
-          }
-        ],
-        "kind": "ObjectValue",
-        "name": "input"
+        "kind": "Variable",
+        "name": "description",
+        "variableName": "description"
+      },
+      {
+        "kind": "Variable",
+        "name": "metadata",
+        "variableName": "metadata"
+      },
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
       }
     ],
-    "concreteType": "DatasetMutationPayload",
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = [
+  (v4/*: any*/),
+  (v5/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "exampleCount",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DatasetLabel",
     "kind": "LinkedField",
-    "name": "createDataset",
-    "plural": false,
+    "name": "labels",
+    "plural": true,
     "selections": [
+      (v4/*: any*/),
+      (v5/*: any*/),
       {
         "alias": null,
         "args": null,
-        "concreteType": "Dataset",
-        "kind": "LinkedField",
-        "name": "dataset",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "description",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "metadata",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "exampleCount",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "experimentCount",
-            "storageKey": null
-          }
-        ],
+        "kind": "ScalarField",
+        "name": "color",
         "storageKey": null
       }
     ],
@@ -153,7 +123,39 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "CreateDatasetFormMutation",
-    "selections": (v3/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "DatasetMutationPayload",
+        "kind": "LinkedField",
+        "name": "createDataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Dataset",
+            "kind": "LinkedField",
+            "name": "dataset",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "kind": "InlineDataFragmentSpread",
+                "name": "DatasetSelect_dataset",
+                "selections": (v6/*: any*/),
+                "args": null,
+                "argumentDefinitions": []
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -166,19 +168,41 @@ return {
     ],
     "kind": "Operation",
     "name": "CreateDatasetFormMutation",
-    "selections": (v3/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "DatasetMutationPayload",
+        "kind": "LinkedField",
+        "name": "createDataset",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Dataset",
+            "kind": "LinkedField",
+            "name": "dataset",
+            "plural": false,
+            "selections": (v6/*: any*/),
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "6aa615e27e1ccaa5431ba481842b43d0",
+    "cacheID": "e795a4b8ebb795f93dea507cba2eef83",
     "id": null,
     "metadata": {},
     "name": "CreateDatasetFormMutation",
     "operationKind": "mutation",
-    "text": "mutation CreateDatasetFormMutation(\n  $name: String!\n  $description: String = null\n  $metadata: JSON = null\n) {\n  createDataset(input: {name: $name, description: $description, metadata: $metadata}) {\n    dataset {\n      id\n      name\n      description\n      metadata\n      createdAt\n      exampleCount\n      experimentCount\n    }\n  }\n}\n"
+    "text": "mutation CreateDatasetFormMutation(\n  $name: String!\n  $description: String = null\n  $metadata: JSON = null\n) {\n  createDataset(input: {name: $name, description: $description, metadata: $metadata}) {\n    dataset {\n      id\n      name\n      ...DatasetSelect_dataset\n    }\n  }\n}\n\nfragment DatasetSelect_dataset on Dataset {\n  id\n  name\n  exampleCount\n  labels {\n    id\n    name\n    color\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5921369d33cc0fb1dffb5d943469a378";
+(node as any).hash = "1948aa8344d9c6feab99a0c18f2a6988";
 
 export default node;

--- a/app/src/components/dataset/__generated__/DatasetSelectQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/DatasetSelectQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<742edb27afdd72f66674aa13bd453e37>>
+ * @generated SignedSource<<263be913bbcc445382e4982594b21d47>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,19 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type DatasetSelectQuery$variables = Record<PropertyKey, never>;
 export type DatasetSelectQuery$data = {
   readonly datasets: {
     readonly edges: ReadonlyArray<{
       readonly dataset: {
-        readonly exampleCount: number;
-        readonly id: string;
-        readonly labels: ReadonlyArray<{
-          readonly color: string;
-          readonly id: string;
-          readonly name: string;
-        }>;
-        readonly name: string;
+        readonly " $fragmentSpreads": FragmentRefs<"DatasetSelect_dataset">;
       };
     }>;
   };
@@ -46,46 +40,37 @@ v1 = {
   "name": "name",
   "storageKey": null
 },
-v2 = {
-  "alias": "dataset",
-  "args": null,
-  "concreteType": "Dataset",
-  "kind": "LinkedField",
-  "name": "node",
-  "plural": false,
-  "selections": [
-    (v0/*: any*/),
-    (v1/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "exampleCount",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "DatasetLabel",
-      "kind": "LinkedField",
-      "name": "labels",
-      "plural": true,
-      "selections": [
-        (v0/*: any*/),
-        (v1/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "color",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
+v2 = [
+  (v0/*: any*/),
+  (v1/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "exampleCount",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DatasetLabel",
+    "kind": "LinkedField",
+    "name": "labels",
+    "plural": true,
+    "selections": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "color",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
 v3 = {
   "alias": null,
   "args": null,
@@ -155,7 +140,24 @@ return {
             "name": "edges",
             "plural": true,
             "selections": [
-              (v2/*: any*/),
+              {
+                "alias": "dataset",
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "InlineDataFragmentSpread",
+                    "name": "DatasetSelect_dataset",
+                    "selections": (v2/*: any*/),
+                    "args": null,
+                    "argumentDefinitions": []
+                  }
+                ],
+                "storageKey": null
+              },
               (v3/*: any*/),
               {
                 "alias": null,
@@ -202,7 +204,16 @@ return {
             "name": "edges",
             "plural": true,
             "selections": [
-              (v2/*: any*/),
+              {
+                "alias": "dataset",
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": (v2/*: any*/),
+                "storageKey": null
+              },
               (v3/*: any*/),
               {
                 "alias": null,
@@ -236,7 +247,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e93c9a6139e4afa7840eb6f1318f2f7f",
+    "cacheID": "fff04130b98b951a22dd558022ce4745",
     "id": null,
     "metadata": {
       "connection": [
@@ -252,11 +263,11 @@ return {
     },
     "name": "DatasetSelectQuery",
     "operationKind": "query",
-    "text": "query DatasetSelectQuery {\n  datasets(first: 100) {\n    edges {\n      dataset: node {\n        id\n        name\n        exampleCount\n        labels {\n          id\n          name\n          color\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query DatasetSelectQuery {\n  datasets(first: 100) {\n    edges {\n      dataset: node {\n        ...DatasetSelect_dataset\n        id\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment DatasetSelect_dataset on Dataset {\n  id\n  name\n  exampleCount\n  labels {\n    id\n    name\n    color\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0bc5073a96b85b3783e4c23379337775";
+(node as any).hash = "c50a9ca70f0f2beee00480213fef8b58";
 
 export default node;

--- a/app/src/components/dataset/__generated__/DatasetSelect_dataset.graphql.ts
+++ b/app/src/components/dataset/__generated__/DatasetSelect_dataset.graphql.ts
@@ -1,0 +1,36 @@
+/**
+ * @generated SignedSource<<10b8acfcbaaa1a153c35ece7fd816392>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderInlineDataFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DatasetSelect_dataset$data = {
+  readonly exampleCount: number;
+  readonly id: string;
+  readonly labels: ReadonlyArray<{
+    readonly color: string;
+    readonly id: string;
+    readonly name: string;
+  }>;
+  readonly name: string;
+  readonly " $fragmentType": "DatasetSelect_dataset";
+};
+export type DatasetSelect_dataset$key = {
+  readonly " $data"?: DatasetSelect_dataset$data;
+  readonly " $fragmentSpreads": FragmentRefs<"DatasetSelect_dataset">;
+};
+
+const node: ReaderInlineDataFragment = {
+  "kind": "InlineDataFragment",
+  "name": "DatasetSelect_dataset"
+};
+
+(node as any).hash = "e5a0b1650426283637ea59a109398aa9";
+
+export default node;


### PR DESCRIPTION
Resolves #10182 

Fixes a bug where attempting to create a new dataset from SpanToDatasetExampleDialog fails with `Cannot read properties of undefined (reading 'length')`. The problem is that when the dataset creation mutation succeeds, we append the returned dataset node to the datasets connection used by the dataset picker. This node is missing a `labels` field which is required by the dataset picker, causing the page to crash. 

The fix in this PR is to refactor to a shared fragment to ensure data requirements stay in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors dataset picker and create mutation to share an inline fragment and updates queries/mutation and generated artifacts accordingly.
> 
> - **Dataset picker (`DatasetSelect.tsx`)**:
>   - Adds inline fragment `DatasetSelect_dataset` and uses `readInlineData` + `useMemo` to consume it.
>   - Updates `DatasetSelectQuery` to spread `...DatasetSelect_dataset` on `edges.dataset`.
> - **Create dataset form (`CreateDatasetForm.tsx`)**:
>   - Mutation now spreads `...DatasetSelect_dataset` to ensure returned dataset matches picker needs.
> - **Relay artifacts**:
>   - Adds `__generated__/DatasetSelect_dataset.graphql.ts` and updates `CreateDatasetFormMutation.graphql.ts` and `DatasetSelectQuery.graphql.ts` to use the shared fragment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbc228825a8fa8f564cd746a6aa577e129eb9151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->