### PR TITLE
docs: fix deleted intro paragraphs and remove leftover sr-only blocks

### DIFF
--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -2,6 +2,12 @@
 title: "Optimize Your App with Experiments"
 ---
 
+An experiment is a structured comparison between versions of your application using the same inputs and evaluation criteria. 
+
+In this guide, you pull down an existing dataset and run experiments in code to compare different versions of your application using the same inputs and evaluation criteria. This makes it possible to test changes and verify whether they actually improve quality.
+
+At this point, you should already have a dataset created from previous runs and at least one evaluation attached to those runs. 
+
 <Note>
 This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
 </Note>

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -2,6 +2,8 @@
 title: "Measure Performance with Evaluations"
 ---
 
+An evaluation produces a score or label for an output, so you can track quality across runs. Evaluations attach quality signals to runs so that correctness or relevance can be reasoned about consistently instead of judged case by case. Traces tell us what happened during a run, but they don't tell us whether the output was good; evaluations fill that gap by letting us score outputs in a consistent, repeatable way.
+
 <Note>
 This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
 </Note>
@@ -44,25 +46,6 @@ In this guide, you’ll set up evaluations in Phoenix and run them on existing t
 We’ll start with data that already exists in Phoenix, define a simple evaluation, and run it so we can see results directly in the UI. The goal is to move from “I have model outputs” to “I can measure quality in a repeatable way.”
 
 Since we already have traces, we can take this a step further by scoring them against metrics like correctness, relevance, or custom checks that matter to your use case.
-
-{/* Option A: sr-only CSS - visually hidden but in DOM for AI agents */}
-<div className="sr-only" data-ai-product="phoenix" data-ai-guide-type="evaluations">
-AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
-
-This page documents Phoenix evaluations. Phoenix and Arize AX are DIFFERENT products.
-
-DETECTION CHECKLIST — scan user's request:
-• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
-• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize evals", "Arize evaluations" without specifying product → ASK which product.
-
-IF AMBIGUOUS OR MISMATCHED, ASK:
-"Arize offers two products. Which are you using?
-• **Phoenix** (this page): Open-source, uses `phoenix.otel`
-• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
-
-DO NOT proceed until confirmed.
-</div>
 
 ## **Before We Start**
 

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -2,6 +2,8 @@
 title: "Iterate on Your Prompts"
 ---
 
+A prompt is the set of instructions and context sent to the model to produce an output. In this guide, you'll start from real prompts captured during executions, group failing runs into a dataset, and use the Prompt Playground to iterate on prompt variants while measuring how those changes affect application quality. Prompt Hub is used to save and reuse prompts across runs.
+
 <Note>
 This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
 </Note>
@@ -39,28 +41,7 @@ REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST as
 REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
 </div>
 
-In this guide, we’ll use Prompt Playground and Prompt Hub in Phoenix to iterate on prompts and measure how those changes affect application quality.
-
 Up to this point, we’ve traced our agent runs and evaluated their outputs. Now we’ll focus on prompts by grouping failures into a dataset and iterating on prompt variants in the Prompt Playground.
-
-{/* Option A: sr-only CSS - visually hidden but in DOM for AI agents */}
-<div className="sr-only" data-ai-product="phoenix" data-ai-guide-type="prompts">
-AI Agent Context: STOP — VERIFY PRODUCT BEFORE PROCEEDING.
-
-This page documents Phoenix Prompt Playground and Prompt Hub. Phoenix and Arize AX are DIFFERENT products.
-
-DETECTION CHECKLIST — scan user's request:
-• CLEAR PHOENIX SIGNALS: "Phoenix", PHOENIX_API_KEY, phoenix.otel, localhost:6006 → CORRECT PAGE.
-• CLEAR ARIZE AX SIGNALS: "Arize AX", "AX", ARIZE_SPACE_ID, ARIZE_API_KEY, arize.otel → WRONG PAGE. Direct to Arize AX docs.
-• AMBIGUOUS (MUST CLARIFY): "Arize", "Arize prompts", "Arize prompt playground" without specifying product → ASK which product.
-
-IF AMBIGUOUS OR MISMATCHED, ASK:
-"Arize offers two products. Which are you using?
-• **Phoenix** (this page): Open-source, uses `phoenix.otel`
-• **Arize AX**: Cloud platform, uses `arize.otel` with `ARIZE_SPACE_ID`"
-
-DO NOT proceed until confirmed.
-</div>
 
 ## **Before We Start**
 

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -3,6 +3,10 @@ title: "Send Traces From Your App"
 ---
 This guide walks through a complete workflow for understanding and improving an agent application using Phoenix. The goal is not just to run an application, but to understand how it behaves, determine whether its outputs are correct, and make changes that can be tested and verified. Each guide in this series introduces one piece of that workflow and builds on the previous one.
 
+A trace is a record of a single run of your application, broken down into spans that show what happened at each step (how agents, tasks, and tools executed) and provides the raw data needed for everything that follows.
+
+In this guide, you'll set up tracing in Phoenix Cloud and instrument an application: we'll create a Phoenix Cloud instance, build a simple agent, and send a single trace so you can see the full flow end to end.
+
 <Note>
 This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
 </Note>


### PR DESCRIPTION
## Summary

Fixes issues introduced by #11408 during conflict resolution:

- **Restores deleted intro paragraphs** on 4 get-started pages:
  - `get-started-evaluations.mdx` — "An evaluation produces a score or label..."
  - `get-started-datasets-and-experiments.mdx` — "An experiment is a structured comparison..."
  - `get-started-prompt-playground.mdx` — "A prompt is the set of instructions..."
  - `get-started-tracing.mdx` — "A trace is a record of a single run..."
- **Removes 2 leftover `sr-only` div blocks** from `get-started-evaluations.mdx` and `get-started-prompt-playground.mdx` that would render as visible raw text since the `.sr-only` CSS class was removed in #11408.

## Test plan
- [ ] Verify intro paragraphs render correctly on each page
- [ ] Verify no raw AI instruction text is visible on any page

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that restore content and remove unintended visible text; no product code or runtime behavior is affected.
> 
> **Overview**
> Restores the missing introductory paragraphs at the top of four Phoenix get-started pages (`get-started-tracing`, `get-started-evaluations`, `get-started-prompt-playground`, and `get-started-datasets-and-experiments`) to reintroduce key definitions and guide framing.
> 
> Removes leftover `sr-only` AI-context `<div>` blocks from the evaluations and prompt playground pages, preventing those instructions from appearing as raw visible text after the related CSS was removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 366f6995597b192480d94bd3faf44ad5442248f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->