### PR TITLE
ci: update ci to increment helm major version for new phoenix major versions

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -102,25 +102,14 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
       - name: Update Kustomize image version
-        run: |
-          sed -i "s/arizephoenix\/phoenix:version-.*$/arizephoenix\/phoenix:version-${{ needs.push_to_registry.outputs.version }}/" kustomize/base/phoenix.yaml
-          cat kustomize/base/phoenix.yaml
-          sed -i "s/tag:\ version-.*$/tag:\ version-${{ needs.push_to_registry.outputs.version }}-nonroot/" helm/values.yaml
-          cat helm/values.yaml
-          export newPhoenixMajor=$(echo "${{ needs.push_to_registry.outputs.version }}" | cut -d. -f1)
-          export oldPhoenixMajor=$(grep 'appVersion:' helm/Chart.yaml | sed -n 's/appVersion: "\([0-9]*\).*/\1/p')
-          export helmMajor=$(grep "version: [0-9]*\.[0-9]*\.[0-9]*" helm/Chart.yaml | sed -n 's/version: \([0-9]*\)\..*/\1/p')
-          export helmMinor=$(grep "version: [0-9]*\.[0-9]*\.[0-9]*" helm/Chart.yaml | sed -n 's/version: [0-9]*\.\([0-9]*\)\..*/\1/p')
-          export helmPatch=$(grep "version: [0-9]*\.[0-9]*\.[0-9]*" helm/Chart.yaml | sed -n 's/version: [0-9]*\.[0-9]*\.\([0-9]*\)/\1/p')
-          if [ "$newPhoenixMajor" -gt "$oldPhoenixMajor" ]; then
-            export newHelmVersion="$((helmMajor + 1)).0.0"
-          else
-            export newHelmVersion="${helmMajor}.${helmMinor}.$((helmPatch + 1))"
-          fi
-          sed -i "s/version: ${helmMajor}\.${helmMinor}\.${helmPatch}/version: ${newHelmVersion}/" helm/Chart.yaml
-          sed -i 's/appVersion: "[^"]*"/appVersion: "${{ needs.push_to_registry.outputs.version }}"/' helm/Chart.yaml
-          cat helm/Chart.yaml
+        run: python scripts/update_kustomize.py "${{ needs.push_to_registry.outputs.version }}"
+      - name: Update Helm chart version
+        run: python scripts/update_helm.py "${{ needs.push_to_registry.outputs.version }}"
       - name: Setup helm-docs
         uses: gabe565/setup-helm-docs-action@v1
       - name: Run helm-docs

--- a/scripts/update_helm.py
+++ b/scripts/update_helm.py
@@ -1,0 +1,107 @@
+"""
+Updates the Helm chart for a new Phoenix release version.
+
+Usage:
+    python scripts/update_helm.py <new_phoenix_version>
+
+Example:
+    python scripts/update_helm.py 13.0.0
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELM_VALUES_PATH = REPO_ROOT / "helm" / "values.yaml"
+HELM_CHART_PATH = REPO_ROOT / "helm" / "Chart.yaml"
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.match(version)
+    if not match:
+        raise ValueError(f"Invalid semver: {version!r}")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def update_helm_values(new_version: str) -> None:
+    text = HELM_VALUES_PATH.read_text()
+    updated = re.sub(
+        r"tag:\s*version-\S+",
+        f"tag: version-{new_version}-nonroot",
+        text,
+    )
+    HELM_VALUES_PATH.write_text(updated)
+    print(f"Updated {HELM_VALUES_PATH}")
+
+
+def update_helm_chart(new_version: str) -> None:
+    text = HELM_CHART_PATH.read_text()
+
+    # Parse the current appVersion from Chart.yaml.
+    app_version_match = re.search(r'appVersion:\s*"([^"]+)"', text)
+    if not app_version_match:
+        print("Error: could not find appVersion in Chart.yaml", file=sys.stderr)
+        sys.exit(1)
+    old_app_version = app_version_match.group(1)
+
+    # Parse the current chart version from Chart.yaml.
+    chart_version_match = re.search(r"version:\s*(\d+\.\d+\.\d+)", text)
+    if not chart_version_match:
+        print("Error: could not find chart version in Chart.yaml", file=sys.stderr)
+        sys.exit(1)
+    old_chart_version = chart_version_match.group(1)
+
+    old_app_major, _, _ = parse_semver(old_app_version)
+    new_app_major, _, _ = parse_semver(new_version)
+    helm_major, helm_minor, helm_patch = parse_semver(old_chart_version)
+
+    # Bump the helm chart major version when the Phoenix major version increases;
+    # otherwise, bump the patch version.
+    if new_app_major > old_app_major:
+        new_chart_version = f"{helm_major + 1}.0.0"
+    else:
+        new_chart_version = f"{helm_major}.{helm_minor}.{helm_patch + 1}"
+
+    updated = text.replace(
+        f"version: {old_chart_version}",
+        f"version: {new_chart_version}",
+        1,
+    )
+    updated = re.sub(
+        r'appVersion:\s*"[^"]*"',
+        f'appVersion: "{new_version}"',
+        updated,
+    )
+    HELM_CHART_PATH.write_text(updated)
+    print(
+        f"Updated {HELM_CHART_PATH} "
+        f"(chart version {old_chart_version} -> {new_chart_version}, "
+        f"appVersion {old_app_version} -> {new_version})"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update the Helm chart for a new Phoenix version.",
+    )
+    parser.add_argument(
+        "version",
+        help="New Phoenix version (e.g. 13.0.0)",
+    )
+    args = parser.parse_args()
+
+    try:
+        parse_semver(args.version)
+    except ValueError:
+        parser.error(f"Invalid version format: {args.version!r} (expected MAJOR.MINOR.PATCH)")
+
+    update_helm_values(args.version)
+    update_helm_chart(args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_kustomize.py
+++ b/scripts/update_kustomize.py
@@ -1,0 +1,43 @@
+"""
+Updates the Kustomize template with a new Phoenix Docker image version.
+
+Usage:
+    python scripts/update_kustomize.py <new_phoenix_version>
+
+Example:
+    python scripts/update_kustomize.py 13.0.0
+"""
+
+import argparse
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KUSTOMIZE_PATH = REPO_ROOT / "kustomize" / "base" / "phoenix.yaml"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update the Kustomize template with a new Phoenix Docker image version.",
+    )
+    parser.add_argument(
+        "version",
+        help="New Phoenix version (e.g. 13.0.0)",
+    )
+    args = parser.parse_args()
+
+    if not re.match(r"^\d+\.\d+\.\d+$", args.version):
+        parser.error(f"Invalid version format: {args.version!r} (expected MAJOR.MINOR.PATCH)")
+
+    text = KUSTOMIZE_PATH.read_text()
+    updated = re.sub(
+        r"arizephoenix/phoenix:version-\S+",
+        f"arizephoenix/phoenix:version-{args.version}",
+        text,
+    )
+    KUSTOMIZE_PATH.write_text(updated)
+    print(f"Updated {KUSTOMIZE_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes that affect how release automation edits deployment manifests; risk is mainly incorrect regex/version-bump logic producing wrong chart/image versions.
> 
> **Overview**
> Automates self-deployment manifest updates in `docker-build-release.yml` by replacing inlined `sed` logic with two new Python scripts and adding a Python setup step.
> 
> `scripts/update_kustomize.py` updates the Kustomize image tag, and `scripts/update_helm.py` updates Helm `values.yaml` image tag plus bumps `Chart.yaml` version (major bump when Phoenix major increases, otherwise patch) while setting `appVersion` to the released Phoenix version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e090cc6f09df61b930b879209a510d50db674405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->