### PR TITLE
feat: add cursor rule for creating new built-in metrics (llm classification evaluators)

### DIFF
--- a/.cursor/rules/new-builtin-metric.mdc
+++ b/.cursor/rules/new-builtin-metric.mdc
@@ -32,7 +32,9 @@ choices:
   incorrect: 0.0 # Adjust labels as needed
 ```
 
-**Template placeholders:** Use `{{variable_name}}` syntax (Mustache format). Common placeholders:
+**Template placeholders:** Use `{{variable_name}}` syntax (Mustache format). IMPORTANT: If the user does not specify what input data is provided, ask follow-up questions so you know exactly what placeholders are needed in the prompt template and what they should be called.
+
+Common placeholders:
 
 - `{{input}}` - User query or conversation context
 - `{{output}}` - LLM response to evaluate


### PR DESCRIPTION
## Rule: new-builtin-metric.mdc

### Purpose

A comprehensive guide for creating new built-in classification evaluator metrics for Phoenix evals. This includes all artifacts needed for a complete metric implementation.

### What Gets Created

1. **YAML Config** - Prompt template in `prompts/classification_evaluator_configs/`
2. **Generated Types** - Auto-generated via `tox -e compile_prompts`
3. **Python Evaluator** - Class in `packages/phoenix-evals/src/phoenix/evals/metrics/`
4. **TypeScript Evaluator** - Factory function in `js/packages/phoenix-evals/src/llm/`
5. **Benchmark Suite** - Test file in `js/benchmarks/evals-benchmarks/src/`

### Example Prompts

**Create a new metric from scratch:**

```
@new-builtin-metric.mdc Create a new metric called "factual_accuracy" with choices: accurate, inaccurate. It should evaluate whether an LLM's response contains factually correct information based on provided reference documents.
```

**Generate synthetic benchmark data:**

```
@new-builtin-metric.mdc I'm at Step 6 (benchmark creation). Generate 40 synthetic examples for the "factual_accuracy" metric. Include:
- 10 examples of accurate responses
- 10 examples with factual errors
- 10 examples with partially correct information
- 5 examples with hallucinated facts
- 5 edge cases (ambiguous or subjective claims)
```

**Improve an existing metric's prompt:**

```
@new-builtin-metric.mdc The benchmark for my "code_quality" metric is showing 65% accuracy. Review the YAML config and suggest improvements to the prompt criteria.
```

**Debug a failing step:**

```
@new-builtin-metric.mdc I'm getting import errors after running tox -e compile_prompts. The generated types aren't being found. Help me debug.
```

## Tips for Best Results

1. **Be specific about the metric's purpose** - Include what it evaluates, what the choices/labels should be, and any edge cases to consider. Be sure to describe what input fields it will accept so it can format the mustache template appropriately (e.g. `{{messages}}` or `{{input}}`)

2. **Provide examples of correct/incorrect cases** - This helps the agent understand the evaluation criteria.

3. **Use separate sessions for synthetic data** - Complex benchmark datasets benefit from dedicated agent sessions focused only on data generation.

4. **Iterate on the prompt** - Run benchmarks, analyze failures, and refine the YAML config criteria.

5. **Reference existing metrics** - Point to similar metrics as patterns (e.g., "similar to tool_selection but for X").

---

## Usage

### Method 1: Reference with `@` in Chat

Reference a rule directly in your prompt using the `@` symbol:

```
@new-builtin-metric.mdc Create a new metric called "response_relevance" that evaluates if an LLM response is relevant to the user's question
```

### Method 2: Chain with Other Context

Combine rule references with file references for more specific guidance:

```
@new-builtin-metric.mdc Look at @TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG.yaml as a reference and create a similar metric for API call validation
```

### Method 3: Step-by-Step Execution

For complex tasks, reference the rule and specify which step you're on:

```
@new-builtin-metric.mdc I've completed steps 1-4. Now help me with Step 5 - creating the TypeScript evaluator wrapper for my "code_quality" metric.
```

---

## Using Rules in Claude Code

### Option 1: Reference the File Path

Include the rule file path in your prompt:

```
Using the guide at .cursor/rules/new-builtin-metric.mdc, create a new metric called "response_relevance"
```

### Option 2: Add to CLAUDE.md

For project-wide availability, reference the rule in your `CLAUDE.md` file:

```markdown
## Rules

When creating new built-in metrics, follow the guide at `.cursor/rules/new-builtin-metric.mdc`
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a concise, end-to-end rule file to standardize creation of built-in classification evaluator metrics.
> 
> - Adds `/.cursor/rules/new-builtin-metric.mdc` with steps for YAML config, prompt compilation, Python and TypeScript evaluators, JS build, and benchmark suite
> - Provides code templates for `packages/phoenix-evals/src/phoenix/evals/metrics/{metric_name}.py` and `js/packages/phoenix-evals/src/llm/create{MetricName}Evaluator.ts`, plus export guidance for `llm/index.ts`
> - Details benchmark structure, dataset targets, accuracy evaluator, and run instructions
> - Includes checklist and prompt-writing tips for clarity and edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 231d6fa795517085605db079d701da6d82b985ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->