### PR TITLE
chore: fix typo in toxiproxy script

### DIFF
--- a/scripts/docker/devops/scripts/setup-toxiproxy.sh
+++ b/scripts/docker/devops/scripts/setup-toxiproxy.sh
@@ -15,8 +15,8 @@ curl -X POST "http://toxiproxy:8474/proxies" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "postgres",
-    "listen": "0.0.0.0:5432",
-    "upstream": "db:5432",
+    "listen": "0.0.0.0:5433",
+    "upstream": "db:5433",
     "enabled": true
   }'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Shell script change in local/dev tooling only; risk is limited to dev Postgres connectivity if any consumers still expect port `5432`.
> 
> **Overview**
> Updates the devops Toxiproxy setup script to create the `postgres` proxy on port `5433` instead of `5432`, aligning the proxy’s listen/upstream configuration with the rest of the Docker dev environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d87ccbb2ca1bfb638e2cefa014103a6047b1c9c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->