### PR TITLE
fix: handle duplicate buildin evals by using dataset evaluator ids for the API

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetSection.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetSection.tsx
@@ -115,7 +115,7 @@ export function PlaygroundDatasetSection({
       )
       .reduce(
         (acc, datasetEvaluator) => {
-          acc[datasetEvaluator.evaluator.id] = {
+          acc[datasetEvaluator.id] = {
             name: datasetEvaluator.name,
             inputMapping:
               datasetEvaluator.inputMapping as Mutable<EvaluatorInputMappingInput>,

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1289,7 +1289,7 @@ export const getChatCompletionOverDatasetInput = ({
   datasetId: string;
   splitIds?: string[];
   /**
-   * Record of evaluator id to name and input mappings
+   * Record of datasetEvaluatorId to name and input mappings
    */
   evaluatorMappings: Record<
     string,
@@ -1316,8 +1316,8 @@ export const getChatCompletionOverDatasetInput = ({
     datasetId,
     splitIds: splitIds ?? null,
     evaluators: Object.entries(evaluatorMappings).map(
-      ([evaluatorId, { name, inputMapping }]) => ({
-        id: evaluatorId,
+      ([datasetEvaluatorId, { name, inputMapping }]) => ({
+        id: datasetEvaluatorId,
         name,
         inputMapping,
       })

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -386,18 +386,16 @@ class ChatCompletionMutationMixin:
 
         evaluations: dict[tuple[ExampleRowID, RepetitionNumber], list[EvaluationResultUnion]] = {}
         if input.evaluators:
-            dataset_id = from_global_id_with_expected_type(input.dataset_id, Dataset.__name__)
-            evaluator_node_ids = [evaluator.id for evaluator in input.evaluators]
+            dataset_evaluator_node_ids = [evaluator.id for evaluator in input.evaluators]
             async with info.context.db() as session:
                 evaluators = await get_evaluators(
-                    evaluator_node_ids=evaluator_node_ids,
+                    dataset_evaluator_node_ids=dataset_evaluator_node_ids,
                     session=session,
                     decrypt=info.context.decrypt,
                     credentials=input.credentials,
                 )
                 project_ids = await get_evaluator_project_ids(
-                    evaluator_node_ids=evaluator_node_ids,
-                    dataset_id=dataset_id,
+                    dataset_evaluator_node_ids=dataset_evaluator_node_ids,
                     session=session,
                 )
                 for (revision, repetition_number), experiment_run in zip(
@@ -517,7 +515,7 @@ class ChatCompletionMutationMixin:
         if input.evaluators:
             async with info.context.db() as session:
                 evaluators = await get_evaluators(
-                    evaluator_node_ids=[evaluator.id for evaluator in input.evaluators],
+                    dataset_evaluator_node_ids=[evaluator.id for evaluator in input.evaluators],
                     session=session,
                     decrypt=info.context.decrypt,
                     credentials=input.credentials,

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -274,7 +274,7 @@ class Subscription:
                 credentials=input.credentials,
             )
             evaluators = await get_evaluators(
-                evaluator_node_ids=[evaluator.id for evaluator in input.evaluators],
+                dataset_evaluator_node_ids=[evaluator.id for evaluator in input.evaluators],
                 session=session,
                 decrypt=info.context.decrypt,
                 credentials=input.credentials,
@@ -406,16 +406,15 @@ class Subscription:
                 decrypt=info.context.decrypt,
                 credentials=input.credentials,
             )
-            evaluator_node_ids = [evaluator.id for evaluator in input.evaluators]
+            dataset_evaluator_node_ids = [evaluator.id for evaluator in input.evaluators]
             evaluators = await get_evaluators(
-                evaluator_node_ids=evaluator_node_ids,
+                dataset_evaluator_node_ids=dataset_evaluator_node_ids,
                 session=session,
                 decrypt=info.context.decrypt,
                 credentials=input.credentials,
             )
             project_ids = await get_evaluator_project_ids(
-                evaluator_node_ids=evaluator_node_ids,
-                dataset_id=dataset_id,
+                dataset_evaluator_node_ids=dataset_evaluator_node_ids,
                 session=session,
             )
             if (

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -15,6 +15,7 @@ from strawberry.relay.types import GlobalID
 from vcr.request import Request as VCRRequest
 
 from phoenix.db import models
+from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.evaluators import (
     TEMPLATE_FORMATTED_MESSAGES,
     TEMPLATE_LITERAL_MAPPING,
@@ -34,7 +35,7 @@ from phoenix.server.api.types.ChatCompletionSubscriptionPayload import (
 from phoenix.server.api.types.Dataset import Dataset
 from phoenix.server.api.types.DatasetExample import DatasetExample
 from phoenix.server.api.types.DatasetVersion import DatasetVersion
-from phoenix.server.api.types.Evaluator import BuiltInEvaluator, LLMEvaluator
+from phoenix.server.api.types.Evaluator import DatasetEvaluator
 from phoenix.server.api.types.Experiment import Experiment
 from phoenix.server.api.types.node import from_global_id
 from phoenix.server.experiments.utils import is_experiment_project_name
@@ -886,14 +887,40 @@ class TestChatCompletionSubscription:
         openai_api_key: str,
         correctness_llm_evaluator: models.LLMEvaluator,
         custom_vcr: CustomVCR,
+        db: DbSessionFactory,
     ) -> None:
-        llm_evaluator_gid = str(
-            GlobalID(type_name=LLMEvaluator.__name__, node_id=str(correctness_llm_evaluator.id))
-        )
+        # Create dataset and DatasetEvaluators
         contains_id = _generate_builtin_evaluator_id("Contains")
-        builtin_evaluator_gid = str(
-            GlobalID(type_name=BuiltInEvaluator.__name__, node_id=str(contains_id))
-        )
+        async with db() as session:
+            dataset = models.Dataset(name="test-sub-eval-dataset", metadata_={})
+            session.add(dataset)
+            await session.flush()
+
+            llm_dataset_evaluator = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                evaluator_id=correctness_llm_evaluator.id,
+                name=Identifier("correctness"),
+                input_mapping={},
+                project=models.Project(name="sub-correctness-project", description=""),
+            )
+            builtin_dataset_evaluator = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                builtin_evaluator_id=contains_id,
+                name=Identifier("contains-four"),
+                input_mapping={},
+                project=models.Project(name="sub-contains-project", description=""),
+            )
+            session.add_all([llm_dataset_evaluator, builtin_dataset_evaluator])
+            await session.flush()
+
+            llm_evaluator_gid = str(
+                GlobalID(type_name=DatasetEvaluator.__name__, node_id=str(llm_dataset_evaluator.id))
+            )
+            builtin_evaluator_gid = str(
+                GlobalID(
+                    type_name=DatasetEvaluator.__name__, node_id=str(builtin_dataset_evaluator.id)
+                )
+            )
         variables = {
             "input": {
                 "messages": [
@@ -981,11 +1008,28 @@ class TestChatCompletionSubscription:
         openai_api_key: str,
         correctness_llm_evaluator: models.LLMEvaluator,
         custom_vcr: CustomVCR,
+        db: DbSessionFactory,
     ) -> None:
         """Test that no evaluation chunks are emitted when the chat completion errors out."""
-        evaluator_gid = str(
-            GlobalID(type_name=LLMEvaluator.__name__, node_id=str(correctness_llm_evaluator.id))
-        )
+        # Create dataset and DatasetEvaluator
+        async with db() as session:
+            dataset = models.Dataset(name="test-sub-error-dataset", metadata_={})
+            session.add(dataset)
+            await session.flush()
+
+            dataset_evaluator = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                evaluator_id=correctness_llm_evaluator.id,
+                name=Identifier("correctness"),
+                input_mapping={},
+                project=models.Project(name="sub-error-project", description=""),
+            )
+            session.add(dataset_evaluator)
+            await session.flush()
+
+            evaluator_gid = str(
+                GlobalID(type_name=DatasetEvaluator.__name__, node_id=str(dataset_evaluator.id))
+            )
         variables = {
             "input": {
                 "messages": [
@@ -1050,13 +1094,31 @@ class TestChatCompletionSubscription:
         gql_client: AsyncGraphQLClient,
         openai_api_key: str,
         custom_vcr: CustomVCR,
+        db: DbSessionFactory,
     ) -> None:
         """Test that builtin evaluators use name for annotation names."""
         exact_match_id = _generate_builtin_evaluator_id("ExactMatch")
-        evaluator_gid = str(
-            GlobalID(type_name=BuiltInEvaluator.__name__, node_id=str(exact_match_id))
-        )
         custom_name = "my-custom-exact-match"
+
+        # Create dataset and DatasetEvaluator
+        async with db() as session:
+            dataset = models.Dataset(name="test-sub-builtin-name-dataset", metadata_={})
+            session.add(dataset)
+            await session.flush()
+
+            dataset_evaluator = models.DatasetEvaluators(
+                dataset_id=dataset.id,
+                builtin_evaluator_id=exact_match_id,
+                name=Identifier(custom_name),
+                input_mapping={},
+                project=models.Project(name="sub-builtin-name-project", description=""),
+            )
+            session.add(dataset_evaluator)
+            await session.flush()
+
+            evaluator_gid = str(
+                GlobalID(type_name=DatasetEvaluator.__name__, node_id=str(dataset_evaluator.id))
+            )
         variables = {
             "input": {
                 "messages": [
@@ -1957,17 +2019,15 @@ class TestChatCompletionOverDatasetSubscription:
             single_example_dataset.id
         )
         llm_evaluator_gid = str(
-            GlobalID(
-                type_name=LLMEvaluator.__name__, node_id=str(llm_dataset_evaluator.evaluator_id)
-            )
+            GlobalID(type_name=DatasetEvaluator.__name__, node_id=str(llm_dataset_evaluator.id))
         )
         builtin_dataset_evaluator = await assign_exact_match_builtin_evaluator_to_dataset(
             single_example_dataset.id
         )
         builtin_evaluator_gid = str(
             GlobalID(
-                type_name=BuiltInEvaluator.__name__,
-                node_id=str(builtin_dataset_evaluator.builtin_evaluator_id),
+                type_name=DatasetEvaluator.__name__,
+                node_id=str(builtin_dataset_evaluator.id),
             )
         )
 
@@ -2484,7 +2544,7 @@ class TestChatCompletionOverDatasetSubscription:
             single_example_dataset.id
         )
         evaluator_gid = str(
-            GlobalID(type_name=LLMEvaluator.__name__, node_id=str(dataset_evaluator.evaluator_id))
+            GlobalID(type_name=DatasetEvaluator.__name__, node_id=str(dataset_evaluator.id))
         )
         dataset_gid = str(
             GlobalID(type_name=Dataset.__name__, node_id=str(single_example_dataset.id))
@@ -2569,8 +2629,8 @@ class TestChatCompletionOverDatasetSubscription:
         )
         evaluator_gid = str(
             GlobalID(
-                type_name=BuiltInEvaluator.__name__,
-                node_id=str(builtin_dataset_evaluator.builtin_evaluator_id),
+                type_name=DatasetEvaluator.__name__,
+                node_id=str(builtin_dataset_evaluator.id),
             )
         )
         custom_name = "my-dataset-exact-match"


### PR DESCRIPTION
resolves #11099
<img width="974" height="513" alt="Screenshot 2026-01-28 at 12 05 35 PM" src="https://github.com/user-attachments/assets/c1697d0c-7db8-491d-9304-6bbebd1d96fd" />

