### PR TITLE
fix: preserve literal mode in evaluator forms when editing

### DIFF
--- a/app/src/components/evaluators/ContainsEvaluatorForm.tsx
+++ b/app/src/components/evaluators/ContainsEvaluatorForm.tsx
@@ -45,6 +45,13 @@ export const ContainsEvaluatorForm = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
+
+  // Determine initial mode based on existing values
+  const textDefaultMode =
+    getValues("literalMapping.text") != null ? "literal" : "path";
+  const wordsDefaultMode =
+    getValues("pathMapping.words") != null ? "path" : "literal";
+
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="column" gap="size-100">
@@ -52,7 +59,7 @@ export const ContainsEvaluatorForm = () => {
           fieldName="text"
           label="Text"
           description="The text to search for the words in."
-          defaultMode="path"
+          defaultMode={textDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}
@@ -65,7 +72,7 @@ export const ContainsEvaluatorForm = () => {
           fieldName="words"
           label="Words"
           description="A comma separated list of words to search for in the text."
-          defaultMode="literal"
+          defaultMode={wordsDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}

--- a/app/src/components/evaluators/ExactMatchEvaluatorForm.tsx
+++ b/app/src/components/evaluators/ExactMatchEvaluatorForm.tsx
@@ -48,6 +48,13 @@ export const ExactMatchEvaluatorForm = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
+
+  // Determine initial mode based on existing values
+  const expectedDefaultMode =
+    getValues("literalMapping.expected") != null ? "literal" : "path";
+  const actualDefaultMode =
+    getValues("literalMapping.actual") != null ? "literal" : "path";
+
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="column" gap="size-100">
@@ -55,7 +62,7 @@ export const ExactMatchEvaluatorForm = () => {
           fieldName="expected"
           label="Expected"
           description="The expected text to compare against."
-          defaultMode="path"
+          defaultMode={expectedDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}
@@ -68,7 +75,7 @@ export const ExactMatchEvaluatorForm = () => {
           fieldName="actual"
           label="Actual"
           description="The actual text to compare."
-          defaultMode="path"
+          defaultMode={actualDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}

--- a/app/src/components/evaluators/JSONDistanceEvaluatorForm.tsx
+++ b/app/src/components/evaluators/JSONDistanceEvaluatorForm.tsx
@@ -48,6 +48,13 @@ export const JSONDistanceEvaluatorForm = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
+
+  // Determine initial mode based on existing values
+  const expectedDefaultMode =
+    getValues("literalMapping.expected") != null ? "literal" : "path";
+  const actualDefaultMode =
+    getValues("literalMapping.actual") != null ? "literal" : "path";
+
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="column" gap="size-100">
@@ -55,7 +62,7 @@ export const JSONDistanceEvaluatorForm = () => {
           fieldName="expected"
           label="Expected"
           description="The expected JSON string."
-          defaultMode="path"
+          defaultMode={expectedDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}
@@ -68,7 +75,7 @@ export const JSONDistanceEvaluatorForm = () => {
           fieldName="actual"
           label="Actual"
           description="The actual JSON string to compare."
-          defaultMode="path"
+          defaultMode={actualDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}

--- a/app/src/components/evaluators/LevenshteinDistanceEvaluatorForm.tsx
+++ b/app/src/components/evaluators/LevenshteinDistanceEvaluatorForm.tsx
@@ -49,6 +49,13 @@ export const LevenshteinDistanceEvaluatorForm = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
+
+  // Determine initial mode based on existing values
+  const expectedDefaultMode =
+    getValues("literalMapping.expected") != null ? "literal" : "path";
+  const actualDefaultMode =
+    getValues("literalMapping.actual") != null ? "literal" : "path";
+
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="column" gap="size-100">
@@ -56,7 +63,7 @@ export const LevenshteinDistanceEvaluatorForm = () => {
           fieldName="expected"
           label="Expected"
           description="The expected text."
-          defaultMode="path"
+          defaultMode={expectedDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}
@@ -69,7 +76,7 @@ export const LevenshteinDistanceEvaluatorForm = () => {
           fieldName="actual"
           label="Actual"
           description="The actual text to compare."
-          defaultMode="path"
+          defaultMode={actualDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}

--- a/app/src/components/evaluators/RegexEvaluatorForm.tsx
+++ b/app/src/components/evaluators/RegexEvaluatorForm.tsx
@@ -46,6 +46,11 @@ export const RegexEvaluatorForm = () => {
     (state) => state.evaluatorMappingSource
   );
   const allExampleKeys = useFlattenedEvaluatorInputKeys(evaluatorMappingSource);
+
+  // Determine initial mode based on existing values
+  const textDefaultMode =
+    getValues("literalMapping.text") != null ? "literal" : "path";
+
   return (
     <Flex direction="column" gap="size-200">
       <Flex direction="column" gap="size-100">
@@ -68,7 +73,7 @@ export const RegexEvaluatorForm = () => {
           fieldName="text"
           label="Text"
           description="The text to search."
-          defaultMode="path"
+          defaultMode={textDefaultMode}
           control={control}
           setValue={setValue}
           pathOptions={allExampleKeys}


### PR DESCRIPTION
When editing a saved dataset evaluator with fields set to "Text" (literal) mode, the form would incorrectly default to "Path" mode on load with empty data, and needed a manual mode change to restore saved data.

This fix sets the form's initial mode based on existing values, when present.

Applies to:
- ContainsEvaluatorForm
- ExactMatchEvaluatorForm
- JSONDistanceEvaluatorForm
- LevenshteinDistanceEvaluatorForm
- RegexEvaluatorForm

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->