### PR TITLE
fix: Simplify tool_calls handling in message helpers

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -44,7 +44,10 @@ from phoenix.server.api.evaluators import (
     get_llm_evaluators,
 )
 from phoenix.server.api.exceptions import NotFound
-from phoenix.server.api.helpers.message_helpers import extract_and_convert_example_messages
+from phoenix.server.api.helpers.message_helpers import (
+    ChatCompletionMessage,
+    extract_and_convert_example_messages,
+)
 from phoenix.server.api.helpers.playground_clients import (
     PlaygroundStreamingClient,
     get_playground_client,
@@ -62,7 +65,6 @@ from phoenix.server.api.input_types.ChatCompletionInput import (
     ChatCompletionInput,
     ChatCompletionOverDatasetInput,
 )
-from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
 from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
     ChatCompletionSubscriptionError,
     ChatCompletionSubscriptionExperiment,
@@ -98,9 +100,6 @@ logger = logging.getLogger(__name__)
 
 initialize_playground_clients()
 
-ChatCompletionMessage: TypeAlias = tuple[
-    ChatCompletionMessageRole, str, Optional[str], Optional[list[str]]
-]
 DatasetExampleID: TypeAlias = GlobalID
 ChatCompletionResult: TypeAlias = tuple[
     DatasetExampleID, Optional[models.Span], models.ExperimentRun
@@ -905,7 +904,7 @@ def _formatted_messages(
     messages: Iterable[ChatCompletionMessage],
     template_format: PromptTemplateFormat,
     template_variables: Mapping[str, Any],
-) -> Iterator[tuple[ChatCompletionMessageRole, str, Optional[str], Optional[list[str]]]]:
+) -> Iterator[ChatCompletionMessage]:
     """
     Formats the messages using the given template options.
     """

--- a/tests/unit/db/test_models.py
+++ b/tests/unit/db/test_models.py
@@ -768,9 +768,9 @@ class TestNumDocuments:
 
                 stmt = select(models.Span.num_documents).where(models.Span.id == span.id)
                 result = await session.scalar(stmt)
-                assert (
-                    result == expected
-                ), f"Case {i} ({span_kind}): expected {expected}, got {result}"
+                assert result == expected, (
+                    f"Case {i} ({span_kind}): expected {expected}, got {result}"
+                )
 
 
 class TestEvaluatorPolymorphism:

--- a/tests/unit/server/api/helpers/test_message_helpers.py
+++ b/tests/unit/server/api/helpers/test_message_helpers.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import pytest
@@ -241,10 +240,8 @@ class TestConvertOpenaiMessageToInternal:
         assert result[0] == ChatCompletionMessageRole.AI
         assert result[1] == ""
         assert result[2] is None
-        assert result[3] is not None
-        assert len(result[3]) == 1
-        # Tool calls are JSON-serialized
-        assert json.loads(result[3][0]) == tool_calls[0]
+        # Tool calls are passed through directly
+        assert result[3] == tool_calls
 
     def test_assistant_message_with_multiple_tool_calls(self) -> None:
         tool_calls = [
@@ -267,10 +264,8 @@ class TestConvertOpenaiMessageToInternal:
         result = convert_openai_message_to_internal(openai_message)
         assert result[0] == ChatCompletionMessageRole.AI
         assert result[1] == "Let me check both for you."
-        assert result[3] is not None
-        assert len(result[3]) == 2
-        assert json.loads(result[3][0]) == tool_calls[0]
-        assert json.loads(result[3][1]) == tool_calls[1]
+        # Tool calls are passed through directly
+        assert result[3] == tool_calls
 
     def test_assistant_message_with_empty_tool_calls_list(self) -> None:
         openai_message = {
@@ -279,8 +274,8 @@ class TestConvertOpenaiMessageToInternal:
             "tool_calls": [],
         }
         result = convert_openai_message_to_internal(openai_message)
-        # Empty list is falsy, so tool_calls should be None
-        assert result[3] is None
+        # Empty list is passed through directly
+        assert result[3] == []
 
 
 class TestExtractAndConvertExampleMessages:


### PR DESCRIPTION
- Remove unnecessary _convert_tool_calls_to_json_strings function
- Pass through tool_calls directly without JSON serialization
- Remove unused json import

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines message handling and type usage across helpers and subscriptions.
> 
> - Update `ChatCompletionMessage` to allow `tool_calls` as `list[dict]` and remove JSON-string conversion
> - Simplify `convert_openai_message_to_internal` to pass `tool_calls` through directly
> - Centralize message tuple type by importing `ChatCompletionMessage` in `subscriptions.py` and adjust `_formatted_messages` return type
> - Remove unused JSON helper and import in `message_helpers.py`
> - Update unit tests to expect direct `tool_calls` pass-through; minor assertion formatting tweak in `db/test_models.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c1133bdda6c3a5518c33ba1451eea10cad3068c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->