### PR TITLE
ci: add await to page.goto for login navigation

### DIFF
--- a/app/global-setup.ts
+++ b/app/global-setup.ts
@@ -4,7 +4,7 @@ async function globalSetup(config: FullConfig) {
   const { baseURL } = config.projects[0].use;
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  page.goto(`${baseURL}/login`);
+  await page.goto(`${baseURL}/login`);
   await page.getByLabel("Email").fill("admin@localhost");
   await page.getByLabel("Password").fill("admin");
   await page.getByRole("button", { name: "Log In", exact: true }).click();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Test setup reliability**
> 
> - Add `await` to `page.goto(`${baseURL}/login`)` in `app/global-setup.ts` to ensure navigation completes before subsequent actions in Playwright global setup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b008650e8c2b000af7a345928ea840f19d2a5e92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->