### PR TITLE
chore(mock-llm-server): add tool call probability control to dashboard

### DIFF
--- a/scripts/mock-llm-server/dashboard/src/App.tsx
+++ b/scripts/mock-llm-server/dashboard/src/App.tsx
@@ -12,7 +12,7 @@ import { TimeRangeSelector } from "./components/TimeRangeSelector";
 import type { TimeRange } from "./utils/timeRange";
 
 function App() {
-  const [timeRange, setTimeRange] = useState<TimeRange>("10m");
+  const [timeRange, setTimeRange] = useState<TimeRange>("5m");
   const {
     connected,
     metrics,

--- a/scripts/mock-llm-server/dashboard/src/components/LatencyControls.tsx
+++ b/scripts/mock-llm-server/dashboard/src/components/LatencyControls.tsx
@@ -10,7 +10,7 @@ export function LatencyControls({ config, onUpdate }: Props) {
   if (!config) {
     return (
       <div className="bg-gray-800 rounded-lg p-3 border border-gray-700">
-        <h2 className="text-sm font-medium mb-2">Latency Controls</h2>
+        <h2 className="text-sm font-medium mb-2">Streaming Controls</h2>
         <div className="text-gray-500 text-xs">Waiting for config...</div>
       </div>
     );
@@ -20,7 +20,7 @@ export function LatencyControls({ config, onUpdate }: Props) {
 
   return (
     <div className="bg-gray-800 rounded-lg p-3 border border-gray-700">
-      <h2 className="text-sm font-medium mb-2">Latency Controls</h2>
+      <h2 className="text-sm font-medium mb-2">Streaming Controls</h2>
       <div className="space-y-2">
         <SliderControl
           label="Initial Delay"
@@ -57,6 +57,16 @@ export function LatencyControls({ config, onUpdate }: Props) {
           step={1}
           unit=" chars"
           onChange={(value) => onUpdate({ streamChunkSize: value })}
+        />
+        <SliderControl
+          label="Tool Call Probability"
+          value={global.toolCallProbability}
+          min={0}
+          max={1}
+          step={0.01}
+          unit="%"
+          displayMultiplier={100}
+          onChange={(value) => onUpdate({ toolCallProbability: value })}
         />
       </div>
     </div>

--- a/scripts/mock-llm-server/dashboard/src/components/RateLimitPanel.tsx
+++ b/scripts/mock-llm-server/dashboard/src/components/RateLimitPanel.tsx
@@ -121,15 +121,14 @@ export function RateLimitPanel({ config, onUpdate }: Props) {
           {rateLimit.strategy === "random" && (
             <SliderControl
               label="Failure Probability"
-              value={Math.round(rateLimit.failProbability * 100)}
+              value={rateLimit.failProbability}
               min={0}
-              max={100}
-              step={5}
+              max={1}
+              step={0.05}
               unit="%"
+              displayMultiplier={100}
               accentColor="yellow"
-              onChange={(value) =>
-                updateRateLimit({ failProbability: value / 100 })
-              }
+              onChange={(value) => updateRateLimit({ failProbability: value })}
             />
           )}
         </div>

--- a/scripts/mock-llm-server/dashboard/src/components/SliderControl.tsx
+++ b/scripts/mock-llm-server/dashboard/src/components/SliderControl.tsx
@@ -6,6 +6,7 @@ interface SliderControlProps {
   step: number;
   unit?: string;
   accentColor?: "blue" | "yellow";
+  displayMultiplier?: number; // Multiply displayed value (e.g., 100 for percentages)
   onChange: (value: number) => void;
 }
 
@@ -22,14 +23,23 @@ export function SliderControl({
   step,
   unit = "",
   accentColor = "blue",
+  displayMultiplier = 1,
   onChange,
 }: SliderControlProps) {
+  const displayValue = value * displayMultiplier;
+  // Format percentage values to whole numbers, others to reasonable precision
+  const formattedValue =
+    unit === "%"
+      ? Math.round(displayValue)
+      : displayValue % 1 === 0
+        ? displayValue
+        : displayValue.toFixed(1);
   return (
     <div>
       <div className="flex justify-between text-xs mb-0.5">
         <span className="text-gray-500">{label}</span>
         <span className="font-mono text-gray-300">
-          {value}
+          {formattedValue}
           {unit}
         </span>
       </div>

--- a/scripts/mock-llm-server/dashboard/src/components/TimeRangeSelector.tsx
+++ b/scripts/mock-llm-server/dashboard/src/components/TimeRangeSelector.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const TIME_RANGES: { value: TimeRange; label: string }[] = [
-  { value: "10m", label: "10m" },
+  { value: "5m", label: "5m" },
   { value: "30m", label: "30m" },
   { value: "60m", label: "60m" },
 ];

--- a/scripts/mock-llm-server/dashboard/src/utils/timeRange.ts
+++ b/scripts/mock-llm-server/dashboard/src/utils/timeRange.ts
@@ -1,9 +1,9 @@
-export type TimeRange = "10m" | "30m" | "60m";
+export type TimeRange = "5m" | "30m" | "60m";
 
 export function getTimeRangeMs(range: TimeRange): number {
   switch (range) {
-    case "10m":
-      return 10 * 60 * 1000;
+    case "5m":
+      return 5 * 60 * 1000;
     case "30m":
       return 30 * 60 * 1000;
     case "60m":

--- a/scripts/mock-llm-server/src/config.ts
+++ b/scripts/mock-llm-server/src/config.ts
@@ -106,7 +106,7 @@ export function getConfig(): ServerConfig {
 
     // Tool calls
     toolCallProbability: parseFloat(
-      process.env.TOOL_CALL_PROBABILITY || "0.75",
+      process.env.TOOL_CALL_PROBABILITY || "1.0",
     ),
 
     // Response content

--- a/scripts/mock-llm-server/src/handlers/anthropic-messages.ts
+++ b/scripts/mock-llm-server/src/handlers/anthropic-messages.ts
@@ -47,13 +47,12 @@ export function handleNonStreaming(
 
   // Decide whether to make a tool call
   const toolChoice = req.tool_choice as { type?: string } | undefined;
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     toolChoice?.type !== "none" &&
-    (toolChoice?.type === "any" ||
-      toolChoice?.type === "tool" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   let content: ContentBlock[] = [];
   let stopReason: StopReason = "end_turn";
@@ -128,13 +127,12 @@ export async function handleStreaming(
 
   // Decide whether to make a tool call
   const toolChoice = req.tool_choice as { type?: string } | undefined;
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     toolChoice?.type !== "none" &&
-    (toolChoice?.type === "any" ||
-      toolChoice?.type === "tool" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   const inputTokens = estimateTokens(
     req.messages

--- a/scripts/mock-llm-server/src/handlers/chat-completions.ts
+++ b/scripts/mock-llm-server/src/handlers/chat-completions.ts
@@ -53,12 +53,12 @@ export function handleNonStreaming(
   const created = Math.floor(Date.now() / 1000);
 
   // Decide whether to make a tool call
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     req.tool_choice !== "none" &&
-    (req.tool_choice === "required" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   let content: string | null = null;
   let toolCalls: ChatCompletionMessageToolCall[] | undefined = undefined;
@@ -133,12 +133,12 @@ export async function handleStreaming(
   };
 
   // Decide whether to make a tool call
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     req.tool_choice !== "none" &&
-    (req.tool_choice === "required" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   if (shouldMakeToolCall && req.tools) {
     await streamToolCall(req, res, id, created, config, sendChunk);

--- a/scripts/mock-llm-server/src/handlers/gemini.ts
+++ b/scripts/mock-llm-server/src/handlers/gemini.ts
@@ -84,11 +84,12 @@ export function handleNonStreaming(
   const functionDeclarations = extractFunctionDeclarations(request);
 
   // Decide whether to make a function call
+  // toolCallProbability overrides client's tool_choice (except "NONE" which always disables)
   const toolConfig = getToolConfig(request);
   const shouldMakeFunctionCall =
     functionDeclarations.length > 0 &&
     toolConfig?.mode !== "NONE" &&
-    (toolConfig?.mode === "ANY" || Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   let candidate: MockGenerateContentResponse["candidates"][0];
   const finishReason = "STOP";
@@ -217,11 +218,12 @@ export async function handleStreaming(
   };
 
   // Decide whether to make a function call
+  // toolCallProbability overrides client's tool_choice (except "NONE" which always disables)
   const toolConfig = getToolConfig(request);
   const shouldMakeFunctionCall =
     functionDeclarations.length > 0 &&
     toolConfig?.mode !== "NONE" &&
-    (toolConfig?.mode === "ANY" || Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   const contentsText = extractContentsText(request.contents);
   const promptTokens = estimateTokens(contentsText);

--- a/scripts/mock-llm-server/src/handlers/responses.ts
+++ b/scripts/mock-llm-server/src/handlers/responses.ts
@@ -78,12 +78,12 @@ export function handleNonStreaming(
   const createdAt = Date.now() / 1000;
 
   // Decide whether to make a tool call
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     req.tool_choice !== "none" &&
-    (req.tool_choice === "required" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   const output: ResponseOutputItem[] = [];
 
@@ -186,12 +186,12 @@ export async function handleStreaming(
   };
 
   // Decide whether to make a tool call
+  // toolCallProbability overrides client's tool_choice (except "none" which always disables)
   const shouldMakeToolCall =
     req.tools &&
     req.tools.length > 0 &&
     req.tool_choice !== "none" &&
-    (req.tool_choice === "required" ||
-      Math.random() < config.toolCallProbability);
+    Math.random() < config.toolCallProbability;
 
   // Create initial response object
   const initialResponse: ResponseObject = {

--- a/scripts/mock-llm-server/src/registry.ts
+++ b/scripts/mock-llm-server/src/registry.ts
@@ -92,7 +92,7 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   streamDelayMs: 50,
   streamJitterMs: 30,
   streamChunkSize: 10,
-  toolCallProbability: 0.75,
+  toolCallProbability: 1.0,
   errorRate: 0,
   errorTypes: ["server_error"],
   streamInterruptRate: 0,


### PR DESCRIPTION
## Summary
- Add slider control for tool call probability in streaming controls panel
- Rename "Latency Controls" to "Streaming Controls" for clarity
- Add `displayMultiplier` support to `SliderControl` for percentage formatting
- Change default time range from 10m to 5m and default tool call probability to 1.0


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because tool-call decision logic changes across multiple providers/endpoints; clients relying on `tool_choice` modes like "required"/"any" may see different behavior. UI-only changes are low risk, but the backend behavior shift affects response shape and tooling flows.
> 
> **Overview**
> **Dashboard:** Renames *Latency Controls* to *Streaming Controls*, adds a new `Tool Call Probability` slider, and enhances `SliderControl` with `displayMultiplier` so percentage-style sliders can store 0–1 values while displaying 0–100.
> 
> **Behavior/defaults:** Changes the default chart time range from `10m` to `5m`, increases default `toolCallProbability` to `1.0`, and updates tool/function-call selection in Anthropic/OpenAI/Gemini/Responses handlers so the global probability gates tool calls (with client `tool_choice: "none"`/`mode: "NONE"` still disabling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a31244a0ad16af256aa9b7ebf610205d007a89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->