### PR TITLE
fix(ui): render dict tool returns as JSON (#10921)

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -93,7 +93,10 @@ import {
 } from "@phoenix/openInference/tracing/types";
 import { assertUnreachable, isStringArray } from "@phoenix/typeUtils";
 import { isModelProvider } from "@phoenix/utils/generativeUtils";
-import { safelyParseJSON } from "@phoenix/utils/jsonUtils";
+import {
+  formatMessageContent,
+  safelyParseJSON,
+} from "@phoenix/utils/jsonUtils";
 import { formatFloat, numberFormatter } from "@phoenix/utils/numberFormatUtils";
 
 import { RetrievalEvaluationLabel } from "../project/RetrievalEvaluationLabel";
@@ -1444,7 +1447,11 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
           <Flex direction="row" gap="size-100" alignItems="center">
             <ConnectedMarkdownModeSelect />
             <CopyToClipboardButton
-              text={messageContent || JSON.stringify(message)}
+              text={
+                messageContent
+                  ? formatMessageContent(messageContent)
+                  : JSON.stringify(message)
+              }
             />
           </Flex>
         }
@@ -1497,7 +1504,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
                   {messageContent ? (
                     <View width="100%">
                       <ConnectedMarkdownBlock>
-                        {messageContent}
+                        {formatMessageContent(messageContent)}
                       </ConnectedMarkdownBlock>
                     </View>
                   ) : null}
@@ -1507,7 +1514,7 @@ function LLMMessage({ message }: { message: AttributeMessage }) {
             messageContent ? (
               <View width="100%">
                 <ConnectedMarkdownBlock>
-                  {messageContent}
+                  {formatMessageContent(messageContent)}
                 </ConnectedMarkdownBlock>
               </View>
             ) : null}

--- a/app/src/utils/__tests__/jsonUtils.test.ts
+++ b/app/src/utils/__tests__/jsonUtils.test.ts
@@ -1,4 +1,8 @@
-import { isJSONObjectString, jsonStringToFlatObject } from "../jsonUtils";
+import {
+  formatMessageContent,
+  isJSONObjectString,
+  jsonStringToFlatObject,
+} from "../jsonUtils";
 
 describe("isJSONObjectString", () => {
   it("detects invalid JSON and JSON that's not objects", () => {
@@ -33,5 +37,53 @@ describe("jsonStringToFlatObject", () => {
       "a.b": 1,
       c: 2,
     });
+  });
+});
+
+describe("formatMessageContent", () => {
+  it("returns empty string for null and undefined", () => {
+    expect(formatMessageContent(null)).toEqual("");
+    expect(formatMessageContent(undefined)).toEqual("");
+  });
+
+  it("returns strings as-is", () => {
+    expect(formatMessageContent("hello")).toEqual("hello");
+    expect(formatMessageContent("")).toEqual("");
+    expect(formatMessageContent("test message")).toEqual("test message");
+  });
+
+  it("serializes objects to formatted JSON", () => {
+    expect(formatMessageContent({ a: 1 })).toEqual('{\n  "a": 1\n}');
+    expect(formatMessageContent({ foo: "bar", baz: 123 })).toEqual(
+      '{\n  "foo": "bar",\n  "baz": 123\n}'
+    );
+    expect(formatMessageContent({ nested: { key: "value" } })).toEqual(
+      '{\n  "nested": {\n    "key": "value"\n  }\n}'
+    );
+  });
+
+  it("serializes arrays to formatted JSON", () => {
+    expect(formatMessageContent([1, 2, 3])).toEqual("[\n  1,\n  2,\n  3\n]");
+    expect(formatMessageContent(["a", "b"])).toEqual('[\n  "a",\n  "b"\n]');
+  });
+
+  it("handles mixed content types", () => {
+    expect(formatMessageContent({ accessible_by_AI: ["file1", "file2"] })).toEqual(
+      '{\n  "accessible_by_AI": [\n    "file1",\n    "file2"\n  ]\n}'
+    );
+    expect(
+      formatMessageContent({
+        accessible_by_AI: ["doc1.txt", "doc2.pdf"],
+        not_accessible_by_AI: ["secret.txt"],
+      })
+    ).toEqual(
+      '{\n  "accessible_by_AI": [\n    "doc1.txt",\n    "doc2.pdf"\n  ],\n  "not_accessible_by_AI": [\n    "secret.txt"\n  ]\n}'
+    );
+  });
+
+  it("falls back to String() for non-serializable values", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    expect(formatMessageContent(circular)).toEqual("[object Object]");
   });
 });

--- a/app/src/utils/jsonUtils.ts
+++ b/app/src/utils/jsonUtils.ts
@@ -100,3 +100,31 @@ export function jsonStringToFlatObject(
   }
   return {} satisfies Record<string, string | boolean | number>;
 }
+
+/**
+ * Formats message content for display in the UI.
+ * Handles strings, objects, arrays, null, and undefined values.
+ * Objects and arrays are serialized to formatted JSON strings.
+ *
+ * @param content - The content to format. Can be any type.
+ * @returns A string representation suitable for display.
+ */
+export function formatMessageContent(content: unknown): string {
+  // Handle null and undefined
+  if (content == null) {
+    return "";
+  }
+
+  // If it's already a string, return as-is
+  if (typeof content === "string") {
+    return content;
+  }
+
+  // For objects and arrays, serialize to JSON
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch {
+    // Fallback for circular references or other serialization errors
+    return String(content);
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #10921 - Tool returns that are dictionaries (e.g., `dict[str, list[str]]`) now render as formatted JSON instead of `[object Object]` in the Phoenix UI messages view.

## Problem
When tools returned dictionary/object values like `{"accessible_by_AI": [...], "not_accessible_by_AI": [...]}`, they were displaying as `[object Object]` in the UI. The span attributes contained the correct data, but the rendering was broken because React cannot directly render objects as strings.

## Solution
Created a utility function `formatMessageContent()` that properly handles content serialization:
- Strings → returned as-is
- Objects/arrays → serialized to formatted JSON (2-space indent)
- null/undefined → empty string
- Circular references → fallback to String()

Updated the `LLMMessage` component in `SpanDetails.tsx` to use this formatter when rendering tool message content.

## Changes
- Added `formatMessageContent()` utility to `utils/jsonUtils.ts`
- Updated `LLMMessage` component to format message content before rendering
- Added comprehensive test coverage (6 new test cases)

## Testing
- ✅ All unit tests pass (312 tests)
- ✅ TypeScript type checking passes
- ✅ ESLint passes
- ✅ Build succeeds
- ✅ Tests cover null/undefined, strings, objects, arrays, and circular references

🤖 Generated with [Claude Code](https://claude.com/claude-code)