### PR TITLE
fix: eval in same order as runs

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -788,6 +788,8 @@ class Subscription:
             )
 
         if input.evaluators:
+            # Process revisions in reverse order to match the order in which chat completions
+            # were executed, since not_started pops from the right
             for revision in reversed(revisions):
                 example_id = GlobalID(DatasetExample.__name__, str(revision.dataset_example_id))
                 for repetition_number in range(1, input.repetitions + 1):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small control-flow change limited to evaluator iteration order; low risk aside from potentially changing the sequence of emitted evaluation chunks.
> 
> **Overview**
> Fixes evaluation ordering for `chat_completion_over_dataset` by iterating over `revisions` in reverse when running post-run evaluators, aligning evaluator output with the actual run execution order (since work is popped from the right of `not_started`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11085a3acb147d1712da4153c5aaa5e1a908bd81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->