### PR TITLE
fix: fix input_schema access for builtin evaluators

### DIFF
--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -503,7 +503,7 @@ class BuiltInEvaluator(Evaluator, Node):
         evaluator_class = get_builtin_evaluator_by_id(self.id)
         if evaluator_class is None:
             raise NotFound(f"Built-in evaluator not found: {self.id}")
-        return evaluator_class.input_schema
+        return evaluator_class().input_schema
 
     @strawberry.field
     async def user(


### PR DESCRIPTION
Fixes crash on built-in evaluator slideover by instantiating the evaluator before trying to access input_schema.

<img width="4112" height="2332" alt="image" src="https://github.com/user-attachments/assets/80c52e35-745b-42ad-8a5a-c23f5d4ee32d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures built-in evaluator `input_schema` is accessed from an instance to match how `output_config` is retrieved.
> 
> - In `Evaluator.py`, `BuiltInEvaluator.input_schema` now returns `evaluator_class().input_schema` instead of the class attribute, fixing crashes when resolving this field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baa491bb8be2a0ef4d0bf33eaf4ce4c8b80e2a21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->