### PR TITLE
docs: remove unnecessary note from narrative docs 

### DIFF
--- a/docs/phoenix/datasets-and-experiments/tutorial/run-experiments-with-llm-judge.mdx
+++ b/docs/phoenix/datasets-and-experiments/tutorial/run-experiments-with-llm-judge.mdx
@@ -152,8 +152,6 @@ const actionabilityJudge = createClassificationEvaluator({
 
 </CodeGroup>
 
-Note: In TypeScript, the `createClassificationEvaluator` returns an evaluator that can be passed directly to `runExperiment` without needing a wrapper function. The template variables use double curly braces `{{variable}}` instead of single braces.
-
 ### Run the Experiment
 
 Run the experiment on your dataset.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that deletes a narrative note; no code or API behavior changes.
> 
> **Overview**
> Removes a TypeScript-specific note in `run-experiments-with-llm-judge.mdx` that claimed `createClassificationEvaluator` can be passed directly to `runExperiment` without a wrapper and that templates use `{{variable}}` syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3afa9941dcc9d1a282e28409e72c28177cf9826b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->