### PR TITLE
feat: center evaluator details layout

### DIFF
--- a/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails.tsx
@@ -4,7 +4,7 @@ import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 import { css } from "@emotion/react";
 
-import { Flex, Heading, Text, View } from "@phoenix/components";
+import { Flex, Heading, Text } from "@phoenix/components";
 import { EditBuiltInDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditBuiltInDatasetEvaluatorSlideover";
 import { ContainsEvaluatorCodeBlock } from "@phoenix/components/evaluators/ContainsEvaluatorCodeBlock";
 import { ContainsEvaluatorDetails } from "@phoenix/components/evaluators/ContainsEvaluatorDetails";
@@ -228,19 +228,17 @@ export function BuiltInDatasetEvaluatorDetails({
 
   return (
     <>
-      <View padding="size-200" overflow="auto" maxWidth={1000}>
-        <Flex direction="column" gap="size-200">
-          <Section title="Input Mapping">
-            <DetailsComponent inputMapping={inputMapping} />
-          </Section>
-          <OutputConfigsSection configs={outputConfigs} />
-          {name === "json_distance" ? (
-            <JSONDistanceEvaluatorCodeBlock parseStrings={parseStrings} />
-          ) : (
-            <CodeBlockComponent />
-          )}
-        </Flex>
-      </View>
+      <Flex direction="column" gap="size-200">
+        <Section title="Input Mapping">
+          <DetailsComponent inputMapping={inputMapping} />
+        </Section>
+        <OutputConfigsSection configs={outputConfigs} />
+        {name === "json_distance" ? (
+          <JSONDistanceEvaluatorCodeBlock parseStrings={parseStrings} />
+        ) : (
+          <CodeBlockComponent />
+        )}
+      </Flex>
       <EditBuiltInDatasetEvaluatorSlideover
         datasetEvaluatorId={datasetEvaluator.id}
         datasetId={datasetId}

--- a/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
+++ b/app/src/pages/dataset/evaluators/DatasetEvaluatorDetailsPage.tsx
@@ -6,6 +6,7 @@ import { css } from "@emotion/react";
 
 import {
   Button,
+  Flex,
   Icon,
   Icons,
   LazyTabPanel,
@@ -14,6 +15,7 @@ import {
   Tab,
   TabList,
   Tabs,
+  View,
 } from "@phoenix/components";
 import { datasetEvaluatorDetailsLoaderQuery } from "@phoenix/pages/dataset/evaluators/__generated__/datasetEvaluatorDetailsLoaderQuery.graphql";
 import { BuiltInDatasetEvaluatorDetails } from "@phoenix/pages/dataset/evaluators/BuiltInDatasetEvaluatorDetails";
@@ -91,22 +93,34 @@ function DatasetEvaluatorDetailsPageContent({
           <Tab id="spans">Spans</Tab>
         </TabList>
         <LazyTabPanel id="configuration">
-          {isLLMEvaluator && (
-            <LLMDatasetEvaluatorDetails
-              datasetEvaluatorRef={datasetEvaluator}
-              datasetId={datasetId}
-              isEditSlideoverOpen={isEditSlideoverOpen}
-              onEditSlideoverOpenChange={setIsEditSlideoverOpen}
-            />
-          )}
-          {isBuiltInEvaluator && (
-            <BuiltInDatasetEvaluatorDetails
-              datasetEvaluatorRef={datasetEvaluator}
-              datasetId={datasetId}
-              isEditSlideoverOpen={isEditSlideoverOpen}
-              onEditSlideoverOpenChange={setIsEditSlideoverOpen}
-            />
-          )}
+          <View width="100%" overflow="auto" height="100%">
+            <View padding="size-200">
+              <Flex
+                direction="column"
+                gap="size-300"
+                maxWidth={1000}
+                marginStart="auto"
+                marginEnd="auto"
+              >
+                {isLLMEvaluator && (
+                  <LLMDatasetEvaluatorDetails
+                    datasetEvaluatorRef={datasetEvaluator}
+                    datasetId={datasetId}
+                    isEditSlideoverOpen={isEditSlideoverOpen}
+                    onEditSlideoverOpenChange={setIsEditSlideoverOpen}
+                  />
+                )}
+                {isBuiltInEvaluator && (
+                  <BuiltInDatasetEvaluatorDetails
+                    datasetEvaluatorRef={datasetEvaluator}
+                    datasetId={datasetId}
+                    isEditSlideoverOpen={isEditSlideoverOpen}
+                    onEditSlideoverOpenChange={setIsEditSlideoverOpen}
+                  />
+                )}
+              </Flex>
+            </View>
+          </View>
         </LazyTabPanel>
         <LazyTabPanel id="spans">
           <DatasetEvaluatorSpans projectRef={datasetEvaluator.project} />

--- a/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
+++ b/app/src/pages/dataset/evaluators/LLMDatasetEvaluatorDetails.tsx
@@ -3,7 +3,7 @@ import { useRevalidator } from "react-router";
 import { graphql } from "relay-runtime";
 import { css } from "@emotion/react";
 
-import { Flex, Heading, Text, View } from "@phoenix/components";
+import { Flex, Heading, Text } from "@phoenix/components";
 import { EditLLMDatasetEvaluatorSlideover } from "@phoenix/components/dataset/EditLLMDatasetEvaluatorSlideover";
 import { inferIncludeExplanationFromPrompt } from "@phoenix/components/evaluators/utils";
 import { PromptChatMessages } from "@phoenix/components/prompt/PromptChatMessagesCard";
@@ -84,76 +84,74 @@ export function LLMDatasetEvaluatorDetails({
 
   return (
     <>
-      <View padding="size-200" overflow="auto" maxWidth={1000}>
-        <Flex direction="column" gap="size-300">
-          {datasetEvaluator.outputConfigs &&
-            datasetEvaluator.outputConfigs.length > 0 &&
-            (() => {
-              const outputConfig = datasetEvaluator.outputConfigs[0];
-              return (
-                <Flex direction="column" gap="size-100">
-                  <Heading level={2}>Evaluator Annotation</Heading>
-                  <div
-                    css={css`
-                      background-color: var(--ac-global-background-color-dark);
-                      border-radius: var(--ac-global-rounding-medium);
-                      padding: var(--ac-global-dimension-static-size-200);
-                      margin-top: var(--ac-global-dimension-static-size-50);
-                      border: 1px solid var(--ac-global-border-color-default);
-                    `}
-                  >
-                    <Flex direction="column" gap="size-100">
+      <Flex direction="column" gap="size-300">
+        {datasetEvaluator.outputConfigs &&
+          datasetEvaluator.outputConfigs.length > 0 &&
+          (() => {
+            const outputConfig = datasetEvaluator.outputConfigs[0];
+            return (
+              <Flex direction="column" gap="size-100">
+                <Heading level={2}>Evaluator Annotation</Heading>
+                <div
+                  css={css`
+                    background-color: var(--ac-global-background-color-dark);
+                    border-radius: var(--ac-global-rounding-medium);
+                    padding: var(--ac-global-dimension-static-size-200);
+                    margin-top: var(--ac-global-dimension-static-size-50);
+                    border: 1px solid var(--ac-global-border-color-default);
+                  `}
+                >
+                  <Flex direction="column" gap="size-100">
+                    <Text size="S">
+                      <Text weight="heavy">Name:</Text> {outputConfig.name}
+                    </Text>
+                    {outputConfig.optimizationDirection && (
                       <Text size="S">
-                        <Text weight="heavy">Name:</Text> {outputConfig.name}
+                        <Text weight="heavy">Optimization Direction:</Text>{" "}
+                        {outputConfig.optimizationDirection}
                       </Text>
-                      {outputConfig.optimizationDirection && (
-                        <Text size="S">
-                          <Text weight="heavy">Optimization Direction:</Text>{" "}
-                          {outputConfig.optimizationDirection}
+                    )}
+                    {outputConfig.values &&
+                      outputConfig.values.length > 0 && (
+                        <Text>
+                          <Text size="S" weight="heavy">
+                            Values:{" "}
+                          </Text>
+                          {outputConfig.values.map((v, valIdx, arr) => (
+                            <Text key={valIdx} size="S">
+                              {v.label}
+                              {v.score != null ? ` (${v.score})` : ""}
+                              {valIdx < arr.length - 1 ? ", " : ""}
+                            </Text>
+                          ))}
                         </Text>
                       )}
-                      {outputConfig.values &&
-                        outputConfig.values.length > 0 && (
-                          <Text>
-                            <Text size="S" weight="heavy">
-                              Values:{" "}
-                            </Text>
-                            {outputConfig.values.map((v, valIdx, arr) => (
-                              <Text key={valIdx} size="S">
-                                {v.label}
-                                {v.score != null ? ` (${v.score})` : ""}
-                                {valIdx < arr.length - 1 ? ", " : ""}
-                              </Text>
-                            ))}
-                          </Text>
-                        )}
-                      <Text size="S">
-                        <Text weight="heavy">Explanations:</Text>{" "}
-                        {includeExplanation ? "Enabled" : "Disabled"}
-                      </Text>
-                    </Flex>
-                  </div>
-                </Flex>
-              );
-            })()}
-          <Flex direction="column" gap="size-100">
-            <Flex justifyContent="space-between">
-              <Heading level={2}>Prompt</Heading>
-              {evaluator.prompt?.id && evaluator.prompt?.name && (
-                <PromptLink
-                  promptId={evaluator.prompt.id}
-                  promptName={evaluator.prompt.name}
-                  promptVersionTag={evaluator.promptVersionTag?.name}
-                />
-              )}
-            </Flex>
-            {evaluator.promptVersion && (
-              <PromptChatMessages promptVersion={evaluator.promptVersion} />
+                    <Text size="S">
+                      <Text weight="heavy">Explanations:</Text>{" "}
+                      {includeExplanation ? "Enabled" : "Disabled"}
+                    </Text>
+                  </Flex>
+                </div>
+              </Flex>
+            );
+          })()}
+        <Flex direction="column" gap="size-100">
+          <Flex justifyContent="space-between">
+            <Heading level={2}>Prompt</Heading>
+            {evaluator.prompt?.id && evaluator.prompt?.name && (
+              <PromptLink
+                promptId={evaluator.prompt.id}
+                promptName={evaluator.prompt.name}
+                promptVersionTag={evaluator.promptVersionTag?.name}
+              />
             )}
           </Flex>
-          <LLMEvaluatorInputMapping inputMapping={inputMapping} />
+          {evaluator.promptVersion && (
+            <PromptChatMessages promptVersion={evaluator.promptVersion} />
+          )}
         </Flex>
-      </View>
+        <LLMEvaluatorInputMapping inputMapping={inputMapping} />
+      </Flex>
       <EditLLMDatasetEvaluatorSlideover
         datasetEvaluatorId={datasetEvaluator.id}
         datasetId={datasetId}


### PR DESCRIPTION
Summary
- wrap the evaluator details tab content in a centered container with padding and max-width, so both prompt and built-in views match the prompt details page alignment
- drop redundant View wrappers inside the built-in and LLM evaluator details components, keeping only the new shared layout and preserving existing slideover hooks

Testing
- Not run (not requested)