### PR TITLE
fix: correct the validation icon on regex field

### DIFF
--- a/app/src/components/RegexField.tsx
+++ b/app/src/components/RegexField.tsx
@@ -5,8 +5,12 @@ import { debounce } from "lodash";
 
 import { RegexFieldQuery } from "@phoenix/components/__generated__/RegexFieldQuery.graphql";
 import { Text } from "@phoenix/components/content";
-import { TextField, TextFieldProps } from "@phoenix/components/field";
-import { Icon, Icons } from "@phoenix/components/icon";
+import {
+  FieldDangerIcon,
+  FieldSuccessIcon,
+  TextField,
+  TextFieldProps,
+} from "@phoenix/components/field";
 
 type RegexFieldProps = {
   value: string;
@@ -42,18 +46,8 @@ export const RegexField = ({
       <Input placeholder={placeholder} />
       {!error && description && <Text slot="description">{description}</Text>}
       {error && <FieldError>{error}</FieldError>}
-      {isInvalid && value && (
-        <Icon
-          style={{ color: "var(--ac-global-color-danger)" }}
-          svg={<Icons.CloseCircle />}
-        />
-      )}
-      {!isInvalid && value && (
-        <Icon
-          style={{ color: "var(--ac-global-color-success)" }}
-          svg={<Icons.CheckmarkCircleFilled />}
-        />
-      )}
+      {isInvalid && value && <FieldDangerIcon />}
+      {!isInvalid && value && <FieldSuccessIcon />}
     </TextField>
   );
 };

--- a/app/src/components/field/FieldDangerIcon.tsx
+++ b/app/src/components/field/FieldDangerIcon.tsx
@@ -5,7 +5,7 @@ export const FieldDangerIcon = () => {
     <Icon
       color="danger"
       className="ac-field-icon"
-      svg={<Icons.CloseCircle />}
+      svg={<Icons.CloseCircleOutline />}
     />
   );
 };

--- a/app/src/components/field/FieldSuccessIcon.tsx
+++ b/app/src/components/field/FieldSuccessIcon.tsx
@@ -2,10 +2,6 @@ import { Icon, Icons } from "@phoenix/components/icon";
 
 export const FieldSuccessIcon = () => {
   return (
-    <Icon
-      color="success"
-      className="ac-field-icon"
-      svg={<Icons.CheckmarkCircleFilled />}
-    />
+    <Icon color="success" className="ac-field-icon" svg={<Icons.Checkmark />} />
   );
 };

--- a/app/src/components/field/index.tsx
+++ b/app/src/components/field/index.tsx
@@ -5,4 +5,6 @@ export * from "./CredentialInput";
 export * from "./NumberField";
 export * from "./SearchIcon";
 export * from "./DebouncedSearch";
+export * from "./FieldDangerIcon";
+export * from "./FieldSuccessIcon";
 export { TextArea } from "react-aria-components";

--- a/app/stories/TextField.stories.tsx
+++ b/app/stories/TextField.stories.tsx
@@ -9,7 +9,7 @@ import {
   TextField,
   TextFieldProps,
 } from "@phoenix/components";
-import { FieldDangerIcon } from "@phoenix/components/field/FieldDangerIcon";
+import { FieldDangerIcon, FieldSuccessIcon } from "@phoenix/components/field";
 
 const meta: Meta = {
   title: "TextField",
@@ -48,6 +48,12 @@ export const Gallery = () => (
       <Input type="text" />
       <FieldDangerIcon />
       <FieldError>Field error</FieldError>
+    </TextField>
+    <TextField>
+      <Label>Label</Label>
+      <Input type="text" />
+      <FieldSuccessIcon />
+      <Text slot="description">Field success</Text>
     </TextField>
     <TextField isReadOnly>
       <Label>Label</Label>


### PR DESCRIPTION

<img width="792" height="183" alt="Screenshot 2025-11-19 at 1 22 01 PM" src="https://github.com/user-attachments/assets/f0157b81-ae6f-42a8-bf87-1f89d1e710b6" />
<img width="827" height="294" alt="Screenshot 2025-11-19 at 1 23 31 PM" src="https://github.com/user-attachments/assets/5808b8bb-8dfc-40fa-8325-fb54ae799ff0" />
resolves #10272 

This makes the minimum change to fix the icon positioning for the regex validation field. Also updates the icons to match the figma more.