### PR TITLE
refactor: add some types for evaluators

### DIFF
--- a/app/src/components/evaluators/EvaluatorExampleDataset.tsx
+++ b/app/src/components/evaluators/EvaluatorExampleDataset.tsx
@@ -5,7 +5,7 @@ import { Flex, Heading, Text } from "@phoenix/components";
 import { DatasetSelectWithSplits } from "@phoenix/components/dataset";
 import { DatasetExampleSelect } from "@phoenix/components/dataset/DatasetExampleSelect";
 import { EvaluatorInputPreview } from "@phoenix/components/evaluators/EvaluatorInputPreview";
-import { EvaluatorInput } from "@phoenix/components/evaluators/utils";
+import { EvaluatorParams } from "@phoenix/types";
 
 type EvaluatorExampleDatasetProps = {
   selectedDatasetId: string | null;
@@ -16,7 +16,7 @@ type EvaluatorExampleDatasetProps = {
   onSelectExampleId: (exampleId: string | null) => void;
   datasetSelectIsDisabled?: boolean;
   onEvaluatorInputObjectChange: (
-    evaluatorInputObject: EvaluatorInput | null
+    evaluatorInputObject: EvaluatorParams | null
   ) => void;
 };
 

--- a/app/src/components/evaluators/EvaluatorForm.tsx
+++ b/app/src/components/evaluators/EvaluatorForm.tsx
@@ -21,15 +21,13 @@ import {
 import { EvaluatorChatTemplate } from "@phoenix/components/evaluators/EvaluatorChatTemplate";
 import { EvaluatorExampleDataset } from "@phoenix/components/evaluators/EvaluatorExampleDataset";
 import { EvaluatorInputMapping } from "@phoenix/components/evaluators/EvaluatorInputMapping";
-import {
-  ChoiceConfig,
-  EvaluatorLLMChoice,
-} from "@phoenix/components/evaluators/EvaluatorLLMChoice";
+import { EvaluatorLLMChoice } from "@phoenix/components/evaluators/EvaluatorLLMChoice";
 import { EvaluatorPlaygroundProvider } from "@phoenix/components/evaluators/EvaluatorPlaygroundProvider";
 import { EvaluatorPromptPreview } from "@phoenix/components/evaluators/EvaluatorPromptPreview";
 import { EvaluatorInput } from "@phoenix/components/evaluators/utils";
 import { fetchPlaygroundPrompt_promptVersionToInstance_promptVersion$key } from "@phoenix/pages/playground/__generated__/fetchPlaygroundPrompt_promptVersionToInstance_promptVersion.graphql";
 import { useDerivedPlaygroundVariables } from "@phoenix/pages/playground/useDerivedPlaygroundVariables";
+import { ClassificationEvaluatorAnnotationConfig } from "@phoenix/types";
 import { validateIdentifier } from "@phoenix/utils/identifierUtils";
 
 export type EvaluatorFormValues = {
@@ -37,7 +35,7 @@ export type EvaluatorFormValues = {
     name: string;
     description: string;
   };
-  choiceConfig: ChoiceConfig;
+  choiceConfig: ClassificationEvaluatorAnnotationConfig;
   dataset?: {
     readonly: boolean;
     id: string;

--- a/app/src/components/evaluators/EvaluatorInputMapping.tsx
+++ b/app/src/components/evaluators/EvaluatorInputMapping.tsx
@@ -26,8 +26,6 @@ import { Flex } from "@phoenix/components/layout/Flex";
 import { Truncate } from "@phoenix/components/utility/Truncate";
 import { flattenObject } from "@phoenix/utils/jsonUtils";
 
-export type InputMapping = Record<string, string>;
-
 type EvaluatorInputMappingProps = {
   control: Control<EvaluatorFormValues, unknown, EvaluatorFormValues>;
   evaluatorInput: EvaluatorInput | null;

--- a/app/src/components/evaluators/EvaluatorLLMChoice.tsx
+++ b/app/src/components/evaluators/EvaluatorLLMChoice.tsx
@@ -17,19 +17,7 @@ import {
   TextField,
 } from "@phoenix/components";
 import type { EvaluatorFormValues } from "@phoenix/components/evaluators/EvaluatorForm";
-
-type Choice = {
-  label: string;
-  score?: number;
-};
-
-export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
-
-export type ChoiceConfig = {
-  name: string;
-  optimizationDirection: OptimizationDirection;
-  choices: Choice[];
-};
+import { EvaluatorOptimizationDirection } from "@phoenix/types";
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
@@ -37,7 +25,7 @@ const optimizationDirections = [
   "MAXIMIZE",
   "MINIMIZE",
   "NONE",
-] satisfies OptimizationDirection[];
+] satisfies EvaluatorOptimizationDirection[];
 
 type EvaluatorLLMChoiceProps = {
   control: Control<EvaluatorFormValues, unknown>;

--- a/app/src/components/evaluators/utils.ts
+++ b/app/src/components/evaluators/utils.ts
@@ -3,8 +3,6 @@ import { graphql, readInlineData } from "relay-runtime";
 import { CreateLLMEvaluatorInput } from "@phoenix/components/dataset/__generated__/CreateDatasetEvaluatorSlideover_createLLMEvaluatorMutation.graphql";
 import { UpdateLLMEvaluatorInput } from "@phoenix/components/evaluators/__generated__/EditEvaluatorSlideover_updateLLMEvaluatorMutation.graphql";
 import { utils_datasetExampleToEvaluatorInput_example$key } from "@phoenix/components/evaluators/__generated__/utils_datasetExampleToEvaluatorInput_example.graphql";
-import { InputMapping } from "@phoenix/components/evaluators/EvaluatorInputMapping";
-import { ChoiceConfig } from "@phoenix/components/evaluators/EvaluatorLLMChoice";
 import { usePlaygroundStore } from "@phoenix/contexts/PlaygroundContext";
 import { getInstancePromptParamsFromStore } from "@phoenix/pages/playground/playgroundPromptUtils";
 import { fromOpenAIToolDefinition } from "@phoenix/schemas";
@@ -13,6 +11,10 @@ import {
   CategoricalChoiceToolTypeSchema,
 } from "@phoenix/schemas/phoenixToolTypeSchemas";
 import { fromOpenAIToolChoice } from "@phoenix/schemas/toolChoiceSchemas";
+import {
+  ClassificationEvaluatorAnnotationConfig,
+  EvaluatorInputMapping,
+} from "@phoenix/types";
 
 /**
  * Create a payload for the createLLMEvaluator or updateLLMEvaluator mutations.
@@ -46,11 +48,11 @@ export const createLLMEvaluatorPayload = ({
   /**
    * The choice config of the evaluator.
    */
-  choiceConfig: ChoiceConfig;
+  choiceConfig: ClassificationEvaluatorAnnotationConfig;
   /**
    * The input mapping of the evaluator.
    */
-  inputMapping?: InputMapping;
+  inputMapping?: EvaluatorInputMapping;
   /**
    * The dataset ID to assign the evaluator to.
    */

--- a/app/src/types/evaluators.ts
+++ b/app/src/types/evaluators.ts
@@ -1,0 +1,96 @@
+/**
+ * The parameters that are passed to the evaluator execution
+ * @example
+ * {
+ *   output: {
+ *     "answer": "The capital of France is Paris"
+ *   },
+ *   expected: {
+ *     "answer": "The capital of France is Paris"
+ *   },
+ * }
+ *
+ * The pseudo code for the evaluator execution would be:
+ * ```
+ * evaluator(output, expected, input)
+ *   return score
+ * ```
+ */
+export type EvaluatorParams = {
+  /**
+   * The output of the task that is being evaluated
+   */
+  output: Record<string, unknown>;
+  /**
+   * The expected output of the task that is being evaluated
+   */
+  expected: Record<string, unknown>;
+  /**
+   * The input of the task that is being evaluated
+   * @example
+   * {
+   *   "question": "What is the capital of France?",
+   * }
+   */
+  input: Record<string, unknown>;
+  /**
+   * The metadata of the task that is being evaluated
+   */
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * How to map from the upstream data of an evaluator (e.x. a dataset example, a span)
+ * to the parameters of the evaluator or in some cases the variables of an LLM Evaluator
+ * @example
+ * {
+ *   "input": "input.question",
+ *   "output": "output.answer",
+ * }
+ *
+ * the value of the key is a JSONPath expression that is evaluated on the upstream data.
+ *
+ * If a value is left empty, the key will be set to the value of the upstream data.
+ *
+ */
+export type EvaluatorInputMapping = Record<string, string>;
+
+/**
+ * The direction to optimize the numeric evaluation score
+ * E.x. "MAXIMIZE" means that the higher the score, the better the evaluation
+ */
+export type EvaluatorOptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
+
+/**
+ * The choice a classification form of evaluation may choose from
+ * @example
+ * {
+ *   "label": "positive",
+ *   "score": 1,
+ * }
+ */
+export type ClassificationChoice = {
+  label: string;
+  score?: number;
+};
+
+/**
+ * A classification evaluator's annotation configuration
+ */
+export type ClassificationEvaluatorAnnotationConfig = {
+  /**
+   * The name of the annotation produced by the evaluator
+   * @example
+   * "helpfulness"
+   */
+  name: string;
+  /**
+   * The direction to optimize the numeric evaluation score
+   * E.x. "MAXIMIZE" means that the higher the score, the better the evaluation
+   */
+  optimizationDirection: EvaluatorOptimizationDirection;
+  /**
+   * The choices that the evaluator may choose from
+   */
+  choices: ClassificationChoice[];
+};

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./inferences";
 export * from "./dimension";
+export * from "./evaluators";


### PR DESCRIPTION
Adds a central types directory for consensus on naming of fields for shared understanding and documentation across components and utils.