### PR TITLE
ci: Prevent demo examples from being published

### DIFF
--- a/js/.changeset/config.json
+++ b/js/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["phoenix-experiment-runner"]
+  "ignore": ["phoenix-experiment-runner", "demo-document-relevancy-experiment"],
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
 }


### PR DESCRIPTION
Summary
- add the demo-document-relevancy-experiment package to the ignored changelog list so demo packages do not get published accidentally
- mark private packages as not versioned/tagged in the JS changeset config to reinforce the non-publish behavior

Testing
- Not run (not requested)