### PR TITLE
Feat/gpt 5 support evals

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/models/openai.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/models/openai.py
@@ -163,9 +163,9 @@ class OpenAIModel(BaseModel):
     timeout: int = 120
 
     # GPT-5 specific parameters
-    reasoning_effort: Optional[str] = field(default="medium")
+    reasoning_effort: Optional[str] = field(default=None)
     """Controls reasoning depth for GPT-5 models: 'none', 'low', 'medium', 'high', 'xhigh'"""
-    verbosity: Optional[str] = field(default="medium")
+    verbosity: Optional[str] = field(default=None)
     """Controls output length for GPT-5 models: 'low', 'medium', 'high'"""
 
     # Azure options


### PR DESCRIPTION
# GPT-5 Support for Phoenix OpenAI Wrapper

Changes made to `phoenix.evals.legacy.models.openai.OpenAIModel` to support GPT-5 models.

## Problem

GPT-5 models differ from GPT-4 in several ways:
- Temperature is not supported
- Sampling params (`top_p`, `frequency_penalty`, `presence_penalty`) are not supported
- Uses `"developer"` role instead of `"system"`
- Uses `max_completion_tokens` instead of `max_tokens`
- Has new params: `reasoning_effort` and `verbosity`

## Usage Example

```python
from phoenix.evals import OpenAIModel

model = OpenAIModel(
    model="gpt-5-mini",
    max_tokens=1024,  # Set high - reasoning uses tokens too
    #reasoning_effort="medium", 
    #verbosity="medium",
)

response = model("Explain quantum computing.")
print(response)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **GPT-5 support in `OpenAIModel`**
> 
> - Treats `gpt-5*` like reasoning models: disables `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`; adds GPT-5-only `reasoning_effort` and `verbosity` (sent via `extra_body`).
> - Maps system role to `developer` for `gpt-5*` models.
> - Updates token param selection to use `max_completion_tokens` broadly and includes `gpt-5` in Azure reasoning model checks.
> - Minor: adjusts legacy completion prompt join and keeps existing async/sync paths and usage parsing unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40f01ea643af1ef4220228a10640cd6ac0f0250b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->