### PR TITLE
docs: update developer guide with new uv install and upgrade instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,7 +23,7 @@
 
 We recommend using a virtual environment to isolate your Python dependencies. This guide will use `uv`, but you can use a different virtual environment management tool such as `conda` if you want.
 
-**First**, ensure that your virtual environment manager is installed. For macOS users, we recommend installing the project version of `uv` (found in `pyproject.toml` under `tool.uv.required-version`) by using the [standalone installer](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer). This will enable you to upgrade `uv` using the `uv self update` command.
+We recommend installing the project version of `uv` (found in `pyproject.toml` under `tool.uv.required-version`) by using the [standalone installer](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer). This will enable you to upgrade `uv` using the `uv self update` command when the project `uv` version is updated.
 
 The following command installs the main `arize-phoenix` package and all sub-packages in editable mode with development dependencies. It uses the lowest currently supported Python version to ensure compatibilty with all supported Python versions.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that affects developer setup instructions but does not modify runtime code or build logic.
> 
> **Overview**
> Updates `DEVELOPMENT.md` to replace Homebrew/venv setup steps with guidance to install the *project-pinned* `uv` version (from `pyproject.toml` `tool.uv.required-version`) via the standalone installer, enabling upgrades via `uv self update`.
> 
> Keeps the workflow centered on `uv sync --python 3.10` for setting up the editable dev environment, but removes the explicit `uv venv` creation/activation instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155d8245861a0cd839a306268d9d4073220b942f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->