### PR TITLE
chore: cherry-pick uv changes

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -110,10 +110,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
-      - run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e phoenix_client -- -ra -x
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
     name: Phoenix Evals
@@ -134,10 +132,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
-      - run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e phoenix_evals -- -ra -x
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
     name: Phoenix OTel
@@ -157,10 +153,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
-      - run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e phoenix_otel -- -ra -x
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e phoenix_otel -- -ra -x
 
   clean-jupyter-notebooks:
     name: Clean Jupyter Notebooks
@@ -179,16 +173,15 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             requirements/clean-jupyter-notebooks.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Clean Jupyter notebooks
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e clean_jupyter_notebooks -- ${{ needs.changes.outputs.ipynb_files }}
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e clean_jupyter_notebooks -- ${{ needs.changes.outputs.ipynb_files }}
       - run: git diff --exit-code
 
   build-graphql-schema:
@@ -208,16 +201,15 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             requirements/build-graphql-schema.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build GraphQL schema
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e build_graphql_schema
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e build_graphql_schema
       - run: git diff --exit-code
 
   build-openapi-schema:
@@ -237,15 +229,14 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build OpenAPI schema
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e build_openapi_schema
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e build_openapi_schema
       - run: git diff --exit-code
 
   compile-protobuf:
@@ -265,16 +256,15 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             requirements/compile-protobuf.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Protobuf
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e compile_protobuf
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e compile_protobuf
       - run: git diff --exit-code
 
   compile-prompts:
@@ -294,11 +284,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
+        uses: astral-sh/setup-uv@v7
       - name: Compile Prompts
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e compile_prompts
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e compile_prompts
       - name: Check for changes
         run: git diff --exit-code
 
@@ -320,9 +308,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
+        uses: astral-sh/setup-uv@v7
       - name: Check lockfile is up to date
         run: uv lock --check
 
@@ -342,11 +328,9 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
+        uses: astral-sh/setup-uv@v7
       - name: Run `ruff`
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e ruff
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e ruff
       - run: git diff --exit-code
 
   type-check:
@@ -373,9 +357,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -383,9 +366,9 @@ jobs:
             requirements/type-check.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e type_check
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e type_check
       - name: Ensure GraphQL mutations have permission classes
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e ensure_graphql_mutations_have_permission_classes
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e ensure_graphql_mutations_have_permission_classes
 
   type-check-unit-tests:
     name: Type Check Unit Tests
@@ -414,9 +397,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -424,7 +406,7 @@ jobs:
             requirements/unit-tests.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types on unit tests
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e type_check_unit_tests
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e type_check_unit_tests
 
   unit-tests:
     name: Unit Tests
@@ -452,9 +434,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -467,11 +448,11 @@ jobs:
       - name: Run tests with PostgreSQL (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 60
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e unit_tests -- -ra -x --reruns 5 --run-postgres
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e unit_tests -- -ra -x --reruns 5 --run-postgres
       - name: Run tests without PostgreSQL (non-Linux)
         if: runner.os != 'Linux'
         timeout-minutes: 60
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e unit_tests -- -ra -x --reruns 5
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e unit_tests -- -ra -x --reruns 5
 
   type-check-integration-tests:
     name: Type Check Integration Tests
@@ -499,9 +480,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -509,7 +489,7 @@ jobs:
             requirements/integration-tests.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types on integration tests
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e type_check_integration_tests
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e type_check_integration_tests
 
   integration-tests:
     name: Integration Tests
@@ -556,9 +536,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -567,7 +546,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e integration_tests -- -ra -x --reruns 5
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e integration_tests -- -ra -x --reruns 5 -n auto
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }})
@@ -597,9 +576,7 @@ jobs:
         with:
           python-version: 3.13
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: 0.8.6
+        uses: astral-sh/setup-uv@v7
       - name: Install arize-phoenix and database dependencies
         run: |
           uv pip install --system -qU 'arize-phoenix[pg]'
@@ -659,9 +636,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: Set up `uv`
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: 0.8.6
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
@@ -669,4 +645,4 @@ jobs:
             requirements/canary/sdk/${{ matrix.pkg }}.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run canary tests for ${{ matrix.pkg }}
-        run: uvx --with tox-uv==1.27.0 --with uv==0.8.6 tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
+        run: uvx --with tox-uv==1.29.0 --with uv==0.9.30 tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,6 +352,9 @@ force-single-line = false
 [tool.ruff.format]
 line-ending = "native"
 
+[tool.uv]
+required-version = "==0.9.30"
+
 [tool.uv.workspace]
 members = ["packages/*"]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/workflow-only changes plus a tool version pin; primary risk is CI behavior changes (dependency resolution or test execution differences), not production code.
> 
> **Overview**
> Updates Python CI to use `astral-sh/setup-uv@v7` and refreshes the `uv`/`tox-uv` versions used for all `uvx tox` jobs (including lint, type checks, schema generation, and tests).
> 
> Pins the repo to `uv==0.9.30` via `pyproject.toml` (`[tool.uv].required-version`) and enables parallelized integration test execution by adding `-n auto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a28c10662ac0bac94cbcf880e85c7f22a9e70df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->