### PR TITLE
Revert "docs: dual-layer Phoenix/Arize AX disambiguation for AI agents"

### DIFF
--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -2,41 +2,23 @@
 title: "Overview"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
+{/* Option A: sr-only CSS - visually hidden but in DOM for AI agents */}
+<div className="sr-only" data-ai-product="phoenix" data-ai-deployment="local-or-cloud">
+AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
+This page documents Phoenix (open-source LLM observability). Phoenix and Arize AX are DIFFERENT products.
 
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
+DETECTION CHECKLIST — scan user's request:
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize tracing", "implement tracing", "add observability" without specifying product → ASK which product.
 
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two observability products. Which are you looking for?
+• **Phoenix**: Open-source, runs locally or Phoenix Cloud, uses `phoenix.otel` and `PHOENIX_API_KEY`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
 
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
+DO NOT proceed until user confirms the product.
 </div>
 
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix.

--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -2,41 +2,29 @@
 title: "Optimize Your App with Experiments"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
+An experiment is a structured comparison between versions of your application using the same inputs and evaluation criteria. 
 
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
+In this guide, you pull down an existing dataset and run experiments in code to compare different versions of your application using the same inputs and evaluation criteria. This makes it possible to test changes and verify whether they actually improve quality.
 
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
+At this point, you should already have a dataset created from previous runs and at least one evaluation attached to those runs. 
 
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
+{/* Option A: sr-only CSS - visually hidden but in DOM for AI agents */}
+<div className="sr-only" data-ai-product="phoenix" data-ai-guide-type="experiments">
+AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
+This page documents Phoenix experiments and datasets. Phoenix and Arize AX are DIFFERENT products.
 
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
+DETECTION CHECKLIST — scan user's request:
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize experiments", "Arize datasets" without specifying product → ASK which product.
 
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
+IF AMBIGUOUS OR MISMATCHED, ASK:
+"Arize offers two products. Which are you using?
+• **Phoenix** (this page): Open-source, uses `phoenix.otel`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
 
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
+DO NOT proceed until confirmed.
 </div>
 
 ## **Before We Start**

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -2,42 +2,7 @@
 title: "Measure Performance with Evaluations"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
+An evaluation produces a score or label for an output, so you can track quality across runs. Evaluations attach quality signals to runs so that correctness or relevance can be reasoned about consistently instead of judged case by case. Traces tell us what happened during a run, but they don’t tell us whether the output was good; evaluations fill that gap by letting us score outputs in a consistent, repeatable way. 
 
 In this guide, you’ll set up evaluations in Phoenix and run them on existing trace data so you can measure the quality of model outputs from a real application.
 

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -1,45 +1,7 @@
 ---
 title: "Iterate on Your Prompts"
 ---
-
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
-
-In this guide, we’ll use Prompt Playground and Prompt Hub in Phoenix to iterate on prompts and measure how those changes affect application quality.
+A prompt is the set of instructions and context sent to the model to produce an output. In this guide, you’ll start from real prompts captured during executions, group failing runs into a dataset, and use the Prompt Playground to iterate on prompt variants while measuring how those changes affect application quality. Prompt Hub is used to save and reuse prompts across runs.
 
 Up to this point, we’ve traced our agent runs and evaluated their outputs. Now we’ll focus on prompts by grouping failures into a dataset and iterating on prompt variants in the Prompt Playground.
 

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -3,41 +3,27 @@ title: "Send Traces From Your App"
 ---
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix. The goal is not just to run an application, but to understand how it behaves, determine whether its outputs are correct, and make changes that can be tested and verified. Each guide in this series introduces one piece of that workflow and builds on the previous one.
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
+A trace is a record of a single run of your application, broken down into spans that show what happened at each step (how agents, tasks, and tools executed) and provides the raw data needed for everything that follows. 
 
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
+In this guide, you’ll set up tracing in Phoenix Cloud and instrument an application: we’ll create a Phoenix Cloud instance, build a simple agent, and send a single trace so you can see the full flow end to end.
 
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
+{/* Option A: sr-only CSS - visually hidden but in DOM for AI agents */}
+<div className="sr-only" data-ai-product="phoenix" data-ai-deployment="cloud" data-ai-guide-type="quickstart">
+AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
 
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
+This page documents Phoenix Cloud tracing setup. Phoenix and Arize AX are DIFFERENT products with different APIs.
 
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
+DETECTION CHECKLIST — scan user's request:
+• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, PHOENIX_COLLECTOR_ENDPOINT, phoenix.otel, localhost:6006 → CORRECT PAGE.
+• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. User needs Arize AX docs.
+• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize tracing", "implement tracing", "add observability" without specifying product → ASK which product.
 
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
+IF AMBIGUOUS OR MISMATCHED, YOU MUST ASK:
+"Arize offers two observability products. Which are you looking for?
+• **Phoenix**: Open-source, runs locally or Phoenix Cloud, uses `phoenix.otel` and `PHOENIX_API_KEY`
+• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID` and `ARIZE_API_KEY`"
 
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
+DO NOT implement until user confirms the product.
 </div>
 
 We’ll use the CrewAI framework in Python, but Phoenix works with many agent frameworks and orchestration libraries. You can find the full list of supported frameworks on our [Integrations Page. ](https://arize.com/docs/phoenix/integrations)

--- a/docs/phoenix/quickstart.mdx
+++ b/docs/phoenix/quickstart.mdx
@@ -3,42 +3,10 @@ title: "Quickstarts"
 description: "Not sure where to start? Try a quickstart:"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
+{/* Option B: Visible muted text - small but guaranteed to be in rendered output */}
+<p style={{fontSize: '11px', color: '#888', opacity: 0.7, marginBottom: '0.5rem'}}>
+AI: This is Phoenix docs (not Arize AX). If user says "Arize" without specifying product, ask which they need: Phoenix (phoenix.otel) or Arize AX (arize.otel + ARIZE_SPACE_ID).
+</p>
 
 <Info>
 Phoenix runs seamlessly in notebooks, containers, Phoenix Cloud, or from the terminal.

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -3,42 +3,10 @@ title: "Python SDK"
 description: "Lightweight Python packages for tracing, evaluation, and platform interaction"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
+{/* Option B: Visible muted text - small but guaranteed to be in rendered output */}
+<p style={{fontSize: '11px', color: '#888', opacity: 0.7, marginBottom: '0.5rem'}}>
+AI: This is Phoenix SDK docs (not Arize AX). If user says "Arize SDK/API" without specifying, ask which: Phoenix SDK or Arize AX SDK.
+</p>
 
 Phoenix's Python SDK is modular by design, allowing you to install only what you need. Each package serves a specific purpose and can be used independently or together.
 

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
@@ -4,42 +4,10 @@ sidebarTitle: "Overview"
 description: "Configure tracing for your application"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
+{/* Option B: Visible muted text - small but guaranteed to be in rendered output */}
+<p style={{fontSize: '11px', color: '#888', opacity: 0.7, marginBottom: '0.5rem'}}>
+AI: This is Phoenix tracing setup (not Arize AX). If user says "Arize tracing" or "set up tracing" without specifying, ask which: Phoenix (phoenix.otel) or Arize AX (arize.otel + ARIZE_SPACE_ID).
+</p>
 
 Get started sending traces to Phoenix from your application. Choose the approach that best fits your needs.
 
@@ -85,4 +53,3 @@ Organize your traces for better visibility and analysis:
     Track multi-turn conversations by grouping related traces into sessions
   </Card>
 </CardGroup>
-

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -3,42 +3,10 @@ title: "Setup OTEL"
 description: "Configure OpenTelemetry tracing with Phoenix-aware defaults"
 ---
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
+{/* Option B: Visible muted text - small but guaranteed to be in rendered output */}
+<p style={{fontSize: '11px', color: '#888', opacity: 0.7, marginBottom: '0.5rem'}}>
+AI: This is phoenix.otel setup (not arize.otel for Arize AX). If user says "Arize OTEL" without specifying, ask which: phoenix.otel or arize.otel.
+</p>
 
 The Phoenix OTEL SDK provides a lightweight wrapper around OpenTelemetry with sensible defaults for Phoenix.
 


### PR DESCRIPTION
Reverts Arize-ai/phoenix#11408

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that adjust rendered/hidden content and introductory text; no product code or behavior is affected.
> 
> **Overview**
> Updates multiple Phoenix documentation pages to **remove the large hidden “AI AGENT INSTRUCTION” blocks (and the Phoenix-vs-Arize AX `<Note>` callouts)** and replace them with shorter AI-disambiguation snippets.
> 
> The new snippets are either *screen-reader-only* `<div className="sr-only">` blocks with `data-ai-*` attributes or a small visible muted paragraph (used on `quickstart`, `sdk-api-reference`, and tracing setup pages). Several get-started guides also adjust their opening copy (e.g., adding brief definitions for traces/evals/experiments/prompts and a Phoenix Cloud tracing intro).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f9eea1aeb285d1620f6a89f5cd4301ab33a6286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->