### PR TITLE
fix(playground): remove shift when scrollbar appears in playground dataset examples table

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -1499,6 +1499,7 @@ export function PlaygroundDatasetExamplesTable({
           flex: 1 1 auto;
           overflow: auto;
           height: 100%;
+          scrollbar-gutter: stable;
         `}
         ref={tableContainerCallbackRef}
         onScroll={(e) => fetchMoreOnBottomReached(e.target as HTMLDivElement)}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure CSS tweak scoped to the table scroll container; low risk aside from potential cross-browser styling differences.
> 
> **Overview**
> Prevents layout jitter in the Playground dataset examples table by reserving space for the scrollbar via `scrollbar-gutter: stable` on the table’s scroll container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f25fe9e5230c1772b2c128c6f685a4ae031f8fc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->