### PR TITLE
docs: improve AI agent context for Phoenix/Arize AX disambiguation

### DIFF
--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -7,14 +7,17 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 
 This page documents Phoenix (open-source LLM observability). Phoenix and Arize AX are DIFFERENT products.
 
-BEFORE implementing, check user's request for these signals:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → User wants Arize AX, NOT this page. Direct them to Arize AX docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → User wants Phoenix (this page).
+DETECTION CHECKLIST — scan user's request:
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize tracing", "implement tracing", "add observability" without specifying product → ASK which product.
 
-IF UNCLEAR OR MISMATCHED (user says "AX" but linked here, or vice versa), ASK:
-"I see you're on Phoenix documentation, but want to confirm: are you looking for Phoenix (open-source, runs locally or Phoenix Cloud, uses phoenix.otel) or Arize AX (cloud platform, uses arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two observability products. Which are you looking for?
+• **Phoenix**: Open-source, runs locally or Phoenix Cloud, uses `phoenix.otel` and `PHOENIX_API_KEY`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
 
-DO NOT proceed with implementation until product is confirmed.
+DO NOT proceed until user confirms the product.
 </div>
 
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix.

--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -8,10 +8,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents Phoenix experiments and datasets. Phoenix and Arize AX are DIFFERENT products.
 
 DETECTION CHECKLIST — scan user's request:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize experiments", "Arize datasets" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "You're on Phoenix docs. Did you mean Phoenix (open-source, phoenix.otel) or Arize AX (cloud, arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two products. Which are you using?
+• **Phoenix** (this page): Open-source, uses `phoenix.otel`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
 
 DO NOT proceed until confirmed.
 </div>

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -8,10 +8,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents Phoenix evaluations. Phoenix and Arize AX are DIFFERENT products.
 
 DETECTION CHECKLIST — scan user's request:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize evals", "Arize evaluations" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "You're on Phoenix docs. Did you mean Phoenix (open-source, phoenix.otel) or Arize AX (cloud, arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two products. Which are you using?
+• **Phoenix** (this page): Open-source, uses `phoenix.otel`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
 
 DO NOT proceed until confirmed.
 </div>

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -8,10 +8,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents Phoenix Prompt Playground and Prompt Hub. Phoenix and Arize AX are DIFFERENT products.
 
 DETECTION CHECKLIST — scan user's request:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize prompts", "Arize prompt playground" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "You're on Phoenix docs. Did you mean Phoenix (open-source, phoenix.otel) or Arize AX (cloud, arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two products. Which are you using?
+• **Phoenix** (this page): Open-source, uses `phoenix.otel`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
 
 DO NOT proceed until confirmed.
 </div>
@@ -116,9 +120,9 @@ This gives us a baseline for how the current prompt performs.
 
 Now that we have a baseline, we can make a change.
 
-In this step, we’ll modify the prompt in the playground to address issues we saw in previous runs, such as unclear instructions or missing constraints. 
+In this step, we’ll modify the prompt in the playground to address issues we saw in previous runs, such as unclear instructions or missing constraints.
 
-To understand why our evaluations came to a specific score, click into a trace and under the annotations column we can see the explanations of our evaluations. 
+To understand why our evaluations came to a specific score, click into a trace and under the annotations column we can see the explanations of our evaluations.
 
 Using these explanations, we can notice that many times the reason our agent run was labeled incomplete is due to the lack of financial ratios in our report -- so we can go ahead and add that into our prompt.
 
@@ -143,10 +147,10 @@ Saving prompt variants makes it easy to track changes and compare different appr
 
 ## **Step 5: Compare Prompts Using Experiments**
 
-Once we have multiple prompt versions, we want to compare them in a structured way to see if each prompt will result in unique results. 
+Once we have multiple prompt versions, we want to compare them in a structured way to see if each prompt will result in unique results.
 
-Since you just ran the prompt playground with both your prompts, you can see them side by side in the experiment view. 
- 
+Since you just ran the prompt playground with both your prompts, you can see them side by side in the experiment view.
+
 In this step, we'll just navigate to the experiments page and take a look at the runs we just made by using the prompt playground in this guide.
 
 1. Navigate to the Datasets Page & click on the dataset we made earlier in this guide.

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -8,13 +8,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents Phoenix Cloud tracing setup. Phoenix and Arize AX are DIFFERENT products with different APIs.
 
 DETECTION CHECKLIST — scan user's request:
-• User mentions "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, or imports from arize.otel → WRONG PAGE. User needs Arize AX docs, not Phoenix.
-• User mentions "Phoenix", PHOENIX_API_KEY, PHOENIX_COLLECTOR_ENDPOINT, phoenix.otel, or localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, PHOENIX_COLLECTOR_ENDPOINT, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. User needs Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize tracing", "implement tracing", "add observability" without specifying product → ASK which product.
 
-IF USER'S REQUEST DOESN'T MATCH THIS PAGE (e.g., they said "implement Arize AX" but linked here), YOU MUST ASK:
-"You mentioned Arize AX but linked to Phoenix docs. Which product do you need?
-• Phoenix: Open-source observability, runs locally or Phoenix Cloud, uses `phoenix.otel` and `PHOENIX_API_KEY`
-• Arize AX: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
+IF AMBIGUOUS OR MISMATCHED, YOU MUST ASK:
+"Arize offers two observability products. Which are you looking for?
+• **Phoenix**: Open-source, runs locally or Phoenix Cloud, uses `phoenix.otel` and `PHOENIX_API_KEY`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
 
 DO NOT implement until user confirms the product.
 </div>

--- a/docs/phoenix/quickstart.mdx
+++ b/docs/phoenix/quickstart.mdx
@@ -9,10 +9,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This is the Phoenix quickstart page. Phoenix and Arize AX are DIFFERENT products.
 
 DETECTION CHECKLIST — scan user's request:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize quickstart", "get started with Arize" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "You're on Phoenix docs. Did you mean Phoenix (open-source, phoenix.otel) or Arize AX (cloud, arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two products. Which quickstart do you need?
+• **Phoenix**: Open-source observability, uses `phoenix.otel`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
 
 DO NOT proceed until confirmed.
 </div>

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -9,10 +9,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This is Phoenix SDK API reference. Phoenix and Arize AX are DIFFERENT products with different SDKs.
 
 DETECTION CHECKLIST — scan user's request:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX SDK docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX SDK docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize SDK", "Arize API" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "You're on Phoenix SDK docs. Did you mean Phoenix (phoenix.otel) or Arize AX (arize.otel with ARIZE_SPACE_ID)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Which SDK documentation do you need?
+• **Phoenix SDK** (this page): For Phoenix observability
+• **Arize AX SDK**: For Arize AX platform"
 
 DO NOT proceed until confirmed.
 </div>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
@@ -10,10 +10,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents Phoenix tracing setup. Phoenix and Arize AX are DIFFERENT products with different setup procedures.
 
 DETECTION CHECKLIST — scan user's request and code:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, imports from arize.otel → WRONG PAGE. User needs Arize AX tracing docs.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize tracing", "set up tracing", "add tracing" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED (e.g., user's code has arize.otel imports), ASK: "Your code uses arize.otel which is for Arize AX. Did you mean to set up Arize AX tracing, or Phoenix tracing (which uses phoenix.otel)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two tracing products. Which are you setting up?
+• **Phoenix**: Open-source, uses `phoenix.otel` and optionally `PHOENIX_API_KEY`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
 
 DO NOT proceed until confirmed.
 </div>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -9,10 +9,14 @@ AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 This page documents phoenix.otel setup (Phoenix tracing). Phoenix and Arize AX use DIFFERENT OTEL packages.
 
 DETECTION CHECKLIST — scan user's request and code:
-• "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel, arize-otel package → WRONG PAGE. Direct to Arize AX OTEL setup.
-• "Phoenix", PHOENIX_API_KEY, phoenix.otel, arize-phoenix-otel package → CORRECT PAGE.
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, arize-phoenix-otel → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX OTEL setup.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize OTEL", "set up OTEL tracing" without specifying product → ASK which product.
 
-IF MISMATCH DETECTED, ASK: "This page covers phoenix.otel (Phoenix). Did you mean phoenix.otel or arize.otel (Arize AX)?"
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Which OTEL package do you need?
+• **phoenix.otel** (this page): For Phoenix tracing
+• **arize.otel**: For Arize AX tracing"
 
 DO NOT proceed until confirmed.
 </div>


### PR DESCRIPTION
## Summary

Improves the AI Agent Context blocks in 9 documentation files to make AI coding assistants stop and verify which product (Phoenix vs Arize AX) the user actually wants before implementing.

**Problem:** When users say "implement Arize AX" but link to Phoenix docs, AI agents currently proceed with Phoenix implementation without clarifying.

**Solution:** Updated frontmatter with:
- "STOP — VERIFY PRODUCT BEFORE PROCEEDING" directive
- Detection checklist with specific signals for each product
- Explicit instruction to ASK when there's a mismatch
- Scripted clarification questions for AI agents
- "DO NOT proceed until confirmed" instruction

## Files changed

- `docs/phoenix/get-started.mdx`
- `docs/phoenix/get-started/get-started-tracing.mdx`
- `docs/phoenix/get-started/get-started-datasets-and-experiments.mdx`
- `docs/phoenix/get-started/get-started-evaluations.mdx`
- `docs/phoenix/get-started/get-started-prompt-playground.mdx`
- `docs/phoenix/quickstart.mdx`
- `docs/phoenix/sdk-api-reference.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx`

## Test plan

- AI agents reading these pages should now pause and ask for clarification when user's request mentions "Arize AX" but they landed on Phoenix docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add stronger guardrails for AI assistants; no product code or runtime behavior is affected.
> 
> **Overview**
> Adds a standardized **“STOP — VERIFY PRODUCT BEFORE PROCEEDING”** gate to multiple Phoenix docs pages’ hidden `AI Agent Context` blocks, to prevent assistants from implementing Phoenix guidance when the user actually means *Arize AX*.
> 
> Each updated page now includes a detection checklist (Phoenix vs AX signals), a scripted clarification question for ambiguous/mismatched requests, and an explicit instruction to **not proceed until the product is confirmed**; additionally makes minor wording/whitespace edits in `get-started-prompt-playground.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 857e4d77097d7b959f357abde1e4cdeea77e8b1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>857e4d7</u></sup><!-- /BUGBOT_STATUS -->