### PR TITLE
docs: Add Dataset Evaluators release notes

### DIFF
--- a/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
@@ -79,6 +79,8 @@ If there is a LLM endpoint you would like to use, reach out to [mailto://phoenix
 
 Custom providers let you store provider credentials and routing settings on the server and reuse them across the playground and prompt versions. This is ideal for shared environments where you want a single, managed configuration instead of per-browser API keys or ephemeral routing fields.
 
+![Custom provider configuration in Phoenix](https://storage.googleapis.com/arize-phoenix-assets/assets/images/custom-provider-config.png)
+
 To create a custom provider:
 
 1. Go to **Settings** → **AI Providers**.

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -9,10 +9,26 @@ GitHub
 
 
 
+<Update label="02.12.2026">
+## [02.12.2026: Dataset Evaluators](/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators)
+**Requires Phoenix 13.x.**
+**Dataset evaluators** let you attach evaluators directly to a dataset so they automatically run server-side whenever you execute experiments from the Phoenix UI (for example, from the Playground). This turns your dataset into a reusable evaluation suite and removes the need to reconfigure evaluators for every experiment.
+
+**Key capabilities:**
+
+- **Attach once, evaluate everywhere:** Add LLM or built-in code evaluators to a dataset and reuse them across Playground experiments.
+- **Flexible input mapping:** Map evaluator inputs to dataset fields so each example is evaluated consistently.
+- **Built-in visibility:** Each evaluator captures traces for debugging and refinement, with details available from the evaluator view.
+
+To get started, open a dataset, navigate to the **Evaluators** tab, click **Add evaluator**, configure your input mapping, and run an experiment from the Playground to see server-side scores and traces.
+</Update>
+
 
 <Update label="02.11.2026">
 ## [02.11.2026: Custom Providers for Playground and Prompts](/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers)
 Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
+
+![Custom provider configuration in Phoenix](https://storage.googleapis.com/arize-phoenix-assets/assets/images/custom-provider-config.png)
 
 **Key capabilities:**
 

--- a/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers.mdx
@@ -8,6 +8,8 @@ February 11, 2026
 
 Phoenix now supports **custom providers** for OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, and Google GenAI. Custom providers let you store provider credentials and routing configuration on the server and reuse them across the playground and saved prompt versions.
 
+![Custom provider configuration in Phoenix](https://storage.googleapis.com/arize-phoenix-assets/assets/images/custom-provider-config.png)
+
 **Key capabilities:**
 
 - **Centralized configuration:** Manage provider credentials and routing in Settings and reuse them across the playground and prompt versions.

--- a/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators.mdx
@@ -1,0 +1,16 @@
+---
+title: "Dataset Evaluators"
+description: "Attach evaluators to datasets for automatic scoring during experiments."
+---
+
+**Requires Phoenix 13.x.**
+
+**Dataset evaluators** let you attach evaluators directly to a dataset so they automatically run server-side whenever you execute experiments from the Phoenix UI (for example, from the Playground). This turns your dataset into a reusable evaluation suite and removes the need to reconfigure evaluators for every experiment.
+
+**Key capabilities:**
+
+- **Attach once, evaluate everywhere:** Add LLM or built-in code evaluators to a dataset and reuse them across Playground experiments.
+- **Flexible input mapping:** Map evaluator inputs to dataset fields so each example is evaluated consistently.
+- **Built-in visibility:** Each evaluator captures traces for debugging and refinement, with details available from the evaluator view.
+
+To get started, open a dataset, navigate to the **Evaluators** tab, click **Add evaluator**, configure your input mapping, and run an experiment from the Playground to see server-side scores and traces.


### PR DESCRIPTION
Summary
- document the dataset evaluators release across the main release notes and a dedicated 02-12-2026 entry noting the Phoenix 13.x requirement
- surface the custom provider configuration image in the prompt-engineering guide and the custom provider release note so readers see the feature visually
- emphasize in the release-section banner that Dataset Evaluators require Phoenix 13.x in addition to the dedicated page

Testing
- Not run (not requested)