### PR TITLE
ci: run helm-docs

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -113,6 +113,10 @@ jobs:
           sed -i "s/\(version:\ [0-9]*\.[0-9]*\.\)[0-9]*/\1$incrementedHelmPatchVersion/" helm/Chart.yaml
           sed -i 's/appVersion: "[^"]*"/appVersion: "${{ needs.push_to_registry.outputs.version }}"/' helm/Chart.yaml
           cat helm/Chart.yaml
+      - name: Setup helm-docs
+        uses: gabe565/setup-helm-docs-action@v1
+      - name: Run helm-docs
+        run: helm-docs --chart-search-root=helm
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds helm-docs setup and execution to the docker-build-release workflow to generate Helm chart docs before creating the PR.
> 
> - **CI/CD**:
>   - **docker-build-release workflow** (`.github/workflows/docker-build-release.yml`):
>     - Add steps to set up `helm-docs` and run `helm-docs --chart-search-root=helm` prior to PR creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6a0767df0f6a4e2c3ad58910ccf2d33f905e142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->