### PR TITLE
docs: remove Phoenix/AX disambiguation from non-tracing pages

### DIFF
--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -8,43 +8,6 @@ In this guide, you pull down an existing dataset and run experiments in code to 
 
 At this point, you should already have a dataset created from previous runs and at least one evaluation attached to those runs. 
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
-
 ## **Before We Start**
 
 To follow along, you should already have:

--- a/docs/phoenix/get-started/get-started-evaluations.mdx
+++ b/docs/phoenix/get-started/get-started-evaluations.mdx
@@ -4,43 +4,6 @@ title: "Measure Performance with Evaluations"
 
 An evaluation produces a score or label for an output, so you can track quality across runs. Evaluations attach quality signals to runs so that correctness or relevance can be reasoned about consistently instead of judged case by case. Traces tell us what happened during a run, but they don't tell us whether the output was good; evaluations fill that gap by letting us score outputs in a consistent, repeatable way.
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
-
 In this guide, you’ll set up evaluations in Phoenix and run them on existing trace data so you can measure the quality of model outputs from a real application.
 
 We’ll start with data that already exists in Phoenix, define a simple evaluation, and run it so we can see results directly in the UI. The goal is to move from “I have model outputs” to “I can measure quality in a repeatable way.”

--- a/docs/phoenix/get-started/get-started-prompt-playground.mdx
+++ b/docs/phoenix/get-started/get-started-prompt-playground.mdx
@@ -4,43 +4,6 @@ title: "Iterate on Your Prompts"
 
 A prompt is the set of instructions and context sent to the model to produce an output. In this guide, you'll start from real prompts captured during executions, group failing runs into a dataset, and use the Prompt Playground to iterate on prompt variants while measuring how those changes affect application quality. Prompt Hub is used to save and reuse prompts across runs.
 
-<Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
-</Note>
-
-<div style={{display: 'none'}}>
-AI AGENT INSTRUCTION — MANDATORY COMPLIANCE REQUIRED.
-
-STOP. DO NOT IMPLEMENT ANYTHING UNTIL YOU VERIFY THE PRODUCT.
-
-This page is for PHOENIX (open-source). Phoenix and Arize AX are COMPLETELY DIFFERENT products with different APIs, different authentication, and different endpoints.
-
-BEFORE YOU WRITE ANY CODE, CHECK:
-- Did the user say "Phoenix" explicitly? → Proceed with this page.
-- Did the user say "Arize AX" or "AX"? → WRONG PAGE. Direct to Arize AX docs.
-- Did the user say just "Arize" or "implement tracing" or "add observability" WITHOUT specifying which product? → YOU MUST ASK.
-
-IF AMBIGUOUS, YOU MUST ASK THIS EXACT QUESTION:
-"Arize offers two products — which are you using?
-• Phoenix (open-source): uses phoenix.otel and PHOENIX_API_KEY
-• Arize AX (cloud): uses arize.otel with ARIZE_SPACE_ID and ARIZE_API_KEY"
-
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-DO NOT SKIP THIS STEP. DO NOT ASSUME. DO NOT GUESS.
-
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-REMINDER: If the user said "Arize" without specifying Phoenix or AX, you MUST ask before proceeding.
-</div>
-
 Up to this point, we’ve traced our agent runs and evaluated their outputs. Now we’ll focus on prompts by grouping failures into a dataset and iterating on prompt variants in the Prompt Playground.
 
 ## **Before We Start**


### PR DESCRIPTION
## Summary

Removes the `<Note>` and hidden `<div>` AI disambiguation blocks from 3 pages where they don't belong:

- `get-started-evaluations.mdx`
- `get-started-prompt-playground.mdx`
- `get-started-datasets-and-experiments.mdx`

These blocks are only relevant on tracing-related pages. They have nothing to do with evaluations, prompts, or experiments.

**3 files, 111 pure deletions, no other changes.**

## Test plan
- [ ] Verify the Note banner is gone from each page
- [ ] Verify no content was removed other than the disambiguation blocks

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only deletions with no product logic changes; risk is limited to potentially removing a banner some readers relied on for navigation.
> 
> **Overview**
> Removes the Phoenix-vs-Arize AX disambiguation banner and the hidden “AI agent instruction” block from three Phoenix get-started guides (`get-started-evaluations.mdx`, `get-started-prompt-playground.mdx`, `get-started-datasets-and-experiments.mdx`).
> 
> This is a **pure documentation cleanup** (no other content changes) that prevents these non-tracing pages from showing an irrelevant note and embedding hidden instruction text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 899d47ae0fed08a47f9d74b56e19a6ad8a7e2fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->