### PR TITLE
feat: add phoenix-sdk-python Claude Code skill

### DIFF
--- a/skills/phoenix-sdk-python/SKILL.md
+++ b/skills/phoenix-sdk-python/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: phoenix-sdk-python
+description: Current Phoenix Python SDK patterns for client, evals, and tracing. Corrects common mistakes from outdated training data. Use when writing Python code that uses phoenix.client or phoenix.evals.
+license: Apache-2.0
+metadata:
+  author: oss@arize.com
+  version: "1.0.0"
+  languages: Python
+---
+
+# Phoenix Python SDK
+
+Correct, up-to-date patterns for the Phoenix Python SDK. This skill exists because LLMs frequently generate code using outdated Phoenix 1.0 patterns from their training data.
+
+## Quick Reference
+
+| Task | Files |
+| ---- | ----- |
+| **End-to-end eval pipeline (START HERE)** | **`eval-pipeline`** |
+| Client setup & fetching spans | `client-setup` |
+| Code-based evaluators | `evaluators-code` |
+| LLM-based evaluators | `evaluators-llm` |
+| Batch evaluation with DataFrames | `evaluate-dataframe` |
+| Common mistakes to avoid | `common-mistakes` |
+
+**If you are writing an evaluation script**, read `eval-pipeline` first — it has a complete working template that avoids all common pitfalls.
+
+## CRITICAL: Avoid Outdated Patterns
+
+**DO NOT USE** these legacy 1.0 patterns (common in training data):
+
+| Outdated (1.0) | Current (2.0) |
+| --------------- | ------------- |
+| `OpenAIModel(model="gpt-4")` | `LLM(provider="openai", model="gpt-4o")` |
+| `AnthropicModel(model="...")` | `LLM(provider="anthropic", model="...")` |
+| `run_evals(dataframe, evaluators)` | `evaluate_dataframe(dataframe, evaluators)` |
+| `llm_classify(dataframe, template, model, rails)` | `create_classifier(name, prompt_template, llm, choices)` |
+| `HallucinationEvaluator(model)` | `FaithfulnessEvaluator(llm=llm)` or custom classifier |
+| `QAEvaluator(model)` | Custom `create_classifier()` |
+| `project_name=` in `get_spans_dataframe` | `project_identifier=` |
+| `Client(endpoint="...")` | `Client(base_url="...", api_key="...")` |
+
+## Correct Imports
+
+```python
+# Client
+from phoenix.client import Client
+
+# Evals 2.0 API
+from phoenix.evals import (
+    create_classifier,       # Factory for LLM classification evaluators
+    create_evaluator,        # Decorator for code-based evaluators
+    evaluate_dataframe,      # Batch evaluate a DataFrame
+    ClassificationEvaluator, # LLM classification evaluator class
+    LLMEvaluator,           # Base LLM evaluator class
+    Score,                   # Score dataclass
+)
+from phoenix.evals.llm import LLM  # Provider-agnostic LLM wrapper
+
+# Pre-built evaluators
+from phoenix.evals.metrics import (
+    FaithfulnessEvaluator,     # Checks faithfulness to context
+    DocumentRelevanceEvaluator, # Checks document relevance
+    CorrectnessEvaluator,      # Checks answer correctness
+)
+```
+
+## Minimal Working Example
+
+```python
+import pandas as pd
+from phoenix.client import Client
+from phoenix.evals import create_evaluator, create_classifier, evaluate_dataframe
+from phoenix.evals.llm import LLM
+
+# 1. Fetch spans
+client = Client(base_url="https://app.phoenix.arize.com/s/your-space", api_key="...")
+df = client.spans.get_spans_dataframe(
+    project_identifier="my-project",
+    root_spans_only=True,
+    limit=50,
+)
+
+# 2. Prepare data — rename columns for evaluators
+df = df.rename(columns={
+    "attributes.input.value": "input",
+    "attributes.output.value": "output",
+})
+
+# 3. Code-based evaluator
+@create_evaluator(name="has_answer", kind="code")
+def has_answer(output: str) -> bool:
+    return len(output.strip()) > 0
+
+# 4. LLM-based classifier
+llm = LLM(provider="openai", model="gpt-4o")
+relevance = create_classifier(
+    name="relevance",
+    prompt_template="Is this response relevant?\n<question>{input}</question>\n<response>{output}</response>\nAnswer (relevant/irrelevant):",
+    llm=llm,
+    choices={"relevant": 1.0, "irrelevant": 0.0},
+)
+
+# 5. Run evaluations
+results = evaluate_dataframe(dataframe=df, evaluators=[has_answer, relevance])
+
+# 6. Extract scores (results are dicts, not raw numbers!)
+scores = results["relevance_score"].apply(lambda x: x.get("score", 0.0))
+print(f"Relevance: {scores.mean():.2f}")
+```
+
+## Key Principles
+
+| Principle | Details |
+| --------- | ------- |
+| Results are dicts | `evaluate_dataframe` returns `{name}_score` columns containing Score dicts, not raw numbers |
+| Template vars | Both `{input}` and `{{input}}` work in prompt templates |
+| Code first | Use `@create_evaluator(kind="code")` for deterministic checks before resorting to LLM |
+| LLM for nuance | Use `create_classifier()` only for subjective judgments |
+| Root spans only | Always use `root_spans_only=True` when fetching spans for evaluation |

--- a/skills/phoenix-sdk-python/rules/client-setup.md
+++ b/skills/phoenix-sdk-python/rules/client-setup.md
@@ -1,0 +1,125 @@
+# Client Setup and Fetching Spans
+
+## Client Initialization
+
+```python
+from phoenix.client import Client
+
+# Constructor signature
+client = Client(
+    base_url="https://app.phoenix.arize.com/s/your-space",  # NOT endpoint=
+    api_key="your-api-key",        # Optional, for authenticated instances
+    headers={"Custom": "header"},   # Optional additional headers
+)
+```
+
+### Base URL vs Collector Endpoint
+
+The OTEL collector endpoint (used for sending traces) and the Client base URL are different:
+
+```python
+# OTEL collector endpoint (for tracing):
+#   https://app.phoenix.arize.com/s/your-space/v1/traces
+
+# Client base URL (for fetching data):
+#   https://app.phoenix.arize.com/s/your-space
+#   (strip the /v1/traces suffix!)
+
+import os
+collector = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "")
+base_url = collector.rstrip("/")
+if base_url.endswith("/v1/traces"):
+    base_url = base_url[:-len("/v1/traces")]
+
+client = Client(base_url=base_url, api_key=os.environ.get("PHOENIX_API_KEY"))
+```
+
+## Fetching Spans
+
+```python
+df = client.spans.get_spans_dataframe(
+    project_identifier="my-project",  # NOT project_name= (deprecated)
+    root_spans_only=True,             # Only top-level spans
+    limit=50,                         # Max rows to return (default: 1000)
+    start_time=datetime_obj,          # Optional: filter by time (generous!)
+    end_time=datetime_obj,            # Optional: filter by time
+)
+```
+
+### Important Parameters
+
+| Parameter | Notes |
+| --------- | ----- |
+| `project_identifier` | Use this, NOT `project_name` (deprecated) |
+| `root_spans_only` | Always `True` for evaluation — gets top-level spans with user input/output |
+| `limit` | Default 1000. Set lower for faster queries |
+| `start_time` | **Be generous** — `timedelta(hours=1)` often misses data. Use `timedelta(days=7)` or omit |
+
+### DataFrame Columns
+
+The returned DataFrame has these columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `context.span_id` | Unique span ID (also the DataFrame index) |
+| `context.trace_id` | Trace ID grouping related spans |
+| `name` | Span name (e.g., "RunnableSequence", "ChatAnthropic") |
+| `span_kind` | Type: "CHAIN", "LLM", "RETRIEVER", "UNKNOWN", etc. |
+| `parent_id` | Parent span ID (null for root spans) |
+| `start_time` | Span start timestamp |
+| `end_time` | Span end timestamp |
+| `status_code` | "OK" or "ERROR" |
+| `attributes.input.value` | Input text or JSON string |
+| `attributes.output.value` | Output text or JSON string |
+| `attributes.input.mime_type` | MIME type of input |
+| `attributes.output.mime_type` | MIME type of output |
+| `attributes.llm.model_name` | Model used (LLM spans) |
+| `attributes.llm.token_count.total` | Total tokens (LLM spans) |
+| `attributes.llm.token_count.prompt` | Prompt tokens (LLM spans) |
+| `attributes.llm.token_count.completion` | Completion tokens (LLM spans) |
+
+### Output Value is Often JSON
+
+For LangChain/framework instrumented apps, root span output is often a JSON string,
+not plain text:
+
+```python
+import json
+
+# Root span output might be:
+#   {"context": "...", "question": "...", "docs": [...], "answer": "actual answer text"}
+
+def extract_answer(output_value):
+    """Extract answer text from span output."""
+    if not isinstance(output_value, str):
+        return str(output_value) if output_value is not None else ""
+    try:
+        parsed = json.loads(output_value)
+        if isinstance(parsed, dict) and "answer" in parsed:
+            return parsed["answer"]
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return output_value
+
+# Apply before passing to evaluators
+df["attributes.output.value"] = df["attributes.output.value"].apply(extract_answer)
+```
+
+## SpanQuery for Advanced Filtering
+
+```python
+from phoenix.client.types.spans import SpanQuery
+
+query = (
+    SpanQuery()
+    .select("span_id", "name", "attributes.llm.token_count.total")
+    .where("span_kind == 'LLM'")
+    .with_index("span_id")
+)
+
+df = client.spans.get_spans_dataframe(
+    query=query,
+    project_identifier="my-project",
+    limit=100,
+)
+```

--- a/skills/phoenix-sdk-python/rules/common-mistakes.md
+++ b/skills/phoenix-sdk-python/rules/common-mistakes.md
@@ -1,0 +1,209 @@
+# Common Mistakes
+
+Patterns that LLMs frequently generate incorrectly from training data.
+
+## 1. Legacy Model Classes
+
+```python
+# WRONG
+from phoenix.evals import OpenAIModel, AnthropicModel
+model = OpenAIModel(model="gpt-4")
+
+# RIGHT
+from phoenix.evals.llm import LLM
+llm = LLM(provider="openai", model="gpt-4o")
+```
+
+**Why**: `OpenAIModel`, `AnthropicModel`, etc. are legacy 1.0 wrappers. The `LLM` class
+is provider-agnostic and is the current API.
+
+## 2. Using run_evals Instead of evaluate_dataframe
+
+```python
+# WRONG
+from phoenix.evals import run_evals
+results = run_evals(dataframe=df, evaluators=[eval1], provide_explanation=True)
+# Returns list of DataFrames
+
+# RIGHT
+from phoenix.evals import evaluate_dataframe
+results_df = evaluate_dataframe(dataframe=df, evaluators=[eval1])
+# Returns single DataFrame with {name}_score dict columns
+```
+
+**Why**: `run_evals` is the legacy 1.0 batch function. `evaluate_dataframe` is the current
+2.0 function with a different return format.
+
+## 3. Wrong Result Column Names
+
+```python
+# WRONG — column doesn't exist
+score = results_df["relevance"].mean()
+
+# WRONG — column exists but contains dicts, not numbers
+score = results_df["relevance_score"].mean()
+
+# RIGHT — extract numeric score from dict
+scores = results_df["relevance_score"].apply(lambda x: x.get("score", 0.0))
+score = scores.mean()
+```
+
+**Why**: `evaluate_dataframe` returns columns named `{name}_score` containing Score dicts
+like `{"name": "...", "score": 1.0, "label": "...", "explanation": "..."}`.
+
+## 4. Deprecated project_name Parameter
+
+```python
+# WRONG
+df = client.spans.get_spans_dataframe(project_name="my-project")
+
+# RIGHT
+df = client.spans.get_spans_dataframe(project_identifier="my-project")
+```
+
+**Why**: `project_name` is deprecated in favor of `project_identifier`.
+
+## 5. Wrong Client Constructor
+
+```python
+# WRONG
+client = Client(endpoint="https://app.phoenix.arize.com")
+client = Client(url="https://app.phoenix.arize.com")
+
+# RIGHT
+client = Client(base_url="https://app.phoenix.arize.com/s/your-space", api_key="...")
+```
+
+**Why**: The parameter is `base_url`, not `endpoint` or `url`. Also, the base URL
+must NOT include `/v1/traces` (that's the OTEL collector endpoint, not the API base).
+
+## 6. Too-Aggressive Time Filters
+
+```python
+# WRONG — often returns zero spans
+from datetime import datetime, timedelta
+df = client.spans.get_spans_dataframe(
+    project_identifier="my-project",
+    start_time=datetime.now() - timedelta(hours=1),
+)
+
+# RIGHT — either omit time filter or use generous window
+df = client.spans.get_spans_dataframe(
+    project_identifier="my-project",
+    limit=50,  # Use limit to control result size instead
+)
+```
+
+**Why**: Traces may be from any time period. A 1-hour window frequently returns
+nothing. Use `limit=` to control result size instead.
+
+## 7. Not Using root_spans_only
+
+```python
+# WRONG — fetches all spans including internal LLM calls, retrievers, etc.
+df = client.spans.get_spans_dataframe(project_identifier="my-project")
+root_spans = df[df["parent_id"].isna()]  # Manual filtering wastes bandwidth
+
+# RIGHT — let the API filter
+df = client.spans.get_spans_dataframe(
+    project_identifier="my-project",
+    root_spans_only=True,
+)
+```
+
+**Why**: For evaluation, you typically want root spans (the top-level operation with
+user input and final output). Fetching all spans returns internal sub-operations
+(LLM calls, retriever calls, etc.) that aren't useful for output evaluation.
+
+## 8. Assuming Span Output is Plain Text
+
+```python
+# WRONG — output may be JSON, not plain text
+df = df.rename(columns={"attributes.output.value": "output"})
+# Then passing to evaluators that expect plain text...
+
+# RIGHT — parse JSON and extract the answer field
+import json
+
+def extract_answer(output_value):
+    if not isinstance(output_value, str):
+        return str(output_value) if output_value is not None else ""
+    try:
+        parsed = json.loads(output_value)
+        if isinstance(parsed, dict) and "answer" in parsed:
+            return parsed["answer"]
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return output_value
+
+df["attributes.output.value"] = df["attributes.output.value"].apply(extract_answer)
+```
+
+**Why**: LangChain and other frameworks often output structured JSON from root spans,
+like `{"context": "...", "question": "...", "answer": "..."}`. Evaluators need
+the actual answer text, not the raw JSON.
+
+## 9. Using @create_evaluator for LLM-Based Evaluation
+
+```python
+# WRONG — @create_evaluator doesn't call an LLM
+@create_evaluator(name="relevance", kind="llm")
+def relevance(input: str, output: str) -> str:
+    # This is just a regular function — no LLM is involved
+    pass
+
+# RIGHT — use create_classifier for LLM-based evaluation
+relevance = create_classifier(
+    name="relevance",
+    prompt_template="Is this relevant?\n{input}\n{output}\nAnswer:",
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-20250514"),
+    choices={"relevant": 1.0, "irrelevant": 0.0},
+)
+```
+
+**Why**: `@create_evaluator` wraps a plain Python function. Setting `kind="llm"`
+does NOT make it call an LLM. For LLM-based evaluation, use `create_classifier()`
+or `ClassificationEvaluator`.
+
+## 10. Using llm_classify Instead of create_classifier
+
+```python
+# WRONG — legacy 1.0 API
+from phoenix.evals import llm_classify
+results = llm_classify(
+    dataframe=df,
+    template=template_str,
+    model=model,
+    rails=["relevant", "irrelevant"],
+)
+
+# RIGHT — current 2.0 API
+from phoenix.evals import create_classifier, evaluate_dataframe
+from phoenix.evals.llm import LLM
+
+classifier = create_classifier(
+    name="relevance",
+    prompt_template=template_str,
+    llm=LLM(provider="anthropic", model="claude-sonnet-4-20250514"),
+    choices={"relevant": 1.0, "irrelevant": 0.0},
+)
+results_df = evaluate_dataframe(dataframe=df, evaluators=[classifier])
+```
+
+**Why**: `llm_classify` is the legacy 1.0 function. The current pattern is to create
+an evaluator with `create_classifier()` and run it with `evaluate_dataframe()`.
+
+## 11. Using HallucinationEvaluator
+
+```python
+# WRONG — deprecated
+from phoenix.evals import HallucinationEvaluator
+eval = HallucinationEvaluator(model)
+
+# RIGHT — use FaithfulnessEvaluator
+from phoenix.evals.metrics import FaithfulnessEvaluator
+from phoenix.evals.llm import LLM
+eval = FaithfulnessEvaluator(llm=LLM(provider="openai", model="gpt-4o"))
+```
+
+**Why**: `HallucinationEvaluator` is deprecated. `FaithfulnessEvaluator` is its replacement.

--- a/skills/phoenix-sdk-python/rules/eval-pipeline.md
+++ b/skills/phoenix-sdk-python/rules/eval-pipeline.md
@@ -1,0 +1,187 @@
+# Complete Evaluation Pipeline
+
+End-to-end recipe for building an evaluation script that fetches traces from Phoenix and runs evaluators. Use this as your starting template — do NOT fall back to training data patterns.
+
+## Full Working Template
+
+```python
+#!/usr/bin/env python3
+"""Evaluation pipeline: fetch traces from Phoenix, run evaluators, report results."""
+
+import json
+import os
+import sys
+
+import pandas as pd
+from phoenix.client import Client                    # NOT: from phoenix import Client
+from phoenix.evals import (
+    create_evaluator,          # Decorator for code-based evaluators
+    create_classifier,         # Factory for LLM classification evaluators
+    evaluate_dataframe,        # Batch evaluate a DataFrame
+)
+from phoenix.evals.llm import LLM                    # NOT: AnthropicModel, OpenAIModel
+
+
+# --- Step 1: Connect to Phoenix ---
+
+def get_phoenix_client() -> Client:
+    """Create a Phoenix client from environment variables."""
+    # The OTEL collector endpoint and the Client base URL are DIFFERENT.
+    # Collector: https://app.phoenix.arize.com/v1/traces  (for sending traces)
+    # Client:    https://app.phoenix.arize.com             (for fetching data)
+    collector = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", "")
+    base_url = collector.rstrip("/")
+    if base_url.endswith("/v1/traces"):
+        base_url = base_url[: -len("/v1/traces")]
+
+    api_key = os.environ.get("PHOENIX_API_KEY", "")
+
+    return Client(base_url=base_url, api_key=api_key)  # NOT: Client() or Client(endpoint=...)
+
+
+# --- Step 2: Fetch traces ---
+
+def fetch_traces(client: Client, project_name: str, limit: int = 100) -> pd.DataFrame:
+    """Fetch root spans from Phoenix."""
+    df = client.spans.get_spans_dataframe(       # NOT: client.get_spans_dataframe(...)
+        project_identifier=project_name,          # NOT: project_name=
+        root_spans_only=True,                     # Essential for evaluation
+        limit=limit,                              # NOT: start_time/end_time filters
+    )
+    if df is None or df.empty:
+        return pd.DataFrame()
+    return df
+
+
+# --- Step 3: Prepare data for evaluators ---
+
+def prepare_eval_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Extract input/output columns and parse JSON outputs."""
+    # Root span output is often JSON — extract the answer text
+    def extract_answer(output_value):
+        if not isinstance(output_value, str):
+            return str(output_value) if output_value is not None else ""
+        try:
+            parsed = json.loads(output_value)
+            if isinstance(parsed, dict):
+                # Common keys: "answer", "result", "output", "response"
+                for key in ("answer", "result", "output", "response"):
+                    if key in parsed:
+                        return str(parsed[key])
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return output_value
+
+    result = pd.DataFrame()
+    result["input"] = df["attributes.input.value"].fillna("")
+    result["output"] = df["attributes.output.value"].fillna("").apply(extract_answer)
+    result["trace_id"] = df["context.trace_id"] if "context.trace_id" in df.columns else ""
+    return result[result["input"].str.len() > 0]  # Drop rows with no input
+
+
+# --- Step 4: Define evaluators ---
+
+# Code-based evaluator (deterministic — use for anything you CAN check with code)
+@create_evaluator(name="has_answer", kind="code")
+def has_answer(output: str) -> bool:
+    """Check that the response is non-empty."""
+    return len(output.strip()) > 10
+
+# LLM-based classifier (use ONLY for subjective judgments)
+def make_relevance_classifier() -> object:
+    llm = LLM(provider="anthropic", model="claude-sonnet-4-20250514")  # NOT: AnthropicModel(...)
+    return create_classifier(
+        name="relevance",
+        prompt_template="""Is this response relevant to the user's question?
+
+<question>{input}</question>
+<response>{output}</response>
+
+Answer (relevant/irrelevant):""",
+        llm=llm,
+        choices={"relevant": 1.0, "irrelevant": 0.0},
+    )
+
+
+# --- Step 5: Run evaluations ---
+
+def run_evaluations(eval_df: pd.DataFrame, evaluators: list) -> pd.DataFrame:
+    """Run all evaluators via evaluate_dataframe."""
+    return evaluate_dataframe(                    # NOT: run_evals() or evaluator.evaluate()
+        dataframe=eval_df,
+        evaluators=evaluators,
+        exit_on_error=False,
+    )
+
+
+# --- Step 6: Extract results ---
+
+def extract_eval_results(results_df: pd.DataFrame, eval_name: str) -> dict:
+    """Extract score and failed examples from evaluate_dataframe results."""
+    score_col = f"{eval_name}_score"
+    if score_col not in results_df.columns:
+        return {"score": 0.0, "num_samples": 0, "failed_examples": []}
+
+    # Result columns contain DICTS, not raw numbers
+    scores = results_df[score_col].apply(
+        lambda x: x.get("score", 0.0) if isinstance(x, dict) else 0.0
+    )
+
+    mean_score = float(scores.mean()) if len(scores) > 0 else 0.0
+
+    # Collect failed examples
+    failed_mask = scores < 0.5
+    failed_examples = []
+    for idx in results_df[failed_mask].head(3).index:
+        row = results_df.loc[idx]
+        failed_examples.append({
+            "query": str(row.get("input", "")),
+            "response_snippet": str(row.get("output", ""))[:200],
+            "reason": f"{eval_name} check failed",
+        })
+
+    return {
+        "score": mean_score,
+        "num_samples": len(scores),
+        "failed_examples": failed_examples,
+    }
+
+
+# --- Putting it all together ---
+
+def main():
+    project_name = os.environ.get("PHOENIX_PROJECT_NAME", "default")
+
+    client = get_phoenix_client()
+    traces_df = fetch_traces(client, project_name)
+
+    if traces_df.empty:
+        print("No traces found", file=sys.stderr)
+        # Handle gracefully — output empty results, don't crash
+        return
+
+    eval_df = prepare_eval_dataframe(traces_df)
+    print(f"Evaluating {len(eval_df)} traces", file=sys.stderr)
+
+    evaluators = [has_answer, make_relevance_classifier()]
+    results_df = run_evaluations(eval_df, evaluators)
+
+    for eval_name in ["has_answer", "relevance"]:
+        result = extract_eval_results(results_df, eval_name)
+        print(f"{eval_name}: {result['score']:.2f} ({result['num_samples']} samples)", file=sys.stderr)
+```
+
+## Key Points This Template Enforces
+
+| Step | Correct Pattern | Common Mistake |
+|------|----------------|----------------|
+| Import Client | `from phoenix.client import Client` | `from phoenix import Client` |
+| Create client | `Client(base_url=..., api_key=...)` | `Client()` or `Client(endpoint=...)` |
+| Base URL | Strip `/v1/traces` from collector endpoint | Using collector endpoint directly |
+| Fetch spans | `client.spans.get_spans_dataframe(...)` | `client.get_spans_dataframe(...)` |
+| Project param | `project_identifier=` | `project_name=` (deprecated) |
+| Limit results | `limit=100` | `start_time=now-1h` (misses data) |
+| Parse output | Extract `answer` from JSON | Assume plain text |
+| LLM wrapper | `LLM(provider="anthropic", model="...")` | `AnthropicModel(model="...")` |
+| Run evals | `evaluate_dataframe(df, evaluators)` | `evaluator.evaluate(df)` or `run_evals()` |
+| Read scores | `x.get("score", 0.0)` from dict | `.mean()` on dict column |

--- a/skills/phoenix-sdk-python/rules/evaluate-dataframe.md
+++ b/skills/phoenix-sdk-python/rules/evaluate-dataframe.md
@@ -1,0 +1,134 @@
+# Batch Evaluation with evaluate_dataframe
+
+## Function Signature
+
+```python
+from phoenix.evals import evaluate_dataframe
+
+results_df = evaluate_dataframe(
+    dataframe=df,              # pandas DataFrame with columns matching evaluator params
+    evaluators=[eval1, eval2], # List of evaluators
+    exit_on_error=False,       # Optional: stop on first error
+    max_retries=3,             # Optional: retry failed LLM calls
+)
+```
+
+## CRITICAL: Result Column Format
+
+`evaluate_dataframe` returns the original DataFrame with added columns.
+**Result columns contain dicts, NOT raw numbers.**
+
+For each evaluator named `"foo"`, two columns are added:
+
+| Column | Type | Contents |
+| ------ | ---- | -------- |
+| `foo_score` | `dict` | `{"name": "foo", "score": 1.0, "label": "True", "explanation": "...", "metadata": {...}, "kind": "code", "direction": "maximize"}` |
+| `foo_execution_details` | `dict` | `{"status": "COMPLETED", "exceptions": [], "execution_seconds": 0.001}` |
+
+### Extracting Numeric Scores
+
+```python
+# WRONG — this will fail or produce unexpected results
+score = results_df["relevance"].mean()                    # KeyError!
+score = results_df["relevance_score"].mean()              # Tries to average dicts!
+
+# RIGHT — extract the numeric score from each dict
+scores = results_df["relevance_score"].apply(
+    lambda x: x.get("score", 0.0) if isinstance(x, dict) else 0.0
+)
+mean_score = scores.mean()
+```
+
+### Extracting Labels
+
+```python
+labels = results_df["relevance_score"].apply(
+    lambda x: x.get("label", "") if isinstance(x, dict) else ""
+)
+```
+
+### Extracting Explanations (LLM evaluators)
+
+```python
+explanations = results_df["relevance_score"].apply(
+    lambda x: x.get("explanation", "") if isinstance(x, dict) else ""
+)
+```
+
+### Finding Failures
+
+```python
+scores = results_df["relevance_score"].apply(
+    lambda x: x.get("score", 0.0) if isinstance(x, dict) else 0.0
+)
+failed_mask = scores < 0.5
+failures = results_df[failed_mask]
+```
+
+## Helper Pattern
+
+To avoid repeating the extraction logic:
+
+```python
+def extract_scores(results_df, eval_name):
+    """Extract numeric scores from evaluate_dataframe results."""
+    score_col = f"{eval_name}_score"
+    if score_col not in results_df.columns:
+        return None
+    return results_df[score_col].apply(
+        lambda x: x.get("score", 0.0) if isinstance(x, dict) else 0.0
+    )
+
+# Usage
+scores = extract_scores(results_df, "relevance")
+mean = float(scores.mean()) if scores is not None else 0.0
+```
+
+## Preparing DataFrames for Evaluation
+
+Evaluators receive each row as a dict. Column names must match the evaluator's
+expected parameter names:
+
+```python
+# If your evaluator function has params (input, output):
+@create_evaluator(name="check", kind="code")
+def check(input: str, output: str) -> bool:
+    ...
+
+# Your DataFrame must have 'input' and 'output' columns:
+df = df.rename(columns={
+    "attributes.input.value": "input",
+    "attributes.output.value": "output",
+})
+```
+
+## Async Version
+
+For better throughput with LLM evaluators:
+
+```python
+from phoenix.evals import async_evaluate_dataframe
+
+results_df = await async_evaluate_dataframe(
+    dataframe=df,
+    evaluators=[llm_evaluator],
+    concurrency=5,  # Max concurrent LLM calls
+)
+```
+
+## DO NOT use run_evals
+
+```python
+# WRONG — legacy 1.0 API
+from phoenix.evals import run_evals
+results = run_evals(dataframe=df, evaluators=[eval1])
+
+# RIGHT — current 2.0 API
+from phoenix.evals import evaluate_dataframe
+results_df = evaluate_dataframe(dataframe=df, evaluators=[eval1])
+```
+
+Key differences:
+- `run_evals` returns a **list** of DataFrames (one per evaluator)
+- `evaluate_dataframe` returns a **single** DataFrame with all results merged
+- `evaluate_dataframe` uses the `{name}_score` dict column format

--- a/skills/phoenix-sdk-python/rules/evaluators-code.md
+++ b/skills/phoenix-sdk-python/rules/evaluators-code.md
@@ -1,0 +1,126 @@
+# Code-Based Evaluators
+
+Deterministic evaluators that don't use an LLM. Fast, cheap, and reproducible.
+
+## Creating a Code Evaluator
+
+Use the `@create_evaluator` decorator:
+
+```python
+from phoenix.evals import create_evaluator
+
+@create_evaluator(name="has_citation", kind="code")
+def has_citation(output: str) -> bool:
+    """Returns True if the output contains a citation."""
+    return bool(re.search(r'\[\d+\]', output))
+```
+
+### Decorator Parameters
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `name` | `str` | Name of the evaluator (used in result column names) |
+| `kind` | `str` | Must be `"code"` for code-based evaluators |
+| `direction` | `str` | `"maximize"` (default) or `"minimize"` |
+
+### Function Parameters
+
+The decorated function receives data from each row of the DataFrame.
+Parameter names must match column names in the DataFrame:
+
+| Parameter | Maps to column |
+| --------- | -------------- |
+| `output` | `output` column (the response to evaluate) |
+| `input` | `input` column (the user query) |
+| `expected` | `expected` column (expected answer, if present) |
+| `metadata` | `metadata` column |
+
+```python
+# Evaluator using both input and output
+@create_evaluator(name="budget_check", kind="code")
+def budget_check(input: str, output: str) -> bool:
+    budget = extract_budget(input)
+    if budget is None:
+        return True  # No budget constraint
+    prices = extract_prices(output)
+    return all(p <= budget for p in prices)
+```
+
+### Return Types
+
+| Return type | Result |
+| ----------- | ------ |
+| `bool` | `True` → score=1.0, label="True"; `False` → score=0.0, label="False" |
+| `float`/`int` | Used as the `score` value directly |
+| `str` (short, ≤3 words) | Used as the `label` value |
+| `str` (long, ≥4 words) | Used as the `explanation` value |
+| `dict` with `score`/`label`/`explanation` | Mapped to Score fields directly |
+| `Score` object | Used as-is |
+
+## Using the Evaluator
+
+### With evaluate_dataframe (batch)
+
+```python
+from phoenix.evals import evaluate_dataframe
+
+results_df = evaluate_dataframe(
+    dataframe=df,  # Must have columns matching function params
+    evaluators=[has_citation],
+)
+```
+
+### Direct function call (single item)
+
+```python
+# Still callable as a regular function
+result = has_citation(output="See reference [1] for details")
+# Returns: True (the raw function return value)
+
+# Or use the evaluator API
+scores = has_citation.evaluate({"output": "See reference [1]"})
+# Returns: [Score(name="has_citation", score=1.0, label="True", ...)]
+```
+
+## Common Patterns
+
+```python
+import re
+import json
+
+# Regex matching
+@create_evaluator(name="has_date", kind="code")
+def has_date(output: str) -> bool:
+    return bool(re.search(r'\d{4}-\d{2}-\d{2}', output))
+
+# JSON validation
+@create_evaluator(name="valid_json", kind="code")
+def valid_json(output: str) -> bool:
+    try:
+        json.loads(output)
+        return True
+    except json.JSONDecodeError:
+        return False
+
+# Keyword presence
+@create_evaluator(name="has_disclaimer", kind="code")
+def has_disclaimer(output: str) -> bool:
+    return "disclaimer" in output.lower()
+
+# Numeric score (not just bool)
+@create_evaluator(name="word_count", kind="code")
+def word_count(output: str) -> int:
+    return len(output.split())
+
+# Using input + output together
+@create_evaluator(name="mentions_query_topic", kind="code")
+def mentions_query_topic(input: str, output: str) -> bool:
+    keywords = [w for w in input.lower().split() if len(w) > 3]
+    return any(kw in output.lower() for kw in keywords)
+```
+
+## Important: kind="code" Only
+
+The `@create_evaluator` decorator is for **code-based** evaluators only.
+Do NOT set `kind="llm"` — it won't magically call an LLM.
+For LLM-based evaluation, use `create_classifier()` or `ClassificationEvaluator`.

--- a/skills/phoenix-sdk-python/rules/evaluators-llm.md
+++ b/skills/phoenix-sdk-python/rules/evaluators-llm.md
@@ -1,0 +1,139 @@
+# LLM-Based Evaluators
+
+Use an LLM to judge outputs when criteria are subjective or require reasoning.
+
+## LLM Wrapper
+
+The `LLM` class is provider-agnostic:
+
+```python
+from phoenix.evals.llm import LLM
+# Also available: from phoenix.evals import LLM
+
+# Anthropic
+llm = LLM(provider="anthropic", model="claude-sonnet-4-20250514")
+
+# OpenAI
+llm = LLM(provider="openai", model="gpt-4o")
+
+# Google
+llm = LLM(provider="google", model="gemini-pro")
+```
+
+### DO NOT use legacy model classes
+
+```python
+# WRONG — these are legacy 1.0 classes
+from phoenix.evals import OpenAIModel, AnthropicModel
+model = OpenAIModel(model="gpt-4")      # OUTDATED
+model = AnthropicModel(model="claude-3") # OUTDATED
+
+# RIGHT — use the unified LLM wrapper
+from phoenix.evals.llm import LLM
+llm = LLM(provider="openai", model="gpt-4o")
+```
+
+## create_classifier (Recommended)
+
+Factory function that returns a `ClassificationEvaluator`:
+
+```python
+from phoenix.evals import create_classifier
+from phoenix.evals.llm import LLM
+
+llm = LLM(provider="anthropic", model="claude-sonnet-4-20250514")
+
+relevance = create_classifier(
+    name="relevance",
+    prompt_template="""Is this response relevant to the question?
+
+<question>{input}</question>
+<response>{output}</response>
+
+Answer (relevant/irrelevant):""",
+    llm=llm,
+    choices={"relevant": 1.0, "irrelevant": 0.0},
+)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `name` | `str` | Evaluator name (used in result columns) |
+| `prompt_template` | `str` | Template with `{input}`, `{output}`, etc. |
+| `llm` | `LLM` | LLM instance to use for classification |
+| `choices` | `dict` | Maps label strings to numeric scores |
+| `direction` | `str` | `"maximize"` (default) or `"minimize"` |
+
+### Choices Format
+
+```python
+# Labels → scores
+choices = {"relevant": 1.0, "irrelevant": 0.0}
+
+# Labels → (score, description) for more context
+choices = {
+    "relevant": (1.0, "Directly addresses the question"),
+    "irrelevant": (0.0, "Does not address the question"),
+}
+
+# Labels only (no numeric scores)
+choices = ["relevant", "irrelevant"]
+```
+
+### Template Variables
+
+Both `{input}` (Python format) and `{{input}}` (Jinja) work in templates.
+Variable names must match column names in the DataFrame.
+
+Common variables:
+
+| Variable | Typical column |
+| -------- | -------------- |
+| `{input}` | User query |
+| `{output}` | AI response |
+| `{context}` | Retrieved context/documents |
+| `{reference}` | Reference/expected answer |
+
+## ClassificationEvaluator (Direct)
+
+Same as `create_classifier` but using the class directly:
+
+```python
+from phoenix.evals import ClassificationEvaluator, LLM
+
+evaluator = ClassificationEvaluator(
+    name="tone",
+    llm=LLM(provider="openai", model="gpt-4o"),
+    prompt_template="Is the tone professional?\n<text>{output}</text>\nAnswer (professional/casual):",
+    choices={"professional": 1.0, "casual": 0.0},
+    include_explanation=True,  # Default True — LLM explains its choice
+)
+```
+
+## Pre-Built Evaluators
+
+```python
+from phoenix.evals.metrics import FaithfulnessEvaluator, DocumentRelevanceEvaluator
+from phoenix.evals.llm import LLM
+
+llm = LLM(provider="openai", model="gpt-4o")
+
+# Checks if output is faithful to provided context
+faithfulness = FaithfulnessEvaluator(llm=llm)
+# Expects columns: input, output, context
+
+# Checks if retrieved documents are relevant to query
+doc_relevance = DocumentRelevanceEvaluator(llm=llm)
+# Expects columns: input, output
+```
+
+**Note**: `HallucinationEvaluator` is DEPRECATED. Use `FaithfulnessEvaluator` instead.
+
+## Best Practices
+
+1. **Be specific in templates** — Define exactly what each label means
+2. **Use XML tags** — `<question>`, `<response>`, `<context>` for clarity
+3. **Binary labels** — Pass/fail is more reliable than Likert scales (1-5)
+4. **Code first** — Use `@create_evaluator(kind="code")` for anything deterministic; reserve LLM for subjective judgments


### PR DESCRIPTION
## Summary

Adds a new Claude Code skill (`phoenix-sdk-python`) that provides LLMs with correct, up-to-date Phoenix Python SDK patterns. This skill exists because LLMs frequently generate code using **outdated Phoenix 1.0 patterns** from their training data, leading to broken or deprecated code when users ask for help with Phoenix evaluations and tracing.

## Problem

When users ask Claude (or other LLMs) to write Phoenix Python code, the generated code commonly includes:

- **Legacy model classes** like `OpenAIModel(model="gpt-4")` and `AnthropicModel(model="...")` instead of the current `LLM(provider="openai", model="gpt-4o")` unified wrapper
- **Deprecated functions** like `run_evals()` and `llm_classify()` instead of `evaluate_dataframe()` and `create_classifier()`
- **Wrong constructor parameters** like `Client(endpoint="...")` instead of `Client(base_url="...", api_key="...")`
- **Deprecated parameter names** like `project_name=` instead of `project_identifier=`
- **Removed evaluators** like `HallucinationEvaluator` and `QAEvaluator` instead of `FaithfulnessEvaluator` and custom classifiers
- **Incorrect result handling** — treating `evaluate_dataframe` result columns as raw numbers when they are actually Score dicts

These errors cause immediate runtime failures and frustrating debugging sessions for users.

## What's Included

The skill is structured as a `SKILL.md` manifest plus six rule files covering every aspect of the Phoenix Python SDK:

### SKILL.md (Entry Point)
- Quick reference table mapping tasks to rule files
- Critical "do not use" table of all legacy 1.0 → current 2.0 pattern mappings
- Correct import statements for all major APIs
- Minimal working example (complete, runnable script)
- Key principles summary

### Rule Files

| File | Description |
|------|-------------|
| **`rules/eval-pipeline.md`** | Complete end-to-end evaluation pipeline template — the primary "start here" document. Covers all 6 steps: client connection, trace fetching, data preparation, evaluator definition, batch evaluation, and result extraction. Includes a key-points table mapping each step to correct vs. incorrect patterns. |
| **`rules/client-setup.md`** | Client initialization (`Client(base_url=..., api_key=...)`), the distinction between OTEL collector endpoints and API base URLs, `get_spans_dataframe()` parameters and their pitfalls (`project_identifier` not `project_name`, `root_spans_only=True`), full DataFrame column reference, JSON output parsing, and `SpanQuery` for advanced filtering. |
| **`rules/evaluators-code.md`** | Creating deterministic code-based evaluators with `@create_evaluator(name=..., kind="code")`. Covers decorator parameters, function parameter-to-column mapping, all supported return types (`bool`, `float`, `str`, `dict`, `Score`), batch usage with `evaluate_dataframe`, direct invocation, and common patterns (regex, JSON validation, keyword presence, numeric scores). |
| **`rules/evaluators-llm.md`** | LLM-based evaluation using the provider-agnostic `LLM(provider=..., model=...)` wrapper. Covers `create_classifier()` (recommended factory), `ClassificationEvaluator` (direct class), choices format options, template variable conventions, pre-built evaluators (`FaithfulnessEvaluator`, `DocumentRelevanceEvaluator`), and best practices (XML tags, binary labels, code-first philosophy). |
| **`rules/evaluate-dataframe.md`** | Deep dive on `evaluate_dataframe()` — the batch evaluation function. Documents the critical result column format (`{name}_score` columns containing Score dicts, NOT raw numbers), extraction patterns for scores/labels/explanations, failure detection, DataFrame preparation requirements, the async variant (`async_evaluate_dataframe`), and the explicit warning against using legacy `run_evals()`. |
| **`rules/common-mistakes.md`** | Catalog of 11 specific mistakes LLMs make, each with wrong/right code examples and explanations: legacy model classes, `run_evals` vs `evaluate_dataframe`, wrong result column names, deprecated `project_name`, wrong client constructor, aggressive time filters, missing `root_spans_only`, assuming plain text output, misusing `@create_evaluator` for LLM tasks, `llm_classify` vs `create_classifier`, and `HallucinationEvaluator` deprecation. |

## How It Works

When a user installs this skill in Claude Code and writes Python code that uses `phoenix.client` or `phoenix.evals`, the skill's rules are loaded into context, ensuring the LLM generates code using the current 2.0 API surface rather than the deprecated 1.0 patterns in its training data.

## Test plan

- [ ] Verify skill metadata (name, description, version, license) is correctly formatted in `SKILL.md` frontmatter
- [ ] Confirm all rule files referenced in the SKILL.md quick reference table exist and are correctly named
- [ ] Validate that all import paths (`phoenix.client.Client`, `phoenix.evals.create_classifier`, `phoenix.evals.llm.LLM`, etc.) match the actual Phoenix SDK source
- [ ] Verify the minimal working example in SKILL.md is syntactically valid Python
- [ ] Confirm the eval-pipeline.md template runs end-to-end against a live Phoenix instance
- [ ] Cross-reference common-mistakes.md patterns against the actual deprecated/removed APIs in the Phoenix changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `skills/` with no runtime code changes; risk is limited to potential inaccuracies in the examples or API names.
> 
> **Overview**
> Adds a new Claude Code skill, `phoenix-sdk-python`, consisting of a `SKILL.md` manifest plus rule docs that codify **current Phoenix Python SDK (v2) usage** for clients, tracing/span retrieval, and evaluations.
> 
> The rules provide an end-to-end eval script template and targeted guidance on client initialization (`base_url`/`api_key`, `project_identifier`, `root_spans_only`), building code/LLM evaluators (`create_evaluator`, `create_classifier`, `LLM`), and correctly interpreting `evaluate_dataframe` outputs (dict-based `{name}_score` columns), while explicitly calling out and replacing deprecated v1 APIs like `run_evals`, `llm_classify`, legacy model wrappers, and removed evaluators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d8304935f4b98f20e27c6b3014a47258cb616e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->