### PR TITLE
ci: downgrade uv to 0.9.18 for Dependabot

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -43,5 +43,5 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Run Helm chart tests
-        run: uvx --with uv==0.9.30 tox r -e helm_tests
+        run: uvx --with uv==0.9.18 tox r -e helm_tests
 

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@v7
-      - run: uvx --with uv==0.9.30 tox run -e phoenix_client -- -ra -x
+      - run: uvx --with uv==0.9.18 tox run -e phoenix_client -- -ra -x
 
   phoenix-evals:
     name: Phoenix Evals
@@ -133,7 +133,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@v7
-      - run: uvx --with uv==0.9.30 tox run -e phoenix_evals -- -ra -x
+      - run: uvx --with uv==0.9.18 tox run -e phoenix_evals -- -ra -x
 
   phoenix-otel:
     name: Phoenix OTel
@@ -154,7 +154,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - uses: astral-sh/setup-uv@v7
-      - run: uvx --with uv==0.9.30 tox run -e phoenix_otel -- -ra -x
+      - run: uvx --with uv==0.9.18 tox run -e phoenix_otel -- -ra -x
 
   clean-jupyter-notebooks:
     name: Clean Jupyter Notebooks
@@ -181,7 +181,7 @@ jobs:
             requirements/clean-jupyter-notebooks.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Clean Jupyter notebooks
-        run: uvx --with uv==0.9.30 tox run -e clean_jupyter_notebooks -- ${{ needs.changes.outputs.ipynb_files }}
+        run: uvx --with uv==0.9.18 tox run -e clean_jupyter_notebooks -- ${{ needs.changes.outputs.ipynb_files }}
       - run: git diff --exit-code
 
   build-graphql-schema:
@@ -209,7 +209,7 @@ jobs:
             requirements/build-graphql-schema.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build GraphQL schema
-        run: uvx --with uv==0.9.30 tox run -e build_graphql_schema
+        run: uvx --with uv==0.9.18 tox run -e build_graphql_schema
       - run: git diff --exit-code
 
   build-openapi-schema:
@@ -236,7 +236,7 @@ jobs:
             pyproject.toml
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build OpenAPI schema
-        run: uvx --with uv==0.9.30 tox run -e build_openapi_schema
+        run: uvx --with uv==0.9.18 tox run -e build_openapi_schema
       - run: git diff --exit-code
 
   compile-protobuf:
@@ -264,7 +264,7 @@ jobs:
             requirements/compile-protobuf.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile Protobuf
-        run: uvx --with uv==0.9.30 tox run -e compile_protobuf
+        run: uvx --with uv==0.9.18 tox run -e compile_protobuf
       - run: git diff --exit-code
 
   compile-prompts:
@@ -286,7 +286,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@v7
       - name: Compile Prompts
-        run: uvx --with uv==0.9.30 tox run -e compile_prompts
+        run: uvx --with uv==0.9.18 tox run -e compile_prompts
       - name: Check for changes
         run: git diff --exit-code
 
@@ -330,7 +330,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@v7
       - name: Run `ruff`
-        run: uvx --with uv==0.9.30 tox run -e ruff
+        run: uvx --with uv==0.9.18 tox run -e ruff
       - run: git diff --exit-code
 
   type-check:
@@ -366,9 +366,9 @@ jobs:
             requirements/type-check.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types
-        run: uvx --with uv==0.9.30 tox run -e type_check
+        run: uvx --with uv==0.9.18 tox run -e type_check
       - name: Ensure GraphQL mutations have permission classes
-        run: uvx --with uv==0.9.30 tox run -e ensure_graphql_mutations_have_permission_classes
+        run: uvx --with uv==0.9.18 tox run -e ensure_graphql_mutations_have_permission_classes
 
   type-check-unit-tests:
     name: Type Check Unit Tests
@@ -406,7 +406,7 @@ jobs:
             requirements/unit-tests.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types on unit tests
-        run: uvx --with uv==0.9.30 tox run -e type_check_unit_tests
+        run: uvx --with uv==0.9.18 tox run -e type_check_unit_tests
 
   unit-tests:
     name: Unit Tests
@@ -448,11 +448,11 @@ jobs:
       - name: Run tests with PostgreSQL (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 60
-        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra --reruns 5 --run-postgres
+        run: uvx --with uv==0.9.18 tox run -e unit_tests -- -n auto -ra --reruns 5 --run-postgres
       - name: Run tests without PostgreSQL (non-Linux)
         if: runner.os != 'Linux'
         timeout-minutes: 60
-        run: uvx --with uv==0.9.30 tox run -e unit_tests -- -n auto -ra --reruns 5
+        run: uvx --with uv==0.9.18 tox run -e unit_tests -- -n auto -ra --reruns 5
 
   type-check-integration-tests:
     name: Type Check Integration Tests
@@ -489,7 +489,7 @@ jobs:
             requirements/integration-tests.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check types on integration tests
-        run: uvx --with uv==0.9.30 tox run -e type_check_integration_tests
+        run: uvx --with uv==0.9.18 tox run -e type_check_integration_tests
 
   integration-tests:
     name: Integration Tests
@@ -546,7 +546,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx --with uv==0.9.30 tox run -e integration_tests -- -ra --reruns 5 -n auto
+        run: uvx --with uv==0.9.18 tox run -e integration_tests -- -ra --reruns 5 -n auto
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }})
@@ -578,7 +578,7 @@ jobs:
       - name: Set up `uv`
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.9.30"
+          version: "0.9.18"
       - name: Install arize-phoenix and database dependencies
         run: |
           uv pip install --system -qU 'arize-phoenix[pg]'
@@ -647,4 +647,4 @@ jobs:
             requirements/canary/sdk/${{ matrix.pkg }}.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run canary tests for ${{ matrix.pkg }}
-        run: uvx --with uv==0.9.30 tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
+        run: uvx --with uv==0.9.18 tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
-          version: "0.9.30"
-      - run: uvx --with uv==0.9.30 hatch build
-      - run: uvx --with uv==0.9.30 check-wheel-contents dist/*.whl
-      - run: uvx --with uv==0.9.30 twine upload --skip-existing --verbose dist/*
+          version: "0.9.18"
+      - run: uvx --with uv==0.9.18 hatch build
+      - run: uvx --with uv==0.9.18 check-wheel-contents dist/*.whl
+      - run: uvx --with uv==0.9.18 twine upload --skip-existing --verbose dist/*
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
@@ -87,11 +87,11 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
-          version: "0.9.30"
+          version: "0.9.18"
       - name: Build distribution
-        run: rm -rf dist && uvx --with uv==0.9.30 hatch build
+        run: rm -rf dist && uvx --with uv==0.9.18 hatch build
       - name: Check wheel contents
-        run: uvx --with uv==0.9.30 check-wheel-contents --ignore W004 dist/*.whl
+        run: uvx --with uv==0.9.18 check-wheel-contents --ignore W004 dist/*.whl
       - uses: pypa/gh-action-pypi-publish@release/v1
       - uses: slackapi/slack-github-action@v1
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pnpm install
 RUN pnpm run build
 
 # The second stage builds the backend.
-FROM ghcr.io/astral-sh/uv:0.9.30-python3.11-bookworm-slim AS backend-builder
+FROM ghcr.io/astral-sh/uv:0.9.18-python3.11-bookworm-slim AS backend-builder
 WORKDIR /phoenix
 COPY ./src /phoenix/src
 COPY ./pyproject.toml /phoenix/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,7 +358,7 @@ force-single-line = false
 line-ending = "native"
 
 [tool.uv]
-required-version = "==0.9.30"  # When updating this version, also update the `backend-builder` image in the Dockerfile
+required-version = "==0.9.18"  # When updating this version, also update the `backend-builder` image in the Dockerfile
 
 [tool.uv.workspace]
 members = ["packages/*"]


### PR DESCRIPTION
resolves https://github.com/Arize-ai/phoenix/issues/11329

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/build tooling version pin change only; primary risk is unexpected CI or packaging behavior differences due to the `uv` downgrade.
> 
> **Overview**
> Pins/downgrades the `uv` tooling version from `0.9.30` to `0.9.18` across all GitHub Actions workflows (Python CI, Helm CI, and release publishing), ensuring CI runs `tox`, schema builds, formatting/type checks, and publishing with the same `uv` version.
> 
> Updates build-time pinning to match by changing the `Dockerfile` backend builder base image to `ghcr.io/astral-sh/uv:0.9.18-...` and setting `[tool.uv].required-version` in `pyproject.toml` to `==0.9.18`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d95bfacc1218ee735b145739bb87230260dabd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->