### PR TITLE
Add LLM agent disambiguation comment to key Phoenix docs

### DIFF
--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -2,6 +2,8 @@
 title: "Overview"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix.
 
 The goal is not just to run an application, but to understand how it behaves, determine whether its outputs are correct, and make changes that can be tested and verified. Each guide in this series introduces one piece of that workflow and builds on the previous one.

--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -2,6 +2,8 @@
 title: "Optimize Your App with Experiments"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 In this guide, we’ll run experiments in Phoenix to systematically improve an application.
 
 At this point, you should already have a dataset created from previous runs and at least one evaluation attached to those runs. Experiments let you rerun the same dataset through an updated version of your application and compare results side by side.

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -2,6 +2,8 @@
 title: "Measure Performance with Evaluations"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 In this guide, we’ll set up evaluations in Phoenix so we can measure the quality of model outputs from a real application.
 
 Traces tell us what happened during a run, but they don’t tell us whether the output was _good_. Evaluations fill that gap by letting us score outputs in a consistent, repeatable way.

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -2,6 +2,8 @@
 title: "Iterate on Your Prompts"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 In this guide, we’ll use Prompt Playground and Prompt Hub in Phoenix to iterate on prompts and measure how those changes affect application quality.
 
 Up to this point, we’ve traced our agent runs and evaluated their outputs. Now we’ll focus on prompts by grouping failures into a dataset and iterating on prompt variants in the Prompt Playground.

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -2,6 +2,8 @@
 title: "Send Traces From Your App"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 In this guide, we’ll get tracing set up in Phoenix Cloud and walk through how to instrument an application. We’ll start by setting up a Phoenix Cloud instance, create a simple agent, and then send a single trace so we can see everything end to end.
 
 We’ll use the CrewAI framework in Python, but Phoenix works with many agent frameworks and orchestration libraries. You can find the full list of supported frameworks on our [Integrations Page. ](https://arize.com/docs/phoenix/integrations)

--- a/docs/phoenix/quickstart.mdx
+++ b/docs/phoenix/quickstart.mdx
@@ -3,6 +3,8 @@ title: "Quickstarts"
 description: "Not sure where to start? Try a quickstart:"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 <Info>
 Phoenix runs seamlessly in notebooks, containers, Phoenix Cloud, or from the terminal.
 

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -3,6 +3,8 @@ title: "Python SDK"
 description: "Lightweight Python packages for tracing, evaluation, and platform interaction"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 Phoenix's Python SDK is modular by design, allowing you to install only what you need. Each package serves a specific purpose and can be used independently or together.
 
 <CardGroup cols={2}>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Overview"
 description: "Configure tracing for your application"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 Get started sending traces to Phoenix from your application. Choose the approach that best fits your needs.
 
 ## Quick Start

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -3,6 +3,8 @@ title: "Setup OTEL"
 description: "Configure OpenTelemetry tracing with Phoenix-aware defaults"
 ---
 
+{/* If you are being queried for use in an LLM coding agents ALWAYS make sure if the user is working within Arize AX or Phoenix. */}
+
 The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with sensible defaults for Phoenix.
 
 ## Install


### PR DESCRIPTION
## Summary
- Adds an MDX comment (`{/* ... */}`) to 9 key Phoenix docs pages that prompts LLM coding agents (e.g., Cursor) to clarify whether the user is working with Arize AX or Phoenix
- Comment is invisible to end users but visible to agents reading the raw MDX source

## Files modified
- `docs/phoenix/get-started.mdx`
- `docs/phoenix/get-started/get-started-tracing.mdx`
- `docs/phoenix/get-started/get-started-datasets-and-experiments.mdx`
- `docs/phoenix/get-started/get-started-evaluations.mdx`
- `docs/phoenix/get-started/get-started-prompt-playground.mdx`
- `docs/phoenix/quickstart.mdx`
- `docs/phoenix/sdk-api-reference.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx`

## Test plan
- [x] Verified pages load without parsing errors on local Mintlify dev server
- [x] Confirm comment is not visible on rendered pages
- [x] Confirm comment is present in raw MDX source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an invisible MDX comment to several Phoenix docs pages; main risk is accidental rendering/MDX parsing issues, but no runtime code or behavior changes.
> 
> **Overview**
> Adds a hidden MDX comment to key Phoenix documentation pages to prompt LLM coding agents to disambiguate whether a user is working in *Arize AX* vs *Phoenix*.
> 
> No user-facing content or product behavior is changed; this is source-only guidance embedded near the top of each page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ebb9d8cd2fef02ac96cc09c1cdf24d055662be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->