### PR TITLE
fix: fix empty progress bar for zero score evals

### DIFF
--- a/app/src/pages/experiment/__tests__/utils.test.ts
+++ b/app/src/pages/experiment/__tests__/utils.test.ts
@@ -1,0 +1,63 @@
+import { calculateAnnotationScorePercentile } from "../utils";
+
+describe("calculateAnnotationScorePercentile", () => {
+  describe("with default min/max (0 to 1 range)", () => {
+    it("returns 0 for value of 0", () => {
+      expect(calculateAnnotationScorePercentile(0)).toEqual(0);
+    });
+
+    it("returns 50 for value of 0.5", () => {
+      expect(calculateAnnotationScorePercentile(0.5)).toEqual(50);
+    });
+
+    it("returns 100 for value of 1", () => {
+      expect(calculateAnnotationScorePercentile(1)).toEqual(100);
+    });
+  });
+
+  describe("with explicit min/max", () => {
+    it("calculates percentile correctly for custom range", () => {
+      expect(calculateAnnotationScorePercentile(5, 0, 10)).toEqual(50);
+      expect(calculateAnnotationScorePercentile(0, 0, 10)).toEqual(0);
+      expect(calculateAnnotationScorePercentile(10, 0, 10)).toEqual(100);
+    });
+
+    it("handles negative ranges", () => {
+      expect(calculateAnnotationScorePercentile(0, -10, 10)).toEqual(50);
+      expect(calculateAnnotationScorePercentile(-10, -10, 10)).toEqual(0);
+      expect(calculateAnnotationScorePercentile(10, -10, 10)).toEqual(100);
+    });
+
+    it("handles ranges not starting at 0", () => {
+      expect(calculateAnnotationScorePercentile(75, 50, 100)).toEqual(50);
+      expect(calculateAnnotationScorePercentile(50, 50, 100)).toEqual(0);
+      expect(calculateAnnotationScorePercentile(100, 50, 100)).toEqual(100);
+    });
+  });
+
+  describe("with null min/max values", () => {
+    it("uses default min of 0 when min is null", () => {
+      expect(calculateAnnotationScorePercentile(0.5, null, 1)).toEqual(50);
+    });
+
+    it("uses default max of 1 when max is null", () => {
+      expect(calculateAnnotationScorePercentile(0.5, 0, null)).toEqual(50);
+    });
+
+    it("uses default range when both are null", () => {
+      expect(calculateAnnotationScorePercentile(0.5, null, null)).toEqual(50);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns 0 when min === max === value === 0", () => {
+      expect(calculateAnnotationScorePercentile(0, 0, 0)).toEqual(0);
+    });
+
+    it("returns 100 when min === max === value and value is non-zero", () => {
+      expect(calculateAnnotationScorePercentile(1, 1, 1)).toEqual(100);
+      expect(calculateAnnotationScorePercentile(5, 5, 5)).toEqual(100);
+      expect(calculateAnnotationScorePercentile(-1, -1, -1)).toEqual(100);
+    });
+  });
+});

--- a/app/src/pages/experiment/utils.ts
+++ b/app/src/pages/experiment/utils.ts
@@ -8,8 +8,9 @@ export function calculateAnnotationScorePercentile(
   const correctedMax = typeof max === "number" ? max : 1;
 
   if (correctedMin === correctedMax && correctedMax === value) {
-    // All the values are the same, so we want to display it as full rather than empty
-    return 100;
+    // All the values are the same
+    // If the value is 0, show empty; if non-zero, show full
+    return value === 0 ? 0 : 100;
   }
 
   // Avoid division by zero


### PR DESCRIPTION
Resolves https://github.com/Arize-ai/phoenix/issues/11100

Adds a special case to the annotation score percentile helper function to return 0 for annotations where the value, min, and max are all 0, rather than 100.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes percentile calculation for zero-score annotations.
> 
> - Updates `calculateAnnotationScorePercentile` in `app/src/pages/experiment/utils.ts` to return `0` when `min === max === value === 0`, otherwise `100` when all equal
> - Adds comprehensive unit tests in `app/src/pages/experiment/__tests__/utils.test.ts` covering default range, custom min/max (including negative/non-zero starts), null min/max handling, and edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edf068943afd44658129678119ae60d1881b1e48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->