### PR TITLE
fix: correct corepack invocation in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /phoenix/app/
 COPY ./app /phoenix/app
 RUN npm i -g corepack
 RUN corepack enable
-RUN corepack use pnpm
+RUN corepack install
 RUN pnpm install
 RUN pnpm run build
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `corepack use pnpm` with `corepack install` in Dockerfile’s frontend build stage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfa33a974e9d4519a1e106064af1a6914ebab109. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->