### PR TITLE
fix: resolve KeyError in spans query with pandas 3.0

### DIFF
--- a/src/phoenix/trace/dsl/query.py
+++ b/src/phoenix/trace/dsl/query.py
@@ -835,7 +835,7 @@ def _get_spans_dataframe(
     if df.empty:
         return df.drop("attributes", axis=1)
     df_attributes = pd.DataFrame.from_records(
-        df.attributes.map(_flatten_semantic_conventions),
+        df.attributes.map(_flatten_semantic_conventions).tolist(),
     ).set_axis(df.index, axis=0)
     df = pd.concat(
         [


### PR DESCRIPTION
## Summary

- Fix `KeyError: 0` when querying spans with pandas 3.0
- Convert Series to list before passing to `pd.DataFrame.from_records()` to maintain compatibility

## Root Cause

In pandas 3.0, the deprecated fallback behavior for integer indexing on Series with non-integer indices was removed. When `from_records()` internally does `data[0]` to inspect the first element, it now raises `KeyError: 0` instead of falling back to positional indexing.

## Test plan

- [x] Existing tests pass
- [ ] Verify fix works with pandas 3.0 in CI

Resolves #11034

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures spans querying works with pandas 3.0 by fixing attribute flattening.
> 
> - In `query.py::_get_spans_dataframe()`, change `pd.DataFrame.from_records(df.attributes.map(_flatten_semantic_conventions))` to `pd.DataFrame.from_records(df.attributes.map(_flatten_semantic_conventions).tolist())` to avoid `KeyError: 0` in pandas 3.0
> - No other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54b4e8920a61477bca436c246b66b865d9aa85e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->