### PR TITLE
fix: Improve UX for adding trace to dataset

### DIFF
--- a/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
+++ b/app/src/pages/trace/SpanToDatasetExampleDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { css } from "@emotion/react";
 
@@ -95,6 +95,8 @@ export function SpanToDatasetExampleDialog({
     },
   });
 
+  const datasetId = useWatch({ control, name: "datasetId" });
+
   const onSubmit = useCallback(
     (newExample: ExampleToAdd) => {
       setSubmitError(null);
@@ -148,7 +150,7 @@ export function SpanToDatasetExampleDialog({
               <Button
                 variant="primary"
                 size="S"
-                isDisabled={!isValid || isCommitting}
+                isDisabled={!isValid || isCommitting || !datasetId}
                 onPress={() => {
                   handleSubmit(onSubmit)();
                   close();


### PR DESCRIPTION
Fixes #11151 

This PR contains implementation of the following

1. After creating a dataset, it will get auto selected in the dataset dropdown.
2. The "Add Example" button will be disabled until a dataset is selected.


https://github.com/user-attachments/assets/882c6059-0fa3-4678-9741-2dbb03477a09




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only form validation/state changes; low risk aside from potential regressions in dataset selection wiring.
> 
> **Overview**
> Improves the *Add Example to Dataset* dialog UX by making dataset selection a first-class form requirement.
> 
> The `Add Example` action is now disabled until a `datasetId` is selected, dataset validation is enforced via `react-hook-form` rules (instead of a manual submit-time check), and newly created datasets are auto-selected by wiring `NewDatasetButton`’s `onDatasetCreated` to update the `DatasetSelect` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75054ad828161aa8382dd98ae41385b5479b8ba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->