### PR TITLE
fix(helm): update helm docs and remove deprecated values

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -128,36 +128,6 @@ postgresql:
       cpu: 100m
       memory: 256Mi
 
-## DEPRECATED
-postgres:
-  # -- Docker image for PostgreSQL (DEPRECATED for new postgresql.image)
-  image: "postgres:14.5"
-
-  persistence:
-    # -- Enable persistent storage for PostgreSQL data (DEPRECATED for new postgresql.primary.persistence)
-    enabled: true
-
-    # -- Size of the persistent volume for PostgreSQL  (DEPRECATED for new postgresql.primary.persistence)
-    size: "20Gi"
-
-    # -- Kubernetes storage class for PostgreSQL volume (DEPRECATED for new postgresql.primary.persistence)
-    storageClass: "standard"
-
-  resources:
-    limits:
-      # -- CPU limit for PostgreSQL container (DEPRECATED for new postgresql)
-      cpu: "500m"
-
-      # -- Memory limit for PostgreSQL container (DEPRECATED for new postgresql)
-      memory: "512Mi"
-
-    requests:
-      # -- CPU request for PostgreSQL container (DEPRECATED for new postgresql)
-      cpu: "100m"
-
-      # -- Memory request for PostgreSQL container (DEPRECATED for new postgresql)
-      memory: "256Mi"
-
 server:
   # -- Annotations to add to the Phoenix service
   annotations: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps chart/app/image versions, documents new `auth`, `database.postgres` (AWS IAM), and `server` settings, and removes deprecated `postgres` values block.
> 
> - **Helm docs (README)**:
>   - Bump chart `Version` to `4.0.15` and `AppVersion` to `12.17.0`; update `image.tag` to `version-12.17.0-nonroot`.
>   - Add new settings: `auth.admins`, `auth.cookiesPath`, `auth.disableBasicAuth`, `database.postgres.useAwsIamAuth`, `database.postgres.awsIamTokenLifetimeSeconds`, `server.maxSpansQueueSize`.
>   - Expand `auth.oauth2.providers` description for env-based configuration.
> - **Values**:
>   - Remove deprecated `postgres` block (old inline Postgres config).
>   - No functional changes to active keys besides version/tag alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8254dacc5b4e9a2fb956ea639924e98011636e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->