### PR TITLE
feat: add generate api key buttons to project onboarding modals

### DIFF
--- a/app/src/components/auth/GenerateAPIKeyButton.tsx
+++ b/app/src/components/auth/GenerateAPIKeyButton.tsx
@@ -1,0 +1,61 @@
+import invariant from "tiny-invariant";
+
+import { Button } from "@phoenix/components";
+import { useViewer } from "@phoenix/contexts";
+
+import { GeneratePersonalAPIKeyButton } from "./GeneratePersonalAPIKeyButton";
+import { GenerateSystemAPIKeyButton } from "./GenerateSystemAPIKeyButton";
+
+type GenerateAPIKeyButtonProps = {
+  /**
+   * Callback invoked when an API key is successfully generated.
+   * @param apiKey - The generated JWT API key
+   */
+  onApiKeyGenerated: (apiKey: string) => void;
+  /**
+   * The name to give the generated API key.
+   * @default "System Key" for admins, "Personal Key" for members
+   */
+  keyName?: string;
+};
+
+/**
+ * A button that generates an API key based on the user's role.
+ * - Admin users will generate a system API key
+ * - Member users will generate a personal API key
+ * - Viewer users will see a disabled button (no permission to create keys)
+ */
+export function GenerateAPIKeyButton({
+  onApiKeyGenerated,
+  keyName,
+}: GenerateAPIKeyButtonProps) {
+  const { viewer } = useViewer();
+
+  invariant(viewer?.role, "User role is required to generate an API key");
+
+  const roleName = viewer.role.name;
+
+  if (roleName === "VIEWER") {
+    return (
+      <Button size="S" isDisabled>
+        Generate API Key
+      </Button>
+    );
+  }
+
+  if (roleName === "ADMIN") {
+    return (
+      <GenerateSystemAPIKeyButton
+        onApiKeyGenerated={onApiKeyGenerated}
+        keyName={keyName}
+      />
+    );
+  }
+
+  return (
+    <GeneratePersonalAPIKeyButton
+      onApiKeyGenerated={onApiKeyGenerated}
+      keyName={keyName}
+    />
+  );
+}

--- a/app/src/components/auth/GeneratePersonalAPIKeyButton.tsx
+++ b/app/src/components/auth/GeneratePersonalAPIKeyButton.tsx
@@ -1,0 +1,69 @@
+import { graphql, useMutation } from "react-relay";
+
+import { Button } from "@phoenix/components";
+import { useNotifyError } from "@phoenix/contexts";
+
+import { GeneratePersonalAPIKeyButtonMutation } from "./__generated__/GeneratePersonalAPIKeyButtonMutation.graphql";
+
+type GeneratePersonalAPIKeyButtonProps = {
+  /**
+   * Callback invoked when an API key is successfully generated.
+   * @param apiKey - The generated JWT API key
+   */
+  onApiKeyGenerated: (apiKey: string) => void;
+  /**
+   * The name to give the generated API key.
+   * @default "Personal Key"
+   */
+  keyName?: string;
+};
+
+/**
+ * A button that generates a personal/user API key with default settings when clicked.
+ * Handles its own mutation and loading state.
+ */
+export function GeneratePersonalAPIKeyButton({
+  onApiKeyGenerated,
+  keyName = "Personal Key",
+}: GeneratePersonalAPIKeyButtonProps) {
+  const notifyError = useNotifyError();
+
+  const [commit, isCommitting] =
+    useMutation<GeneratePersonalAPIKeyButtonMutation>(graphql`
+      mutation GeneratePersonalAPIKeyButtonMutation(
+        $input: CreateUserApiKeyInput!
+      ) {
+        createUserApiKey(input: $input) {
+          jwt
+          apiKey {
+            id
+          }
+        }
+      }
+    `);
+
+  const handlePress = () => {
+    commit({
+      variables: {
+        input: {
+          name: keyName,
+        },
+      },
+      onCompleted: (response) => {
+        onApiKeyGenerated(response.createUserApiKey.jwt);
+      },
+      onError: (error) => {
+        notifyError({
+          title: "Error creating personal key",
+          message: error.message,
+        });
+      },
+    });
+  };
+
+  return (
+    <Button size="S" onPress={handlePress} isDisabled={isCommitting}>
+      {isCommitting ? "Generating..." : "Generate API Key"}
+    </Button>
+  );
+}

--- a/app/src/components/auth/GenerateSystemAPIKeyButton.tsx
+++ b/app/src/components/auth/GenerateSystemAPIKeyButton.tsx
@@ -1,0 +1,65 @@
+import { graphql, useMutation } from "react-relay";
+
+import { Button } from "@phoenix/components";
+import { useNotifyError } from "@phoenix/contexts";
+
+import { GenerateSystemAPIKeyButtonMutation } from "./__generated__/GenerateSystemAPIKeyButtonMutation.graphql";
+
+type GenerateSystemAPIKeyButtonProps = {
+  /**
+   * Callback invoked when an API key is successfully generated.
+   * @param apiKey - The generated JWT API key
+   */
+  onApiKeyGenerated: (apiKey: string) => void;
+  /**
+   * The name to give the generated API key.
+   * @default "System Key"
+   */
+  keyName?: string;
+};
+
+/**
+ * A button that generates a system API key with default settings when clicked.
+ * Handles its own mutation and loading state.
+ */
+export function GenerateSystemAPIKeyButton({
+  onApiKeyGenerated,
+  keyName = "System Key",
+}: GenerateSystemAPIKeyButtonProps) {
+  const notifyError = useNotifyError();
+
+  const [commit, isCommitting] =
+    useMutation<GenerateSystemAPIKeyButtonMutation>(graphql`
+      mutation GenerateSystemAPIKeyButtonMutation($name: String!) {
+        createSystemApiKey(input: { name: $name }) {
+          jwt
+          apiKey {
+            id
+          }
+        }
+      }
+    `);
+
+  const handlePress = () => {
+    commit({
+      variables: {
+        name: keyName,
+      },
+      onCompleted: (response) => {
+        onApiKeyGenerated(response.createSystemApiKey.jwt);
+      },
+      onError: (error) => {
+        notifyError({
+          title: "Error creating system key",
+          message: error.message,
+        });
+      },
+    });
+  };
+
+  return (
+    <Button size="S" onPress={handlePress} isDisabled={isCommitting}>
+      {isCommitting ? "Generating..." : "Generate API Key"}
+    </Button>
+  );
+}

--- a/app/src/components/auth/__generated__/GeneratePersonalAPIKeyButtonMutation.graphql.ts
+++ b/app/src/components/auth/__generated__/GeneratePersonalAPIKeyButtonMutation.graphql.ts
@@ -1,0 +1,115 @@
+/**
+ * @generated SignedSource<<ee9f7b5c87995aade65d4fe2eca2e466>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateUserApiKeyInput = {
+  description?: string | null;
+  expiresAt?: string | null;
+  name: string;
+};
+export type GeneratePersonalAPIKeyButtonMutation$variables = {
+  input: CreateUserApiKeyInput;
+};
+export type GeneratePersonalAPIKeyButtonMutation$data = {
+  readonly createUserApiKey: {
+    readonly apiKey: {
+      readonly id: string;
+    };
+    readonly jwt: string;
+  };
+};
+export type GeneratePersonalAPIKeyButtonMutation = {
+  response: GeneratePersonalAPIKeyButtonMutation$data;
+  variables: GeneratePersonalAPIKeyButtonMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateUserApiKeyMutationPayload",
+    "kind": "LinkedField",
+    "name": "createUserApiKey",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "jwt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "UserApiKey",
+        "kind": "LinkedField",
+        "name": "apiKey",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GeneratePersonalAPIKeyButtonMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "GeneratePersonalAPIKeyButtonMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "ab1efbf3367063e9ca4ca6164ad57049",
+    "id": null,
+    "metadata": {},
+    "name": "GeneratePersonalAPIKeyButtonMutation",
+    "operationKind": "mutation",
+    "text": "mutation GeneratePersonalAPIKeyButtonMutation(\n  $input: CreateUserApiKeyInput!\n) {\n  createUserApiKey(input: $input) {\n    jwt\n    apiKey {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cab8091abb5961321e069ebd0756d2e3";
+
+export default node;

--- a/app/src/components/auth/__generated__/GenerateSystemAPIKeyButtonMutation.graphql.ts
+++ b/app/src/components/auth/__generated__/GenerateSystemAPIKeyButtonMutation.graphql.ts
@@ -1,0 +1,116 @@
+/**
+ * @generated SignedSource<<a9e4058ef6021bcd2d88e7e2fefb07c0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type GenerateSystemAPIKeyButtonMutation$variables = {
+  name: string;
+};
+export type GenerateSystemAPIKeyButtonMutation$data = {
+  readonly createSystemApiKey: {
+    readonly apiKey: {
+      readonly id: string;
+    };
+    readonly jwt: string;
+  };
+};
+export type GenerateSystemAPIKeyButtonMutation = {
+  response: GenerateSystemAPIKeyButtonMutation$data;
+  variables: GenerateSystemAPIKeyButtonMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "name",
+            "variableName": "name"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "input"
+      }
+    ],
+    "concreteType": "CreateSystemApiKeyMutationPayload",
+    "kind": "LinkedField",
+    "name": "createSystemApiKey",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "jwt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "SystemApiKey",
+        "kind": "LinkedField",
+        "name": "apiKey",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "GenerateSystemAPIKeyButtonMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "GenerateSystemAPIKeyButtonMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "b495f2792476469f7084ece9689b8b32",
+    "id": null,
+    "metadata": {},
+    "name": "GenerateSystemAPIKeyButtonMutation",
+    "operationKind": "mutation",
+    "text": "mutation GenerateSystemAPIKeyButtonMutation(\n  $name: String!\n) {\n  createSystemApiKey(input: {name: $name}) {\n    jwt\n    apiKey {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a4a6b1b433242b55ad39cef1f6db92a6";
+
+export default node;

--- a/app/src/components/auth/index.tsx
+++ b/app/src/components/auth/index.tsx
@@ -1,4 +1,7 @@
 export * from "./CreateAPIKeyDialog";
+export * from "./GenerateAPIKeyButton";
+export * from "./GeneratePersonalAPIKeyButton";
+export * from "./GenerateSystemAPIKeyButton";
 export * from "./OneTimeAPIKeyDialog";
 export * from "./DeleteAPIKeyButton";
 export * from "./AuthGuard";

--- a/app/src/components/project/TypeScriptProjectGuide.tsx
+++ b/app/src/components/project/TypeScriptProjectGuide.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+
 import {
   ExternalLink,
+  Flex,
   Heading,
   Tab,
   TabList,
@@ -8,7 +11,11 @@ import {
   Text,
   View,
 } from "@phoenix/components";
-import { IsAdmin, IsAuthenticated } from "@phoenix/components/auth";
+import {
+  GenerateAPIKeyButton,
+  IsAdmin,
+  IsAuthenticated,
+} from "@phoenix/components/auth";
 import { CodeWrap } from "@phoenix/components/code/CodeWrap";
 import { PythonBlockWithCopy } from "@phoenix/components/code/PythonBlockWithCopy";
 import { BASE_URL } from "@phoenix/config";
@@ -71,14 +78,22 @@ registerInstrumentations({
 });`;
 };
 
-const PHOENIX_OTEL_ENV_VARS = [
-  `export PHOENIX_COLLECTOR_ENDPOINT="${BASE_URL}"`,
-  `export PHOENIX_API_KEY="your-api-key"`,
-].join("\n");
+const getPhoenixOtelEnvVars = (apiKey?: string) => {
+  const apiKeyValue = apiKey || "your-api-key";
+  return [
+    `export PHOENIX_COLLECTOR_ENDPOINT="${BASE_URL}"`,
+    `export PHOENIX_API_KEY="${apiKeyValue}"`,
+  ].join("\n");
+};
 
 export function TypeScriptProjectGuide(props: PythonProjectGuideProps) {
   const existingProjectName = props.projectName;
   const projectName = existingProjectName || "your-next-llm-project";
+  const isAuthEnabled = window.Config.authenticationEnabled;
+  const [generatedApiKey, setGeneratedApiKey] = useState<string | null>(null);
+  const phoenixOtelEnvVars = getPhoenixOtelEnvVars(
+    generatedApiKey ?? undefined
+  );
   return (
     <div>
       <View paddingTop="size-200" paddingBottom="size-100">
@@ -147,12 +162,28 @@ export function TypeScriptProjectGuide(props: PythonProjectGuideProps) {
         </Heading>
       </View>
       <View paddingBottom="size-100">
-        <Text>
-          Alternatively, you can configure Phoenix using environment variables:
-        </Text>
+        <Flex
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          gap="size-100"
+        >
+          <Text>
+            Alternatively, you can configure Phoenix using environment
+            variables:
+          </Text>
+          {isAuthEnabled && !generatedApiKey ? (
+            <IsAuthenticated>
+              <GenerateAPIKeyButton
+                onApiKeyGenerated={setGeneratedApiKey}
+                keyName="project-setup-generated"
+              />
+            </IsAuthenticated>
+          ) : null}
+        </Flex>
       </View>
       <CodeWrap>
-        <PythonBlockWithCopy value={PHOENIX_OTEL_ENV_VARS} />
+        <PythonBlockWithCopy value={phoenixOtelEnvVars} />
       </CodeWrap>
       <View paddingTop="size-200" paddingBottom="size-100">
         <Heading level={2} weight="heavy">


### PR DESCRIPTION
Streamlines the onboarding experience for projects by letting you generate a token right in the UI

<img width="902" height="1328" alt="Screenshot 2025-12-23 at 6 08 05 PM" src="https://github.com/user-attachments/assets/f506bafa-bc28-4450-9afd-78a8567c4abe" />
<img width="1416" height="1149" alt="Screenshot 2025-12-23 at 6 12 50 PM" src="https://github.com/user-attachments/assets/73930382-e3d2-4a45-8a98-e1c056c9e538" />
