### PR TITLE
docs: reorganize sidebar navigation with Quick Start section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -35,21 +35,18 @@
                 "group": " ",
                 "pages": [
                   "docs/phoenix",
-                  {
-                    "group": "Get Started",
-                    "pages": [
-                      "docs/phoenix/get-started",
-                      "docs/phoenix/get-started/get-started-tracing",
-                      "docs/phoenix/get-started/get-started-evaluations",
-                      "docs/phoenix/get-started/get-started-datasets-and-experiments",
-                      "docs/phoenix/get-started/get-started-prompt-playground"
-                    ]
-                  },
-                  "docs/phoenix/user-guide",
-                  "docs/phoenix/environments",
-                  "docs/phoenix/phoenix-demo",
-                  "docs/phoenix/end-to-end-features-notebook",
-                  "docs/phoenix/production-guide"
+                  "docs/phoenix/phoenix-demo"
+                ]
+              },
+              {
+                "group": "Quick Start",
+                "pages": [
+                  "docs/phoenix/get-started",
+                  "docs/phoenix/get-started/get-started-tracing",
+                  "docs/phoenix/get-started/get-started-datasets-and-experiments",
+                  "docs/phoenix/get-started/get-started-evaluations",
+                  "docs/phoenix/get-started/get-started-prompt-playground",
+                  "docs/phoenix/end-to-end-features-notebook"
                 ]
               },
               {
@@ -66,7 +63,6 @@
                       "docs/phoenix/tracing/llm-traces/metrics"
                     ]
                   },
-                  "docs/phoenix/get-started/get-started-tracing",
                   {
                     "group": "How-to: Tracing",
                     "pages": [
@@ -122,15 +118,6 @@
                         ]
                       }
                     ]
-                  },
-                  {
-                    "group": "Concepts: Tracing",
-                    "pages": [
-                      "docs/phoenix/tracing/concepts-tracing/what-are-traces",
-                      "docs/phoenix/tracing/concepts-tracing/how-tracing-works",
-                      "docs/phoenix/tracing/concepts-tracing/annotations-concepts",
-                      "docs/phoenix/tracing/concepts-tracing/faqs-tracing"
-                    ]
                   }
                 ]
               },
@@ -158,7 +145,6 @@
                       "docs/phoenix/prompt-engineering/overview-prompts/prompts-in-code"
                     ]
                   },
-                  "docs/phoenix/get-started/get-started-prompt-playground",
                   {
                     "group": "How to: Prompts",
                     "pages": [
@@ -170,13 +156,6 @@
                       "docs/phoenix/prompt-engineering/how-to-prompts/tag-a-prompt",
                       "docs/phoenix/prompt-engineering/how-to-prompts/using-a-prompt"
                     ]
-                  },
-                  {
-                    "group": "Concepts: Prompts",
-                    "pages": [
-                      "docs/phoenix/prompt-engineering/concepts-prompts/prompts-concepts",
-                      "docs/phoenix/prompt-engineering/concepts-prompts/context-engineering-basics"
-                    ]
                   }
                 ]
               },
@@ -185,7 +164,6 @@
                 "icon": "flask",
                 "pages": [
                   "docs/phoenix/datasets-and-experiments/overview-datasets",
-                  "docs/phoenix/get-started/get-started-datasets-and-experiments",
                   {
                     "group": "How-to: Datasets",
                     "pages": [
@@ -203,8 +181,7 @@
                       "docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions",
                       "docs/phoenix/datasets-and-experiments/how-to-experiments/splits"
                     ]
-                  },
-                  "docs/phoenix/datasets-and-experiments/concepts-datasets"
+                  }
                 ]
               },
               {
@@ -219,14 +196,6 @@
                       "docs/phoenix/evaluation/llm-evals",
                       "docs/phoenix/evaluation/llm-evals/executors",
                       "docs/phoenix/evaluation/llm-evals/evaluator-traces"
-                    ]
-                  },
-                  {
-                    "group": "Concepts: Evals",
-                    "pages": [
-                      "docs/phoenix/evaluation/concepts-evals/llm-as-a-judge",
-                      "docs/phoenix/evaluation/concepts-evals/evaluators",
-                      "docs/phoenix/evaluation/concepts-evals/input-mapping"
                     ]
                   },
                   {
@@ -279,6 +248,45 @@
                   "docs/phoenix/settings/api-keys",
                   "docs/phoenix/settings/data-retention",
                   "docs/phoenix/settings/phoenix-to-arize-ax-migration"
+                ]
+              },
+              {
+                "group": "Concepts",
+                "icon": "lightbulb",
+                "pages": [
+                  "docs/phoenix/user-guide",
+                  "docs/phoenix/production-guide",
+                  "docs/phoenix/environments",
+                  {
+                    "group": "Tracing",
+                    "pages": [
+                      "docs/phoenix/tracing/concepts-tracing/what-are-traces",
+                      "docs/phoenix/tracing/concepts-tracing/how-tracing-works",
+                      "docs/phoenix/tracing/concepts-tracing/annotations-concepts",
+                      "docs/phoenix/tracing/concepts-tracing/faqs-tracing"
+                    ]
+                  },
+                  {
+                    "group": "Prompts",
+                    "pages": [
+                      "docs/phoenix/prompt-engineering/concepts-prompts/prompts-concepts",
+                      "docs/phoenix/prompt-engineering/concepts-prompts/context-engineering-basics"
+                    ]
+                  },
+                  {
+                    "group": "Datasets & Experiments",
+                    "pages": [
+                      "docs/phoenix/datasets-and-experiments/concepts-datasets"
+                    ]
+                  },
+                  {
+                    "group": "Evals",
+                    "pages": [
+                      "docs/phoenix/evaluation/concepts-evals/llm-as-a-judge",
+                      "docs/phoenix/evaluation/concepts-evals/evaluators",
+                      "docs/phoenix/evaluation/concepts-evals/input-mapping"
+                    ]
+                  }
                 ]
               },
               {

--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Quickstart: Overview"
 ---
 
 To begin using Phoenix, you can either run it locally or launch a Phoenix Cloud instance.

--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Started: Datasets & Experiments"
+title: "Datasets & Experiments"
 ---
 Now that you have Phoenix up and running, one of the next steps you can take is creating a **Dataset** & Running **Experiments**.
 

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Started: Evaluations"
+title: "Evals"
 ---
 
 Now that you have Phoenix up and running, and sent traces to your first project, the next step you can take is running **evaluations** of your Python application. Evaluations let you measure and monitor the quality of your application by scoring traces against metrics like accuracy, relevance, or custom checks.

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Started: Prompt Playground"
+title: "Prompt Playground"
 ---
 Now that you have Phoenix up and running, you're now able to use **Prompt Playground** & the **Prompt** **Hub**.
 

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get Started: Tracing"
+title: "Tracing"
 ---
 
 Now that you have Phoenix up and running, the next step is to start sending **traces** from your Python application. Traces let you see what's happening inside your system, including function calls, LLM requests, tool calls, and other operations.


### PR DESCRIPTION
- Add Quick Start section directly below Arize Phoenix hero page
- Move quickstart guides (Tracing, Datasets & Experiments, Evals, Prompt Playground) to Quick Start
- Add End to End Features Notebook to Quick Start
- Create new Concepts section with User Guide, Production Guide, Environments, and all concept pages
- Remove duplicate quickstart links from individual feature sections
- Rename page titles to remove "Get Started:" prefix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes docs sidebar to add Quick Start and Concepts sections, deduplicate quickstart links, and rename quickstart page titles.
> 
> - **Navigation (docs.json)**
>   - **Quick Start**: New group under `Documentation` with `docs/phoenix/get-started`, quickstart guides (`.../get-started-tracing`, `.../get-started-datasets-and-experiments`, `.../get-started-evaluations`, `.../get-started-prompt-playground`) and `docs/phoenix/end-to-end-features-notebook`.
>   - **Concepts**: New group consolidating `docs/phoenix/user-guide`, `.../production-guide`, `.../environments`, plus concept pages for Tracing, Prompts, Datasets & Experiments, and Evals.
>   - **Deduplication**: Removed quickstart links from individual feature sections (`Tracing`, `Prompt Engineering`, `Datasets & Experiments`, `Evaluation`).
>   - **Landing group trim**: Top group now only `docs/phoenix` and `docs/phoenix/phoenix-demo`.
> - **Content titles**
>   - Renamed quickstart page titles to remove "Get Started:" prefix: `docs/phoenix/get-started.mdx` → "Quickstart: Overview"; `.../get-started-tracing.mdx` → "Tracing"; `.../get-started-datasets-and-experiments.mdx` → "Datasets & Experiments"; `.../get-started-evaluations.mdx` → "Evals"; `.../get-started-prompt-playground.mdx` → "Prompt Playground".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7815996b6123aec775bc7f386e4e2cd8bc1a0450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->