### PR TITLE
fix: Add require all toggle to contains evaluator

### DIFF
--- a/app/src/components/evaluators/ContainsEvaluatorForm.tsx
+++ b/app/src/components/evaluators/ContainsEvaluatorForm.tsx
@@ -107,6 +107,31 @@ export const ContainsEvaluatorForm = () => {
             </Switch>
           )}
         />
+        <Controller
+          name="literalMapping.require_all"
+          control={control}
+          defaultValue={false}
+          render={({ field }) => (
+            <Switch
+              {...field}
+              value={String(field.value ?? "")}
+              onChange={(value) => field.onChange(value)}
+              isSelected={Boolean(
+                typeof field.value === "boolean"
+                  ? field.value
+                  : typeof field.value === "string"
+                    ? field.value.toLowerCase() === "true"
+                    : false
+              )}
+            >
+              <Label>Require all</Label>
+              <Text slot="description">
+                Whether to require all words in the list to be present in the
+                text. If false, any word in the list can be present in the text.
+              </Text>
+            </Switch>
+          )}
+        />
       </Flex>
       <BuiltInEvaluatorOutputConfig />
       <ContainsEvaluatorCodeBlock />

--- a/app/src/pages/playground/PlaygroundEvaluatorSelect.tsx
+++ b/app/src/pages/playground/PlaygroundEvaluatorSelect.tsx
@@ -184,7 +184,9 @@ export function PlaygroundEvaluatorSelect(
       <EditBuiltInDatasetEvaluatorSlideover
         datasetEvaluatorId={editingEvaluator?.datasetEvaluatorId}
         datasetId={datasetId}
-        isOpen={editingEvaluator !== null && editingEvaluator.isBuiltIn}
+        isOpen={
+          editingEvaluator !== null && editingEvaluator.kind === "BUILTIN"
+        }
         onOpenChange={(open) => {
           if (!open) {
             setEditingEvaluator(null);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI/state-wiring changes that add a new boolean flag and tighten a conditional for opening an editor; low blast radius and no security/data-path changes.
> 
> **Overview**
> Adds a new `Require all` switch to the Contains evaluator form, persisting a `literalMapping.require_all` boolean to control whether *all* listed words must match versus *any* word.
> 
> Fixes the playground evaluator editor slideover gating by opening the built-in editor based on `editingEvaluator.kind === "BUILTIN"` (instead of `isBuiltIn`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22aae4248a0077ada6bef3dafee74f7a8d6a3776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->