### PR TITLE
chore: add PostToolUse hooks to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,46 @@
 {
   "enabledPlugins": {
     "github@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".py\"))' | xargs -r uv tool run ruff format >&2 || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".py\"))' | xargs -r uv tool run ruff check --fix >&2 || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".py\"))' | xargs -r uv run mypy --strict >&2 || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run build:relay >&2' || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm exec prettier --write \"$@\" >&2' _ || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm exec eslint --fix \"$@\" >&2' _ || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r sh -c 'cd app && pnpm run typecheck >&2' || { [ $? -eq 1 ] && exit 2; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(contains(\"src/phoenix/db/migrations/versions\"))' | xargs -r sh -c 'tox run -e ddl_extract >&2' || { [ $? -eq 1 ] && exit 2; }"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add PostToolUse hooks to Claude Code settings for automatic code quality checks
- Python files: Auto-format with ruff, lint with ruff, type-check with mypy
- TypeScript/TSX files: Build GraphQL schema, format with prettier, lint with eslint, run type-check
- Database migrations: Auto-run DDL extraction

## Test plan
- [ ] Verify hooks trigger on Python file edits
- [ ] Verify hooks trigger on TypeScript file edits
- [ ] Verify hooks don't break existing Claude Code workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated post-edit hooks in `.claude/settings.json` to enforce code quality on save.
> 
> - Adds `hooks.PostToolUse` for `Write|Edit` to run language-specific tasks
> - Python: `ruff format`, `ruff check --fix`, `mypy --strict`
> - TypeScript/TSX: `app` `pnpm run build:relay`, `prettier --write`, `eslint --fix`, `pnpm run typecheck`
> - DB migrations: trigger `tox run -e ddl_extract` for files in `src/phoenix/db/migrations/versions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bbc8c2eeec92e2c5b94071a051cc560070f9aeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->