### PR TITLE
fix: Remove unused PublicSubnetIds parameter from CloudFormation template

### DIFF
--- a/tutorials/deployment/AWS Cloudformation/app.yml
+++ b/tutorials/deployment/AWS Cloudformation/app.yml
@@ -17,9 +17,6 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
 
-  PublicSubnetIds:
-    Type: List<AWS::EC2::Subnet::Id>
-
   PrivateSubnetIds:
     Type: List<AWS::EC2::Subnet::Id>
 


### PR DESCRIPTION
The `PublicSubnetIds` parameter was declared but never referenced in the app.yml template. Since this is an agent-only deployment that runs in private subnets with no ALB, the parameter serves no purpose.

Fixes #10876

Generated with [Claude Code](https://claude.ai/code)