### PR TITLE
fix(repetitions): Store correct repetition count for non-streaming experiments

### DIFF
--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -212,7 +212,7 @@ class ChatCompletionMutationMixin:
                 name=input.experiment_name
                 or _default_playground_experiment_name(input.prompt_name),
                 description=input.experiment_description,
-                repetitions=1,
+                repetitions=input.repetitions,
                 metadata_=input.experiment_metadata or dict(),
                 project_name=project_name,
                 user_id=user_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures experiments over datasets reflect the requested repetition count.
> 
> - In `chat_mutations.chat_completion_over_dataset`, set `Experiment.repetitions = input.repetitions` (was hardcoded to `1`), so experiment snapshots and subsequent runs store the correct repetition count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59061b4296e00f8a7d458cb55b754b218a10fcbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->