### PR TITLE
feat: add Claude Opus 4.6 model to playground

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -646,7 +646,7 @@ class OllamaStreamingClient(OpenAIBaseStreamingClient):
     provider_key=GenerativeProviderKey.AWS,
     model_names=[
         PROVIDER_DEFAULT,
-        "anthropic.claude-opus-4-6-v1:0",
+        "anthropic.claude-opus-4-6-v1",
         "anthropic.claude-opus-4-5-20251101-v1:0",
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/src/phoenix/server/cost_tracking/model_cost_manifest.json
+++ b/src/phoenix/server/cost_tracking/model_cost_manifest.json
@@ -477,33 +477,6 @@
       ]
     },
     {
-      "name": "claude-opus-4-6",
-      "name_pattern": "claude-opus-4-6",
-      "source": "manual",
-      "token_prices": [
-        {
-          "base_rate": 5e-6,
-          "is_prompt": true,
-          "token_type": "input"
-        },
-        {
-          "base_rate": 0.000025,
-          "is_prompt": false,
-          "token_type": "output"
-        },
-        {
-          "base_rate": 5e-7,
-          "is_prompt": true,
-          "token_type": "cache_read"
-        },
-        {
-          "base_rate": 6.25e-6,
-          "is_prompt": true,
-          "token_type": "cache_write"
-        }
-      ]
-    },
-    {
       "name": "claude-opus-4-5",
       "name_pattern": "claude-opus-4-5",
       "source": "litellm",


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.6 (`claude-opus-4-6`) support to the Phoenix playground and cost tracking, addressing the request in #11270.

### Changes

- **Playground (Anthropic provider):** Register `claude-opus-4-6` with `AnthropicReasoningStreamingClient`, which provides extended thinking parameter support
- **Playground (AWS Bedrock provider):** Register `anthropic.claude-opus-4-6-v1` with `BedrockStreamingClient`
- **Cost tracking:** Add `claude-opus-4-6` entry to `model_cost_manifest.json` with correct pricing ($5/$25 per MTok input/output, plus cache read/write rates matching Opus 4.5)

### Why this approach

Claude Opus 4.6 supports extended thinking (like all Claude 4.x models), so it is registered with `AnthropicReasoningStreamingClient` rather than the base `AnthropicStreamingClient`. This ensures the `thinking` invocation parameter is available in the playground UI.

The model does not have a separate dated version ID -- Anthropic uses `claude-opus-4-6` as both the alias and the API ID ([source](https://platform.claude.com/docs/en/about-claude/models)).

Pricing is sourced from [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing).

### Note on scope

This PR covers the core integration (model registration + cost tracking). The more advanced features mentioned in #11270 (adaptive thinking toggle, effort parameter, compaction API, data residency controls) would require more significant UI and backend changes and are better suited for follow-up work.

## Test plan

- [ ] Verify `claude-opus-4-6` appears in the Anthropic provider model dropdown
- [ ] Verify `anthropic.claude-opus-4-6-v1` appears in the AWS Bedrock provider model dropdown
- [ ] Verify the `thinking` (extended thinking) invocation parameter is available when Opus 4.6 is selected
- [ ] Verify cost tracking correctly calculates costs for Opus 4.6 spans

Closes #11270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new model identifiers and pricing metadata without changing core request/streaming logic; risk is limited to incorrect model routing or cost calculations if the IDs/rates are wrong.
> 
> **Overview**
> Adds Claude Opus 4.6 model selection support in the playground by registering `claude-opus-4-6` under the Anthropic reasoning client (enabling the `thinking` parameter) and `anthropic.claude-opus-4-6-v1` under the AWS Bedrock client.
> 
> Updates cost tracking by adding `claude-opus-4-6` (and a dated variant) to `model_cost_manifest.json` with token pricing (input/output plus cache read/write rates) so spans can be costed correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f576a41468c4b2c39cc7a0880581eb97d26e4155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->