### PR TITLE
fix: show absolute path in logs when a relative path is used for PHOENIX_WORKING_DIR

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -943,7 +943,7 @@ def get_working_dir() -> Path:
     """
     working_dir_str = getenv(ENV_PHOENIX_WORKING_DIR)
     if working_dir_str is not None:
-        return Path(working_dir_str)
+        return Path(working_dir_str).resolve()
     # Fall back to ~/.phoenix if PHOENIX_WORKING_DIR is not set
     return Path.home().resolve() / ".phoenix"
 


### PR DESCRIPTION
<img width="969" height="621" alt="Screenshot 2026-01-14 at 1 35 41 PM" src="https://github.com/user-attachments/assets/51f6dd42-8b7a-44d3-b84d-3f02c2fdc65f" />

Previously, this said something like `sqlite:///../phoenix.db` if `PHOENIX_WORKING_DIR=../`. This is not incorrect, but just slightly less convenient.