### PR TITLE
chore: Phoenix Release Notes: 02-10-2026

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -9,6 +9,20 @@ GitHub
 
 
 
+
+<Update label="02.09.2026">
+## [02.09.2026: Claude Opus 4.6 Model Support](/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support)
+Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship model. Select `claude-opus-4-6` in the Anthropic provider or `anthropic.claude-opus-4-6-v1` in AWS Bedrock to start using the model with full extended thinking parameter support and accurate cost tracking.
+
+**Key capabilities:**
+
+- **Anthropic provider integration:** Access Claude Opus 4.6 directly through the playground with the `thinking` invocation parameter enabled for extended reasoning workflows
+- **AWS Bedrock support:** Deploy Opus 4.6 through Bedrock with the region-specific model identifier
+- **Automatic cost tracking:** Token costs are calculated using the latest pricing ($5 per million input tokens, $25 per million output tokens, plus cache read/write rates)
+
+The model appears in playground dropdowns alongside other Claude models and inherits the same reasoning capabilities as other Claude 4.x models.
+</Update>
+
 <Update label="01.31.2026">
 ## [01.31.2026: Tool Selection and Tool Invocation Evaluators](/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators)
 **Available in arize-phoenix-evals 0.16.0+ (Python) and @arizeai/phoenix-evals 1.3.0+ (TypeScript)**
@@ -717,78 +731,6 @@ Quick filters in experiment views let you drill down by eval scores and labels t
 
 
 The platform now features refreshed design elements including expandable navigation, an “Action” bar, and dynamic color contrast for clearer and more intuitive workflows.
-
-</Update>
-
-<Update label="08.09.2025">
-## [08.09.2025: Day 0 Playground Support for GPT-5 🚀](/docs/phoenix/release-notes/08-2025/08-09-2025-playground-support-for-gpt-5)
-
-**Available in Phoenix 11.21+**
-
-<Frame>
-![](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/gpt-5-release-notes.png)
-</Frame>
-
-</Update>
-
-<Update label="08.07.2025">
-## [08.07.2025: Improved Error Handling in Prompt Playground ⚠️](/docs/phoenix/release-notes/08-2025/08-07-2025-improved-error-handling-in-prompt-playground)
-
-**Available in Phoenix 11.20+**
-
-<Frame>
-![](https://storage.googleapis.com/arize-phoenix-assets/assets/images/phoenix-docs-images/playground_error_handling.png)
-</Frame>
-
-Prompt Playground experiments now provide clearer error messages, listing valid options when an input is invalid.
-
-</Update>
-
-<Update label="08.06.2025">
-## [08.06.2025: Expanded Search Capabilities 🔍](/docs/phoenix/release-notes/08-2025/08-06-2025-expanded-search-capabilities)
-
-**Available in Phoenix 11.19+**
-
-<Frame>
-<iframe src="https://cdn.iframe.ly/flavAd2Y" className="aspect-video" allowfullscreen="" allow="encrypted-media *;"></iframe>
-</Frame>
-
-Search functionality has been enhanced across the platform. Users can now search projects, prompts, and datasets, making it easier to quickly find and access the resources they need.
-
-</Update>
-
-<Update label="08.05.2025">
-## [08.05.2025: Claude Opus 4-1 Support 🤖](/docs/phoenix/release-notes/08-2025/08-05-2025-claude-opus-4-1-support)
-
-**Available in Phoenix 11.19+**
-
-<Frame>
-<iframe src="https://cdn.iframe.ly/sOaicT9u" className="aspect-video" allowfullscreen="" allow="encrypted-media *;"></iframe>
-</Frame>
-
-Support for Claude Opus 4-1 is now available, enabling teams to begin experimenting and evaluating with the new model from day 0.
-
-</Update>
-
-<Update label="08.04.2025">
-## [08.04.2025: Manual Project Creation & Trace Duplication 📂](/docs/phoenix/release-notes/08-2025/08-04-2025-manual-project-creation-and-trace-duplication)
-
-**Available in Phoenix 11.19+**
-
-<Frame>
-<iframe src="https://cdn.iframe.ly/mRMXQ9QK" className="aspect-video" allowfullscreen="" allow="encrypted-media *;"></iframe>
-</Frame>
-
-You can now create projects manually in the UI and duplicate traces into other projects via the SDK, making it easier to organize evaluation data and streamline workflows.
-
-</Update>
-
-<Update label="08.03.2025">
-## [08.03.2025: Delete Spans via REST API 🧹](/docs/phoenix/release-notes/08-2025/08-03-2025-delete-spans-via-rest-api)
-
-**Available in Phoenix 11.18+**
-
-You can now delete spans using the REST API, enabling efficient data redaction and giving teams greater control over trace data.
 
 </Update>
 

--- a/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support.mdx
@@ -1,0 +1,17 @@
+---
+title: "Release Notes"
+---
+
+# Claude Opus 4.6 Model Support
+
+February 9, 2026
+
+Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship model. Select `claude-opus-4-6` in the Anthropic provider or `anthropic.claude-opus-4-6-v1` in AWS Bedrock to start using the model with full extended thinking parameter support and accurate cost tracking.
+
+**Key capabilities:**
+
+- **Anthropic provider integration:** Access Claude Opus 4.6 directly through the playground with the `thinking` invocation parameter enabled for extended reasoning workflows
+- **AWS Bedrock support:** Deploy Opus 4.6 through Bedrock with the region-specific model identifier
+- **Automatic cost tracking:** Token costs are calculated using the latest pricing ($5 per million input tokens, $25 per million output tokens, plus cache read/write rates)
+
+The model appears in playground dropdowns alongside other Claude models and inherits the same reasoning capabilities as other Claude 4.x models.

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,5 +4,6 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support" arrow="true" title="02.10.2026"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" arrow="true" title="02.01.2026"/>
 </CardGroup>


### PR DESCRIPTION
This PR adds release notes for Phoenix (02-10-2026).

**Changes:**
- Added release note file: 
- Updated main changelog: 
- Updated year index: 

Generated by Release Reporter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only update adding a new release note page and index links; no production code or behavior changes.
> 
> **Overview**
> Adds a new 02/2026 release note page documenting **Phoenix Playground support for Claude Opus 4.6** (Anthropic + AWS Bedrock identifiers, `thinking` parameter support, and updated cost tracking).
> 
> Updates the release notes index pages (`release-notes.mdx` and `2026.mdx`) to surface and link to this new entry, and trims older 08/2025 entries from the main `release-notes.mdx` page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1722086c43a61cecf2b3298e4a7620939bd6ec8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->