### PR TITLE
chore: remove macos-13 from CI

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -375,10 +375,7 @@ jobs:
       fail-fast: false
       matrix:
         py: [3.9, 3.13]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        exclude:
-          - py: 3.13
-            os: macos-13
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
macos-13 is being removed by github.

see https://github.com/actions/runner-images/issues/13046

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch CI matrices from macos-13 to macos-latest and simplify unit test matrix in `.github/workflows/python-CI.yml`.
> 
> - **CI (GitHub Actions)** in `/.github/workflows/python-CI.yml`:
>   - Replace `macos-13` with `macos-latest` in job matrices for `phoenix-client`, `phoenix-evals`, and `phoenix-otel`.
>   - Simplify `unit-tests` matrix:
>     - Set `os` to `[ubuntu-latest, windows-latest, macos-latest]`.
>     - Remove `exclude` entry for `py: 3.13` on `macos-13`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9640b8549f8b47f22b3d9bca3d24fc8202028d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->