### PR TITLE
feat: Improve UX of retention policy form

### DIFF
--- a/app/src/pages/settings/RetentionPolicyForm.tsx
+++ b/app/src/pages/settings/RetentionPolicyForm.tsx
@@ -3,6 +3,7 @@ import { CronExpressionParser } from "cron-parser";
 
 import {
   Button,
+  FieldError,
   Flex,
   Form,
   Heading,
@@ -19,7 +20,7 @@ import {
 } from "@phoenix/utils/retentionPolicyUtils";
 export type RetentionPolicyFormParams = {
   name: string;
-  numberOfTraces?: number;
+  numberOfTraces?: number | null;
   numberOfDays?: number;
   schedule: string;
 };
@@ -37,7 +38,7 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
   const { control, watch, handleSubmit } = useForm<RetentionPolicyFormParams>({
     defaultValues: defaultValues ?? {
       name: "New Policy",
-      numberOfTraces: undefined,
+      numberOfTraces: null,
       numberOfDays: 400,
       schedule: "0 0 * * 0",
     },
@@ -74,13 +75,22 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
               rules={{
                 required: "Name is required",
               }}
-              render={({ field }) => (
-                <TextField {...field} size="S" value={field.value}>
+              render={({ field, fieldState: { invalid, error } }) => (
+                <TextField
+                  {...field}
+                  size="S"
+                  value={field.value}
+                  isInvalid={invalid}
+                >
                   <Label>Name</Label>
                   <Input />
-                  <Text slot="description">
-                    The name of the retention policy
-                  </Text>
+                  {!error ? (
+                    <Text slot="description">
+                      The name of the retention policy
+                    </Text>
+                  ) : (
+                    <FieldError>{error?.message}</FieldError>
+                  )}
                 </TextField>
               )}
             />
@@ -95,13 +105,17 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
                   message: "Number of days must be at least 0",
                 },
               }}
-              render={({ field }) => (
-                <NumberField step={1} size="S" {...field}>
+              render={({ field, fieldState: { invalid, error } }) => (
+                <NumberField step={1} size="S" {...field} isInvalid={invalid}>
                   <Label>Number of Days</Label>
                   <Input />
-                  <Text slot="description">
-                    The number of days that will be kept
-                  </Text>
+                  {!error ? (
+                    <Text slot="description">
+                      The number of days that will be kept
+                    </Text>
+                  ) : (
+                    <FieldError>{error?.message}</FieldError>
+                  )}
                 </NumberField>
               )}
             />
@@ -114,19 +128,24 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
                   message: "Number of traces must be at least 0",
                 },
               }}
-              render={({ field }) => (
+              render={({ field, fieldState: { invalid, error } }) => (
                 <NumberField
                   step={1}
                   size="S"
                   value={field.value ?? undefined}
                   onChange={field.onChange}
                   onBlur={field.onBlur}
+                  isInvalid={invalid}
                 >
                   <Label>Number of Traces</Label>
                   <Input />
-                  <Text slot="description">
-                    The number of traces that will be kept
-                  </Text>
+                  {!error ? (
+                    <Text slot="description">
+                      The number of traces that will be kept
+                    </Text>
+                  ) : (
+                    <FieldError>{error?.message}</FieldError>
+                  )}
                 </NumberField>
               )}
             />
@@ -167,9 +186,7 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
                   <Label>Schedule</Label>
                   <Input />
                   {fieldState.error ? (
-                    <Text slot="errorMessage" color="danger">
-                      {fieldState.error.message}
-                    </Text>
+                    <FieldError>{fieldState.error.message}</FieldError>
                   ) : (
                     <Text slot="description">
                       A cron expression for the hour of the week
@@ -185,7 +202,7 @@ export function RetentionPolicyForm(props: RetentionPolicyFormProps) {
             <Text color="text-700">
               {createPolicyDeletionSummaryText({
                 numberOfDays,
-                numberOfTraces,
+                numberOfTraces: numberOfTraces ?? undefined,
               })}
             </Text>
             <br />

--- a/app/src/utils/retentionPolicyUtils.ts
+++ b/app/src/utils/retentionPolicyUtils.ts
@@ -17,9 +17,11 @@ export const createPolicyDeletionSummaryText = ({
     return "This policy will not delete any traces.";
   }
   const daysPolicyString =
-    typeof numberOfDays === "number" ? `older than ${numberOfDays} days` : "";
+    numberOfDays != null && !isNaN(numberOfDays)
+      ? `older than ${numberOfDays} days`
+      : "";
   const tracesPolicyString =
-    typeof numberOfTraces === "number"
+    numberOfTraces != null && !isNaN(numberOfTraces)
       ? `when there are more than ${numberOfTraces} traces`
       : "";
 
@@ -27,6 +29,10 @@ export const createPolicyDeletionSummaryText = ({
     daysPolicyString && tracesPolicyString
       ? `${daysPolicyString} or ${tracesPolicyString}`
       : daysPolicyString || tracesPolicyString;
+
+  if (policyString === "") {
+    return "Enter a number of days or a number of traces, or both, to configure this policy.";
+  }
   return `This policy will delete traces ${policyString}`;
 };
 /**


### PR DESCRIPTION
- Show validation errors on fields
- Show alert error when submission fails validation
- Prevent trace count field from going uncontrolled
- Fix policy message when both days and trace count fields are empty
- Allow users to submit 0 days without silently failing validation

Resolves #10320 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds field-level validation and top-level error alerts, supports null trace count and 0-day policies, and improves summary text and cron validation across create/edit flows.
> 
> - **UI/Forms**:
>   - `RetentionPolicyForm`:
>     - Add field-level validation with `isInvalid` and `FieldError` for `name`, `numberOfDays`, `numberOfTraces`, and `schedule` (cron validation tightened).
>     - Prevent uncontrolled `numberOfTraces` by using `null` default and handling `undefined` in summary; update defaults.
>   - `CreateRetentionPolicy` / `EditRetentionPolicy`:
>     - Replace `notifyError` with inline `<Alert>` using local error state; surface Relay mutation errors via `getErrorMessagesFromRelayMutationError`.
>     - Update rule construction to allow `numberOfDays === 0`; remove thrown errors and show user-facing validation message instead.
>     - Set edit `defaultValues.numberOfTraces` to `null`.
> - **Utils**:
>   - `createPolicyDeletionSummaryText`: handle `null`/`NaN` inputs; show guidance when both days and trace count are empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a23a6437b30f453382662c65a04f0d6c9857f8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->