### PR TITLE
feat: add optimization direction for evaluators

### DIFF
--- a/app/src/components/dataset/EditDatasetEvaluatorSlideover.tsx
+++ b/app/src/components/dataset/EditDatasetEvaluatorSlideover.tsx
@@ -106,6 +106,7 @@ const EditEvaluatorDialog = ({
             }
             outputConfig {
               name
+              optimizationDirection
               values {
                 label
                 score
@@ -184,6 +185,8 @@ const EditEvaluatorDialog = ({
       },
       choiceConfig: {
         name: evaluator.outputConfig?.name ?? "",
+        optimizationDirection:
+          evaluator.outputConfig?.optimizationDirection ?? "MAXIMIZE",
         choices: evaluator.outputConfig?.values.map((value) => ({
           label: value.label,
           score: value.score ?? undefined,

--- a/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_evaluator.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_evaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0eaefe8f706193d9d5995e0b8e07716d>>
+ * @generated SignedSource<<d9c12719a0ae37286cf982f76ae4d964>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type EvaluatorKind = "CODE" | "LLM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 import { FragmentRefs } from "relay-runtime";
 export type EditDatasetEvaluatorSlideover_evaluator$data = {
   readonly description: string | null;
@@ -19,6 +20,7 @@ export type EditDatasetEvaluatorSlideover_evaluator$data = {
   readonly name: string;
   readonly outputConfig?: {
     readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
     readonly values: ReadonlyArray<{
       readonly label: string;
       readonly score: number | null;
@@ -358,6 +360,13 @@ return {
             {
               "alias": null,
               "args": null,
+              "kind": "ScalarField",
+              "name": "optimizationDirection",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
               "concreteType": "CategoricalAnnotationValue",
               "kind": "LinkedField",
               "name": "values",
@@ -393,6 +402,6 @@ return {
 };
 })();
 
-(node as any).hash = "197e8cfa7d6e4901f15c722aadc00411";
+(node as any).hash = "e50af1ad653615d2563ac8589db6c0ee";
 
 export default node;

--- a/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_evaluatorQuery.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_evaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bac1c32eb4ae4f68c3fc6e026151dd5a>>
+ * @generated SignedSource<<30dbb547ff80a8213fb2e4df6eb2d90c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -400,6 +400,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "optimizationDirection",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "CategoricalAnnotationValue",
                         "kind": "LinkedField",
                         "name": "values",
@@ -440,12 +447,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "47b9b80553ef2cb76d731268f37e511f",
+    "cacheID": "3cd66fe2ad86dc30e84c0e27915b953d",
     "id": null,
     "metadata": {},
     "name": "EditDatasetEvaluatorSlideover_evaluatorQuery",
     "operationKind": "query",
-    "text": "query EditDatasetEvaluatorSlideover_evaluatorQuery(\n  $evaluatorId: ID!\n  $datasetId: ID!\n) {\n  evaluator: node(id: $evaluatorId) {\n    __typename\n    ... on Evaluator {\n      __isEvaluator: __typename\n      ...EditDatasetEvaluatorSlideover_evaluator_1wYocp\n    }\n    id\n  }\n}\n\nfragment EditDatasetEvaluatorSlideover_evaluator_1wYocp on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  isAssignedToDataset(datasetId: $datasetId)\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
+    "text": "query EditDatasetEvaluatorSlideover_evaluatorQuery(\n  $evaluatorId: ID!\n  $datasetId: ID!\n) {\n  evaluator: node(id: $evaluatorId) {\n    __typename\n    ... on Evaluator {\n      __isEvaluator: __typename\n      ...EditDatasetEvaluatorSlideover_evaluator_1wYocp\n    }\n    id\n  }\n}\n\nfragment EditDatasetEvaluatorSlideover_evaluator_1wYocp on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  isAssignedToDataset(datasetId: $datasetId)\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
+++ b/app/src/components/dataset/__generated__/EditDatasetEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ab68ac25efbe6bf947ea941a3bc77807>>
+ * @generated SignedSource<<dd11e66f732f90054bcac17e8894dbb7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -532,6 +532,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "optimizationDirection",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "CategoricalAnnotationValue",
                             "kind": "LinkedField",
                             "name": "values",
@@ -596,12 +603,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "11acc063ab393002a5ea4c46704c97ed",
+    "cacheID": "9e64d8cda11b55ff4e0a8f3a3eb3e36e",
     "id": null,
     "metadata": {},
     "name": "EditDatasetEvaluatorSlideover_updateLLMEvaluatorMutation",
     "operationKind": "mutation",
-    "text": "mutation EditDatasetEvaluatorSlideover_updateLLMEvaluatorMutation(\n  $input: UpdateLLMEvaluatorInput!\n) {\n  updateLlmEvaluator(input: $input) {\n    evaluator {\n      id\n      name\n      ...EvaluatorsTable_row\n      ...EditEvaluatorSlideover_evaluator\n    }\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  isAssignedToDataset\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
+    "text": "mutation EditDatasetEvaluatorSlideover_updateLLMEvaluatorMutation(\n  $input: UpdateLLMEvaluatorInput!\n) {\n  updateLlmEvaluator(input: $input) {\n    evaluator {\n      id\n      name\n      ...EvaluatorsTable_row\n      ...EditEvaluatorSlideover_evaluator\n    }\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  isAssignedToDataset\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/evaluators/EditEvaluatorSlideover.tsx
+++ b/app/src/components/evaluators/EditEvaluatorSlideover.tsx
@@ -94,6 +94,7 @@ const EditEvaluatorDialog = ({
           }
           outputConfig {
             name
+            optimizationDirection
             values {
               label
               score
@@ -159,6 +160,8 @@ const EditEvaluatorDialog = ({
       },
       choiceConfig: {
         name: evaluator.outputConfig?.name ?? "",
+        optimizationDirection:
+          evaluator.outputConfig?.optimizationDirection ?? "MAXIMIZE",
         choices: evaluator.outputConfig?.values.map((value) => ({
           label: value.label,
           score: value.score ?? undefined,

--- a/app/src/components/evaluators/EvaluatorForm.tsx
+++ b/app/src/components/evaluators/EvaluatorForm.tsx
@@ -53,6 +53,7 @@ const DEFAULT_FORM_VALUES: EvaluatorFormValues = {
   },
   choiceConfig: {
     name: "",
+    optimizationDirection: "MAXIMIZE",
     choices: [
       { label: "", score: undefined },
       { label: "", score: undefined },

--- a/app/src/components/evaluators/EvaluatorLLMChoice.tsx
+++ b/app/src/components/evaluators/EvaluatorLLMChoice.tsx
@@ -11,6 +11,8 @@ import {
   Input,
   Label,
   NumberField,
+  Radio,
+  RadioGroup,
   Text,
   TextField,
 } from "@phoenix/components";
@@ -21,12 +23,21 @@ type Choice = {
   score?: number;
 };
 
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+
 export type ChoiceConfig = {
   name: string;
+  optimizationDirection: OptimizationDirection;
   choices: Choice[];
 };
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+
+const optimizationDirections = [
+  "MAXIMIZE",
+  "MINIMIZE",
+  "NONE",
+] satisfies OptimizationDirection[];
 
 type EvaluatorLLMChoiceProps = {
   control: Control<EvaluatorFormValues, unknown>;
@@ -60,6 +71,36 @@ export const EvaluatorLLMChoice = ({ control }: EvaluatorLLMChoiceProps) => {
               <Input placeholder="e.g. correctness" />
               <FieldError>{error?.message}</FieldError>
             </TextField>
+          )}
+        />
+        <Controller
+          control={control}
+          name="choiceConfig.optimizationDirection"
+          render={({ field }) => (
+            <RadioGroup
+              {...field}
+              aria-label="Optimization Direction"
+              data-testid="optimization-direction-picker"
+              css={css`
+                height: 100%;
+              `}
+            >
+              <Label>Optimization Direction</Label>
+              {optimizationDirections.map((direction) => (
+                <Radio key={direction} value={direction}>
+                  {direction.charAt(0).toUpperCase() +
+                    direction.slice(1).toLowerCase()}
+                </Radio>
+              ))}
+              <Text marginTop="auto" slot="description">
+                Maximize - higher the score the better - e.g., correctness
+                <br />
+                Minimize - lower the score the better - e.g., hallucinations
+                <br />
+                None - higher is not better or worse
+                <br />
+              </Text>
+            </RadioGroup>
           )}
         />
         <Flex direction="column" gap="size-100">

--- a/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_evaluator.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_evaluator.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f4e77ecc0a7cd514133e60144d88db76>>
+ * @generated SignedSource<<0ff66b357e23827008a914fece743140>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type EvaluatorKind = "CODE" | "LLM";
+export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 import { FragmentRefs } from "relay-runtime";
 export type EditEvaluatorSlideover_evaluator$data = {
   readonly description: string | null;
@@ -18,6 +19,7 @@ export type EditEvaluatorSlideover_evaluator$data = {
   readonly name: string;
   readonly outputConfig?: {
     readonly name: string;
+    readonly optimizationDirection: OptimizationDirection;
     readonly values: ReadonlyArray<{
       readonly label: string;
       readonly score: number | null;
@@ -338,6 +340,13 @@ return {
             {
               "alias": null,
               "args": null,
+              "kind": "ScalarField",
+              "name": "optimizationDirection",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
               "concreteType": "CategoricalAnnotationValue",
               "kind": "LinkedField",
               "name": "values",
@@ -373,6 +382,6 @@ return {
 };
 })();
 
-(node as any).hash = "6ea69e99c30d3ee0d1d6c72c78ad3349";
+(node as any).hash = "17b8cb2a70cbd45aaae568a7ce4c3f48";
 
 export default node;

--- a/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_evaluatorQuery.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_evaluatorQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd98639ffa064616881877a434ffa72e>>
+ * @generated SignedSource<<156d975b500ff41a414627e91349109e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -376,6 +376,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "optimizationDirection",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "CategoricalAnnotationValue",
                         "kind": "LinkedField",
                         "name": "values",
@@ -416,12 +423,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "290dcbe27be79c36ad1a31254fe43f55",
+    "cacheID": "3d71644844610acbfe9cf18bdd023f2a",
     "id": null,
     "metadata": {},
     "name": "EditEvaluatorSlideover_evaluatorQuery",
     "operationKind": "query",
-    "text": "query EditEvaluatorSlideover_evaluatorQuery(\n  $evaluatorId: ID!\n) {\n  evaluator: node(id: $evaluatorId) {\n    __typename\n    ... on Evaluator {\n      __isEvaluator: __typename\n      ...EditEvaluatorSlideover_evaluator\n    }\n    id\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
+    "text": "query EditEvaluatorSlideover_evaluatorQuery(\n  $evaluatorId: ID!\n) {\n  evaluator: node(id: $evaluatorId) {\n    __typename\n    ... on Evaluator {\n      __isEvaluator: __typename\n      ...EditEvaluatorSlideover_evaluator\n    }\n    id\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EditEvaluatorSlideover_updateLLMEvaluatorMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<60e37d5824c4f8e804355ce01266ad6c>>
+ * @generated SignedSource<<f5697a5563de8ecd44cde1a972a00a56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -532,6 +532,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "optimizationDirection",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "CategoricalAnnotationValue",
                             "kind": "LinkedField",
                             "name": "values",
@@ -596,12 +603,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e815074894259748fa4ae09730354de6",
+    "cacheID": "39a105492e92fd4d96caf8fc82e62ba9",
     "id": null,
     "metadata": {},
     "name": "EditEvaluatorSlideover_updateLLMEvaluatorMutation",
     "operationKind": "mutation",
-    "text": "mutation EditEvaluatorSlideover_updateLLMEvaluatorMutation(\n  $input: UpdateLLMEvaluatorInput!\n) {\n  updateLlmEvaluator(input: $input) {\n    evaluator {\n      id\n      name\n      ...EvaluatorsTable_row\n      ...EditEvaluatorSlideover_evaluator\n    }\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  isAssignedToDataset\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
+    "text": "mutation EditEvaluatorSlideover_updateLLMEvaluatorMutation(\n  $input: UpdateLLMEvaluatorInput!\n) {\n  updateLlmEvaluator(input: $input) {\n    evaluator {\n      id\n      name\n      ...EvaluatorsTable_row\n      ...EditEvaluatorSlideover_evaluator\n    }\n  }\n}\n\nfragment EditEvaluatorSlideover_evaluator on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  description\n  kind\n  ... on LLMEvaluator {\n    prompt {\n      id\n      name\n    }\n    promptVersion {\n      ...fetchPlaygroundPrompt_promptVersionToInstance_promptVersion\n      id\n    }\n    outputConfig {\n      name\n      optimizationDirection\n      values {\n        label\n        score\n      }\n      id\n    }\n  }\n}\n\nfragment EvaluatorsTable_row on Evaluator {\n  __isEvaluator: __typename\n  id\n  name\n  kind\n  description\n  createdAt\n  updatedAt\n  isAssignedToDataset\n}\n\nfragment fetchPlaygroundPrompt_promptVersionToInstance_promptVersion on PromptVersion {\n  id\n  modelName\n  modelProvider\n  invocationParameters\n  responseFormat {\n    definition\n  }\n  template {\n    __typename\n    ... on PromptChatTemplate {\n      messages {\n        role\n        content {\n          __typename\n          ... on TextContentPart {\n            text {\n              text\n            }\n          }\n          ... on ToolCallContentPart {\n            toolCall {\n              toolCallId\n              toolCall {\n                name\n                arguments\n              }\n            }\n          }\n          ... on ToolResultContentPart {\n            toolResult {\n              toolCallId\n              result\n            }\n          }\n        }\n      }\n    }\n    ... on PromptStringTemplate {\n      template\n    }\n  }\n  tools {\n    definition\n  }\n}\n"
   }
 };
 })();

--- a/app/src/components/evaluators/utils.ts
+++ b/app/src/components/evaluators/utils.ts
@@ -110,7 +110,7 @@ export const createLLMEvaluatorPayload = ({
     promptVersion: prunedPromptInput,
     outputConfig: {
       name: choiceConfig.name,
-      optimizationDirection: "MAXIMIZE",
+      optimizationDirection: choiceConfig.optimizationDirection,
       values: choiceConfig.choices.map((choice) => ({
         label: choice.label,
         score: choice.score,


### PR DESCRIPTION
Resolves #10470 

Adds the ability to save an optimization direction for an evaluator.

https://github.com/user-attachments/assets/b9cb83c1-a75c-4497-9352-9fbb1c85f011


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds view/edit and persistence of optimization direction (maximize/minimize/none) for LLM evaluator choice configs.
> 
> - **Evaluators UI**:
>   - Add `optimizationDirection` control via radio group in `EvaluatorLLMChoice` and set default in `EvaluatorForm`.
> - **Edit Flows**:
>   - Update `EditEvaluatorSlideover.tsx` and `dataset/EditDatasetEvaluatorSlideover.tsx` to load, display, and initialize `outputConfig.optimizationDirection`.
> - **Relay GraphQL**:
>   - Extend fragments, queries, and mutations to include `outputConfig.optimizationDirection` in generated files under `__generated__`.
> - **Utils**:
>   - Modify `createLLMEvaluatorPayload` to use `choiceConfig.optimizationDirection` instead of a hardcoded value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 961ff86bf66a5acfffa92b257ab2c9c00834d8ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->