### PR TITLE
fix(playground): avoid contextvars in streaming generator cleanup

### DIFF
--- a/internal_docs/vignettes/otel-contextvars-async/README.md
+++ b/internal_docs/vignettes/otel-contextvars-async/README.md
@@ -1,6 +1,6 @@
 # OTel contextvars + async generators
 
-Why we use **explicit OpenTelemetry context** (no contextvars) across async boundaries in the Phoenix playground (chat, evaluators, streaming), and how we proved and designed around it.
+Why we avoid **contextvars in async generator cleanup** in the Phoenix playground (chat, evaluators, streaming), and how we proved and designed around it.
 
 - **[Analysis](otel-contextvars-async.md)** — problem, root cause (CPython/asyncio), fixes, and design decisions.
 - **Supporting demo** — `contextvars_async_gen_demo.py`: empirical tests (contextvars + async generators, no OTel). Run from repo root:

--- a/internal_docs/vignettes/otel-contextvars-async/contextvars_async_gen_demo.py
+++ b/internal_docs/vignettes/otel-contextvars-async/contextvars_async_gen_demo.py
@@ -10,7 +10,7 @@ Consumer (evaluator) scenario: when the consumer sets context and does
 async for over a generator that raises, our tests show the consumer's token
 remains valid in the consumer's finally. So we do not reproduce a consumer-side
 failure; avoiding start_as_current_span in evaluate is defensive (same
-mechanism class, explicit otel_context is safer).
+mechanism class; generator-side fix is safer).
 
 Run from repo root:
   uv run python internal_docs/vignettes/otel-contextvars-async/contextvars_async_gen_demo.py

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -391,11 +391,9 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
             )
         )
 
-        # Use explicit otel_context and start_span (no contextvars) so that span lifecycle
-        # is independent of async context switches. Avoids "Failed to detach context" /
-        # "Token was created in a different Context" when the async generator yields.
-        # Not using current-context is the safest approach; it stays safe if more async
-        # is added later. Callers pass context explicitly (Go-style).
+        # Use start_span (not start_as_current_span) and span.end() in finally so we never
+        # attach contextvars in the generator. Avoids "Failed to detach context" /
+        # "Token was created in a different Context" when the generator is closed in another task.
         span = tracer_.start_span(
             "ChatCompletion",
             attributes=attributes,


### PR DESCRIPTION
```
Failed to detach context
Traceback (most recent call last):
  File "/Users/rogeryang/fourth/phoenix/.venv/lib/python3.12/site-packages/opentelemetry/context/__init__.py", line 155, in detach
    _RUNTIME_CONTEXT.detach(token)
  File "/Users/rogeryang/fourth/phoenix/.venv/lib/python3.12/site-packages/opentelemetry/context/contextvars_context.py", line 53, in detach
    self._current_context.reset(token)
ValueError: <Token var=<ContextVar name='current_context' default={} at 0x114e8b6a0> at 0x122750f00> was created in a different Context
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tracing behavior on the hot path for streamed chat completions; mistakes could affect span lifetimes/exception recording, but the change is localized and primarily alters instrumentation cleanup semantics.
> 
> **Overview**
> Fixes intermittent OpenTelemetry errors like "Failed to detach context" during streaming chat by changing `PlaygroundStreamingClient.chat_completion_create()` to create spans with `tracer.start_span()` and explicitly `span.end()` in `finally`, rather than using `start_as_current_span()` within the async generator.
> 
> Adds an internal vignette (`internal_docs/vignettes/otel-contextvars-async/`) with a runnable demo and written analysis documenting the CPython/asyncio async-generator finalization behavior that leads to contextvar token reset failures, and the rationale for the generator-side mitigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77725ad2101de5b681f92aed2908050e4970f31d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->