### PR TITLE
ci: fix bytearray type error in python 3.13

### DIFF
--- a/tests/unit/transport.py
+++ b/tests/unit/transport.py
@@ -117,7 +117,7 @@ class ASGIWebSocketAsyncNetworkStream(AsyncNetworkStream):
             else:
                 data_bytes: typing.Optional[bytes] = message.get("bytes")
                 if data_bytes is not None:
-                    event = wsproto.events.BytesMessage(data_bytes)
+                    event = wsproto.events.BytesMessage(bytearray(data_bytes))
                 else:
                     # If neither text nor bytes are provided, raise an error
                     raise ValueError("websocket.send message missing 'text' or 'bytes'")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wraps `bytes` payload in `bytearray` when creating `wsproto.events.BytesMessage` in `tests/unit/transport.py` to resolve Python 3.13 type error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed25e3cb465b067353b4e51620adb91818dddbf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->