### PR TITLE
fix(evaluators): enable sub-millisecond precision on span sort

### DIFF
--- a/app/src/components/trace/utils.ts
+++ b/app/src/components/trace/utils.ts
@@ -4,6 +4,27 @@ export type SpanTreeNode<TSpan> = {
   span: TSpan;
   children: SpanTreeNode<TSpan>[];
 };
+
+/**
+ * Compare two ISO 8601 timestamp strings with sub-millisecond precision.
+ *
+ * Handles timestamps with different timezone offsets by using Date for conversion.
+ * Preserves sub-millisecond precision by comparing fractional seconds as floats.
+ */
+export function compareTimestamps(a: string, b: string): number {
+  const dateA = new Date(a);
+  const dateB = new Date(b);
+
+  if (dateA.getTime() === dateB.getTime()) {
+    // Dates are equal at millisecond precision, compare fractional seconds
+    const fracA = parseFloat("0." + (a.match(/\.(\d+)/)?.[1] || "0"));
+    const fracB = parseFloat("0." + (b.match(/\.(\d+)/)?.[1] || "0"));
+    return Math.sign(fracA - fracB);
+  }
+
+  return Math.sign(dateA.getTime() - dateB.getTime());
+}
+
 /**
  * Create a span tree from a list of spans
  * @param spans
@@ -34,16 +55,12 @@ export function createSpanTree<TSpan extends ISpanItem>(
   // We must sort the children of each span by their start time
   // So that the children are in the correct order
   for (const spanNode of spanMap.values()) {
-    spanNode.children.sort(
-      (a, b) =>
-        new Date(a.span.startTime).valueOf() -
-        new Date(b.span.startTime).valueOf()
+    spanNode.children.sort((a, b) =>
+      compareTimestamps(a.span.startTime, b.span.startTime)
     );
   }
-  rootSpans.sort(
-    (a, b) =>
-      new Date(a.span.startTime).valueOf() -
-      new Date(b.span.startTime).valueOf()
+  rootSpans.sort((a, b) =>
+    compareTimestamps(a.span.startTime, b.span.startTime)
   );
   return rootSpans;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes span ordering logic in `createSpanTree`, which can affect trace UI ordering; timestamp parsing differences (timezones/fractional precision) could still cause edge-case mis-sorts if inputs deviate from expected ISO formats.
> 
> **Overview**
> Fixes span sorting in the trace tree to correctly order spans that differ only at sub-millisecond resolution.
> 
> Introduces `compareTimestamps` to compare ISO timestamps by millisecond time (with timezone handling) and then by fractional seconds, and switches `createSpanTree` to use this comparator for sorting both root spans and children. Adds targeted unit tests covering microsecond ordering, timezone offsets, and mixed fractional-second precision to prevent lexicographic-sort regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dcdfaa7d26294c9fcb078e06e4a0b7c0c96ca1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->