### PR TITLE
fix: remove outline from <ColorSwatchPicker /> component

### DIFF
--- a/app/src/components/color/ColorSwatchPicker.tsx
+++ b/app/src/components/color/ColorSwatchPicker.tsx
@@ -16,23 +16,16 @@ const colorSwatchPickerCSS = css`
 
   .react-aria-ColorSwatchPickerItem {
     position: relative;
-    outline: none;
     width: fit-content;
     height: fit-content;
     forced-color-adjust: none;
     display: inline-flex;
-
-    &[data-focus-visible] {
-      outline: 2px solid var(--focus-ring-color);
-      outline-offset: 2px;
-    }
 
     &[data-selected]::after {
       content: "";
       position: absolute;
       inset: 0;
       border: 2px solid var(--ac-global-text-color-900);
-      outline-offset: -4px;
       border-radius: inherit;
     }
   }


### PR DESCRIPTION
This PR closes #10275 

This PR contains code changes to remove the outline styling from the `ColorSwatchPicker />` component for better accessibility support and show the moving outline on arrow changes with the keyboard.


https://github.com/user-attachments/assets/aa9d58b5-949a-45af-ae68-c909dbb74d23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes outline and focus-visible outlines from ColorSwatchPicker items, keeping selection indicated via a border on `data-selected::after`.
> 
> - **UI**:
>   - **`app/src/components/color/ColorSwatchPicker.tsx`**:
>     - Remove `outline` and `[data-focus-visible]` outline styles from `.react-aria-ColorSwatchPickerItem`.
>     - Drop `outline-offset` usage; retain selection indicator via `&[data-selected]::after` border.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3a134da0016819f3766587c593063dbf393a691. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->