### PR TITLE
fix(postgresql) connection pool issues in #11243

### DIFF
--- a/src/phoenix/db/pg_config.py
+++ b/src/phoenix/db/pg_config.py
@@ -53,6 +53,13 @@ def get_pg_config(
             connect_args = {"ssl": _get_ssl_context(ssl_args)}
         else:
             connect_args = {}
+        # Add TCP keepalive settings to detect broken connections through firewalls/proxies
+        # These settings help prevent "connection was closed" errors in Kubernetes environments
+        connect_args["server_settings"] = {
+            "tcp_keepalives_idle": "60",      # Send keepalive probe after 60s of idle
+            "tcp_keepalives_interval": "10",  # Send probe every 10s if no response
+            "tcp_keepalives_count": "5",      # Close connection after 5 failed probes
+        }
     else:
         assert_never(driver)
     return base_url, connect_args


### PR DESCRIPTION
Phoenix was experiencing `asyncpg.exceptions.ConnectionDoesNotExistError` errors due to:
1. No connection pool configuration (using SQLAlchemy defaults of only 5 connections + 10 overflow)
2. No connection health checking (`pool_pre_ping` disabled)
3. No connection recycling
4. No TCP keepalive settings

## Files Changed
1. `src/phoenix/config.py` - Added 4 environment variables and getter functions
2. `src/phoenix/db/engines.py` - Applied pool settings to PostgreSQL engine creation
3. `src/phoenix/db/pg_config.py` - Added TCP keepalive to asyncpg connections

## Related Issue
Fixes `asyncpg.exceptions.ConnectionDoesNotExistError: connection was closed in the middle of operation` #11243 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database connection pooling and driver settings, which can affect throughput and connection counts in production if misconfigured.
> 
> **Overview**
> Reduces PostgreSQL `asyncpg` disconnect errors by making SQLAlchemy’s connection pool behavior configurable and more resilient.
> 
> Adds new env-driven pool controls (`PHOENIX_SQL_DATABASE_POOL_SIZE`, `..._MAX_OVERFLOW`, `..._POOL_PRE_PING`, `..._POOL_RECYCLE`) and applies them when creating the async PostgreSQL engine; for AWS RDS IAM auth, pool recycling is tied to the IAM token lifetime.
> 
> Updates `asyncpg` connection args to always include TCP keepalive `server_settings` to better detect broken connections (e.g., through Kubernetes networking).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8233265a7c8cfa4aaaaf6eb03fec2fba57810058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->