### PR TITLE
feat: client side regex validation for code eval form

### DIFF
--- a/app/src/components/RegexField.tsx
+++ b/app/src/components/RegexField.tsx
@@ -16,6 +16,7 @@ type RegexFieldProps = {
   value: string;
   onChange: (value: string) => void;
   isInvalid?: boolean;
+  isPending?: boolean;
   error?: string;
   description?: string;
   label?: string;
@@ -28,6 +29,7 @@ export const RegexField = ({
   onChange,
   error,
   isInvalid,
+  isPending,
   description,
   label,
   ariaLabel,
@@ -46,8 +48,8 @@ export const RegexField = ({
       <Input placeholder={placeholder} />
       {!error && description && <Text slot="description">{description}</Text>}
       {error && <FieldError>{error}</FieldError>}
-      {isInvalid && value && <FieldDangerIcon />}
-      {!isInvalid && value && <FieldSuccessIcon />}
+      {!isPending && isInvalid && value && <FieldDangerIcon />}
+      {!isPending && !isInvalid && value && <FieldSuccessIcon />}
     </TextField>
   );
 };


### PR DESCRIPTION
Previously, the regex form showed a green checkmark no matter what was input.

This validates regex inputs clientside, with a brief grace period to avoid turning red as soon as you open a bracket.

Grace period is UI-only, so there's no window where you can submit something invalid while it's "checking"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/form validation change; it tightens client-side validation and only affects the regex evaluator input/feedback behavior.
> 
> **Overview**
> Adds **client-side regex validation** to the regex evaluator form by validating `literalMapping.pattern` with `new RegExp(...)` and blocking form validity when the pattern is invalid.
> 
> Improves UX by **debouncing error display** (750ms grace period) and updating `RegexField` with an `isPending` state so success/error icons don’t flash while validation feedback is intentionally delayed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bb80299b40760be6fc35e12be5cc56bb463ce29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->