### PR TITLE
fix(app): upgrade @apollo/client to 4.1.3 for multipart subscription cancellation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "license": "None",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.13.9",
+    "@apollo/client": "^4.1.3",
     "@arizeai/openinference-semantic-conventions": "^1.1.0",
     "@arizeai/point-cloud": "^4.1.0",
     "@codemirror/autocomplete": "6.12.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
   .:
     dependencies:
       '@apollo/client':
-        specifier: ^3.13.9
-        version: 3.13.9(@types/react@19.2.0)(graphql@16.11.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^4.1.3
+        version: 4.1.3(graphql@16.11.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)
       '@arizeai/openinference-semantic-conventions':
         specifier: ^1.1.0
         version: 1.1.0
@@ -362,13 +362,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@apollo/client@3.13.9':
-    resolution: {integrity: sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==}
+  '@apollo/client@4.1.3':
+    resolution: {integrity: sha512-2D0eN9R0IHj9qp1RwjM1/brKqcBGldlDfY0YiP5ecCj9FtVrhOtXqMj98SZ1CA0YGDY5X+dxx32Ljh7J0VHTfA==}
     peerDependencies:
-      graphql: ^15.0.0 || ^16.0.0
+      graphql: ^16.0.0
       graphql-ws: ^5.5.5 || ^6.0.3
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      react-dom: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+      rxjs: ^7.3.0
       subscriptions-transport-ws: ^0.9.0 || ^0.11.0
     peerDependenciesMeta:
       graphql-ws:
@@ -4488,17 +4489,6 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  rehackt@0.1.0:
-    resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: '*'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-
   relay-compiler@20.1.1:
     resolution: {integrity: sha512-J/FFFLS/3vnbDkyQMw8l3Ev7dNHXMgC1RAs0fITz4Q63TFPOw142knKxY1Mm5ZZBABkAs9g2JghXaqM+phwTxw==}
     hasBin: true
@@ -4580,6 +4570,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -4815,10 +4808,6 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
-  symbol-observable@4.0.0:
-    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
-    engines: {node: '>=0.10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4913,10 +4902,6 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  ts-invariant@0.10.3:
-    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
-    engines: {node: '>=8'}
 
   ts-plugin-sort-import-suggestions@1.0.4:
     resolution: {integrity: sha512-85n5lm2OQQ+b7aRNK9omU1gmjMNXRsgeLwojm5u4OSY5sVBkAHTcgMQPEeHMNlyyfFW0uXnwgqAU0pNfhD96Bw==}
@@ -5276,12 +5261,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zen-observable-ts@1.2.5:
-    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
-
-  zen-observable@0.8.15:
-    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
-
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
@@ -5341,7 +5320,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@apollo/client@3.13.9(@types/react@19.2.0)(graphql@16.11.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@apollo/client@4.1.3(graphql@16.11.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rxjs@7.8.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
       '@wry/caches': 1.0.1
@@ -5349,19 +5328,12 @@ snapshots:
       '@wry/trie': 0.5.0
       graphql: 16.11.0
       graphql-tag: 2.12.6(graphql@16.11.0)
-      hoist-non-react-statics: 3.3.2
       optimism: 0.18.1
-      prop-types: 15.8.1
-      rehackt: 0.1.0(@types/react@19.2.0)(react@19.2.0)
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
+      rxjs: 7.8.2
       tslib: 2.8.1
-      zen-observable-ts: 1.2.5
     optionalDependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@arizeai/openinference-semantic-conventions@1.1.0': {}
 
@@ -10587,11 +10559,6 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  rehackt@0.1.0(@types/react@19.2.0)(react@19.2.0):
-    optionalDependencies:
-      '@types/react': 19.2.0
-      react: 19.2.0
-
   relay-compiler@20.1.1: {}
 
   relay-runtime@20.1.1:
@@ -10706,6 +10673,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -10970,8 +10941,6 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  symbol-observable@4.0.0: {}
-
   symbol-tree@3.2.4: {}
 
   three-mesh-bvh@0.8.3(three@0.180.0):
@@ -11052,10 +11021,6 @@ snapshots:
       typescript: 5.4.5
 
   ts-dedent@2.2.0: {}
-
-  ts-invariant@0.10.3:
-    dependencies:
-      tslib: 2.8.1
 
   ts-plugin-sort-import-suggestions@1.0.4: {}
 
@@ -11449,12 +11414,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  zen-observable-ts@1.2.5:
-    dependencies:
-      zen-observable: 0.8.15
-
-  zen-observable@0.8.15: {}
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:

--- a/app/src/RelayEnvironment.ts
+++ b/app/src/RelayEnvironment.ts
@@ -1,13 +1,11 @@
-import { readMultipartBody } from "@apollo/client/link/http/parseAndCheckHttpResponse";
+import { createFetchMultipartSubscription } from "@apollo/client/utilities/subscriptions/relay";
 import {
   Environment,
-  type FetchFunction,
-  type GraphQLResponse,
+  FetchFunction,
   Network,
   Observable,
   RecordSource,
   Store,
-  type SubscribeFunction,
 } from "relay-runtime";
 import invariant from "tiny-invariant";
 
@@ -107,73 +105,9 @@ const fetchRelay: FetchFunction = (params, variables, _cacheConfig) =>
     }
   );
 
-/**
- * Custom multipart subscription function that properly supports cancellation.
- *
- * Apollo's createFetchMultipartSubscription doesn't use AbortController,
- * so dispose() has no effect. This implementation fixes that by:
- * 1. Creating an AbortController for each subscription
- * 2. Passing the signal to fetch
- * 3. Returning a cleanup function that aborts the fetch
- *
- * @see https://github.com/apollographql/apollo-client/blob/c33652da7c239275720831338f40674765897be7/src/utilities/subscriptions/relay/index.ts#L35-L61
- */
-function createSubscribe(
-  uri: string,
-  fetchFn: typeof fetch
-): SubscribeFunction {
-  return (operation, variables) => {
-    return Observable.create<GraphQLResponse>((sink) => {
-      const controller = new AbortController();
-
-      const body = JSON.stringify({
-        operationName: operation.name,
-        variables,
-        query: operation.text || "",
-      });
-
-      fetchFn(uri, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept:
-            "multipart/mixed;boundary=graphql;subscriptionSpec=1.0,application/json",
-        },
-        body,
-        signal: controller.signal,
-      })
-        .then((response) => {
-          const ctype = response.headers?.get("content-type");
-
-          if (ctype !== null && /^multipart\/mixed/i.test(ctype)) {
-            return readMultipartBody(response, (value: GraphQLResponse) => {
-              sink.next(value);
-            });
-          }
-
-          throw new Error("Expected multipart response");
-        })
-        .then(() => {
-          sink.complete();
-        })
-        .catch((err: Error) => {
-          if (err.name === "AbortError") {
-            // Subscription was cancelled - complete normally
-            sink.complete();
-          } else {
-            sink.error(err);
-          }
-        });
-
-      // Return cleanup function that aborts the fetch
-      return () => {
-        controller.abort();
-      };
-    });
-  };
-}
-
-const subscribe = createSubscribe(graphQLPath, graphQLFetch);
+const subscribe = createFetchMultipartSubscription(graphQLPath, {
+  fetch: graphQLFetch,
+});
 
 // Export a singleton instance of Relay Environment configured with our network layer:
 export default new Environment({

--- a/app/src/components/evaluators/EvaluatorInputVariablesContext/useEvaluatorInputVariables.ts
+++ b/app/src/components/evaluators/EvaluatorInputVariablesContext/useEvaluatorInputVariables.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { invariant } from "@apollo/client/utilities/globals";
+import invariant from "tiny-invariant";
 
 import { EvaluatorInputVariablesContext } from "@phoenix/components/evaluators/EvaluatorInputVariablesContext/evaluatorInputVariablesContext";
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the frontend GraphQL network/subscription layer and upgrades a major dependency; regressions could affect subscription streaming and cancellation behavior across the app.
> 
> **Overview**
> **Upgrades `@apollo/client` to `^4.1.3`** and updates the lockfile accordingly.
> 
> **Replaces the custom Relay multipart subscription handling** with Apollo’s `createFetchMultipartSubscription`, enabling native abort/cancel behavior for streaming GraphQL subscriptions (e.g., Playground cancel).
> 
> Also **removes reliance on deprecated Apollo globals** by using `tiny-invariant` for runtime assertions in the Relay network code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1075d60e77baebce67d62df9e8c1332a0483c61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->