### PR TITLE
fix: preserve dataset examples table tab and selection state

### DIFF
--- a/app/src/pages/dataset/DatasetPage.tsx
+++ b/app/src/pages/dataset/DatasetPage.tsx
@@ -135,10 +135,13 @@ function isTabName(name: unknown): name is TabName {
 }
 
 function getTabIndexFromPathname(pathname: string): number {
-  // We only need the last part of the path
-  const path = pathname.split("/").at(-1);
-  if (isTabName(path)) {
-    return TABS_LIST.indexOf(path);
+  // Check all path segments for a valid tab name
+  // This handles nested routes like /datasets/:id/examples/:exampleId
+  const segments = pathname.split("/");
+  for (const segment of segments) {
+    if (isTabName(segment)) {
+      return TABS_LIST.indexOf(segment);
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Fixes #10924

Path match failures caused tab nav to incorrectly reset and destroy selection state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves tab selection by making URL parsing robust to nested routes, preserving selection state across navigations.
> 
> - `getTabIndexFromPathname` now scans all path segments for a valid tab name (e.g., works for `/datasets/:id/examples/:exampleId`) instead of only the last segment
> - Ensures `Tabs` `selectedKey` remains correct, preventing resets of the Examples table tab/selection state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6376401c40b876d5afb8bff8d3a9e150b74d1ae8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->