### PR TITLE
ci: update `make install-python` command use `uv` sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,7 @@ check-tools: ## Verify required tools are installed
 
 install-python: ## Install Python dependencies
 	@echo -e "$(CYAN)Installing Python dependencies...$(NC)"
-	@$(UV) venv --python 3.10
-	@$(UV) pip install -e ".[dev]"
+	@$(UV) sync --python 3.10
 	@echo -e "$(GREEN)✓ Done$(NC)"
 
 install-node: ## Install Node.js dependencies


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Makefile command change; risk is limited to Python dependency installation behavior (e.g., venv creation/editable installs) differing from the previous approach.
> 
> **Overview**
> Updates the `Makefile`’s `install-python` target to use `uv sync --python 3.10` instead of creating a venv and doing an editable `pip install -e ".[dev]"`, aligning local/CI installs with uv’s lockfile-driven workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2daedb0cdea7cdd50b8a248a8a2d94fdb378300b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->