### PR TITLE
fix(gemini): model deprecation changes

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1996,13 +1996,8 @@ class AnthropicReasoningStreamingClient(AnthropicStreamingClient):
 
 GEMINI_2_0_MODELS = [
     PROVIDER_DEFAULT,
-    "gemini-2.0-flash-lite",
-    "gemini-2.0-flash-001",
-    "gemini-2.0-flash-thinking-exp-01-21",
-    "gemini-1.5-flash",
-    "gemini-1.5-flash-8b",
-    "gemini-1.5-pro",
-    "gemini-1.0-pro",
+    "gemini-2.0-flash-lite",  # Will be deprecated and will be shut down on March 31, 2026.
+    "gemini-2.0-flash-001",  # Will be deprecated and will be shut down on March 31, 2026.
 ]
 
 
@@ -2159,10 +2154,9 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
 
 GEMINI_2_5_MODELS = [
     PROVIDER_DEFAULT,
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini-2.5-pro-preview-03-25",
+    "gemini-2.5-pro",  # Will be deprecated and will be shut down on June 17, 2026.
+    "gemini-2.5-flash",  # Will be deprecated and will be shut down on June 17, 2026.
+    "gemini-2.5-flash-lite",  # Will be deprecated and will be shut down on July 22, 2026.
 ]
 
 


### PR DESCRIPTION
Fixes #11380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple configuration/allowlist update that only affects which Gemini model names are selectable/recognized; no auth or request logic changes.
> 
> **Overview**
> Updates the Google Gemini model allowlists used for playground client registration.
> 
> **Gemini 2.0** drops several older `gemini-1.x`/experimental entries and keeps only `gemini-2.0-flash-lite` and `gemini-2.0-flash-001`, annotating them with planned shutdown dates. **Gemini 2.5** removes the preview model and adds deprecation/shutdown comments for the remaining models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9ed895aa74ed99eb4f2d923a24957823f843802. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->