### PR TITLE
chore: Update openai version in dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 asyncpg
-openai
+openai>=2.14
 anthropic>=0.49.0
 google-genai
 psycopg[binary,pool]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates dev dependencies to require a minimum OpenAI SDK version.
> 
> - In `requirements/dev.txt`, change `openai` to `openai>=2.14` to enforce a minimum version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5e9f6bae172b3c080744464d111333e6ff0bd54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->