### PR TITLE
fix(experiments): fix casing on avg in experiment compare page

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -624,7 +624,7 @@ export function ExperimentCompareListPage({
                 <li key={experiment.id}>
                   <Flex direction="row" gap="size-100" alignItems="center">
                     <Text size="S" fontFamily="mono" color="grey-500">
-                      avg
+                      AVG
                     </Text>
                     <Text size="S" fontFamily="mono">
                       {floatFormatter(averageTotalTokens)}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Uppercases the "avg" label to "AVG" in `ExperimentCompareListPage.tsx` tokens header averages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0040e409abf906a7bd21e3e7a9090c8f92bfb7c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->