### PR TITLE
fix: add timezone validation to log_spans_dataframe

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -2543,13 +2543,13 @@ export interface components {
             /**
              * Start Time
              * Format: date-time
-             * @description Start time of the span
+             * @description Start time of the span (must be timezone-aware)
              */
             start_time: string;
             /**
              * End Time
              * Format: date-time
-             * @description End time of the span
+             * @description End time of the span (must be timezone-aware)
              */
             end_time: string;
             /**
@@ -2732,7 +2732,7 @@ export interface components {
             /**
              * Timestamp
              * Format: date-time
-             * @description When the event occurred
+             * @description When the event occurred (must be timezone-aware)
              */
             timestamp: string;
             /**

--- a/packages/phoenix-client/src/phoenix/client/helpers/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/helpers/spans/__init__.py
@@ -292,23 +292,6 @@ def dataframe_to_spans(df: "pd.DataFrame") -> list[Span]:
     """
     import pandas as pd
 
-    # Validate timezone-aware timestamps before processing
-    for time_column in ["start_time", "end_time"]:
-        if time_column in df.columns:
-            # Check if column has datetime dtype and if any values are timezone-naive
-            time_values = df[time_column].dropna()  # pyright: ignore
-            if len(time_values) > 0:  # pyright: ignore
-                # Check first non-null value to determine if timestamps are timezone-aware
-                first_value = time_values.iloc[0]  # pyright: ignore
-                if hasattr(first_value, "tzinfo"):  # pyright: ignore
-                    if first_value.tzinfo is None:  # pyright: ignore
-                        raise ValueError(
-                            f"Column '{time_column}' contains timezone-naive timestamps. "
-                            f"All timestamps must be timezone-aware (e.g., use UTC). "
-                            f"Convert naive timestamps to timezone-aware using: "
-                            f"df['{time_column}'] = df['{time_column}'].dt.tz_localize('UTC')"
-                        )
-
     spans: list[Span] = []
 
     for idx, row in df.iterrows():  # pyright: ignore
@@ -354,6 +337,13 @@ def dataframe_to_spans(df: "pd.DataFrame") -> list[Span]:
             if field in row and pd.notna(row[field]):  # pyright: ignore[reportGeneralTypeIssues,reportUnknownMemberType,reportUnknownArgumentType]
                 value = row[field]  # pyright: ignore
                 if field in ["start_time", "end_time"]:
+                    if hasattr(value, "tzinfo") and value.tzinfo is None:  # pyright: ignore
+                        raise ValueError(
+                            f"Row {idx}: column '{field}' contains a timezone-naive timestamp. "
+                            f"All timestamps must be timezone-aware (e.g., use UTC). "
+                            f"Convert naive timestamps using: "
+                            f"df['{field}'] = df['{field}'].dt.tz_localize('UTC')"
+                        )
                     if hasattr(value, "isoformat"):  # pyright: ignore
                         value = value.isoformat()  # pyright: ignore
                     else:

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -8837,13 +8837,13 @@
             "type": "string",
             "format": "date-time",
             "title": "Start Time",
-            "description": "Start time of the span"
+            "description": "Start time of the span (must be timezone-aware)"
           },
           "end_time": {
             "type": "string",
             "format": "date-time",
             "title": "End Time",
-            "description": "End time of the span"
+            "description": "End time of the span (must be timezone-aware)"
           },
           "status_code": {
             "type": "string",
@@ -9168,7 +9168,7 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "When the event occurred"
+            "description": "When the event occurred (must be timezone-aware)"
           },
           "attributes": {
             "additionalProperties": true,


### PR DESCRIPTION
## Summary

Fixes #11224 - When using `log_spans_dataframe()` with Phoenix Cloud, timezone-naive timestamps cause silent failures. The API reports correct `total_received` and `total_queued` counts, but only the first span of each trace is actually logged due to type errors during backend time comparisons.

This PR adds client-side validation to detect and reject timezone-naive timestamps with a clear, actionable error message.

## Root Cause

As identified by @RogerHYang in [this comment](https://github.com/Arize-ai/phoenix/issues/11224#issuecomment-3849647365), timestamps without timezone information cause type errors when the backend tries to compare times. This results in spans being silently dropped during ingestion.

## Changes

### Validation Logic
- Added timezone-awareness check in `dataframe_to_spans()` for `start_time` and `end_time` columns
- Validates the first non-null value in each timestamp column
- Raises `ValueError` with helpful message if naive timestamps detected

### Error Message
The error message provides clear guidance on how to fix the issue:
```
ValueError: Column 'start_time' contains timezone-naive timestamps. 
All timestamps must be timezone-aware (e.g., use UTC). 
Convert naive timestamps to timezone-aware using: 
df['start_time'] = df['start_time'].dt.tz_localize('UTC')
```

### Tests
Added comprehensive test coverage in `test_dataframe_to_spans.py`:
- ✅ Timezone-aware timestamps (UTC) - should pass
- ✅ Timezone-naive timestamps in start_time - should fail with clear error
- ✅ Timezone-naive timestamps in end_time - should fail with clear error
- ✅ Null/None timestamps - should pass (nulls are filtered before validation)
- ✅ Mixed timezones (UTC + offset) - should pass (all timezone-aware)

## Impact

### Before
```python
import pandas as pd
from datetime import datetime

df = pd.DataFrame([{
    "context.trace_id": trace_id,
    "context.span_id": span_id,
    "start_time": datetime.now(),  # Naive timestamp
    "end_time": datetime.now(),
    ...
}])

# Silently fails - only logs first span per trace
client.spans.log_spans_dataframe(project_identifier="test", spans_dataframe=df)
```

### After
```python
# Same code now raises clear error:
# ValueError: Column 'start_time' contains timezone-naive timestamps...
# Convert naive timestamps to timezone-aware using:
# df['start_time'] = df['start_time'].dt.tz_localize('UTC')

# Fix is straightforward:
from datetime import timezone
df = pd.DataFrame([{
    "context.trace_id": trace_id,
    "context.span_id": span_id,
    "start_time": datetime.now(timezone.utc),  # Timezone-aware
    "end_time": datetime.now(timezone.utc),
    ...
}])

# Now works correctly - all spans logged
client.spans.log_spans_dataframe(project_identifier="test", spans_dataframe=df)
```

## Test plan

- [x] Added 5 new unit tests covering all timezone scenarios
- [x] Tests verify validation logic for both start_time and end_time
- [x] Tests verify helpful error messages guide users to fix
- [x] Existing dataframe_to_spans functionality unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens API validation for span ingestion, which may cause previously-accepted (but incorrect) client payloads to start failing with 422/ValueError; behavior is straightforward and test-covered.
> 
> **Overview**
> Enforces *timezone-aware* timestamps for span ingestion to prevent spans being silently dropped when clients submit naive datetimes.
> 
> Adds validation in the Python client `dataframe_to_spans()` to raise a clear `ValueError` when `start_time`/`end_time` values are timezone-naive, and adds server-side Pydantic `model_validator`s on `Span` and `SpanEvent` to reject timezone-naive `start_time`/`end_time` and event `timestamp` fields. OpenAPI/TS generated schema docs are updated to document the new requirement, and new unit + integration tests cover both accepted timezone-aware values and expected failures for naive timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6868577bc53acbe21fa88b83d1723121d0df158. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->