### PR TITLE
fix: exclude none values for bedrock invocation parameters

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -795,9 +795,15 @@ class BedrockStreamingClient(PlaygroundStreamingClient):
         converse_messages = self._build_converse_messages(messages)
 
         inference_config = {}
-        if "max_tokens" in invocation_parameters and invocation_parameters["max_tokens"] is not None:
+        if (
+            "max_tokens" in invocation_parameters
+            and invocation_parameters["max_tokens"] is not None
+        ):
             inference_config["maxTokens"] = invocation_parameters["max_tokens"]
-        if "temperature" in invocation_parameters and invocation_parameters["temperature"] is not None:
+        if (
+            "temperature" in invocation_parameters
+            and invocation_parameters["temperature"] is not None
+        ):
             inference_config["temperature"] = invocation_parameters["temperature"]
         if "top_p" in invocation_parameters and invocation_parameters["top_p"] is not None:
             inference_config["topP"] = invocation_parameters["top_p"]
@@ -944,9 +950,15 @@ class BedrockStreamingClient(PlaygroundStreamingClient):
             "tools": tools,
         }
 
-        if "max_tokens" in invocation_parameters and invocation_parameters["max_tokens"] is not None:
+        if (
+            "max_tokens" in invocation_parameters
+            and invocation_parameters["max_tokens"] is not None
+        ):
             bedrock_params["max_tokens"] = invocation_parameters["max_tokens"]
-        if "temperature" in invocation_parameters and invocation_parameters["temperature"] is not None:
+        if (
+            "temperature" in invocation_parameters
+            and invocation_parameters["temperature"] is not None
+        ):
             bedrock_params["temperature"] = invocation_parameters["temperature"]
         if "top_p" in invocation_parameters and invocation_parameters["top_p"] is not None:
             bedrock_params["top_p"] = invocation_parameters["top_p"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exclude None-valued `max_tokens`, `temperature`, and `top_p` from Bedrock Converse and Invoke request payloads.
> 
> - **AWS Bedrock**:
>   - In `src/phoenix/server/api/helpers/playground_clients.py`:
>     - _Converse API_ (`_handle_converse_api`): Only set `inferenceConfig.maxTokens`, `temperature`, and `topP` when corresponding invocation params are non-null.
>     - _Invoke API_ (`_handle_invoke_api`): Only include `max_tokens`, `temperature`, and `top_p` in `bedrock_params` when provided and non-null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2785c4ebd3b0eac319d0c92cd6b16454bbdda9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->