### PR TITLE
chore: add hook to build phoenix client when openapi schema changes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(contains(\"schemas/openapi.json\"))' | xargs -r sh -c 'cd js && pnpm i && pnpm build >&2' || { [ $? -eq 1 ] && exit 2; }"
+            "command": "jq -r '.tool_input.file_path | select(contains(\"schemas/openapi.json\"))' | xargs -r sh -c 'cd js && { pnpm i && pnpm build; } >&2' || { [ $? -eq 1 ] && exit 2; }"
           }
         ]
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates Claude post-edit hooks to run an additional local build command when `schemas/openapi.json` changes; no runtime or production code is modified.
> 
> **Overview**
> Adds a new `.claude/settings.json` `PostToolUse` hook that detects edits to `schemas/openapi.json` and runs `pnpm i` + `pnpm build` in the `js` workspace to keep the Phoenix client in sync with OpenAPI schema changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a89423f5b3463d35f90b87d07cb3906d140779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->