### PR TITLE
fix(playground): ensure playground repetition status is cleared

### DIFF
--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -743,7 +743,6 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
           instances: instances.map((instance) => ({
             ...instance,
             activeRunId: generateRunId(),
-            spanId: null, // Clear out the span when (re)running
             repetitions: Object.fromEntries(
               Array.from({ length: repetitions }, (_, i) => [
                 i + 1,
@@ -770,7 +769,6 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
           instances: instances.map((instance) => ({
             ...instance,
             activeRunId: null,
-            spanId: null,
             repetitions: Object.fromEntries(
               Object.entries(instance.repetitions).map(
                 ([repetitionNumber, repetition]) => [


### PR DESCRIPTION
resolves #10350

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure all repetitions are marked finished when canceling or completing, remove unused instance-level span clearing, and add targeted tests.
> 
> - **Store (`app/src/store/playground/playgroundStore.tsx`)**:
>   - `markPlaygroundInstanceComplete`: also sets all `repetitions[*].status` to `"finished"` and clears `activeRunId`.
>   - `cancelPlaygroundInstances`: sets all `repetitions[*].status` to `"finished"` and clears `activeRunId`.
>   - `runPlaygroundInstances`: initializes repetitions fresh without clearing an instance-level `spanId` field.
> - **Tests (`app/src/store/playground/__tests__/playgroundStore.test.ts`)**:
>   - Add coverage for `markPlaygroundInstanceComplete` (only target instance affected; all reps finished).
>   - Add coverage for `cancelPlaygroundInstances` (all instances; all reps finished).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e0dddde13192361118433b2f0426dbe1af1a7be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->