### PR TITLE
ci: Update test command to use auto parallelization

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -448,11 +448,11 @@ jobs:
       - name: Run tests with PostgreSQL (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 60
-        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra -x --reruns 5 --run-postgres
+        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra --reruns 5 --run-postgres
       - name: Run tests without PostgreSQL (non-Linux)
         if: runner.os != 'Linux'
         timeout-minutes: 60
-        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra -x --reruns 5
+        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra --reruns 5
 
   type-check-integration-tests:
     name: Type Check Integration Tests
@@ -546,7 +546,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         timeout-minutes: 20
-        run: uvx --with uv==0.9.30 tox run -e integration_tests -- -ra -x --reruns 5 -n auto
+        run: uvx --with uv==0.9.30 tox run -e integration_tests -- -ra --reruns 5 -n auto
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes that affect CI runtime/behavior (parallelism and fail-fast), with no production code impact; main risk is increased CI flakiness or altered failure reporting.
> 
> **Overview**
> **CI test execution is updated to run in parallel by default.** The `python-CI.yml` workflow switches unit and integration test invocations to pass pytest `-n auto` and removes the previous `-x` fail-fast behavior (including the Postgres-backed unit test run on Linux).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe0dbf97f18a2a5ad7d2bd07524d4a14761856b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->