### PR TITLE
refactor: use classification evaluator config for document relevance prompt

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/__init__.py
@@ -1,5 +1,8 @@
 # This file is generated. Do not edit by hand.
 
+from ._document_relevance_classification_evaluator_config import (
+    DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG,
+)
 from ._hallucination_classification_evaluator_config import (
     HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG,
 )
@@ -8,5 +11,6 @@ from ._models import ClassificationEvaluatorConfig, PromptMessage
 __all__ = [
     "ClassificationEvaluatorConfig",
     "PromptMessage",
+    "DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG",
     "HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/packages/phoenix-evals/src/phoenix/evals/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -1,0 +1,16 @@
+# This file is generated. Do not edit by hand.
+# ruff: noqa: E501
+
+from ._models import ClassificationEvaluatorConfig, PromptMessage
+
+DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
+    name="document_relevance",
+    description="A specialized evaluator for determining document relevance to a given question.",
+    messages=[
+        PromptMessage(
+            role="user",
+            content='You are comparing a document text to a question and trying to determine\nif the document text contains information relevant to answering the\nquestion. Here is the data:\n\n[BEGIN DATA]\n************\n[Question]: {{input}}\n************\n[Document text]: {{document}}\n************\n[END DATA]\n\nCompare the question above to the document text. You must determine\nwhether the document text contains information that can answer the\nquestion. Please focus on whether the very specific question can be\nanswered by the information in the document text. Your response must be\neither "relevant" or "unrelated". "unrelated" means that the document\ntext does not contain an answer to the question. "relevant" means the\ndocument text contains an answer to the question.\n',
+        )
+    ],
+    choices={"unrelated": 0.0, "relevant": 1.0},
+)

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py
@@ -1,30 +1,11 @@
 from pydantic import BaseModel, Field
 
+from ..__generated__.classification_evaluator_configs import (
+    DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG,
+)
 from ..evaluators import ClassificationEvaluator
 from ..llm import LLM
-from ..templating import Template
-
-_DEFAULT_DOCUMENT_RELEVANCY_TEMPLATE = """\
-You are comparing a document text to a question and trying to determine
-if the document text contains information relevant to answering the
-question. Here is the data:
-
-[BEGIN DATA]
-************
-[Question]: {input}
-************
-[Document text]: {document}
-************
-[END DATA]
-
-Compare the question above to the document text. You must determine
-whether the document text contains information that can answer the
-question. Please focus on whether the very specific question can be
-answered by the information in the document text. Your response must be
-either "relevant" or "unrelated". "unrelated" means that the document
-text does not contain an answer to the question. "relevant" means the
-document text contains an answer to the question.
-"""
+from ..templating import Template, TemplateFormat
 
 
 class DocumentRelevanceEvaluator(ClassificationEvaluator):
@@ -57,9 +38,12 @@ class DocumentRelevanceEvaluator(ClassificationEvaluator):
         print(scores)
     """
 
-    NAME = "document_relevance"
-    PROMPT = Template(template=_DEFAULT_DOCUMENT_RELEVANCY_TEMPLATE)
-    CHOICES = {"unrelated": 0.0, "relevant": 1.0}
+    NAME = DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.name
+    PROMPT = Template(
+        template=DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.messages[0].content,
+        template_format=TemplateFormat.MUSTACHE,
+    )
+    CHOICES = DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.choices
 
     class DocumentRelevanceInputSchema(BaseModel):
         input: str = Field(description="The input query.")

--- a/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
+++ b/prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml
@@ -1,0 +1,28 @@
+name: document_relevance
+description: A specialized evaluator for determining document relevance to a given question.
+messages:
+  - role: user
+    content: |
+      You are comparing a document text to a question and trying to determine
+      if the document text contains information relevant to answering the
+      question. Here is the data:
+      
+      [BEGIN DATA]
+      ************
+      [Question]: {{input}}
+      ************
+      [Document text]: {{document}}
+      ************
+      [END DATA]
+      
+      Compare the question above to the document text. You must determine
+      whether the document text contains information that can answer the
+      question. Please focus on whether the very specific question can be
+      answered by the information in the document text. Your response must be
+      either "relevant" or "unrelated". "unrelated" means that the document
+      text does not contain an answer to the question. "relevant" means the
+      document text contains an answer to the question.
+choices:
+  unrelated: 0.0
+  relevant: 1.0
+

--- a/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/__init__.py
@@ -1,5 +1,8 @@
 # This file is generated. Do not edit by hand.
 
+from ._document_relevance_classification_evaluator_config import (
+    DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG,
+)
 from ._hallucination_classification_evaluator_config import (
     HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG,
 )
@@ -8,5 +11,6 @@ from ._models import ClassificationEvaluatorConfig, PromptMessage
 __all__ = [
     "ClassificationEvaluatorConfig",
     "PromptMessage",
+    "DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG",
     "HALLUCINATION_CLASSIFICATION_EVALUATOR_CONFIG",
 ]

--- a/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
+++ b/src/phoenix/__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py
@@ -1,0 +1,16 @@
+# This file is generated. Do not edit by hand.
+# ruff: noqa: E501
+
+from ._models import ClassificationEvaluatorConfig, PromptMessage
+
+DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG = ClassificationEvaluatorConfig(
+    name="document_relevance",
+    description="A specialized evaluator for determining document relevance to a given question.",
+    messages=[
+        PromptMessage(
+            role="user",
+            content='You are comparing a document text to a question and trying to determine\nif the document text contains information relevant to answering the\nquestion. Here is the data:\n\n[BEGIN DATA]\n************\n[Question]: {{input}}\n************\n[Document text]: {{document}}\n************\n[END DATA]\n\nCompare the question above to the document text. You must determine\nwhether the document text contains information that can answer the\nquestion. Please focus on whether the very specific question can be\nanswered by the information in the document text. Your response must be\neither "relevant" or "unrelated". "unrelated" means that the document\ntext does not contain an answer to the question. "relevant" means the\ndocument text contains an answer to the question.\n',
+        )
+    ],
+    choices={"unrelated": 0.0, "relevant": 1.0},
+)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace hardcoded document relevance prompt with generated config and Mustache template; add YAML/source and generated config files and export them.
> 
> - **Evaluators**:
>   - Update `DocumentRelevanceEvaluator` in `packages/phoenix-evals/src/phoenix/evals/metrics/document_relevance.py` to use `DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG` with `TemplateFormat.MUSTACHE`; remove inline prompt/choices.
> - **Generated Configs**:
>   - Add `DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG` in `__generated__/classification_evaluator_configs/_document_relevance_classification_evaluator_config.py` for both `packages/phoenix-evals` and `src/phoenix` trees.
>   - Export the new config via `__init__.py` in both trees.
> - **Prompts**:
>   - Add `prompts/classification_evaluator_configs/DOCUMENT_RELEVANCE_CLASSIFICATION_EVALUATOR_CONFIG.yaml` defining name, description, messages, and choices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a19970d6b57fbbd6ccd70d5cd0c011de5592d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->