### PR TITLE
ci: disable parallel execution for integration tests to reduce flakes

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -536,7 +536,7 @@ jobs:
             requirements/integration-tests.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e integration_tests -- -ra -x --reruns 5
 
   test-migrations:


### PR DESCRIPTION
Removes `-n auto` from the integration tests command to disable parallel test execution, which should help reduce flaky test failures.