### PR TITLE
refactor: use getSpanByOtelId query in _get_existing_spans

### DIFF
--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -9,6 +9,7 @@ import sys
 from abc import ABC, abstractmethod
 from base64 import b64decode, urlsafe_b64encode
 from collections.abc import Iterable, Iterator, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from contextvars import ContextVar
 from dataclasses import dataclass, replace


### PR DESCRIPTION
## Summary
- Refactors `_get_existing_spans` helper function to use the `getSpanByOtelId` GraphQL query
- Replaces the previous approach that queried all projects and filtered by span IDs
- Gets project information through `trace.project` instead of outer projects iteration

## Test plan
- [ ] Run integration tests that use `_get_existing_spans`
- [ ] Verify span lookup works correctly with the new query

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites `tests/integration/_helpers.py::_get_existing_spans` to directly query spans by OTEL span ID and fetch associated trace/project/session details.
> 
> - Switches to `getSpanByOtelId` GraphQL query; updates mapping to use `trace.project` and `trace.session`
> - Performs per-span queries concurrently via `ThreadPoolExecutor`; returns only found spans
> - Removes broad `projects` traversal and filter-by-ID logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c247aea5174c09a9f2929ef1bffa57459953e43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->