### PR TITLE
chore: add boto3 as a dev dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ phoenix = "phoenix.server.main:main"
 
 [dependency-groups]
 dev = [
+  "aioboto3",
   "aiobotocore>=3.1.1",
   "aiosqlite<0.22.0",  # new version is causing tests to hang
   "anthropic>=0.79.0",

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,7 @@ pg = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aioboto3" },
     { name = "aiobotocore" },
     { name = "aiosqlite" },
     { name = "anthropic" },
@@ -545,6 +546,7 @@ provides-extras = ["aws", "container", "embeddings", "evals", "experimental", "p
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aioboto3" },
     { name = "aiobotocore", specifier = ">=3.1.1" },
     { name = "aiosqlite", specifier = "<0.22.0" },
     { name = "anthropic", specifier = ">=0.79.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only change limited to the development environment; no runtime code or production dependency graph is modified.
> 
> **Overview**
> Adds `aioboto3` to the `dev` dependency group in `pyproject.toml`.
> 
> Updates `uv.lock` to include `aioboto3` in the recorded dev dependency metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 669d80f52b85b4c8f211fba06008ee77c00a871b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->