### PR TITLE
docs: update skills installation to use npx skills add

### DIFF
--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -30,6 +30,7 @@ This installs the skill to your project's skills directory (`.cursor/skills/`, `
 | Skill | Description | Recommended |
 |-------|-------------|-------------|
 | `phoenix-cli` | Debug and analyze LLM applications using Phoenix CLI tools. Teaches agents to fetch traces, analyze performance, and review experiments. | Yes |
+| `phoenix-evals` | Build and run evaluators for AI/LLM applications. Teaches agents to create code and LLM evaluators, run experiments, and validate against human feedback. | Optional |
 | `phoenix-tracing` | OpenInference semantic conventions and instrumentation. Teaches agents proper span types, attributes, and production deployment patterns. | Optional |
 
 #### skills add Options


### PR DESCRIPTION
Updates the coding agents documentation to use the current npx skills add command instead of the deprecated add-skill command. Also corrects GitHub repository URLs to point to vercel-labs/skills.