### PR TITLE
docs: update PRs that contain nav changes

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -1,23 +1,25 @@
 name: Generate Sitemap
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - "docs.json"
   workflow_dispatch: # Allow manual trigger
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate-sitemap:
     runs-on: ubuntu-latest
+    # Don't run on PRs from forks (they don't have write access)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Checkout repository
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update sitemap GitHub Actions workflow to run on PRs touching docs.json, check out the PR branch, and restrict runs from forks with added pull-requests write permission.
> 
> - **CI (GitHub Actions)**:
>   - **Triggers**: Switch from `push` on `main` to `pull_request` limited to `docs.json`; retain `workflow_dispatch`.
>   - **Permissions**: Add `pull-requests: write`.
>   - **Safety**: Gate job to same-repo PRs or manual dispatch via `if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'`.
>   - **Checkout**: Use PR head ref with `actions/checkout@v4` (`ref: ${{ github.head_ref }}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19e21728a7ae1675ad657335ec40d317bb682567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->