### PR TITLE
fix: return undefined instead of empty braces for playground tool calls

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -200,13 +200,16 @@ const createExampleResponsesForInstance = (
             span,
             content,
             errorMessage,
-            toolCalls: toolCalls.reduce<Record<string, PartialOutputToolCall>>(
-              (map, toolCall) => {
-                map[toolCall.id] = toolCall;
-                return map;
-              },
-              {}
-            ),
+            toolCalls:
+              toolCalls.length > 0
+                ? toolCalls.reduce<Record<string, PartialOutputToolCall>>(
+                    (map, toolCall) => {
+                      map[toolCall.id] = toolCall;
+                      return map;
+                    },
+                    {}
+                  )
+                : undefined,
             evaluations: successfulEvaluations,
           },
         },
@@ -499,7 +502,7 @@ function ExampleOutputContent({
             {content != null ? (
               <DynamicContent value={content} key="content" />
             ) : null}
-            {toolCalls != null && Object.keys(toolCalls).length > 0 ? (
+            {toolCalls != null ? (
               <DynamicContent value={toolCalls} key="tool-calls-wrap" />
             ) : null}
           </Flex>


### PR DESCRIPTION
Latent bug exposed by recent changes in markdown rendering. Empty tool calls got converted to curly braces and displayed in playground output (example below). Fixed by returning undefined instead of empty braces when there are no tool calls.

<img width="1208" height="551" alt="Screenshot 2026-01-29 at 4 31 47 PM" src="https://github.com/user-attachments/assets/bd479007-0ae5-47d8-bb38-174e0632b927" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI data-shaping change that only affects how empty tool call results are represented/rendered in the playground output.
> 
> **Overview**
> Prevents empty tool-call output from rendering as `{}` in the dataset playground table by setting `toolCalls` to `undefined` when the backend returns no tool calls, instead of always reducing to an empty object. This keeps `DynamicContent` for tool calls gated on `toolCalls != null` and avoids a latent markdown/rendering regression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf8c6e7cc9c5f3cf64f06aef0565399d0204db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->