### PR TITLE
feat: graceful input shaping for evaluator name field

### DIFF
--- a/app/src/utils/identifierUtils.ts
+++ b/app/src/utils/identifierUtils.ts
@@ -1,18 +1,50 @@
 import type { ValidateResult } from "react-hook-form";
 
-const allowedIdentifierCharactersRegex = /^[_a-z0-9-]*$/;
-const leadingAndTrailingAlphanumericCharactersRegex =
+export const allowedIdentifierCharactersRegex = /^[_a-z0-9-]*$/;
+export const leadingAndTrailingAlphanumericCharactersRegex =
   /^([a-z0-9](.*[a-z0-9])?)?$/;
 
-export function validateIdentifier(value: string): ValidateResult {
+export const IDENTIFIER_ERROR_MESSAGES = {
+  empty: "Cannot be empty",
+  allowedChars:
+    "Must have only lowercase alphanumeric characters, dashes, and underscores",
+  leadingTrailing: "Must start and end with lowercase alphanumeric characters",
+} as const;
+
+/**
+ * Validates that identifier is not empty and contains only allowed characters.
+ * Used for immediate validation feedback while typing.
+ */
+export function validateIdentifierAllowedChars(value: string): ValidateResult {
   if (value.trim() === "") {
-    return "Cannot be empty";
+    return IDENTIFIER_ERROR_MESSAGES.empty;
   }
   if (!allowedIdentifierCharactersRegex.test(value)) {
-    return "Must have only lowercase alphanumeric characters, dashes, and underscores";
-  }
-  if (!leadingAndTrailingAlphanumericCharactersRegex.test(value)) {
-    return "Must start and end with lowercase alphanumeric characters";
+    return IDENTIFIER_ERROR_MESSAGES.allowedChars;
   }
   return true;
+}
+
+/**
+ * Validates that identifier starts and ends with alphanumeric characters.
+ * Used for deferred validation feedback on blur.
+ */
+export function validateIdentifierLeadingTrailing(
+  value: string
+): ValidateResult {
+  if (!leadingAndTrailingAlphanumericCharactersRegex.test(value)) {
+    return IDENTIFIER_ERROR_MESSAGES.leadingTrailing;
+  }
+  return true;
+}
+
+/**
+ * Full identifier validation combining all checks.
+ */
+export function validateIdentifier(value: string): ValidateResult {
+  const allowedCharsResult = validateIdentifierAllowedChars(value);
+  if (allowedCharsResult !== true) {
+    return allowedCharsResult;
+  }
+  return validateIdentifierLeadingTrailing(value);
 }


### PR DESCRIPTION
This improves the validation UX for evaluator name fields to preempt almost all invalid entries:
* Spaces are remapped to dashes
* uppercase chars are remapped to lower
* special chars are disallowed/swallowed
* moves "ends with" check to an onblur to avoid turning red the moment you press a dash. fields with invalid ending chars won't throw until focus moves elsewhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes user input handling (auto-transforming values, managing cursor position, and deferring certain error display), which could introduce subtle UX regressions or unexpected stored names, though it remains client-side only.
> 
> **Overview**
> Improves the evaluator name field UX by *auto-shaping input* (lowercasing, converting spaces to dashes, and stripping invalid characters) while preserving cursor position during edits.
> 
> Refactors identifier validation in `identifierUtils` into reusable checks with centralized `IDENTIFIER_ERROR_MESSAGES`, and updates `EvaluatorNameInput` to *defer* the leading/trailing alphanumeric error message until after blur while still blocking submission on invalid values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffeabae2f3dae0f987bde37bc5646d10e96ac037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->