### PR TITLE
fix: Ensure mustache templates handle unicode characters

### DIFF
--- a/src/phoenix/utilities/template_formatters.py
+++ b/src/phoenix/utilities/template_formatters.py
@@ -87,9 +87,14 @@ class MustacheTemplateFormatter(TemplateFormatter):
 
     def _format(self, template: str, variable_names: Iterable[str], **variables: Any) -> str:
         for variable_name in variable_names:
+            replacement = str(variables[variable_name])
+            # Use a lambda instead of passing the replacement string directly. When re.sub
+            # receives a string as `repl`, it interprets backslash escape sequences like \u, \n,
+            # \1, etc. This causes errors when the replacement contains JSON with Unicode escapes
+            # (e.g., \u2019). A callable `repl` returns the string literally without processing.
             template = re.sub(
                 pattern=rf"(?<!\\){{{{\s*{variable_name}\s*}}}}",
-                repl=str(variables[variable_name]),
+                repl=lambda _: replacement,
                 string=template,
             )
         return template

--- a/tests/unit/utilities/test_template_formatters.py
+++ b/tests/unit/utilities/test_template_formatters.py
@@ -112,6 +112,20 @@ from phoenix.utilities.template_formatters import (
             id="mustache-none-value",
         ),
         pytest.param(
+            MustacheTemplateFormatter,
+            "{{ output }}",
+            {"output": r'{"content": "Here\u2019s an example"}'},
+            r'{"content": "Here\u2019s an example"}',
+            id="mustache-value-with-unicode-escape-sequence",
+        ),
+        pytest.param(
+            MustacheTemplateFormatter,
+            "{{ output }}",
+            {"output": r"line1\nline2"},
+            r"line1\nline2",
+            id="mustache-value-with-backslash-n",
+        ),
+        pytest.param(
             FStringTemplateFormatter,
             "{hello}",
             {"hello": "world"},


### PR DESCRIPTION
This was causing issues sporadically when running llm evaluators in playground; If the playground output included certain unicode characters, template application would fail during llm evaluator runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mustache formatter now uses a callable replacement to avoid escape-sequence processing (preserving unicode and \n), with tests added for these cases.
> 
> - **Template formatting (`src/phoenix/utilities/template_formatters.py`)**
>   - Change `MustacheTemplateFormatter._format` to use a callable `repl` in `re.sub`, ensuring replacements are inserted literally (no backslash escape interpretation).
> - **Tests (`tests/unit/utilities/test_template_formatters.py`)**
>   - Add cases verifying mustache replacements preserve unicode escape sequences (e.g., `\u2019`) and `\n` without unintended processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4eb7b6236a0e829e61fab0bbf7b30b489686151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->