### PR TITLE
docs: adding splits example

### DIFF
--- a/js/examples/notebooks/tracing_openai_sessions_tutorial.ipynb
+++ b/js/examples/notebooks/tracing_openai_sessions_tutorial.ipynb
@@ -133,11 +133,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Deno",
-   "language": "typescript",
-   "name": "deno"
-  },
   "language_info": {
    "name": "typescript"
   }

--- a/tutorials/experiments/run_experiments_splits.ipynb
+++ b/tutorials/experiments/run_experiments_splits.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f9c9f1b9",
    "metadata": {},
    "outputs": [],
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "cec85161",
    "metadata": {},
    "outputs": [],
@@ -690,12 +690,12 @@
     "        },\n",
     "        \"metadata\": {\"source\": \"support_ticket\", \"language\": \"en\", \"channel\": \"web\"},\n",
     "    },\n",
-    "]\n"
+    "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "8f95d182",
    "metadata": {},
    "outputs": [],
@@ -724,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4f670acb",
    "metadata": {},
    "outputs": [],
@@ -751,7 +751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0df7375b",
    "metadata": {},
    "outputs": [],
@@ -821,25 +821,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3369b2fe",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'phoenix_client' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m dataset \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m \u001b[43mphoenix_client\u001b[49m\u001b[38;5;241m.\u001b[39mdatasets\u001b[38;5;241m.\u001b[39mget_dataset(\n\u001b[1;32m      2\u001b[0m         dataset\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtriage-dataset\u001b[39m\u001b[38;5;124m\"\u001b[39m, splits\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhard_examples\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m      3\u001b[0m )\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'phoenix_client' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dataset = await phoenix_client.datasets.get_dataset(\n",
-    "        dataset=\"triage-dataset\", splits=[\"hard_examples\"]\n",
+    "    dataset=\"triage-dataset\", splits=[\"hard_examples\"]\n",
     ")"
    ]
   },
@@ -859,22 +847,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new notebook showing how to run experiments on Phoenix dataset splits using OpenAI and the Phoenix Python client.
> 
> - **Tutorials**:
>   - **New notebook** `tutorials/experiments/run_experiments_splits.ipynb`:
>     - Demonstrates creating a dataset in Phoenix, assigning UI-defined splits, and fetching subsets via `get_dataset(..., splits=[...])`.
>     - Implements `triage_issue` with OpenAI `chat.completions` tool-calling and runs experiments using `phoenix_client.experiments.run_experiment`.
>     - Includes sample examples, environment setup, and async clients for OpenAI and Phoenix.
> - **Notebooks**:
>   - Minor metadata cleanup in `js/examples/notebooks/tracing_openai_sessions_tutorial.ipynb`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6651cd55a3e806783b81e6cef285241a38140651. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->