### PR TITLE
fix: Disable codemirror search keymap

### DIFF
--- a/app/src/pages/project/SessionSearchField.tsx
+++ b/app/src/pages/project/SessionSearchField.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { type BasicSetupOptions } from "@uiw/react-codemirror";
 import { css } from "@emotion/react";
 
 import { Flex, Icon, Icons } from "@phoenix/components";
@@ -46,6 +46,17 @@ const fieldCSS = css`
   }
 `;
 
+const basicSetupOptions: BasicSetupOptions = {
+  lineNumbers: false,
+  foldGutter: false,
+  bracketMatching: false,
+  syntaxHighlighting: false,
+  highlightActiveLine: false,
+  highlightActiveLineGutter: false,
+  defaultKeymap: false,
+  searchKeymap: false,
+};
+
 type SessionsSubstringFieldProps = {
   placeholder?: string;
 };
@@ -69,15 +80,7 @@ export function SessionSearchField(props: SessionsSubstringFieldProps) {
         <CodeMirror
           css={codeMirrorCSS}
           indentWithTab={false}
-          basicSetup={{
-            lineNumbers: false,
-            foldGutter: false,
-            bracketMatching: false,
-            syntaxHighlighting: false,
-            highlightActiveLine: false,
-            highlightActiveLineGutter: false,
-            defaultKeymap: false,
-          }}
+          basicSetup={basicSetupOptions}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           value={filterIoSubstringOrSessionId}

--- a/app/src/pages/project/SpanFilterConditionField.tsx
+++ b/app/src/pages/project/SpanFilterConditionField.tsx
@@ -13,7 +13,11 @@ import {
 } from "@codemirror/autocomplete";
 import { python } from "@codemirror/lang-python";
 import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
-import CodeMirror, { EditorView, keymap } from "@uiw/react-codemirror";
+import CodeMirror, {
+  type BasicSetupOptions,
+  EditorView,
+  keymap,
+} from "@uiw/react-codemirror";
 import { fetchQuery, graphql } from "relay-runtime";
 import { css } from "@emotion/react";
 
@@ -253,6 +257,17 @@ const extensions = [
   autocompletion({ override: [filterConditionCompletions] }),
 ];
 
+const basicSetupOptions: BasicSetupOptions = {
+  lineNumbers: false,
+  foldGutter: false,
+  bracketMatching: true,
+  syntaxHighlighting: true,
+  highlightActiveLine: false,
+  highlightActiveLineGutter: false,
+  defaultKeymap: false,
+  searchKeymap: false,
+};
+
 type SpanFilterConditionFieldProps = {
   /**
    * Callback when the condition is valid
@@ -307,15 +322,7 @@ export function SpanFilterConditionField(props: SpanFilterConditionFieldProps) {
         <CodeMirror
           css={codeMirrorCSS}
           indentWithTab={false}
-          basicSetup={{
-            lineNumbers: false,
-            foldGutter: false,
-            bracketMatching: true,
-            syntaxHighlighting: true,
-            highlightActiveLine: false,
-            highlightActiveLineGutter: false,
-            defaultKeymap: false,
-          }}
+          basicSetup={basicSetupOptions}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           value={filterCondition}


### PR DESCRIPTION
cmd/ctrl + f was triggering a codemirror search field rather than browser native search

## Before

https://github.com/user-attachments/assets/5ebbdcab-a9e5-4364-bd76-6e89545c82cd

## After

https://github.com/user-attachments/assets/1d71af0c-6ec6-4300-8ecd-b41918b36922


Resolves #10809 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 860035270dd110efab454db6deacde09d6fe116b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->