### PR TITLE
fix: update links to typescript documentation

### DIFF
--- a/app/src/components/project/Integrations.tsx
+++ b/app/src/components/project/Integrations.tsx
@@ -350,16 +350,14 @@ const TYPESCRIPT_INTEGRATIONS: IntegrationLinkProps[] = [
   },
   {
     name: "BeeAI",
-    docsHref:
-      "https://arize.com/docs/phoenix/integrations/typescript/beeai",
+    docsHref: "https://arize.com/docs/phoenix/integrations/typescript/beeai",
     githubHref:
       "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-beeai",
     icon: <BeeAISVG />,
   },
   {
     name: "MCP",
-    docsHref:
-      "https://arize.com/docs/phoenix/integrations/typescript/mcp",
+    docsHref: "https://arize.com/docs/phoenix/integrations/typescript/mcp",
     githubHref:
       "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-mcp",
     icon: <McpSVG />,


### PR DESCRIPTION
Fixes #11085 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates broken/outdated TypeScript integration docs links in `app/src/components/project/Integrations.tsx`.
> 
> - Updated `docsHref` for `OpenAI NodeJS SDK`, `LangChain.js`, `BeeAI`, and `MCP` to new documentation paths
> - No functional logic changes; UI and GitHub links remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a13da3f6bbafd9d436b1280de731596218f418db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->