### PR TITLE
chore: fix TypeScript errors

### DIFF
--- a/app/src/components/CodeBlock.tsx
+++ b/app/src/components/CodeBlock.tsx
@@ -1,15 +1,12 @@
-import {
-  type CodeLanguage,
-  PythonBlock,
-  TypeScriptBlock,
-} from "@phoenix/components/code";
+import { PythonBlock, TypeScriptBlock } from "@phoenix/components/code";
+import { ProgrammingLanguage } from "@phoenix/types/code";
 import { assertUnreachable } from "@phoenix/typeUtils";
 
 export function CodeBlock({
   language,
   value,
 }: {
-  language: CodeLanguage;
+  language: ProgrammingLanguage;
   value: string;
 }) {
   switch (language) {

--- a/app/src/components/evaluators/ContainsEvaluatorCodeBlock.tsx
+++ b/app/src/components/evaluators/ContainsEvaluatorCodeBlock.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from "react";
 
 import { Card, Flex } from "@phoenix/components";
-import {
-  type CodeLanguage,
-  CodeLanguageRadioGroup,
-} from "@phoenix/components/code";
+import { CodeLanguageRadioGroup } from "@phoenix/components/code";
 import { CodeBlock } from "@phoenix/components/CodeBlock";
+import { ProgrammingLanguage } from "@phoenix/types/code";
 
 const PYTHON_CODE = `
 def contains(
@@ -35,7 +33,7 @@ function contains(
 `.trim();
 
 export const ContainsEvaluatorCodeBlock = () => {
-  const [language, setLanguage] = useState<CodeLanguage>("Python");
+  const [language, setLanguage] = useState<ProgrammingLanguage>("Python");
   return (
     <Card
       title="Code"

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1,6 +1,7 @@
 "use no memo";
 import {
   memo,
+  type ReactNode,
   SetStateAction,
   useCallback,
   useEffect,


### PR DESCRIPTION
Fix missing type imports: replace non-existent CodeLanguage with ProgrammingLanguage and add missing ReactNode import to resolve typecheck failures.