### PR TITLE
docs: fix sef-hosting link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1703,6 +1703,10 @@
     {
       "source": "/docs/phoenix/prompt-engineering/quickstart-prompts/quickstart-prompts-ui",
       "destination": "/docs/phoenix/get-started/get-started-prompt-playground"
+    },
+    {
+      "source": "/docs/phoenix/deployment",
+      "destination": "/docs/phoenix/self-hosting"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a docs redirect from `docs/phoenix/deployment` to `docs/phoenix/self-hosting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf59aecc0d13b60e39f315f4d56b29f906240e18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->