### PR TITLE
Phoenix Release Notes: 02-01-2026

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -8,6 +8,132 @@ GitHub
 </Card>
 
 
+
+<Update label="01.31.2026">
+## [01.31.2026: Tool Selection and Tool Invocation Evaluators](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in arize-phoenix-evals 0.16.0+ (Python) and @arizeai/phoenix-evals 1.3.0+ (TypeScript)**
+
+Phoenix now provides two specialized evaluators for assessing AI agent tool usage. The **Tool Selection Evaluator** judges whether an agent correctly chose the most appropriate tool from its available toolkit to answer a user's question, without evaluating the parameters passed. The **Tool Invocation Evaluator** assesses whether the agent correctly invoked a tool with proper parameters, JSON formatting, and safe values.
+
+These evaluators help developers:
+- **Identify tool selection errors** where agents choose suboptimal or incorrect tools
+- **Debug parameter issues** including hallucinated fields, malformed JSON, and incorrect values
+- **Improve tool descriptions** and agent prompts based on systematic evaluation
+- **Validate multi-tool and multi-turn interactions** across complex agent workflows
+
+Both evaluators are available as `ToolSelectionEvaluator` and `ToolInvocationEvaluator` in Python's `phoenix.evals.metrics` module, and as `createToolSelectionEvaluator` and `createToolInvocationEvaluator` in TypeScript.
+</Update>
+
+<Update label="01.28.2026">
+## [01.28.2026: Configurable Email Extraction for OAuth2 Providers](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in Phoenix 12.33.1+**
+
+Phoenix now supports custom email extraction from OAuth2 identity providers through the `PHOENIX_OAUTH2_{IDP}_EMAIL_ATTRIBUTE_PATH` environment variable. This solves authentication issues with providers like Azure AD/Entra ID where the standard `email` claim may be null but alternative claims like `preferred_username` contain the user's identity.
+
+Configure email extraction using JMESPath expressions:
+
+```bash
+</Update>
+
+<Update label="02.01.2026">
+## [02.01.2026: Extract from Azure AD preferred_username claim](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+PHOENIX_OAUTH2_AZURE_AD_EMAIL_ATTRIBUTE_PATH=preferred_username
+</Update>
+
+<Update label="02.01.2026">
+## [02.01.2026: Extract from nested claims](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+PHOENIX_OAUTH2_CUSTOM_IDP_EMAIL_ATTRIBUTE_PATH=user.contact.email
+```
+
+The default behavior remains unchanged, using the standard OIDC `email` claim when no custom path is specified. JMESPath expressions are validated at startup for immediate feedback on configuration errors.
+</Update>
+
+<Update label="01.22.2026">
+## [01.22.2026: CLI Commands for Prompts, Datasets, and Experiments](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in @arizeai/phoenix-cli 0.4.0+**
+
+The Phoenix CLI now provides comprehensive commands for managing prompts, datasets, and experiments directly from your terminal. Access version-controlled prompts, create evaluation datasets, and run experiments—all without leaving your development environment.
+
+**Prompt Management:**
+- **List and view prompts** with `px prompts` and `px prompt <name>`
+- **Pipe prompts to AI assistants** for optimization and analysis
+- **Text format output** with XML-style role tags for LLM consumption
+
+**Dataset Operations:**
+- **Create and manage datasets** with `px datasets` and `px dataset <name>`
+- **Add examples** and query dataset contents
+- **Export datasets** for offline analysis
+
+**Experiment Workflows:**
+- **Run experiments** and compare results across configurations
+- **View experiment details** and performance metrics
+- **Track changes** across prompt and model variations
+
+These commands integrate seamlessly with AI coding assistants and enable systematic testing of LLM applications through terminal-based workflows.
+</Update>
+
+<Update label="01.23.2026">
+## [01.23.2026: CLI Authentication Configuration](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in @arizeai/phoenix-cli 0.4.0+**
+
+The Phoenix CLI now includes enhanced authentication configuration commands, resolving database race conditions and improving connection reliability. Users can configure authentication settings directly through the CLI for more predictable and stable connections to Phoenix servers.
+</Update>
+
+<Update label="01.21.2026">
+## [01.21.2026: Create Datasets from Traces with Span Associations](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
+
+Phoenix now enables converting production traces into curated datasets while preserving bidirectional links back to source spans. Use the new `span_id_key` parameter to maintain traceability from evaluation examples to their original production executions.
+
+**Python Example:**
+```python
+from phoenix.client import Client
+
+client = Client()
+dataset = client.datasets.create_dataset(
+    name="production-queries",
+    dataframe=spans_df,
+    input_keys=["input"],
+    output_keys=["output"],
+    span_id_key="context.span_id"  # Links examples to spans
+)
+```
+
+**TypeScript Example:**
+```typescript
+import { createClient } from '@arizeai/phoenix-client';
+
+const client = createClient();
+await client.createDataset({
+    name: "production-queries",
+    examples: examples.map(ex => ({
+        input: ex.input,
+        output: ex.output,
+        spanId: ex.spanId  // Preserves trace links
+    }))
+});
+```
+
+Key capabilities:
+- **Batch resolution** of span IDs for optimal performance
+- **Graceful fallback** when span IDs are missing or invalid
+- **Backwards compatible** with existing dataset creation workflows
+- **Bidirectional navigation** between evaluation results and production traces
+</Update>
+
+<Update label="01.19.2026">
+## [01.19.2026: Export Annotations with Traces](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
+**Available in @arizeai/phoenix-cli 0.3.0+**
+
+The Phoenix CLI now supports exporting annotations alongside traces using the `--include-annotations` flag. Annotations—including manual labels, LLM evaluation scores, and programmatic feedback—are now preserved when exporting traces for offline analysis, backup, or migration workflows.
+
+```bash
+px traces export --include-annotations > traces_with_feedback.jsonl
+```
+
+This enables teams to maintain complete evaluation history when moving data between environments or conducting retrospective analysis of model performance.
+</Update>
+
 <Update label="01.22.2026">
 ## [01.22.2026: CLI Prompt Commands: Pipe Prompts to AI Assistants](/docs/phoenix/release-notes/01-2026/01-22-2026-cli-prompt-commands) 📝
 
@@ -143,8 +269,6 @@ You can now assign data splits (ex: train/test/validation) directly when uploadi
 
 This update adds an easy way to run several repetitions of the same prompt directly from the Playground.
 </Update>
-
-
 
 <Update label="11.14.2025">
 ## [11.14.2025: Expanded Provider Support with OpenAI 5.1 + Gemini 3](/docs/phoenix/release-notes/11-2025/11-19-2025-expanded-provider-support-with-openai-5-1-+-gemini-3) 🔧
@@ -542,6 +666,7 @@ Added client-side support for logging document annotations with a new `log_docum
 Easily spot timing bottlenecks with the new trace timeline visualization.
 
 </Update>
+
 <Update label="08.20.2025">
 ## [08.20.2025: New Experiment and Annotation Quick Filters 🏎️](/docs/phoenix/release-notes/08-2025/08-20-2025-new-experiment-and-annotation-quick-filters)
 
@@ -667,809 +792,12 @@ You can now delete spans using the REST API, enabling efficient data redaction a
 
 </Update>
 
-<Update label="07.29.2025" >
-## [07.29.2025: Google GenAI Evals](/docs/phoenix/release-notes/07-2025/07-29-2025-google-genai-evals) 🌐
-
-<Frame>
-    ![](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/gemini_logo.png)
-</Frame>
-
-New in `phoenix-evals`: Added support for Google's Gemini models via the Google GenAI SDK — multimodal, async, and ready to scale. Huge shoutout to [Siddharth Sahu](https://github.com/sahusiddharth) for this contribution!
-</Update>
-
-
-
-<Update label="07.25.2025" >
-## [07.25.2025: Project Dashboards](/docs/phoenix/release-notes/07-2025/07-25-2025-project-dashboards) 📈
-
-**Available in Phoenix 11.12+**
-
-<Frame>
-    ![](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/dashboards-release-notes.png)
-</Frame>
-
-Phoenix now has comprehensive project dashboards for detailed performance, cost, and error insights.
-</Update>
-
-
-
-<Update label="07.25.2025" >
-## [07.25.2025: Average Metrics in Experiment Comparison Table](/docs/phoenix/release-notes/07-2025/07-25-2025-average-metrics-in-experiment-comparison-table) 📊
-
-**Available in Phoenix 11.12+**
-
-<Frame>
-<video width="800" height="450" controls>
-<source src="https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/experiment-headers-average-metrics.mp4" type="video/mp4" />
-Your browser does not support the video tag.
-</video>
-</Frame>
-
-View average run metrics directly in the headers of the experiment comparison table for quick insights.
-</Update>
-
-
-
-<Update label="07.21.2025" >
-## [07.21.2025: Project and Trace Management via GraphQL](/docs/phoenix/release-notes/07-2025/07-21-2025-project-and-trace-management-via-graphql) 📤
-
-**Available in Phoenix 11.9+**
-
-Create new projects and transfer traces between them via GraphQL, with full preservation of annotations and cost data.
-</Update>
-
-
-
-<Update label="07.18.2025" >
-## [07.18.2025: OpenInference Java ✨](/docs/phoenix/release-notes/07-2025/07-18-2025-openinference-java)
-
-OpenInference Java now offers full OpenTelemetry-compatible tracing for AI apps, including auto-instrumentation for LangChain4j and semantic conventions.
-</Update>
-
-
-
-<Update label="07.13.2025" >
-## [07.13.2025: Experiments Module in `phoenix-client`](/docs/phoenix/release-notes/07-2025/07-13-2025-experiments-module-in-phoenix-client)  🧪
-
-**Available in Phoenix 11.7+**
-
-New experiments feature set in phoenix-client, enabling sync and async execution with task runs, evaluations, rate limiting, and progress reporting.
-</Update>
-
-
-
-<Update label="07.09.2025" >
-## [07.09.2025: Baseline for Experiment Comparisons](/docs/phoenix/release-notes/07-2025/07-09-2025-baseline-for-experiment-comparisons) 🔁
-
-**Available in Phoenix 11.6+**
-
-<Frame>
-<video controls width="800">
-<source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/experiment-baseline-comparison.mp4" type="video/mp4"/>
-Your browser does not support the video tag or cannot load the video from this source.
-</video>
-</Frame>
-
-Compare experiments relative to a baseline run to easily spot regressions and improvements across metrics.
-</Update>
-
-
-
-<Update label="07.07.2025" >
-## [07.07.2025: Database Disk Usage Monitor](/docs/phoenix/release-notes/07-2025/07-07-2025-databse-disk-usage-monitor) 🛑
-
-**Available in Phoenix 11.5+**
-
-Monitor database disk usage, notify admins when nearing capacity, and automatically block writes when critical thresholds are reached.
-</Update>
-
-
-
-<Update label="07.03.2025" >
-## [07.03.2025: Cost Summaries in Trace Headers](/docs/phoenix/release-notes/07-2025/07-03-2025-cost-summaries-in-trace-headers) 💸
-
-**Available in Phoenix 11.4+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/v6DMYMvx" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Added cost summaries to trace headers, showing total and segmented (prompt & completion) costs at a glance while debugging.
-</Update>
-
-
-
-<Update label="07.02.2025" >
-## [07.02.2025: Cursor MCP Button](/docs/phoenix/release-notes/07-2025/07-02-2025-cursor-mcp-button) ⚡️
-
-**Available in Phoenix 11.3+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/81oyvI06" width={1000} height={400} allowFullScreen scrolling="no" allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix README now has a "Add to Cursor" button for seamless IDE integration with Cursor. `@arizeai/phoenix-mcp@2.2.0` also includes a new tool called `phoenix-support`, letting agents like Cursor auto-instrument your apps using Phoenix and OpenInference best practices.
-</Update>
-
-
-
-<Update label="06.25.2025" >
-## [06.25.2025: Cost Tracking](/docs/phoenix/release-notes/06-2025/06-25-2025-cost-tracking) 💰
-
-**Available in Phoenix 11.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/rIqN5QUj" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix now automatically tracks token-based LLM costs using model pricing and token counts, rolling them up to trace and project levels for clear, actionable cost insights.
-</Update>
-
-
-
-<Update label="06.25.2025" >
-## [06.25.2025: New Phoenix Cloud](/docs/phoenix/release-notes/06-2025/06-25-2025-new-phoenix-cloud) ☁️
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/dBzo5JPj" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix now supports multiple customizable spaces with individual user access and collaboration, enabling teams to work together seamlessly.
-</Update>
-
-
-
-<Update label="06.25.2025" >
-## [06.25.2025: Amazon Bedrock Support in Playground](/docs/phoenix/release-notes/06-2025/06-25-2025-amazon-bedrock-support-in-playground) 🛝
-
-**Available in Phoenix 10.15+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/43ycpquD" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix’s Playground now supports Amazon Bedrock, letting you run, compare, and track Bedrock models alongside others—all in one place.
-</Update>
-
-
-
-<Update label="06.13.2025" >
-## [06.13.2025: Session Filtering 🪄](/docs/phoenix/release-notes/06-2025/06-13-2025-session-filtering)
-
-**Available in Phoenix 10.12+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/mYd4HURy" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Now you can filter sessions by their unique `session_id` across the API and UI, making it easier to pinpoint and inspect specific sessions.
-</Update>
-
-
-
-<Update label="06.13.2025" >
-## [06.13.2025: Enhanced Span Creation and Logging](/docs/phoenix/release-notes/06-2025/06-13-2025-enhanced-span-creation-and-logging) 🪐
-
-**Available in Phoenix 10.12+**
-
-Now you can create spans directly via a new POST API and client methods, with helpers to safely regenerate IDs and prevent conflicts on insertion.
-</Update>
-
-
-
-<Update label="06.12.2025" >
-## [06.12.2025: Dataset Filtering 🔍](/docs/phoenix/release-notes/06-2025/06-12-2025-dataset-filtering)
-
-**Available in Phoenix 10.11+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/D9lKIPd9" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Dataset name filtering with live search support across the API and UI.
-</Update>
-
-
-
-<Update label="06.06.2025" >
-## [06.06.2025: Experiment Progress Graph](/docs/phoenix/release-notes/06-2025/06-06-2025-experiment-progress-graph) 📊
-
-**Available in Phoenix 10.9+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/YEIcIgm6" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix now has experiment graphs to track how your evaluation scores and latency evolve over time.
-</Update>
-
-
-
-<Update label="06.04.2025" >
-## [06.04-2025: Ollama Support in Playground 🛝](/docs/phoenix/release-notes/06-2025/06-04-2025-ollama-support-in-playground)
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/mFE0Hgex" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-**Ollama** is now supported in the Playground, letting you experiment with its models and customize parameters for tailored prompting.
-</Update>
-
-
-
-<Update label="06.03.2025" >
-## [06.03.2025: Deploy Phoenix via Helm](/docs/phoenix/release-notes/06-2025/06-03-2025-deploy-via-helm) ☸️
-
-**Available in Phoenix 10.6+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/oApxptTr" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Added Helm chart support for Phoenix, making Kubernetes deployment fast, consistent, and easy to upgrade.
-</Update>
-
-
-
-<Update label="05.30.2025" >
-## [05.30.2025: xAI and Deepseek Support in Playground](/docs/phoenix/release-notes/05-2025/05-30-2025-xai-and-deepseek-support-in-playground) 🛝
-
-**Available in Phoenix 10.7+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/GZuNzZG7" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Deepseek and xAI models are now available in Prompt Playground!
-</Update>
-
-
-
-<Update label="05.20.2025" >
-## [05.20.2025: Datasets and Experiment Evaluations in the JS Client](/docs/phoenix/release-notes/05-2025/05-20-2025-datasets-and-experiment-evaluations-in-the-js-client) 🧪
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/z3Fw8fwy" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We've added a host of new methods to the JS client:
-
-* [getExperiment](https://arize-ai.github.io/docs/phoenix/functions/experiments.getExperiment.html) - allows you to retrieve an Experiment to view its results, and run evaluations on it
-
-* [evaluateExperiment](https://arize-ai.github.io/docs/phoenix/functions/experiments.evaluateExperiment.html) - allows you to evaluate previously run Experiments using LLM as a Judge or Code-based evaluators
-
-* [createDataset](https://arize-ai.github.io/docs/phoenix/functions/datasets.createDataset.html) - allows you to create Datasets in Phoenix using the client
-
-* [appendDatasetExamples](https://arize-ai.github.io/docs/phoenix/functions/datasets.appendDatasetExamples.html) - allows you to append additional examples to a Dataset
-</Update>
-
-
-
-<Update label="05.14.2025" >
-## [05.14.2025: Experiments in the JS Client](/docs/phoenix/release-notes/05-2025/05-14-2025-experiments-in-the-js-client) **🔬**
-
-<Frame caption="Experiments CLI output">
-    <iframe src="https://cdn.iframe.ly/4vqTlUCW" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-You can now run Experiments using the Phoenix JS client! Use Experiments to test different iterations of your applications over a set of test cases, then evaluate the results. This release includes:
-
-* Native tracing of tasks and evaluators
-
-* Async concurrency queues
-
-* Support for any evaluator (including bring your own evals)
-</Update>
-
-
-
-<Update label="05.09.2025" >
-## [05.09.2025: Annotations, Data Retention Policies, Hotkeys](/docs/phoenix/release-notes/05-2025/05-09-2025-annotations-data-retention-policies-hotkeys) 📓
-
-**Available in Phoenix 9.0+**
-
-<Tip>
-**Major Release:** Phoenix v9.0.0
-
-</Tip>
-
-<Frame caption="Annotation Improvements">
-    <iframe src="https://cdn.iframe.ly/Gfnn20w" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-Phoenix's v9.0.0 release brings with it:
-
-* A host of improvements to [Annotations](/docs/phoenix/tracing/llm-traces/how-to-annotate-traces), including one-to-many support, API access, annotation configs, and custom metadata
-
-* Customizable data retention policies
-
-* Hotkeys! 🔥
-</Update>
-
-
-
-<Update label="05.05.2025" >
-## [05.05.2025: OpenInference Google GenAI Instrumentation](/docs/phoenix/release-notes/05-2025/05-05-2025-openinference-google-genai-instrumentation) 🧩
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/bdf8oY5" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-We’ve added a Python auto-instrumentation library for the Google GenAI SDK. This enables seamless tracing of GenAI workflows with full OpenTelemetry compatibility. Additionally, the Google GenAI instrumentor is now supported and works seamlessly with Span Replay in Phoenix.
-</Update>
-
-
-
-<Update label="04.30.2025" >
-## [04.30.2025: Span Querying & Data Extraction for PX Client 📊](/docs/phoenix/release-notes/04-2025/04-30-2025-span-querying-and-data-extraction-for-phoenix-client)
-
-**Available in Phoenix 8.30+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/SKzAJon" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-The Phoenix client now includes the `SpanQuery` DSL for more advanced span querying. Additionally, a `get_spans_dataframe` method has been added to facilitate easier data extraction for span-related information.
-</Update>
-
-
-
-<Update label="04.28.2025" >
-## [04.28.2025: TLS Support for Phoenix Server 🔐](/docs/phoenix/release-notes/04-2025/04-28-2025-tls-support-for-phoenix-server)
-
-**Available in Phoenix 8.29+**
-
-Phoenix now supports Transport Layer Security (TLS) for both HTTP and gRPC connections, enabling encrypted communication and optional mutual TLS (mTLS) authentication. This enhancement provides a more secure foundation for production deployments.
-</Update>
-
-
-
-<Update label="04.28.2025" >
-## [04.28.2025: Improved Shutdown Handling 🛑](/docs/phoenix/release-notes/04-2025/04-28-2025-improved-shutdown-handling)
-
-**Available in Phoenix 8.28+**
-
-When stopping the Phoenix server via `Ctrl+C`, the shutdown process now exits cleanly with code 0 to reflect intentional termination. Previously, this would trigger a traceback with `KeyboardInterrupt`, misleadingly indicating a failure.
-</Update>
-
-
-
-<Update label="04.25.2025" >
-## [04.25.2025: Scroll Selected Span Into View 🖱️](/docs/phoenix/release-notes/04-2025/04-25-2025-scroll-selected-span-into-view)
-
-**Available in Phoenix 8.27+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/mtPPUrb" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Improved trace navigation by automatically scrolling the selected span into view when a user navigates to a specific trace. This enhances usability by making it easier to locate and focus on the relevant span without manual scrolling.
-</Update>
-
-
-
-<Update label="04.18.2025" >
-## [04.18.2025: Tracing for MCP Client-Server Applications](/docs/phoenix/release-notes/04-2025/04-18-2025-tracing-for-mcp-client-server-applications) 🔌
-
-**Available in Phoenix 8.26+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/Yqc5Yah" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We’ve released `openinference-instrumentation-mcp`, a new package in the OpenInference OSS library that enables seamless OpenTelemetry context propagation across MCP clients and servers. It automatically creates spans, injects and extracts context, and connects the full trace across services to give you complete visibility into your MCP-based AI systems.
-
-Big thanks to Adrian Cole and Anuraag Agrawal for their contributions to this feature.
-</Update>
-
-
-
-<Update label="04.16.2025" >
-## [04.16.2025: API Key Generation via API 🔐](/docs/phoenix/release-notes/04-2025/04-16-2025-api-key-generation-via-api)
-
-**Available in Phoenix 8.26+**
-
-Phoenix now supports programmatic API key creation through a new endpoint, making it easier to automate project setup and trace logging. To enable this, set the `PHOENIX_ADMIN_SECRET` environment variable in your deployment.
-</Update>
-
-
-
-<Update label="04.15.2025" >
-## [04.15.2025: Display Tool Call and Result IDs in Span Details 🫆](/docs/phoenix/release-notes/04-2025/04-15-2025-display-tool-call-and-result-ids-in-span-details)
-
-**Available in Phoenix 8.25+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/koXx6rf" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Tool call and result IDs are now shown in the span details view. Each ID is placed within a collapsible header and can be easily copied. This update also supports spans with multiple tool calls. Get started with tracing your tool calls [here](/docs/phoenix/tracing/llm-traces-1).
-</Update>
-
-
-
-<Update label="04.09.2025" >
-## [04.09.2025: Project Management API Enhancements ✨](/docs/phoenix/release-notes/04-2025/04-09-2025-project-management-api-enhancements)
-
-**Available in Phoenix 8.24+**
-
-This update enhances the Project Management API with more flexible project identification We've added support for identifying projects by both ID and hex-encoded name and introduced a new `_get_project_by_identifier` helper function.
-</Update>
-
-
-
-<Update label="04.09.2025" >
-## [04.09.2025: New REST API for Projects with RBAC 📽️](/docs/phoenix/release-notes/04-2025/04-09-2025-new-rest-api-for-projects-with-rbac)
-
-**Available in Phoenix 8.23+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/a2mKu6h" width={1000} height={400} allowFullScreen allow="encrypted-media *;"></iframe>
-</Frame>
-
-This release introduces a REST API for managing projects, complete with full CRUD functionality and access control. Key features include CRUD Operations and Role-Based Access Control. Check out our [new documentation](/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects)to test these features.
-</Update>
-
-
-
-<Update label="04.03.2025" >
-## [04.03.2025: Phoenix Client Prompt Tagging 🏷️](/docs/phoenix/release-notes/04-2025/04-03-2025-phoenix-client-prompt-tagging)
-
-**Available in Phoenix 8.22+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/mv6TDpf" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We’ve added support for Prompt Tagging in the Phoenix client. This new feature gives you more control and visibility over your prompts throughout the development lifecycle. Tag prompts directly in code, label prompt versions, and add tag descriptions. Check out documentation on [prompt tags](/docs/phoenix/prompt-engineering/how-to-prompts/tag-a-prompt).
-</Update>
-
-
-
-<Update label="04.02.2025" >
-## [04.02.2025 Improved Span Annotation Editor ✍️](/docs/phoenix/release-notes/04-2025/04-02-2025-improved-span-annotation-editor)
-
-**Available in Phoenix 8.21+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/YFp43kO" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-The new span aside moves the Span Annotation editor into a dedicated panel, providing a clearer view for adding annotations and enhancing customization of your setup. Read this documentation to learn how annotations can be used.
-</Update>
-
-
-
-<Update label="04.01.2025" >
-## [04.01.2025: Support for MCP Span Tool Info in OpenAI Agents SDK 🔨](/docs/phoenix/release-notes/04-2025/04-01-2025-support-for-mcp-span-tool-info-in-openai-agents-sdk)
-
-**Available in Phoenix 8.20+**
-
-Newly added to the OpenAI Agent SDK is support for MCP Span Info, allowing for the tracing and extraction of useful information about MCP tool listings. Use the Phoenix OpenAI Agents SDK for powerful agent tracing.
-</Update>
-
-
-
-<Update label="03.27.2025" >
-## [03.27.2025 Span View Improvements 👀](/docs/phoenix/release-notes/03-2025/03-27-2025-span-view-improvements)
-
-**Available in Phoenix 8.20+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/WsCbM8Y" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-You can now toggle the option to treat orphan spans as root when viewing your spans. Additionally, we've enhanced the UI with an icon view in span details for better visibility in smaller displays. Learn more [here](/docs/phoenix/tracing/how-to-tracing/setup-tracing).
-</Update>
-
-
-
-<Update label="03.24.2025" >
-## [03.24.2025: Tracing Configuration Tab 🖌️](/docs/phoenix/release-notes/03-2025/03-24-2025-tracing-configuration-tab)
-
-**Available in Phoenix 8.19+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/7hf3YeA" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Within each project, there is now a **Config** tab to enhance customization. The default tab can now be set per project, ensuring the preferred view is displayed. Learn more in [projects docs](/docs/phoenix/tracing/llm-traces/projects).
-</Update>
-
-
-
-<Update label="03.21.2025" >
-## [03.21.2025: Environmental Variable Based Admin User Configuration 🗝️](/docs/phoenix/release-notes/03-2025/03-21-2025-environment-variable-based-admin-user-configuration)
-
-**Available in Phoenix 8.17+**
-
-You can now preconfigure admin users at startup using an environment variable, making it easier to manage access during deployment. Admins defined this way are automatically seeded into the database and ready to log in.
-</Update>
-
-
-
-<Update label="03.20.2025" >
-## 03.20.2025: Delete Experiment from Action Menu 🗑️
-
-**Available in Phoenix 8.16+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/nK58mrP" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-You can now delete experiments directly from the action menu, making it quicker to manage and clean up your workspace.
-</Update>
-
-
-
-<Update label="03.19.2025" >
-## [03.19.2025: Access to New Integrations in Projects 🔌](/docs/phoenix/release-notes/03-2025/03-19-2025-access-to-new-integrations-in-projects)
-
-**Available in Phoenix 8.15+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/gxMnPmb" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-In the New Project tab, we've added quick setup to instrument your application for **BeeAI**, **SmolAgents**, and the **OpenAI Agents SDK**. Easily configure these integrations with streamlined instructions. Check out all Phoenix [tracing integrations](/docs/phoenix/integrations) here.
-</Update>
-
-
-
-<Update label="03.18.2025" >
-## [03.18.2025: Resize Span, Trace, and Session Tables 🔀](/docs/phoenix/release-notes/03-2025/03-18-2025-resize-span-trace-and-session-tables)
-
-**Available in Phoenix 8.14+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/bro1tIy" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We've added the ability to resize Span, Trace, and Session tables. Resizing preferences are now persisted in the tracing store, ensuring settings are maintained per-project and per-table.
-</Update>
-
-
-
-<Update label="03.14.2025" >
-## [03.14.2025: OpenAI Agents Instrumentation 📡](/docs/phoenix/release-notes/03-2025/03-14-2025-openai-agents-instrumentation)
-
-**Available in Phoenix 8.13+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/sDk1x3T" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We've introduced the **OpenAI Agents SDK** for Python which provides enhanced visibility into agent behavior and performance. For more details on a quick setup, check out our [docs](/docs/phoenix/integrations/llm-providers/openai/openai-agents-sdk-tracing).
-
-```sh
-pip install openinference-instrumentation-openai-agents openai-agents
-```
-</Update>
-
-
-
-<Update label="03.07.2025" >
-## [03.07.2025: Model Config Enhancements for Prompts](/docs/phoenix/release-notes/03-2025/03-07-2025-model-config-enhancements-for-prompts) 💡
-
-**Available in Phoenix 8.11+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/bqCqcAn" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-You can now save and load configurations directly from prompts or default model settings. Additionally, you can adjust the budget token value and enable/disable the "thinking" feature, giving you more control over model behavior and resource allocation.
-</Update>
-
-
-
-<Update label="03.07.2025" >
-## [03.07.2025: New Prompt Playground, Evals, and Integration Support 🦾](/docs/phoenix/release-notes/03-2025/03-07-2025-new-prompt-playground-evals-and-integration-support)
-
-**Available in Phoenix 8.9+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/GFVzMH7" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Prompt Playground now supports new GPT and Anthropic models with enhanced configuration options. Instrumentation options have been improved for better traceability, and evaluation capabilities have expanded to cover Audio & Multi-Modal Evaluations. Phoenix also introduces new integration support for LiteLLM Proxy & Cleanlabs evals.
-</Update>
-
-
-
-<Update label="03.06.2025" >
-## [03.06.2025: Project Improvements 📽️](/docs/phoenix/release-notes/03-2025/03-06-2025-project-improvements)
-
-**Available in Phoenix 8.8+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/GCKlvL0" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We’ve rolled out several enhancements to Projects, offering more flexibility and control over your data. Key updates include persistent column selection, advanced filtering options for metadata and spans, custom time ranges, and improved performance for tracing views. These changes streamline workflows, making data navigation and debugging more efficient.
-
-Check out [projects](/docs/phoenix/tracing/llm-traces/projects) docs for more.
-</Update>
-
-
-
-<Update label="02.19.2025" >
-## [02.19.2025: Prompts 📃](/docs/phoenix/release-notes/02-2025/02-19-2025-prompts)
-
-**Available in Phoenix 8.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/rH9HehD" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Phoenix prompt management will now let you create, modify, tag, and version control prompts for your applications. Some key highlights from this release:
-
-* **Versioning & Iteration**: Seamlessly manage prompt versions in both Phoenix and your codebase.
-
-* **New TypeScript Client**: Sync prompts with your JavaScript runtime, now with native support for OpenAI, Anthropic, and the Vercel AI SDK.
-
-* **New Python Client**: Sync templates and apply them to AI SDKs like OpenAI, Anthropic, and more.
-
-* **Standardized Prompt Handling**: Native normalization for OpenAI, Anthropic, Azure OpenAI, and Google AI Studio.
-
-* **Enhanced Metadata Propagation**: Track prompt metadata on Playground spans and experiment metadata in dataset runs.
-
-Check out the docs and this [walkthrough](https://youtu.be/qbeohWaRlsM?feature=shared) for more on prompts!📝
-</Update>
-
-
-
-<Update label="02.18.2025" >
-## [02.18.2025: One-Line Instrumentation⚡️](/docs/phoenix/release-notes/02-2025/02-18-2025-one-line-instrumentation)
-
-**Available in Phoenix 8.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/vMqnP30" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Phoenix has made it even simpler to get started with tracing by introducing one-line auto-instrumentation. By using `register(auto_instrument=True)`, you can enable automatic instrumentation in your application, which will set up instrumentors based on your installed packages.
-
-```python
-from phoenix.otel import register
-
-register(auto_instrument=True)
-```
-</Update>
-
-
-
-<Update label="01.18.2025" >
-## [01.18.2025: Automatic & Manual Span Tracing ⚙️](/docs/phoenix/release-notes/01-2025/01-18-2025-automatic-and-manual-span-tracing)
-
-**Available in Phoenix 7.9+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/eYTN9GP" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-In addition to using our automatic instrumentors and tracing directly using OTEL, we've now added our own layer to let you have the granularity of manual instrumentation without as much boilerplate code.
-
-You can now access a tracer object with streamlined options to trace functions and code blocks. The main two options are using the **decorator** `@tracer.chain` and using the tracer in a `with` clause.
-
-Check out the [docs](/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument-python#using-your-tracer) for more on how to use tracer objects.
-</Update>
-
-
-
-<Update label="12.09.2024" >
-## [12.09.2024: Sessions 💬](/docs/phoenix/release-notes/2024/12-09-2024-sessions)
-
-**Available in Phoenix 7.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/4WN09Ih" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Sessions allow you to group multiple responses into a single thread. Each response is still captured as a single trace, but each trace is linked together and presented in a combined view.
-
-Sessions make it easier to visualize multi-turn exchanges with your chatbot or agent. Sessions launches with Phoenix 7.0, and for more on sessions, check out[a walkthrough video](https://www.youtube.com/watch?v=dzS6x0BE-EU) and the [docs](/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions).
-</Update>
-
-
-
-<Update label="11.18.2024" >
-## [11.18.2024: Prompt Playground 🛝](/docs/phoenix/release-notes/2024/11-18-2024-prompt-playground)
-
-**Available in Phoenix 6.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/islLPi9" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Prompt Playground is now available in the Phoenix platform! This new release allows you to test the effects of different prompts, tools, and structured output formats to see which performs best.
-
-* Replay individual spans with modified prompts, or run full Datasets through your variations.
-
-* Easily test different models, prompts, tools, and output formats side-by-side, directly in the platform.
-
-* Automatically capture traces as Experiment runs for later debugging. See [here](/docs/phoenix/prompt-engineering/overview-prompts/prompt-playground) for more information on Prompt Playground, or jump into the platform to try it out for yourself.
-</Update>
-
-
-
-<Update label="09.26.2024" >
-## [09.26.2024: Authentication & RBAC 🔐](/docs/phoenix/release-notes/2024/09-26-2024-authentication-and-rbac)
-
-**Available in Phoenix 5.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/WQTHhwp" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We've added Authentication and Rules-based Access Controls to Phoenix. This was a long-requested feature set, and we're excited for the new uses of Phoenix this will unlock!
-
-The auth feature set includes secure access, RBAC, API keys, and OAuth2 Support. For all the details on authentication, view our [docs](/docs/phoenix/self-hosting/features/authentication).
-</Update>
-
-
-
-<Update label="07.18.2024" >
-## [07.18.2024: Guardrails AI Integrations💂](/docs/phoenix/release-notes/2024/07-18-2024-guardrails-ai-integrations)
-
-**Available in Phoenix 4.11.0+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/MvHONPu" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-Our integration with Guardrails AI allows you to capture traces on guard usage and create datasets based on these traces. This integration is designed to enhance the safety and reliability of your LLM applications, ensuring they adhere to predefined rules and guidelines.
-
-Check out the [Cookbook](https://colab.research.google.com/drive/1NDn5jzsW5k0UrwaBjZenRX29l6ocrZ-_?usp=sharing\&utm_campaign=Phoenix%20Newsletter\&utm_source=hs_email\&utm_medium=email&_hsenc=p2ANqtz-9Tx_lYbuasbD3Mzdwl0VNPcvy_YcbPudxu1qwBZ3T7Mh---A4PO-OJfhas-RR4Ys_IEb0F)here.
-</Update>
-
-
-
-<Update label="07.11.2024" >
-## [07.11.2024: Hosted Phoenix and LlamaTrace 💻](/docs/phoenix/release-notes/2024/07-11-2024-hosted-phoenix-and-llamatrace)
-
-**Phoenix is now available for deployment as a fully hosted service.**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/nGUXe7g" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-In addition to our existing notebook, CLI, and self-hosted deployment options, we’re excited to announce that Phoenix is now available as a [fully hosted service](https://arize.com/resource/introducing-hosted-phoenix-llamatrace/). With hosted instances, your data is stored between sessions, and you can easily share your work with team members.
-
-We are partnering with LlamaIndex to power a new observability platform in LlamaCloud: LlamaTrace. LlamaTrace will automatically capture traces emitted from your LlamaIndex application.
-
-Hosted Phoenix is 100% free-to-use, [check it out today](https://app.phoenix.arize.com/login)!
-</Update>
-
-
-
-<Update label="07.03.2024" >
-## [07.03.2024: Datasets & Experiments 🧪](/docs/phoenix/release-notes/2024/07-03-2024-datasets-and-experiments)
-
-**Available in Phoenix 4.6+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/V7B9uLu" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-**Datasets**: Datasets are a new core feature in Phoenix that live alongside your projects. They can be imported, exported, created, curated, manipulated, and viewed within the platform, and make fine-tuning and experimentation easier.
-
-For more details on using datasets see our [documentation](/docs/phoenix/datasets-and-experiments/overview-datasets?utm_campaign=Phoenix%20Newsletter\&utm_source=hs_email\&utm_medium=email&_hsenc=p2ANqtz-9Tx_lYbuasbD3Mzdwl0VNPcvy_YcbPudxu1qwBZ3T7Mh---A4PO-OJfhas-RR4Ys_IEb0F) or [example notebook](https://colab.research.google.com/drive/1e4vZR5VPelXXYGtWfvM3CErPhItHAIp2?usp=sharing\&utm_campaign=Phoenix%20Newsletter\&utm_source=hs_email\&utm_medium=email&_hsenc=p2ANqtz-9Tx_lYbuasbD3Mzdwl0VNPcvy_YcbPudxu1qwBZ3T7Mh---A4PO-OJfhas-RR4Ys_IEb0F).
-
-**Experiments:** Our new Datasets and Experiments feature enables you to create and manage datasets for rigorous testing and evaluation of your models. Check out our full [walkthrough](https://www.youtube.com/watch?v=rzxN-YV_DbE\&t=25s).
-</Update>
-
-
-
-<Update label="07.02.2024" >
-## [07.02.2024: Function Call Evaluations ⚒️](/docs/phoenix/release-notes/2024/07-02-2024-function-call-evaluations)
-
-**Available in Phoenix 4.6+**
-
-<Frame>
-    <iframe src="https://cdn.iframe.ly/dfaK0Mb" width={1000} height={400} allowFullScreen></iframe>
-</Frame>
-
-We are introducing a new built-in function call evaluator that scores the function/tool-calling capabilities of your LLMs. This off-the-shelf evaluator will help you ensure that your models are not just generating text but also effectively interacting with tools and functions as intended. Check out a [full walkthrough of the evaluator](https://www.youtube.com/watch?v=Rsu-UZ1ZVZU).
-</Update>
-
-
+## See more
+
+<Card href="/docs/phoenix/release-notes/2026" horizontal arrow="true">
+  2026
+</Card>
+
+<Card href="/docs/phoenix/release-notes/2025" horizontal arrow="true">
+  2025
+</Card>

--- a/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators.mdx
@@ -1,0 +1,129 @@
+---
+title: "Release Notes"
+---
+
+# Tool Selection and Tool Invocation Evaluators
+
+January 31, 2026
+
+**Available in arize-phoenix-evals 0.16.0+ (Python) and @arizeai/phoenix-evals 1.3.0+ (TypeScript)**
+
+Phoenix now provides two specialized evaluators for assessing AI agent tool usage. The **Tool Selection Evaluator** judges whether an agent correctly chose the most appropriate tool from its available toolkit to answer a user's question, without evaluating the parameters passed. The **Tool Invocation Evaluator** assesses whether the agent correctly invoked a tool with proper parameters, JSON formatting, and safe values.
+
+These evaluators help developers:
+- **Identify tool selection errors** where agents choose suboptimal or incorrect tools
+- **Debug parameter issues** including hallucinated fields, malformed JSON, and incorrect values
+- **Improve tool descriptions** and agent prompts based on systematic evaluation
+- **Validate multi-tool and multi-turn interactions** across complex agent workflows
+
+Both evaluators are available as `ToolSelectionEvaluator` and `ToolInvocationEvaluator` in Python's `phoenix.evals.metrics` module, and as `createToolSelectionEvaluator` and `createToolInvocationEvaluator` in TypeScript.
+
+# Configurable Email Extraction for OAuth2 Providers
+
+January 28, 2026
+
+**Available in Phoenix 12.33.1+**
+
+Phoenix now supports custom email extraction from OAuth2 identity providers through the `PHOENIX_OAUTH2_{IDP}_EMAIL_ATTRIBUTE_PATH` environment variable. This solves authentication issues with providers like Azure AD/Entra ID where the standard `email` claim may be null but alternative claims like `preferred_username` contain the user's identity.
+
+Configure email extraction using JMESPath expressions:
+
+```bash
+# Extract from Azure AD preferred_username claim
+PHOENIX_OAUTH2_AZURE_AD_EMAIL_ATTRIBUTE_PATH=preferred_username
+
+# Extract from nested claims
+PHOENIX_OAUTH2_CUSTOM_IDP_EMAIL_ATTRIBUTE_PATH=user.contact.email
+```
+
+The default behavior remains unchanged, using the standard OIDC `email` claim when no custom path is specified. JMESPath expressions are validated at startup for immediate feedback on configuration errors.
+
+# CLI Commands for Prompts, Datasets, and Experiments
+
+January 22, 2026
+
+**Available in @arizeai/phoenix-cli 0.4.0+**
+
+The Phoenix CLI now provides comprehensive commands for managing prompts, datasets, and experiments directly from your terminal. Access version-controlled prompts, create evaluation datasets, and run experiments—all without leaving your development environment.
+
+**Prompt Management:**
+- **List and view prompts** with `px prompts` and `px prompt <name>`
+- **Pipe prompts to AI assistants** for optimization and analysis
+- **Text format output** with XML-style role tags for LLM consumption
+
+**Dataset Operations:**
+- **Create and manage datasets** with `px datasets` and `px dataset <name>`
+- **Add examples** and query dataset contents
+- **Export datasets** for offline analysis
+
+**Experiment Workflows:**
+- **Run experiments** and compare results across configurations
+- **View experiment details** and performance metrics
+- **Track changes** across prompt and model variations
+
+These commands integrate seamlessly with AI coding assistants and enable systematic testing of LLM applications through terminal-based workflows.
+
+# CLI Authentication Configuration
+
+January 23, 2026
+
+**Available in @arizeai/phoenix-cli 0.4.0+**
+
+The Phoenix CLI now includes enhanced authentication configuration commands, resolving database race conditions and improving connection reliability. Users can configure authentication settings directly through the CLI for more predictable and stable connections to Phoenix servers.
+
+# Create Datasets from Traces with Span Associations
+
+January 21, 2026
+
+**Available in arize-phoenix-client 1.28.0+ (Python) and @arizeai/phoenix-client 2.0.0+ (TypeScript)**
+
+Phoenix now enables converting production traces into curated datasets while preserving bidirectional links back to source spans. Use the new `span_id_key` parameter to maintain traceability from evaluation examples to their original production executions.
+
+**Python Example:**
+```python
+from phoenix.client import Client
+
+client = Client()
+dataset = client.datasets.create_dataset(
+    name="production-queries",
+    dataframe=spans_df,
+    input_keys=["input"],
+    output_keys=["output"],
+    span_id_key="context.span_id"  # Links examples to spans
+)
+```
+
+**TypeScript Example:**
+```typescript
+import { createClient } from '@arizeai/phoenix-client';
+
+const client = createClient();
+await client.createDataset({
+    name: "production-queries",
+    examples: examples.map(ex => ({
+        input: ex.input,
+        output: ex.output,
+        spanId: ex.spanId  // Preserves trace links
+    }))
+});
+```
+
+Key capabilities:
+- **Batch resolution** of span IDs for optimal performance
+- **Graceful fallback** when span IDs are missing or invalid
+- **Backwards compatible** with existing dataset creation workflows
+- **Bidirectional navigation** between evaluation results and production traces
+
+# Export Annotations with Traces
+
+January 19, 2026
+
+**Available in @arizeai/phoenix-cli 0.3.0+**
+
+The Phoenix CLI now supports exporting annotations alongside traces using the `--include-annotations` flag. Annotations—including manual labels, LLM evaluation scores, and programmatic feedback—are now preserved when exporting traces for offline analysis, backup, or migration workflows.
+
+```bash
+px traces export --include-annotations > traces_with_feedback.jsonl
+```
+
+This enables teams to maintain complete evaluation history when moving data between environments or conducting retrospective analysis of model performance.

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -1,0 +1,8 @@
+---
+title: "2026"
+sidebarTitle: "Overview"
+---
+
+<CardGroup>
+    <Card href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" arrow="true" title="02.01.2026"/>
+</CardGroup>


### PR DESCRIPTION
This PR adds release notes for Phoenix (02-01-2026).

**Changes:**
- Added release note file: 
- Updated main changelog: 
- Updated year index: 

Generated by Release Reporter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docs-only change, but the main `release-notes.mdx` now contains new MDX/JSX blocks and code fencing that could break the docs build/rendering if the markup is malformed.
> 
> **Overview**
> Adds a new release-notes page at `release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators.mdx` covering late-Jan 2026 updates (tool-usage evaluators, OAuth2 email extraction config, expanded CLI capabilities, span-linked dataset creation, and trace export including annotations).
> 
> Updates `release-notes.mdx` to include these new items near the top and trims older entries in favor of a **year index**, adding `release-notes/2026.mdx` plus navigation cards for `2026` and `2025`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99b425467759565824489800644533bb1d41f967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->