### PR TITLE
fix: handle non-array values in NumDocuments to prevent PostgreSQL error

### DIFF
--- a/src/phoenix/db/insertion/document_annotation.py
+++ b/src/phoenix/db/insertion/document_annotation.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import TypeAlias
 
 from phoenix.db import models
-from phoenix.db.helpers import dedup, num_docs_col
+from phoenix.db.helpers import dedup
 from phoenix.db.insertion.helpers import as_kv
 from phoenix.db.insertion.types import (
     Insertables,
@@ -139,7 +139,11 @@ class DocumentAnnotationQueueInserter(
     def _select_existing(self, *keys: _Key) -> Select[_Existing]:
         anno = self.table
         span = (
-            select(models.Span.id, models.Span.span_id, num_docs_col(self._db.dialect))
+            select(
+                models.Span.id,
+                models.Span.span_id,
+                models.Span.num_documents.label("num_docs"),
+            )
             .where(models.Span.span_id.in_({k.span_id for k in keys}))
             .cte()
         )

--- a/src/phoenix/db/insertion/evaluation.py
+++ b/src/phoenix/db/insertion/evaluation.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import assert_never
 
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect, num_docs_col
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import insert_on_conflict
 from phoenix.exceptions import PhoenixException
 from phoenix.trace import v1 as pb
@@ -153,12 +153,11 @@ async def _insert_document_evaluation(
     score: Optional[float],
     explanation: Optional[str],
 ) -> EvaluationInsertionEvent:
-    dialect = SupportedSQLDialect(session.bind.dialect.name)
     stmt = (
         select(
             models.Trace.project_rowid,
             models.Span.id,
-            num_docs_col(dialect),
+            models.Span.num_documents,
         )
         .join_from(models.Span, models.Trace)
         .where(models.Span.span_id == span_id)

--- a/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
+++ b/src/phoenix/server/api/dataloaders/document_evaluation_summaries.py
@@ -10,7 +10,7 @@ from strawberry.dataloader import AbstractCache, DataLoader
 from typing_extensions import TypeAlias
 
 from phoenix.db import models
-from phoenix.db.helpers import SupportedSQLDialect, num_docs_col
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.metrics.retrieval_metrics import RetrievalMetrics
 from phoenix.server.api.dataloaders.cache import TwoTierCache
 from phoenix.server.api.input_types.TimeRange import TimeRange
@@ -122,7 +122,7 @@ def _get_stmt(
         select(
             mda.name,
             models.Span.id,
-            num_docs_col(dialect),
+            models.Span.num_documents.label("num_docs"),
             mda.score,
             mda.document_position,
         )


### PR DESCRIPTION
## Problem

PostgreSQL's `jsonb_array_length` function throws an error when called on non-array JSONB values:

```
cannot get array length of a scalar
```

This error occurs when querying spans where the `retrieval.documents` or `reranker.output_documents` attribute contains a malformed value (e.g., a string, number, or object instead of an array).

The error was observed in the `ProjectPageQueriesTracesQuery` GraphQL query when loading the traces table, specifically when resolving `descendants` spans that have malformed document attributes.

## Solution

Check `jsonb_typeof` before calling `jsonb_array_length` for PostgreSQL to handle non-array values gracefully by returning 0 instead of throwing an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures robust cross-dialect computation of document counts and removes ad-hoc helpers.
> 
> - Implement `NumDocuments` SQL expression in `models.py` with PostgreSQL `jsonb_typeof` checks and SQLite fallbacks; expose via hybrid `Span.num_documents`
> - Remove `num_docs_col` and related imports; update queries in insertion (`document_annotation.py`, `evaluation.py`) and dataloader (`document_evaluation_summaries.py`) to use `Span.num_documents`
> - Add unit tests verifying `NumDocuments` returns 0 for non-array values and correct counts for arrays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3a7f02b5b0ca6debc9b5e358fd36783525a76db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->