### PR TITLE
feat: Phoenix connection timeout handling

### DIFF
--- a/app/src/components/exception/BugReportErrorBoundaryFallback.tsx
+++ b/app/src/components/exception/BugReportErrorBoundaryFallback.tsx
@@ -1,12 +1,18 @@
 import { css } from "@emotion/react";
 
-import { ExternalLink, Flex, View } from "@phoenix/components";
+import { Button, ExternalLink, Flex, View } from "@phoenix/components";
 
+import { isConnectionTimeoutError } from "./isConnectionTimeoutError";
 import { ErrorBoundaryFallbackProps } from "./types";
 
 export function BugReportErrorBoundaryFallback({
   error,
 }: ErrorBoundaryFallbackProps) {
+  // Check if this is a connection timeout error
+  if (isConnectionTimeoutError(error)) {
+    return <ConnectionTimeoutFallback error={error} />;
+  }
+
   return (
     <View padding="size-200">
       <Flex direction="column">
@@ -39,6 +45,65 @@ export function BugReportErrorBoundaryFallback({
             {error}
           </pre>
         </details>
+      </Flex>
+    </View>
+  );
+}
+
+function ConnectionTimeoutFallback({
+  error,
+}: {
+  error: string | null | undefined;
+}) {
+  return (
+    <View padding="size-200">
+      <Flex direction="column">
+        <Flex direction="column" width="100%" alignItems="center">
+          <h1>Connection timed out</h1>
+        </Flex>
+        <p>
+          The connection to the Phoenix server timed out before a response was
+          received. This typically happens when a load balancer or proxy closes
+          the connection before the server can respond.
+        </p>
+        <p>Possible solutions:</p>
+        <ul
+          css={css`
+            margin: var(--ac-global-dimension-static-size-100) 0;
+            padding-left: var(--ac-global-dimension-static-size-300);
+          `}
+        >
+          <li>Increase your load balancer or proxy timeout settings</li>
+          <li>Check if the Phoenix server is overloaded or slow to respond</li>
+          <li>Verify network connectivity between components</li>
+        </ul>
+        <Flex direction="row" width="100%" justifyContent="end">
+          <Button
+            variant="primary"
+            size="S"
+            onPress={() => {
+              window.location.reload();
+            }}
+          >
+            Retry
+          </Button>
+        </Flex>
+        {error && (
+          <details>
+            <summary>error details</summary>
+            <pre
+              css={css`
+                white-space: pre-wrap;
+                overflow-wrap: break-word;
+                overflow: hidden;
+                overflow-y: auto;
+                max-height: 500px;
+              `}
+            >
+              {error}
+            </pre>
+          </details>
+        )}
       </Flex>
     </View>
   );

--- a/app/src/components/exception/__tests__/isConnectionTimeoutError.test.ts
+++ b/app/src/components/exception/__tests__/isConnectionTimeoutError.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { isConnectionTimeoutError } from "../isConnectionTimeoutError";
+
+describe("isConnectionTimeoutError", () => {
+  describe("returns true for connection timeout errors", () => {
+    it("detects Chrome JSON parse error from HTML response", () => {
+      expect(
+        isConnectionTimeoutError(
+          `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+        )
+      ).toBe(true);
+    });
+
+    it("detects Firefox JSON parse error from HTML response", () => {
+      expect(
+        isConnectionTimeoutError(
+          "JSON.parse: unexpected character at line 1 column 1 of the JSON data"
+        )
+      ).toBe(true);
+    });
+
+    it("detects error messages containing DOCTYPE", () => {
+      expect(isConnectionTimeoutError("<!DOCTYPE html>")).toBe(true);
+    });
+
+    it("detects timeout errors", () => {
+      expect(isConnectionTimeoutError("Request timeout")).toBe(true);
+      expect(isConnectionTimeoutError("Connection timeout")).toBe(true);
+    });
+
+    it("detects gateway errors", () => {
+      expect(isConnectionTimeoutError("502 Bad Gateway")).toBe(true);
+      expect(isConnectionTimeoutError("504 Gateway Timeout")).toBe(true);
+      expect(isConnectionTimeoutError("Bad Gateway")).toBe(true);
+    });
+
+    it("works with Error objects", () => {
+      const error = new Error(
+        `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+      );
+      expect(isConnectionTimeoutError(error)).toBe(true);
+    });
+  });
+
+  describe("returns false for non-timeout errors", () => {
+    it("returns false for null", () => {
+      expect(isConnectionTimeoutError(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isConnectionTimeoutError(undefined)).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isConnectionTimeoutError("")).toBe(false);
+    });
+
+    it("returns false for regular errors", () => {
+      expect(isConnectionTimeoutError("Something went wrong")).toBe(false);
+      expect(isConnectionTimeoutError("TypeError: Cannot read property")).toBe(
+        false
+      );
+      expect(isConnectionTimeoutError("Network error")).toBe(false);
+    });
+
+    it("returns false for valid JSON parse errors not caused by HTML", () => {
+      expect(
+        isConnectionTimeoutError("Unexpected token 'u' in JSON at position 0")
+      ).toBe(false);
+    });
+  });
+});

--- a/app/src/components/exception/index.tsx
+++ b/app/src/components/exception/index.tsx
@@ -1,2 +1,3 @@
 export * from "./ErrorBoundary";
+export * from "./isConnectionTimeoutError";
 export * from "./TextErrorBoundaryFallback";

--- a/app/src/components/exception/isConnectionTimeoutError.ts
+++ b/app/src/components/exception/isConnectionTimeoutError.ts
@@ -1,0 +1,51 @@
+/**
+ * Patterns that indicate a connection timeout error.
+ *
+ * When a load balancer or proxy times out before the server can respond,
+ * it typically returns an HTML error page (e.g., 502, 504). When the app
+ * tries to parse this HTML as JSON, it throws an error like:
+ * - Chrome: `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+ * - Firefox: `JSON.parse: unexpected character at line 1 column 1 of the JSON data`
+ *
+ * These patterns help detect such scenarios.
+ */
+const CONNECTION_TIMEOUT_PATTERNS = [
+  // Chrome/Safari/Edge pattern when trying to parse HTML as JSON
+  /Unexpected token ['"]?<['"]?/i,
+  // Firefox pattern when trying to parse HTML as JSON
+  /JSON\.parse.*unexpected character/i,
+  // Generic patterns for HTML response instead of JSON
+  /<!DOCTYPE/i,
+  // Network-level timeouts
+  /timeout/i,
+  // Gateway errors that may appear in error messages
+  /502|504|gateway/i,
+] as const;
+
+/**
+ * Detects if an error is likely a connection timeout error.
+ *
+ * This happens when a load balancer or proxy returns an HTML error page
+ * (e.g., 502 Bad Gateway, 504 Gateway Timeout) instead of the expected
+ * JSON response, and the JSON parser fails.
+ *
+ * @param error - The error to check (can be Error, string, or null/undefined)
+ * @returns true if the error matches connection timeout patterns
+ */
+export function isConnectionTimeoutError(
+  error: Error | string | null | undefined
+): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  const errorMessage = error instanceof Error ? error.message : error;
+
+  if (typeof errorMessage !== "string" || errorMessage.length === 0) {
+    return false;
+  }
+
+  return CONNECTION_TIMEOUT_PATTERNS.some((pattern) =>
+    pattern.test(errorMessage)
+  );
+}

--- a/app/src/pages/ErrorElement.tsx
+++ b/app/src/pages/ErrorElement.tsx
@@ -3,6 +3,7 @@ import { useRouteError } from "react-router";
 import { css } from "@emotion/react";
 
 import { Button, ExternalLink, Flex } from "@phoenix/components";
+import { isConnectionTimeoutError } from "@phoenix/components/exception/isConnectionTimeoutError";
 
 export function ErrorElement() {
   const error = useRouteError();
@@ -11,6 +12,10 @@ export function ErrorElement() {
     if (error instanceof Error && error.message === "Failed to fetch") {
       // We know this means the server disconnected
       return <NotFoundContent />;
+    }
+    if (error instanceof Error && isConnectionTimeoutError(error)) {
+      // Load balancer or proxy timed out before server could respond
+      return <ConnectionTimeoutContent />;
     }
     return <ErrorContent error={error} />;
   }, [error]);
@@ -50,6 +55,51 @@ function NotFoundContent() {
         We are unable to reach the Phoenix server. Please ensure that Phoenix is
         running and try again.
       </p>
+    </>
+  );
+}
+
+function ConnectionTimeoutContent() {
+  return (
+    <>
+      <Flex direction="column" width="100%" alignItems="center">
+        <h1>Connection timed out</h1>
+      </Flex>
+      <p>
+        The connection to the Phoenix server timed out before a response was
+        received. This typically happens when a load balancer or proxy closes
+        the connection before the server can respond.
+      </p>
+      <p>Possible solutions:</p>
+      <ul
+        css={css`
+          margin: var(--ac-global-dimension-static-size-100) 0;
+          padding-left: var(--ac-global-dimension-static-size-300);
+        `}
+      >
+        <li>Increase your load balancer or proxy timeout settings</li>
+        <li>Check if the Phoenix server is overloaded or slow to respond</li>
+        <li>Verify network connectivity between components</li>
+      </ul>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: row;
+          justify-content: flex-end;
+          align-items: center;
+          gap: var(--ac-global-dimension-static-size-100);
+        `}
+      >
+        <Button
+          variant="primary"
+          size="S"
+          onPress={() => {
+            window.location.reload();
+          }}
+        >
+          Retry
+        </Button>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Detect and surface connection timeout errors in the error boundary to provide users with actionable information instead of generic JSON parsing errors.

Previously, when a load balancer or proxy timed out before the server could respond, the application would receive an HTML error page instead of JSON. This led to unhelpful JSON parsing errors (e.g., "Unexpected token '<'") being displayed to the user. This PR introduces pattern matching to identify these specific timeout scenarios (e.g., `<!DOCTYPE`, `502`, `504`) and displays a user-friendly message with potential solutions, improving the user experience and reducing misfiled bug reports.

---
<a href="https://cursor.com/background-agent?bcId=bc-c748af7e-d07f-4183-9820-39ea78cd133b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c748af7e-d07f-4183-9820-39ea78cd133b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

