### PR TITLE
docs: Add release notes for OpenAI Responses API support

### DIFF
--- a/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers.mdx
@@ -75,6 +75,10 @@ If there is a LLM endpoint you would like to use, reach out to [mailto://phoenix
 
 </Warning>
 
+<Info>
+OpenAI and Azure OpenAI support two API types: **Chat Completions** (`chat.completions.create`) and **Responses** (`responses.create`). For built-in providers, choose the API type from the model configuration panel in the Playground. For custom providers, set the API type in the provider configuration. Built-in providers default to Chat Completions, while custom providers default to Responses.
+</Info>
+
 ## Custom Providers
 
 Custom providers let you store provider credentials and routing settings on the server and reuse them across the playground and prompt versions. This is ideal for shared environments where you want a single, managed configuration instead of per-browser API keys or ephemeral routing fields.

--- a/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
@@ -29,6 +29,10 @@ Every prompt instance can be configured to use a specific LLM and set of invocat
   <img src="https://storage.googleapis.com/arize-phoenix-assets/assets/gifs/model_config.gif" />
 </Frame>
 
+<Info>
+For OpenAI and Azure OpenAI models, you can select the **OpenAI API type** in the model configuration panel. Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) depending on the model and feature set you need.
+</Info>
+
 ## Comparing Prompts
 
 The Prompt Playground offers the capability to compare multiple prompt variants directly within the playground. Simply click the **+ Compare** button at the top of the first prompt to create duplicate instances. Each prompt variant manages its own independent template, model, and parameters. This allows you to quickly compare prompts (labeled A, B, C, and D in the UI) and run experiments to determine which prompt and model configuration is optimal for the given task.

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -10,6 +10,19 @@ GitHub
 
 
 <Update label="02.12.2026">
+## [02.12.2026: OpenAI Responses API Type Support](/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support)
+Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure OpenAI calls in the Playground and custom providers. Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) depending on the model and features you want to use.
+
+**Key capabilities:**
+
+- **API type selection:** Choose Chat Completions or Responses per model configuration.
+- **Custom provider support:** OpenAI and Azure OpenAI custom providers can be configured with an API type for consistent routing.
+- **Parameter compatibility:** Phoenix maps shared invocation parameters to the chosen API type and filters unsupported fields automatically.
+
+To get started, open the Playground model configuration panel and select an **OpenAI API type**, or set it in **Settings → AI Providers → Custom Providers** for server-managed routing.
+</Update>
+
+<Update label="02.12.2026">
 ## [02.12.2026: Dataset Evaluators](/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators)
 **Requires Phoenix 13.x.**
 **Dataset evaluators** let you attach evaluators directly to a dataset so they automatically run server-side whenever you execute experiments from the Phoenix UI (for example, from the Playground). This turns your dataset into a reusable evaluation suite and removes the need to reconfigure evaluators for every experiment.

--- a/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support.mdx
+++ b/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support.mdx
@@ -1,0 +1,14 @@
+---
+title: "OpenAI Responses API Type Support"
+description: "Choose between Chat Completions and Responses API for OpenAI and Azure OpenAI."
+---
+
+Phoenix now supports selecting the **OpenAI API type** for OpenAI and Azure OpenAI calls in the Playground and custom providers.
+
+**Key capabilities:**
+
+- **API type selection:** Choose **Chat Completions** (`chat.completions.create`) or **Responses** (`responses.create`) per model configuration.
+- **Custom provider support:** OpenAI and Azure OpenAI custom providers can be configured with an API type for consistent routing.
+- **Parameter compatibility:** Phoenix maps shared invocation parameters to the chosen API type and filters unsupported fields automatically.
+
+To get started, open the model configuration panel in the Playground and select an **OpenAI API type**. For server-managed setups, configure the API type in **Settings → AI Providers → Custom Providers**.

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support" arrow="true" title="02.12.2026" icon="calendar" description="OpenAI Responses API type support"/>
+    <Card href="/docs/phoenix/release-notes/02-2026/02-12-2026-dataset-evaluators" arrow="true" title="02.12.2026" icon="calendar" description="Dataset evaluators"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-11-2026-custom-providers" arrow="true" title="02.11.2026" icon="calendar" description="Release note entry"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-10-2026-claude-opus-4-6-model-support" arrow="true" title="02.10.2026" icon="calendar" description="Release note entry"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-01-2026-tool-selection-and-tool-invocation-evaluators" arrow="true" title="02.01.2026" icon="calendar" description="Release note entry"/>


### PR DESCRIPTION
Summary
- document how to pick the OpenAI API type for playground models and custom providers
- add the release note entry plus the 2026 overview card for the new OpenAI Responses API support release
- describe the new support for Chat Completions vs Responses selection in the release notes page

Testing
- Not run (not requested)