### PR TITLE
fix: fix fetching composite ids

### DIFF
--- a/src/phoenix/server/api/types/node.py
+++ b/src/phoenix/server/api/types/node.py
@@ -3,7 +3,7 @@ from base64 import b64decode
 
 from strawberry.relay import GlobalID
 
-_COMPOSITE_GLOBAL_ID_PATTERN = re.compile(r"[^:]+:[^:]+(:[^:]+:[^:]+)+")
+_COMPOSITE_GLOBAL_ID_PATTERN = re.compile(r"[^:]+:[^:]+(:[^:]+)+")
 
 
 def is_composite_global_id(node_id: str) -> bool:


### PR DESCRIPTION
Fixes a bug where the experiment compare page crashes when attempting to fetch an ExperimentRepeatedRunGroup node with an ID such as `ExperimentRepeatedRunGroup:experiment_id=206:dataset_example_id=840`. This updates the regex for matching composite IDs such that 2 or more node IDs must be after the initial composite type name (previously was requiring 3 or more).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens the composite global ID regex to match IDs with variable segment counts (2+), enabling parsing of shorter composite IDs.
> 
> - **API**:
>   - Update `_COMPOSITE_GLOBAL_ID_PATTERN` in `src/phoenix/server/api/types/node.py` from `[^:]+:[^:]+(:[^:]+:[^:]+)+` to `[^:]+:[^:]+(:[^:]+)+` to allow composite IDs with 2+ segments after the type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ba2c90b58a68b887d92381e36c203fb9c5e440. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->