### PR TITLE
feat: Enable sync- and async- client kwargs for LLM constructor

### DIFF
--- a/docs/phoenix/evaluation/how-to-evals/configuring-the-llm.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/configuring-the-llm.mdx
@@ -18,7 +18,9 @@ When creating an `LLM`, specify:
 - `provider`: The provider name (e.g., `"openai"`, `"azure"`, `"anthropic"`)
 - `model`: The model identifier
 - `client` (optional): Which client SDK to use if multiple are installed (e.g., `"openai"`, `"langchain"`, `"litellm"`)
-- `**kwargs`: Client configuration parameters forwarded to the underlying client constructor.
+- `sync_client_kwargs` (optional): Client configuration forwarded only to the sync client
+- `async_client_kwargs` (optional): Client configuration forwarded only to the async client
+- `**kwargs`: Client configuration parameters forwarded to both sync and async client constructors.
 
 To see the currently supported LLM providers and their availability, use the `show_provider_availability` function:
 
@@ -216,6 +218,43 @@ evaluator = ClassificationEvaluator(
     choices={"positive": 1, "negative": 0},
     llm=llm,
     temperature=0.0,
+)
+```
+
+### Separate Sync/Async Client Configuration
+
+Some providers (OpenAI, Anthropic) create separate sync and async SDK clients internally. The `sync_client_kwargs` and `async_client_kwargs` parameters allow passing configuration that applies only to one client type, useful for:
+
+- **Different timeouts**: Longer timeouts for async batch operations
+- **Different HTTP clients**: Custom httpx clients for sync vs async
+- **Different retry configurations**: More aggressive retries for batch async calls
+
+**Example: Different Timeouts for Sync and Async Clients**
+
+```python
+from phoenix.evals.llm import LLM
+
+llm = LLM(
+    provider="openai",
+    model="gpt-4o",
+    api_key="your-api-key",
+    sync_client_kwargs={"timeout": 30.0},
+    async_client_kwargs={"timeout": 120.0},
+)
+```
+
+**Example: Custom HTTP Clients**
+
+```python
+import httpx
+from phoenix.evals.llm import LLM
+
+llm = LLM(
+    provider="openai",
+    model="gpt-4o",
+    api_key="your-api-key",
+    sync_client_kwargs={"http_client": httpx.Client(timeout=30.0)},
+    async_client_kwargs={"http_client": httpx.AsyncClient(timeout=120.0)},
 )
 ```
 

--- a/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
+++ b/packages/phoenix-evals/src/phoenix/evals/llm/wrapper.py
@@ -169,6 +169,15 @@ class LLM:
                 api_version="api-version",
                 base_url="base-url",
             )
+
+            # Using sync_client_kwargs and async_client_kwargs for different timeouts
+            llm = LLM(
+                provider="openai",
+                model="gpt-4o",
+                api_key="your-api-key",
+                sync_client_kwargs={"timeout": 60.0},
+                async_client_kwargs={"timeout": 120.0},
+            )
         """
         self.provider = provider
         self.model = model


### PR DESCRIPTION
resolves #10585 

Add `sync_client_kwargs` and `async_client_kwargs` kwargs to the `LLM` constructor. This allows passing sync- and async- specific client kwargs to each client constructor for deeper configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-client configuration for the Python `LLM` wrapper.
> 
> - Adds `sync_client_kwargs` and `async_client_kwargs` to `LLM(...)` and merges them with shared `**kwargs` when constructing SDK clients (specific kwargs override shared ones)
> - Updates client construction to pass merged kwargs to `registration.client_factory(..., is_async=False/True)`
> - Expands docs in `configuring-the-llm.mdx` to describe new params and provide examples (different timeouts, custom HTTP clients)
> - Enhances `LLM.__init__` docstring with details on precedence and usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1839c979c828649e1e4fc815e1d7d45b784f8375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->