### PR TITLE
fix: Preserve response format during model updates in playground store

### DIFF
--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -406,14 +406,24 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
                 );
 
               // Add back the response format if it exists and is supported by the model
+              // but only if it's not already present in mergedInvocationParameters
+              // (it would be present if the parameter had dirty: true)
               const modelSupportsResponseFormat =
                 supportedInvocationParameters.some(
                   (p) =>
                     p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME ||
                     p.invocationName === RESPONSE_FORMAT_PARAM_NAME
                 );
+              const responseFormatAlreadyInMerged =
+                mergedInvocationParameters.some(
+                  (p) =>
+                    p.canonicalName === RESPONSE_FORMAT_PARAM_CANONICAL_NAME ||
+                    p.invocationName === RESPONSE_FORMAT_PARAM_NAME
+                );
               const finalInvocationParameters =
-                responseFormatInvocationParameter && modelSupportsResponseFormat
+                responseFormatInvocationParameter &&
+                modelSupportsResponseFormat &&
+                !responseFormatAlreadyInMerged
                   ? [
                       ...mergedInvocationParameters,
                       responseFormatInvocationParameter,

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -325,7 +325,7 @@ export interface PlaygroundState extends Omit<PlaygroundProps, "instances"> {
    */
   upsertInvocationParameterInput: (params: {
     instanceId: number;
-    invocationParameterInput: InvocationParameterInput;
+    invocationParameterInput: ModelInvocationParameterInput;
   }) => void;
   /**
    * Delete an invocation parameter input for a model


### PR DESCRIPTION


https://github.com/user-attachments/assets/41cea67d-fd2c-4de0-a050-0f68bf1517c8



- Implement logic to retain the response format invocation parameter when changing models, ensuring it is not lost if marked as non-dirty.
- Update the invocation parameters to include the response format if supported by the new model.
- Add tests to verify that the response format is preserved when updating supported invocation parameters and when instances are copied.

Resolves #10487

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents loss of `response_format` when models update or instances are copied, and avoids duplicate entries when user-modified.
> 
> - In `playgroundStore.updateModelSupportedInvocationParameters`, retain existing `response_format` if the new model supports it and it isn’t already included; use `finalInvocationParameters` instead of the merged defaults alone
> - Import `RESPONSE_FORMAT` constants and add `createOpenAIResponseFormat` helper used by tests
> - Add tests verifying preservation on model change, during "Compare" (`addInstance`), and no duplication when `dirty: true`
> - Types: `upsertInvocationParameterInput` now accepts `ModelInvocationParameterInput`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 784f6d6fca02733225750942d8b880ecbaf78efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->