### PR TITLE
chore: fix type check error in ddl_extract script

### DIFF
--- a/scripts/ddl/generate_ddl_postgresql.py
+++ b/scripts/ddl/generate_ddl_postgresql.py
@@ -121,14 +121,13 @@ class PostgreSQLDDLExtractor:
     def connect(self) -> bool:
         """Establish database connection."""
         try:
-            conn_dict = {
-                "host": self.conn_params.host,
-                "port": self.conn_params.port,
-                "dbname": self.conn_params.database,
-                "user": self.conn_params.user,
-                "password": self.conn_params.password,
-            }
-            self.conn = psycopg.connect(**conn_dict)
+            self.conn = psycopg.connect(
+                host=self.conn_params.host,
+                port=self.conn_params.port,
+                dbname=self.conn_params.database,
+                user=self.conn_params.user,
+                password=self.conn_params.password,
+            )
             return True
         except psycopg.Error as e:
             print(f"Error connecting to database: {e}", file=sys.stderr)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors `PostgreSQLDDLExtractor.connect` to pass connection parameters to `psycopg.connect` as explicit kwargs instead of via a dict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a463caea8ec980d23e7f38f177a0fa333ea6c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->