### PR TITLE
fix: Fix builtin evaluator edge cases

### DIFF
--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -1026,8 +1027,14 @@ def cast_template_variable_types(
     for key, prop_schema in properties.items():
         if key in casted_template_variables:
             prop_type = prop_schema.get("type")
-            if prop_type == "string" and not isinstance(casted_template_variables[key], str):
-                casted_template_variables[key] = str(casted_template_variables[key])
+            if prop_type == "string":
+                value = casted_template_variables[key]
+                if isinstance(value, (type(None), list, dict)):
+                    raise ValueError(
+                        f"Field '{key}' expects a string but got {type(value).__name__}"
+                    )
+                if not isinstance(value, str):
+                    casted_template_variables[key] = str(value)
 
     return casted_template_variables
 
@@ -1394,7 +1401,7 @@ class ExactMatchEvaluator(BuiltInEvaluator):
                 },
                 "case_sensitive": {
                     "type": "boolean",
-                    "description": "Whether comparison is case-sensitive (default: True)",
+                    "description": "Whether comparison is case-sensitive (default: False)",
                 },
             },
             "required": ["expected", "actual"],
@@ -1472,7 +1479,7 @@ class ExactMatchEvaluator(BuiltInEvaluator):
 
                 expected = inputs.get("expected", "")
                 actual = inputs.get("actual", "")
-                case_sensitive = inputs.get("case_sensitive", True)
+                case_sensitive = inputs.get("case_sensitive", False)
 
                 with tracer_.start_as_current_span(
                     self.name,
@@ -1825,7 +1832,7 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
                 },
                 "case_sensitive": {
                     "type": "boolean",
-                    "description": "Whether comparison is case-sensitive (default: True)",
+                    "description": "Whether comparison is case-sensitive (default: False)",
                 },
             },
             "required": ["expected", "actual"],
@@ -1900,7 +1907,17 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
 
                 expected = inputs.get("expected", "")
                 actual = inputs.get("actual", "")
-                case_sensitive = inputs.get("case_sensitive", True)
+                case_sensitive = inputs.get("case_sensitive", False)
+
+                if case_sensitive:
+                    compare_expected, compare_actual = expected, actual
+                else:
+                    compare_expected, compare_actual = expected.lower(), actual.lower()
+
+                if max(len(compare_expected), len(compare_actual)) > 5000:
+                    raise ValueError(
+                        "Inputs too long for Levenshtein distance (max 5000 characters)"
+                    )
 
                 with tracer_.start_as_current_span(
                     self.name,
@@ -1915,10 +1932,10 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
                         ),
                     },
                 ) as execution_span:
-                    if case_sensitive:
-                        distance = levenshtein_distance(expected, actual)
+                    if compare_expected == compare_actual:
+                        distance = 0
                     else:
-                        distance = levenshtein_distance(expected.lower(), actual.lower())
+                        distance = levenshtein_distance(compare_expected, compare_actual)
 
                     explanation = f"edit distance between expected and actual is {distance}"
 
@@ -1999,6 +2016,15 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
 
 
 def json_diff_count(expected: Any, actual: Any) -> int:
+    # Handle bools first (isinstance(True, int) is True in Python)
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if type(expected) is not type(actual):
+            return 1
+        return 0 if expected == actual else 1
+    # Handle numeric equivalence (int/float interchangeable)
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        return 0 if math.isclose(float(expected), float(actual), rel_tol=1e-9) else 1
+    # Original type check for non-numeric types
     if type(expected) is not type(actual):
         return 1
 

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -1029,11 +1029,11 @@ def cast_template_variable_types(
             prop_type = prop_schema.get("type")
             if prop_type == "string":
                 value = casted_template_variables[key]
-                if isinstance(value, (type(None), list, dict)):
-                    raise ValueError(
-                        f"Field '{key}' expects a string but got {type(value).__name__}"
-                    )
-                if not isinstance(value, str):
+                if value is None:
+                    raise ValueError(f"Field '{key}' expects a string but got NoneType")
+                if isinstance(value, (dict, list)):
+                    casted_template_variables[key] = json.dumps(value, default=str)
+                elif not isinstance(value, str):
                     casted_template_variables[key] = str(value)
 
     return casted_template_variables
@@ -2020,6 +2020,9 @@ def json_diff_count(expected: Any, actual: Any) -> int:
     if isinstance(expected, bool) or isinstance(actual, bool):
         if type(expected) is not type(actual):
             return 1
+        return 0 if expected == actual else 1
+    # Integer fast-path (avoids float overflow for large ints)
+    if isinstance(expected, int) and isinstance(actual, int):
         return 0 if expected == actual else 1
     # Handle numeric equivalence (int/float interchangeable)
     if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):

--- a/tests/unit/server/api/mutations/test_chat_mutations.py
+++ b/tests/unit/server/api/mutations/test_chat_mutations.py
@@ -1248,9 +1248,13 @@ class TestChatCompletionMutationMixin:
             attributes = dict(flatten(llm_prompt_span.attributes, recurse_on_sequence=True))
             assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "PROMPT"
             input_value = json.loads(attributes.pop(INPUT_VALUE))
+            input_json = json.dumps({"city": "Paris"})
+            output_json = json.dumps(
+                {"messages": [{"role": "assistant", "content": "France"}], "available_tools": []}
+            )
             assert input_value == {
-                "input": "{'city': 'Paris'}",
-                "output": "{'messages': [{'role': 'assistant', 'content': 'France'}], 'available_tools': []}",
+                "input": input_json,
+                "output": output_json,
             }
             assert attributes.pop(INPUT_MIME_TYPE) == JSON
             assert json.loads(attributes.pop(OUTPUT_VALUE)) == {
@@ -1262,9 +1266,8 @@ class TestChatCompletionMutationMixin:
                     {
                         "role": "user",
                         "content": (
-                            "Input: {'city': 'Paris'}\n\n"
-                            "Output: {'messages': [{'role': 'assistant', 'content': 'France'}], "
-                            "'available_tools': []}\n\n"
+                            f"Input: {input_json}\n\n"
+                            f"Output: {output_json}\n\n"
                             "Is this output correct?"
                         ),
                     },
@@ -1556,7 +1559,7 @@ class TestChatCompletionMutationMixin:
             assert json.loads(attributes.pop(INPUT_VALUE)) == {
                 "expected": "France",
                 "actual": "France",
-                "case_sensitive": True,
+                "case_sensitive": False,
             }
             assert attributes.pop(INPUT_MIME_TYPE) == JSON
             assert json.loads(attributes.pop(OUTPUT_VALUE)) is True

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -2002,9 +2002,13 @@ class TestChatCompletionOverDatasetSubscription:
             }
             assert attributes.pop(INPUT_MIME_TYPE) == JSON
             output_value = json.loads(attributes.pop(OUTPUT_VALUE))
+            input_json = json.dumps({"city": "Paris"})
+            output_json = json.dumps(
+                {"messages": [{"role": "assistant", "content": "France"}], "available_tools": []}
+            )
             assert output_value == {
-                "input": "{'city': 'Paris'}",
-                "output": "{'messages': [{'role': 'assistant', 'content': 'France'}], 'available_tools': []}",
+                "input": input_json,
+                "output": output_json,
             }
             assert attributes.pop(OUTPUT_MIME_TYPE) == JSON
             assert not attributes
@@ -2019,8 +2023,8 @@ class TestChatCompletionOverDatasetSubscription:
             assert attributes.pop(OPENINFERENCE_SPAN_KIND) == "PROMPT"
             input_value = json.loads(attributes.pop(INPUT_VALUE))
             assert input_value == {
-                "input": "{'city': 'Paris'}",
-                "output": "{'messages': [{'role': 'assistant', 'content': 'France'}], 'available_tools': []}",
+                "input": input_json,
+                "output": output_json,
             }
             assert attributes.pop(INPUT_MIME_TYPE) == JSON
             output_value = json.loads(attributes.pop(OUTPUT_VALUE))
@@ -2033,9 +2037,8 @@ class TestChatCompletionOverDatasetSubscription:
                     {
                         "role": "user",
                         "content": (
-                            "Input: {'city': 'Paris'}\n\n"
-                            "Output: {'messages': [{'role': 'assistant', 'content': 'France'}], "
-                            "'available_tools': []}\n\n"
+                            f"Input: {input_json}\n\n"
+                            f"Output: {output_json}\n\n"
                             "Is this output correct?"
                         ),
                     },
@@ -2309,7 +2312,7 @@ class TestChatCompletionOverDatasetSubscription:
             assert json.loads(attributes.pop(INPUT_VALUE)) == {
                 "expected": "France",
                 "actual": "France",
-                "case_sensitive": True,
+                "case_sensitive": False,
             }
             assert attributes.pop(INPUT_MIME_TYPE) == JSON
             assert json.loads(attributes.pop(OUTPUT_VALUE)) is True


### PR DESCRIPTION
- Reject None, list, and dict values for string-typed template fields instead of silently coercing them (e.g. `str(None)` → `"None"`)
- Change `case_sensitive` default from `True` to `False` for ExactMatch and Levenshtein evaluators
- Cap Levenshtein distance inputs at 5000 characters to prevent expensive O(n*m) computations
- Add early-exit for identical strings in Levenshtein to skip unnecessary computation
- Fix `json_diff_count` to treat int/float as equivalent (1 == 1.0) using `math.isclose`, and distinguish bool from int (`True` != `1`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in evaluator defaults and input casting/serialization can affect existing evaluation results and traces, though scope is limited to evaluator logic and covered by unit tests.
> 
> **Overview**
> Hardens evaluator input handling by making `cast_template_variable_types` *fail fast* on `None` for string fields and JSON-serializing `dict`/`list` values (instead of Python `str()` output), which also changes LLM prompt/span inputs to use JSON strings.
> 
> Changes `ExactMatchEvaluator` and `LevenshteinDistanceEvaluator` to default `case_sensitive` to `False`, and adds guardrails to Levenshtein evaluation (5000-char length cap plus early-exit when strings already match). `json_diff_count` now treats `int`/`float` as numerically equivalent (via `math.isclose`) while distinguishing `bool` from `int`, with tests updated/added accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95de6734b329967efe02c8a780e7ccf02d9a44e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->