### PR TITLE
docs: update prompt quickstart redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1679,6 +1679,10 @@
     {
       "source": "/docs/phoenix/tracing/llm-traces-1",
       "destination": "/docs/phoenix/get-started/get-started-tracing"
+    },
+    {
+      "source": "/docs/phoenix/prompt-engineering/quickstart-prompts/quickstart-prompts-ui",
+      "destination": "/docs/phoenix/get-started/get-started-prompt-playground"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a redirect from `docs/phoenix/prompt-engineering/quickstart-prompts/quickstart-prompts-ui` to `docs/phoenix/get-started/get-started-prompt-playground`.
> 
> - **Redirects**:
>   - Map `docs/phoenix/prompt-engineering/quickstart-prompts/quickstart-prompts-ui` → `docs/phoenix/get-started/get-started-prompt-playground`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa5ccc92f3669557152f62ff2aa2632db69d410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->