### PR TITLE
update to any Arize AX mentions

### DIFF
--- a/docs/evaluation/legacy/how-to-evals/running-pre-tested-evals/ai-vs-human-groundtruth.md
+++ b/docs/evaluation/legacy/how-to-evals/running-pre-tested-evals/ai-vs-human-groundtruth.md
@@ -10,7 +10,7 @@ description: >-
 
 A workflow we see for high quality RAG deployments is generating a golden dataset of questions and a high quality set of answers. These can be in the range of 100-200 but provide a strong check for the AI generated answers. This Eval checks that the human ground truth matches the AI generated answer. Its designed to catch missing data in "half" answers and differences of substance.
 
-### Example Human vs AI on Arize Docs:
+### Example Human vs AI on Arize AX Docs:
 
 _**Question:**_
 
@@ -18,13 +18,13 @@ What Evals are supported for LLMs on generative models?
 
 _**Human:**_
 
-Arize supports a suite of Evals available from the Phoenix Evals library, they include both pre-tested Evals and the ability to configure cusotm Evals. Some of the pre-tested LLM Evals are listed below:
+Arize AX supports a suite of Evals available from the Phoenix Evals library, they include both pre-tested Evals and the ability to configure cusotm Evals. Some of the pre-tested LLM Evals are listed below:
 
 Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Code Execution, Hallucination Detection and Summarizaiton
 
 **AI:**
 
-Arize supports LLM Evals.
+Arize AX supports LLM Evals.
 
 **Eval:**
 
@@ -32,7 +32,7 @@ Incorrect
 
 **Explanation of Eval:**
 
-The AI answer is very brief and lacks the specific details that are present in the human ground truth answer. While the AI answer is not incorrect in stating that Arize supports LLM Evals, it fails to mention the specific types of Evals that are supported, such as Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Hallucination Detection, and Summarization. Therefore, the AI answer does not fully capture the substance of the human answer.
+The AI answer is very brief and lacks the specific details that are present in the human ground truth answer. While the AI answer is not incorrect in stating that Arize AX supports LLM Evals, it fails to mention the specific types of Evals that are supported, such as Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Hallucination Detection, and Summarization. Therefore, the AI answer does not fully capture the substance of the human answer.
 
 Overview of template:
 
@@ -91,7 +91,7 @@ relevance_classifications = llm_classify(
 
 ## Benchmark Results:
 
-The follow benchmarking data was gathered by comparing various model results to ground truth data. The ground truth data used was a handcrafted dataset consisting of questions about the Arize platform. That[ dataset is availabe here](https://storage.googleapis.com/arize-phoenix-assets/evals/human_vs_ai/human_vs_ai_classifications.csv).
+The follow benchmarking data was gathered by comparing various model results to ground truth data. The ground truth data used was a handcrafted dataset consisting of questions about the Arize AX platform. That[ dataset is availabe here](https://storage.googleapis.com/arize-phoenix-assets/evals/human_vs_ai/human_vs_ai_classifications.csv).
 
 **GPT-4 Results**
 

--- a/docs/evaluation/legacy/how-to-evals/running-pre-tested-evals/reference-link-evals.md
+++ b/docs/evaluation/legacy/how-to-evals/running-pre-tested-evals/reference-link-evals.md
@@ -68,7 +68,7 @@ relevance_classifications = llm_classify(
 
 ## Benchmark Results
 
-This benchmark was obtained using notebook below. It was run using a handcrafted ground truth dataset consisting of questions on the Arize platform. That [dataset is available here](https://storage.googleapis.com/arize-assets/phoenix/evals/ref-link-classification/ref_link_golden_test_data.csv).
+This benchmark was obtained using notebook below. It was run using a handcrafted ground truth dataset consisting of questions on the Arize AX platform. That [dataset is available here](https://storage.googleapis.com/arize-assets/phoenix/evals/ref-link-classification/ref_link_golden_test_data.csv).
 
 Each example in the dataset was evaluating using the `REF_LINK_EVAL_PROMPT_TEMPLATE_STR` above, then the resulting labels were compared against the ground truth label in the benchmark dataset to generate the confusion matrices below.
 

--- a/docs/evaluation/running-pre-tested-evals/ai-vs-human-groundtruth.md
+++ b/docs/evaluation/running-pre-tested-evals/ai-vs-human-groundtruth.md
@@ -10,7 +10,7 @@ description: >-
 
 A workflow we see for high quality RAG deployments is generating a golden dataset of questions and a high quality set of answers. These can be in the range of 100-200 but provide a strong check for the AI generated answers. This Eval checks that the human ground truth matches the AI generated answer. Its designed to catch missing data in "half" answers and differences of substance.
 
-### Example Human vs AI on Arize Docs:
+### Example Human vs AI on Arize AX Docs:
 
 _**Question:**_
 
@@ -18,13 +18,13 @@ What Evals are supported for LLMs on generative models?
 
 _**Human:**_
 
-Arize supports a suite of Evals available from the Phoenix Evals library, they include both pre-tested Evals and the ability to configure cusotm Evals. Some of the pre-tested LLM Evals are listed below:
+Arize AX supports a suite of Evals available from the Phoenix Evals library, they include both pre-tested Evals and the ability to configure cusotm Evals. Some of the pre-tested LLM Evals are listed below:
 
 Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Code Execution, Hallucination Detection and Summarizaiton
 
 **AI:**
 
-Arize supports LLM Evals.
+Arize AX supports LLM Evals.
 
 **Eval:**
 
@@ -32,7 +32,7 @@ Incorrect
 
 **Explanation of Eval:**
 
-The AI answer is very brief and lacks the specific details that are present in the human ground truth answer. While the AI answer is not incorrect in stating that Arize supports LLM Evals, it fails to mention the specific types of Evals that are supported, such as Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Hallucination Detection, and Summarization. Therefore, the AI answer does not fully capture the substance of the human answer.
+The AI answer is very brief and lacks the specific details that are present in the human ground truth answer. While the AI answer is not incorrect in stating that Arize AX supports LLM Evals, it fails to mention the specific types of Evals that are supported, such as Retrieval Relevance, Question and Answer, Toxicity, Human Groundtruth vs AI, Citation Reference Link Relevancy, Code Readability, Hallucination Detection, and Summarization. Therefore, the AI answer does not fully capture the substance of the human answer.
 
 Overview of template:
 
@@ -91,7 +91,7 @@ relevance_classifications = llm_classify(
 
 ## Benchmark Results:
 
-The follow benchmarking data was gathered by comparing various model results to ground truth data. The ground truth data used was a handcrafted dataset consisting of questions about the Arize platform. That[ dataset is availabe here](https://storage.googleapis.com/arize-phoenix-assets/evals/human_vs_ai/human_vs_ai_classifications.csv).
+The follow benchmarking data was gathered by comparing various model results to ground truth data. The ground truth data used was a handcrafted dataset consisting of questions about the Arize AX platform. That[ dataset is availabe here](https://storage.googleapis.com/arize-phoenix-assets/evals/human_vs_ai/human_vs_ai_classifications.csv).
 
 **GPT-4 Results**
 

--- a/docs/evaluation/running-pre-tested-evals/reference-link-evals.md
+++ b/docs/evaluation/running-pre-tested-evals/reference-link-evals.md
@@ -68,7 +68,7 @@ relevance_classifications = llm_classify(
 
 ## Benchmark Results
 
-This benchmark was obtained using notebook below. It was run using a handcrafted ground truth dataset consisting of questions on the Arize platform. That [dataset is available here](https://storage.googleapis.com/arize-assets/phoenix/evals/ref-link-classification/ref_link_golden_test_data.csv).
+This benchmark was obtained using notebook below. It was run using a handcrafted ground truth dataset consisting of questions on the Arize AX platform. That [dataset is available here](https://storage.googleapis.com/arize-assets/phoenix/evals/ref-link-classification/ref_link_golden_test_data.csv).
 
 Each example in the dataset was evaluating using the `REF_LINK_EVAL_PROMPT_TEMPLATE_STR` above, then the resulting labels were compared against the ground truth label in the benchmark dataset to generate the confusion matrices below.
 

--- a/docs/integrations/bring-production-data-to-notebook-for-eda-or-retraining.md
+++ b/docs/integrations/bring-production-data-to-notebook-for-eda-or-retraining.md
@@ -4,29 +4,29 @@ description: >-
   team can perform further investigation or kick off retraining workflows.
 ---
 
-# Export Data from Arize to Phoenix
+# Export Data from Arize AX to Phoenix
 
 Oftentimes, the team that notices an issue in their model, for example a prompt/response LLM model, may not be the same team that continues the investigations or kicks off retraining workflows.
 
-To help connect teams and workflows, Phoenix enables continued analysis of production data from [Arize](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) in a notebook environment for fine-tuning workflows.
+To help connect teams and workflows, Phoenix enables continued analysis of production data from [Arize AX](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) in a notebook environment for fine-tuning workflows.
 
-For example, a user may have noticed in [Arize](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) that this prompt template is not performing well.
+For example, a user may have noticed in [Arize AX](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) that this prompt template is not performing well.
 
-<figure><img src="../.gitbook/assets/image (1) (2).png" alt=""><figcaption><p>Arize UI, investigating prompt template: "You are an agent created to accurately translate sentences into the desired language."</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (1) (2).png" alt=""><figcaption><p>Arize AX UI, investigating prompt template: "You are an agent created to accurately translate sentences into the desired language."</p></figcaption></figure>
 
 With a few lines of Python code, users can export this data into Phoenix for further analysis. This allows team members, such as data scientists, who may not have access to production data today, an easy way to access relevant product data for further analysis in an environment they are familiar with.
 
 They can then easily augment and fine-tune the data and verify improved performance, before deploying back to production.
 
-There are two ways to export data out of [Arize](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) for further investigation:
+There are two ways to export data out of [Arize AX](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) for further investigation:
 
-1. The easiest way is to click the export button on the Embeddings and Inferences pages. This will produce a code snippet that you can copy into a Python environment and install Phoenix. This code snippet will include the date range you have selected in the [Arize](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) platform, in addition to the inferences you have selected.
+1. The easiest way is to click the export button on the Embeddings and Inferences pages. This will produce a code snippet that you can copy into a Python environment and install Phoenix. This code snippet will include the date range you have selected in the [Arize AX](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) platform, in addition to the inferences you have selected.
 
-<figure><img src="../.gitbook/assets/image (4).png" alt=""><figcaption><p>Export button on Embeddings tab in Arize UI</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (4).png" alt=""><figcaption><p>Export button on Embeddings tab in Arize AX UI</p></figcaption></figure>
 
-<figure><img src="../.gitbook/assets/image (6).png" alt=""><figcaption><p>Export to Phoenix module in Arize UI</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (6).png" alt=""><figcaption><p>Export to Phoenix module in Arize AX UI</p></figcaption></figure>
 
-2. Users can also query [Arize](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) for data directly using the Arize Python export client. We recommend doing this once you're more comfortable with the in-platform export functionality, as you will need to manually enter in the data ranges and data you want to export.
+2. Users can also query [Arize AX](https://app.gitbook.com/o/-MB4weB2E-qpBe07nmSL/s/-MAlgpMyBRcl2qFZRQ67/) for data directly using the Arize AX Python export client. We recommend doing this once you're more comfortable with the in-platform export functionality, as you will need to manually enter in the data ranges and data you want to export.
 
 ```python
 os.environ['ARIZE_API_KEY'] = ARIZE_API_KEY
@@ -47,4 +47,4 @@ primary_df = client.export_model_to_df(
 )
 ```
 
-#### Test out this workflow by signing up for a [free Arize account](https://app.arize.com/auth/join).
+#### Test out this workflow by signing up for a [free Arize AX account](https://app.arize.com/auth/join).

--- a/docs/quickstart/phoenix-inferences/README.md
+++ b/docs/quickstart/phoenix-inferences/README.md
@@ -233,11 +233,11 @@ Once you have identified datapoints of interest, you can export this data direct
 
 See more on exporting data [here](../../how-to/export-your-data.md).
 
-### Step 8 (Optional): Enable production observability with Arize
+### Step 8 (Optional): Enable production observability with Arize AX
 
-Once your model is ready for production, you can add Arize to enable production-grade observability. Phoenix works in conjunction with Arize to enable end-to-end model development and observability.
+Once your model is ready for production, you can add Arize AX to enable production-grade observability. Phoenix works in conjunction with Arize AX to enable end-to-end model development and observability.
 
-With Arize, you will additionally benefit from:
+With Arize AX, you will additionally benefit from:
 
 * Being able to publish and observe your models in real-time as inferences are being served, and/or via direct connectors from your table/storage solution
 * Scalable compute to handle billions of predictions
@@ -247,7 +247,7 @@ With Arize, you will additionally benefit from:
 * Enterprise-grade RBAC and SSO
 * Experiment with infinite permutations of model versions and filters
 
-Create your [free account](https://arize.com/join) and see the full suite of [Arize](https://docs.arize.com/arize/) features.
+Create your [free account](https://arize.com/join) and see the full suite of [Arize AX](https://docs.arize.com/arize/) features.
 
 ## Where to go from here?
 

--- a/docs/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison.md
+++ b/docs/resources/frequently-asked-questions/braintrust-open-source-alternative-llm-evaluation-platform-comparison.md
@@ -94,7 +94,7 @@ Phoenix deploys with one Docker command and is free/unlimited to run on-prem or 
 
 #### Instrumentation & Agent Tracing
 
-Phoenix ships OpenInference—an OTel-compatible auto-instrumentation layer that captures every prompt, tool call and agent step with sub-second latency. Braintrust has 5 instrumentation options supported versus Arize Ax & Phoenix who have 50+ instrumentations.
+Phoenix ships OpenInference—an OTel-compatible auto-instrumentation layer that captures every prompt, tool call and agent step with sub-second latency. Braintrust has 5 instrumentation options supported versus Arize AX and Phoenix who have 50+ instrumentations.
 
 Arize AX and Phoenix are the leaders in agent tracing solutions. Brainstrust does not trace agents today. Braintrust accepts OTel spans but has no auto-instrumentors or semantic conventions; most teams embed an SDK or proxy into their code, adding dev effort and potential latency.
 
@@ -110,7 +110,7 @@ Phoenix and Arize AX include annotation queues that let reviewers label any trac
 
 #### Agent Evaluation
 
-Phoenix and AX have released extensive Agent evaluation including path evaluations, convergence evaluations and session level evaluations. The investment in research, material and technology spans over a year of work from the Arize team. Arize is the leading company thinking and working on Agent evaluation.
+Phoenix and Arize AX have released extensive Agent evaluation including path evaluations, convergence evaluations and session level evaluations. The investment in research, material and technology spans over a year of work from the Arize team. Arize is the leading company thinking and working on Agent evaluation.
 
 {% embed url="https://www.youtube.com/watch?v=Qvp9vw4jJQ8" %}
 

--- a/docs/section-integrations/frameworks-and-platforms/graphite/arize-integration.md
+++ b/docs/section-integrations/frameworks-and-platforms/graphite/arize-integration.md
@@ -1,6 +1,6 @@
-# Arize & Phoenix Integration Guide
+# Arize AX & Phoenix Integration Guide
 
-This document provides comprehensive guidance on integrating Graphite with Arize and Phoenix for distributed tracing and observability.
+This document provides comprehensive guidance on integrating Graphite with Arize AX and Phoenix for distributed tracing and observability.
 
 ## Table of Contents
 
@@ -16,7 +16,7 @@ This document provides comprehensive guidance on integrating Graphite with Arize
 
 Graphite integrates with OpenTelemetry to provide distributed tracing through multiple backends:
 
-- **Arize**: Production-grade monitoring and observability platform for AI applications
+- **Arize AX**: Production-grade monitoring and observability platform for AI applications
 - **Phoenix**: Local/remote tracing solution ideal for development and debugging
 - **Auto**: Automatic detection of available tracing endpoints
 - **In-Memory**: Testing mode without external dependencies
@@ -86,9 +86,9 @@ services:
 
 ### Environment Variables
 
-#### Arize Configuration
+#### Arize AX Configuration
 
-Set these environment variables when using Arize:
+Set these environment variables when using Arize AX:
 
 ```bash
 # Required for Arize
@@ -130,9 +130,9 @@ def setup_tracing(
 
 Grafi provides four tracing backend options through the `TracingOptions` enum:
 
-### 1. ARIZE - Production Monitoring
+### 1. ARIZE AX - Production Monitoring
 
-Use Arize for production environments with enterprise-grade observability:
+Use Arize AX for production environments with enterprise-grade observability:
 
 ```python
 from grafi.common.instrumentations.tracing import TracingOptions, setup_tracing
@@ -225,7 +225,7 @@ container.register_tracer(tracer)
 # Your assistant code here
 ```
 
-### Example 2: Production Setup with Arize
+### Example 2: Production Setup with Arize AX
 
 ```python
 from grafi.common.containers.container import container
@@ -485,9 +485,9 @@ def setup_test_tracing():
    tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
    ```
 
-### Issue: Arize traces not appearing
+### Issue: Arize AX traces not appearing
 
-**Symptom**: No traces visible in Arize dashboard
+**Symptom**: No traces visible in the Arize AX dashboard
 
 **Solution**:
 1. Verify environment variables are set:
@@ -565,10 +565,10 @@ tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
 
 ## Additional Resources
 
-### Arize Resources
-- [Arize Platform Documentation](https://docs.arize.com/)
-- [Arize OpenTelemetry Integration](https://arize.com/docs/ax/integrations/opentelemetry/opentelemetry-arize-otel)
-- [Arize Python SDK](https://arize-client-python.readthedocs.io/en/latest/)
+### Arize AX Resources
+- [Arize AX Platform Documentation](https://docs.arize.com/)
+- [Arize AX OpenTelemetry Integration](https://arize.com/docs/ax/integrations/opentelemetry/opentelemetry-arize-otel)
+- [Arize AX Python SDK](https://arize-client-python.readthedocs.io/en/latest/)
 
 ### Phoenix Resources
 - [Phoenix Documentation](https://docs.arize.com/phoenix)
@@ -585,6 +585,5 @@ tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
 For issues related to:
 
 - **Graphite tracing integration**: Open an issue on the Grafi repository
-- **Arize platform**: Contact Arize support or consult their documentation
+- **Arize AX platform**: Contact Arize support or consult their documentation
 - **Phoenix**: Check the Phoenix GitHub issues or documentation
-

--- a/docs/section-integrations/python/graphite/README.md
+++ b/docs/section-integrations/python/graphite/README.md
@@ -11,6 +11,6 @@ description: >-
 Graphite combines a drag-and-drop workflow canvas with Python tooling so teams
 can prototype, orchestrate, and monitor complex multi-agent applications. The
 Phoenix integration streams Graphite's OpenTelemetry traces into Phoenix or
-Arize for observability across development and production environments.
+Arize AX for observability across development and production environments.
 
 <table data-card-size="large" data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><a href="arize-integration.md"><strong>Graphite Integration Guide</strong></a></td><td><a href="arize-integration.md">arize-integration.md</a></td></tr></tbody></table>

--- a/docs/section-integrations/python/graphite/arize-integration.md
+++ b/docs/section-integrations/python/graphite/arize-integration.md
@@ -1,6 +1,6 @@
-# Arize & Phoenix Integration Guide
+# Arize AX & Phoenix Integration Guide
 
-This document provides comprehensive guidance on integrating Graphite with Arize and Phoenix for distributed tracing and observability.
+This document provides comprehensive guidance on integrating Graphite with Arize AX and Phoenix for distributed tracing and observability.
 
 ## Table of Contents
 
@@ -16,7 +16,7 @@ This document provides comprehensive guidance on integrating Graphite with Arize
 
 Graphite integrates with OpenTelemetry to provide distributed tracing through multiple backends:
 
-- **Arize**: Production-grade monitoring and observability platform for AI applications
+- **Arize AX**: Production-grade monitoring and observability platform for AI applications
 - **Phoenix**: Local/remote tracing solution ideal for development and debugging
 - **Auto**: Automatic detection of available tracing endpoints
 - **In-Memory**: Testing mode without external dependencies
@@ -86,9 +86,9 @@ services:
 
 ### Environment Variables
 
-#### Arize Configuration
+#### Arize AX Configuration
 
-Set these environment variables when using Arize:
+Set these environment variables when using Arize AX:
 
 ```bash
 # Required for Arize
@@ -130,9 +130,9 @@ def setup_tracing(
 
 Grafi provides four tracing backend options through the `TracingOptions` enum:
 
-### 1. ARIZE - Production Monitoring
+### 1. ARIZE AX - Production Monitoring
 
-Use Arize for production environments with enterprise-grade observability:
+Use Arize AX for production environments with enterprise-grade observability:
 
 ```python
 from grafi.common.instrumentations.tracing import TracingOptions, setup_tracing
@@ -225,7 +225,7 @@ container.register_tracer(tracer)
 # Your assistant code here
 ```
 
-### Example 2: Production Setup with Arize
+### Example 2: Production Setup with Arize AX
 
 ```python
 from grafi.common.containers.container import container
@@ -485,9 +485,9 @@ def setup_test_tracing():
    tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
    ```
 
-### Issue: Arize traces not appearing
+### Issue: Arize AX traces not appearing
 
-**Symptom**: No traces visible in Arize dashboard
+**Symptom**: No traces visible in the Arize AX dashboard
 
 **Solution**:
 1. Verify environment variables are set:
@@ -565,10 +565,10 @@ tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
 
 ## Additional Resources
 
-### Arize Resources
-- [Arize Platform Documentation](https://docs.arize.com/)
-- [Arize OpenTelemetry Integration](https://arize.com/docs/ax/integrations/opentelemetry/opentelemetry-arize-otel)
-- [Arize Python SDK](https://arize-client-python.readthedocs.io/en/latest/)
+### Arize AX Resources
+- [Arize AX Platform Documentation](https://docs.arize.com/)
+- [Arize AX OpenTelemetry Integration](https://arize.com/docs/ax/integrations/opentelemetry/opentelemetry-arize-otel)
+- [Arize AX Python SDK](https://arize-client-python.readthedocs.io/en/latest/)
 
 ### Phoenix Resources
 - [Phoenix Documentation](https://docs.arize.com/phoenix)
@@ -585,6 +585,5 @@ tracer = setup_tracing(tracing_options=TracingOptions.AUTO)
 For issues related to:
 
 - **Graphite tracing integration**: Open an issue on the Grafi repository
-- **Arize platform**: Contact Arize support or consult their documentation
+- **Arize AX platform**: Contact Arize support or consult their documentation
 - **Phoenix**: Check the Phoenix GitHub issues or documentation
-

--- a/docs/section-integrations/typescript/mastra/mastra-tracing.md
+++ b/docs/section-integrations/typescript/mastra/mastra-tracing.md
@@ -28,7 +28,7 @@ PHOENIX_PROJECT_NAME=mastra-service # Optional, defaults to "mastra-service"
 
 ## Setup
 
-Initialize the Arize exporter inside your Mastra project:
+Initialize the Arize AX exporter inside your Mastra project:
 
 ```typescript
 import { Mastra } from "@mastra/core";

--- a/docs/section-integrations/typescript/vercel/vercel-ai-sdk-tracing-js.md
+++ b/docs/section-integrations/typescript/vercel/vercel-ai-sdk-tracing-js.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel.svg)](https://badge.fury.io/js/@arizeai%2Fopeninference-vercel)
 
-This package provides a set of utilities to ingest [Vercel AI SDK](https://github.com/vercel/ai)(>= 3.3) spans into platforms like [Arize](https://arize.com/) and [Phoenix](https://phoenix.arize.com/).
+This package provides a set of utilities to ingest [Vercel AI SDK](https://github.com/vercel/ai)(>= 3.3) spans into platforms like [Arize AX](https://arize.com/) and [Phoenix](https://phoenix.arize.com/).
 
 > Note: This package requires you to be using the Vercel AI SDK version 3.3 or higher.
 

--- a/docs/section-learn/resources/faqs/braintrust-open-source-alternative-llm-evaluation-platform-comparison.md
+++ b/docs/section-learn/resources/faqs/braintrust-open-source-alternative-llm-evaluation-platform-comparison.md
@@ -100,7 +100,7 @@ Phoenix deploys with one Docker command and is free/unlimited to run on-prem or 
 
 #### Instrumentation & Agent Tracing
 
-Phoenix ships OpenInference—an OTel-compatible auto-instrumentation layer that captures every prompt, tool call and agent step with sub-second latency. Braintrust has 5 instrumentation options supported versus Arize Ax & Phoenix who have 50+ instrumentations.
+Phoenix ships OpenInference—an OTel-compatible auto-instrumentation layer that captures every prompt, tool call and agent step with sub-second latency. Braintrust has 5 instrumentation options supported versus Arize AX and Phoenix who have 50+ instrumentations.
 
 Arize AX and Phoenix are the leaders in agent tracing solutions. Brainstrust does not trace agents today. Braintrust accepts OTel spans but has no auto-instrumentors or semantic conventions; most teams embed an SDK or proxy into their code, adding dev effort and potential latency.
 
@@ -116,7 +116,7 @@ Phoenix and Arize AX include annotation queues that let reviewers label any trac
 
 #### Agent Evaluation&#x20;
 
-Phoenix and AX have released extensive Agent evaluation including path evaluations, convergence evaluations and session level evaluations. The investment in research, material and technology spans over a year of work from the Arize team. Arize is the leading company thinking and working on Agent evaluation.&#x20;
+Phoenix and Arize AX have released extensive Agent evaluation including path evaluations, convergence evaluations and session level evaluations. The investment in research, material and technology spans over a year of work from the Arize team. Arize is the leading company thinking and working on Agent evaluation.&#x20;
 
 {% embed url="https://www.youtube.com/watch?v=Qvp9vw4jJQ8" %}
 

--- a/docs/section-release-notes/07.2025/07.18.2025-openinference-java.md
+++ b/docs/section-release-notes/07.2025/07.18.2025-openinference-java.md
@@ -1,6 +1,6 @@
 # 07.18.2025: OpenInference Java ✨
 
-OpenInference Java is now available, providing a comprehensive solution for tracing AI applications using OpenTelemetry. Fully compatible with any OpenTelemetry-compatible collector or backend like Arize.
+OpenInference Java is now available, providing a comprehensive solution for tracing AI applications using OpenTelemetry. Fully compatible with any OpenTelemetry-compatible collector or backend like Arize AX.
 
 Included in this release:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -112,7 +112,7 @@ Add guardrails to your application to prevent malicious and erroneous inputs and
 
 ## 🚀 Production
 
-In production, Phoenix works hand-in-hand with Arize, which focuses on the production side of the LLM lifecycle. The integration ensures a smooth transition from development to production, with consistent tooling and metrics across both platforms.
+In production, Phoenix works hand-in-hand with Arize AX, which focuses on the production side of the LLM lifecycle. The integration ensures a smooth transition from development to production, with consistent tooling and metrics across both platforms.
 
 {% tabs %}
 {% tab title="Traces in Production" %}
@@ -120,7 +120,7 @@ In production, Phoenix works hand-in-hand with Arize, which focuses on the produ
 
 {% embed url="https://storage.googleapis.com/arize-phoenix-assets/assets/gifs/tracing.mp4" %}
 
-Phoenix and Arize use the same collector frameworks in development and production. This allows teams to monitor latency, token usage, and other performance metrics, setting up alerts when thresholds are exceeded.
+Phoenix and Arize AX use the same collector frameworks in development and production. This allows teams to monitor latency, token usage, and other performance metrics, setting up alerts when thresholds are exceeded.
 
 * [llm-traces-1](tracing/llm-traces-1/ "mention")
 {% endtab %}
@@ -130,7 +130,7 @@ Phoenix and Arize use the same collector frameworks in development and productio
 
 {% embed url="https://storage.googleapis.com/arize-phoenix-assets/assets/gifs/evals.mp4" %}
 
-Phoenix's evaluation framework can be used to generate ongoing assessments of LLM performance in production. Arize complements this with online evaluations, enabling teams to set up alerts if evaluation metrics, such as hallucination rates, go beyond acceptable thresholds.
+Phoenix's evaluation framework can be used to generate ongoing assessments of LLM performance in production. Arize AX complements this with online evaluations, enabling teams to set up alerts if evaluation metrics, such as hallucination rates, go beyond acceptable thresholds.
 
 * [how-to-evals](evaluation/how-to-evals/ "mention")
 {% endtab %}
@@ -140,9 +140,9 @@ Phoenix's evaluation framework can be used to generate ongoing assessments of LL
 
 {% embed url="https://storage.googleapis.com/arize-phoenix-assets/assets/gifs/ExportForFinetuning.mp4" %}
 
-Phoenix and Arize together help teams identify data points for fine-tuning based on production performance and user feedback. This targeted approach ensures that fine-tuning efforts are directed towards the most impactful areas, maximizing the return on investment.
+Phoenix and Arize AX together help teams identify data points for fine-tuning based on production performance and user feedback. This targeted approach ensures that fine-tuning efforts are directed towards the most impactful areas, maximizing the return on investment.
 
-Phoenix, in collaboration with Arize, empowers teams to build, optimize, and maintain high-quality LLM applications throughout the entire lifecycle. By providing a comprehensive observability platform and seamless integration with production monitoring tools, Phoenix and Arize enable teams to deliver exceptional LLM-driven experiences with confidence and efficiency.
+Phoenix, in collaboration with Arize AX, empowers teams to build, optimize, and maintain high-quality LLM applications throughout the entire lifecycle. By providing a comprehensive observability platform and seamless integration with production monitoring tools, Phoenix and Arize AX enable teams to deliver exceptional LLM-driven experiences with confidence and efficiency.
 
 * [Fine-Tuning](https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/exporting-datasets#exporting-for-fine-tuning)
 {% endtab %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rebrands docs to "Arize AX" and updates headings, examples, troubleshooting, and resource links across evaluation guides, integrations, quickstarts, FAQs, user guide, and release notes.
> 
> - **Branding and terminology**:
>   - Replace `Arize` with `Arize AX` across docs, including headings, examples, explanations, troubleshooting labels, and resource sections.
> - **Evals documentation**:
>   - Update `AI vs Human (Groundtruth)` and `Reference Link Evals` pages (legacy and current) to reference `Arize AX` datasets and wording.
> - **Integrations**:
>   - **Graphite (Frameworks & Python)**: Rename guides to `Arize AX & Phoenix Integration Guide`; update environment variable sections, production setup examples, troubleshooting (“Arize AX traces”), and resources links.
>   - **Mastra (TS)**: Rename setup to “Initialize the Arize AX exporter”.
>   - **Vercel AI SDK (JS)**: Update platform mention to `Arize AX`.
> - **Product docs**:
>   - Update Quickstart Step 8 to “Enable production observability with Arize AX” and related copy/links.
>   - Update User Guide production section to reference `Arize AX` throughout.
>   - Update “Export Data from Arize AX to Phoenix” guide titles, captions, and signup link.
> - **FAQs/Comparisons**:
>   - Braintrust comparison pages: adjust instrumentation and agent evaluation sections to `Arize AX`.
> - **Release notes**:
>   - OpenInference Java note now references compatibility with `Arize AX`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0b5498e1c067c4bbe26614d84259a53f56289f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->