### PR TITLE
fix: anthropic streaming handling for new stop events

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1628,7 +1628,7 @@ class AnthropicStreamingClient(PlaygroundStreamingClient):
                     # Incremental tool-call JSON; we use the complete block at content_block_stop
                     pass
                 elif event.type == "citation":
-                    raise NotImplementedError
+                    pass
                 elif event.type == "thinking":
                     pass
                 elif event.type == "signature":


### PR DESCRIPTION
Added handling for ParsedMessageStopEvent and ParsedContentBlockStopEvent in the AnthropicStreamingClient. This includes updating output token counts and yielding tool call chunks based on new event types.

Fixes #11284 & Fixes #11285

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Anthropic streaming parsing and token/tool-call extraction; incorrect event handling could drop tool calls or misreport usage, but changes are localized to one client.
> 
> **Overview**
> Fixes `AnthropicStreamingClient` event handling to match newer Anthropic streaming events by switching from `isinstance` checks on SDK event classes to `event.type` string routing.
> 
> This updates token accounting to be captured on `message_start`/`message_stop`, yields tool-call chunks on `content_block_stop` for `tool_use` blocks, and explicitly ignores other stream event types (`content_block_*`, `message_delta`, `input_json`, etc.) instead of raising `NotImplementedError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aa50c9745121f193f65de80138e67af34081931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->