### PR TITLE
feat: Add dataset deep link after selection from playground

### DIFF
--- a/app/src/components/dataset/DatasetSelectWithSplits.tsx
+++ b/app/src/components/dataset/DatasetSelectWithSplits.tsx
@@ -480,7 +480,7 @@ export function DatasetSelectWithSplits(props: DatasetSelectWithSplitsProps) {
             <LinkButton
               to={`/datasets/${selectedDataset.id}`}
               size="S"
-              variant="external"
+              variant="quiet"
               leadingVisual={<Icon svg={<Icons.DatabaseOutline />} />}
             >
               View <Truncate maxWidth="10rem">{selectedDataset.name}</Truncate>


### PR DESCRIPTION

https://github.com/user-attachments/assets/d0611969-5664-4857-ac7d-fdd8bdd5ccde


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a context-aware footer action to the dataset picker for quick navigation.
> 
> - When a dataset is selected, `MenuFooter` now shows a "View <dataset>" link (with icon and truncated name) to `/datasets/{id}`
> - Falls back to "Go to Datasets" when no dataset is selected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df4bc8ec7756b1034ff3157ca74e64cb1e68f163. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->