### PR TITLE
fix(api): update OpenAI client API type handling 

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2512,6 +2512,10 @@ async def _get_builtin_provider_client(
 
         client_factory: ClientFactory = create_openai_client
         api_type = obj.openai_api_type
+        if model_name in OPENAI_RESPONSES_API_MODELS:
+            api_type = OpenAIApiType.RESPONSES
+        elif model_name in OPENAI_CHAT_COMPLETIONS_API_MODELS:
+            api_type = OpenAIApiType.CHAT_COMPLETIONS
         if api_type is OpenAIApiType.CHAT_COMPLETIONS:
             return OpenAIStreamingClient(
                 client_factory=client_factory,
@@ -2584,6 +2588,10 @@ async def _get_builtin_provider_client(
 
             client_factory = create_client_with_token
         api_type = obj.openai_api_type
+        if model_name in OPENAI_RESPONSES_API_MODELS:
+            api_type = OpenAIApiType.RESPONSES
+        elif model_name in OPENAI_CHAT_COMPLETIONS_API_MODELS:
+            api_type = OpenAIApiType.CHAT_COMPLETIONS
         if api_type is OpenAIApiType.CHAT_COMPLETIONS:
             return AzureOpenAIStreamingClient(
                 client_factory=client_factory,


### PR DESCRIPTION
Fixes #11425

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in client selection logic; risk is limited to potentially changing which OpenAI endpoint is used for a given model name.
> 
> **Overview**
> Ensures builtin `OPENAI` and `AZURE_OPENAI` playground client selection **overrides** `openai_api_type` based on the chosen `model_name`, forcing known models onto `OpenAIApiType.RESPONSES` or `OpenAIApiType.CHAT_COMPLETIONS`.
> 
> This prevents mismatches where a model that only supports one OpenAI surface would be routed to the wrong streaming client (`*StreamingClient` vs `*ResponsesAPIStreamingClient`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1590ad49ad97f6de5b643260338b0a0c23ccd05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->