### PR TITLE
fix(dataset_helpers): normalize legacy function_call into tool_calls

### DIFF
--- a/tests/unit/server/api/helpers/test_dataset_helpers.py
+++ b/tests/unit/server/api/helpers/test_dataset_helpers.py
@@ -117,7 +117,9 @@ TOOL_CALL_FUNCTION_NAME = ToolCallAttributes.TOOL_CALL_FUNCTION_NAME
                     {"content": "user-message", "role": "user"},
                     {
                         "role": "assistant",
-                        "function_call": {"name": "add", "arguments": {"a": 363, "b": 42}},
+                        "tool_calls": [
+                            {"function": {"name": "add", "arguments": {"a": 363, "b": 42}}},
+                        ],
                     },
                     {"content": "user-message", "role": "user"},
                     {
@@ -281,7 +283,9 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             ),
             {
                 "role": "assistant",
-                "function_call": {"name": "add", "arguments": {"a": 1, "b": 2}},
+                "tool_calls": [
+                    {"function": {"name": "add", "arguments": {"a": 1, "b": 2}}},
+                ],
             },
             id="function_call_json_string_deserialized",
         ),
@@ -295,7 +299,9 @@ def test_get_dataset_example_input(span: Span, expected_input_value: dict[str, A
             ),
             {
                 "role": "assistant",
-                "function_call": {"name": "add", "arguments": "not valid json"},
+                "tool_calls": [
+                    {"function": {"name": "add", "arguments": "not valid json"}},
+                ],
             },
             id="function_call_invalid_json_left_as_string",
         ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped normalization of message serialization plus test updates; low risk aside from potential minor downstream expectations around the removed `function_call` field.
> 
> **Overview**
> Dataset example message extraction now **always emits tool invocations via `tool_calls`** by folding legacy `MESSAGE_FUNCTION_CALL_*` attributes into a single-item `tool_calls` list.
> 
> `_get_message` was hardened to tolerate malformed/non-sequence `MESSAGE_TOOL_CALLS` values and to only append tool calls when a function name or arguments are present, and unit tests were updated to assert the unified `tool_calls` output shape (including for legacy `function_call` inputs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 729e29caf960bebd64edfa8c96142a98c64c219a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->