### PR TITLE
refactor: remove card wrappng from playground template

### DIFF
--- a/app/src/components/card/styles.ts
+++ b/app/src/components/card/styles.ts
@@ -14,6 +14,7 @@ export const cardCSS = (style?: CSSProperties) => css`
   border-radius: var(--ac-global-rounding-medium);
   border: 1px solid var(--scope-border-color);
   overflow: hidden;
+  box-sizing: border-box;
 
   /* Card Header Styles */
   & > header {

--- a/app/src/pages/playground/PlaygroundChatTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundChatTemplate.tsx
@@ -19,7 +19,6 @@ import {
   Button,
   Card,
   CopyToClipboardButton,
-  DisclosureGroup,
   Flex,
   Form,
   Icon,
@@ -142,8 +141,7 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
           css={css`
             display: flex;
             flex-direction: column;
-            gap: var(--ac-global-dimension-size-200);
-            padding: var(--ac-global-dimension-size-200);
+            gap: var(--ac-global-dimension-size-100);
           `}
         >
           {messageIds.map((messageId) => {
@@ -158,25 +156,17 @@ export function PlaygroundChatTemplate(props: PlaygroundChatTemplateProps) {
           })}
         </ul>
       </SortableContext>
-      <View
-        paddingStart="size-200"
-        paddingEnd="size-200"
-        paddingTop="size-100"
-        paddingBottom="size-100"
-        borderColor="dark"
-        borderTopWidth="thin"
-        borderBottomWidth={hasTools || hasResponseFormat ? "thin" : undefined}
-      >
+      <View paddingTop="size-100" paddingBottom="size-100">
         <PlaygroundChatTemplateFooter
           instanceId={id}
           hasResponseFormat={hasResponseFormat}
         />
       </View>
       {hasTools || hasResponseFormat ? (
-        <DisclosureGroup defaultExpandedKeys={["tools", "response-format"]}>
+        <Flex direction="column" gap="size-100">
           {hasTools ? <PlaygroundTools {...props} /> : null}
           {hasResponseFormat ? <PlaygroundResponseFormat {...props} /> : null}
-        </DisclosureGroup>
+        </Flex>
       ) : null}
     </DndContext>
   );

--- a/app/src/pages/playground/PlaygroundOutput.tsx
+++ b/app/src/pages/playground/PlaygroundOutput.tsx
@@ -521,7 +521,6 @@ export function PlaygroundOutput(props: PlaygroundOutputProps) {
           />
         </Flex>
       }
-      collapsible
     >
       {(() => {
         switch (true) {

--- a/app/src/pages/playground/PlaygroundResponseFormat.tsx
+++ b/app/src/pages/playground/PlaygroundResponseFormat.tsx
@@ -5,13 +5,9 @@ import {
   Button,
   Card,
   CopyToClipboardButton,
-  Disclosure,
-  DisclosurePanel,
-  DisclosureTrigger,
   Flex,
   Icon,
   Icons,
-  View,
 } from "@phoenix/components";
 import { JSONEditor } from "@phoenix/components/code";
 import { LazyEditorWrapper } from "@phoenix/components/code/LazyEditorWrapper";
@@ -111,46 +107,36 @@ export function PlaygroundResponseFormat({
   );
 
   return (
-    <Disclosure id="response-format">
-      <DisclosureTrigger arrowPosition="start">
-        Response Format
-      </DisclosureTrigger>
-      <DisclosurePanel>
-        <View padding="size-200">
-          <Card
-            title="Schema"
-            extra={
-              <Flex direction="row" gap="size-100">
-                <CopyToClipboardButton text={currentValueRef} />
-                <Button
-                  aria-label="Delete Response Format"
-                  leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
-                  size="S"
-                  onPress={() => {
-                    deleteInvocationParameterInput({
-                      instanceId: playgroundInstanceId,
-                      invocationParameterInputInvocationName:
-                        RESPONSE_FORMAT_PARAM_NAME,
-                    });
-                  }}
-                />
-              </Flex>
-            }
-          >
-            <LazyEditorWrapper
-              preInitializationMinHeight={
-                RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT
-              }
-            >
-              <JSONEditor
-                value={initialResponseFormatDefinition}
-                onChange={onChange}
-                jsonSchema={openAIResponseFormatJSONSchema as JSONSchema7}
-              />
-            </LazyEditorWrapper>
-          </Card>
-        </View>
-      </DisclosurePanel>
-    </Disclosure>
+    <Card
+      title="Response Format"
+      collapsible
+      extra={
+        <Flex direction="row" gap="size-100">
+          <CopyToClipboardButton text={currentValueRef} />
+          <Button
+            aria-label="Delete Response Format"
+            leadingVisual={<Icon svg={<Icons.TrashOutline />} />}
+            size="S"
+            onPress={() => {
+              deleteInvocationParameterInput({
+                instanceId: playgroundInstanceId,
+                invocationParameterInputInvocationName:
+                  RESPONSE_FORMAT_PARAM_NAME,
+              });
+            }}
+          />
+        </Flex>
+      }
+    >
+      <LazyEditorWrapper
+        preInitializationMinHeight={RESPONSE_FORMAT_EDITOR_PRE_INIT_HEIGHT}
+      >
+        <JSONEditor
+          value={initialResponseFormatDefinition}
+          onChange={onChange}
+          jsonSchema={openAIResponseFormatJSONSchema as JSONSchema7}
+        />
+      </LazyEditorWrapper>
+    </Card>
   );
 }

--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -2,7 +2,6 @@ import { Suspense, useCallback, useMemo } from "react";
 
 import {
   Button,
-  Card,
   DialogTrigger,
   Flex,
   Icon,
@@ -13,9 +12,9 @@ import {
   Tooltip,
   TooltipArrow,
   TooltipTrigger,
+  View,
 } from "@phoenix/components";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
-import { StopPropagation } from "@phoenix/components/StopPropagation";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
 import { fetchPlaygroundPromptAsInstance } from "@phoenix/pages/playground/fetchPlaygroundPrompt";
 import { PromptMenu } from "@phoenix/pages/playground/PromptMenu";
@@ -109,40 +108,34 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
 
   return (
     <>
-      <Card
-        title={
-          <StopPropagation>
-            <Flex
-              direction="row"
-              gap="size-100"
-              alignItems="center"
-              marginEnd="size-100"
-            >
-              <AlphabeticIndexIcon index={index} />
-              <PromptMenu value={promptMenuValue} onChange={onChangePrompt} />
-            </Flex>
-          </StopPropagation>
-        }
-        collapsible
-        extra={
-          <Flex direction="row" gap="size-100">
-            <Suspense
-              fallback={
-                <div>
-                  <Loading size="S" />
-                </div>
-              }
-            >
-              {/* As long as this component mounts, it will sync the supported
+      <Flex direction="row" justifyContent="space-between">
+        <Flex
+          direction="row"
+          gap="size-100"
+          alignItems="center"
+          marginEnd="size-100"
+        >
+          <AlphabeticIndexIcon index={index} />
+          <PromptMenu value={promptMenuValue} onChange={onChangePrompt} />
+        </Flex>
+        <Flex direction="row" gap="size-100">
+          <Suspense
+            fallback={
+              <div>
+                <Loading size="S" />
+              </div>
+            }
+          >
+            {/* As long as this component mounts, it will sync the supported
               invocation parameters for the model to the instance in the store */}
-              <ModelSupportedParamsFetcher instanceId={instanceId} />
-            </Suspense>
-            <ModelConfigButton {...props} />
-            <SaveButton instanceId={instanceId} dirty={dirty} />
-            {instances.length > 1 ? <DeleteButton {...props} /> : null}
-          </Flex>
-        }
-      >
+            <ModelSupportedParamsFetcher instanceId={instanceId} />
+          </Suspense>
+          <ModelConfigButton {...props} />
+          <SaveButton instanceId={instanceId} dirty={dirty} />
+          {instances.length > 1 ? <DeleteButton {...props} /> : null}
+        </Flex>
+      </Flex>
+      <View paddingY="size-100">
         {template.__type === "chat" ? (
           <Suspense>
             <PlaygroundChatTemplate {...props} />
@@ -150,7 +143,7 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
         ) : (
           "Completion Template"
         )}
-      </Card>
+      </View>
     </>
   );
 }
@@ -189,7 +182,12 @@ function SaveButton({ instanceId, dirty }: SaveButtonProps) {
   }
   return (
     <DialogTrigger>
-      <Button variant={dirty ? "primary" : undefined} size="S">
+      <Button
+        variant={dirty ? "primary" : undefined}
+        size="S"
+        leadingVisual={<Icon svg={<Icons.SaveOutline />} />}
+        aria-label="Save prompt"
+      >
         Save Prompt
       </Button>
       <ModalOverlay>

--- a/app/src/pages/playground/PlaygroundTools.tsx
+++ b/app/src/pages/playground/PlaygroundTools.tsx
@@ -1,13 +1,6 @@
 import { useMemo } from "react";
 
-import {
-  Counter,
-  Disclosure,
-  DisclosurePanel,
-  DisclosureTrigger,
-  Flex,
-  View,
-} from "@phoenix/components";
+import { Card, Counter, Flex, View } from "@phoenix/components";
 import {
   isSupportedToolChoiceProvider,
   ToolChoiceSelector,
@@ -51,42 +44,44 @@ export function PlaygroundTools(props: PlaygroundToolsProps) {
   }
 
   return (
-    <Disclosure id="tools">
-      <DisclosureTrigger arrowPosition="start">
-        Tools
-        <Counter>{tools.length}</Counter>
-      </DisclosureTrigger>
-      <DisclosurePanel>
-        <View padding="size-200">
-          <Flex direction="column" gap="size-200">
-            <ToolChoiceSelector
-              provider={provider}
-              choice={instance.toolChoice}
-              onChange={(choice) => {
-                updateInstance({
-                  instanceId,
-                  patch: {
-                    toolChoice: choice,
-                  },
-                  dirty: true,
-                });
-              }}
-              toolNames={toolNames}
-            />
-            <Flex direction={"column"} gap="size-200">
-              {tools.map((tool) => {
-                return (
-                  <PlaygroundTool
-                    key={tool.id}
-                    playgroundInstanceId={instanceId}
-                    toolId={tool.id}
-                  />
-                );
-              })}
-            </Flex>
+    <Card
+      title={
+        <Flex direction="row" gap="size-100" alignItems="center">
+          Tools
+          <Counter>{tools.length}</Counter>
+        </Flex>
+      }
+      collapsible
+    >
+      <View padding="size-200">
+        <Flex direction="column" gap="size-200">
+          <ToolChoiceSelector
+            provider={provider}
+            choice={instance.toolChoice}
+            onChange={(choice) => {
+              updateInstance({
+                instanceId,
+                patch: {
+                  toolChoice: choice,
+                },
+                dirty: true,
+              });
+            }}
+            toolNames={toolNames}
+          />
+          <Flex direction={"column"} gap="size-200">
+            {tools.map((tool) => {
+              return (
+                <PlaygroundTool
+                  key={tool.id}
+                  playgroundInstanceId={instanceId}
+                  toolId={tool.id}
+                />
+              );
+            })}
           </Flex>
-        </View>
-      </DisclosurePanel>
-    </Disclosure>
+        </Flex>
+      </View>
+    </Card>
   );
 }


### PR DESCRIPTION
Beter align with mocks and to start showing prompts in it's own form elements.

<img width="2424" height="1655" alt="Screenshot 2025-12-22 at 12 00 37 PM" src="https://github.com/user-attachments/assets/8817a39c-1832-430b-9cbe-ce19b4a33e40" />
