### PR TITLE
docs: Add Agent Spec integration to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Phoenix is built on top of OpenTelemetry and is vendor, language, and framework 
 | [Pydantic AI](https://arize.com/docs/phoenix/integrations/pydantic) | `openinference-instrumentation-pydantic-ai` | [![PyPI Version](https://img.shields.io/pypi/v/openinference-instrumentation-pydantic-ai.svg)](https://pypi.python.org/pypi/openinference-instrumentation-pydantic-ai) |
 | [Autogen AgentChat](https://arize.com/docs/phoenix/integrations/frameworks/autogen/autogen-tracing) | `openinference-instrumentation-autogen-agentchat` | [![PyPI Version](https://img.shields.io/pypi/v/openinference-instrumentation-autogen-agentchat.svg)](https://pypi.python.org/pypi/openinference-instrumentation-autogen-agentchat) |
 | [Portkey](https://arize.com/docs/phoenix/integrations/portkey) | `openinference-instrumentation-portkey` | [![PyPI Version](https://img.shields.io/pypi/v/openinference-instrumentation-portkey.svg)](https://pypi.python.org/pypi/openinference-instrumentation-portkey) |
+| [Agent Spec](https://arize.com/docs/phoenix/tracing/integrations-tracing/agentspec) | `openinference-instrumentation-agentspec` | [![PyPI Version](https://img.shields.io/pypi/v/openinference-instrumentation-agentspec.svg)](https://pypi.python.org/pypi/openinference-instrumentation-agentspec) |
 
 ## Span Processors
 

--- a/docs.json
+++ b/docs.json
@@ -510,6 +510,13 @@
             "icon": "python",
             "pages": [
               {
+                "group": "Agent Spec",
+                "pages": [
+                  "docs/phoenix/integrations/python/agentspec",
+                  "docs/phoenix/integrations/python/agentspec/agentspec-tracing"
+                ]
+              },
+              {
                 "group": "Agno",
                 "pages": [
                   "docs/phoenix/integrations/python/agno",

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -85,6 +85,7 @@ Phoenix captures detailed traces from your AI applications, giving you visibilit
       <Card title="Graphite" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/graphite-logo.png" href="/docs/phoenix/integrations/python/graphite" />
       <Card title="NVIDIA" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/nvidia-logo.png" href="/docs/phoenix/integrations/python/nvidia" />
       <Card title="MCP" href="/docs/phoenix/integrations/python/mcp-tracing" />
+      <Card title="Agent Spec" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-logo.png" href="/docs/phoenix/integrations/python/agentspec" />
     </CardGroup>
   </Tab>
   <Tab title="TypeScript" icon="js">

--- a/docs/phoenix/integrations/python/agentspec.mdx
+++ b/docs/phoenix/integrations/python/agentspec.mdx
@@ -1,0 +1,13 @@
+---
+title: "Agent Spec"
+sidebarTitle: "Overview"
+description: Open Agent Spec (Agent Spec) is a portable language for defining agentic systems. It defines building blocks for standalone agents and structured agentic workflows as well as common ways of composing them into multi-agent systems.
+---
+
+<Card title="Agent Spec" href="https://oracle.github.io/agent-spec/" icon="globe" horizontal>
+</Card>
+
+<Columns cols={2}>
+
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-logo.png" horizontal title="Agent Spec Tracing" href="/docs/phoenix/integrations/python/agentspec/agentspec-tracing"/>
+</Columns>

--- a/docs/phoenix/integrations/python/agentspec/agentspec-tracing.mdx
+++ b/docs/phoenix/integrations/python/agentspec/agentspec-tracing.mdx
@@ -1,0 +1,91 @@
+---
+title: "Agent Spec Tracing"
+description: How to use the python AgentSpecInstrumentor to trace Agent Spec workflows
+---
+
+[Open Agent Spec (Agent Spec)](https://oracle.github.io/agent-spec/) is a portable language for defining agentic systems.
+It defines building blocks for standalone agents and structured agentic workflows as well as common ways of composing them into multi-agent systems.
+
+[Agent Spec Tracing](https://oracle.github.io/agent-spec/development/agentspec/tracing.html) is an extension of Agent Spec that standardizes how agent and flow executions emit traces.
+Agent Spec Tracing enables:
+- Runtime adapters to emit consistent traces across different frameworks.
+- Consumers (observability backends, UIs, developer tooling) to ingest one standardized format regardless of the producer.
+
+With Agent Spec, tracing instrumentation is implemented using the OpenTelemetry instrumentor known as AgentSpecInstrumentor.
+This callback handles the creation of spans and transmits them to the Phoenix collector.
+
+## Install
+
+```bash
+pip install openinference-instrumentation-agentspec pyagentspec[langgraph]
+```
+
+This installs the [LangGraph adapter](https://oracle.github.io/agent-spec/development/adapters/langgraph.html) for Agent Spec, which allows developers to run Agent Spec workflows using [LangGraph](https://www.langchain.com/langgraph) as a backend.
+You can find out the list of available adapters and how to install them in the [Agent Spec installation instructions](https://oracle.github.io/agent-spec/development/installation.html#extra-dependencies).
+
+## Setup
+
+Use the register function to connect your application to Phoenix:
+
+```python
+from phoenix.otel import register
+
+# configure the Phoenix tracer
+tracer_provider = register(
+  project_name="my-llm-app", # Default is 'default'
+  auto_instrument=True # Auto-instrument your app based on installed OI dependencies
+)
+```
+
+## Create the Agent Spec agent
+
+```python
+from pyagentspec.agent import Agent
+from pyagentspec.llms import OpenAiConfig
+
+agent = Agent(
+    name="assistant",
+    description="A general purpose agent without tools",
+    llm_config=OpenAiConfig(name="openai-gpt-5-mini", model_id="gpt-5-mini"),
+    system_prompt="You are a helpful assistant. Help the user answering politely.",
+)
+```
+
+## Run the agent using LangGraph
+
+```python
+# Transform the Agent Spec agent into a LangGraph's executable component
+from pyagentspec.adapters.langgraph import AgentSpecLoader
+
+langgraph_agent = AgentSpecLoader().load_component(agent)
+
+# Instrument the agent's execution
+from openinference.instrumentation.agentspec import AgentSpecInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register(batch=True, project_name="hello-world-app")
+AgentSpecInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# Run the agent's execution loop
+while True:
+    user_input = input("USER  >>> ")
+    if user_input.lower() in ["exit", "quit"]:
+        break
+    response = langgraph_agent.invoke(
+        input={"messages": [{"role": "user", "content": user_input}]},
+        config={"configurable": {"thread_id": "1"}},
+    )
+    print("AGENT >>>", response['messages'][-1].content.strip())
+```
+
+## Observe
+
+With tracing now configured, all calls to your Agent Spec agent will be streamed to Phoenix for enhanced observability and evaluation.
+
+## Resources
+
+* [OpenInference package](https://pypi.org/project/openinference-instrumentation-agentspec/)
+
+* [Examples](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-agentspec/examples)
+
+


### PR DESCRIPTION
Solves https://github.com/Arize-ai/phoenix/issues/11196

The Agent Spec Instrumentor was recently added to OpenInference and released: https://arize-ai.github.io/openinference/python/instrumentation/openinference-instrumentation-agentspec/

This PR adds Agent Spec to the integrations tab in the Phoenix documentation.

<img width="1467" height="1213" alt="Screenshot 2026-02-02 at 10 22 20" src="https://github.com/user-attachments/assets/d513c263-5caa-4d8d-b589-5c0408219d41" />
<img width="1419" height="1218" alt="Screenshot 2026-02-02 at 10 23 18" src="https://github.com/user-attachments/assets/8ac04c88-ed03-4a84-8cbf-96116a07071d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only navigation and content additions; main risk is broken links or sidebar placement issues.
> 
> **Overview**
> Adds **Agent Spec** as a first-class Phoenix docs integration.
> 
> Updates the integrations surface area by adding an `Agent Spec` card on `docs/phoenix/integrations.mdx`, a new Python navigation group in `docs.json`, and a new entry in the root `README.md` tracing integrations table.
> 
> Introduces new docs pages (`docs/phoenix/integrations/python/agentspec.mdx` and `agentspec-tracing.mdx`) describing installation and basic usage of `openinference-instrumentation-agentspec` with Phoenix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c890acb0ab926d7ed3d4f1f498ef22fcaaa552e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->