### PR TITLE
feat: Add span note function to typescript

### DIFF
--- a/js/packages/phoenix-client/src/spans/addSpanNote.ts
+++ b/js/packages/phoenix-client/src/spans/addSpanNote.ts
@@ -1,0 +1,69 @@
+import { createClient } from "../client";
+import { ClientFn } from "../types/core";
+
+/**
+ * Parameters for a single span note
+ */
+export interface SpanNote {
+  /**
+   * The OpenTelemetry Span ID (hex format without 0x prefix)
+   */
+  spanId: string;
+  /**
+   * The note text to add to the span
+   */
+  note: string;
+}
+
+/**
+ * Parameters to add a span note
+ */
+export interface AddSpanNoteParams extends ClientFn {
+  spanNote: SpanNote;
+}
+
+/**
+ * Add a note to a span.
+ *
+ * Notes are a special type of annotation that allow multiple entries per span
+ * (unlike regular annotations which are unique by name and identifier).
+ * Each note gets a unique timestamp-based identifier.
+ *
+ * @param params - The parameters to add a span note
+ * @returns The ID of the created note annotation
+ *
+ * @example
+ * ```ts
+ * const result = await addSpanNote({
+ *   spanNote: {
+ *     spanId: "123abc",
+ *     note: "This span looks suspicious, needs review"
+ *   }
+ * });
+ * ```
+ */
+export async function addSpanNote({
+  client: _client,
+  spanNote,
+}: AddSpanNoteParams): Promise<{ id: string }> {
+  const client = _client ?? createClient();
+
+  const { data, error } = await client.POST("/v1/span_notes", {
+    body: {
+      data: {
+        span_id: spanNote.spanId.trim(),
+        note: spanNote.note,
+      },
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to add span note: ${error}`);
+  }
+
+  if (!data?.data) {
+    throw new Error("Failed to add span note: no data returned");
+  }
+
+  return data.data;
+}

--- a/js/packages/phoenix-client/src/spans/index.ts
+++ b/js/packages/phoenix-client/src/spans/index.ts
@@ -1,4 +1,5 @@
 export * from "./addSpanAnnotation";
+export * from "./addSpanNote";
 export * from "./logSpanAnnotations";
 export * from "./addDocumentAnnotation";
 export * from "./logDocumentAnnotations";

--- a/js/packages/phoenix-client/test/spans/addSpanNote.test.ts
+++ b/js/packages/phoenix-client/test/spans/addSpanNote.test.ts
@@ -1,0 +1,94 @@
+import { addSpanNote } from "../../src/spans/addSpanNote";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Create mock POST function
+const mockPOST = vi.fn();
+
+// Mock the fetch module
+vi.mock("openapi-fetch", () => ({
+  default: () => ({
+    POST: mockPOST.mockResolvedValue({
+      data: {
+        data: { id: "test-note-id-1" },
+      },
+      error: null,
+    }),
+    use: () => {},
+  }),
+}));
+
+describe("addSpanNote", () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+    // Reset default mock behavior
+    mockPOST.mockResolvedValue({
+      data: {
+        data: { id: "test-note-id-1" },
+      },
+      error: null,
+    });
+  });
+
+  it("should add a span note", async () => {
+    const result = await addSpanNote({
+      spanNote: {
+        spanId: "123abc",
+        note: "This is a test note",
+      },
+    });
+
+    expect(result).toEqual({ id: "test-note-id-1" });
+  });
+
+  it("should trim span ID", async () => {
+    await addSpanNote({
+      spanNote: {
+        spanId: "  123abc  ",
+        note: "This is a test note",
+      },
+    });
+
+    expect(mockPOST).toHaveBeenCalledWith("/v1/span_notes", {
+      body: {
+        data: {
+          span_id: "123abc",
+          note: "This is a test note",
+        },
+      },
+    });
+  });
+
+  it("should throw error when API returns error", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: "Span not found",
+    });
+
+    await expect(
+      addSpanNote({
+        spanNote: {
+          spanId: "nonexistent",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add span note: Span not found");
+  });
+
+  it("should throw error when no data is returned", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: undefined,
+    });
+
+    await expect(
+      addSpanNote({
+        spanNote: {
+          spanId: "123abc",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add span note: no data returned");
+  });
+});


### PR DESCRIPTION
Add `addSpanNote` function to the Phoenix client for posting notes to spans.

---
<a href="https://cursor.com/background-agent?bcId=bc-092e51cc-e9f7-42e5-8c3f-d5c38ad92148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-092e51cc-e9f7-42e5-8c3f-d5c38ad92148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

