### PR TITLE
fix: dataset experiments action button same size as siblings

### DIFF
--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -494,6 +494,7 @@ export function ExperimentsTable({
                 projectId={project?.id || null}
                 experimentId={row.original.id}
                 metadata={metadata}
+                size="S"
                 canDeleteExperiment={true}
                 onExperimentDeleted={() => {
                   refetch({}, { fetchPolicy: "network-only" });


### PR DESCRIPTION
Dataset experiments table omitted size prop, causing incorrect button size.

before
<img width="657" height="674" alt="Screenshot 2026-01-29 at 4 12 13 PM" src="https://github.com/user-attachments/assets/1e7d8df6-6ac2-45f0-944a-2a40595c5435" />

after
<img width="637" height="647" alt="Screenshot 2026-01-29 at 4 14 10 PM" src="https://github.com/user-attachments/assets/20c56b5a-73eb-41a1-93e7-d6df701f94f4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts a component prop to standardize button sizing; no data fetching or business logic changes.
> 
> **Overview**
> Fixes inconsistent action button sizing in the dataset `ExperimentsTable` by passing `size="S"` to `ExperimentActionMenu`, matching the sizing used by adjacent action controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2375c14c62e5951982628c21282c4d532edf1b77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->