### PR TITLE
fix: move namespace package discovery before imports

### DIFF
--- a/src/phoenix/__init__.py
+++ b/src/phoenix/__init__.py
@@ -1,3 +1,9 @@
+# The following line is needed to ensure that other modules using the
+# `phoenix.*` path can be discovered by Bazel. For details,
+# see: https://github.com/Arize-ai/openinference/issues/398
+# IMPORTANT: This must come BEFORE any imports that depend on namespace packages
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 import sys
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
@@ -36,11 +42,6 @@ Here are just a few of the things that phoenix does well:
   - Identify problematic embeddings cohorts using UMAP and clustering
   - Explore model performance, drift, and data quality metrics
 """
-
-# The following line is needed to ensure that other modules using the
-# `phoenix.*` path can be discovered by Bazel. For details,
-# see: https://github.com/Arize-ai/openinference/issues/398
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## Summary
Fixes `ModuleNotFoundError` when running `uv run arize-phoenix` in a uv workspace with editable sub-packages.

## Problem
The `pkgutil.extend_path()` call in `src/phoenix/__init__.py` was positioned after imports that depended on namespace packages (`phoenix.evals`, `phoenix.client`, `phoenix.otel`). This caused import errors when the main package tried to import from workspace subpackages installed in editable mode.

## Solution
Move the `extend_path()` call to the top of the file, before any imports. The namespace discovery mechanism must run before any code attempts to import from those namespaces.

## Changes
- Moved `__path__ = __import__("pkgutil").extend_path(__path__, __name__)` from line 43 to the top of `src/phoenix/__init__.py`
- Added clarifying comment that this must come before imports

## Test Plan
Verified that `uv run python -c "import phoenix.evals"` works correctly in a uv workspace setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures namespace package discovery runs before any imports to prevent import errors with editable subpackages.
> 
> - Moves `__path__ = __import__("pkgutil").extend_path(__path__, __name__)` to the top of `src/phoenix/__init__.py`
> - Adds clarifying comments about ordering; removes the old placement later in the file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f1c579780e9dd30b78490f1feb799680fc2fb88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->