### PR TITLE
docs: Add MLflow to eval library integrations

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -707,6 +707,7 @@
             "icon": "clipboard-check",
             "pages": [
               "docs/phoenix/integrations/evaluation-integrations/cleanlab",
+              "docs/phoenix/integrations/evaluation-integrations/mlflow",
               "docs/phoenix/integrations/evaluation-integrations/ragas",
               "docs/phoenix/integrations/evaluation-integrations/uqlm"
             ]

--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -30,7 +30,7 @@ Phoenix offers several types of integrations to support your AI development work
     Use any LLM provider to power Phoenix's evaluation capabilities for scoring and classifying your traces.
   </Card>
   <Card title="Eval Library Integrations" icon="clipboard-check" href="#eval-library-integrations">
-    Integrate with external evaluation libraries like Ragas and Cleanlab to visualize results in Phoenix.
+    Integrate with external evaluation libraries like Ragas, Cleanlab, and MLflow to visualize results in Phoenix.
   </Card>
   <Card title="Vector Database Integrations" icon="database" href="#vector-database-integrations">
     Connect with vector databases for embedding analysis and retrieval debugging.
@@ -161,6 +161,7 @@ Use external evaluation libraries alongside Phoenix to get the best of both worl
   <Card title="Ragas" href="/docs/phoenix/integrations/evaluation-integrations/ragas" />
   <Card title="Cleanlab" href="/docs/phoenix/integrations/evaluation-integrations/cleanlab" />
   <Card title="Pydantic Evals" href="/docs/phoenix/integrations/python/pydantic/pydantic-evals" />
+  <Card title="MLflow" href="/docs/phoenix/integrations/evaluation-integrations/mlflow" />
 </CardGroup>
 
 ---

--- a/docs/phoenix/integrations/evaluation-integrations/mlflow.mdx
+++ b/docs/phoenix/integrations/evaluation-integrations/mlflow.mdx
@@ -1,0 +1,26 @@
+---
+title: "MLflow"
+description: "Use Phoenix evaluators as MLflow scorers for GenAI evaluation workflows."
+---
+
+[MLflow](https://mlflow.org/) includes built-in support for Phoenix evaluators through its third-party scorer interface. This allows Phoenix users to run their existing evaluation metrics within MLflow's `mlflow.genai.evaluate()` pipeline alongside experiment tracking and model management.
+
+## Using Phoenix Evaluators in MLflow
+
+Phoenix evaluators such as `Hallucination`, `QACorrectness`, and `Toxicity` can be used directly as MLflow scorers:
+
+```python
+from mlflow.genai.scorers.phoenix import Hallucination, QACorrectness
+
+import mlflow
+
+results = mlflow.genai.evaluate(
+    data=eval_dataset,
+    scorers=[
+        Hallucination(model="openai:/gpt-4o"),
+        QACorrectness(model="openai:/gpt-4o"),
+    ],
+)
+```
+
+For details on available scorers and configuration, see the [MLflow Phoenix integration docs](https://mlflow.org/docs/latest/genai/eval-monitor/scorers/third-party/phoenix.html).


### PR DESCRIPTION
Per @mikeldking's feedback on #11192, this is a smaller version scoped to a brief mention in the eval library integrations section.

## Changes
- Added a short MLflow page under `evaluation-integrations/` showing that Phoenix evaluators work as MLflow scorers
- Added MLflow card to the Eval Library Integrations section in `integrations.mdx`
- Added entry to `docs.json` nav

No full tutorial -- just a quick pointer for Phoenix users who also use MLflow for experiment tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new page + nav/index links) with no runtime or API behavior impact.
> 
> **Overview**
> Adds **MLflow** as an Eval Library Integration, including a new `evaluation-integrations/mlflow` page showing how to use Phoenix evaluators as MLflow `mlflow.genai.evaluate()` scorers.
> 
> Updates the integrations landing page to mention MLflow and include an MLflow card, and updates `docs.json` navigation so the new page appears under *Evaluation Integrations*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 256e65058291e9f44cb6e8e69b1a960ea46e00ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->