### PR TITLE
fix: fix some react compiler issues

### DIFF
--- a/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
+++ b/app/src/pages/experiment/ExperimentCompareDetailsDialog.tsx
@@ -67,6 +67,7 @@ export function ExperimentCompareDetailsDialog({
             compareExperimentIds={compareExperimentIds}
             defaultSelectedRepetitionNumber={repetitionNumber}
             openTraceDialog={openTraceDialog}
+            key={repetitionNumber} // reset selection state when repetition number changes
           />
         </Suspense>
       </DialogContent>

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -1340,6 +1340,7 @@ function TableBody<T>({
   table: Table<T>;
   virtualizer: ReturnType<typeof useVirtualizer<HTMLDivElement, Element>>;
 }) {
+  "use no memo";
   const rows = table.getRowModel().rows;
   const virtualRows = virtualizer.getVirtualItems();
   const totalHeight = virtualizer.getTotalSize();

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -76,6 +76,7 @@ const TableBody = <T extends { id: string }>({
   isLoadingNext: boolean;
   dataset: ExperimentsTableFragment$data;
 }) => {
+  "use no memo";
   const navigate = useNavigate();
   return (
     <tbody>

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -528,6 +528,7 @@ function TableBody<T>({
   table: Table<T>;
   virtualizer: Virtualizer<HTMLDivElement, Element>;
 }) {
+  "use no memo";
   const rows = table.getRowModel().rows;
 
   const virtualRows = virtualizer.getVirtualItems();

--- a/app/src/pages/project/SessionsTable.tsx
+++ b/app/src/pages/project/SessionsTable.tsx
@@ -71,6 +71,7 @@ const TableBody = <T extends { id: string }>({
 }: {
   table: Table<T>;
 }) => {
+  "use no memo";
   const navigate = useNavigate();
   return (
     <tbody>

--- a/app/src/pages/project/SpansTable.tsx
+++ b/app/src/pages/project/SpansTable.tsx
@@ -95,6 +95,7 @@ const TableBody = <T extends { trace: { traceId: string }; id: string }>({
   onLoadNext: () => void;
   isLoadingNext: boolean;
 }) => {
+  "use no memo";
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { traceId } = useParams();

--- a/app/src/pages/project/TracesTable.tsx
+++ b/app/src/pages/project/TracesTable.tsx
@@ -108,6 +108,7 @@ const TableBody = <
 }: {
   table: Table<T>;
 }) => {
+  "use no memo";
   const navigate = useNavigate();
   const { traceId } = useParams();
   return (


### PR DESCRIPTION
This adds the "use no memo" directive to bypass react compiler optimization on a few tables that weren't properly re-rendering. The main issues this addresses are virtualized tables appearing empty due to incompatibilities between react-virtualized and the react compiler, and table row selection state not being updated in the UI for selectable tables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables React compiler memoization in several table bodies and resets ExperimentCompareDetails state when repetition changes to ensure proper re-renders.
> 
> - **Tables**:
>   - Add `"use no memo"` directive to un-memoized `TableBody` components to force re-renders in:
>     - `experiments/ExperimentsTable.tsx`
>     - `experiment/ExperimentCompareListPage.tsx`
>     - `playground/PlaygroundDatasetExamplesTable.tsx`
>     - `project/SessionsTable.tsx`
>     - `project/SpansTable.tsx`
>     - `project/TracesTable.tsx`
> - **Experiment Compare**:
>   - In `experiment/ExperimentCompareDetailsDialog.tsx`, add `key={repetitionNumber}` to `ExperimentCompareDetails` to reset selection state when the repetition changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 854ceb42562303671afe840b2b13369deb3356e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->