### PR TITLE
fix: Raise on missing label

### DIFF
--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -417,7 +417,9 @@ class LLMEvaluator(BaseEvaluator):
                         args = json.loads(tool_call["arguments"])
                         label = args.get("label")
                         if label is None:
-                            continue
+                            raise ValueError(
+                                "LLM response missing required 'label' field in tool call arguments"
+                            )
                         scores_by_label = {
                             config_value.label: config_value.score
                             for config_value in matched_config.values

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -3248,6 +3248,67 @@ class TestLLMEvaluator:
         assert attributes.pop(INPUT_MIME_TYPE) == "application/json"
         assert not attributes
 
+    async def test_evaluate_with_missing_label_in_tool_call_records_error(
+        self,
+        db: DbSessionFactory,
+        project: models.Project,
+        tracer: Tracer,
+        llm_evaluator: LLMEvaluator,
+        output_config: CategoricalAnnotationConfig,
+        input_mapping: EvaluatorInputMappingInput,
+    ) -> None:
+        tool_call_response_body = (
+            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
+            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":null,'
+            '"tool_calls":[{"index":0,"id":"call_abc123","type":"function",'
+            '"function":{"name":"correctness","arguments":""}}],"refusal":null},'
+            '"logprobs":null,"finish_reason":null}],"usage":null}\n\n'
+            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
+            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,'
+            '"function":{"arguments":"{\\"explanation\\": \\"The output is correct.\\"}"}}]},'
+            '"logprobs":null,"finish_reason":null}],"usage":null}\n\n'
+            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
+            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},'
+            '"finish_reason":"tool_calls"}],"usage":null}\n\n'
+            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
+            '"model":"gpt-4o-mini","choices":[],"usage":{"prompt_tokens":10,'
+            '"completion_tokens":20,"total_tokens":30}}\n\n'
+            "data: [DONE]\n\n"
+        )
+        with respx.mock:
+            respx.post("https://api.openai.com/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    200,
+                    content=tool_call_response_body,
+                    headers={"content-type": "text/event-stream"},
+                )
+            )
+            evaluation_results = await llm_evaluator.evaluate(
+                context={"input": "What is 2 + 2?", "output": "4"},
+                input_mapping=input_mapping,
+                name="correctness",
+                output_configs=[output_config],
+                tracer=tracer,
+            )
+            assert len(evaluation_results) == 1
+            evaluation_result = evaluation_results[0]
+
+        result = dict(evaluation_result)
+        error = result.pop("error")
+        assert isinstance(error, str)
+        assert "LLM response missing required 'label' field in tool call arguments" in error
+        assert result.pop("label") is None
+        assert result.pop("score") is None
+        assert result.pop("explanation") is None
+        assert result.pop("annotator_kind") == "LLM"
+        assert result.pop("name") == "correctness"
+        trace_id = result.pop("trace_id")
+        assert isinstance(trace_id, str)
+        assert isinstance(result.pop("start_time"), datetime)
+        assert isinstance(result.pop("end_time"), datetime)
+        assert result.pop("metadata") == {}
+        assert not result
+
     async def test_evaluate_with_multipart_template(
         self,
         db: DbSessionFactory,


### PR DESCRIPTION
resolves #10850 

Previously, when the LLM returned a tool call without the required 'label' field, the evaluator silently skipped the result via `continue`. This caused intermittent missing evaluation results that were difficult to diagnose, since no error was surfaced to the user.

Now, a ValueError is raised instead. The exception is caught by the existing error handler in `evaluate()`, which records the exception on the OTel span, sets the span status to ERROR, and returns an EvaluationResult with `label=None`, `score=None`, `explanation=None`, and the error message in the `error` field. This surfaces the problem to the user as a visible evaluation error rather than a silent gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change in evaluator result parsing plus a new unit test; behavior only changes for malformed/partial LLM outputs.
> 
> **Overview**
> LLM evaluator parsing now **fails fast** when an LLM tool call is missing the required `label` argument, raising a `ValueError` instead of silently skipping that tool call and producing missing evaluation results.
> 
> Adds a unit test that mocks a streaming tool-call response without `label` and asserts the evaluator returns a single error `EvaluationResult` (with `label/score/explanation=None`) containing the new error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99c2c50494fb21251fa648049b0481226ac72ae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->