### PR TITLE
feat: upgrade react router

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -52,7 +52,7 @@
     "react-relay": "^20.1.1",
     "react-resizable": "^3.0.5",
     "react-resizable-panels": "^2.1.9",
-    "react-router": "^7.8.0",
+    "react-router": "^7.12.0",
     "recharts": "^3.1.0",
     "relay-runtime": "^20.1.1",
     "remark-gfm": "^4.0.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-router:
-        specifier: ^7.8.0
-        version: 7.8.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       recharts:
         specifier: ^3.1.0
         version: 3.1.0(@types/react@19.2.0)(react-dom@19.2.0(react@19.2.0))(react-is@17.0.2)(react@19.2.0)(redux@5.0.1)
@@ -4405,8 +4405,8 @@ packages:
     peerDependencies:
       react: '>= 16.3'
 
-  react-router@7.8.0:
-    resolution: {integrity: sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==}
+  react-router@7.12.0:
+    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -10444,7 +10444,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  react-router@7.8.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.0.2
       react: 19.2.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Dependency upgrade**
> 
> - Bumps `react-router` from `^7.8.0` to `^7.12.0` in `app/package.json`
> - Updates related entries in `pnpm-lock.yaml`
> 
> *No application code changes included.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 384c7a56b4110a4bededebbf9eaf8cb8eb40110b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->