### PR TITLE
docs: Add documentation for custom provider workflow

### DIFF
--- a/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
@@ -75,6 +75,55 @@ If there is a LLM endpoint you would like to use, reach out to [mailto://phoenix
 
 </Warning>
 
+## Custom Providers
+
+Custom providers let you store provider credentials and routing settings on the server and reuse them across the playground and prompt versions. This is ideal for shared environments where you want a single, managed configuration instead of per-browser API keys or ephemeral routing fields.
+
+To create a custom provider:
+
+1. Go to **Settings** → **AI Providers**.
+2. In **Custom Providers**, select **New Provider**.
+3. Enter a **Name** and a **Provider String**.
+4. Choose the **SDK** and fill in the required fields.
+5. Click **Test** to validate the credentials, then **Create Provider**.
+
+### Supported SDKs and Fields
+
+**OpenAI**
+Required: API key, API type (Chat Completions or Responses)
+Optional: Base URL, Organization, Project, Default headers
+
+**Azure OpenAI**
+Required: Endpoint, authentication method
+API key auth: API key
+AD token provider auth: Tenant ID, Client ID, Client Secret (Scope optional)
+Default credentials auth: Endpoint only
+Optional: Default headers
+
+**Anthropic**
+Required: API key
+Optional: Base URL, Default headers
+
+**AWS Bedrock**
+Required: Region, authentication method
+Access keys auth: Access Key ID, Secret Access Key (Session Token optional)
+Default credentials auth: Region only
+Optional: Endpoint URL
+
+**Google GenAI**
+Required: API key
+Optional: Base URL, Headers
+
+### Using Custom Providers in the Playground and Prompts
+
+Custom providers appear in model selection menus as their own provider group. When you select one:
+
+1. The model list mirrors the built-in model list for that SDK.
+2. Routing fields (base URL, Azure endpoint, AWS region) are pulled from the custom provider config.
+3. You can still add request-level custom headers from the model configuration panel.
+
+Prompt versions and evaluators use custom providers when a prompt version is saved with a custom provider selection. If you do not select a custom provider for a prompt, Phoenix falls back to environment variables or saved secrets for the built-in provider.
+
 
 ## Custom Headers
 

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -10,6 +10,20 @@ GitHub
 
 
 
+<Update label="02.11.2026">
+## [02.11.2026: Custom Providers for Playground and Prompts](/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers)
+Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
+
+**Key capabilities:**
+
+- **Centralized configuration:** Manage provider credentials and routing in Settings and reuse them across the playground and prompt versions.
+- **SDK-specific authentication:** Support API keys, Azure AD token providers, or default credentials (Azure/AWS) depending on the SDK.
+- **Model selection integration:** Custom providers show up in model menus as their own provider group and inherit model listings from the underlying SDK.
+- **Request-level overrides:** Continue to supply custom request headers per prompt while using custom provider configuration for routing and authentication.
+
+To get started, open **Settings → AI Providers → Custom Providers**, create a provider configuration, and select it from the model menu in the playground.
+</Update>
+
 <Update label="02.09.2026">
 ## [02.09.2026: Claude Opus 4.6 Model Support](/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support)
 Phoenix playground now supports Claude Opus 4.6, Anthropic's latest flagship model. Select `claude-opus-4-6` in the Anthropic provider or `anthropic.claude-opus-4-6-v1` in AWS Bedrock to start using the model with full extended thinking parameter support and accurate cost tracking.

--- a/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers.mdx
@@ -1,0 +1,18 @@
+---
+title: "Release Notes"
+---
+
+# Custom Providers for Playground and Prompts
+
+February 11, 2026
+
+Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
+
+**Key capabilities:**
+
+- **Centralized configuration:** Manage provider credentials and routing in Settings and reuse them across the playground and prompt versions.
+- **SDK-specific authentication:** Support API keys, Azure AD token providers, or default credentials (Azure/AWS) depending on the SDK.
+- **Model selection integration:** Custom providers show up in model menus as their own provider group and inherit model listings from the underlying SDK.
+- **Request-level overrides:** Continue to supply custom request headers per prompt while using custom provider configuration for routing and authentication.
+
+To get started, open **Settings → AI Providers → Custom Providers**, create a provider configuration, and select it from the model menu in the playground.

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers" arrow="true" title="02.11.2026"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support" arrow="true" title="02.10.2026"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" arrow="true" title="02.01.2026"/>
 </CardGroup>


### PR DESCRIPTION
Summary
- document how to configure and use custom AI providers, including supported SDK fields and integration notes for the playground and prompt versions
- add release notes for the February 11, 2026 update describing the new custom provider capabilities and link from the 2026 overview
Testing
- Not run (not requested)