### PR TITLE
feat(evals): add neutral optimization direction option

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/evaluators.py
+++ b/packages/phoenix-evals/src/phoenix/evals/evaluators.py
@@ -49,7 +49,7 @@ from .utils import (
 EvalInput = Dict[str, Any]
 ToolSchema = Optional[Dict[str, Any]]
 KindType = Literal["human", "llm", "heuristic", "code"]
-DirectionType = Literal["maximize", "minimize", "none"]
+DirectionType = Literal["maximize", "minimize", "neutral"]
 InputMappingType = Optional[Mapping[str, Union[str, Callable[[Mapping[str, Any]], Any]]]]
 
 


### PR DESCRIPTION
Some eval metrics may be neutral, e.g. "refusal" which could be good or bad, depending on context, so we should have an optimization direction that is neither positive nor negative. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a neutral optimization direction for evaluations.
> 
> - Extends `DirectionType` to include `"neutral"`, enabling non-optimizing metrics
> - `Score.direction`, `Evaluator.direction`, `LLMEvaluator`, `ClassificationEvaluator`, `create_evaluator`, and `create_classifier` now accept `"neutral"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2f0a115ae60cf0806b2e94187e06fe1ff4c913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->