### PR TITLE
fix: enhance EvaluatorInputMapping for react-hook-form compatibility

### DIFF
--- a/app/src/components/evaluators/__tests__/dottedKeyFieldName.test.ts
+++ b/app/src/components/evaluators/__tests__/dottedKeyFieldName.test.ts
@@ -1,0 +1,145 @@
+/**
+ * This test demonstrates the bug with react-hook-form when using field names
+ * that contain dots. React-hook-form interprets dots as nested object paths,
+ * so `pathMapping.output.available_tools` becomes:
+ *   { pathMapping: { output: { available_tools: "value" } } }
+ * Instead of:
+ *   { pathMapping: { "output.available_tools": "value" } }
+ *
+ * The fix is to escape dots in the key when constructing react-hook-form field names.
+ * We use URL-encoding style escaping (. -> %2E, % -> %25) to handle edge cases
+ * where the escape sequence itself might appear in the original field name.
+ */
+
+import {
+  escapeFieldNameForReactHookForm,
+  unescapeFieldNameFromReactHookForm,
+} from "../fieldNameUtils";
+
+describe("fieldNameUtils", () => {
+  describe("escapeFieldNameForReactHookForm", () => {
+    it("escapes dots in field names", () => {
+      expect(escapeFieldNameForReactHookForm("output.available_tools")).toBe(
+        "output%2Eavailable_tools"
+      );
+    });
+
+    it("escapes multiple dots", () => {
+      expect(escapeFieldNameForReactHookForm("a.b.c.d")).toBe("a%2Eb%2Ec%2Ed");
+    });
+
+    it("leaves names without dots or percent signs unchanged", () => {
+      expect(escapeFieldNameForReactHookForm("simple_name")).toBe(
+        "simple_name"
+      );
+    });
+
+    it("handles empty string", () => {
+      expect(escapeFieldNameForReactHookForm("")).toBe("");
+    });
+
+    it("escapes percent signs to prevent conflicts with escape sequence", () => {
+      expect(escapeFieldNameForReactHookForm("foo%bar")).toBe("foo%25bar");
+    });
+
+    it("handles field names that contain the escape sequence itself", () => {
+      // If someone has a literal %2E in their field name, it should be preserved
+      expect(escapeFieldNameForReactHookForm("foo%2Ebar")).toBe("foo%252Ebar");
+    });
+
+    it("handles field names with both dots and percent signs", () => {
+      expect(escapeFieldNameForReactHookForm("foo.bar%baz")).toBe(
+        "foo%2Ebar%25baz"
+      );
+    });
+  });
+
+  describe("unescapeFieldNameFromReactHookForm", () => {
+    it("unescapes escaped dots", () => {
+      expect(
+        unescapeFieldNameFromReactHookForm("output%2Eavailable_tools")
+      ).toBe("output.available_tools");
+    });
+
+    it("unescapes multiple escaped dots", () => {
+      expect(unescapeFieldNameFromReactHookForm("a%2Eb%2Ec%2Ed")).toBe(
+        "a.b.c.d"
+      );
+    });
+
+    it("leaves names without escape sequences unchanged", () => {
+      expect(unescapeFieldNameFromReactHookForm("simple_name")).toBe(
+        "simple_name"
+      );
+    });
+
+    it("handles empty string", () => {
+      expect(unescapeFieldNameFromReactHookForm("")).toBe("");
+    });
+
+    it("unescapes percent signs", () => {
+      expect(unescapeFieldNameFromReactHookForm("foo%25bar")).toBe("foo%bar");
+    });
+
+    it("correctly restores literal %2E that was in the original", () => {
+      // %252E should become %2E (the original literal value)
+      expect(unescapeFieldNameFromReactHookForm("foo%252Ebar")).toBe(
+        "foo%2Ebar"
+      );
+    });
+  });
+
+  describe("round-trip escaping", () => {
+    const testCases = [
+      "simple",
+      "output.value",
+      "deeply.nested.path",
+      "multiple.dots.in.name",
+      "no_dots_here",
+      "output.available_tools",
+      "",
+      // Edge cases with percent signs
+      "foo%bar",
+      "foo%2Ebar", // literal %2E in original
+      "foo%25bar", // literal %25 in original
+      "100%",
+      "a.b%c.d",
+      "%2E", // just the escape sequence
+      "%25", // just the percent escape
+      "%%%", // multiple percent signs
+      ".%.", // dot, percent, dot
+    ];
+
+    test.each(testCases)("escaping and unescaping '%s' is identity", (key) => {
+      const escaped = escapeFieldNameForReactHookForm(key);
+      const unescaped = unescapeFieldNameFromReactHookForm(escaped);
+      expect(unescaped).toBe(key);
+    });
+
+    test.each(testCases.filter((k) => k.includes(".")))(
+      "escaped key '%s' does not contain dots",
+      (key) => {
+        const escaped = escapeFieldNameForReactHookForm(key);
+        expect(escaped).not.toContain(".");
+      }
+    );
+  });
+
+  describe("edge case: escape sequence collision prevention", () => {
+    it("handles the case where user has ___DOT___ in their variable name (old escape sequence)", () => {
+      // This was the original escape sequence - make sure it doesn't cause issues
+      const input = "foo___DOT___bar";
+      const escaped = escapeFieldNameForReactHookForm(input);
+      const unescaped = unescapeFieldNameFromReactHookForm(escaped);
+      expect(unescaped).toBe(input);
+    });
+
+    it("handles complex combinations", () => {
+      // A very adversarial input
+      const input = "foo.%2E.%25.bar";
+      const escaped = escapeFieldNameForReactHookForm(input);
+      const unescaped = unescapeFieldNameFromReactHookForm(escaped);
+      expect(unescaped).toBe(input);
+    });
+  });
+});

--- a/app/src/components/evaluators/fieldNameUtils.ts
+++ b/app/src/components/evaluators/fieldNameUtils.ts
@@ -1,0 +1,58 @@
+/**
+ * Utilities for handling field names that contain dots when used with react-hook-form.
+ *
+ * react-hook-form interprets dots in field names as nested object paths. For example,
+ * `pathMapping.output.available_tools` is interpreted as:
+ *   { pathMapping: { output: { available_tools: "value" } } }
+ *
+ * But we want to use keys that literally contain dots:
+ *   { pathMapping: { "output.available_tools": "value" } }
+ *
+ * These utilities escape dots in field names so that react-hook-form treats them
+ * as literal characters rather than path separators.
+ *
+ * We use a URL-encoding style escape scheme to handle edge cases where the escape
+ * sequence itself might appear in the original field name:
+ * - `.` is escaped as `%2E`
+ * - `%` is escaped as `%25` (to prevent conflicts with the escape sequence)
+ */
+
+/**
+ * Escapes dots in a field name so react-hook-form treats them as literal characters.
+ * Use this when constructing field names for react-hook-form's Controller or setValue.
+ *
+ * Uses URL-encoding style escaping to handle edge cases:
+ * - First escapes `%` to `%25` (so existing `%2E` becomes `%252E`)
+ * - Then escapes `.` to `%2E`
+ *
+ * @example
+ * escapeFieldNameForReactHookForm("output.available_tools")
+ * // => "output%2Eavailable_tools"
+ *
+ * @example
+ * // Edge case: literal %2E in field name is preserved
+ * escapeFieldNameForReactHookForm("foo%2Ebar")
+ * // => "foo%252Ebar"
+ */
+export function escapeFieldNameForReactHookForm(fieldName: string): string {
+  // Order matters: escape % first, then .
+  return fieldName.replace(/%/g, "%25").replace(/\./g, "%2E");
+}
+
+/**
+ * Unescapes a field name that was escaped with escapeFieldNameForReactHookForm.
+ * Use this when reading values from form state to get back the original key name.
+ *
+ * @example
+ * unescapeFieldNameFromReactHookForm("output%2Eavailable_tools")
+ * // => "output.available_tools"
+ *
+ * @example
+ * // Edge case: escaped %2E is restored correctly
+ * unescapeFieldNameFromReactHookForm("foo%252Ebar")
+ * // => "foo%2Ebar"
+ */
+export function unescapeFieldNameFromReactHookForm(fieldName: string): string {
+  // Order matters: unescape . first, then %
+  return fieldName.replace(/%2E/g, ".").replace(/%25/g, "%");
+}


### PR DESCRIPTION
- Implement escapeMapping and unescapeMapping functions to handle key transformations for react-hook-form.
- Update useForm default values to use escaped mappings.
- Ensure keys are unescaped when writing back to the store.
- Improve variable handling in the rendering logic to maintain compatibility with react-hook-form.

resolves #11182 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how form field names are encoded/decoded and how mappings are persisted back to the evaluator store; mistakes could silently remap or drop inputs, especially for existing configs with dotted keys.
> 
> **Overview**
> Fixes evaluator input mapping for variables/keys containing dots by **escaping mapping keys before passing them to `react-hook-form`** and **unescaping on write-back** so dotted keys aren’t treated as nested paths.
> 
> Adds shared `fieldNameUtils` (`escapeFieldNameForReactHookForm`/`unescapeFieldNameFromReactHookForm`) plus comprehensive unit tests, and updates `EvaluatorInputMapping` to use escaped field names in `defaultValues`, `setValue`, and `SwitchableEvaluatorInput` while keeping the store representation unescaped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6aa40cbdc2cef111afe434b2ac1ce0ff78c22ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->