### PR TITLE
fix: Add model and developer role mappings

### DIFF
--- a/src/phoenix/server/api/helpers/message_helpers.py
+++ b/src/phoenix/server/api/helpers/message_helpers.py
@@ -18,7 +18,9 @@ ChatCompletionMessage = tuple[ChatCompletionMessageRole, str, Optional[str], Opt
 _ROLE_MAPPING = {
     "user": ChatCompletionMessageRole.USER,
     "assistant": ChatCompletionMessageRole.AI,
+    "model": ChatCompletionMessageRole.AI,
     "system": ChatCompletionMessageRole.SYSTEM,
+    "developer": ChatCompletionMessageRole.SYSTEM,
     "tool": ChatCompletionMessageRole.TOOL,
     # Also handle our internal names
     "ai": ChatCompletionMessageRole.AI,


### PR DESCRIPTION
- Map 'model' to AI role (Google/Gemini convention)
- Map 'developer' to SYSTEM role (OpenAI convention)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maps additional external role strings to internal enums for message conversion.
> 
> - Add `"model" -> ChatCompletionMessageRole.AI` (Gemini)
> - Add `"developer" -> ChatCompletionMessageRole.SYSTEM` (OpenAI)
> 
> Affects role handling in `message_helpers.py` when converting OpenAI-format messages to internal tuples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57e684ffd7c64688a0d5cccfe175993e14c7f59d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->