### PR TITLE
refactor: don't open browser for vite

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -51,9 +51,6 @@ export default defineConfig(() => {
     preview: {
       port: 6006,
     },
-    server: {
-      open: "http://localhost:6006",
-    },
     resolve: {
       alias: {
         "@phoenix": resolve(__dirname, "src"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stops auto-launching the browser during local development.
> 
> - Removes `server.open` from `vite.config.mts`; preview still runs on port `6006`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe4dbc48fb384ab45ba9423101be0a7ff9f4e953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->