### PR TITLE
feat: only include dataset-specific evaluators in playground eval select

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -42,21 +42,6 @@ export function PlaygroundDatasetSection({
   const data = useLazyLoadQuery<PlaygroundDatasetSectionQuery>(
     graphql`
       query PlaygroundDatasetSectionQuery($datasetId: ID!, $splitIds: [ID!]) {
-        evaluators {
-          edges {
-            evaluator: node {
-              id
-              name
-              kind
-              isAssignedToDataset(datasetId: $datasetId)
-              ... on LLMEvaluator {
-                outputConfig {
-                  name
-                }
-              }
-            }
-          }
-        }
         dataset: node(id: $datasetId) {
           ... on Dataset {
             name
@@ -65,6 +50,21 @@ export function PlaygroundDatasetSection({
               id
               name
               color
+            }
+            evaluators {
+              edges {
+                evaluator: node {
+                  id
+                  name
+                  kind
+                  isAssignedToDataset(datasetId: $datasetId)
+                  ... on LLMEvaluator {
+                    outputConfig {
+                      name
+                    }
+                  }
+                }
+              }
             }
           }
           ...EvaluatorConfigDialog_dataset
@@ -92,7 +92,7 @@ export function PlaygroundDatasetSection({
   }, [data, splitIds]);
 
   const evaluators =
-    data.evaluators?.edges?.map((edge) => ({
+    data.dataset.evaluators?.edges?.map((edge) => ({
       ...edge.evaluator,
       annotationName: edge.evaluator.outputConfig?.name,
     })) ?? [];

--- a/app/src/pages/playground/PlaygroundEvaluatorSelect.tsx
+++ b/app/src/pages/playground/PlaygroundEvaluatorSelect.tsx
@@ -1,11 +1,4 @@
-import { useMemo } from "react";
-import {
-  Autocomplete,
-  Collection,
-  Input,
-  MenuSection,
-  useFilter,
-} from "react-aria-components";
+import { Autocomplete, Input, useFilter } from "react-aria-components";
 import { css } from "@emotion/react";
 
 import {
@@ -17,7 +10,6 @@ import {
   MenuContainer,
   MenuFooter,
   MenuHeader,
-  MenuSectionTitle,
   MenuTrigger,
   SearchField,
   SearchIcon,
@@ -42,31 +34,6 @@ export function PlaygroundEvaluatorSelect(
     props;
   const { contains } = useFilter({ sensitivity: "base" });
 
-  const evaluatorSections = useMemo(() => {
-    return evaluators.reduce(
-      (acc, evaluator) => {
-        if (evaluator.isAssignedToDataset) {
-          acc[0].children.push(evaluator);
-        } else {
-          acc[1].children.push(evaluator);
-        }
-        return acc;
-      },
-      [
-        {
-          name: "Mapped to this dataset",
-          id: "mapped",
-          children: [] as EvaluatorItem[],
-        },
-        {
-          name: "Not yet mapped",
-          id: "unmapped",
-          children: [] as EvaluatorItem[],
-        },
-      ]
-    );
-  }, [evaluators]);
-
   return (
     <MenuTrigger>
       <Button size="S" leadingVisual={<Icon svg={<Icons.PlusOutline />} />}>
@@ -83,7 +50,7 @@ export function PlaygroundEvaluatorSelect(
           <Menu
             selectionMode="multiple"
             selectedKeys={selectedIds}
-            items={evaluatorSections}
+            items={evaluators}
             renderEmptyState={() => (
               <Text color="grey-300" size="S">
                 No evaluators found
@@ -93,19 +60,12 @@ export function PlaygroundEvaluatorSelect(
               max-width: 600px;
             `}
           >
-            {(section) => (
-              <MenuSection aria-label={section.name}>
-                <MenuSectionTitle title={section.name} />
-                <Collection items={section.children}>
-                  {(item) => (
-                    <EvaluatorSelectMenuItem
-                      evaluator={item}
-                      onSelectionChange={() => onSelectionChange(item.id)}
-                      isSelected={selectedIds?.includes(item.id) ?? false}
-                    />
-                  )}
-                </Collection>
-              </MenuSection>
+            {(evaluator) => (
+              <EvaluatorSelectMenuItem
+                evaluator={evaluator}
+                onSelectionChange={() => onSelectionChange(evaluator.id)}
+                isSelected={selectedIds?.includes(evaluator.id) ?? false}
+              />
             )}
           </Menu>
         </Autocomplete>

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetSectionQuery.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetSectionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d7ab6bbbc5b5209d5d24ab1d2b6edf1e>>
+ * @generated SignedSource<<001c9ba25bd5415ac5ae0aa643be76a5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,19 @@ export type PlaygroundDatasetSectionQuery$variables = {
 };
 export type PlaygroundDatasetSectionQuery$data = {
   readonly dataset: {
+    readonly evaluators?: {
+      readonly edges: ReadonlyArray<{
+        readonly evaluator: {
+          readonly id: string;
+          readonly isAssignedToDataset: boolean;
+          readonly kind: EvaluatorKind;
+          readonly name: string;
+          readonly outputConfig?: {
+            readonly name: string;
+          };
+        };
+      }>;
+    };
     readonly exampleCount?: number;
     readonly name?: string;
     readonly splits?: ReadonlyArray<{
@@ -25,19 +38,6 @@ export type PlaygroundDatasetSectionQuery$data = {
       readonly name: string;
     }>;
     readonly " $fragmentSpreads": FragmentRefs<"EvaluatorConfigDialog_dataset">;
-  };
-  readonly evaluators: {
-    readonly edges: ReadonlyArray<{
-      readonly evaluator: {
-        readonly id: string;
-        readonly isAssignedToDataset: boolean;
-        readonly kind: EvaluatorKind;
-        readonly name: string;
-        readonly outputConfig?: {
-          readonly name: string;
-        };
-      };
-    }>;
   };
 };
 export type PlaygroundDatasetSectionQuery = {
@@ -58,13 +58,13 @@ var v0 = [
     "name": "splitIds"
   }
 ],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "datasetId"
+  }
+],
 v2 = {
   "alias": null,
   "args": null,
@@ -74,12 +74,52 @@ v2 = {
 },
 v3 = {
   "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "splitIds",
+      "variableName": "splitIds"
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "exampleCount",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "DatasetSplit",
+  "kind": "LinkedField",
+  "name": "splits",
+  "plural": true,
+  "selections": [
+    (v4/*: any*/),
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "color",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "kind",
   "storageKey": null
 },
-v4 = {
+v7 = {
   "alias": null,
   "args": [
     {
@@ -92,55 +132,7 @@ v4 = {
   "name": "isAssignedToDataset",
   "storageKey": null
 },
-v5 = [
-  {
-    "kind": "Variable",
-    "name": "id",
-    "variableName": "datasetId"
-  }
-],
-v6 = {
-  "kind": "InlineFragment",
-  "selections": [
-    (v2/*: any*/),
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "splitIds",
-          "variableName": "splitIds"
-        }
-      ],
-      "kind": "ScalarField",
-      "name": "exampleCount",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "DatasetSplit",
-      "kind": "LinkedField",
-      "name": "splits",
-      "plural": true,
-      "selections": [
-        (v1/*: any*/),
-        (v2/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "color",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    }
-  ],
-  "type": "Dataset",
-  "abstractKey": null
-},
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -155,70 +147,79 @@ return {
     "name": "PlaygroundDatasetSectionQuery",
     "selections": [
       {
-        "alias": null,
-        "args": null,
-        "concreteType": "EvaluatorConnection",
-        "kind": "LinkedField",
-        "name": "evaluators",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EvaluatorEdge",
-            "kind": "LinkedField",
-            "name": "edges",
-            "plural": true,
-            "selections": [
-              {
-                "alias": "evaluator",
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "node",
-                "plural": false,
-                "selections": [
-                  (v1/*: any*/),
-                  (v2/*: any*/),
-                  (v3/*: any*/),
-                  (v4/*: any*/),
-                  {
-                    "kind": "InlineFragment",
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CategoricalAnnotationConfig",
-                        "kind": "LinkedField",
-                        "name": "outputConfig",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "type": "LLMEvaluator",
-                    "abstractKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      },
-      {
         "alias": "dataset",
-        "args": (v5/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EvaluatorConnection",
+                "kind": "LinkedField",
+                "name": "evaluators",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EvaluatorEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "evaluator",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationConfig",
+                                "kind": "LinkedField",
+                                "name": "outputConfig",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "LLMEvaluator",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          },
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -238,90 +239,99 @@ return {
     "name": "PlaygroundDatasetSectionQuery",
     "selections": [
       {
-        "alias": null,
-        "args": null,
-        "concreteType": "EvaluatorConnection",
-        "kind": "LinkedField",
-        "name": "evaluators",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EvaluatorEdge",
-            "kind": "LinkedField",
-            "name": "edges",
-            "plural": true,
-            "selections": [
-              {
-                "alias": "evaluator",
-                "args": null,
-                "concreteType": null,
-                "kind": "LinkedField",
-                "name": "node",
-                "plural": false,
-                "selections": [
-                  (v7/*: any*/),
-                  (v1/*: any*/),
-                  (v2/*: any*/),
-                  (v3/*: any*/),
-                  (v4/*: any*/),
-                  {
-                    "kind": "InlineFragment",
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CategoricalAnnotationConfig",
-                        "kind": "LinkedField",
-                        "name": "outputConfig",
-                        "plural": false,
-                        "selections": [
-                          (v2/*: any*/),
-                          (v1/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "type": "LLMEvaluator",
-                    "abstractKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      },
-      {
         "alias": "dataset",
-        "args": (v5/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v7/*: any*/),
-          (v1/*: any*/),
-          (v6/*: any*/)
+          (v8/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EvaluatorConnection",
+                "kind": "LinkedField",
+                "name": "evaluators",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "EvaluatorEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": "evaluator",
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          (v4/*: any*/),
+                          (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CategoricalAnnotationConfig",
+                                "kind": "LinkedField",
+                                "name": "outputConfig",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  (v4/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "LLMEvaluator",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Dataset",
+            "abstractKey": null
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "4882eb588fc8b57622cf0ff0ea645eb2",
+    "cacheID": "b58aa00be507c9355f245e98a05987ca",
     "id": null,
     "metadata": {},
     "name": "PlaygroundDatasetSectionQuery",
     "operationKind": "query",
-    "text": "query PlaygroundDatasetSectionQuery(\n  $datasetId: ID!\n  $splitIds: [ID!]\n) {\n  evaluators {\n    edges {\n      evaluator: node {\n        __typename\n        id\n        name\n        kind\n        isAssignedToDataset(datasetId: $datasetId)\n        ... on LLMEvaluator {\n          outputConfig {\n            name\n            id\n          }\n        }\n      }\n    }\n  }\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      name\n      exampleCount(splitIds: $splitIds)\n      splits {\n        id\n        name\n        color\n      }\n    }\n    ...EvaluatorConfigDialog_dataset\n    id\n  }\n}\n\nfragment EvaluatorConfigDialog_dataset on Dataset {\n  id\n  name\n}\n"
+    "text": "query PlaygroundDatasetSectionQuery(\n  $datasetId: ID!\n  $splitIds: [ID!]\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    ... on Dataset {\n      name\n      exampleCount(splitIds: $splitIds)\n      splits {\n        id\n        name\n        color\n      }\n      evaluators {\n        edges {\n          evaluator: node {\n            __typename\n            id\n            name\n            kind\n            isAssignedToDataset(datasetId: $datasetId)\n            ... on LLMEvaluator {\n              outputConfig {\n                name\n                id\n              }\n            }\n          }\n        }\n      }\n    }\n    ...EvaluatorConfigDialog_dataset\n    id\n  }\n}\n\nfragment EvaluatorConfigDialog_dataset on Dataset {\n  id\n  name\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2f503a4a49b55157153d6e457a836c8b";
+(node as any).hash = "8178813823f7d6875f7f9cb145982784";
 
 export default node;


### PR DESCRIPTION
resolves #10037 

Updates the playground's evaluator dropdown to remove mapped/unmapped sections and only include evaluators for the selected dataset.

<img width="1325" height="557" alt="image" src="https://github.com/user-attachments/assets/0a755ef2-d89b-45a1-bbf5-591228acd518" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes the playground evaluator selection to the current dataset and simplifies the dropdown to a flat, searchable list.
> 
> - **Playground**:
>   - **GraphQL/query**: Move `evaluators` under `Dataset` in `PlaygroundDatasetSectionQuery`; update usage from `data.evaluators` to `data.dataset.evaluators`.
>   - **UI/dropdown**: Simplify `PlaygroundEvaluatorSelect` to a flat list (no mapped/unmapped sections); keep multi-select with search.
>   - **Behavior**: Default-select evaluators with `isAssignedToDataset`; selecting unassigned triggers `EvaluatorConfigDialog`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281cc2f1b60b61799256b263b0858945e222af9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->