### PR TITLE
refactor(tox): use uv pip install in commands_pre instead of deps

### DIFF
--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -14,7 +14,7 @@ numpy
 openai>=1.0.0
 pandas-stubs==2.0.3.230814
 pandas>=1.0
-protobuf==4.25.8  # version minimum (for tests)
+protobuf
 psycopg[binary,pool]
 pyarrow-stubs
 pytest-postgresql

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ allowlist_externals =
 [testenv:phoenix_client]
 description = Run tests for the arize-phoenix-client package
 changedir = packages/phoenix-client/
-deps =
-  -r requirements/packages/phoenix-client.txt
-commands_pre = uv pip install --strict --reinstall-package arize-phoenix-client .
+commands_pre = 
+  uv pip install --strict -U -r {toxinidir}/requirements/packages/phoenix-client.txt
+  uv pip install --strict --reinstall-package arize-phoenix-client .
 commands =
   uv pip list -v
   {envbindir}/pyright .
@@ -104,9 +104,9 @@ commands =
 [testenv:phoenix_evals]
 description = Run tests for the arize-phoenix-evals package
 changedir = packages/phoenix-evals/
-deps =
-  -r requirements/packages/phoenix-evals.txt
-commands_pre = uv pip install --strict --reinstall-package arize-phoenix-evals .[test]
+commands_pre = 
+  uv pip install --strict -U -r {toxinidir}/requirements/packages/phoenix-evals.txt
+  uv pip install --strict --reinstall-package arize-phoenix-evals .[test]
 commands =
   uv pip list -v
   mypy .
@@ -115,9 +115,9 @@ commands =
 [testenv:phoenix_otel]
 description = Run tests for the arize-phoenix-otel package
 changedir = packages/phoenix-otel/
-deps =
-  -r requirements/ci.txt
-commands_pre = uv pip install --strict --reinstall-package arize-phoenix-otel .[test]
+commands_pre = 
+  uv pip install --strict -U -r {toxinidir}/requirements/ci.txt
+  uv pip install --strict --reinstall-package arize-phoenix-otel .[test]
 commands =
   uv pip list -v
   mypy .
@@ -126,9 +126,8 @@ commands =
 [testenv:type_check_integration_tests]
 description = Run type checking with mypy on integration tests
 changedir = tests/integration
-deps =
-  -r requirements/integration-tests.txt
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/integration-tests.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
   uv pip install --strict --reinstall-package arize-phoenix-client {toxinidir}/packages/phoenix-client
 commands =
@@ -141,11 +140,10 @@ description = Run integration tests
 pass_env =
   CI_TEST_DB_BACKEND
 changedir = tests/integration
-deps =
-  -r requirements/integration-tests.txt
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/integration-tests.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
   uv pip install --strict --reinstall-package arize-phoenix-client {toxinidir}/packages/phoenix-client
 commands =
@@ -155,9 +153,8 @@ commands =
 [testenv:type_check_unit_tests]
 description = Run type checking with mypy on unit tests
 changedir = tests/
-deps =
-  -r requirements/unit-tests.txt
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/unit-tests.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
 commands =
   uv pip list -v
@@ -166,11 +163,10 @@ commands =
 [testenv:unit_tests]
 description = Run unit tests
 changedir = tests
-deps =
-  -r requirements/unit-tests.txt
 setenv =
   PHOENIX_MASK_INTERNAL_SERVER_ERRORS = false
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/unit-tests.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
 commands =
   uv pip list -v
@@ -179,9 +175,8 @@ commands =
 [testenv:unit_tests_local_evals]
 description = Run unit tests with phoenix-evals installed from local source
 changedir = tests
-deps =
-  -r requirements/unit-tests.txt
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/unit-tests.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix --reinstall-package arize-phoenix-evals ../. arize-phoenix-evals@../packages/phoenix-evals
 commands =
   uv pip list -v
@@ -189,9 +184,8 @@ commands =
 
 [testenv:type_check]
 description = Run type checking with mypy on src/phoenix
-deps =
-  -r requirements/type-check.txt
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/type-check.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix .
   uv pip install --strict --reinstall-package arize-phoenix-client {toxinidir}/packages/phoenix-client
 commands =
@@ -207,8 +201,8 @@ commands =
 
 [testenv:clean_jupyter_notebooks]
 description = Clear output and metadata from Jupyter notebooks
-deps =
-  -r requirements/clean-jupyter-notebooks.txt
+commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/clean-jupyter-notebooks.txt
 commands =
   uv pip list -v
   find . -type f -name "*.ipynb" -not -path "*/tutorials/evals/*" -not -path "*/tutorials/ai_evals_course/*" -exec jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace {} \;
@@ -221,9 +215,8 @@ description = Export GraphQL schema to a file (Python 3.10)
 recreate = true
 basepython = python3.10
 changedir = app
-deps =
-  -r requirements/build-graphql-schema.txt
 commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/build-graphql-schema.txt
   uv pip install --no-sources --strict --reinstall-package arize-phoenix {toxinidir}
   uv pip install 'libcst<1.8' # https://github.com/strawberry-graphql/strawberry/issues/3874
 commands =
@@ -244,8 +237,8 @@ commands =
 [testenv:compile_protobuf]
 description = Compile protobuf files (Python 3.10)
 basepython = python3.10
-deps =
-  -r requirements/compile-protobuf.txt
+commands_pre =
+  uv pip install --strict -U -r {toxinidir}/requirements/compile-protobuf.txt
 commands =
   uv pip list -v
   python -m grpc_tools.protoc -I src/phoenix/proto --python_out=src/phoenix --mypy_out=src/phoenix src/phoenix/proto/trace/v1/evaluation.proto


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly CI/test harness refactoring, but it changes dependency resolution (notably unpinning `protobuf`) and could introduce non-deterministic test failures across environments.
> 
> **Overview**
> Updates `tox.ini` to stop using per-env `deps = -r ...` and instead install those requirement files explicitly in `commands_pre` using `uv pip install --strict -U -r ...` before reinstalling local packages.
> 
> Adjusts `requirements/unit-tests.txt` by removing the explicit `protobuf==4.25.8` pin and relying on unpinned `protobuf`, which may change the resolved version during test runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d2116bfb90bd9fb8f9e4b5e26efeeedd385020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->