### PR TITLE
ci: add --no-sources to uv pip install for migration tests

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -594,7 +594,7 @@ jobs:
           sparse-checkout: src/phoenix/
       - name: Install Phoenix from current branch
         run: |
-          uv pip install --system --reinstall-package arize-phoenix .
+          uv pip install --system --reinstall-package arize-phoenix --no-sources .
       - name: Test new migrations
         working-directory: ${{ env.PHOENIX_PATH }}
         run: |


### PR DESCRIPTION
## Summary
- Fixes the migration test CI job failing with `arize-phoenix-client references a workspace in tool.uv.sources but is not a workspace member`
- The `uv pip install --system` command doesn't operate in workspace mode, so `workspace = true` references fail
- Adding `--no-sources` tells uv to ignore `[tool.uv.sources]` and resolve dependencies from PyPI instead

## Test plan
- [ ] Migration test CI job passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes DB migration CI by altering install behavior and refreshes CI/dev tooling.
> 
> - In `python-CI.yml` migration job, adds `--no-sources` to `uv pip install --system --reinstall-package arize-phoenix` to ignore `[tool.uv.sources]` and resolve from PyPI
> - Introduces/updates Playwright E2E workflow to run app tests with cached browsers and PNPM install
> - Aligns Python/TypeScript CI steps (pin `setup-uv` to 0.8.6, consistent tox-uv invocations, caching globs) and minor matrix/runner tweaks
> - Adds Storybook config files and updates `app/package.json` scripts/dev deps to support Storybook and E2E workflows
> - Adds/updates developer docs (`CLAUDE.md`, `DEVELOPMENT.md`, `MIGRATION.md`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70772cfce96d85d4a9a9dc6da41df979e9191e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->