### PR TITLE
feat: Add span notes endpoint

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -526,6 +526,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/span_notes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a span note
+         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.
+         */
+        post: operations["createSpanNote"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/spans/{span_identifier}": {
         parameters: {
             query?: never;
@@ -1095,6 +1115,14 @@ export interface components {
         /** CreatePromptResponseBody */
         CreatePromptResponseBody: {
             data: components["schemas"]["PromptVersion"];
+        };
+        /** CreateSpanNoteRequestBody */
+        CreateSpanNoteRequestBody: {
+            data: components["schemas"]["SpanNoteData"];
+        };
+        /** CreateSpanNoteResponseBody */
+        CreateSpanNoteResponseBody: {
+            data: components["schemas"]["InsertedSpanAnnotation"];
         };
         /** CreateSpansRequestBody */
         CreateSpansRequestBody: {
@@ -2714,6 +2742,19 @@ export interface components {
             attributes?: {
                 [key: string]: unknown;
             };
+        };
+        /** SpanNoteData */
+        SpanNoteData: {
+            /**
+             * Span Id
+             * @description OpenTelemetry Span ID (hex format w/o 0x prefix)
+             */
+            span_id: string;
+            /**
+             * Note
+             * @description The note text to add to the span
+             */
+            note: string;
         };
         /** SpansResponseBody */
         SpansResponseBody: {
@@ -4693,6 +4734,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnnotateSpansResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Span not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createSpanNote: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSpanNoteRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Span note created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateSpanNoteResponseBody"];
                 };
             };
             /** @description Forbidden */

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -467,6 +467,11 @@ class SpanEvent(TypedDict):
     attributes: NotRequired[Mapping[str, Any]]
 
 
+class SpanNoteData(TypedDict):
+    span_id: str
+    note: str
+
+
 class TextContentPart(TypedDict):
     type: Literal["text"]
     text: str
@@ -633,6 +638,14 @@ class CreateExperimentRunResponseBody(TypedDict):
 
 class CreateProjectResponseBody(TypedDict):
     data: Project
+
+
+class CreateSpanNoteRequestBody(TypedDict):
+    data: SpanNoteData
+
+
+class CreateSpanNoteResponseBody(TypedDict):
+    data: InsertedSpanAnnotation
 
 
 class CreateUserRequestBody(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2975,6 +2975,68 @@
         }
       }
     },
+    "/v1/span_notes": {
+      "post": {
+        "tags": [
+          "spans"
+        ],
+        "summary": "Create a span note",
+        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.",
+        "operationId": "createSpanNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSpanNoteRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Span note created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSpanNoteResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Span not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/spans/{span_identifier}": {
       "delete": {
         "tags": [
@@ -5161,6 +5223,30 @@
           "data"
         ],
         "title": "CreatePromptResponseBody"
+      },
+      "CreateSpanNoteRequestBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SpanNoteData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateSpanNoteRequestBody"
+      },
+      "CreateSpanNoteResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InsertedSpanAnnotation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateSpanNoteResponseBody"
       },
       "CreateSpansRequestBody": {
         "properties": {
@@ -9069,6 +9155,26 @@
           "timestamp"
         ],
         "title": "SpanEvent"
+      },
+      "SpanNoteData": {
+        "properties": {
+          "span_id": {
+            "type": "string",
+            "title": "Span Id",
+            "description": "OpenTelemetry Span ID (hex format w/o 0x prefix)"
+          },
+          "note": {
+            "type": "string",
+            "title": "Note",
+            "description": "The note text to add to the span"
+          }
+        },
+        "type": "object",
+        "required": [
+          "span_id",
+          "note"
+        ],
+        "title": "SpanNoteData"
       },
       "SpansResponseBody": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -980,18 +980,15 @@ async def create_span_note(
 
     async with request.app.state.db() as session:
         # Find the span by OpenTelemetry span_id
-        span_result = await session.execute(
+        span_rowid = await session.scalar(
             select(models.Span.id).where(models.Span.span_id == note_data.span_id)
         )
-        span_row = span_result.first()
 
-        if span_row is None:
+        if span_rowid is None:
             raise HTTPException(
                 status_code=404,
                 detail=f"Span with ID {note_data.span_id} not found",
             )
-
-        span_rowid = span_row[0]
 
         # Generate a unique identifier for the note using timestamp
         timestamp = datetime.now(timezone.utc).isoformat()

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2242,6 +2242,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/prompt_versions/fake-id-{}/tags"),
     (422, "POST", "v1/session_annotations"),
     (422, "POST", "v1/span_annotations"),
+    (422, "POST", "v1/span_notes"),
     (422, "POST", "v1/spans"),
     (422, "POST", "v1/trace_annotations"),
     (415, "POST", "v1/traces"),

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -7,12 +7,12 @@ import httpx
 import pandas as pd
 import pytest
 from faker import Faker
-from phoenix.client import Client
 from sqlalchemy import insert, select
 from strawberry.relay import GlobalID
 
 from phoenix import Client as LegacyClient
 from phoenix import TraceDataset
+from phoenix.client import Client
 from phoenix.db import models
 from phoenix.server.api.routers.v1.spans import (
     OtlpAnyValue,


### PR DESCRIPTION
Add a dedicated POST endpoint `/v1/span_notes` to allow users to append notes to spans.

---
<a href="https://cursor.com/background-agent?bcId=bc-1276edc8-1e81-4ba0-a289-1395461a2677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1276edc8-1e81-4ba0-a289-1395461a2677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

