### PR TITLE
docs: add in weave icons

### DIFF
--- a/docs/phoenix/evaluation/llm-evals.mdx
+++ b/docs/phoenix/evaluation/llm-evals.mdx
@@ -37,3 +37,7 @@ Phoenix Evals provides **lightweight, composable building blocks** for writing a
     Run evaluations systematically with datasets and experiments
   </Card>
 </CardGroup>
+
+<Info>
+  For continuous monitoring of application performance—evals on production traffic with alerting and threshold-based triggers—see [Arize AX Online Evals](https://arize.com/docs/ax/evaluate/online-evals).
+</Info>

--- a/docs/phoenix/production-guide.mdx
+++ b/docs/phoenix/production-guide.mdx
@@ -5,6 +5,10 @@ description: "Moving your application to production: steps for reliability and s
 
 Moving your Phoenix deployment from development to production requires additional configuration for reliability, performance, and scalability. This page outlines the key steps and considerations to prepare your Phoenix instance for production workloads.
 
+<Info>
+  For a managed deployment where Arize handles installation, maintenance, and ongoing operations, see [Arize AX](https://arize.com/docs/ax/selfhosting).
+</Info>
+
 ## Configuration
 
 ### Enable Batch Processing

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -208,6 +208,8 @@ The Phoenix CLI now supports datasets, experiments, and annotations. Pull evalua
 **Available in @arizeai/phoenix-cli 0.1.0+**
 
 AI coding assistants operate through terminals and files—they run shell commands, read output, and process data. The new Phoenix CLI makes trace data accessible through these interfaces, enabling tools like Claude Code, Cursor, and Windsurf to query your Phoenix instance directly. Export traces to JSON, pipe to `jq`, or save to disk for analysis.
+</Update>
+
 <Update label="01.05.2026">
 ## [01.05.2026: Appended Messages for Playground Experiments](/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments) 💬
 

--- a/docs/phoenix/resources/frequently-asked-questions.mdx
+++ b/docs/phoenix/resources/frequently-asked-questions.mdx
@@ -3,6 +3,10 @@ title: "Frequently Asked Questions"
 sidebarTitle: "Overview"
 ---
 
+<Info>
+  For support, join the [community Slack](https://arize-ai.slack.com/ssb/redirect#/shared-invite/email) to ask questions and connect with other developers. For professional services and response-time guarantees, see [Arize AX](https://arize.com/docs/ax).
+</Info>
+
 <CardGroup cols={2}>
   <Card title="What is the difference between Phoenix and Arize?" href="/docs/phoenix/resources/frequently-asked-questions/what-is-the-difference-between-phoenix-and-arize" icon="angles-right" horizontal/>
   <Card title="What is my Phoenix Endpoint?" href="/docs/phoenix/resources/frequently-asked-questions/what-is-my-phoenix-endpoint" icon="angles-right" horizontal/>

--- a/docs/phoenix/self-hosting.mdx
+++ b/docs/phoenix/self-hosting.mdx
@@ -44,6 +44,10 @@ Phoenix is **free to self-host** with no feature limitations. Your data stays en
   </Card>
 </CardGroup>
 
+<Info>
+  For an on-premise or self-hosted enterprise option with Arize support, see [Arize AX](https://arize.com/docs/ax/selfhosting/info/on-premise-overview).
+</Info>
+
 ## Configure Your Instance
 
 <CardGroup cols={2}>

--- a/docs/phoenix/self-hosting/architecture.mdx
+++ b/docs/phoenix/self-hosting/architecture.mdx
@@ -17,6 +17,10 @@ Phoenix supports two database backends. Choose based on your deployment needs:
 | **SQLite** | Local development, single-user deployments | Default, no setup required |
 | **PostgreSQL** | Production, multi-user, high availability | Set [PHOENIX_SQL_DATABASE_URL](/docs/phoenix/self-hosting/configuration#environment-variables) |
 
+<Info>
+  For high-volume ingestion, sub-second queries at scale, and OLAP workloads beyond what SQLite or PostgreSQL are designed for, [Arize AX](https://arize.com/docs/ax/release-notes/history/2025/06-2025#arize-database-adb) runs on [adb](https://arize.com/blog/introducing-adb-arizes-proprietary-olap-database/), Arize's proprietary OLAP database.
+</Info>
+
 ### SQLite
 
 The default storage option. Phoenix stores data in `~/.phoenix/` or the directory specified by [PHOENIX_WORKING_DIR](/docs/phoenix/self-hosting/configuration#environment-variables). Simple to get started—just mount a volume for persistence.
@@ -34,6 +38,10 @@ See the [Docker deployment guide](/docs/phoenix/self-hosting/deployment-options/
 A single Phoenix instance represents **one tenant**. All data within an instance—projects, traces, datasets, experiments—is accessible to users based on their [role-based access controls](/docs/phoenix/settings/access-control-rbac).
 
 This single-tenant model keeps deployments simple with clear data isolation boundaries. For multi-team scenarios, deploy multiple Phoenix instances.
+
+<Info>
+  When multiple teams rely on the same system and need isolation, [Arize AX](https://arize.com/docs/ax/security-and-settings/sso-and-rbac) provides multi-tenancy via organizations and spaces.
+</Info>
 
 ## Scaling
 

--- a/docs/phoenix/self-hosting/security/privacy.mdx
+++ b/docs/phoenix/self-hosting/security/privacy.mdx
@@ -13,6 +13,10 @@ This means you have complete control over:
 - How long your data is retained
 - Your compliance with data privacy regulations
 
+<Info>
+  When SaaS compliance and security certifications are a requirement, [Arize AX](https://arize.com/docs/ax/security-and-settings/compliance) is a good option, a fully managed platform with the compliance and security controls many organizations need.
+</Info>
+
 ## Telemetry
 
 ### What kind of telemetry does Phoenix collect?

--- a/docs/phoenix/settings/access-control-rbac.mdx
+++ b/docs/phoenix/settings/access-control-rbac.mdx
@@ -10,6 +10,10 @@ The role-based access control (RBAC) in Phoenix is based on the following user r
 
 A user's role controls their access via the UI as well as through the APIs.
 
+<Info>
+  For SSO (SAML), multi-level RBAC (account → organizations → spaces), and JIT user provisioning, see [Arize AX](https://arize.com/docs/ax/security-and-settings/sso-and-rbac).
+</Info>
+
 ## User Management
 
 | Action | Admin | Member | Viewer |

--- a/docs/phoenix/settings/data-retention.mdx
+++ b/docs/phoenix/settings/data-retention.mdx
@@ -3,7 +3,6 @@ title: "Data Retention"
 ---
 By default Phoenix will store and preserve all your data and data retention is entirely under your control. However in production environments there might be good reasons to purge older data.
 
-
 Similar to data retention being infinite by default, Phoenix also does not gate the deletion of the data. If you no longer need certain projects, traces, datasets, experiments, or prompts, you can delete these resources through the UI as well as through the REST API.
 
 ## Project Retention Policies
@@ -15,6 +14,10 @@ In Phoenix 9.0 or greater you can automatically purge traces from projects by co
 </Frame>
 
 By default Phoenix comes with 1 project retention policy called `Default`. Every project in your instance is associated with this retention policy unless specified otherwise. The `Default` policy also specifies 0 days, which is equal to "Indefinite" retention.
+
+<Info>
+  For multi-party data governance, explicit retention and access policies, and auditability across stakeholders, [Arize AX](https://arize.com/docs/ax/security-and-settings/data-fabric) provides a data fabric with defined ownership and control boundaries.
+</Info>
 
 ### Configuring the Default Retention Policy
 

--- a/docs/phoenix/tracing/llm-traces/metrics.mdx
+++ b/docs/phoenix/tracing/llm-traces/metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Metrics
+title: Metrics Dashboard
 description: Each project comes with a pre-defined metrics dashboard
 ---
 
@@ -18,6 +18,10 @@ Traces that are sent to a project are automatically indexed for metrics. This le
 - Top Models by Tokens
 - LLM Invocation and Errors
 - Tool calls and Errors
+
+<Info>
+  For custom alerting and dashboards on top of your trace data, including metrics tailored for non-developer stakeholders, see [Arize AX's Dashboard features](https://arize.com/docs/ax/observe/dashboards).
+</Info>
 
 ## Next Steps
 

--- a/docs/phoenix/tracing/llm-traces/projects.mdx
+++ b/docs/phoenix/tracing/llm-traces/projects.mdx
@@ -33,6 +33,10 @@ The Project structure also enables comparative analysis across different impleme
 </Card>
 </Tip>
 
+<Info>
+  When you need data segmentation above the project level, for example by department or business unit, [Arize AX](https://arize.com/docs/ax/security-and-settings/sso-and-rbac#spaces) provides Workspaces to isolate and scope access across organizational boundaries.
+</Info>
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes; primary risk is minor MDX rendering/link issues due to added components and formatting fixes.
> 
> **Overview**
> Adds multiple new `<Info>` callouts across Phoenix docs to point readers to Arize AX offerings for managed deployments, enterprise self-hosting/support, compliance/security, multi-tenancy/SSO, dashboards/alerting, online evals, and data governance.
> 
> Also fixes minor documentation formatting issues: closes an unclosed `<Update>` in `release-notes.mdx`, updates the `tracing/llm-traces/metrics.mdx` page title to “Metrics Dashboard”, and corrects a missing closing `</CardGroup>`/newline in `evaluation/llm-evals.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc2c1383e3c926e4c64111f55ed630d19e142510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->