### PR TITLE
ci: skip PR comment step on workflow_dispatch trigger

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -33,7 +33,7 @@ jobs:
         run: python scripts/generate_sitemap.py
 
       - name: Comment on PR if sitemap generation failed
-        if: failure() && steps.generate.outcome == 'failure'
+        if: failure() && steps.generate.outcome == 'failure' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

- Fix sitemap generation workflow to skip the "Comment on PR" step when triggered via `workflow_dispatch`
- Previously, the step would fail because `context.issue.number` is undefined when there's no associated PR

## Context

This addresses feedback from PR #11123 where both `claude` and `cursor[bot]` identified that the PR comment step would error when the workflow is manually triggered.

## Test plan

- [ ] Verify workflow runs correctly on pull_request events (existing behavior)
- [ ] Verify workflow doesn't fail on workflow_dispatch when sitemap generation fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts the PR comment step in `generate-sitemap.yml` to only run on `pull_request` events.
> 
> - Updates the `if` condition for "Comment on PR if sitemap generation failed" to include `github.event_name == 'pull_request'`, preventing failures when triggered via `workflow_dispatch`
> - No other workflow logic changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34fdb1cff51d5b37ff7d1fdf7b1b828b39ea185e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->