### PR TITLE
feat(evals): return evaluation trace id in scores

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -320,10 +320,14 @@ class Evaluator(ABC):
             except ValidationError as e:
                 raise ValueError(f"Input validation failed: {e}")
 
-        with trace_evaluation(f"{self.name}.evaluate") as get_trace_id:
+        with trace_evaluation(
+            f"{self.name}.evaluate",
+            eval_input=remapped_eval_input,
+            evaluator_kind=self.kind,
+        ) as finish:
             scores = self._evaluate(remapped_eval_input)
-            if get_trace_id:
-                trace_id = get_trace_id()
+            if finish:
+                trace_id = finish(scores)
                 if trace_id is not None:
                     scores = _inject_trace_id_into_scores(scores, trace_id)
             return scores
@@ -351,10 +355,14 @@ class Evaluator(ABC):
             except ValidationError as e:
                 raise ValueError(f"Input validation failed: {e}")
 
-        with trace_evaluation(f"{self.name}.evaluate") as get_trace_id:
+        with trace_evaluation(
+            f"{self.name}.evaluate",
+            eval_input=remapped_eval_input,
+            evaluator_kind=self.kind,
+        ) as finish:
             scores = await self._async_evaluate(remapped_eval_input)
-            if get_trace_id:
-                trace_id = get_trace_id()
+            if finish:
+                trace_id = finish(scores)
                 if trace_id is not None:
                     scores = _inject_trace_id_into_scores(scores, trace_id)
             return scores

--- a/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/test_evaluators.py
@@ -329,6 +329,7 @@ class TestEvaluator:
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor
         from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+        from opentelemetry.trace import NoOpTracerProvider
         from pydantic import create_model
 
         # Setup in-memory tracing
@@ -373,9 +374,7 @@ class TestEvaluator:
             assert span.attributes.get("evaluator.class") == "MockEvaluator"
 
         finally:
-            # Cleanup: reset tracer provider
-            from opentelemetry.trace import NoOpTracerProvider
-
+            # Cleanup: disable tracing to avoid affecting other tests
             trace.set_tracer_provider(NoOpTracerProvider())
 
 


### PR DESCRIPTION
Now, if tracing is enabled, evaluators return the`trace_id` of the evaluation's root span in the returned `Score` metadata. This enables users to link eval traces to project traces being evaluated so the trail is maintained. 

Now, all other traces (e.g. LLM calls) are nested under a root span named `{evaluator_name}.evaluate`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OpenTelemetry tracing around evaluations and injects the root span `trace_id` into returned scores for cross-linking.
> 
> - Introduces `trace_evaluation` context manager in `tracing.py` to start `EVALUATOR` spans, record `INPUT/OUTPUT` values, and add `trace_id` to results
> - Wraps `Evaluator.evaluate` and `Evaluator.async_evaluate` with `trace_evaluation`; outputs include updated `Score.metadata['trace_id']`
> - Helper additions: `_scores_with_trace_id`, `get_current_trace_id`, `_str_trace_id`
> - Adds tests verifying `trace_id` propagation and span attributes (`evaluator.kind`, `evaluator.class`, span name `{evaluator}.evaluate`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f18d781228701c0584816015ea3aaefa779e634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->