### PR TITLE
Enable create-more toggle by default in dataset example modal

### DIFF
--- a/app/src/pages/dataset/AddDatasetExampleDialog.tsx
+++ b/app/src/pages/dataset/AddDatasetExampleDialog.tsx
@@ -66,7 +66,7 @@ const defaultCardProps: Partial<CardProps> = {
 export function AddDatasetExampleDialog(props: AddDatasetExampleDialogProps) {
   const { datasetId, onCompleted } = props;
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [createMore, setCreateMore] = useState(false);
+  const [createMore, setCreateMore] = useState(true);
   const modifierKey = useModifierKey();
   const [commit, isCommitting] = useMutation<AddDatasetExampleDialogMutation>(
     graphql`


### PR DESCRIPTION
Summary
- default the “create more examples” checkbox to checked in the dataset add example modal so repeated uploads are quicker

Testing
- Not run (not requested)