### PR TITLE
chore: add K8s test setup for ROLE_ATTRIBUTE_PATH validation

### DIFF
--- a/scripts/docker/devops/k8s/README.md
+++ b/scripts/docker/devops/k8s/README.md
@@ -1,0 +1,103 @@
+# K8s Test Setup for ROLE_ATTRIBUTE_PATH
+
+This setup tests whether `ROLE_ATTRIBUTE_PATH` works with a constant value (e.g., `'MEMBER'`) 
+without requiring `ROLE_MAPPING` in a Kubernetes environment.
+
+## Prerequisites
+
+- Docker Desktop with Kubernetes enabled
+- kubectl configured to access the cluster
+- Helm 3.x
+
+## Setup
+
+### 1. Verify you're using Docker Desktop (NOT production!)
+
+```bash
+# Check current context - MUST be "docker-desktop"
+kubectl config current-context
+
+# If not docker-desktop, switch to it:
+kubectl config use-context docker-desktop
+
+# Double-check you're on the right cluster before proceeding
+kubectl cluster-info
+```
+
+> **⚠️ WARNING**: Do NOT proceed if your context is pointing to a production cluster!
+
+### 2. Build the OIDC dev image
+
+```bash
+cd scripts/docker/devops
+
+# Build the image (Docker Desktop K8s uses the same Docker daemon, so no need to load)
+docker build -t oidc-dev:local ./oidc-server
+```
+
+### 3. Deploy Postgres
+
+```bash
+kubectl apply -f k8s/postgres.yml
+
+# Wait for Postgres to be ready
+kubectl wait --for=condition=ready pod -l app=postgres --timeout=60s
+```
+
+### 4. Deploy Phoenix with OIDC sidecar
+
+```bash
+# Apply the OAuth secret (contains ROLE_ATTRIBUTE_PATH='MEMBER' with NO ROLE_MAPPING)
+kubectl apply -f k8s/test-secret.yml
+
+# Install Phoenix via Helm (path is relative to scripts/docker/devops)
+helm install phoenix ../../../helm -f k8s/test-values.yml
+
+# Add OIDC dev server as sidecar to Phoenix pod
+kubectl patch deployment phoenix --patch-file k8s/phoenix-oidc-sidecar-patch.yml
+
+# Wait for Phoenix to be ready (may take a moment after patch)
+kubectl wait --for=condition=ready pod -l app=phoenix --timeout=120s
+```
+
+### 5. Verify the environment variable
+
+```bash
+# Check that the secret value is correctly set
+kubectl get secret phoenix-oauth-test -o jsonpath='{.data.PHOENIX_OAUTH2_DEV_ROLE_ATTRIBUTE_PATH}' | base64 -d && echo
+
+# Expected output: 'MEMBER' (with single quotes)
+```
+
+### 6. Test the OIDC login
+
+```bash
+# Port-forward both Phoenix (6006) and OIDC sidecar (9000) from the same pod
+kubectl port-forward deploy/phoenix 6006:6006 9000:9000
+```
+
+Then:
+1. Open http://localhost:6006 in your browser
+2. Click "Login with OIDC Dev"
+3. You'll be automatically logged in as a test user
+4. Verify the user's role by querying the database:
+
+```bash
+kubectl exec deploy/postgres -- psql -U postgres -d postgres -c \
+  "SELECT u.username, u.email, r.name as role FROM users u JOIN user_roles r ON u.user_role_id = r.id WHERE u.oauth2_client_id IS NOT NULL;"
+```
+
+5. **Expected**: User should have MEMBER role (not VIEWER)
+
+## What we're testing
+
+The key question: Does `ROLE_ATTRIBUTE_PATH='MEMBER'` (a constant JMESPath expression) 
+correctly assign the MEMBER role without needing `ROLE_MAPPING`?
+
+## Cleanup
+
+```bash
+helm uninstall phoenix
+kubectl delete -f k8s/test-secret.yml
+kubectl delete -f k8s/postgres.yml
+```

--- a/scripts/docker/devops/k8s/phoenix-oidc-sidecar-patch.yml
+++ b/scripts/docker/devops/k8s/phoenix-oidc-sidecar-patch.yml
@@ -1,0 +1,35 @@
+# Patch to add OIDC dev server as sidecar to Phoenix pod
+# Apply with: kubectl patch deployment phoenix --patch-file k8s/phoenix-oidc-sidecar-patch.yml
+spec:
+  template:
+    spec:
+      containers:
+        - name: oidc-dev
+          image: oidc-dev:local
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 9000
+          env:
+            - name: OIDC_PORT
+              value: "9000"
+            - name: OIDC_ISSUER
+              value: "http://localhost:9000"
+            - name: OIDC_PUBLIC_BASE_URL
+              value: "http://localhost:9000"
+            - name: OIDC_AUTH_ENDPOINT
+              value: "http://localhost:9000/auth"
+            - name: OIDC_CLIENT_ID
+              value: "phoenix-oidc-client-id"
+            - name: OIDC_CLIENT_SECRET
+              value: "phoenix-oidc-client-secret-abc-123"
+            - name: OIDC_CALLBACK_URL
+              value: "http://localhost:6006/oauth2/dev/callback"
+            - name: OIDC_LOGOUT_REDIRECT_URL
+              value: "http://localhost:6006"
+            - name: DATABASE_URL
+              value: "postgresql://postgres:postgres@postgres:5432/postgres"
+          resources:
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+

--- a/scripts/docker/devops/k8s/postgres.yml
+++ b/scripts/docker/devops/k8s/postgres.yml
@@ -1,0 +1,44 @@
+# Postgres Database for testing Phoenix OAuth in K8s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              value: "postgres"
+            - name: POSTGRES_DB
+              value: "postgres"
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+

--- a/scripts/docker/devops/k8s/test-secret.yml
+++ b/scripts/docker/devops/k8s/test-secret.yml
@@ -1,0 +1,15 @@
+# Phoenix OAuth test secret
+# This tests ROLE_ATTRIBUTE_PATH with a constant value and NO ROLE_MAPPING
+apiVersion: v1
+kind: Secret
+metadata:
+  name: phoenix-oauth-test
+type: Opaque
+stringData:
+  PHOENIX_OAUTH2_DEV_CLIENT_ID: "phoenix-oidc-client-id"
+  PHOENIX_OAUTH2_DEV_CLIENT_SECRET: "phoenix-oidc-client-secret-abc-123"
+  # Use localhost since OIDC server runs as sidecar in same pod
+  PHOENIX_OAUTH2_DEV_OIDC_CONFIG_URL: "http://localhost:9000/.well-known/openid-configuration"
+  # This is the key test: constant value with NO ROLE_MAPPING
+  PHOENIX_OAUTH2_DEV_ROLE_ATTRIBUTE_PATH: "'MEMBER'"
+  # Intentionally NO ROLE_MAPPING - testing if Phoenix recognizes 'MEMBER' directly

--- a/scripts/docker/devops/k8s/test-values.yml
+++ b/scripts/docker/devops/k8s/test-values.yml
@@ -1,0 +1,46 @@
+# Phoenix Helm values for testing ROLE_ATTRIBUTE_PATH in K8s
+auth:
+  enabled: true
+  secret:
+    - key: "PHOENIX_SECRET"
+      value: "phoenix-secret-abc-123-for-development-only-not-secure"
+    - key: "PHOENIX_POSTGRES_PASSWORD"
+      value: "postgres"
+
+# Use the OIDC dev Postgres for Phoenix as well
+postgresql:
+  enabled: false
+
+database:
+  postgres:
+    host: "postgres"
+    port: 5432
+    db: "postgres"
+    user: "postgres"
+    password: "postgres"
+
+additionalEnv:
+  - name: PHOENIX_OAUTH2_DEV_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: phoenix-oauth-test
+        key: PHOENIX_OAUTH2_DEV_CLIENT_ID
+  - name: PHOENIX_OAUTH2_DEV_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: phoenix-oauth-test
+        key: PHOENIX_OAUTH2_DEV_CLIENT_SECRET
+  - name: PHOENIX_OAUTH2_DEV_OIDC_CONFIG_URL
+    valueFrom:
+      secretKeyRef:
+        name: phoenix-oauth-test
+        key: PHOENIX_OAUTH2_DEV_OIDC_CONFIG_URL
+  - name: PHOENIX_OAUTH2_DEV_ROLE_ATTRIBUTE_PATH
+    valueFrom:
+      secretKeyRef:
+        name: phoenix-oauth-test
+        key: PHOENIX_OAUTH2_DEV_ROLE_ATTRIBUTE_PATH
+  - name: PHOENIX_OAUTH2_DEV_DISPLAY_NAME
+    value: "OIDC Dev"
+  - name: PHOENIX_OAUTH2_DEV_ALLOW_SIGN_UP
+    value: "true"


### PR DESCRIPTION
## Summary

Adds a K8s test setup to validate that `ROLE_ATTRIBUTE_PATH='\''MEMBER'\'' ` (a constant JMESPath expression) correctly assigns the MEMBER role without requiring `ROLE_MAPPING`.

## What's included

- `postgres.yml` - Postgres database deployment
- `phoenix-oidc-sidecar-patch.yml` - OIDC dev server as sidecar
- `test-secret.yml` - OAuth config with `ROLE_ATTRIBUTE_PATH='\''MEMBER'\'' ` (no ROLE_MAPPING)
- `test-values.yml` - Helm values for Phoenix
- `README.md` - Step-by-step instructions

## Prerequisites

- Docker Desktop with Kubernetes enabled
- kubectl configured to access the cluster
- Helm 3.x

## Test Results

✅ Verified that OIDC login correctly assigns MEMBER role when using a constant `ROLE_ATTRIBUTE_PATH` value.

## Usage

See `scripts/docker/devops/k8s/README.md` for instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Kubernetes-based test harness to verify that a constant JMESPath `ROLE_ATTRIBUTE_PATH='MEMBER'` assigns the MEMBER role without `ROLE_MAPPING`.
> 
> - Adds `postgres.yml` (Postgres deployment/service), `test-secret.yml` (OAuth config with `PHOENIX_OAUTH2_DEV_ROLE_ATTRIBUTE_PATH="'MEMBER'"`), `test-values.yml` (Helm values), and `phoenix-oidc-sidecar-patch.yml` (OIDC dev sidecar for Phoenix)
> - Provides `README.md` with setup, verification, and cleanup steps to run Phoenix (port 6006) and OIDC dev (port 9000) on Docker Desktop K8s
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 406c2eb6f78133a025f409def6a824b5ee0807b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->