### PR TITLE
chore: git ignore sqlite db file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ sdist
 # Server static files
 /src/phoenix/server/static/*
 
+# sqlite db files
+phoenix.db*
+
 # Docgen
 /js/**/docs
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents sqlite databases from being committed.
> 
> - Adds `phoenix.db*` to `.gitignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c103bbd2b7795da52619a144e5707401f330e315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->