### PR TITLE
fix: ensure correct MIME type for JavaScript files on Windows

### DIFF
--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -201,8 +201,9 @@ if TYPE_CHECKING:
 
     from phoenix.config import LDAPConfig
 
-# Fix incorrect MIME types on Windows where the registry may have wrong entries
+# Fix incorrect MIME types on Windows where the registry may have wrong entries.
 # See: https://github.com/python/cpython/issues/88141
+# Using text/javascript per RFC 9239: https://www.rfc-editor.org/rfc/rfc9239
 mimetypes.add_type("text/javascript", ".js", strict=True)
 mimetypes.add_type("text/javascript", ".mjs", strict=True)
 


### PR DESCRIPTION
## Summary

Fixes #10881

On some Windows systems, the registry has incorrect MIME type mappings for `.js` files (`text/plain` instead of `application/javascript`). This causes browsers to reject JavaScript modules due to strict MIME type checking:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/plain".

This is a known issue with Python's `mimetypes` module on Windows: https://github.com/python/cpython/issues/88141

## Fix

Explicitly register the correct MIME types for `.js` and `.mjs` files at module load time, ensuring correct behavior regardless of Windows registry configuration.

## Testing

This change is harmless on correctly-configured systems (it just confirms the correct mapping) and fixes broken Windows installations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures JavaScript files are served with the correct MIME type, avoiding strict MIME type errors in browsers on some Windows systems.
> 
> - Adds `import mimetypes` and registers `text/javascript` for `.js` and `.mjs` (strict) in `server/app.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b561e324baef0d6cff8f97d8e3e77055eeb3ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->