### PR TITLE
fix: prevent simultaneous temperature and top_p for Claude 4.x models in Playground

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib.util
 import inspect
 import json
+import re
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -486,6 +487,11 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
                 formatted_invocation_parameters[invocation_name] = value
         validate_invocation_parameters(supported_params, formatted_invocation_parameters)
         return formatted_invocation_parameters
+
+    def apply_invocation_parameter_constraints(
+        self, invocation_parameters: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        return dict(invocation_parameters)
 
     @classmethod
     def dependencies_are_installed(cls) -> bool:
@@ -1179,6 +1185,15 @@ class BedrockStreamingClient(PlaygroundStreamingClient["BedrockRuntimeClient"]):
             ),
         ]
 
+    @override
+    def apply_invocation_parameter_constraints(
+        self, invocation_parameters: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        return _apply_anthropic_invocation_parameter_constraints(
+            invocation_parameters=invocation_parameters,
+            model_name=self.model_name,
+        )
+
     async def _chat_completion_create(
         self,
         *,
@@ -1788,6 +1803,29 @@ class AzureOpenAIReasoningNonStreamingClient(
         assert_never(role)
 
 
+_CLAUDE_4_MODEL_REGEX = re.compile(r"\bclaude(?:-[a-z]+)?-4(?:[.-]\d+)*", re.IGNORECASE)
+
+
+def _is_claude_4_model(model_name: str) -> bool:
+    return bool(_CLAUDE_4_MODEL_REGEX.search(model_name))
+
+
+def _apply_anthropic_invocation_parameter_constraints(
+    invocation_parameters: Mapping[str, Any],
+    model_name: str,
+) -> dict[str, Any]:
+    constrained = dict(invocation_parameters)
+    if (
+        _is_claude_4_model(model_name)
+        and constrained.get("temperature") is not None
+        and constrained.get("top_p") is not None
+    ):
+        # Claude 4.x rejects requests that specify both temperature and top_p.
+        # Keep temperature and drop top_p to avoid provider-side 400 errors.
+        constrained.pop("top_p", None)
+    return constrained
+
+
 @register_llm_client(
     provider_key=GenerativeProviderKey.ANTHROPIC,
     model_names=[
@@ -1855,6 +1893,15 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
                 canonical_name=CanonicalParameterName.TOOL_CHOICE,
             ),
         ]
+
+    @override
+    def apply_invocation_parameter_constraints(
+        self, invocation_parameters: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        return _apply_anthropic_invocation_parameter_constraints(
+            invocation_parameters=invocation_parameters,
+            model_name=self.model_name,
+        )
 
     async def _chat_completion_create(
         self,

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -738,8 +738,8 @@ class ChatCompletionMutationMixin:
         if appended_messages:
             messages.extend(appended_messages)
 
-        invocation_parameters = llm_client.construct_invocation_parameters(
-            input.invocation_parameters
+        invocation_parameters = llm_client.apply_invocation_parameter_constraints(
+            llm_client.construct_invocation_parameters(input.invocation_parameters)
         )
 
         text_content = ""

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -135,7 +135,9 @@ async def _stream_single_chat_completion(
                 template_variables=template_options.variables,
             )
         )
-    invocation_parameters = llm_client.construct_invocation_parameters(input.invocation_parameters)
+    invocation_parameters = llm_client.apply_invocation_parameter_constraints(
+        llm_client.construct_invocation_parameters(input.invocation_parameters)
+    )
     tracer = Tracer(span_cost_calculator=span_cost_calculator)
     try:
         async for chunk in llm_client.chat_completion_create(
@@ -810,7 +812,9 @@ async def _stream_chat_completion_over_dataset_example(
     experiment_id: int,
 ) -> ChatStream:
     example_id = GlobalID(DatasetExample.__name__, str(revision.dataset_example_id))
-    invocation_parameters = llm_client.construct_invocation_parameters(input.invocation_parameters)
+    invocation_parameters = llm_client.apply_invocation_parameter_constraints(
+        llm_client.construct_invocation_parameters(input.invocation_parameters)
+    )
     messages: list[PlaygroundMessage] = [
         create_playground_message(
             message.role,


### PR DESCRIPTION
## Summary

Fixes #11278

Claude 4.x models (claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5, claude-opus-4-1, etc.) do not support specifying both `temperature` and `top_p` simultaneously. When both are provided, the Anthropic API returns:

```
invalid_request_error: 'temperature' and 'top_p' cannot both be specified for this model. Please use only one.
```

This makes the Playground effectively broken for all Claude 4.x models, since the UI exposes both controls without validation.

## Changes

### Request-level constraint (`playgroundUtils.ts`)
- Added `isClaude4Model()` helper that detects Claude 4.x model names via regex
- Extended `applyAnthropicInvocationParameterConstraints()` to automatically drop `top_p` when both `temperature` and `top_p` are set for Claude 4.x models
- `temperature` is kept over `top_p` as it is the more commonly used sampling parameter
- This constraint is applied at request time (in `applyProviderInvocationParameterConstraints`), so the UI still shows both controls but the invalid combination is silently resolved before sending the API request

### Tests (`playgroundUtils.test.ts`)
- Added `isClaude4Model` test suite covering all known Claude 4.x variants and verifying non-matches (Claude 3.x, GPT-4, Gemini)
- Added `applyProviderInvocationParameterConstraints` test suite verifying:
  - `top_p` is dropped when both params are set for Claude 4.x
  - Individual params are preserved when only one is set
  - Both params are allowed for Claude 3.x models (backward compatible)
  - Both params are allowed for non-Anthropic providers

## Why this approach

The fix follows the existing pattern in `applyAnthropicInvocationParameterConstraints` which already handles extended thinking constraints (removing temperature/top_p when extended thinking is enabled). This is the least invasive approach that:

1. Prevents the API error without changing the UI
2. Is backward compatible with Claude 3.x models
3. Follows the established constraint pattern in the codebase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-time invocation parameters for Anthropic/Bedrock Claude 4.x models, which can subtly alter sampling behavior and relies on regex model-name matching, but is narrowly scoped to avoiding known 400 errors.
> 
> **Overview**
> Prevents Playground chat requests to Anthropic/Bedrock Claude 4.x models from failing by **automatically removing `top_p` when both `temperature` and `top_p` are provided**.
> 
> This introduces a generic `PlaygroundStreamingClient.apply_invocation_parameter_constraints()` hook, applies it in chat mutations/subscriptions before sending requests, and implements Anthropic-specific logic (regex-based Claude 4.x detection) for both `AnthropicStreamingClient` and `BedrockStreamingClient`. Unit tests were added to cover model detection and the `top_p`-dropping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d016d8695b7f121dacfb58a98dc7f6f82a292b16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->