### PR TITLE
ci: change uvx to uv run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           python-version: "3.10"
           version: "0.9.18"
-      - run: uvx hatch build
-      - run: uvx check-wheel-contents dist/*.whl
-      - run: uvx twine upload --skip-existing --verbose dist/*
+      - run: uv run hatch build
+      - run: uv run check-wheel-contents dist/*.whl
+      - run: uv run twine upload --skip-existing --verbose dist/*
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
       - name: Build distribution
         run: rm -rf dist && uv run hatch build
       - name: Check wheel contents
-        run: uvx check-wheel-contents --ignore W004 dist/*.whl
+        run: uv run check-wheel-contents --ignore W004 dist/*.whl
       - uses: pypa/gh-action-pypi-publish@release/v1
       - uses: slackapi/slack-github-action@v1
         if: failure()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only command wrapper change; main risk is altered tool invocation potentially impacting release/publish steps if behavior differs between `uvx` and `uv run`.
> 
> **Overview**
> The release GitHub Actions workflow now runs build, wheel-content verification, and PyPI upload steps via `uv run` rather than `uvx` in both the package and Phoenix publish jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21132773ed39037065814284a0b70fceee241903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->