### PR TITLE
fix: Ensure model config dialog scrolls when screen height is constrained

### DIFF
--- a/app/src/components/playground/model/ModelParametersConfigButton.tsx
+++ b/app/src/components/playground/model/ModelParametersConfigButton.tsx
@@ -3,7 +3,6 @@ import { css } from "@emotion/react";
 
 import {
   Button,
-  Dialog,
   DialogTrigger,
   Flex,
   Icon,
@@ -136,81 +135,84 @@ export function ModelParametersConfigButton(
         aria-label="Configure model parameters"
         leadingVisual={<Icon svg={<Icons.OptionsOutline />} />}
       />
-      <Popover>
+      <Popover
+        css={css`
+          overflow: auto;
+          overscroll-behavior: none;
+        `}
+      >
         <PopoverArrow />
-        <Dialog>
-          <View padding="size-200" overflow="auto" width="400px">
-            <div css={formFieldsCSS}>
-              {/* Model name field - shown for all providers */}
-              <ModelNameConfigFormField
+        <View padding="size-200" minWidth="386px">
+          <div css={formFieldsCSS}>
+            {/* Model name field - shown for all providers */}
+            <ModelNameConfigFormField
+              playgroundInstanceId={playgroundInstanceId}
+            />
+
+            {/* OpenAI / Azure API type - built-in only: editable when ephemeral routing enabled, fixed default when disabled */}
+            {canConfigureOpenAIApiType && (
+              <OpenAIApiTypeConfigFormField
+                playgroundInstanceId={playgroundInstanceId}
+                displayDefaultOnly={disableEphemeralRouting}
+              />
+            )}
+
+            {/* Custom provider info - shown when a custom provider is selected */}
+            {customProvider && (
+              <Flex direction="column" gap="size-50">
+                <Text weight="heavy" size="S" color="text-700">
+                  Custom Provider
+                </Text>
+                <Text size="S">{customProvider.name}</Text>
+              </Flex>
+            )}
+
+            {/* OpenAI / Ollama specific fields */}
+            {showBaseUrl && (
+              <BaseUrlConfigFormField
                 playgroundInstanceId={playgroundInstanceId}
               />
+            )}
 
-              {/* OpenAI / Azure API type - built-in only: editable when ephemeral routing enabled, fixed default when disabled */}
-              {canConfigureOpenAIApiType && (
-                <OpenAIApiTypeConfigFormField
-                  playgroundInstanceId={playgroundInstanceId}
-                  displayDefaultOnly={disableEphemeralRouting}
-                />
-              )}
+            {/* Azure OpenAI specific fields */}
+            {showAzureFields && (
+              <EndpointConfigFormField
+                playgroundInstanceId={playgroundInstanceId}
+              />
+            )}
+            {showEnvVarInfo && canConfigureAzureFields && (
+              <EnvVarRoutingInfo
+                label="Endpoint"
+                envVarName="AZURE_OPENAI_ENDPOINT"
+              />
+            )}
 
-              {/* Custom provider info - shown when a custom provider is selected */}
-              {customProvider && (
-                <Flex direction="column" gap="size-50">
-                  <Text weight="heavy" size="S" color="text-700">
-                    Custom Provider
-                  </Text>
-                  <Text size="S">{customProvider.name}</Text>
-                </Flex>
-              )}
+            {/* AWS Bedrock specific fields */}
+            {showRegion && (
+              <AWSRegionConfigFormField
+                playgroundInstanceId={playgroundInstanceId}
+              />
+            )}
+            {showEnvVarInfo && canConfigureRegion && (
+              <EnvVarRoutingInfo label="Region" envVarName="AWS_REGION" />
+            )}
 
-              {/* OpenAI / Ollama specific fields */}
-              {showBaseUrl && (
-                <BaseUrlConfigFormField
-                  playgroundInstanceId={playgroundInstanceId}
-                />
-              )}
-
-              {/* Azure OpenAI specific fields */}
-              {showAzureFields && (
-                <EndpointConfigFormField
-                  playgroundInstanceId={playgroundInstanceId}
-                />
-              )}
-              {showEnvVarInfo && canConfigureAzureFields && (
-                <EnvVarRoutingInfo
-                  label="Endpoint"
-                  envVarName="AZURE_OPENAI_ENDPOINT"
-                />
-              )}
-
-              {/* AWS Bedrock specific fields */}
-              {showRegion && (
-                <AWSRegionConfigFormField
-                  playgroundInstanceId={playgroundInstanceId}
-                />
-              )}
-              {showEnvVarInfo && canConfigureRegion && (
-                <EnvVarRoutingInfo label="Region" envVarName="AWS_REGION" />
-              )}
-
-              <Suspense>
-                <ModelInvocationParametersFormFields
-                  playgroundInstanceId={playgroundInstanceId}
-                />
-              </Suspense>
-            </div>
-          </View>
-          <View padding="size-100" borderTopColor="dark" borderTopWidth="thin">
-            <SaveModelConfigButton
-              playgroundInstanceId={playgroundInstanceId}
-              variant="quiet"
-              style={{
-                width: "100%",
-              }}
-            />
-          </View>
-        </Dialog>
+            <Suspense>
+              <ModelInvocationParametersFormFields
+                playgroundInstanceId={playgroundInstanceId}
+              />
+            </Suspense>
+          </div>
+        </View>
+        <View padding="size-100" borderTopColor="dark" borderTopWidth="thin">
+          <SaveModelConfigButton
+            playgroundInstanceId={playgroundInstanceId}
+            variant="quiet"
+            style={{
+              width: "100%",
+            }}
+          />
+        </View>
       </Popover>
     </DialogTrigger>
   );

--- a/app/src/pages/playground/PlaygroundTemplate.tsx
+++ b/app/src/pages/playground/PlaygroundTemplate.tsx
@@ -152,8 +152,6 @@ export function PlaygroundTemplate(props: PlaygroundTemplateProps) {
           </Suspense>
           <CompositeField>
             <PlaygroundModelMenu playgroundInstanceId={instanceId} />
-            {/* Un-comment this to get legacy behavior for cross-checking */}
-            {/* <ModelConfigButton {...props} /> */}
             <ModelParametersConfigButton
               playgroundInstanceId={instanceId}
               disableEphemeralRouting={props.disableEphemeralRouting}


### PR DESCRIPTION


https://github.com/user-attachments/assets/25208531-4911-4f3b-9be5-aa3a0dc79a4c



- Remove extraneous dialog within model config popover
- Add overflow and remove overscroll to popover

Resolves #11423 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout/scroll behavior changes with minimal logic impact; low risk aside from potential minor popover styling/regression.
> 
> **Overview**
> Fixes the model parameters configuration UI so it remains usable on short viewports.
> 
> `ModelParametersConfigButton` removes the extra nested `Dialog` wrapper inside the `Popover` and applies `overflow: auto` plus `overscroll-behavior: none` on the popover to ensure its contents scroll instead of clipping. `PlaygroundTemplate` drops a leftover commented legacy config button reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21610b4218709466c95182550566abf057b8d629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->