### PR TITLE
feat: Add builtin evaluator support to crosswalk table

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -150,6 +150,7 @@ interface ApiKey {
 input AssignEvaluatorToDatasetInput {
   datasetId: ID!
   evaluatorId: ID!
+  inputConfig: JSON
 }
 
 enum AuthMethod {

--- a/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
+++ b/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
@@ -142,6 +142,7 @@ def upgrade() -> None:
     )
     op.create_table(
         "datasets_evaluators",
+        sa.Column("id", _Integer, primary_key=True),
         sa.Column(
             "dataset_id",
             _Integer,
@@ -152,13 +153,26 @@ def upgrade() -> None:
             "evaluator_id",
             _Integer,
             sa.ForeignKey("evaluators.id", ondelete="CASCADE"),
-            nullable=False,
+            nullable=True,
             index=True,
         ),
+        sa.Column("builtin_evaluator_id", _Integer, nullable=True, index=True),
         sa.Column("input_config", JSON_, nullable=False),
-        sa.PrimaryKeyConstraint(
+        sa.CheckConstraint(
+            "(evaluator_id IS NOT NULL) != (builtin_evaluator_id IS NOT NULL)",
+            name="evaluator_id_xor_builtin_evaluator_id",
+        ),
+        sa.UniqueConstraint(
             "dataset_id",
             "evaluator_id",
+            postgresql_where=sa.text("evaluator_id IS NOT NULL"),
+            sqlite_where=sa.text("evaluator_id IS NOT NULL"),
+        ),
+        sa.UniqueConstraint(
+            "dataset_id",
+            "builtin_evaluator_id",
+            postgresql_where=sa.text("builtin_evaluator_id IS NOT NULL"),
+            sqlite_where=sa.text("builtin_evaluator_id IS NOT NULL"),
         ),
     )
 

--- a/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
+++ b/src/phoenix/db/migrations/versions/02463bd83119_add_evaluators.py
@@ -162,18 +162,22 @@ def upgrade() -> None:
             "(evaluator_id IS NOT NULL) != (builtin_evaluator_id IS NOT NULL)",
             name="evaluator_id_xor_builtin_evaluator_id",
         ),
-        sa.UniqueConstraint(
-            "dataset_id",
-            "evaluator_id",
-            postgresql_where=sa.text("evaluator_id IS NOT NULL"),
-            sqlite_where=sa.text("evaluator_id IS NOT NULL"),
-        ),
-        sa.UniqueConstraint(
-            "dataset_id",
-            "builtin_evaluator_id",
-            postgresql_where=sa.text("builtin_evaluator_id IS NOT NULL"),
-            sqlite_where=sa.text("builtin_evaluator_id IS NOT NULL"),
-        ),
+    )
+    op.create_index(
+        "ix_datasets_evaluators_dataset_evaluator",
+        "datasets_evaluators",
+        ["dataset_id", "evaluator_id"],
+        unique=True,
+        postgresql_where=sa.text("evaluator_id IS NOT NULL"),
+        sqlite_where=sa.text("evaluator_id IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_datasets_evaluators_dataset_builtin",
+        "datasets_evaluators",
+        ["dataset_id", "builtin_evaluator_id"],
+        unique=True,
+        postgresql_where=sa.text("builtin_evaluator_id IS NOT NULL"),
+        sqlite_where=sa.text("builtin_evaluator_id IS NOT NULL"),
     )
 
 

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2195,15 +2195,19 @@ class DatasetsEvaluators(HasId):
             "(evaluator_id IS NOT NULL) != (builtin_evaluator_id IS NOT NULL)",
             name="evaluator_id_xor_builtin_evaluator_id",
         ),
-        UniqueConstraint(
+        Index(
+            "ix_datasets_evaluators_dataset_evaluator",
             "dataset_id",
             "evaluator_id",
+            unique=True,
             postgresql_where=sa.text("evaluator_id IS NOT NULL"),
             sqlite_where=sa.text("evaluator_id IS NOT NULL"),
         ),
-        UniqueConstraint(
+        Index(
+            "ix_datasets_evaluators_dataset_builtin",
             "dataset_id",
             "builtin_evaluator_id",
+            unique=True,
             postgresql_where=sa.text("builtin_evaluator_id IS NOT NULL"),
             sqlite_where=sa.text("builtin_evaluator_id IS NOT NULL"),
         ),

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -2188,7 +2188,9 @@ class DatasetsEvaluators(HasId):
     )
     input_config: Mapped[dict[str, Any]] = mapped_column(JSON_, nullable=False)
     dataset: Mapped["Dataset"] = relationship("Dataset", back_populates="datasets_evaluators")
-    evaluator: Mapped["Evaluator"] = relationship("Evaluator", back_populates="datasets_evaluators")
+    evaluator: Mapped[Optional["Evaluator"]] = relationship(
+        "Evaluator", back_populates="datasets_evaluators"
+    )
 
     __table_args__ = (
         CheckConstraint(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable assigning/unassigning built-in evaluators via new crosswalk schema while accepting optional input config; update DB model/migration, API mutations, and assignment checks.
> 
> - **Database**:
>   - `datasets_evaluators` now has surrogate `id` PK, optional `evaluator_id`, new `builtin_evaluator_id`, and required XOR check between them.
>   - Add unique partial indexes on (`dataset_id`,`evaluator_id`) and (`dataset_id`,`builtin_evaluator_id`).
> - **Models**:
>   - Update `DatasetsEvaluators` to include `id`, nullable `evaluator_id`, `builtin_evaluator_id`, XOR constraint, and matching indexes.
> - **API (Mutations)**:
>   - Accept `BuiltInEvaluator` IDs; treat negative IDs as built-in and route to `builtin_evaluator_id`.
>   - `assign_evaluator_to_dataset` and `unassign_evaluator_from_dataset` handle built-ins and upsert/delete accordingly; pass through optional `input_config` (defaults to `{}`).
> - **GraphQL Schema**:
>   - `AssignEvaluatorToDatasetInput` adds optional `inputConfig: JSON`.
> - **Evaluator Type**:
>   - Implement `BuiltInEvaluator.isAssignedToDataset` to query `datasets_evaluators` by `builtin_evaluator_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1dec92a11721fcec958d4e78a82d445d5a1ebdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->