### PR TITLE
feat: Add json parse toggle to json distance builtin evaluator

### DIFF
--- a/app/src/components/evaluators/JSONDistanceEvaluatorCodeBlock.tsx
+++ b/app/src/components/evaluators/JSONDistanceEvaluatorCodeBlock.tsx
@@ -3,10 +3,7 @@ import { CodeLanguageRadioGroup } from "@phoenix/components/code";
 import { CodeBlock } from "@phoenix/components/CodeBlock";
 import { usePreferencesContext } from "@phoenix/contexts";
 
-const PYTHON_CODE = `
-import json
-from typing import Any
-
+const PYTHON_DIFF_COUNT = `
 def json_diff_count(expected: Any, actual: Any) -> int:
   if type(expected) is not type(actual):
     return 1
@@ -24,13 +21,28 @@ def json_diff_count(expected: Any, actual: Any) -> int:
     for i in range(min(len(expected), len(actual))):
       diff += json_diff_count(expected[i], actual[i])
     return diff
-  return 0 if expected == actual else 1
+  return 0 if expected == actual else 1`.trim();
+
+const PYTHON_CODE_PARSE = `
+import json
+from typing import Any
+
+${PYTHON_DIFF_COUNT}
 
 def json_distance(expected: str, actual: str) -> int:
   return json_diff_count(json.loads(expected), json.loads(actual))
 `.trim();
 
-const TYPESCRIPT_CODE = `
+const PYTHON_CODE_DIRECT = `
+from typing import Any
+
+${PYTHON_DIFF_COUNT}
+
+def json_distance(expected: Any, actual: Any) -> int:
+  return json_diff_count(expected, actual)
+`.trim();
+
+const TS_DIFF_COUNT = `
 function jsonDiffCount(expected: unknown, actual: unknown): number {
   if (typeof expected !== typeof actual) {
     return 1;
@@ -65,20 +77,37 @@ function jsonDiffCount(expected: unknown, actual: unknown): number {
     return 1;
   }
   return expected === actual ? 0 : 1;
-}
+}`.trim();
+
+const TS_CODE_PARSE = `
+${TS_DIFF_COUNT}
 
 function jsonDistance(expected: string, actual: string): number {
   return jsonDiffCount(JSON.parse(expected), JSON.parse(actual));
 }
 `.trim();
 
-export const JSONDistanceEvaluatorCodeBlock = () => {
+const TS_CODE_DIRECT = `
+${TS_DIFF_COUNT}
+
+function jsonDistance(expected: unknown, actual: unknown): number {
+  return jsonDiffCount(expected, actual);
+}
+`.trim();
+
+export const JSONDistanceEvaluatorCodeBlock = ({
+  parseStrings = true,
+}: {
+  parseStrings?: boolean;
+}) => {
   const { programmingLanguage, setProgrammingLanguage } = usePreferencesContext(
     (state) => ({
       programmingLanguage: state.programmingLanguage,
       setProgrammingLanguage: state.setProgrammingLanguage,
     })
   );
+  const pythonCode = parseStrings ? PYTHON_CODE_PARSE : PYTHON_CODE_DIRECT;
+  const tsCode = parseStrings ? TS_CODE_PARSE : TS_CODE_DIRECT;
   return (
     <Card
       title="Code"
@@ -94,7 +123,7 @@ export const JSONDistanceEvaluatorCodeBlock = () => {
     >
       <CodeBlock
         language={programmingLanguage}
-        value={programmingLanguage === "Python" ? PYTHON_CODE : TYPESCRIPT_CODE}
+        value={programmingLanguage === "Python" ? pythonCode : tsCode}
       />
     </Card>
   );

--- a/app/src/components/evaluators/JSONDistanceEvaluatorDetails.tsx
+++ b/app/src/components/evaluators/JSONDistanceEvaluatorDetails.tsx
@@ -16,6 +16,7 @@ export function JSONDistanceEvaluatorDetails({
   const actualLiteral = inputMapping?.literalMapping?.actual as
     | string
     | undefined;
+  const parseStrings = inputMapping?.literalMapping?.parse_strings;
 
   return (
     <Flex direction="column" gap="size-100">
@@ -27,6 +28,10 @@ export function JSONDistanceEvaluatorDetails({
       <Text size="S">
         <Text weight="heavy">Actual:</Text>{" "}
         {actualPath || (actualLiteral ? `"${actualLiteral}"` : "Not mapped")}
+      </Text>
+      <Text size="S">
+        <Text weight="heavy">Parse strings:</Text>{" "}
+        {parseStrings === false || parseStrings === "false" ? "No" : "Yes"}
       </Text>
     </Flex>
   );

--- a/app/src/components/evaluators/JSONDistanceEvaluatorForm.tsx
+++ b/app/src/components/evaluators/JSONDistanceEvaluatorForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 
-import { Flex } from "@phoenix/components";
+import { Flex, Label, Switch, Text } from "@phoenix/components";
 import { BuiltInEvaluatorOutputConfig } from "@phoenix/components/evaluators/BuiltInEvaluatorOutputConfig";
 import { useFlattenedEvaluatorInputKeys } from "@phoenix/components/evaluators/EvaluatorInputMapping";
 import { JSONDistanceEvaluatorCodeBlock } from "@phoenix/components/evaluators/JSONDistanceEvaluatorCodeBlock";
@@ -38,7 +38,9 @@ const useJSONDistanceEvaluatorForm = () => {
 };
 
 export const JSONDistanceEvaluatorForm = () => {
-  const { control, getValues, setValue } = useJSONDistanceEvaluatorForm();
+  const { control, getValues, setValue, watch } =
+    useJSONDistanceEvaluatorForm();
+  const parseStrings = watch("literalMapping.parse_strings") ?? true;
   const [expectedPath, setExpectedPath] = useState<string>(
     () => getValues("pathMapping.expected") ?? ""
   );
@@ -85,9 +87,34 @@ export const JSONDistanceEvaluatorForm = () => {
           pathInputValue={actualPath}
           onPathInputChange={setActualPath}
         />
+        <Controller
+          name="literalMapping.parse_strings"
+          control={control}
+          defaultValue={true}
+          render={({ field }) => (
+            <Switch
+              {...field}
+              value={String(field.value ?? "")}
+              onChange={(value) => field.onChange(value)}
+              isSelected={Boolean(
+                typeof field.value === "boolean"
+                  ? field.value
+                  : typeof field.value === "string"
+                    ? field.value.toLowerCase() === "true"
+                    : true
+              )}
+            >
+              <Label>Parse strings as JSON</Label>
+              <Text slot="description">
+                When enabled, string inputs are parsed as JSON before
+                comparison. When disabled, inputs are compared as-is.
+              </Text>
+            </Switch>
+          )}
+        />
       </Flex>
       <BuiltInEvaluatorOutputConfig />
-      <JSONDistanceEvaluatorCodeBlock />
+      <JSONDistanceEvaluatorCodeBlock parseStrings={Boolean(parseStrings)} />
     </Flex>
   );
 };

--- a/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
@@ -220,6 +220,12 @@ export function BuiltInDatasetEvaluatorDetails({
       throw new Error(`Unknown built-in evaluator: ${evaluator.name}`);
   }
 
+  const literalMapping = inputMapping.literalMapping as Record<
+    string,
+    unknown
+  > | null;
+  const parseStrings = literalMapping?.parse_strings !== false;
+
   return (
     <>
       <View padding="size-200" overflow="auto" maxWidth={1000}>
@@ -228,7 +234,11 @@ export function BuiltInDatasetEvaluatorDetails({
             <DetailsComponent inputMapping={inputMapping} />
           </Section>
           <OutputConfigsSection configs={outputConfigs} />
-          <CodeBlockComponent />
+          {name === "json_distance" ? (
+            <JSONDistanceEvaluatorCodeBlock parseStrings={parseStrings} />
+          ) : (
+            <CodeBlockComponent />
+          )}
         </Flex>
       </View>
       <EditBuiltInDatasetEvaluatorSlideover


### PR DESCRIPTION
Adds a toggle to either parse a json string or leave an object as is before comparing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluator input schema and execution logic for `json_distance`, which could affect existing integrations if they relied on strict string inputs or tracing/metadata formats.
> 
> **Overview**
> Adds a `parse_strings` input option to the built-in `json_distance` evaluator so it can either `json.loads` string inputs (default) or compare already-structured values (dict/list) directly.
> 
> Updates the UI to expose this as a “Parse strings as JSON” switch, display the chosen setting in evaluator details, and render language-specific code snippets that match the toggle (parse vs direct compare). Server-side tracing/metadata now serializes non-string expected/actual values for readability, and unit tests cover the new toggle behavior and schema changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8a89d45790bd753e041ebdde9531313af2639c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->