### PR TITLE
ci: add github to claude code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "github@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ sdist
 **/.pytest_cache
 **/.ipynb_checkpoints/
 **/.DS_Store
+**/.playwright-mcp/
 
 # Server static files
 /src/phoenix/server/static/*


### PR DESCRIPTION
The affects of this are not 100% clear but it lets claude reason over issues and pull in context dynamically, which should help in feature development and also in review.