### PR TITLE
feat: move add dataset example to be a part of the examples tab

### DIFF
--- a/app/src/pages/dataset/AddDatasetExampleButton.tsx
+++ b/app/src/pages/dataset/AddDatasetExampleButton.tsx
@@ -20,9 +20,10 @@ export function AddDatasetExampleButton(props: AddDatasetExampleButtonProps) {
   return (
     <DialogTrigger>
       <Button
-        leadingVisual={<Icon svg={<Icons.PlusCircleOutline />} />}
-        size="S"
+        leadingVisual={<Icon svg={<Icons.PlusOutline />} />}
+        size="M"
         aria-label="Add Dataset Example"
+        variant="primary"
       >
         Add Example
       </Button>

--- a/app/src/pages/dataset/DatasetPage.tsx
+++ b/app/src/pages/dataset/DatasetPage.tsx
@@ -25,18 +25,13 @@ import {
 } from "@phoenix/components";
 import { DatasetLabelConfigButton } from "@phoenix/components/dataset";
 import { Truncate } from "@phoenix/components/utility/Truncate";
-import { useNotifySuccess } from "@phoenix/contexts";
-import {
-  DatasetProvider,
-  useDatasetContext,
-} from "@phoenix/contexts/DatasetContext";
+import { DatasetProvider } from "@phoenix/contexts/DatasetContext";
 import { useFeatureFlag } from "@phoenix/contexts/FeatureFlagsContext";
 import { datasetLoader } from "@phoenix/pages/dataset/datasetLoader";
 import { prependBasename } from "@phoenix/utils/routingUtils";
 
 import type { datasetLoaderQuery$data } from "./__generated__/datasetLoaderQuery.graphql";
 import { DatasetPageQuery } from "./__generated__/DatasetPageQuery.graphql";
-import { AddDatasetExampleButton } from "./AddDatasetExampleButton";
 import { DatasetCodeButton } from "./DatasetCodeButton";
 import { RunExperimentButton } from "./RunExperimentButton";
 
@@ -160,10 +155,6 @@ function DatasetPageContent({
 }) {
   const isEvaluatorsEnabled = useFeatureFlag("evaluators");
   const datasetId = dataset.id;
-  const refreshLatestVersion = useDatasetContext(
-    (state) => state.refreshLatestVersion
-  );
-  const notifySuccess = useNotifySuccess();
 
   const navigate = useNavigate();
   const onTabChange = useCallback(
@@ -276,17 +267,6 @@ function DatasetPageContent({
             </MenuTrigger>
             <DatasetCodeButton />
             <RunExperimentButton />
-            <AddDatasetExampleButton
-              datasetId={dataset.id}
-              onAddExampleCompleted={() => {
-                notifySuccess({
-                  title: "Example added",
-                  message:
-                    "The example has been added successfully and the version has been updated.",
-                });
-                refreshLatestVersion();
-              }}
-            />
             <DatasetLabelConfigButton datasetId={dataset.id} />
             <Button
               isDisabled={!datasetHasVersions}

--- a/app/src/pages/examples/ExamplesFilterBar.tsx
+++ b/app/src/pages/examples/ExamplesFilterBar.tsx
@@ -2,6 +2,9 @@ import { useParams } from "react-router";
 import invariant from "tiny-invariant";
 
 import { DebouncedSearch, Flex, View } from "@phoenix/components";
+import { useDatasetContext } from "@phoenix/contexts/DatasetContext";
+import { useNotifySuccess } from "@phoenix/contexts/NotificationContext";
+import { AddDatasetExampleButton } from "@phoenix/pages/dataset/AddDatasetExampleButton";
 import { useExamplesFilterContext } from "@phoenix/pages/examples/ExamplesFilterContext";
 import { ExamplesSplitMenu } from "@phoenix/pages/examples/ExamplesSplitMenu";
 
@@ -17,6 +20,10 @@ export const ExamplesFilterBar = () => {
   } = useExamplesFilterContext();
   const { datasetId } = useParams();
   invariant(datasetId, "datasetId is required");
+  const refreshLatestVersion = useDatasetContext(
+    (state) => state.refreshLatestVersion
+  );
+  const notifySuccess = useNotifySuccess();
   return (
     <View
       padding="size-100"
@@ -45,6 +52,17 @@ export const ExamplesFilterBar = () => {
           selectedSplitIds={selectedSplitIds}
           selectedExampleIds={selectedExampleIds}
           examplesCache={examplesCache}
+        />
+        <AddDatasetExampleButton
+          datasetId={datasetId}
+          onAddExampleCompleted={() => {
+            notifySuccess({
+              title: "Example added",
+              message:
+                "The example has been added successfully and the version has been updated.",
+            });
+            refreshLatestVersion();
+          }}
         />
       </Flex>
     </View>


### PR DESCRIPTION
resolves #10627 

<img width="2560" height="1323" alt="Screenshot 2025-12-15 at 4 18 51 PM" src="https://github.com/user-attachments/assets/a67fc6a9-a7e5-4eaa-b622-f15e8f8bdb54" />
