### PR TITLE
ci: add 60-minute timeout to unit test steps

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -436,9 +436,11 @@ jobs:
         run: sudo apt-get -yqq install postgresql
       - name: Run tests with PostgreSQL (Linux)
         if: runner.os == 'Linux'
+        timeout-minutes: 60
         run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e unit_tests -- -ra -x --reruns 5 --run-postgres
       - name: Run tests without PostgreSQL (non-Linux)
         if: runner.os != 'Linux'
+        timeout-minutes: 60
         run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e unit_tests -- -ra -x --reruns 5
 
   type-check-integration-tests:


### PR DESCRIPTION
Prevents CI jobs from hanging indefinitely if tests get stuck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add 60-minute timeouts to unit test steps in GitHub Actions for both Linux and non-Linux runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b736aae174af35faf8a74a948451e4915da09028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->