### PR TITLE
docs: add step headings to evaluation quickstarts for sidebar navigation

### DIFF
--- a/docs/phoenix/evaluation/python-quickstart.mdx
+++ b/docs/phoenix/evaluation/python-quickstart.mdx
@@ -6,6 +6,7 @@ sidebarTitle: "Python Quickstart"
 Now that you have Phoenix up and running, and sent traces to your first project, the next step you can take is running **evaluations** of your Python application. Evaluations let you measure and monitor the quality of your application by scoring traces against metrics like accuracy, relevance, or custom checks.
 
 <Steps>
+  ## Step 1: Launch Phoenix
   <Step title={<span className="step-title">Launch Phoenix</span>}>
     Before running evals, make sure Phoenix is running & you have sent traces in your project. For more step by step instructions, check out this [Get Started guide](/docs/phoenix/get-started) & [Get Started with Tracing guide](./get-started-tracing).
 
@@ -39,6 +40,7 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
+  ## Step 2: Install Phoenix Evals
   <Step title={<span className="step-title">Install Phoenix Evals</span>}>
     You'll need to install the evals library that's apart of Phoenix.
 
@@ -58,6 +60,7 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
+  ## Step 3: Pull down your Trace Data
   <Step title={<span className="step-title">Pull down your Trace Data</span>}>
     Since, we are running our evaluations on our trace data from our first project, we'll need to pull that data into our code.
 
@@ -99,6 +102,7 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
+  ## Step 4: Set Up Evaluations
   <Step title={<span className="step-title">Set Up Evaluations</span>}>
     In this example, we will define, create, and run our own evaluator. There's a number of different evaluators you can run, but this quick start will go through an LLM as a Judge Model.
 
@@ -223,6 +227,7 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
+  ## Step 5: Run Evaluation
   <Step title={<span className="step-title">Run Evaluation</span>}>
     Now that we have defined our evaluator, we're ready to evaluate our traces.
 
@@ -240,6 +245,7 @@ Now that you have Phoenix up and running, and sent traces to your first project,
     </Tabs>
   </Step>
 
+  ## Step 6: Log results to Visualize in Phoenix
   <Step title={<span className="step-title">Log results to Visualize in Phoenix</span>}>
     You'll now be able to log your evaluations in your project view.
 

--- a/docs/phoenix/evaluation/typescript-quickstart.mdx
+++ b/docs/phoenix/evaluation/typescript-quickstart.mdx
@@ -17,6 +17,7 @@ If you'd like to follow along with this evaluation example, you can check out th
 </Info>
 
 <Steps>
+  ## Step 1: Set up and Connect to Phoenix
   <Step title={<span className="step-title">Set up and Connect to Phoenix</span>}>
     Before running your experiment and evaluations, make sure your environment is set up by installing the required dependencies and connecting your application to [Phoenix Cloud](https://app.arize.com/auth/phoenix/).
 
@@ -32,6 +33,7 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
+  ## Step 2: Define a Task
   <Step title={<span className="step-title">Define a Task</span>}>
     Simply put, the task defines how your application should behave. The task specifies exactly which input fields to pass in and how the application should process that input. By standardizing execution across examples, tasks ensure that evaluations are consistent, repeatable, and comparable as your application evolves.
 
@@ -46,6 +48,7 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
+  ## Step 3: Define a Dataset
   <Step title={<span className="step-title">Define a Dataset</span>}>
     A meaningful evaluation starts with a well-constructed dataset. This dataset should contain a diverse set of examples that capture both typical success cases and realistic failure modes.
 
@@ -87,6 +90,7 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
+  ## Step 4: Create an Evaluator
   <Step title={<span className="step-title">Create an Evaluator</span>}>
     Once a task and dataset are defined, the final piece of the experimentation workflow is the evaluator.
 
@@ -117,6 +121,7 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
+  ## Step 5: Run the Experiment
   <Step title={<span className="step-title">Run the Experiment</span>}>
     An experiment ties the dataset, task, and evaluator together into an end-to-end process.
 
@@ -135,6 +140,7 @@ If you'd like to follow along with this evaluation example, you can check out th
     ```
   </Step>
 
+  ## Step 6: View Results in Phoenix Cloud
   <Step title={<span className="step-title">View Results in Phoenix Cloud</span>}>
     After the experiment completes, the results provide a detailed breakdown of how the application performed across all examples. You can quickly identify success cases, pinpoint failure modes, and analyze patterns across the dataset.
 


### PR DESCRIPTION
- Add ## headings for each step in Python and TypeScript evaluation quickstarts
- Enables "on this page" sidebar navigation to show all steps at a glance
- Makes it easier for users to quickly navigate between steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit section headers so quickstart steps appear in the “On this page” sidebar and are easier to scan.
> 
> - Insert `## Step 1–6` headings throughout `python-quickstart.mdx` and `typescript-quickstart.mdx` within their `<Steps>` flows
> - Content otherwise unchanged; no code or API modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 826153f280cf4a5f6b1415154e9349b6f3fb40bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->