### PR TITLE
feat: add OpenAI API type (Chat Completions vs Responses API) support

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -272,11 +272,13 @@ input AzureOpenAIClientKwargsInput {
 type AzureOpenAICustomProviderConfig {
   azureOpenaiAuthenticationMethod: AzureOpenAIAuthenticationMethod!
   azureOpenaiClientKwargs: AzureOpenAIClientKwargs!
+  openaiApiType: OpenAIApiType!
 }
 
 input AzureOpenAICustomProviderConfigInput {
   azureOpenaiAuthenticationMethod: AzureOpenAIAuthenticationMethodInput!
   azureOpenaiClientKwargs: AzureOpenAIClientKwargsInput!
+  openaiApiType: OpenAIApiType = RESPONSES
 }
 
 union Bin = NominalBin | IntervalBin | MissingValueBin
@@ -2016,6 +2018,7 @@ input GenerativeModelBuiltinProviderInput {
   endpoint: String
   region: String
   customHeaders: JSON
+  openaiApiType: OpenAIApiType
 }
 
 """A connection to a list of items."""
@@ -2486,6 +2489,11 @@ type NumericRange {
   end: Float!
 }
 
+enum OpenAIApiType {
+  CHAT_COMPLETIONS
+  RESPONSES
+}
+
 type OpenAIAuthenticationMethod {
   apiKey: String
 }
@@ -2511,11 +2519,13 @@ input OpenAIClientKwargsInput {
 type OpenAICustomProviderConfig {
   openaiAuthenticationMethod: OpenAIAuthenticationMethod!
   openaiClientKwargs: OpenAIClientKwargs
+  openaiApiType: OpenAIApiType!
 }
 
 input OpenAICustomProviderConfigInput {
   openaiAuthenticationMethod: OpenAIAuthenticationMethodInput!
   openaiClientKwargs: OpenAIClientKwargsInput
+  openaiApiType: OpenAIApiType = RESPONSES
 }
 
 enum OptimizationDirection {

--- a/app/src/components/playground/model/ModelParametersConfigButton.tsx
+++ b/app/src/components/playground/model/ModelParametersConfigButton.tsx
@@ -20,6 +20,7 @@ import { BaseUrlConfigFormField } from "./BaseUrlConfigFormField";
 import { EndpointConfigFormField } from "./EndpointConfigFormField";
 import { ModelInvocationParametersFormFields } from "./ModelInvocationParametersFormFields";
 import { ModelNameConfigFormField } from "./ModelNameConfigFormField";
+import { OpenAIApiTypeConfigFormField } from "./OpenAIApiTypeConfigFormField";
 import { SaveModelConfigButton } from "./SaveModelConfigButton";
 
 /**
@@ -113,6 +114,9 @@ export function ModelParametersConfigButton(
   const canConfigureBaseUrl = provider === "OPENAI" || provider === "OLLAMA";
   const canConfigureAzureFields = provider === "AZURE_OPENAI";
   const canConfigureRegion = provider === "AWS";
+  const canConfigureOpenAIApiType =
+    !usingCustomProvider &&
+    (provider === "OPENAI" || provider === "AZURE_OPENAI");
 
   const showBaseUrl =
     !usingCustomProvider && !disableEphemeralRouting && canConfigureBaseUrl;
@@ -141,6 +145,14 @@ export function ModelParametersConfigButton(
               <ModelNameConfigFormField
                 playgroundInstanceId={playgroundInstanceId}
               />
+
+              {/* OpenAI / Azure API type - built-in only: editable when ephemeral routing enabled, fixed default when disabled */}
+              {canConfigureOpenAIApiType && (
+                <OpenAIApiTypeConfigFormField
+                  playgroundInstanceId={playgroundInstanceId}
+                  displayDefaultOnly={disableEphemeralRouting}
+                />
+              )}
 
               {/* Custom provider info - shown when a custom provider is selected */}
               {customProvider && (

--- a/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
+++ b/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
@@ -18,7 +18,7 @@ const API_TYPE_OPTIONS: { id: OpenAIApiType; label: string }[] = [
   { id: "RESPONSES", label: "Responses API" },
 ];
 
-const DEFAULT_API_TYPE: OpenAIApiType = "RESPONSES";
+const DEFAULT_API_TYPE: OpenAIApiType = "CHAT_COMPLETIONS";
 
 function getApiTypeLabel(apiType: OpenAIApiType): string {
   return API_TYPE_OPTIONS.find((opt) => opt.id === apiType)?.label ?? apiType;

--- a/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
+++ b/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
@@ -1,0 +1,94 @@
+import {
+  Button,
+  Flex,
+  Label,
+  ListBox,
+  Popover,
+  Select,
+  SelectChevronUpDownIcon,
+  SelectItem,
+  SelectValue,
+  Text,
+} from "@phoenix/components";
+import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
+import type { OpenAIApiType } from "@phoenix/store";
+
+const API_TYPE_OPTIONS: { id: OpenAIApiType; label: string }[] = [
+  { id: "CHAT_COMPLETIONS", label: "Chat Completions" },
+  { id: "RESPONSES", label: "Responses API" },
+];
+
+const DEFAULT_API_TYPE: OpenAIApiType = "RESPONSES";
+
+function getApiTypeLabel(apiType: OpenAIApiType): string {
+  return API_TYPE_OPTIONS.find((opt) => opt.id === apiType)?.label ?? apiType;
+}
+
+export type OpenAIApiTypeConfigFormFieldProps = {
+  playgroundInstanceId: number;
+  /**
+   * When true, shows only the fixed default "Responses API" as static text (not editable).
+   * Does not read from instance/model or localStorage — used when ephemeral routing is disabled.
+   */
+  displayDefaultOnly?: boolean;
+};
+
+/**
+ * Form field for selecting OpenAI/Azure API type (Chat Completions vs Responses API).
+ * Shown for built-in OpenAI and Azure OpenAI providers only.
+ */
+export function OpenAIApiTypeConfigFormField({
+  playgroundInstanceId,
+  displayDefaultOnly = false,
+}: OpenAIApiTypeConfigFormFieldProps) {
+  const instance = usePlaygroundContext((state) =>
+    state.instances.find((instance) => instance.id === playgroundInstanceId)
+  );
+  const updateModel = usePlaygroundContext((state) => state.updateModel);
+
+  if (!instance) {
+    return null;
+  }
+
+  // When ephemeral routing is disabled: always show RESPONSES, never use stored value
+  if (displayDefaultOnly) {
+    return (
+      <Flex direction="column" gap="size-50">
+        <Label>API Type</Label>
+        <Text size="S">{getApiTypeLabel(DEFAULT_API_TYPE)}</Text>
+      </Flex>
+    );
+  }
+
+  const value = instance.model.openaiApiType ?? DEFAULT_API_TYPE;
+
+  return (
+    <Select
+      key="openai-api-type"
+      value={value}
+      onChange={(key) => {
+        if (key != null) {
+          updateModel({
+            instanceId: playgroundInstanceId,
+            patch: { openaiApiType: key as OpenAIApiType },
+          });
+        }
+      }}
+    >
+      <Label>API Type</Label>
+      <Button>
+        <SelectValue />
+        <SelectChevronUpDownIcon />
+      </Button>
+      <Popover>
+        <ListBox>
+          {API_TYPE_OPTIONS.map((opt) => (
+            <SelectItem key={opt.id} id={opt.id} textValue={opt.label}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  );
+}

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c5946e2f85a716d7793fa3881ed7b61>>
+ * @generated SignedSource<<b95bb68ca4d151ec2f95878cdf4a6af4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type CanonicalParameterName = "ANTHROPIC_EXTENDED_THINKING" | "MAX_COMPLE
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type ExperimentRunAnnotatorKind = "CODE" | "HUMAN" | "LLM";
 export type GenerativeProviderKey = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionOverDatasetInput = {
@@ -50,6 +51,7 @@ export type GenerativeModelBuiltinProviderInput = {
   customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
+  openaiApiType?: OpenAIApiType | null;
   providerKey: GenerativeProviderKey;
   region?: string | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<acab5aafe4580226e9c97dbdad45c891>>
+ * @generated SignedSource<<0b1e74eff0e831525b68d502e0c95f6d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type CanonicalParameterName = "ANTHROPIC_EXTENDED_THINKING" | "MAX_COMPLE
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type ExperimentRunAnnotatorKind = "CODE" | "HUMAN" | "LLM";
 export type GenerativeProviderKey = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionOverDatasetInput = {
@@ -50,6 +51,7 @@ export type GenerativeModelBuiltinProviderInput = {
   customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
+  openaiApiType?: OpenAIApiType | null;
   providerKey: GenerativeProviderKey;
   region?: string | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<942af62861bda68146df120857bf5be8>>
+ * @generated SignedSource<<e6967894739f7f6a87be1024e1219cb3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type CanonicalParameterName = "ANTHROPIC_EXTENDED_THINKING" | "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionInput = {
@@ -40,6 +41,7 @@ export type GenerativeModelBuiltinProviderInput = {
   customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
+  openaiApiType?: OpenAIApiType | null;
   providerKey: GenerativeProviderKey;
   region?: string | null;
 };

--- a/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundOutputSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3096bd1318895a9cc2e59aeb4072009e>>
+ * @generated SignedSource<<c6b4ded592578eebc1ad899e49ffa46d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type CanonicalParameterName = "ANTHROPIC_EXTENDED_THINKING" | "MAX_COMPLETION_TOKENS" | "RANDOM_SEED" | "REASONING_EFFORT" | "RESPONSE_FORMAT" | "STOP_SEQUENCES" | "TEMPERATURE" | "TOOL_CHOICE" | "TOP_P";
 export type ChatCompletionMessageRole = "AI" | "SYSTEM" | "TOOL" | "USER";
 export type GenerativeProviderKey = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "DEEPSEEK" | "GOOGLE" | "OLLAMA" | "OPENAI" | "XAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type OptimizationDirection = "MAXIMIZE" | "MINIMIZE" | "NONE";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
 export type ChatCompletionInput = {
@@ -40,6 +41,7 @@ export type GenerativeModelBuiltinProviderInput = {
   customHeaders?: any | null;
   endpoint?: string | null;
   name: string;
+  openaiApiType?: OpenAIApiType | null;
   providerKey: GenerativeProviderKey;
   region?: string | null;
 };

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -1156,6 +1156,14 @@ const getBaseChatCompletionInput = ({
   // Determine if we're using a custom provider or built-in provider
   const customProvider = instance.model.customProvider;
 
+  const openaiApiTypeParams =
+    instance.model.provider === "OPENAI" ||
+    instance.model.provider === "AZURE_OPENAI"
+      ? {
+          openaiApiType: instance.model.openaiApiType ?? ("RESPONSES" as const),
+        }
+      : {};
+
   const model = customProvider
     ? {
         custom: {
@@ -1170,6 +1178,7 @@ const getBaseChatCompletionInput = ({
           name: instance.model.modelName || "",
           baseUrl: instance.model.baseUrl,
           customHeaders: instance.model.customHeaders,
+          ...openaiApiTypeParams,
           ...azureModelParams,
           ...awsModelParams,
         },

--- a/app/src/pages/settings/CustomProviderForm.tsx
+++ b/app/src/pages/settings/CustomProviderForm.tsx
@@ -82,11 +82,20 @@ export interface BaseProviderFormData {
  */
 type JSONString = string;
 
+/** OpenAI API type: Chat Completions (chat.completions.create) or Responses API (responses.create). */
+export type OpenAIApiTypeForm = "CHAT_COMPLETIONS" | "RESPONSES";
+
+const OPENAI_API_TYPE_OPTIONS: { id: OpenAIApiTypeForm; label: string }[] = [
+  { id: "CHAT_COMPLETIONS", label: "Chat Completions" },
+  { id: "RESPONSES", label: "Responses API" },
+];
+
 /**
  * OpenAI SDK configuration.
  */
 export interface OpenAIFormData extends BaseProviderFormData {
   sdk: "OPENAI";
+  openai_api_type: OpenAIApiTypeForm;
   openai_api_key: string;
   openai_base_url?: string;
   openai_organization?: string;
@@ -100,6 +109,7 @@ export interface OpenAIFormData extends BaseProviderFormData {
  */
 export interface AzureOpenAIFormData extends BaseProviderFormData {
   sdk: "AZURE_OPENAI";
+  openai_api_type: OpenAIApiTypeForm;
   azure_endpoint: string;
   azure_auth_method: AzureAuthMethod;
   // API Key auth
@@ -181,6 +191,37 @@ function OpenAIFields({
 }) {
   return (
     <ProviderSection title="OpenAI Configuration">
+      <Controller
+        name="openai_api_type"
+        control={control}
+        render={({ field }) => (
+          <Select
+            {...field}
+            value={field.value ?? "RESPONSES"}
+            onChange={(key) => {
+              if (key != null) {
+                field.onChange(key);
+              }
+            }}
+            isDisabled={isSubmitting}
+          >
+            <Label>API Type</Label>
+            <Button>
+              <SelectValue />
+              <SelectChevronUpDownIcon />
+            </Button>
+            <Popover>
+              <ListBox>
+                {OPENAI_API_TYPE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.id} id={opt.id} textValue={opt.label}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </ListBox>
+            </Popover>
+          </Select>
+        )}
+      />
       <Controller
         name="openai_api_key"
         control={control}
@@ -288,6 +329,37 @@ function AzureOpenAIFields({
 
   return (
     <ProviderSection title="Azure OpenAI Configuration">
+      <Controller
+        name="openai_api_type"
+        control={control}
+        render={({ field }) => (
+          <Select
+            {...field}
+            value={field.value ?? "RESPONSES"}
+            onChange={(key) => {
+              if (key != null) {
+                field.onChange(key);
+              }
+            }}
+            isDisabled={isSubmitting}
+          >
+            <Label>API Type</Label>
+            <Button>
+              <SelectValue />
+              <SelectChevronUpDownIcon />
+            </Button>
+            <Popover>
+              <ListBox>
+                {OPENAI_API_TYPE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.id} id={opt.id} textValue={opt.label}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </ListBox>
+            </Popover>
+          </Select>
+        )}
+      />
       <Controller
         name="azure_endpoint"
         control={control}

--- a/app/src/pages/settings/EditCustomProviderButton.tsx
+++ b/app/src/pages/settings/EditCustomProviderButton.tsx
@@ -59,6 +59,7 @@ const ProviderQuery = graphql`
             parseError
           }
           ... on OpenAICustomProviderConfig {
+            openaiApiType
             openaiAuthenticationMethod {
               apiKey
             }
@@ -70,6 +71,7 @@ const ProviderQuery = graphql`
             }
           }
           ... on AzureOpenAICustomProviderConfig {
+            openaiApiType
             azureOpenaiAuthenticationMethod {
               apiKey
               azureAdTokenProvider {

--- a/app/src/pages/settings/__generated__/CustomProviderFormTestCredentialsQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/CustomProviderFormTestCredentialsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ca17e0b4177ca8772c71df3c4728cce>>
+ * @generated SignedSource<<3588f2463972c70e29be86b0524a5051>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type GenerativeModelCustomerProviderConfigInput = {
   anthropic?: AnthropicCustomProviderConfigInput | null;
   awsBedrock?: AWSBedrockCustomProviderConfigInput | null;
@@ -17,6 +18,7 @@ export type GenerativeModelCustomerProviderConfigInput = {
   openai?: OpenAICustomProviderConfigInput | null;
 };
 export type OpenAICustomProviderConfigInput = {
+  openaiApiType?: OpenAIApiType | null;
   openaiAuthenticationMethod: OpenAIAuthenticationMethodInput;
   openaiClientKwargs?: OpenAIClientKwargsInput | null;
 };
@@ -32,6 +34,7 @@ export type OpenAIClientKwargsInput = {
 export type AzureOpenAICustomProviderConfigInput = {
   azureOpenaiAuthenticationMethod: AzureOpenAIAuthenticationMethodInput;
   azureOpenaiClientKwargs: AzureOpenAIClientKwargsInput;
+  openaiApiType?: OpenAIApiType | null;
 };
 export type AzureOpenAIAuthenticationMethodInput = {
   apiKey?: string | null;

--- a/app/src/pages/settings/__generated__/EditCustomProviderButtonPatchMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/EditCustomProviderButtonPatchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2595edf12761e835793facb07f6a36b6>>
+ * @generated SignedSource<<6d7a9d77e8946910a96e9a1e1c4fc403>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type GenerativeModelSDK = "ANTHROPIC" | "AWS_BEDROCK" | "AZURE_OPENAI" | "GOOGLE_GENAI" | "OPENAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type PatchGenerativeModelCustomProviderMutationInput = {
   clientConfig?: GenerativeModelCustomerProviderConfigInput | null;
   description?: string | null;
@@ -26,6 +27,7 @@ export type GenerativeModelCustomerProviderConfigInput = {
   openai?: OpenAICustomProviderConfigInput | null;
 };
 export type OpenAICustomProviderConfigInput = {
+  openaiApiType?: OpenAIApiType | null;
   openaiAuthenticationMethod: OpenAIAuthenticationMethodInput;
   openaiClientKwargs?: OpenAIClientKwargsInput | null;
 };
@@ -41,6 +43,7 @@ export type OpenAIClientKwargsInput = {
 export type AzureOpenAICustomProviderConfigInput = {
   azureOpenaiAuthenticationMethod: AzureOpenAIAuthenticationMethodInput;
   azureOpenaiClientKwargs: AzureOpenAIClientKwargsInput;
+  openaiApiType?: OpenAIApiType | null;
 };
 export type AzureOpenAIAuthenticationMethodInput = {
   apiKey?: string | null;

--- a/app/src/pages/settings/__generated__/EditCustomProviderButtonQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/EditCustomProviderButtonQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f2cd08b88b6fc14dc678557fbc1a00f>>
+ * @generated SignedSource<<76e7b94c594902e0b9802d974c617683>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type GenerativeModelSDK = "ANTHROPIC" | "AWS_BEDROCK" | "AZURE_OPENAI" | "GOOGLE_GENAI" | "OPENAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type EditCustomProviderButtonQuery$variables = {
   id: string;
 };
@@ -59,6 +60,7 @@ export type EditCustomProviderButtonQuery$data = {
           readonly headers: any | null;
         } | null;
       } | null;
+      readonly openaiApiType?: OpenAIApiType;
       readonly openaiAuthenticationMethod?: {
         readonly apiKey: string | null;
       };
@@ -208,29 +210,37 @@ v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "openaiApiType",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "apiKey",
   "storageKey": null
 },
-v13 = [
-  (v12/*: any*/)
+v14 = [
+  (v13/*: any*/)
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "baseUrl",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "defaultHeaders",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "kind": "InlineFragment",
   "selections": [
+    (v12/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -238,7 +248,7 @@ v16 = {
       "kind": "LinkedField",
       "name": "openaiAuthenticationMethod",
       "plural": false,
-      "selections": (v13/*: any*/),
+      "selections": (v14/*: any*/),
       "storageKey": null
     },
     {
@@ -249,7 +259,7 @@ v16 = {
       "name": "openaiClientKwargs",
       "plural": false,
       "selections": [
-        (v14/*: any*/),
+        (v15/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -264,7 +274,7 @@ v16 = {
           "name": "project",
           "storageKey": null
         },
-        (v15/*: any*/)
+        (v16/*: any*/)
       ],
       "storageKey": null
     }
@@ -272,16 +282,17 @@ v16 = {
   "type": "OpenAICustomProviderConfig",
   "abstractKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "defaultCredentials",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "kind": "InlineFragment",
   "selections": [
+    (v12/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -290,7 +301,7 @@ v18 = {
       "name": "azureOpenaiAuthenticationMethod",
       "plural": false,
       "selections": [
-        (v12/*: any*/),
+        (v13/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -330,7 +341,7 @@ v18 = {
           ],
           "storageKey": null
         },
-        (v17/*: any*/)
+        (v18/*: any*/)
       ],
       "storageKey": null
     },
@@ -349,7 +360,7 @@ v18 = {
           "name": "azureEndpoint",
           "storageKey": null
         },
-        (v15/*: any*/)
+        (v16/*: any*/)
       ],
       "storageKey": null
     }
@@ -357,7 +368,7 @@ v18 = {
   "type": "AzureOpenAICustomProviderConfig",
   "abstractKey": null
 },
-v19 = {
+v20 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -367,7 +378,7 @@ v19 = {
       "kind": "LinkedField",
       "name": "anthropicAuthenticationMethod",
       "plural": false,
-      "selections": (v13/*: any*/),
+      "selections": (v14/*: any*/),
       "storageKey": null
     },
     {
@@ -378,8 +389,8 @@ v19 = {
       "name": "anthropicClientKwargs",
       "plural": false,
       "selections": [
-        (v14/*: any*/),
-        (v15/*: any*/)
+        (v15/*: any*/),
+        (v16/*: any*/)
       ],
       "storageKey": null
     }
@@ -387,7 +398,7 @@ v19 = {
   "type": "AnthropicCustomProviderConfig",
   "abstractKey": null
 },
-v20 = {
+v21 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -430,7 +441,7 @@ v20 = {
           ],
           "storageKey": null
         },
-        (v17/*: any*/)
+        (v18/*: any*/)
       ],
       "storageKey": null
     },
@@ -463,7 +474,7 @@ v20 = {
   "type": "AWSBedrockCustomProviderConfig",
   "abstractKey": null
 },
-v21 = {
+v22 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -473,7 +484,7 @@ v21 = {
       "kind": "LinkedField",
       "name": "googleGenaiAuthenticationMethod",
       "plural": false,
-      "selections": (v13/*: any*/),
+      "selections": (v14/*: any*/),
       "storageKey": null
     },
     {
@@ -492,7 +503,7 @@ v21 = {
           "name": "httpOptions",
           "plural": false,
           "selections": [
-            (v14/*: any*/),
+            (v15/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -546,11 +557,11 @@ return {
                 "plural": false,
                 "selections": [
                   (v11/*: any*/),
-                  (v16/*: any*/),
-                  (v18/*: any*/),
+                  (v17/*: any*/),
                   (v19/*: any*/),
                   (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -601,11 +612,11 @@ return {
                 "selections": [
                   (v2/*: any*/),
                   (v11/*: any*/),
-                  (v16/*: any*/),
-                  (v18/*: any*/),
+                  (v17/*: any*/),
                   (v19/*: any*/),
                   (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -619,16 +630,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "055742443e6204daed704bfbc25cc58e",
+    "cacheID": "fc778aac4efa16fa707ce67335c87dde",
     "id": null,
     "metadata": {},
     "name": "EditCustomProviderButtonQuery",
     "operationKind": "query",
-    "text": "query EditCustomProviderButtonQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on GenerativeModelCustomProvider {\n      id\n      name\n      description\n      sdk\n      provider\n      createdAt\n      updatedAt\n      user {\n        id\n        username\n        profilePictureUrl\n      }\n      config {\n        __typename\n        ... on UnparsableConfig {\n          parseError\n        }\n        ... on OpenAICustomProviderConfig {\n          openaiAuthenticationMethod {\n            apiKey\n          }\n          openaiClientKwargs {\n            baseUrl\n            organization\n            project\n            defaultHeaders\n          }\n        }\n        ... on AzureOpenAICustomProviderConfig {\n          azureOpenaiAuthenticationMethod {\n            apiKey\n            azureAdTokenProvider {\n              azureTenantId\n              azureClientId\n              azureClientSecret\n              scope\n            }\n            defaultCredentials\n          }\n          azureOpenaiClientKwargs {\n            azureEndpoint\n            defaultHeaders\n          }\n        }\n        ... on AnthropicCustomProviderConfig {\n          anthropicAuthenticationMethod {\n            apiKey\n          }\n          anthropicClientKwargs {\n            baseUrl\n            defaultHeaders\n          }\n        }\n        ... on AWSBedrockCustomProviderConfig {\n          awsBedrockAuthenticationMethod {\n            accessKeys {\n              awsAccessKeyId\n              awsSecretAccessKey\n              awsSessionToken\n            }\n            defaultCredentials\n          }\n          awsBedrockClientKwargs {\n            regionName\n            endpointUrl\n          }\n        }\n        ... on GoogleGenAICustomProviderConfig {\n          googleGenaiAuthenticationMethod {\n            apiKey\n          }\n          googleGenaiClientKwargs {\n            httpOptions {\n              baseUrl\n              headers\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query EditCustomProviderButtonQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on GenerativeModelCustomProvider {\n      id\n      name\n      description\n      sdk\n      provider\n      createdAt\n      updatedAt\n      user {\n        id\n        username\n        profilePictureUrl\n      }\n      config {\n        __typename\n        ... on UnparsableConfig {\n          parseError\n        }\n        ... on OpenAICustomProviderConfig {\n          openaiApiType\n          openaiAuthenticationMethod {\n            apiKey\n          }\n          openaiClientKwargs {\n            baseUrl\n            organization\n            project\n            defaultHeaders\n          }\n        }\n        ... on AzureOpenAICustomProviderConfig {\n          openaiApiType\n          azureOpenaiAuthenticationMethod {\n            apiKey\n            azureAdTokenProvider {\n              azureTenantId\n              azureClientId\n              azureClientSecret\n              scope\n            }\n            defaultCredentials\n          }\n          azureOpenaiClientKwargs {\n            azureEndpoint\n            defaultHeaders\n          }\n        }\n        ... on AnthropicCustomProviderConfig {\n          anthropicAuthenticationMethod {\n            apiKey\n          }\n          anthropicClientKwargs {\n            baseUrl\n            defaultHeaders\n          }\n        }\n        ... on AWSBedrockCustomProviderConfig {\n          awsBedrockAuthenticationMethod {\n            accessKeys {\n              awsAccessKeyId\n              awsSecretAccessKey\n              awsSessionToken\n            }\n            defaultCredentials\n          }\n          awsBedrockClientKwargs {\n            regionName\n            endpointUrl\n          }\n        }\n        ... on GoogleGenAICustomProviderConfig {\n          googleGenaiAuthenticationMethod {\n            apiKey\n          }\n          googleGenaiClientKwargs {\n            httpOptions {\n              baseUrl\n              headers\n            }\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a36bcb56b143e42e1bb091e65a931421";
+(node as any).hash = "271d8936806cb9556ecb690e0d82df19";
 
 export default node;

--- a/app/src/pages/settings/__generated__/NewCustomProviderButtonCreateMutation.graphql.ts
+++ b/app/src/pages/settings/__generated__/NewCustomProviderButtonCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2a1a8d37064f896ed574cc5a33cca06>>
+ * @generated SignedSource<<c2455fb2cacfb8455bdde3fe73506179>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type GenerativeModelSDK = "ANTHROPIC" | "AWS_BEDROCK" | "AZURE_OPENAI" | "GOOGLE_GENAI" | "OPENAI";
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type CreateGenerativeModelCustomProviderMutationInput = {
   clientConfig: GenerativeModelCustomerProviderConfigInput;
   description?: string | null;
@@ -24,6 +25,7 @@ export type GenerativeModelCustomerProviderConfigInput = {
   openai?: OpenAICustomProviderConfigInput | null;
 };
 export type OpenAICustomProviderConfigInput = {
+  openaiApiType?: OpenAIApiType | null;
   openaiAuthenticationMethod: OpenAIAuthenticationMethodInput;
   openaiClientKwargs?: OpenAIClientKwargsInput | null;
 };
@@ -39,6 +41,7 @@ export type OpenAIClientKwargsInput = {
 export type AzureOpenAICustomProviderConfigInput = {
   azureOpenaiAuthenticationMethod: AzureOpenAIAuthenticationMethodInput;
   azureOpenaiClientKwargs: AzureOpenAIClientKwargsInput;
+  openaiApiType?: OpenAIApiType | null;
 };
 export type AzureOpenAIAuthenticationMethodInput = {
   apiKey?: string | null;

--- a/app/src/pages/settings/customProviderFormSchema.ts
+++ b/app/src/pages/settings/customProviderFormSchema.ts
@@ -57,6 +57,7 @@ const baseProviderSchema = z.object({
 // OpenAI schema
 const openAISchema = baseProviderSchema.extend({
   sdk: z.literal("OPENAI"),
+  openai_api_type: z.enum(["CHAT_COMPLETIONS", "RESPONSES"]),
   openai_api_key: z.string().min(1, "API key is required"),
   openai_base_url: urlFieldSchema,
   openai_organization: z.string().optional(),
@@ -82,6 +83,7 @@ const azureEndpointSchema = z
 
 const azureOpenAISchema = baseProviderSchema.extend({
   sdk: z.literal("AZURE_OPENAI"),
+  openai_api_type: z.enum(["CHAT_COMPLETIONS", "RESPONSES"]),
   azure_endpoint: azureEndpointSchema,
   azure_auth_method: z.enum([
     "api_key",

--- a/app/src/pages/settings/customProviderFormUtils.ts
+++ b/app/src/pages/settings/customProviderFormUtils.ts
@@ -56,6 +56,7 @@ export function createDefaultFormData(
         ...baseDefaults,
         sdk: "OPENAI",
         provider: SDK_DEFAULT_PROVIDER.OPENAI,
+        openai_api_type: "RESPONSES",
         openai_api_key: "",
         openai_base_url: undefined,
         openai_organization: undefined,
@@ -68,6 +69,7 @@ export function createDefaultFormData(
         ...baseDefaults,
         sdk: "AZURE_OPENAI",
         provider: SDK_DEFAULT_PROVIDER.AZURE_OPENAI,
+        openai_api_type: "RESPONSES",
         azure_endpoint: "",
         azure_auth_method: "api_key",
         azure_api_key: undefined,
@@ -155,6 +157,9 @@ export function transformConfigToFormValues(
       return {
         ...baseValues,
         sdk: "OPENAI",
+        openai_api_type:
+          (config?.openaiApiType as OpenAIFormData["openai_api_type"]) ??
+          "RESPONSES",
         openai_api_key: config?.openaiAuthenticationMethod?.apiKey || "",
         openai_base_url: config?.openaiClientKwargs?.baseUrl ?? undefined,
         openai_organization:
@@ -180,6 +185,9 @@ export function transformConfigToFormValues(
       return {
         ...baseValues,
         sdk: "AZURE_OPENAI",
+        openai_api_type:
+          (config?.openaiApiType as AzureOpenAIFormData["openai_api_type"]) ??
+          "RESPONSES",
         azure_endpoint: kwargs?.azureEndpoint ?? "",
         azure_auth_method: authMethodType,
         azure_api_key: authMethod?.apiKey ?? undefined,
@@ -267,6 +275,7 @@ export function buildClientConfig(
     case "OPENAI":
       return {
         openai: {
+          openaiApiType: formData.openai_api_type,
           openaiAuthenticationMethod: {
             apiKey: formData.openai_api_key,
           },
@@ -346,6 +355,7 @@ export function buildClientConfig(
 
       return {
         azureOpenai: {
+          openaiApiType: formData.openai_api_type,
           azureOpenaiAuthenticationMethod: authMethod,
           azureOpenaiClientKwargs: {
             azureEndpoint: formData.azure_endpoint,
@@ -523,6 +533,7 @@ function hasConfigChanged(
     case "OPENAI": {
       invariant(originalValues.sdk === "OPENAI", "SDK mismatch");
       return (
+        formData.openai_api_type !== originalValues.openai_api_type ||
         formData.openai_api_key !== originalValues.openai_api_key ||
         formData.openai_base_url !== originalValues.openai_base_url ||
         formData.openai_organization !== originalValues.openai_organization ||
@@ -534,6 +545,7 @@ function hasConfigChanged(
     case "AZURE_OPENAI": {
       invariant(originalValues.sdk === "AZURE_OPENAI", "SDK mismatch");
       return (
+        formData.openai_api_type !== originalValues.openai_api_type ||
         formData.azure_endpoint !== originalValues.azure_endpoint ||
         formData.azure_auth_method !== originalValues.azure_auth_method ||
         formData.azure_api_key !== originalValues.azure_api_key ||

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -72,6 +72,11 @@ export type PlaygroundError = {
   message?: string;
 };
 
+/**
+ * OpenAI/Azure API type for built-in provider: Chat Completions or Responses API.
+ */
+export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
+
 export type ModelConfig = {
   provider: ModelProvider;
   modelName: string | null;
@@ -81,6 +86,11 @@ export type ModelConfig = {
    * The region of the deployment (e.x. us-east-1 for AWS Bedrock)
    */
   region?: string | null;
+  /**
+   * OpenAI/Azure built-in only: which API to use (Chat Completions vs Responses API).
+   * Omitted for custom providers (API type is set on the provider in Settings).
+   */
+  openaiApiType?: OpenAIApiType | null;
   /**
    * Custom headers to be sent with requests to the LLM provider
    */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "opentelemetry-exporter-otlp",
   "openinference-semantic-conventions>=0.1.26",
   "openinference-instrumentation>=0.1.44",
+  "openinference-instrumentation-openai>=0.1.41",
   "sqlalchemy[asyncio]>=2.0.4, <3",
   "alembic>=1.3.0, <2",
   "aiosqlite",
@@ -77,6 +78,7 @@ phoenix = "phoenix.server.main:main"
 [dependency-groups]
 dev = [
   "aiobotocore>=3.1.1",
+  "aioboto3",
   "aiosqlite<0.22.0",  # new version is causing tests to hang
   "anthropic>=0.79.0",
   "arize>=8.1.0",
@@ -110,6 +112,8 @@ dev = [
   "opentelemetry-instrumentation-fastapi",
   "opentelemetry-instrumentation-grpc",
   "opentelemetry-instrumentation-sqlalchemy",
+  "opentelemetry-instrumentation-httpx",
+  "opentelemetry-instrumentation-aiohttp-client",
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-sdk>=1.35.0",
   "opentelemetry-semantic-conventions",

--- a/src/phoenix/db/types/model_provider.py
+++ b/src/phoenix/db/types/model_provider.py
@@ -162,6 +162,10 @@ class OpenAICustomProviderConfig(BaseModel):
         default=None,
         description="OpenAI client kwargs",
     )
+    openai_api_type: Literal["chat_completions", "responses"] = Field(
+        default="responses",
+        description="Which OpenAI API to use: chat_completions or responses",
+    )
 
     def get_client_factory(
         self,
@@ -266,6 +270,10 @@ class AzureOpenAICustomProviderConfig(BaseModel):
     azure_openai_client_kwargs: AzureOpenAIClientKwargs = Field(
         ...,
         description="Azure OpenAI client kwargs",
+    )
+    openai_api_type: Literal["chat_completions", "responses"] = Field(
+        default="responses",
+        description="Which OpenAI API to use: chat_completions or responses",
     )
 
     def get_client_factory(

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -55,6 +55,7 @@ from phoenix.server.api.input_types.GenerativeModelInput import (
     GenerativeModelBuiltinProviderInput,
     GenerativeModelCustomProviderInput,
     GenerativeModelInput,
+    OpenAIApiType,
 )
 from phoenix.server.api.input_types.PlaygroundEvaluatorInput import (
     EvaluatorInputMappingInput,
@@ -736,6 +737,7 @@ async def _get_llm_evaluators(
                 builtin=GenerativeModelBuiltinProviderInput(
                     provider_key=provider_key,
                     name=prompt_version.model_name,
+                    openai_api_type=OpenAIApiType.CHAT_COMPLETIONS,
                 )
             )
 

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -353,6 +353,16 @@ class LLMEvaluator(BaseEvaluator):
                 )
                 invocation_parameters = get_raw_invocation_parameters(self._invocation_parameters)
                 invocation_parameters.update(denormalized_tool_choice)
+                # Only pass params the client supports (e.g. Responses API has no temperature)
+                supported_names = {
+                    p.invocation_name
+                    for p in self._llm_client.__class__.supported_invocation_parameters()
+                }
+                invocation_parameters = {
+                    k: v
+                    for k, v in invocation_parameters.items()
+                    if k in supported_names and v is not None
+                }
                 tool_call_by_id: dict[ToolCallId, ToolCall] = {}
 
                 async for chunk in self._llm_client.chat_completion_create(

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -889,7 +889,7 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
                     pass
                 elif event.type == "response.custom_tool_call_input.delta":
                     pass
-                else:
+                elif TYPE_CHECKING:
                     assert_never(event.type)
 
         if completed_response is not None:

--- a/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
@@ -22,6 +22,7 @@ from phoenix.db.types.model_provider import (
     OpenAIClientKwargs,
     OpenAICustomProviderConfig,
 )
+from phoenix.server.api.input_types.GenerativeModelInput import OpenAIApiType
 
 
 @strawberry.input
@@ -52,14 +53,18 @@ class OpenAIClientKwargsInput:
 class OpenAICustomProviderConfigInput:
     openai_authentication_method: OpenAIAuthenticationMethodInput
     openai_client_kwargs: OpenAIClientKwargsInput | None = UNSET
+    openai_api_type: OpenAIApiType | None = OpenAIApiType.RESPONSES
+    """ Which OpenAI API to use: chat_completions or responses. Default responses. """
 
     def to_orm(self) -> GenerativeModelCustomerProviderConfig:
+        api_type = self.openai_api_type.value if self.openai_api_type else "responses"
         return GenerativeModelCustomerProviderConfig(
             root=OpenAICustomProviderConfig(
                 openai_authentication_method=self.openai_authentication_method.to_orm(),
                 openai_client_kwargs=self.openai_client_kwargs.to_orm()
                 if self.openai_client_kwargs
                 else None,
+                openai_api_type=api_type,
             )
         )
 
@@ -123,13 +128,16 @@ class AzureOpenAIClientKwargsInput:
 class AzureOpenAICustomProviderConfigInput:
     azure_openai_authentication_method: AzureOpenAIAuthenticationMethodInput
     azure_openai_client_kwargs: AzureOpenAIClientKwargsInput
+    openai_api_type: OpenAIApiType | None = OpenAIApiType.RESPONSES
+    """ Which OpenAI API to use: chat_completions or responses. Default responses. """
 
     def to_orm(self) -> GenerativeModelCustomerProviderConfig:
-        # Build authentication method
+        api_type = self.openai_api_type.value if self.openai_api_type else "responses"
         return GenerativeModelCustomerProviderConfig(
             root=AzureOpenAICustomProviderConfig(
                 azure_openai_authentication_method=self.azure_openai_authentication_method.to_orm(),
                 azure_openai_client_kwargs=self.azure_openai_client_kwargs.to_orm(),
+                openai_api_type=api_type,
             )
         )
 

--- a/src/phoenix/server/api/input_types/GenerativeModelInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelInput.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 
 import strawberry
@@ -6,6 +7,14 @@ from strawberry.relay import GlobalID
 from strawberry.scalars import JSON
 
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
+
+
+@strawberry.enum
+class OpenAIApiType(Enum):
+    """Chat Completions (chat.completions.create) or Responses API (responses.create)."""
+
+    CHAT_COMPLETIONS = "chat_completions"
+    RESPONSES = "responses"
 
 
 @strawberry.input
@@ -21,6 +30,8 @@ class GenerativeModelBuiltinProviderInput:
     """ The region to use for the model. """
     custom_headers: Optional[JSON] = UNSET
     """ Custom headers to use for the model. """
+    openai_api_type: Optional[OpenAIApiType] = UNSET
+    """ For OpenAI/Azure: chat_completions or responses. Required for OpenAI/Azure. """
 
 
 @strawberry.input

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -68,6 +68,7 @@ from phoenix.server.api.input_types.GenerativeModelInput import (
     GenerativeModelBuiltinProviderInput,
     GenerativeModelCustomProviderInput,
     GenerativeModelInput,
+    OpenAIApiType,
 )
 from phoenix.server.api.input_types.PromptTemplateOptions import PromptTemplateOptions
 from phoenix.server.api.mutations.evaluator_mutations import (
@@ -649,6 +650,7 @@ class ChatCompletionMutationMixin:
                         builtin=GenerativeModelBuiltinProviderInput(
                             provider_key=generative_provider_key,
                             name=model_name,
+                            openai_api_type=OpenAIApiType.RESPONSES,
                         )
                     )
                 async with info.context.db() as session:

--- a/src/phoenix/server/api/types/GenerativeModelCustomProvider.py
+++ b/src/phoenix/server/api/types/GenerativeModelCustomProvider.py
@@ -14,6 +14,7 @@ from phoenix.db import models
 from phoenix.db.types import model_provider as mp
 from phoenix.server.api.context import Context
 from phoenix.server.api.helpers.playground_registry import PLAYGROUND_CLIENT_REGISTRY
+from phoenix.server.api.input_types.GenerativeModelInput import OpenAIApiType
 from phoenix.server.api.types.GenerativeProvider import GenerativeProviderKey
 
 if TYPE_CHECKING:
@@ -82,6 +83,7 @@ class OpenAIClientKwargs:
 class OpenAICustomProviderConfig:
     openai_authentication_method: OpenAIAuthenticationMethod
     openai_client_kwargs: OpenAIClientKwargs | None = UNSET
+    openai_api_type: OpenAIApiType
 
     @classmethod
     def from_orm(cls, config: mp.OpenAICustomProviderConfig) -> Self:
@@ -90,6 +92,7 @@ class OpenAICustomProviderConfig:
                 config.openai_authentication_method
             ),
             openai_client_kwargs=OpenAIClientKwargs.from_orm(config.openai_client_kwargs),
+            openai_api_type=OpenAIApiType(config.openai_api_type),
         )
 
 
@@ -142,6 +145,7 @@ class AzureOpenAIClientKwargs:
 class AzureOpenAICustomProviderConfig:
     azure_openai_authentication_method: AzureOpenAIAuthenticationMethod
     azure_openai_client_kwargs: AzureOpenAIClientKwargs
+    openai_api_type: OpenAIApiType
 
     @classmethod
     def from_orm(cls, config: mp.AzureOpenAICustomProviderConfig) -> Self:
@@ -152,6 +156,7 @@ class AzureOpenAICustomProviderConfig:
             azure_openai_client_kwargs=AzureOpenAIClientKwargs.from_orm(
                 config.azure_openai_client_kwargs
             ),
+            openai_api_type=OpenAIApiType(config.openai_api_type),
         )
 
 

--- a/tests/integration/experiments/conftest.py
+++ b/tests/integration/experiments/conftest.py
@@ -194,6 +194,7 @@ async def _custom_providers(
                         "openai": {
                             "openaiAuthenticationMethod": {"apiKey": "test-api-key"},
                             "openaiClientKwargs": {"baseUrl": f"{_mock_llm_server.url}/v1"},
+                            "openaiApiType": "CHAT_COMPLETIONS",
                         }
                     },
                 }

--- a/tests/unit/server/api/mutations/test_chat_mutations.py
+++ b/tests/unit/server/api/mutations/test_chat_mutations.py
@@ -77,6 +77,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "messages": [
@@ -134,6 +135,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "messages": [
@@ -212,6 +214,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "credentials": [{"envVarName": "OPENAI_API_KEY", "value": "sk-"}],
@@ -296,7 +299,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": dataset_version_id,
                 "messages": [
@@ -373,7 +382,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": dataset_version_id,
                 "messages": [
@@ -449,7 +464,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": dataset_version_id,
                 "messages": [
@@ -549,6 +570,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "credentials": [{"envVarName": "OPENAI_API_KEY", "value": "sk-"}],
@@ -643,6 +665,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "credentials": [{"envVarName": "OPENAI_API_KEY", "value": "sk-"}],
@@ -758,7 +781,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4o-mini"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4o-mini",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "messages": [
                     {
                         "role": "USER",
@@ -896,6 +925,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-nonexistent-model",  # use a non-existent model to trigger an error
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "messages": [
@@ -1014,7 +1044,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_gid,
                 "datasetVersionId": version_gid,
                 "messages": [
@@ -1604,6 +1640,7 @@ class TestChatCompletionMutationMixin:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-nonexistent-model",  # triggers an error
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "datasetId": dataset_gid,
@@ -1714,7 +1751,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4o-mini"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4o-mini",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "messages": [
                     {
                         "role": "USER",
@@ -1833,7 +1876,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_gid,
                 "datasetVersionId": version_gid,
                 "messages": [
@@ -1977,7 +2026,13 @@ class TestChatCompletionMutationMixin:
         """
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4o-mini"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4o-mini",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "messages": [
                     {
                         "role": "USER",

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -163,7 +163,13 @@ class TestChatCompletionSubscription:
                         "content": "Who won the World Cup in 2018? Answer in one word",
                     }
                 ],
-                "model": {"builtin": {"name": "gpt-4", "providerKey": "OPENAI"}},
+                "model": {
+                    "builtin": {
+                        "name": "gpt-4",
+                        "providerKey": "OPENAI",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "invocationParameters": [
                     {"invocationName": "temperature", "valueFloat": 0.1},
                 ],
@@ -298,7 +304,13 @@ class TestChatCompletionSubscription:
                         "content": "Who won the World Cup in 2018? Answer in one word",
                     }
                 ],
-                "model": {"builtin": {"name": "gpt-4", "providerKey": "OPENAI"}},
+                "model": {
+                    "builtin": {
+                        "name": "gpt-4",
+                        "providerKey": "OPENAI",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "invocationParameters": [
                     {"invocationName": "temperature", "valueFloat": 0.1},
                 ],
@@ -436,7 +448,13 @@ class TestChatCompletionSubscription:
                         "content": "How's the weather in San Francisco?",
                     }
                 ],
-                "model": {"builtin": {"name": "gpt-4", "providerKey": "OPENAI"}},
+                "model": {
+                    "builtin": {
+                        "name": "gpt-4",
+                        "providerKey": "OPENAI",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "tools": [get_current_weather_tool_schema],
                 "invocationParameters": [
                     {"invocationName": "tool_choice", "valueJson": "auto"},
@@ -598,7 +616,13 @@ class TestChatCompletionSubscription:
                         "toolCallId": tool_call_id,
                     },
                 ],
-                "model": {"builtin": {"name": "gpt-4", "providerKey": "OPENAI"}},
+                "model": {
+                    "builtin": {
+                        "name": "gpt-4",
+                        "providerKey": "OPENAI",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "repetitions": 1,
             }
         }
@@ -1009,7 +1033,13 @@ class TestChatCompletionOverDatasetSubscription:
         version_id = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": version_id,
                 "messages": [
@@ -1390,7 +1420,13 @@ class TestChatCompletionOverDatasetSubscription:
         version_id = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": version_id,
                 "messages": [
@@ -1491,7 +1527,13 @@ class TestChatCompletionOverDatasetSubscription:
 
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": version_id,
                 "messages": [
@@ -1573,7 +1615,13 @@ class TestChatCompletionOverDatasetSubscription:
 
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": version_id,
                 "messages": [
@@ -1643,7 +1691,13 @@ class TestChatCompletionOverDatasetSubscription:
 
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_id,
                 "datasetVersionId": version_id,
                 "messages": [
@@ -1733,7 +1787,13 @@ class TestChatCompletionOverDatasetSubscription:
         version_gid = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_gid,
                 "datasetVersionId": version_gid,
                 "messages": [
@@ -2296,6 +2356,7 @@ class TestChatCompletionOverDatasetSubscription:
                     "builtin": {
                         "providerKey": "OPENAI",
                         "name": "gpt-nonexistent-model",  # non-existent model triggers an error
+                        "openaiApiType": "CHAT_COMPLETIONS",
                     }
                 },
                 "datasetId": dataset_gid,
@@ -2380,7 +2441,13 @@ class TestChatCompletionOverDatasetSubscription:
         version_gid = str(GlobalID(type_name=DatasetVersion.__name__, node_id=str(1)))
         variables = {
             "input": {
-                "model": {"builtin": {"providerKey": "OPENAI", "name": "gpt-4"}},
+                "model": {
+                    "builtin": {
+                        "providerKey": "OPENAI",
+                        "name": "gpt-4",
+                        "openaiApiType": "CHAT_COMPLETIONS",
+                    }
+                },
                 "datasetId": dataset_gid,
                 "datasetVersionId": version_gid,
                 "messages": [

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.18.3"
+version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
@@ -203,9 +203,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/41/ab8f624929847b49f84955c594b165855efd829b0c271e1a8cac694138e5/alembic-1.18.3.tar.gz", hash = "sha256:1212aa3778626f2b0f0aa6dd4e99a5f99b94bd25a0c1ac0bba3be65e081e50b0", size = 2052564, upload-time = "2026-01-29T20:24:15.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8e/d79281f323e7469b060f15bd229e48d7cdd219559e67e71c013720a88340/alembic-1.18.3-py3-none-any.whl", hash = "sha256:12a0359bfc068a4ecbb9b3b02cf77856033abfdb59e4a5aca08b7eacd7b74ddd", size = 262282, upload-time = "2026-01-29T20:24:17.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
 [[package]]
@@ -313,6 +313,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openinference-instrumentation" },
+    { name = "openinference-instrumentation-openai" },
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-proto" },
@@ -380,6 +381,7 @@ pg = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aioboto3" },
     { name = "aiobotocore" },
     { name = "aiosqlite" },
     { name = "anthropic" },
@@ -412,8 +414,10 @@ dev = [
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
     { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-grpc" },
+    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
@@ -500,6 +504,7 @@ requires-dist = [
     { name = "numpy", specifier = "!=2.0.0" },
     { name = "openai", marker = "extra == 'container'", specifier = ">=2.14.0" },
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
+    { name = "openinference-instrumentation-openai", specifier = ">=0.1.41" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'container'", specifier = "==1.39.1" },
@@ -545,6 +550,7 @@ provides-extras = ["aws", "container", "embeddings", "evals", "experimental", "p
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aioboto3" },
     { name = "aiobotocore", specifier = ">=3.1.1" },
     { name = "aiosqlite", specifier = "<0.22.0" },
     { name = "anthropic", specifier = ">=0.79.0" },
@@ -576,8 +582,10 @@ dev = [
     { name = "openinference-instrumentation", specifier = ">=0.1.44" },
     { name = "openinference-semantic-conventions", specifier = ">=0.1.26" },
     { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-grpc" },
+    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-proto", specifier = ">=1.12.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.35.0" },
@@ -868,20 +876,20 @@ wheels = [
 
 [[package]]
 name = "azure-core"
-version = "1.38.0"
+version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/9b/23893febea484ad8183112c9419b5eb904773adb871492b5fa8ff7b21e09/azure_core-1.38.1.tar.gz", hash = "sha256:9317db1d838e39877eb94a2240ce92fa607db68adf821817b723f0d679facbf6", size = 363323, upload-time = "2026-02-11T02:03:06.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/db/88/aaea2ad269ce70b446660371286272c1f6ba66541a7f6f635baf8b0db726/azure_core-1.38.1-py3-none-any.whl", hash = "sha256:69f08ee3d55136071b7100de5b198994fc1c5f89d2b91f2f43156d20fcf200a4", size = 217930, upload-time = "2026-02-11T02:03:07.548Z" },
 ]
 
 [[package]]
 name = "azure-identity"
-version = "1.25.1"
+version = "1.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -890,9 +898,9 @@ dependencies = [
     { name = "msal-extensions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", size = 279826, upload-time = "2025-10-06T20:30:02.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/3a/439a32a5e23e45f6a91f0405949dc66cfe6834aba15a430aebfc063a81e7/azure_identity-1.25.2.tar.gz", hash = "sha256:030dbaa720266c796221c6cdbd1999b408c079032c919fef725fcc348a540fe9", size = 284709, upload-time = "2026-02-11T01:55:42.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", size = 191317, upload-time = "2025-10-06T20:30:04.251Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/f658c76f9e9a52c784bd836aaca6fd5b9aae176f1f53273e758a2bcda695/azure_identity-1.25.2-py3-none-any.whl", hash = "sha256:1b40060553d01a72ba0d708b9a46d0f61f56312e215d8896d836653ffdc6753d", size = 191423, upload-time = "2026-02-11T01:55:44.245Z" },
 ]
 
 [[package]]
@@ -947,11 +955,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/af/df70e9b65bc77a1cbe0768c0aa4617147f30f8306ded98c1744bcdc0ae1e/cachetools-7.0.0.tar.gz", hash = "sha256:a9abf18ff3b86c7d05b27ead412e235e16ae045925e531fae38d5fada5ed5b08", size = 35796, upload-time = "2026-02-01T18:59:47.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/07/56595285564e90777d758ebd383d6b0b971b87729bbe2184a849932a3736/cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341", size = 36126, upload-time = "2026-02-10T22:24:05.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/df/2dd32cce20cbcf6f2ec456b58d44368161ad28320729f64e5e1d5d7bd0ae/cachetools-7.0.0-py3-none-any.whl", hash = "sha256:d52fef60e6e964a1969cfb61ccf6242a801b432790fe520d78720d757c81cbd2", size = 13487, upload-time = "2026-02-01T18:59:45.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9e/5faefbf9db1db466d633735faceda1f94aa99ce506ac450d232536266b32/cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf", size = 13484, upload-time = "2026-02-10T22:24:03.741Z" },
 ]
 
 [[package]]
@@ -1140,48 +1148,48 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.4"
+version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/99/157aae7949a5f30d51fcb1a9851e8ebd5c74bf99b5285d8bb4b8b9ee641e/cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485", size = 7173686, upload-time = "2026-01-28T00:23:07.515Z" },
-    { url = "https://files.pythonhosted.org/packages/87/91/874b8910903159043b5c6a123b7e79c4559ddd1896e38967567942635778/cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc", size = 4275871, upload-time = "2026-01-28T00:23:09.439Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/35/690e809be77896111f5b195ede56e4b4ed0435b428c2f2b6d35046fbb5e8/cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0", size = 4423124, upload-time = "2026-01-28T00:23:11.529Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/5b/a26407d4f79d61ca4bebaa9213feafdd8806dc69d3d290ce24996d3cfe43/cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa", size = 4277090, upload-time = "2026-01-28T00:23:13.123Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/d8/4bb7aec442a9049827aa34cee1aa83803e528fa55da9a9d45d01d1bb933e/cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81", size = 4947652, upload-time = "2026-01-28T00:23:14.554Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/08/f83e2e0814248b844265802d081f2fac2f1cbe6cd258e72ba14ff006823a/cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255", size = 4455157, upload-time = "2026-01-28T00:23:16.443Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/05/19d849cf4096448779d2dcc9bb27d097457dac36f7273ffa875a93b5884c/cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e", size = 3981078, upload-time = "2026-01-28T00:23:17.838Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/89/f7bac81d66ba7cde867a743ea5b37537b32b5c633c473002b26a226f703f/cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c", size = 4276213, upload-time = "2026-01-28T00:23:19.257Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9f/7133e41f24edd827020ad21b068736e792bc68eecf66d93c924ad4719fb3/cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32", size = 4912190, upload-time = "2026-01-28T00:23:21.244Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/6d43cbaddf6f65b24816e4af187d211f0bc536a29961f69faedc48501d8e/cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616", size = 4454641, upload-time = "2026-01-28T00:23:22.866Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4f/ebd0473ad656a0ac912a16bd07db0f5d85184924e14fc88feecae2492834/cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0", size = 4405159, upload-time = "2026-01-28T00:23:25.278Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/f7/7923886f32dc47e27adeff8246e976d77258fd2aa3efdd1754e4e323bf49/cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0", size = 4666059, upload-time = "2026-01-28T00:23:26.766Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a7/0fca0fd3591dffc297278a61813d7f661a14243dd60f499a7a5b48acb52a/cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5", size = 3026378, upload-time = "2026-01-28T00:23:28.317Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/12/652c84b6f9873f0909374864a57b003686c642ea48c84d6c7e2c515e6da5/cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b", size = 3478614, upload-time = "2026-01-28T00:23:30.275Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f7/f648fdbb61d0d45902d3f374217451385edc7e7768d1b03ff1d0e5ffc17b/cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab", size = 7169583, upload-time = "2026-01-28T00:23:56.558Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cc/8f3224cbb2a928de7298d6ed4790f5ebc48114e02bdc9559196bfb12435d/cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef", size = 4275419, upload-time = "2026-01-28T00:23:58.364Z" },
-    { url = "https://files.pythonhosted.org/packages/17/43/4a18faa7a872d00e4264855134ba82d23546c850a70ff209e04ee200e76f/cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d", size = 4419058, upload-time = "2026-01-28T00:23:59.867Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/64/6651969409821d791ba12346a124f55e1b76f66a819254ae840a965d4b9c/cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973", size = 4278151, upload-time = "2026-01-28T00:24:01.731Z" },
-    { url = "https://files.pythonhosted.org/packages/20/0b/a7fce65ee08c3c02f7a8310cc090a732344066b990ac63a9dfd0a655d321/cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4", size = 4939441, upload-time = "2026-01-28T00:24:03.175Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a7/20c5701e2cd3e1dfd7a19d2290c522a5f435dd30957d431dcb531d0f1413/cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af", size = 4451617, upload-time = "2026-01-28T00:24:05.403Z" },
-    { url = "https://files.pythonhosted.org/packages/00/dc/3e16030ea9aa47b63af6524c354933b4fb0e352257c792c4deeb0edae367/cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263", size = 3977774, upload-time = "2026-01-28T00:24:06.851Z" },
-    { url = "https://files.pythonhosted.org/packages/42/c8/ad93f14118252717b465880368721c963975ac4b941b7ef88f3c56bf2897/cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095", size = 4277008, upload-time = "2026-01-28T00:24:08.926Z" },
-    { url = "https://files.pythonhosted.org/packages/00/cf/89c99698151c00a4631fbfcfcf459d308213ac29e321b0ff44ceeeac82f1/cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b", size = 4903339, upload-time = "2026-01-28T00:24:12.009Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c3/c90a2cb358de4ac9309b26acf49b2a100957e1ff5cc1e98e6c4996576710/cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019", size = 4451216, upload-time = "2026-01-28T00:24:13.975Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2c/8d7f4171388a10208671e181ca43cdc0e596d8259ebacbbcfbd16de593da/cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4", size = 4404299, upload-time = "2026-01-28T00:24:16.169Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/23/cbb2036e450980f65c6e0a173b73a56ff3bccd8998965dea5cc9ddd424a5/cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b", size = 4664837, upload-time = "2026-01-28T00:24:17.629Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/21/f7433d18fe6d5845329cbdc597e30caf983229c7a245bcf54afecc555938/cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc", size = 3009779, upload-time = "2026-01-28T00:24:20.198Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/6a/bd2e7caa2facffedf172a45c1a02e551e6d7d4828658c9a245516a598d94/cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976", size = 3466633, upload-time = "2026-01-28T00:24:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/59/e0/f9c6c53e1f2a1c2507f00f2faba00f01d2f334b35b0fbfe5286715da2184/cryptography-46.0.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b", size = 3476316, upload-time = "2026-01-28T00:24:24.144Z" },
-    { url = "https://files.pythonhosted.org/packages/27/7a/f8d2d13227a9a1a9fe9c7442b057efecffa41f1e3c51d8622f26b9edbe8f/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da", size = 4216693, upload-time = "2026-01-28T00:24:25.758Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/de/3787054e8f7972658370198753835d9d680f6cd4a39df9f877b57f0dd69c/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80", size = 4382765, upload-time = "2026-01-28T00:24:27.577Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/5f/60e0afb019973ba6a0b322e86b3d61edf487a4f5597618a430a2a15f2d22/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822", size = 4216066, upload-time = "2026-01-28T00:24:29.056Z" },
-    { url = "https://files.pythonhosted.org/packages/81/8e/bf4a0de294f147fee66f879d9bae6f8e8d61515558e3d12785dd90eca0be/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947", size = 4382025, upload-time = "2026-01-28T00:24:30.681Z" },
-    { url = "https://files.pythonhosted.org/packages/79/f4/9ceb90cfd6a3847069b0b0b353fd3075dc69b49defc70182d8af0c4ca390/cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3", size = 3406043, upload-time = "2026-01-28T00:24:32.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
 ]
 
 [[package]]
@@ -1343,7 +1351,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.5"
+version = "0.128.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1352,9 +1360,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/d4/811e7283aaaa84f1e7bd55fb642b58f8c01895e4884a9b7628cb55e00d63/fastapi-0.128.5.tar.gz", hash = "sha256:a7173579fc162d6471e3c6fbd9a4b7610c7a3b367bcacf6c4f90d5d022cab711", size = 374636, upload-time = "2026-02-08T10:22:30.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/af386750b3fd8d8828167e4c82b787a8eeca2eca5c5429c9db8bb7c70e04/fastapi-0.128.7.tar.gz", hash = "sha256:783c273416995486c155ad2c0e2b45905dedfaf20b9ef8d9f6a9124670639a24", size = 375325, upload-time = "2026-02-10T12:26:40.968Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/e0/511972dba23ee76c0e9d09d1ae95e916fc8ebce5322b2b8b65a481428b10/fastapi-0.128.5-py3-none-any.whl", hash = "sha256:bceec0de8aa6564599c5bcc0593b0d287703562c848271fca8546fd2c87bf4dd", size = 103677, upload-time = "2026-02-08T10:22:28.919Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/f983b45661c79c31be575c570d46c437a5409b67a939c1b3d8d6b3ed7a7f/fastapi-0.128.7-py3-none-any.whl", hash = "sha256:6bd9bd31cb7047465f2d3fa3ba3f33b0870b17d4eaf7cdb36d1576ab060ad662", size = 103630, upload-time = "2026-02-10T12:26:39.414Z" },
 ]
 
 [[package]]
@@ -1982,15 +1990,15 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.151.5"
+version = "6.151.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d7/c40dcd401cc360d8d084e584ffb7ab17255fde22e2b9cf2b53bf25aed629/hypothesis-6.151.5.tar.gz", hash = "sha256:ae3a0622f9693e6b19c697777c2c266c02801f9769ab7c2c37b7ec83d4743783", size = 475923, upload-time = "2026-02-03T19:33:55.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/5b/039c095977004f2316225559d591c5a4c62b2e4d7a429db2dd01d37c3ec2/hypothesis-6.151.6.tar.gz", hash = "sha256:755decfa326c8c97a4c8766fe40509985003396442138554b0ae824f9584318f", size = 475846, upload-time = "2026-02-11T04:42:06.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/d9/53a8b53e75279a953fae608bd01025d9afcf393406c0da1dda1b7f5693c5/hypothesis-6.151.5-py3-none-any.whl", hash = "sha256:c0e15c91fa0e67bc0295551ef5041bebad42753b7977a610cd7a6ec1ad04ef13", size = 543338, upload-time = "2026-02-03T19:33:54.583Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/70/42760b369723f8b5aa6a21e5fae58809f503ca7ebb6da13b99f4de36305a/hypothesis-6.151.6-py3-none-any.whl", hash = "sha256:4e6e933a98c6f606b3e0ada97a750e7fff12277a40260b9300a05e7a5c3c5e2e", size = 543324, upload-time = "2026-02-11T04:42:04.025Z" },
 ]
 
 [[package]]
@@ -2253,7 +2261,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.81.9"
+version = "1.81.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2269,9 +2277,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/8f/2a08f3d86fd008b4b02254649883032068378a8551baed93e8d9dcbbdb5d/litellm-1.81.9.tar.gz", hash = "sha256:a2cd9bc53a88696c21309ef37c55556f03c501392ed59d7f4250f9932917c13c", size = 16276983, upload-time = "2026-02-07T21:14:24.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/fc/78887158b4057835ba2c647a1bd4da650fd79142f8412c6d0bbe6d8c6081/litellm-1.81.10.tar.gz", hash = "sha256:8d769a7200888e1295592af5ce5cb0ff035832250bd0102a4ca50acf5820ca50", size = 16297572, upload-time = "2026-02-11T00:17:47.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/672fc06c8a2803477e61e0de383d3c6e686e0f0fc62789c21f0317494076/litellm-1.81.9-py3-none-any.whl", hash = "sha256:24ee273bc8a62299fbb754035f83fb7d8d44329c383701a2bd034f4fd1c19084", size = 14433170, upload-time = "2026-02-07T21:14:21.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bb/3f3cc3d79657bc9daaa1319ec3a9d75e4889fc88d07e327f0ac02cd2ac7d/litellm-1.81.10-py3-none-any.whl", hash = "sha256:9efa1cbe61ac051f6500c267b173d988ff2d511c2eecf1c8f2ee546c0870747c", size = 14457931, upload-time = "2026-02-11T00:17:43.431Z" },
 ]
 
 [[package]]
@@ -2308,6 +2316,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -2383,6 +2403,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/31/ab/05ae008357c8bdb6245ebf8a101d99f26c096e0ea20800b318153da23796/mbstrdecoder-1.1.4.tar.gz", hash = "sha256:8105ef9cf6b7d7d69fe7fd6b68a2d8f281ca9b365d7a9b670be376b2e6c81b21", size = 14527, upload-time = "2025-01-18T10:07:31.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/ac/5ce64a1d4cce00390beab88622a290420401f1cabf05caf2fc0995157c21/mbstrdecoder-1.1.4-py3-none-any.whl", hash = "sha256:03dae4ec50ec0d2ff4743e63fdbd5e0022815857494d35224b60775d3d934a8c", size = 7933, upload-time = "2025-01-18T10:07:29.562Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2800,7 +2829,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.17.0"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2812,9 +2841,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/a2/677f22c4b487effb8a09439fb6134034b5f0a39ca27df8b95fac23a93720/openai-2.17.0.tar.gz", hash = "sha256:47224b74bd20f30c6b0a6a329505243cb2f26d5cf84d9f8d0825ff8b35e9c999", size = 631445, upload-time = "2026-02-05T16:27:40.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5a/f495777c02625bfa18212b6e3b73f1893094f2bf660976eb4bc6f43a1ca2/openai-2.20.0.tar.gz", hash = "sha256:2654a689208cd0bf1098bb9462e8d722af5cbe961e6bba54e6f19fb843d88db1", size = 642355, upload-time = "2026-02-10T19:02:54.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/97/284535aa75e6e84ab388248b5a323fc296b1f70530130dee37f7f4fbe856/openai-2.17.0-py3-none-any.whl", hash = "sha256:4f393fd886ca35e113aac7ff239bcd578b81d8f104f5aedc7d3693eb2af1d338", size = 1069524, upload-time = "2026-02-05T16:27:38.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a0/cf4297aa51bbc21e83ef0ac018947fa06aea8f2364aad7c96cbf148590e6/openai-2.20.0-py3-none-any.whl", hash = "sha256:38d989c4b1075cd1f76abc68364059d822327cf1a932531d429795f4fc18be99", size = 1098479, upload-time = "2026-02-10T19:02:52.157Z" },
 ]
 
 [[package]]
@@ -2830,6 +2859,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/d9/c0d3040c0b5dc2b97ad20c35fb3fc1e3f2006bb4b08741ff325efcf3a96a/openinference_instrumentation-0.1.44.tar.gz", hash = "sha256:141953d2da33d54d428dfba2bfebb27ce0517dc43d52e1449a09db72ec7d318e", size = 23959, upload-time = "2026-02-01T01:45:55.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/6d/6a19587b26ffa273eb27ba7dd2482013afe3b47c8d9f1f39295216975f9f/openinference_instrumentation-0.1.44-py3-none-any.whl", hash = "sha256:86b2a8931e0f39ecfb739901f8987c654961da03baf3cfa5d5b4f45a96897b2d", size = 30093, upload-time = "2026-02-01T01:45:54.932Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-openai"
+version = "0.1.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/06/77b2fe7171336f71313936daf1b644a9968da85ff0b473a03ca05cc3d5c1/openinference_instrumentation_openai-0.1.41.tar.gz", hash = "sha256:ef4db680986a613b1639720f9beaa315c9e388c20bc985dbbbdf0f4df007c6e9", size = 22848, upload-time = "2025-12-04T19:58:35.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/db/48f1f540d335f98fa67891e9c25ad56020be7e7b2c0d4fd5014875fe5ddf/openinference_instrumentation_openai-0.1.41-py3-none-any.whl", hash = "sha256:6fad453446835e51333b660882eacababbf1052689ca53cba444a7d97fa2e910", size = 30273, upload-time = "2025-12-04T19:58:34.17Z" },
 ]
 
 [[package]]
@@ -2931,6 +2978,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/79/95be90c555fd7efde79dcba36ea5c668815aa2d0a4250b63687e0f91c74a/opentelemetry_instrumentation_aiohttp_client-0.60b1.tar.gz", hash = "sha256:d0e7d5aa057791ca4d9090b0d3c9982f253c1a24b6bc78a734fc18d8dd97927b", size = 15907, upload-time = "2025-12-11T13:36:44.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/f4/1a1ec632c86269750ae833c8fbdd4c8d15316eb1c21e3544e34791c805ee/opentelemetry_instrumentation_aiohttp_client-0.60b1-py3-none-any.whl", hash = "sha256:34c5097256a30b16c5a2a88a409ed82b92972a494c43212c85632d204a78c2a1", size = 12694, upload-time = "2025-12-11T13:35:35.034Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-asgi"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
@@ -2975,6 +3038,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/00/f59a3a99709f340a5564c200b79ce48d3bb9d1ac9596208d3c4cdb00f82f/opentelemetry_instrumentation_grpc-0.60b1.tar.gz", hash = "sha256:049573ddfe4c32af151348d2dbeddaaca788a57c320e70770ec216b7e35ccfd4", size = 31426, upload-time = "2025-12-11T13:37:00.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/e7/75ed12f331f4fdca3a81c4dfd32c21255d981d1fcc883b476b4c14360efd/opentelemetry_instrumentation_grpc-0.60b1-py3-none-any.whl", hash = "sha256:f7a81a87b2a26842fc62cba0743a475f151e77eb21d5b93902fbfd0518a7cca7", size = 27234, upload-time = "2025-12-11T13:36:03.267Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
 ]
 
 [[package]]
@@ -4149,6 +4228,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4856,26 +4948,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.15"
+version = "0.0.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/25/257602d316b9333089b688a7a11b33ebc660b74e8dacf400dc3dfdea1594/ty-0.0.15.tar.gz", hash = "sha256:4f9a5b8df208c62dba56e91b93bed8b5bb714839691b8cff16d12c983bfa1174", size = 5101936, upload-time = "2026-02-05T01:06:34.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/18/77f84d89db54ea0d1d1b09fa2f630ac4c240c8e270761cb908c06b6e735c/ty-0.0.16.tar.gz", hash = "sha256:a999b0db6aed7d6294d036ebe43301105681e0c821a19989be7c145805d7351c", size = 5129637, upload-time = "2026-02-10T20:24:16.48Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/c5/35626e732b79bf0e6213de9f79aff59b5f247c0a1e3ce0d93e675ab9b728/ty-0.0.15-py3-none-linux_armv6l.whl", hash = "sha256:68e092458516c61512dac541cde0a5e4e5842df00b4e81881ead8f745ddec794", size = 10138374, upload-time = "2026-02-05T01:07:03.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/8a/48fd81664604848f79d03879b3ca3633762d457a069b07e09fb1b87edd6e/ty-0.0.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79f2e75289eae3cece94c51118b730211af4ba5762906f52a878041b67e54959", size = 9947858, upload-time = "2026-02-05T01:06:47.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/85/c1ac8e97bcd930946f4c94db85b675561d590b4e72703bf3733419fc3973/ty-0.0.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:112a7b26e63e48cc72c8c5b03227d1db280cfa57a45f2df0e264c3a016aa8c3c", size = 9443220, upload-time = "2026-02-05T01:06:44.98Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d9/244bc02599d950f7a4298fbc0c1b25cc808646b9577bdf7a83470b2d1cec/ty-0.0.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71f62a2644972975a657d9dc867bf901235cde51e8d24c20311067e7afd44a56", size = 9949976, upload-time = "2026-02-05T01:07:01.515Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/ab/3a0daad66798c91a33867a3ececf17d314ac65d4ae2bbbd28cbfde94da63/ty-0.0.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e48b42be2d257317c85b78559233273b655dd636fc61e7e1d69abd90fd3cba4", size = 9965918, upload-time = "2026-02-05T01:06:54.283Z" },
-    { url = "https://files.pythonhosted.org/packages/39/4e/e62b01338f653059a7c0cd09d1a326e9a9eedc351a0f0de9db0601658c3d/ty-0.0.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27dd5b52a421e6871c5bfe9841160331b60866ed2040250cb161886478ab3e4f", size = 10424943, upload-time = "2026-02-05T01:07:08.777Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b5/7aa06655ce69c0d4f3e845d2d85e79c12994b6d84c71699cfb437e0bc8cf/ty-0.0.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76b85c9ec2219e11c358a7db8e21b7e5c6674a1fb9b6f633836949de98d12286", size = 10964692, upload-time = "2026-02-05T01:06:37.103Z" },
-    { url = "https://files.pythonhosted.org/packages/13/04/36fdfe1f3c908b471e246e37ce3d011175584c26d3853e6c5d9a0364564c/ty-0.0.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9e8204c61d8ede4f21f2975dce74efdb80fafb2fae1915c666cceb33ea3c90b", size = 10692225, upload-time = "2026-02-05T01:06:49.714Z" },
-    { url = "https://files.pythonhosted.org/packages/13/41/5bf882649bd8b64ded5fbce7fb8d77fb3b868de1a3b1a6c4796402b47308/ty-0.0.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af87c3be7c944bb4d6609d6c63e4594944b0028c7bd490a525a82b88fe010d6d", size = 10516776, upload-time = "2026-02-05T01:06:52.047Z" },
-    { url = "https://files.pythonhosted.org/packages/56/75/66852d7e004f859839c17ffe1d16513c1e7cc04bcc810edb80ca022a9124/ty-0.0.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:50dccf7398505e5966847d366c9e4c650b8c225411c2a68c32040a63b9521eea", size = 9928828, upload-time = "2026-02-05T01:06:56.647Z" },
-    { url = "https://files.pythonhosted.org/packages/65/72/96bc16c7b337a3ef358fd227b3c8ef0c77405f3bfbbfb59ee5915f0d9d71/ty-0.0.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:bd797b8f231a4f4715110259ad1ad5340a87b802307f3e06d92bfb37b858a8f3", size = 9978960, upload-time = "2026-02-05T01:06:29.567Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/18/d2e316a35b626de2227f832cd36d21205e4f5d96fd036a8af84c72ecec1b/ty-0.0.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9deb7f20e18b25440a9aa4884f934ba5628ef456dbde91819d5af1a73da48af3", size = 10135903, upload-time = "2026-02-05T01:06:59.256Z" },
-    { url = "https://files.pythonhosted.org/packages/02/d3/b617a79c9dad10c888d7c15cd78859e0160b8772273637b9c4241a049491/ty-0.0.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7b31b3de031255b90a5f4d9cb3d050feae246067c87130e5a6861a8061c71754", size = 10615879, upload-time = "2026-02-05T01:07:06.661Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b0/2652a73c71c77296a6343217063f05745da60c67b7e8a8e25f2064167fce/ty-0.0.15-py3-none-win32.whl", hash = "sha256:9362c528ceb62c89d65c216336d28d500bc9f4c10418413f63ebc16886e16cc1", size = 9578058, upload-time = "2026-02-05T01:06:42.928Z" },
-    { url = "https://files.pythonhosted.org/packages/84/6e/08a4aedebd2a6ce2784b5bc3760e43d1861f1a184734a78215c2d397c1df/ty-0.0.15-py3-none-win_amd64.whl", hash = "sha256:4db040695ae67c5524f59cb8179a8fa277112e69042d7dfdac862caa7e3b0d9c", size = 10457112, upload-time = "2026-02-05T01:06:39.885Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/be/1991f2bc12847ae2d4f1e3ac5dcff8bb7bc1261390645c0755bb55616355/ty-0.0.15-py3-none-win_arm64.whl", hash = "sha256:e5a98d4119e77d6136461e16ae505f8f8069002874ab073de03fbcb1a5e8bf25", size = 9937490, upload-time = "2026-02-05T01:06:32.388Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/909ebcc7f59eaf8a2c18fb54bfcf1c106f99afb3e5460058d4b46dec7b20/ty-0.0.16-py3-none-linux_armv6l.whl", hash = "sha256:6d8833b86396ed742f2b34028f51c0e98dbf010b13ae4b79d1126749dc9dab15", size = 10113870, upload-time = "2026-02-10T20:24:11.864Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2c/b963204f3df2fdbf46a4a1ea4a060af9bb676e065d59c70ad0f5ae0dbae8/ty-0.0.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:934c0055d3b7f1cf3c8eab78c6c127ef7f347ff00443cef69614bda6f1502377", size = 9936286, upload-time = "2026-02-10T20:24:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/4d/3d78294f2ddfdded231e94453dea0e0adef212b2bd6536296039164c2a3e/ty-0.0.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b55e8e8733b416d914003cd22e831e139f034681b05afed7e951cc1a5ea1b8d4", size = 9442660, upload-time = "2026-02-10T20:24:02.704Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/ce48c0541e3b5749b0890725870769904e6b043e077d4710e5325d5cf807/ty-0.0.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feccae8f4abd6657de111353bd604f36e164844466346eb81ffee2c2b06ea0f0", size = 9934506, upload-time = "2026-02-10T20:24:35.818Z" },
+    { url = "https://files.pythonhosted.org/packages/84/16/3b29de57e1ec6e56f50a4bb625ee0923edb058c5f53e29014873573a00cd/ty-0.0.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1cad5e29d8765b92db5fa284940ac57149561f3f89470b363b9aab8a6ce553b0", size = 9933099, upload-time = "2026-02-10T20:24:43.003Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/e546995c25563d318c502b2f42af0fdbed91e1fc343708241e2076373644/ty-0.0.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86f28797c7dc06f081238270b533bf4fc8e93852f34df49fb660e0b58a5cda9a", size = 10438370, upload-time = "2026-02-10T20:24:33.44Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/22d301a4b2cce0f75ae84d07a495f87da193bcb68e096d43695a815c4708/ty-0.0.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be971a3b42bcae44d0e5787f88156ed2102ad07558c05a5ae4bfd32a99118e66", size = 10992160, upload-time = "2026-02-10T20:24:25.574Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/40/f1892b8c890db3f39a1bab8ec459b572de2df49e76d3cad2a9a239adcde9/ty-0.0.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3c9f982b7c4250eb91af66933f436b3a2363c24b6353e94992eab6551166c8b7", size = 10717892, upload-time = "2026-02-10T20:24:05.914Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/1b/caf9be8d0c738983845f503f2e92ea64b8d5fae1dd5ca98c3fca4aa7dadc/ty-0.0.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d122edf85ce7bdf6f85d19158c991d858fc835677bd31ca46319c4913043dc84", size = 10510916, upload-time = "2026-02-10T20:24:00.252Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ea/28980f5c7e1f4c9c44995811ea6a36f2fcb205232a6ae0f5b60b11504621/ty-0.0.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:497ebdddbb0e35c7758ded5aa4c6245e8696a69d531d5c9b0c1a28a075374241", size = 9908506, upload-time = "2026-02-10T20:24:28.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/80/8672306596349463c21644554f935ff8720679a14fd658fef658f66da944/ty-0.0.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e1e0ac0837bde634b030243aeba8499383c0487e08f22e80f5abdacb5b0bd8ce", size = 9949486, upload-time = "2026-02-10T20:24:18.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8a/d8747d36f30bd82ea157835f5b70d084c9bb5d52dd9491dba8a149792d6a/ty-0.0.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1216c9bcca551d9f89f47a817ebc80e88ac37683d71504e5509a6445f24fd024", size = 10145269, upload-time = "2026-02-10T20:24:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4c/753535acc7243570c259158b7df67e9c9dd7dab9a21ee110baa4cdcec45d/ty-0.0.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:221bbdd2c6ee558452c96916ab67fcc465b86967cf0482e19571d18f9c831828", size = 10608644, upload-time = "2026-02-10T20:24:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/05/8e8db64cf45a8b16757e907f7a3bfde8d6203e4769b11b64e28d5bdcd79a/ty-0.0.16-py3-none-win32.whl", hash = "sha256:d52c4eb786be878e7514cab637200af607216fcc5539a06d26573ea496b26512", size = 9582579, upload-time = "2026-02-10T20:24:30.406Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bc/45759faea132cd1b2a9ff8374e42ba03d39d076594fbb94f3e0e2c226c62/ty-0.0.16-py3-none-win_amd64.whl", hash = "sha256:f572c216aa8ecf79e86589c6e6d4bebc01f1f3cb3be765c0febd942013e1e73a", size = 10436043, upload-time = "2026-02-10T20:23:57.51Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/02/70a491802e7593e444137ed4e41a04c34d186eb2856f452dd76b60f2e325/ty-0.0.16-py3-none-win_arm64.whl", hash = "sha256:430eadeb1c0de0c31ef7bef9d002bdbb5f25a31e3aad546f1714d76cd8da0a87", size = 9915122, upload-time = "2026-02-10T20:24:14.285Z" },
 ]
 
 [[package]]
@@ -4898,16 +4990,30 @@ datetime = [
 ]
 
 [[package]]
-name = "typer-slim"
-version = "0.21.1"
+name = "typer"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
-    { name = "typing-extensions" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/03/b732764b567a81f1aa125a84a0535aa267ea3b1c9ac95e5a97a7b9a0fdaf/typer-0.22.0.tar.gz", hash = "sha256:3cab90c100ca37be24f8b4c942fdb95fc41a96145192af0fd34e0567e83c3880", size = 120281, upload-time = "2026-02-11T11:00:14.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e7/61b0dd194be67021ff7c6c87b66511d7691b9b241b2a67a2a5e3842e531b/typer-0.22.0-py3-none-any.whl", hash = "sha256:7005624db6209bc9228572d7faa3a3a4ebe6b7a3e157c63d34d4b8f17137888b", size = 56641, upload-time = "2026-02-11T11:00:13.109Z" },
+]
+
+[[package]]
+name = "typer-slim"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/269f65fd3fbb6058b39ab1aa3ef3ffcd98bbba071dc4233083715e3053f9/typer_slim-0.22.0.tar.gz", hash = "sha256:99cabb4a601632a61cceb94ce044bbba7f13bf55c1cc9592b21a62dbf629a014", size = 4815, upload-time = "2026-02-11T11:00:13.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/fc/a2fe203a85b998556dfaca0704d3a76a1e39b3301a0ca7013d68b054d84c/typer_slim-0.22.0-py3-none-any.whl", hash = "sha256:7ed4786c26e98e8baad18591fc5387fe1fca1a6c555af56b9d3987a470097897", size = 3362, upload-time = "2026-02-11T11:00:15.478Z" },
 ]
 
 [[package]]
@@ -5047,11 +5153,11 @@ wheels = [
 
 [[package]]
 name = "types-setuptools"
-version = "81.0.0.20260209"
+version = "82.0.0.20260210"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/57/f1f7992d6d7bded78d1f14dc23d59e87601920852bf10ece2325e49bacae/types_setuptools-81.0.0.20260209.tar.gz", hash = "sha256:2c2eb64499b41b672c387f6f45678a28d20a143a81b45a5c77acbfd4da0df3e1", size = 43201, upload-time = "2026-02-09T04:14:15.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/90/796ac8c774a7f535084aacbaa6b7053d16fff5c630eff87c3ecff7896c37/types_setuptools-82.0.0.20260210.tar.gz", hash = "sha256:d9719fbbeb185254480ade1f25327c4654f8c00efda3fec36823379cebcdee58", size = 44768, upload-time = "2026-02-10T04:22:02.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/87/90c9143af95850bdaf7eb0d47c59e5c3a8b55fc5a49aca0eb7f98cb964d5/types_setuptools-81.0.0.20260209-py3-none-any.whl", hash = "sha256:4facf71e3f953f8f5ac0020cd6c1b5e493aaff0183e85830bc34870b6abf8475", size = 64194, upload-time = "2026-02-09T04:14:14.278Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/54/3489432b1d9bc713c9d8aa810296b8f5b0088403662959fb63a8acdbd4fc/types_setuptools-82.0.0.20260210-py3-none-any.whl", hash = "sha256:5124a7daf67f195c6054e0f00f1d97c69caad12fdcf9113eba33eff0bce8cd2b", size = 68433, upload-time = "2026-02-10T04:22:00.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces a new OpenAI/Azure execution path (Responses API) and changes request parameter/tool mapping and tracing behavior, which can affect core LLM invocation correctness and observability.
> 
> **Overview**
> Adds a new `OpenAIApiType` enum to the GraphQL API and threads `openaiApiType` through built-in model inputs and OpenAI/Azure custom provider configs (including Settings create/edit flows and Relay artifacts).
> 
> Updates the Playground UI to let users choose the API type for built-in OpenAI/Azure models, and ensures `playgroundUtils` sends this choice with chat requests.
> 
> Implements streaming support for OpenAI/Azure *Responses API* in `playground_clients.py`, including parameter/tool-shape mapping, span attribute handling via `openinference-instrumentation-openai`, and selection of the appropriate client based on `openai_api_type`; also filters invocation parameters to only those supported by the chosen client and adds validation error handling for invalid custom provider configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3503c79ce3168b49e94bc8d8996ce241da22c001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->