### PR TITLE
fix(playground): render tool calls in dataset examples table with PlaygroundToolCall

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -44,6 +44,7 @@ import {
   ParagraphSkeleton,
   ProgressCircle,
   Text,
+  View,
 } from "@phoenix/components";
 import { AlphabeticIndexIcon } from "@phoenix/components/AlphabeticIndexIcon";
 import type { AnnotationConfig } from "@phoenix/components/annotation";
@@ -126,7 +127,10 @@ import {
 import { PlaygroundErrorWrap } from "./PlaygroundErrorWrap";
 import { PlaygroundInstanceProgressIndicator } from "./PlaygroundInstanceProgressIndicator";
 import { PlaygroundRunTraceDetailsDialog } from "./PlaygroundRunTraceDialog";
-import { PartialOutputToolCall } from "./PlaygroundToolCall";
+import {
+  PartialOutputToolCall,
+  PlaygroundToolCall,
+} from "./PlaygroundToolCall";
 import {
   extractRootVariable,
   getChatCompletionOverDatasetInput,
@@ -531,9 +535,15 @@ function ExampleOutputContent({
             {content != null ? (
               <DynamicContent value={content} key="content" />
             ) : null}
-            {toolCalls != null ? (
-              <DynamicContent value={toolCalls} key="tool-calls-wrap" />
-            ) : null}
+            {toolCalls != null && Object.keys(toolCalls).length > 0
+              ? Object.values(toolCalls)
+                  .filter((tc): tc is PartialOutputToolCall => tc != null)
+                  .map((toolCall) => (
+                    <View key={toolCall.id}>
+                      <PlaygroundToolCall toolCall={toolCall} />
+                    </View>
+                  ))
+              : null}
           </Flex>
         </div>
       </OverflowCell>


### PR DESCRIPTION
# Before

<img width="557" height="463" alt="Screenshot 2026-02-11 at 4 54 04 PM" src="https://github.com/user-attachments/assets/c4e0a8f3-a970-4d60-bdeb-ad5baa13045e" />

# After

<img width="358" height="429" alt="Screenshot 2026-02-11 at 4 53 15 PM" src="https://github.com/user-attachments/assets/9ad9c986-2562-4bf8-9316-a41249589f43" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering change in the playground table; no changes to data fetching, auth, or persistence.
> 
> **Overview**
> Dataset example outputs in the playground table now render tool calls via `PlaygroundToolCall` (one per call) rather than passing the whole `toolCalls` object through `DynamicContent`.
> 
> This adds a `View` wrapper for each tool call and guards against empty/undefined entries when mapping tool calls for display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae16313b330929709636ece17dd78280c8f572df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->