### PR TITLE
fix: handle None values for top_p and temperature in AnthropicModel

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/models/anthropic.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/models/anthropic.py
@@ -134,6 +134,7 @@ class AnthropicModel(BaseModel):
         kwargs.pop("instruction", None)
         invocation_parameters = self.invocation_parameters()
         invocation_parameters.update(kwargs)
+        invocation_parameters = {k: v for k, v in invocation_parameters.items() if v is not None}
         return self._rate_limited_completion(
             model=self.model,
             messages=self._format_prompt_for_claude(prompt),
@@ -166,6 +167,7 @@ class AnthropicModel(BaseModel):
         kwargs.pop("instruction", None)
         invocation_parameters = self.invocation_parameters()
         invocation_parameters.update(kwargs)
+        invocation_parameters = {k: v for k, v in invocation_parameters.items() if v is not None}
         return await self._async_rate_limited_completion(
             model=self.model,
             messages=self._format_prompt_for_claude(prompt),


### PR DESCRIPTION
This PR fixes an issue where passing None for top_p or temperature would still send them to the Anthropic API, causing validation errors. This change ensures that these parameters are only included in the request if they are not None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid sending None-valued parameters (e.g., temperature, top_p) by conditionally building and filtering request params for sync/async calls.
> 
> - **Model: `AnthropicModel`**
>   - Conditionally include `temperature` and `top_p` in `invocation_parameters()` only when not `None`.
>   - Filter out `None` values from merged `invocation_parameters` before making sync/async `messages.create` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 074e9dc271b5dbc08fc82a6e00ca19724e61fe57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->