### PR TITLE
docs: update judge model for datasets and experiments quickstart

### DIFF
--- a/docs/phoenix/datasets-and-experiments/tutorial/run-experiments-with-llm-judge.mdx
+++ b/docs/phoenix/datasets-and-experiments/tutorial/run-experiments-with-llm-judge.mdx
@@ -90,7 +90,7 @@ Return only one label: "correct" or "incorrect".
 actionability_judge = create_classifier(
     name="actionability-judge",
     prompt_template=support_response_actionability_judge,
-    llm=LLM(model="gpt-4o-mini", provider="openai"),
+    llm=LLM(model="gpt-5", provider="openai"),
     choices={"correct": 1.0, "incorrect": 0.0},
 )
 

--- a/tutorials/experiments/python_experiments_quickstart.ipynb
+++ b/tutorials/experiments/python_experiments_quickstart.ipynb
@@ -516,7 +516,7 @@
     "actionability_judge = create_classifier(\n",
     "    name=\"actionability-judge\",\n",
     "    prompt_template=support_response_actionability_judge,\n",
-    "    llm=LLM(model=\"gpt-4o-mini\", provider=\"openai\"),\n",
+    "    llm=LLM(model=\"gpt-5\", provider=\"openai\"),\n",
     "    choices={\"correct\": 1.0, \"incorrect\": 0.0},\n",
     ")\n",
     "\n",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates an example model name; main risk is user cost/availability differences when running the tutorial.
> 
> **Overview**
> Updates the LLM-as-a-judge examples to use **OpenAI `gpt-5`** instead of `gpt-4o-mini` for the `actionability_judge` classifier in both the docs tutorial (`run-experiments-with-llm-judge.mdx`) and the Python experiments quickstart notebook.
> 
> No logic or prompt changes—this is a documentation/tutorial model selection update only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61aea352fadd8a7d68826ad26060430442843056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->