### PR TITLE
ci: pin aiosqlite<0.22.0 to prevent test hanging indefinitely

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -28,3 +28,4 @@ typing-extensions
 vcrpy
 pytest-smtpd
 freezegun
+aiosqlite<0.22.0  # new version is causing tests to hang


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins `aiosqlite<0.22.0` in `requirements/unit-tests.txt` to prevent test hangs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53234da6907340718dd623ca537aef1c3d56ba13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->