### PR TITLE
fix: do not remove endpoint prefix before `/v1/traces`

### DIFF
--- a/packages/phoenix-otel/src/phoenix/otel/otel.py
+++ b/packages/phoenix-otel/src/phoenix/otel/otel.py
@@ -729,7 +729,10 @@ def _construct_http_endpoint(parsed_endpoint: ParseResult) -> ParseResult:
     Returns:
         ParseResult: Modified endpoint with "/v1/traces" path.
     """
-    return parsed_endpoint._replace(path="/v1/traces")
+    traces_suffix = "/v1/traces"
+    if parsed_endpoint.path.endswith(traces_suffix):
+        return parsed_endpoint
+    return parsed_endpoint._replace(path=traces_suffix)
 
 
 def _construct_phoenix_cloud_endpoint(parsed_endpoint: ParseResult) -> ParseResult:

--- a/packages/phoenix-otel/tests/test_settings.py
+++ b/packages/phoenix-otel/tests/test_settings.py
@@ -1,9 +1,11 @@
 import os
 from typing import Optional
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
+from phoenix.otel.otel import _construct_http_endpoint
 from phoenix.otel.settings import get_env_collector_endpoint
 
 
@@ -25,3 +27,17 @@ from phoenix.otel.settings import get_env_collector_endpoint
 def test_get_env_collector_endpoint(env: dict[str, str], expected: Optional[str]) -> None:
     with patch.dict(os.environ, env, clear=True):
         assert get_env_collector_endpoint() == expected
+
+
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        ("http://localhost:6006", "http://localhost:6006/v1/traces"),
+        ("http://localhost:6006/v1/traces", "http://localhost:6006/v1/traces"),
+        ("http://localhost:6006/prefix/v1/traces", "http://localhost:6006/prefix/v1/traces"),
+    ],
+)
+def test_construct_http_endpoint(endpoint: str, expected: str) -> None:
+    parsed = urlparse(endpoint)
+    result = _construct_http_endpoint(parsed)
+    assert result.geturl() == expected


### PR DESCRIPTION
resolves #10416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids stripping existing path prefixes when building HTTP `/v1/traces` endpoints and adds tests to validate behavior.
> 
> - **phoenix-otel**:
>   - Updates `phoenix/otel/otel.py` `_construct_http_endpoint` to preserve existing path prefixes if the URL already ends with `/v1/traces`; otherwise appends the traces path.
> - **Tests**:
>   - Adds parametrized tests in `tests/test_settings.py` for `_construct_http_endpoint`, covering base URL, already-suffixed URL, and prefixed path cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10158131defbe99621a3e2d7254cd39372a9feb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->