### PR TITLE
feat: enable deleting global evaluators

### DIFF
--- a/app/src/pages/evaluators/EvaluatorSelectionToolbar.tsx
+++ b/app/src/pages/evaluators/EvaluatorSelectionToolbar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { graphql, useMutation } from "react-relay";
+import { css } from "@emotion/react";
 
 import {
   Button,
@@ -29,6 +30,7 @@ import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtil
 
 interface SelectedEvaluator {
   id: string;
+  name: string;
 }
 
 type EvaluatorSelectionToolbarProps = {
@@ -148,22 +150,36 @@ export function EvaluatorSelectionToolbar(
                 </DialogTitleExtra>
               </DialogHeader>
               <View padding="size-200">
-                <Text color="danger">
-                  Are you sure you want to delete {selectedEvaluators.length}{" "}
-                  evaluator{isPlural ? "s" : ""}?
+                <Text>Are you sure you want to delete these evaluators?</Text>
+                <ul
+                  css={css`
+                    padding-bottom: var(--ac-global-dimension-size-200);
+                  `}
+                >
+                  {selectedEvaluators.map((evaluator) => (
+                    <li
+                      key={evaluator.id}
+                      css={css`
+                        padding-left: var(--ac-global-dimension-size-200);
+                        padding-top: var(--ac-global-dimension-size-50);
+                      `}
+                    >
+                      <Text>{evaluator.name}</Text>
+                    </li>
+                  ))}
+                </ul>
+                <Text>
+                  This will delete the selected evaluators and remove them from
+                  any datasets that use them. Annotations created by these
+                  evaluators will remain in place.
                 </Text>
               </View>
-              <View
-                paddingEnd="size-200"
-                paddingTop="size-100"
-                paddingBottom="size-100"
-                borderTopColor="light"
-                borderTopWidth="thin"
-              >
-                <Flex direction="row" justifyContent="end" gap="size-100">
+              <View paddingX="size-200" paddingBottom="size-100">
+                <Flex direction="row" justifyContent="end" gap="size-200">
                   <Button
                     size="S"
                     onPress={() => setIsDeleteConfirmationDialogOpen(false)}
+                    variant="quiet"
                   >
                     Cancel
                   </Button>
@@ -175,7 +191,8 @@ export function EvaluatorSelectionToolbar(
                       setIsDeleteConfirmationDialogOpen(false);
                     }}
                   >
-                    Delete
+                    Delete {selectedEvaluators.length} evaluator
+                    {isPlural ? "s" : ""}
                   </Button>
                 </Flex>
               </View>

--- a/app/src/pages/evaluators/EvaluatorSelectionToolbar.tsx
+++ b/app/src/pages/evaluators/EvaluatorSelectionToolbar.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useState } from "react";
+import { graphql, useMutation } from "react-relay";
+
+import {
+  Button,
+  Dialog,
+  Flex,
+  Icon,
+  IconButton,
+  Icons,
+  Modal,
+  ModalOverlay,
+  Text,
+  Toolbar,
+  Tooltip,
+  TooltipTrigger,
+  View,
+} from "@phoenix/components";
+import {
+  DialogCloseButton,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTitleExtra,
+} from "@phoenix/components/dialog";
+import { FloatingToolbarContainer } from "@phoenix/components/toolbar/FloatingToolbarContainer";
+import { useNotifyError, useNotifySuccess } from "@phoenix/contexts";
+import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
+
+interface SelectedEvaluator {
+  id: string;
+}
+
+type EvaluatorSelectionToolbarProps = {
+  selectedEvaluators: SelectedEvaluator[];
+  onClearSelection: () => void;
+  onEvaluatorsDeleted: () => void;
+};
+
+export function EvaluatorSelectionToolbar(
+  props: EvaluatorSelectionToolbarProps
+) {
+  const { selectedEvaluators, onEvaluatorsDeleted, onClearSelection } = props;
+  const [isDeleteConfirmationDialogOpen, setIsDeleteConfirmationDialogOpen] =
+    useState(false);
+  const notifySuccess = useNotifySuccess();
+  const notifyError = useNotifyError();
+
+  const [deleteEvaluators, isDeletingEvaluators] = useMutation(graphql`
+    mutation EvaluatorSelectionToolbarDeleteEvaluatorsMutation(
+      $input: DeleteEvaluatorsInput!
+    ) {
+      deleteEvaluators(input: $input) {
+        evaluatorIds
+      }
+    }
+  `);
+  const isPlural = selectedEvaluators.length !== 1;
+  const onDeleteEvaluators = useCallback(() => {
+    deleteEvaluators({
+      variables: {
+        input: {
+          evaluatorIds: selectedEvaluators.map((evaluator) => evaluator.id),
+        },
+      },
+      onCompleted: () => {
+        notifySuccess({
+          title: "Evaluators Deleted",
+          message: `${selectedEvaluators.length} evaluator${isPlural ? "s" : ""} have been deleted.`,
+        });
+        // Clear the selection
+        onEvaluatorsDeleted();
+        onClearSelection();
+      },
+      onError: (error) => {
+        const formattedError = getErrorMessagesFromRelayMutationError(error);
+        notifyError({
+          title: "An error occurred",
+          message: `Failed to delete evaluators: ${formattedError?.[0] ?? error.message}`,
+        });
+      },
+    });
+  }, [
+    deleteEvaluators,
+    selectedEvaluators,
+    notifySuccess,
+    isPlural,
+    onEvaluatorsDeleted,
+    onClearSelection,
+    notifyError,
+  ]);
+
+  return (
+    <FloatingToolbarContainer>
+      <Toolbar>
+        <View paddingEnd="size-100">
+          <Flex direction="row" gap="size-100" alignItems="center">
+            <TooltipTrigger>
+              <IconButton
+                size="M"
+                onPress={onClearSelection}
+                aria-label="Clear selection"
+              >
+                <Icon svg={<Icons.CloseOutline />} />
+              </IconButton>
+              <Tooltip>Clear selection</Tooltip>
+            </TooltipTrigger>
+            <Text>{`${selectedEvaluators.length} evaluator${isPlural ? "s" : ""} selected`}</Text>
+          </Flex>
+        </View>
+        <Button
+          variant="danger"
+          size="M"
+          leadingVisual={
+            <Icon
+              svg={
+                isDeletingEvaluators ? (
+                  <Icons.LoadingOutline />
+                ) : (
+                  <Icons.TrashOutline />
+                )
+              }
+            />
+          }
+          isDisabled={isDeletingEvaluators}
+          onPress={() => setIsDeleteConfirmationDialogOpen(true)}
+          aria-label="Delete Evaluators"
+        >
+          {isDeletingEvaluators ? "Deleting..." : "Delete"}
+        </Button>
+      </Toolbar>
+      <ModalOverlay
+        isOpen={isDeleteConfirmationDialogOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setIsDeleteConfirmationDialogOpen(false);
+          }
+        }}
+        isDismissable
+      >
+        <Modal>
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Delete Evaluators</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <View padding="size-200">
+                <Text color="danger">
+                  Are you sure you want to delete {selectedEvaluators.length}{" "}
+                  evaluator{isPlural ? "s" : ""}?
+                </Text>
+              </View>
+              <View
+                paddingEnd="size-200"
+                paddingTop="size-100"
+                paddingBottom="size-100"
+                borderTopColor="light"
+                borderTopWidth="thin"
+              >
+                <Flex direction="row" justifyContent="end" gap="size-100">
+                  <Button
+                    size="S"
+                    onPress={() => setIsDeleteConfirmationDialogOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="S"
+                    onPress={() => {
+                      onDeleteEvaluators();
+                      setIsDeleteConfirmationDialogOpen(false);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </Flex>
+              </View>
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </FloatingToolbarContainer>
+  );
+}

--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -377,7 +377,6 @@ export const EvaluatorsTable = ({
         <EvaluatorSelectionToolbar
           selectedEvaluators={selectedEvaluators}
           onEvaluatorsDeleted={() => {
-            // TODO: fix top-level checkbox state after deletion
             refetch({});
           }}
           onClearSelection={clearSelection}

--- a/app/src/pages/evaluators/EvaluatorsTable.tsx
+++ b/app/src/pages/evaluators/EvaluatorsTable.tsx
@@ -27,6 +27,7 @@ import {
   EvaluatorFilter,
   EvaluatorSort,
 } from "@phoenix/pages/evaluators/__generated__/GlobalEvaluatorsTableEvaluatorsQuery.graphql";
+import { EvaluatorSelectionToolbar } from "@phoenix/pages/evaluators/EvaluatorSelectionToolbar";
 import { useEvaluatorsFilterContext } from "@phoenix/pages/evaluators/EvaluatorsFilterProvider";
 
 export const convertEvaluatorSortToTanstackSort = (
@@ -286,6 +287,13 @@ export const EvaluatorsTable = ({
   }, [sort, filter, refetch]);
 
   const rows = table.getRowModel().rows;
+  const selectedRows = table.getSelectedRowModel().rows;
+  const selectedEvaluators = selectedRows.map((row) => row.original);
+
+  const clearSelection = useCallback(() => {
+    setRowSelection({});
+  }, [setRowSelection]);
+
   const isEmpty = rows.length === 0;
 
   if (isEmpty) {
@@ -365,6 +373,16 @@ export const EvaluatorsTable = ({
           })}
         </tbody>
       </table>
+      {selectedRows.length ? (
+        <EvaluatorSelectionToolbar
+          selectedEvaluators={selectedEvaluators}
+          onEvaluatorsDeleted={() => {
+            // TODO: fix top-level checkbox state after deletion
+            refetch({});
+          }}
+          onClearSelection={clearSelection}
+        />
+      ) : null}
     </div>
   );
 };

--- a/app/src/pages/evaluators/__generated__/EvaluatorSelectionToolbarDeleteEvaluatorsMutation.graphql.ts
+++ b/app/src/pages/evaluators/__generated__/EvaluatorSelectionToolbarDeleteEvaluatorsMutation.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<14deddefad66f91b31cc4fa7602c4069>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteEvaluatorsInput = {
+  evaluatorIds: ReadonlyArray<string>;
+};
+export type EvaluatorSelectionToolbarDeleteEvaluatorsMutation$variables = {
+  input: DeleteEvaluatorsInput;
+};
+export type EvaluatorSelectionToolbarDeleteEvaluatorsMutation$data = {
+  readonly deleteEvaluators: {
+    readonly evaluatorIds: ReadonlyArray<string>;
+  };
+};
+export type EvaluatorSelectionToolbarDeleteEvaluatorsMutation = {
+  response: EvaluatorSelectionToolbarDeleteEvaluatorsMutation$data;
+  variables: EvaluatorSelectionToolbarDeleteEvaluatorsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DeleteEvaluatorsPayload",
+    "kind": "LinkedField",
+    "name": "deleteEvaluators",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "evaluatorIds",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EvaluatorSelectionToolbarDeleteEvaluatorsMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EvaluatorSelectionToolbarDeleteEvaluatorsMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d67e230fa2830edd7c40a2f342874c23",
+    "id": null,
+    "metadata": {},
+    "name": "EvaluatorSelectionToolbarDeleteEvaluatorsMutation",
+    "operationKind": "mutation",
+    "text": "mutation EvaluatorSelectionToolbarDeleteEvaluatorsMutation(\n  $input: DeleteEvaluatorsInput!\n) {\n  deleteEvaluators(input: $input) {\n    evaluatorIds\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fefa18d28efa9318626ae845f49ffd8e";
+
+export default node;


### PR DESCRIPTION
Resolves #10279 

Enables deleting evaluators from the global evaluators table, based on this [mock](https://www.figma.com/design/XvvRCSG9NNA5Jf4HJLQKoE/Evals-Rev1?node-id=741-6591&m=dev)


https://github.com/user-attachments/assets/b8706261-429c-4a69-98c2-f48b366138a2


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a floating selection toolbar to the evaluators table enabling bulk delete with confirmation, Relay mutation, notifications, and table refresh.
> 
> - **UI/UX**:
>   - Adds `EvaluatorSelectionToolbar` with selection count, clear action, and danger delete; includes confirmation modal listing selected evaluator names, loading state, and success/error notifications.
>   - Integrates toolbar into `EvaluatorsTable`: derives `selectedEvaluators` from selected rows, provides `onClearSelection`, and conditionally renders toolbar when rows are selected; triggers `refetch` after deletion.
> - **GraphQL/Relay**:
>   - Wires `deleteEvaluators` mutation (`EvaluatorSelectionToolbarDeleteEvaluatorsMutation`) using `DeleteEvaluatorsInput` and returns deleted `evaluatorIds`; includes generated Relay artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c30d170e67ad660eadb0e16091357ca66dfcc43b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->