### PR TITLE
ci: Centralize Playwright timing and drop test-level timeouts

### DIFF
--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -8,6 +8,7 @@ import { defineConfig, devices, Project } from "@playwright/test";
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 // Skip WebKit for CI because of recurring issues with caching binaries.
+const isCI = !!process.env.CI;
 const skipWebKit = process.env.CI_PLAYWRIGHT_SKIP_WEBKIT === "true";
 
 const projects: Project[] = [
@@ -48,19 +49,19 @@ projects.push({
  */
 export default defineConfig({
   globalSetup: require.resolve("./global-setup"),
-  timeout: process.env.CI ? 60000 : 30000,
+  timeout: isCI ? 90_000 : 45_000,
   expect: {
-    /* CI runners are slower; 5s default is too tight for mutations that close dialogs */
-    timeout: process.env.CI ? 10_000 : 5_000,
+    /* CI runners are slower; use one centralized expect timeout policy */
+    timeout: isCI ? 30_000 : 10_000,
   },
   // Use default workers (cpu count) locally, limit to 2 on CI
-  workers: process.env.CI ? 2 : undefined,
+  workers: isCI ? 2 : undefined,
   fullyParallel: true,
   testDir: "./tests",
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: isCI ? 2 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -71,8 +72,8 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
 
-    /* Wait for 15 seconds for each page navigation to complete */
-    navigationTimeout: 15000,
+    /* Wait for each page navigation to complete */
+    navigationTimeout: isCI ? 30_000 : 15_000,
   },
 
   /* Configure projects for major browsers */
@@ -82,7 +83,7 @@ export default defineConfig({
   webServer: {
     command: "pnpm run dev:server:test",
     url: "http://localhost:6006",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    reuseExistingServer: !isCI,
+    timeout: isCI ? 240_000 : 120_000,
   },
 });

--- a/app/tests/member-access.spec.ts
+++ b/app/tests/member-access.spec.ts
@@ -28,9 +28,7 @@ test("can create user key", async ({ page }) => {
     .click();
 
   // Verify the named key appears in the table - which means key creation succeeded
-  await expect(page.getByRole("cell", { name: keyName })).toBeVisible({
-    timeout: 60000,
-  });
+  await expect(page.getByRole("cell", { name: keyName })).toBeVisible();
 });
 
 test("should be able to create a new project", async ({ page }) => {

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -38,14 +38,10 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Create Dataset" }).click();
 
     // Wait for dialog to close and verify we're on the new dataset page
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Wait for the dataset to appear in the table
-    await expect(page.getByRole("link", { name: datasetName })).toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByRole("link", { name: datasetName })).toBeVisible();
 
     // Navigate to the dataset to verify it was created
     await page.getByRole("link", { name: datasetName }).click();
@@ -63,14 +59,14 @@ test.describe.serial("Server Evaluators", () => {
       .click();
 
     // Wait for the Add Example dialog to open
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("dialog")).toBeVisible();
 
     // Fill in the input field with valid JSON
     // JSONEditor renders a CodeMirror editor with .cm-content
     // Scope to the dialog to avoid picking up background editors
     const dialog = page.getByRole("dialog");
     const inputTextArea = dialog.locator(".cm-content").first();
-    await inputTextArea.waitFor({ state: "visible", timeout: 5000 });
+    await expect(inputTextArea).toBeVisible();
     await inputTextArea.click();
     // Select all existing content and replace it
     await page.keyboard.press("ControlOrMeta+a");
@@ -89,10 +85,10 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Add Example" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("dialog")).not.toBeVisible();
 
     // Verify the example appears in the table (or at least the table is no longer empty)
-    await expect(page.getByRole("row")).toHaveCount(2, { timeout: 10000 }); // header + 1 example
+    await expect(page.getByRole("row")).toHaveCount(2); // header + 1 example
   });
 
   test("can navigate to evaluators tab", async ({ page }) => {
@@ -159,9 +155,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Create" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the evaluator appears in the table
     await expect(
@@ -212,9 +206,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Create" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the evaluator appears in the table
     await expect(
@@ -274,9 +266,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Update" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the evaluator still appears in the table
     await expect(
@@ -343,9 +333,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Create" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the evaluator appears in the table
     await expect(
@@ -388,9 +376,7 @@ test.describe.serial("Server Evaluators", () => {
     await page.getByRole("button", { name: "Update" }).click();
 
     // Wait for dialog to close
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Verify the evaluator still appears in the table
     await expect(
@@ -430,9 +416,7 @@ test.describe.serial("Server Evaluators", () => {
 
     // Close the dialog
     await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.getByTestId("dialog")).not.toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.getByTestId("dialog")).not.toBeVisible();
   });
 
   test("evaluators are visible in playground when dataset is selected", async ({
@@ -463,37 +447,39 @@ test.describe.serial("Server Evaluators", () => {
     const noProviderMessage = page.getByText(
       "The playground is not available until an LLM provider client is installed"
     );
-    if (
-      await noProviderMessage.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
+    const readinessResult = await Promise.race([
+      noProviderMessage.waitFor({ state: "visible" }).then(() => "no-provider"),
+      page
+        .getByText("Experiment", { exact: true })
+        .waitFor({ state: "visible" })
+        .then(() => "ready"),
+    ]);
+
+    if (readinessResult === "no-provider") {
       throw new Error(
         "Playground requires an LLM provider to be installed. Playwright test environment is not configured correctly."
       );
     }
 
     // Wait for the playground title to appear first
-    await expect(page.getByRole("heading", { name: "Playground" })).toBeVisible(
-      { timeout: 10000 }
-    );
+    await expect(page.getByRole("heading", { name: "Playground" })).toBeVisible();
 
     // Wait for the "Experiment" text to appear, which indicates
     // the dataset section has loaded (this appears in PlaygroundExperimentToolbar)
-    await expect(page.getByText("Experiment", { exact: true })).toBeVisible({
-      timeout: 30000,
-    });
+    await expect(page.getByText("Experiment", { exact: true })).toBeVisible();
 
     // Find and click the Evaluators button to open the evaluators menu
     // Use the button inside the content area (not the tab)
     const evaluatorsButton = page
       .getByTestId("content")
       .getByRole("button", { name: /Evaluators/i });
-    await expect(evaluatorsButton).toBeVisible({ timeout: 10000 });
+    await expect(evaluatorsButton).toBeVisible();
     await evaluatorsButton.click();
 
     // Wait for the evaluators menu to appear - the GridList has aria-label="Select evaluators"
     // React Aria GridList renders with role="grid"
     const evaluatorsList = page.locator('[aria-label="Select evaluators"]');
-    await expect(evaluatorsList).toBeVisible({ timeout: 10000 });
+    await expect(evaluatorsList).toBeVisible();
 
     // Verify that the prebuilt LLM evaluator (correctness) appears in the list
     // GridList items render as role="row"

--- a/app/tests/utils/login.ts
+++ b/app/tests/utils/login.ts
@@ -55,8 +55,8 @@ export async function login(
 
   // Wait for the projects page URL and content
   // The login flow goes: /login -> / -> /projects (via redirects)
-  await page.waitForURL("**/projects", { timeout: 30000 });
+  await page.waitForURL("**/projects");
   await expect(
     page.getByRole("searchbox", { name: "Search projects by name" })
-  ).toBeVisible({ timeout: 30000 });
+  ).toBeVisible();
 }

--- a/app/tests/viewer-access.spec.ts
+++ b/app/tests/viewer-access.spec.ts
@@ -28,9 +28,7 @@ test("can create user key", async ({ page }) => {
     .click();
 
   // Verify the named key appears in the table - which means key creation succeeded
-  await expect(page.getByRole("cell", { name: keyName })).toBeVisible({
-    timeout: 60000,
-  });
+  await expect(page.getByRole("cell", { name: keyName })).toBeVisible();
 });
 
 test("should not be able to create a new project", async ({ page }) => {


### PR DESCRIPTION
Summary
- centralize CI/local budgets in `app/playwright.config.ts` so timeout, expect timeout, navigation timeout, web server timeout, and worker logic vary only via `isCI`
- purged explicit timeout overrides from `app/tests` (member-access, server-evaluators, viewer-access, login helper) and added a deterministic provider readiness guard
- updated the Phoenix Playwright skill guidance to discourage per-call timeouts, cite the centralized config, and remind authors to build via `pnpm run build`

Testing
- Not run (not requested)