### PR TITLE
ci: fix clean jupyter notebook

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -214,6 +214,7 @@ commands =
   find . -type f -name "*.ipynb" -not -path "*/tutorials/evals/*" -not -path "*/tutorials/ai_evals_course/*" -exec jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace {} \;
 allowlist_externals =
   find
+  uv
 
 [testenv:build_graphql_schema]
 description = Export GraphQL schema to a file (Python 3.10)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CI/tox configuration change that only affects the notebook-cleaning testenv execution.
> 
> **Overview**
> Fixes the `tox -e clean_jupyter_notebooks` environment by allowing `uv` to run as an external command, matching the existing use of `uv pip list -v` in that job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 627b587c0d4399e83695834102cfc4faa2847e11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->