### PR TITLE
fix(graphql): fix asExampleRevision accessing strawberry methods instead of ORM attributes

### DIFF
--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -721,17 +721,20 @@ class Span(Node):
             else await info.context.data_loaders.span_by_id.load(self.id)
         )
 
-        # Fetch annotations associated with this span
-        span_annotations = await self.span_annotations(info)
-        annotations = dict()
+        # Fetch annotations associated with this span using the dataloader
+        # which returns ORM objects directly
+        span_annotations = await info.context.data_loaders.span_annotations.load(self.id)
+        annotations: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for annotation in span_annotations:
-            annotations[annotation.name] = {
-                "label": annotation.label,
-                "score": annotation.score,
-                "explanation": annotation.explanation,
-                "metadata": annotation.metadata,
-                "annotator_kind": annotation.annotator_kind.value,
-            }
+            annotations[annotation.name].append(
+                {
+                    "label": annotation.label,
+                    "score": annotation.score,
+                    "explanation": annotation.explanation,
+                    "metadata": annotation.metadata_,
+                    "annotator_kind": annotation.annotator_kind,
+                }
+            )
         # Merge annotations into the metadata
         metadata = {
             "span_kind": span.span_kind,


### PR DESCRIPTION
## Summary

Fixes `'function' object has no attribute 'value'` error in `asExampleRevision` resolver by accessing ORM attributes directly instead of async strawberry field methods.

- Uses dataloader to get ORM SpanAnnotation objects
- Groups annotations by name as lists to handle duplicates
- Adds unit test

## Test plan

- [x] Unit test added
- [x] Manual test with span containing annotations

resolves #11149


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a GraphQL resolver’s response shape for `metadata.annotations` (now lists per name) and changes how annotation fields are read, which could impact downstream consumers expecting the old map structure.
> 
> **Overview**
> Fixes `Span.asExampleRevision` to load span annotations via the `span_annotations` dataloader and read ORM attributes directly, avoiding strawberry field/method access issues.
> 
> Changes `metadata.annotations` to group annotations by `name` into *lists* (supporting duplicates) and includes annotation details (`label`, `score`, `explanation`, `metadata_`, `annotator_kind`) per entry. Adds a unit test asserting the GraphQL `asExampleRevision` output includes correctly grouped annotations and expected field types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af8187a588ae689b446c73eb47709e40738a17f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->