### PR TITLE
fix: support python 3.10 - 3.14 for all sub-packages

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -93,7 +93,7 @@ jobs:
     if: ${{ needs.changes.outputs.phoenix_client == 'true' }}
     strategy:
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     if: ${{ needs.changes.outputs.phoenix_otel == 'true' }}
     strategy:
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/packages/phoenix-client/pyproject.toml
+++ b/packages/phoenix-client/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-client"
 description = "LLM Observability"
 readme = "README.md"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.10, <3.15"
 license = {text="Apache-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,11 +15,11 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 version = "1.28.0"
 dependencies = [
@@ -69,7 +69,7 @@ exclude = [
 ]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
@@ -99,7 +99,7 @@ exclude = [
 
 [tool.pyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportUnusedFunction = false
 exclude = [
   "dist/",

--- a/packages/phoenix-client/src/phoenix/client/utils/executors.py
+++ b/packages/phoenix-client/src/phoenix/client/utils/executors.py
@@ -290,12 +290,20 @@ class AsyncExecutor(Executor):
                         break
                     await asyncio.sleep(self._concurrency_controller.inactive_check_interval)
                     continue
-            try:
-                priority, item = await asyncio.wait_for(queue.get(), timeout=1)
-            except asyncio.TimeoutError:
+            # Use asyncio.wait instead of wait_for for Python 3.14 compatibility
+            # (wait_for uses asyncio.timeout which requires task context)
+            get_task = asyncio.create_task(queue.get())
+            done, _ = await asyncio.wait({get_task}, timeout=1)
+            if not done:
+                get_task.cancel()
+                try:
+                    await get_task
+                except asyncio.CancelledError:
+                    pass
                 if done_producing.is_set() and queue.empty():
                     break
                 continue
+            priority, item = get_task.result()
             if termination_event.is_set():
                 # discard any remaining items in the queue
                 queue.task_done()
@@ -309,7 +317,7 @@ class AsyncExecutor(Executor):
                 generate_task = asyncio.create_task(self.generate(payload))
                 termination_event_watcher = asyncio.create_task(termination_event.wait())
                 done, _ = await asyncio.wait(
-                    [generate_task, termination_event_watcher],
+                    [generate_task, termination_event_watcher],  # type: ignore[list-item]
                     timeout=self.timeout,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
@@ -341,8 +349,11 @@ class AsyncExecutor(Executor):
                     if not generate_task.done():
                         generate_task.cancel()
                         try:
-                            await asyncio.wait_for(generate_task, timeout=1)
-                        except (asyncio.TimeoutError, asyncio.CancelledError):
+                            # Use asyncio.wait instead of wait_for for Python 3.14 compatibility
+                            done, _ = await asyncio.wait({generate_task}, timeout=1)
+                            if not done:
+                                pass  # Task didn't complete in time, move on
+                        except asyncio.CancelledError:
                             pass
                     # task timeouts are requeued at the same priority
                     await queue.put((priority, item))

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-evals"
 description = "LLM Evaluations"
 readme = "README.md"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.10, <3.15"
 license = {text="Elastic-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,12 +15,11 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 version = "2.8.0"
 dependencies = [
@@ -97,7 +96,7 @@ pypi = [
 exclude = [".git", "__pycache__", ".tox", "dist"]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -58,7 +58,6 @@ test = [
   "nest_asyncio",
   "pandas-stubs==2.0.3.230814",
   "types-tqdm",
-  "lameenc"
 ]
 
 [project.urls]

--- a/packages/phoenix-evals/tests/phoenix/evals/legacy/test_legacy_utils.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/legacy/test_legacy_utils.py
@@ -2,8 +2,6 @@ import base64
 import io
 import wave
 
-import lameenc
-
 from phoenix.evals.utils import NOT_PARSABLE, get_audio_format_from_base64, snap_to_rail
 
 PCM_ENC_STR = "cvhy+AT7BPsP/w//VgJWAhoBGgHyAPIAOgE6AdAA0ACA/4D/Nvs2+735vfkC+AL4EfYR9izy"
@@ -48,18 +46,17 @@ def test_get_audio_format_from_base64_wav():
 
 
 def test_get_audio_format_from_base64_mp3():
-    encoder = lameenc.Encoder()
-    encoder.set_bit_rate(BITRATE)
-    encoder.set_in_sample_rate(SAMPLE_RATE)
-    encoder.set_channels(CHANNELS)
-    encoder.set_quality(2)
+    # mp3 sample - starts with ID3 tag header followed by MP3 frame data
+    # ID3 header: "ID3" + version + flags + size, then MP3 frame sync 0xFF 0xFB
+    audio_base64 = (
+        "SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4Ljc2LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/7"
+        "UMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/7"
+        "UMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    )
 
-    mp3_bytes = encoder.encode(PCM_BYTES)
-    mp3_bytes += encoder.flush()
-
-    mp3_base64 = base64.b64encode(mp3_bytes).decode("utf-8")
-
-    assert get_audio_format_from_base64(mp3_base64) == "mp3"
+    assert get_audio_format_from_base64(audio_base64) == "mp3"
 
 
 def test_get_audio_format_from_base64_ogg():

--- a/packages/phoenix-otel/pyproject.toml
+++ b/packages/phoenix-otel/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-otel"
 description = "LLM Observability"
 readme = "README.md"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.10, <3.15"
 license = {text="Apache-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,12 +15,11 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 version = "0.14.0"
 dependencies = [
@@ -73,7 +72,7 @@ pypi = [
 exclude = [".git", "__pycache__", ".tox", "dist"]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Python support and tooling across packages and CI.
> 
> - Bumps `requires-python` to `>=3.10, <3.15` for `phoenix-client`, `phoenix-evals`, and `phoenix-otel`; removes 3.8/3.9 classifiers, adds 3.14
> - Aligns lint/type-check targets (`ruff` to `py310`, `pyright` to `3.10`)
> - Updates GitHub Actions matrices for `phoenix-client`, `phoenix-evals`, and `phoenix-otel` to test on Python `3.10` and `3.14` across OSes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a935627ef3fcf6743332ec692806952ec1e42e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->