### PR TITLE
fix: add prompt span kind to SpanKind enum

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2889,6 +2889,7 @@ enum SpanKind {
   reranker
   evaluator
   guardrail
+  prompt
   unknown
 }
 

--- a/app/src/pages/__generated__/SpanHeader_span.graphql.ts
+++ b/app/src/pages/__generated__/SpanHeader_span.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6a4e67540b2600d845cf17eb8340841b>>
+ * @generated SignedSource<<fbe514afdb29c68bd3bf6b3f2fc069ff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 import { FragmentRefs } from "relay-runtime";
 export type SpanHeader_span$data = {

--- a/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/SpansTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<903fad585993583a9273b44db363e90a>>
+ * @generated SignedSource<<ce3723b6db1b60627a769f630d10e8b1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type AnnotatorKind = "CODE" | "HUMAN" | "LLM";
-export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 import { FragmentRefs } from "relay-runtime";
 export type SpansTable_spans$data = {

--- a/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
+++ b/app/src/pages/project/__generated__/TracesTable_spans.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<25644e3acbb00a592e2d9acdd67f512a>>
+ * @generated SignedSource<<5dde7221c0119a4a04bbe2f2a148fbce>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type AnnotatorKind = "CODE" | "HUMAN" | "LLM";
-export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 import { FragmentRefs } from "relay-runtime";
 export type TracesTable_spans$data = {

--- a/app/src/pages/trace/__generated__/ConnectedTraceTree.graphql.ts
+++ b/app/src/pages/trace/__generated__/ConnectedTraceTree.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a66b109294902974153c42ee29b73993>>
+ * @generated SignedSource<<0c68a8d6c1010055daccf62b06f202bd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 import { FragmentRefs } from "relay-runtime";
 export type ConnectedTraceTree$data = {

--- a/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
+++ b/app/src/pages/trace/__generated__/SpanDetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<72bf75f7606cebcd15b9959009be538c>>
+ * @generated SignedSource<<8b1c066d3b81b4c0a34fcd93ad340fc9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type MimeType = "json" | "text";
-export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "reranker" | "retriever" | "tool" | "unknown";
+export type SpanKind = "agent" | "chain" | "embedding" | "evaluator" | "guardrail" | "llm" | "prompt" | "reranker" | "retriever" | "tool" | "unknown";
 export type SpanStatusCode = "ERROR" | "OK" | "UNSET";
 export type SpanDetailsQuery$variables = {
   id: string;

--- a/src/phoenix/server/api/types/Span.py
+++ b/src/phoenix/server/api/types/Span.py
@@ -72,6 +72,7 @@ class SpanKind(Enum):
     reranker = "RERANKER"
     evaluator = "EVALUATOR"
     guardrail = "GUARDRAIL"
+    prompt = "PROMPT"
     unknown = "UNKNOWN"
 
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ requires-dist = [
 
 [[package]]
 name = "arize-phoenix-evals"
-version = "2.8.0"
+version = "2.9.0"
 source = { editable = "packages/phoenix-evals" }
 dependencies = [
     { name = "jsonpath-ng" },


### PR DESCRIPTION
Add the `prompt` member to the SpanKind enum to support the PROMPT span kind added in newer versions of openinference-semantic-conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small schema/type expansion to accept a new span kind, with no behavioral logic changes beyond recognizing an additional enum value.
> 
> **Overview**
> Adds support for the new `PROMPT` span kind by extending the `SpanKind` enum across the GraphQL schema and server type (`Span.py`). Updates the Relay-generated TypeScript GraphQL artifacts so the frontend `SpanKind` union now includes `"prompt"`.
> 
> Also bumps `arize-phoenix-evals` from `2.8.0` to `2.9.0` in `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e9894456973736431f41ddb82a1fff439118d3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->