### PR TITLE
fix: Ui annotation link fix

### DIFF
--- a/app/src/pages/trace/SpanAnnotationsEmpty.tsx
+++ b/app/src/pages/trace/SpanAnnotationsEmpty.tsx
@@ -15,7 +15,7 @@ export function SpanAnnotationsEmpty() {
 
         <ExternalLinkButton
           leadingVisual={<Icon svg={<Icons.Edit2Outline />} />}
-          href="https://arize.com/docs/phoenix/tracing/concepts-tracing/how-to-evaluate-traces"
+          href="https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/annotating-in-the-ui"
           size="S"
         >
           How to Annotate


### PR DESCRIPTION
Fix broken documentation link in `SpanAnnotationsEmpty.tsx` to point to the correct "Annotating in the UI" page.

---
[Slack Thread](https://arize-ai.slack.com/archives/C04R3GXC8HK/p1768052239362059?thread_ts=1768052239.362059&cid=C04R3GXC8HK)

<a href="https://cursor.com/background-agent?bcId=bc-071e84b9-0128-435e-b182-4a3358fccfba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-071e84b9-0128-435e-b182-4a3358fccfba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

