### PR TITLE
fix: Show require_all on ContainsEvaluator details

### DIFF
--- a/app/src/components/evaluators/ContainsEvaluatorDetails.tsx
+++ b/app/src/components/evaluators/ContainsEvaluatorDetails.tsx
@@ -13,6 +13,7 @@ export function ContainsEvaluatorDetails({
     | string
     | undefined;
   const caseSensitive = inputMapping?.literalMapping?.case_sensitive;
+  const requireAll = inputMapping?.literalMapping?.require_all;
 
   return (
     <Flex direction="column" gap="size-100">
@@ -27,6 +28,10 @@ export function ContainsEvaluatorDetails({
       <Text size="S">
         <Text weight="heavy">Case sensitive:</Text>{" "}
         {caseSensitive === true || caseSensitive === "true" ? "Yes" : "No"}
+      </Text>
+      <Text size="S">
+        <Text weight="heavy">Require all:</Text>{" "}
+        {requireAll === true || requireAll === "true" ? "Yes" : "No"}
       </Text>
     </Flex>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change that reads and displays an additional flag; no behavior or data-flow changes.
> 
> **Overview**
> The Contains evaluator details view now surfaces the `require_all` setting alongside existing mappings, rendering it as a Yes/No value (handling both boolean and string forms).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6208ab731c365ed261c349a63efca8eaa890d4d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->