### PR TITLE
docs: release notes close update tag

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -208,6 +208,8 @@ The Phoenix CLI now supports datasets, experiments, and annotations. Pull evalua
 **Available in @arizeai/phoenix-cli 0.1.0+**
 
 AI coding assistants operate through terminals and files—they run shell commands, read output, and process data. The new Phoenix CLI makes trace data accessible through these interfaces, enabling tools like Claude Code, Cursor, and Windsurf to query your Phoenix instance directly. Export traces to JSON, pipe to `jq`, or save to disk for analysis.
+</Update>
+
 <Update label="01.05.2026">
 ## [01.05.2026: Appended Messages for Playground Experiments](/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments) 💬
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only markup fix with no runtime or behavioral impact beyond correcting release notes rendering.
> 
> **Overview**
> Fixes a malformed entry in `docs/phoenix/release-notes.mdx` by properly closing the `<Update>` block for the `01.17.2026` Phoenix CLI release note, preventing the following `01.05.2026` section from being nested/merged incorrectly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48416f9801e3cafd5ffbd35dd0d1c79e42433b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->