### PR TITLE
feat: Add annotation summaries to experiment list and get endpoints

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -919,6 +919,39 @@ export interface components {
              */
             explanation?: string | null;
         };
+        /** AnnotationSummary */
+        AnnotationSummary: {
+            /**
+             * Annotation Name
+             * @description Name of the annotation evaluator
+             */
+            annotation_name: string;
+            /**
+             * Min Score
+             * @description Minimum score across all runs
+             */
+            min_score: number | null;
+            /**
+             * Max Score
+             * @description Maximum score across all runs
+             */
+            max_score: number | null;
+            /**
+             * Mean Score
+             * @description Mean score across all runs
+             */
+            mean_score: number | null;
+            /**
+             * Count
+             * @description Total number of annotations
+             */
+            count: number;
+            /**
+             * Error Count
+             * @description Number of annotations with errors
+             */
+            error_count: number;
+        };
         /** CategoricalAnnotationConfig */
         CategoricalAnnotationConfig: {
             /** Name */
@@ -1316,6 +1349,11 @@ export interface components {
              * @description Number of missing (not yet executed) runs in the experiment
              */
             missing_run_count: number;
+            /**
+             * Annotation Summaries
+             * @description Aggregated annotation metrics (min/max/mean score, count, error count) per evaluator. Empty if no annotations exist.
+             */
+            annotation_summaries?: components["schemas"]["AnnotationSummary"][];
         };
         /** ExperimentEvaluationResult */
         ExperimentEvaluationResult: {

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -14,6 +14,15 @@ class AnnotationResult(TypedDict):
     explanation: NotRequired[str]
 
 
+class AnnotationSummary(TypedDict):
+    annotation_name: str
+    min_score: Optional[float]
+    max_score: Optional[float]
+    mean_score: Optional[float]
+    count: int
+    error_count: int
+
+
 class CategoricalAnnotationValue(TypedDict):
     label: str
     score: NotRequired[float]
@@ -100,6 +109,7 @@ class Experiment(TypedDict):
     successful_run_count: int
     failed_run_count: int
     missing_run_count: int
+    annotation_summaries: NotRequired[Sequence[AnnotationSummary]]
 
 
 class ExperimentEvaluationResult(TypedDict):

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4739,6 +4739,71 @@
         "type": "object",
         "title": "AnnotationResult"
       },
+      "AnnotationSummary": {
+        "properties": {
+          "annotation_name": {
+            "type": "string",
+            "title": "Annotation Name",
+            "description": "Name of the annotation evaluator"
+          },
+          "min_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Score",
+            "description": "Minimum score across all runs"
+          },
+          "max_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Score",
+            "description": "Maximum score across all runs"
+          },
+          "mean_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Score",
+            "description": "Mean score across all runs"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "description": "Total number of annotations"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count",
+            "description": "Number of annotations with errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "annotation_name",
+          "min_score",
+          "max_score",
+          "mean_score",
+          "count",
+          "error_count"
+        ],
+        "title": "AnnotationSummary"
+      },
       "CategoricalAnnotationConfig": {
         "properties": {
           "name": {
@@ -5676,6 +5741,14 @@
             "type": "integer",
             "title": "Missing Run Count",
             "description": "Number of missing (not yet executed) runs in the experiment"
+          },
+          "annotation_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/AnnotationSummary"
+            },
+            "type": "array",
+            "title": "Annotation Summaries",
+            "description": "Aggregated annotation metrics (min/max/mean score, count, error count) per evaluator. Empty if no annotations exist."
           }
         },
         "type": "object",

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -40,6 +40,114 @@ from .utils import (
 router = APIRouter(tags=["experiments"], include_in_schema=True)
 
 
+async def _fetch_annotation_summaries(
+    session: AsyncSession,
+    experiment_ids: list[int],
+) -> dict[int, list["AnnotationSummary"]]:
+    """
+    Fetch aggregated annotation summaries for a batch of experiments.
+
+    Returns a dict mapping experiment_id -> list of AnnotationSummary.
+    The SQL mirrors the logic in ExperimentAnnotationSummaryDataLoader but
+    operates directly on the session instead of going through the GraphQL
+    dataloader layer.
+    """
+    if not experiment_ids:
+        return {}
+
+    # Step 1: Average scores per (experiment, example, annotation_name) to handle repetitions
+    repetition_mean_scores_by_example = (
+        select(
+            models.ExperimentRun.experiment_id.label("experiment_id"),
+            models.ExperimentRunAnnotation.name.label("annotation_name"),
+            func.avg(models.ExperimentRunAnnotation.score).label("mean_repetition_score"),
+        )
+        .select_from(models.ExperimentRunAnnotation)
+        .join(
+            models.ExperimentRun,
+            models.ExperimentRunAnnotation.experiment_run_id == models.ExperimentRun.id,
+        )
+        .where(models.ExperimentRun.experiment_id.in_(experiment_ids))
+        .group_by(
+            models.ExperimentRun.experiment_id,
+            models.ExperimentRun.dataset_example_id,
+            models.ExperimentRunAnnotation.name,
+        )
+        .subquery("repetition_mean_scores_by_example")
+    )
+
+    # Step 2: Average per-example means to get overall mean
+    repetition_mean_scores = (
+        select(
+            repetition_mean_scores_by_example.c.experiment_id.label("experiment_id"),
+            repetition_mean_scores_by_example.c.annotation_name.label("annotation_name"),
+            func.avg(repetition_mean_scores_by_example.c.mean_repetition_score).label("mean_score"),
+        )
+        .select_from(repetition_mean_scores_by_example)
+        .group_by(
+            repetition_mean_scores_by_example.c.experiment_id,
+            repetition_mean_scores_by_example.c.annotation_name,
+        )
+        .subquery("repetition_mean_scores")
+    )
+
+    # Step 3: Min, max, count, error_count per (experiment, annotation_name)
+    stats = (
+        select(
+            models.ExperimentRun.experiment_id.label("experiment_id"),
+            models.ExperimentRunAnnotation.name.label("annotation_name"),
+            func.min(models.ExperimentRunAnnotation.score).label("min_score"),
+            func.max(models.ExperimentRunAnnotation.score).label("max_score"),
+            func.count().label("count_"),
+            func.count(models.ExperimentRunAnnotation.error).label("error_count"),
+        )
+        .select_from(models.ExperimentRunAnnotation)
+        .join(
+            models.ExperimentRun,
+            models.ExperimentRunAnnotation.experiment_run_id == models.ExperimentRun.id,
+        )
+        .where(models.ExperimentRun.experiment_id.in_(experiment_ids))
+        .group_by(models.ExperimentRun.experiment_id, models.ExperimentRunAnnotation.name)
+        .subquery()
+    )
+
+    # Step 4: Join mean scores with stats
+    query = (
+        select(
+            repetition_mean_scores.c.experiment_id,
+            repetition_mean_scores.c.annotation_name,
+            repetition_mean_scores.c.mean_score,
+            stats.c.min_score,
+            stats.c.max_score,
+            stats.c.count_,
+            stats.c.error_count,
+        )
+        .select_from(repetition_mean_scores)
+        .join(
+            stats,
+            and_(
+                stats.c.experiment_id == repetition_mean_scores.c.experiment_id,
+                stats.c.annotation_name == repetition_mean_scores.c.annotation_name,
+            ),
+        )
+        .order_by(repetition_mean_scores.c.annotation_name)
+    )
+
+    result: dict[int, list["AnnotationSummary"]] = {}
+    for row in await session.execute(query):
+        result.setdefault(row.experiment_id, []).append(
+            AnnotationSummary(
+                annotation_name=row.annotation_name,
+                min_score=row.min_score,
+                max_score=row.max_score,
+                mean_score=row.mean_score,
+                count=row.count_,
+                error_count=row.error_count,
+            )
+        )
+    return result
+
+
 def _short_uuid() -> str:
     return str(getrandbits(32).to_bytes(4, "big").hex())
 
@@ -50,6 +158,15 @@ def _generate_experiment_name(dataset_name: str) -> str:
     """
     short_ds_name = dataset_name[:8].replace(" ", "-")
     return f"{short_ds_name}-{_short_uuid()}"
+
+
+class AnnotationSummary(V1RoutesBaseModel):
+    annotation_name: str = Field(description="Name of the annotation evaluator")
+    min_score: Optional[float] = Field(description="Minimum score across all runs")
+    max_score: Optional[float] = Field(description="Maximum score across all runs")
+    mean_score: Optional[float] = Field(description="Mean score across all runs")
+    count: int = Field(description="Total number of annotations")
+    error_count: int = Field(description="Number of annotations with errors")
 
 
 class Experiment(V1RoutesBaseModel):
@@ -70,6 +187,11 @@ class Experiment(V1RoutesBaseModel):
     failed_run_count: int = Field(description="Number of failed runs in the experiment")
     missing_run_count: int = Field(
         description="Number of missing (not yet executed) runs in the experiment"
+    )
+    annotation_summaries: list[AnnotationSummary] = Field(
+        default_factory=list,
+        description="Aggregated annotation metrics (min/max/mean score, count, error count) "
+        "per evaluator. Empty if no annotations exist.",
     )
 
 
@@ -359,6 +481,8 @@ async def get_experiment(request: Request, experiment_id: str) -> GetExperimentR
         missing_run_count = (
             total_expected_runs - (successful_run_count or 0) - (failed_run_count or 0)
         )
+
+        summaries_by_id = await _fetch_annotation_summaries(session, [experiment_rowid])
     return GetExperimentResponseBody(
         data=Experiment(
             id=str(experiment_globalid),
@@ -373,6 +497,7 @@ async def get_experiment(request: Request, experiment_id: str) -> GetExperimentR
             successful_run_count=successful_run_count or 0,
             failed_run_count=failed_run_count or 0,
             missing_run_count=missing_run_count,
+            annotation_summaries=summaries_by_id.get(experiment_rowid, []),
         )
     )
 
@@ -713,6 +838,10 @@ async def list_experiments(
             next_cursor = str(GlobalID("Experiment", str(last_experiment.id)))
             experiments = experiments[:-1]  # Remove the extra overfetched experiment
 
+        # Batch-fetch annotation summaries for all experiments on this page
+        page_experiment_ids = [exp.id for exp in experiments]
+        summaries_by_id = await _fetch_annotation_summaries(session, page_experiment_ids)
+
         data = []
         for experiment in experiments:
             counts = counts_by_experiment.get(experiment.id, (0, 0, 0))
@@ -740,6 +869,7 @@ async def list_experiments(
                     successful_run_count=successful_run_count,
                     failed_run_count=failed_run_count,
                     missing_run_count=missing_run_count,
+                    annotation_summaries=summaries_by_id.get(experiment.id, []),
                 )
             )
 

--- a/src/phoenix/server/api/routers/v1/experiments.py
+++ b/src/phoenix/server/api/routers/v1/experiments.py
@@ -83,9 +83,9 @@ async def _fetch_annotation_summaries(
         select(
             repetition_mean_scores_by_example.c.experiment_id.label("experiment_id"),
             repetition_mean_scores_by_example.c.annotation_name.label("annotation_name"),
-            cast(
-                func.avg(repetition_mean_scores_by_example.c.mean_repetition_score), Float
-            ).label("mean_score"),
+            cast(func.avg(repetition_mean_scores_by_example.c.mean_repetition_score), Float).label(
+                "mean_score"
+            ),
         )
         .select_from(repetition_mean_scores_by_example)
         .group_by(


### PR DESCRIPTION
Closes #9294

## Summary

Enriches the `listExperiments` and `getExperiment` REST API responses with per-evaluator annotation summaries (min/max/mean score, count, error count). This lets users export experiment results for visualization in external dashboards without needing to fetch each experiment individually.

Also adds a `get_test_results(dataset_id)` method to the Python client that returns a pandas DataFrame with one row per experiment and columns for each annotation metric, sorted by `created_at` for plotting metrics over time -- similar to LangSmith's `.get_test_results()` that @taoari requested.

## Changes

- **`experiments.py`**: Added `AnnotationSummary` Pydantic model and `_fetch_annotation_summaries()` helper that batch-fetches annotation stats using the same SQL logic as the existing GraphQL `ExperimentAnnotationSummaryDataLoader`. Wired it into both `getExperiment` and `listExperiments` handlers.
- **`v1/__init__.py`** (generated types): Added `AnnotationSummary` TypedDict and `annotation_summaries` field to `Experiment`.
- **Client `experiments/__init__.py`**: Added `get_test_results()` to both sync and async client classes. Returns a DataFrame with experiment metadata + flattened annotation columns (`{name}_mean`, `{name}_min`, `{name}_max`, `{name}_count`, `{name}_error_count`).
- **Tests**: Three new test cases covering annotation summaries in list, get, and empty-annotation scenarios. All 14 existing experiment tests still pass.

## Example usage

```python
from phoenix.client import Client
client = Client()

# DataFrame with experiment metrics over time
df = client.experiments.get_test_results(dataset_id="dataset_123")
df.plot(x="created_at", y=["Hallucination_mean", "Relevance_mean"])
```

Or via the raw REST API:
```
GET /v1/datasets/{dataset_id}/experiments
```
Each experiment now includes:
```json
{
  "annotation_summaries": [
    {
      "annotation_name": "Hallucination",
      "min_score": 0.1,
      "max_score": 0.95,
      "mean_score": 0.72,
      "count": 50,
      "error_count": 2
    }
  ]
}
```

## Design notes

- The annotation summary SQL mirrors the existing `ExperimentAnnotationSummaryDataLoader` logic exactly (two-level averaging to handle repetitions correctly), keeping the GraphQL and REST responses consistent.
- Summaries are batch-fetched for all experiments on the page in a single query, so there's no N+1 penalty.
- The `annotation_summaries` field defaults to an empty list, so this is fully backward-compatible -- existing clients won't break.

## Testing

- All 14 existing experiment tests pass (zero regressions)
- 3 new tests covering:
  - `test_annotation_summaries_in_list_experiments` -- verifies summaries appear in list response
  - `test_annotation_summaries_in_get_experiment` -- verifies correct values for specific annotations
  - `test_annotation_summaries_empty_when_no_annotations` -- verifies empty list for new experiments

cc @mikeldking @taoari

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API response contracts and introduces new aggregation SQL; risk is mainly performance/DB correctness and downstream client expectations despite defaulting to an empty list.
> 
> **Overview**
> Adds per-evaluator `annotation_summaries` (min/max/mean score, total count, error count) to the REST `getExperiment` and `listExperiments` responses, computed via a new batch SQL aggregation helper to avoid per-experiment queries.
> 
> Updates the OpenAPI schema and generated JS/Python client types to include `AnnotationSummary`, and adds Python client `get_test_results()` (sync + async) to return a pandas DataFrame of experiment metadata with flattened annotation metrics for plotting/export. Includes unit tests covering list/get behavior and empty-summary cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d520cc2d8a278b83069d4575195c753f4cad2e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->