### PR TITLE
fix(playground): align openaiApiType default between UI and request builder

### DIFF
--- a/app/src/@types/generative.d.ts
+++ b/app/src/@types/generative.d.ts
@@ -15,6 +15,11 @@ declare type ModelProvider =
 declare type ChatMessageRole = "user" | "system" | "ai" | "tool";
 
 /**
+ * OpenAI/Azure API type for built-in provider: Chat Completions or Responses.
+ */
+declare type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
+
+/**
  * The tool picking mechanism for an LLM
  * Either "auto", "required", "none", or a specific tool
  * @see https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice

--- a/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
+++ b/app/src/components/playground/model/OpenAIApiTypeConfigFormField.tsx
@@ -10,15 +10,13 @@ import {
   SelectValue,
   Text,
 } from "@phoenix/components";
+import { DEFAULT_OPENAI_API_TYPE } from "@phoenix/constants/generativeConstants";
 import { usePlaygroundContext } from "@phoenix/contexts/PlaygroundContext";
-import type { OpenAIApiType } from "@phoenix/store";
 
 const API_TYPE_OPTIONS: { id: OpenAIApiType; label: string }[] = [
   { id: "CHAT_COMPLETIONS", label: "Chat Completions" },
   { id: "RESPONSES", label: "Responses" },
 ];
-
-const DEFAULT_API_TYPE: OpenAIApiType = "CHAT_COMPLETIONS";
 
 function getApiTypeLabel(apiType: OpenAIApiType): string {
   return API_TYPE_OPTIONS.find((opt) => opt.id === apiType)?.label ?? apiType;
@@ -27,7 +25,7 @@ function getApiTypeLabel(apiType: OpenAIApiType): string {
 export type OpenAIApiTypeConfigFormFieldProps = {
   playgroundInstanceId: number;
   /**
-   * When true, shows only the fixed default "Responses" as static text (not editable).
+   * When true, shows only the fixed default API type as static text (not editable).
    * Does not read from instance/model or localStorage — used when ephemeral routing is disabled.
    */
   displayDefaultOnly?: boolean;
@@ -50,17 +48,17 @@ export function OpenAIApiTypeConfigFormField({
     return null;
   }
 
-  // When ephemeral routing is disabled: always show RESPONSES, never use stored value
+  // When ephemeral routing is disabled: always show the default API type, never use stored value
   if (displayDefaultOnly) {
     return (
       <Flex direction="column" gap="size-50">
         <Label>API Type</Label>
-        <Text size="S">{getApiTypeLabel(DEFAULT_API_TYPE)}</Text>
+        <Text size="S">{getApiTypeLabel(DEFAULT_OPENAI_API_TYPE)}</Text>
       </Flex>
     );
   }
 
-  const value = instance.model.openaiApiType ?? DEFAULT_API_TYPE;
+  const value = instance.model.openaiApiType ?? DEFAULT_OPENAI_API_TYPE;
 
   return (
     <Select

--- a/app/src/constants/generativeConstants.ts
+++ b/app/src/constants/generativeConstants.ts
@@ -24,6 +24,11 @@ export const DEFAULT_MODEL_NAME = "gpt-4o";
 export const DEFAULT_CHAT_ROLE: ChatMessageRole = "user";
 
 /**
+ * The default OpenAI API type for built-in OpenAI and Azure OpenAI providers.
+ */
+export const DEFAULT_OPENAI_API_TYPE: OpenAIApiType = "CHAT_COMPLETIONS";
+
+/**
  * Map of {@link ChatMessageRole} to potential role values.
  * Used to map roles to a canonical role.
  */

--- a/app/src/pages/playground/playgroundUtils.ts
+++ b/app/src/pages/playground/playgroundUtils.ts
@@ -7,6 +7,7 @@ import {
   ChatRoleMap,
   DEFAULT_CHAT_ROLE,
   DEFAULT_MODEL_PROVIDER,
+  DEFAULT_OPENAI_API_TYPE,
   ProviderToCredentialsConfigMap,
 } from "@phoenix/constants/generativeConstants";
 import {
@@ -1160,7 +1161,8 @@ const getBaseChatCompletionInput = ({
     instance.model.provider === "OPENAI" ||
     instance.model.provider === "AZURE_OPENAI"
       ? {
-          openaiApiType: instance.model.openaiApiType ?? ("RESPONSES" as const),
+          openaiApiType:
+            instance.model.openaiApiType ?? DEFAULT_OPENAI_API_TYPE,
         }
       : {};
 

--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -531,6 +531,7 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
             region: null,
             customHeaders: null,
             customProvider: null,
+            openaiApiType: null,
           };
 
           // Build final model config

--- a/app/src/store/playground/types.ts
+++ b/app/src/store/playground/types.ts
@@ -72,11 +72,6 @@ export type PlaygroundError = {
   message?: string;
 };
 
-/**
- * OpenAI/Azure API type for built-in provider: Chat Completions or Responses.
- */
-export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
-
 export type ModelConfig = {
   provider: ModelProvider;
   modelName: string | null;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized defaulting/reset logic changes in the playground; main risk is an unexpected default API type being sent for OpenAI/Azure if callers relied on the previous implicit fallback.
> 
> **Overview**
> Aligns the default OpenAI/Azure API type used by the playground by introducing a shared `DEFAULT_OPENAI_API_TYPE` constant and using it in both the UI selector (`OpenAIApiTypeConfigFormField`) and the request builder (`playgroundUtils`).
> 
> Moves the `OpenAIApiType` type definition to the global generative types, and ensures provider switches reset `openaiApiType` to `null` to prevent cross-provider contamination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95a962743408a710f04d7e1afe0b89d2619e6c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->