### PR TITLE
fix: render plain string message content without extra quotes in Trace Details

### DIFF
--- a/app/src/pages/trace/SpanDetails.tsx
+++ b/app/src/pages/trace/SpanDetails.tsx
@@ -1417,7 +1417,9 @@ function DocumentItem({
 
 function LLMMessage({ message }: { message: AttributeMessage }) {
   const messageContent = message[MessageAttributePostfixes.content];
-  const normalizedContent = formatContentAsString(messageContent);
+  const normalizedContent = formatContentAsString(messageContent, {
+    unquotePlainString: true,
+  });
   // as of multi-modal models, a message can also be a list
   const messagesContents = message[MessageAttributePostfixes.contents];
   const toolCalls = message[MessageAttributePostfixes.tool_calls]
@@ -1756,7 +1758,9 @@ function MessageContentListItem({
 }) {
   const { message_content } = messageContentAttribute;
   const text = message_content?.text;
-  const normalizedText = text ? formatContentAsString(text) : undefined;
+  const normalizedText = text
+    ? formatContentAsString(text, { unquotePlainString: true })
+    : undefined;
   const image = message_content?.image;
   const imageUrl = image?.image?.url;
 

--- a/app/src/utils/__tests__/jsonUtils.test.ts
+++ b/app/src/utils/__tests__/jsonUtils.test.ts
@@ -108,4 +108,11 @@ describe("formatContentAsString", () => {
     const content = `"\\"Hello, world!\\""`;
     expect(formatContentAsString(content)).toBe(`"Hello, world!"`);
   });
+
+  it("should return 'undefined' when content is undefined", () => {
+    expect(formatContentAsString(undefined)).toBe("undefined");
+    expect(formatContentAsString(undefined, { unquotePlainString: true })).toBe(
+      "undefined"
+    );
+  });
 });


### PR DESCRIPTION
Root cause: #10941 fixed the tool-return React error by running all message content in SpanDetails through formatContentAsString(). That function was moved from playgroundUtils (where it was only used for tool content) and was designed to JSON.stringify plain strings. Using it for every message in the trace UI made system/user/model text show with extra quotes and escaped newlines.

Fix: return plain string content as-is from formatContentAsString when it is not double-stringified JSON or a non-string JSON value. Tool results (objects/arrays) still get pretty-printed via JSON.stringify. Other call sites (playground, messageSchemas, ChatTemplateMessageCard) only pass tool content, so behavior there is unchanged.

# Before

<img width="600" src="https://github.com/user-attachments/assets/c243b32f-e00f-492e-a77a-b742787d72c1" />

# After

<img width="600" src="https://github.com/user-attachments/assets/4d326e20-15c8-426a-98fc-b1b86492fea6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting changes to how message content is stringified/rendered; low risk aside from potential edge-case display differences for string-like JSON inputs.
> 
> **Overview**
> Trace span details now render *plain text* LLM message content without extra JSON quotes by calling `formatContentAsString` with `unquotePlainString: true` for message bodies and multi-modal text items.
> 
> `formatContentAsString` is extended with an optional `unquotePlainString` flag, updated to keep double-stringified JSON pretty-printing while making string vs non-string handling more explicit (including a defined fallback for `undefined`), and tests are updated to cover the `undefined` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c0fd74c29a710302b2cd27f17de0eea2750de1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->