### PR TITLE
fix(release): use uv + uvx for publish jobs (hatch/check-wheel-contents/twine)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,15 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: slackapi/slack-github-action@v1
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "text": "FAILED Publish Package: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
 
   publish-phoenix:
     name: Publish Phoenix
@@ -84,3 +93,12 @@ jobs:
       - name: Check wheel contents
         run: uvx --with uv==0.9.30 check-wheel-contents --ignore W004 dist/*.whl
       - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: slackapi/slack-github-action@v1
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "text": "FAILED Publish Phoenix: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to packaging/release steps; main risk is publish failures due to toolchain/version differences rather than runtime behavior.
> 
> **Overview**
> Switches the GitHub Actions release workflow to use `astral-sh/setup-uv` (pinned to Python `3.10` / `uv` `0.9.30`) and runs `hatch`, `check-wheel-contents`, and `twine` via `uvx` instead of installing them with `pip`.
> 
> Applies the same `uvx`-based build/check flow to both `publish-package` and `publish-phoenix`, keeping the existing PyPI publish mechanisms but changing how distributions are built and validated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 209a2a1d209072c7c87a05959f21b4741cce6e0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->