### PR TITLE
fix(evaluators): apply input mapping

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3252,7 +3252,7 @@ type Query {
   getSpanByOtelId(spanId: String!): Span
   getTraceByOtelId(traceId: String!): Trace
   getProjectSessionById(sessionId: String!): ProjectSession
-  applyChatTemplate(template: PromptChatTemplateInput!, templateOptions: PromptTemplateOptions!): PromptChatTemplate!
+  applyChatTemplate(template: PromptChatTemplateInput!, templateOptions: PromptTemplateOptions!, inputMapping: EvaluatorInputMappingInput = null): PromptChatTemplate!
 }
 
 input RemoveAnnotationConfigFromProjectInput {

--- a/app/src/components/evaluators/__generated__/EvaluatorPromptPreviewQuery.graphql.ts
+++ b/app/src/components/evaluators/__generated__/EvaluatorPromptPreviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e74e5e0af1b3f0aff5d0e252f0763b96>>
+ * @generated SignedSource<<04989ec3e6dd99bd6655a91a87f1ce21>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,7 +43,12 @@ export type PromptTemplateOptions = {
   format: PromptTemplateFormat;
   variables: any;
 };
+export type EvaluatorInputMappingInput = {
+  literalMapping?: any;
+  pathMapping?: any;
+};
 export type EvaluatorPromptPreviewQuery$variables = {
+  inputMapping: EvaluatorInputMappingInput;
   template: PromptChatTemplateInput;
   templateOptions: PromptTemplateOptions;
 };
@@ -70,22 +75,30 @@ export type EvaluatorPromptPreviewQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "template"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "templateOptions"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "inputMapping"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "template"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "templateOptions"
+},
+v3 = [
   {
     "alias": "prompt",
     "args": [
+      {
+        "kind": "Variable",
+        "name": "inputMapping",
+        "variableName": "inputMapping"
+      },
       {
         "kind": "Variable",
         "name": "template",
@@ -169,32 +182,40 @@ v1 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "EvaluatorPromptPreviewQuery",
-    "selections": (v1/*: any*/),
+    "selections": (v3/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "EvaluatorPromptPreviewQuery",
-    "selections": (v1/*: any*/)
+    "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "5af2f40ebddca4f5c3a13ab452f32188",
+    "cacheID": "b630d62ab6032a1853f794b1b27a6849",
     "id": null,
     "metadata": {},
     "name": "EvaluatorPromptPreviewQuery",
     "operationKind": "query",
-    "text": "query EvaluatorPromptPreviewQuery(\n  $template: PromptChatTemplateInput!\n  $templateOptions: PromptTemplateOptions!\n) {\n  prompt: applyChatTemplate(template: $template, templateOptions: $templateOptions) {\n    messages {\n      role\n      content {\n        __typename\n        ... on TextContentPart {\n          text {\n            text\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query EvaluatorPromptPreviewQuery(\n  $template: PromptChatTemplateInput!\n  $templateOptions: PromptTemplateOptions!\n  $inputMapping: EvaluatorInputMappingInput!\n) {\n  prompt: applyChatTemplate(template: $template, templateOptions: $templateOptions, inputMapping: $inputMapping) {\n    messages {\n      role\n      content {\n        __typename\n        ... on TextContentPart {\n          text {\n            text\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ea8f766e54d53fc5747a3bb0a68aa6bb";
+(node as any).hash = "abd2c94a67df6ac84d61bcab11b66a24";
 
 export default node;


### PR DESCRIPTION
resolves #10500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies evaluator input mapping when rendering chat templates, wiring it through GraphQL and the Evaluator prompt preview UI.
> 
> - **GraphQL API**
>   - Extend `Query.applyChatTemplate` to accept `inputMapping: EvaluatorInputMappingInput` (schema change in `app/schema.graphql`).
>   - Resolver (`src/phoenix/server/api/queries.py`): infer input schema from the template and apply `input_mapping` to variables before formatting.
> - **Backend Helpers**
>   - Add `infer_input_schema_from_template` and integrate `apply_input_mapping` usage (`src/phoenix/server/api/evaluators.py`).
> - **Frontend**
>   - `EvaluatorPromptPreview.tsx`: pass `inputMapping` from form to the `applyChatTemplate` query; clone form value to avoid Relay immutability issues.
>   - Update Relay generated query to include `$inputMapping` and pass it to `applyChatTemplate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ad79fae55802793755827b4dcedc95b8b53017b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->