### PR TITLE
feat: template format selector on LLM evaluator form

### DIFF
--- a/app/src/components/evaluators/LLMEvaluatorForm.tsx
+++ b/app/src/components/evaluators/LLMEvaluatorForm.tsx
@@ -6,6 +6,7 @@ import type { EvaluatorFormValues } from "@phoenix/components/evaluators/Evaluat
 import { EvaluatorLLMChoice } from "@phoenix/components/evaluators/EvaluatorLLMChoice";
 import { EvaluatorPromptPreview } from "@phoenix/components/evaluators/EvaluatorPromptPreview";
 import type { EvaluatorInput } from "@phoenix/components/evaluators/utils";
+import { TemplateFormatRadioGroup } from "@phoenix/pages/playground/TemplateFormatRadioGroup";
 
 /**
  * TODO: move all of these into zustand
@@ -33,9 +34,18 @@ export const LLMEvaluatorForm = ({
         <Text color="text-500">
           Define or load a prompt for your evaluator.
         </Text>
-        <Switch isSelected={showPromptPreview} onChange={setShowPromptPreview}>
-          <Label>Preview</Label>
-        </Switch>
+        <Flex direction="row" justifyContent="space-between">
+          <TemplateFormatRadioGroup size="S" showNoneOption={false} />
+          <Switch
+            isSelected={showPromptPreview}
+            onChange={setShowPromptPreview}
+            labelPlacement="start"
+          >
+            <Label>Preview</Label>
+          </Switch>
+        </Flex>
+      </Flex>
+      <Flex direction="column" gap="size-100">
         {showPromptPreview ? (
           <EvaluatorPromptPreview evaluatorInput={evaluatorInputObject} />
         ) : (

--- a/app/src/pages/playground/TemplateFormatRadioGroup.tsx
+++ b/app/src/pages/playground/TemplateFormatRadioGroup.tsx
@@ -6,7 +6,18 @@ import { isTemplateFormat } from "@phoenix/components/templateEditor/types";
 import { SizingProps } from "@phoenix/components/types";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 
-export function TemplateFormatRadioGroup({ size }: SizingProps) {
+export type TemplateFormatRadioGroupProps = SizingProps & {
+  /**
+   * Whether to show the "None" option
+   * @default true
+   */
+  showNoneOption?: boolean;
+};
+
+export function TemplateFormatRadioGroup({
+  size,
+  showNoneOption = true,
+}: TemplateFormatRadioGroupProps) {
   const templateFormat = usePlaygroundContext((state) => state.templateFormat);
   const setTemplateFormat = usePlaygroundContext(
     (state) => state.setTemplateFormat
@@ -33,15 +44,17 @@ export function TemplateFormatRadioGroup({ size }: SizingProps) {
           }
         }}
       >
-        <ToggleButton aria-label="None" id={TemplateFormats.NONE}>
-          None
-        </ToggleButton>
         <ToggleButton aria-label="Mustache" id={TemplateFormats.Mustache}>
           Mustache
         </ToggleButton>
         <ToggleButton aria-label="F-String" id={TemplateFormats.FString}>
           F-String
         </ToggleButton>
+        {showNoneOption && (
+          <ToggleButton aria-label="None" id={TemplateFormats.NONE}>
+            None
+          </ToggleButton>
+        )}
       </ToggleButtonGroup>
     </div>
   );


### PR DESCRIPTION
Lets you configure the prompt template format for a given llm evaluator

<img width="3207" height="1653" alt="Screenshot 2025-12-16 at 3 48 28 PM" src="https://github.com/user-attachments/assets/e6f675be-3dda-485f-8502-dd7141d1f79a" />
