### PR TITLE
feat: Make Phoenix gRPC port configurable via env or flag

### DIFF
--- a/tests/unit/server/test_main.py
+++ b/tests/unit/server/test_main.py
@@ -1,0 +1,15 @@
+from argparse import Namespace
+
+from phoenix.server.main import _resolve_grpc_port
+
+
+def test_resolve_grpc_port_uses_cli_flag(monkeypatch) -> None:
+    monkeypatch.setenv("PHOENIX_GRPC_PORT", "4318")
+
+    assert _resolve_grpc_port(Namespace(grpc_port=9000)) == 9000
+
+
+def test_resolve_grpc_port_uses_env_when_cli_flag_missing(monkeypatch) -> None:
+    monkeypatch.setenv("PHOENIX_GRPC_PORT", "4318")
+
+    assert _resolve_grpc_port(Namespace(grpc_port=None)) == 4318


### PR DESCRIPTION
Summary
- read gRPC port from `--grpc-port` flag with environment fallback when starting the server and pass it into the lifecycle and gRPC server
- update `GrpcServer` to accept the resolved port explicitly instead of hardcoding the env lookup
- add unit tests to verify `_resolve_grpc_port` prefers the CLI flag over `PHOENIX_GRPC_PORT`

Testing
- Not run (not requested)