### PR TITLE
docs: add in code links to evals tutorials

### DIFF
--- a/docs/phoenix/evaluation/tutorials/customize-eval-template.mdx
+++ b/docs/phoenix/evaluation/tutorials/customize-eval-template.mdx
@@ -8,11 +8,11 @@ This guide shows how to customize an evaluation template in Phoenix by refining 
 Follow along with the following code assets:
 
 <Columns cols={2}>
-  <Card title="TypeScript Tutorial" icon="js" href="">
-    Companion TypeScript project with runnable examples
-  </Card>
-  <Card title="Python Tutorial" icon="python" href="">
+  <Card title="Python Tutorial" icon="python" href="https://github.com/Arize-ai/phoenix/blob/main/tutorials/quickstarts/agno_agent_for_evals.ipynb">
     Companion Python project with runnable examples
+  </Card>
+  <Card title="TypeScript Tutorial" icon="js" href="https://github.com/Arize-ai/phoenix/tree/main/tutorials/quickstarts/langchain-ts-quickstart">
+    Companion TypeScript project with runnable examples
   </Card>
 </Columns>
 --- 

--- a/docs/phoenix/evaluation/tutorials/customize-your-llm-endpoint.mdx
+++ b/docs/phoenix/evaluation/tutorials/customize-your-llm-endpoint.mdx
@@ -20,11 +20,11 @@ In this guide, we focus on configuring the judge model, then reusing the same bu
 Follow along with the following code assets: 
 
 <Columns cols={2}>
-  <Card title="TypeScript Tutorial" icon="js" href="">
-    Companion TypeScript project with runnable examples
-  </Card>
-  <Card title="Python Tutorial" icon="python" href="">
+  <Card title="Python Tutorial" icon="python" href="https://github.com/Arize-ai/phoenix/blob/main/tutorials/quickstarts/agno_agent_for_evals.ipynb">
     Companion Python project with runnable examples
+  </Card>
+  <Card title="TypeScript Tutorial" icon="js" href="https://github.com/Arize-ai/phoenix/tree/main/tutorials/quickstarts/langchain-ts-quickstart">
+    Companion TypeScript project with runnable examples
   </Card>
 </Columns>
 

--- a/docs/phoenix/evaluation/tutorials/run-evals-with-built-in-evals.mdx
+++ b/docs/phoenix/evaluation/tutorials/run-evals-with-built-in-evals.mdx
@@ -21,11 +21,11 @@ This guide walks through how to configure a judge model and run built-in eval te
 Follow along with the following code assets: 
 
 <Columns cols={2}>
-  <Card title="TypeScript Tutorial" icon="js" href="">
-    Companion TypeScript project with runnable examples
-  </Card>
-  <Card title="Python Tutorial" icon="python" href="">
+  <Card title="Python Tutorial" icon="python" href="https://github.com/Arize-ai/phoenix/blob/main/tutorials/quickstarts/agno_agent_for_evals.ipynb">
     Companion Python project with runnable examples
+  </Card>
+  <Card title="TypeScript Tutorial" icon="js" href="https://github.com/Arize-ai/phoenix/tree/main/tutorials/quickstarts/langchain-ts-quickstart">
+    Companion TypeScript project with runnable examples
   </Card>
 </Columns>
 

--- a/tutorials/quickstarts/agno_agent_for_evals.ipynb
+++ b/tutorials/quickstarts/agno_agent_for_evals.ipynb
@@ -313,15 +313,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "agent_spans[\"attributes.output.value\", \"attributes.input.value\"]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates plus a minor notebook cleanup; no runtime/library code paths are affected.
> 
> **Overview**
> Adds **working code asset links** in the eval tutorial pages so the “Python Tutorial” and “TypeScript Tutorial” cards point to the corresponding runnable quickstarts (instead of empty `href`s).
> 
> Cleans up the `agno_agent_for_evals.ipynb` quickstart by removing a stray/incorrect dataframe indexing cell in the spans export section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bcd50cad0ae46d66002533fd56b1ae49661d459. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->