### PR TITLE
fix: use context.span_id column when DataFrame has integer index

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/helpers/spans/rag.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/spans/rag.py
@@ -212,8 +212,8 @@ def get_input_output_context(
         return None
 
     # Group by trace_id (index level 0) and concatenate contexts
-    ref: pd.Series[str] = df_docs.groupby(level=0)["context"].apply(
-        lambda x: _concat_contexts(x, separator)
+    ref: pd.Series[str] = df_docs.groupby(level=0)["context"].apply(  # pyright: ignore[reportCallIssue]
+        lambda x: _concat_contexts(x, separator)  # pyright: ignore[reportArgumentType]
     )
     df_ref = pd.DataFrame({"context": ref})
     df_qa_ref = pd.concat([df_qa, df_ref], axis=1, join="inner")
@@ -418,8 +418,8 @@ async def async_get_input_output_context(
         return None
 
     # Group by trace_id (index level 0) and concatenate contexts
-    ref: pd.Series[str] = df_docs.groupby(level=0)["context"].apply(
-        lambda x: _concat_contexts(x, separator)
+    ref: pd.Series[str] = df_docs.groupby(level=0)["context"].apply(  # pyright: ignore[reportCallIssue]
+        lambda x: _concat_contexts(x, separator)  # pyright: ignore[reportArgumentType]
     )
     df_ref = pd.DataFrame({"context": ref})
     df_qa_ref = pd.concat([df_qa, df_ref], axis=1, join="inner")


### PR DESCRIPTION
## Summary

When `dataframe_to_spans` receives a DataFrame with a default integer index (0, 1, 2...), it was incorrectly converting those integers to strings and using them as span IDs (e.g., "0", "1", "2").

## Fix

Now it properly:
1. Checks for the `context.span_id` column first and uses that if available
2. Only falls back to the index if it's explicitly named "span_id" OR if the index value is a string (indicating it contains actual span IDs)

## Testing

Added integration test `test_log_spans_dataframe_with_integer_index` that:
- Creates a DataFrame with default integer index (not span_id index)
- Logs spans using `log_spans_dataframe`
- Verifies the created spans have correct span IDs from the `context.span_id` column, not from the integer index

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves span ID extraction from DataFrames and adds coverage.
> 
> - Fixes `dataframe_to_spans` to prioritize `context.span_id` (then `span_id`) and only fall back to the index if it's a string; raises on missing `span_id`
> - Adds integration test `test_log_spans_dataframe_with_integer_index` validating `log_spans_dataframe` does not use default integer indices as span IDs
> - Minor typing/pyright adjustments in RAG helpers (`rag.py`) for groupby/apply calls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3cbf4633df90bbd9720c303a1932ca3f32d1845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->