### PR TITLE
feat: Render session chat using dynamic markdown content

### DIFF
--- a/app/src/pages/trace/SessionDetailsTraceList.tsx
+++ b/app/src/pages/trace/SessionDetailsTraceList.tsx
@@ -172,14 +172,8 @@ function RootSpanDetails({
 function RootSpanInputOutput({ rootSpan }: RootSpanProps) {
   return (
     <Flex direction={"column"} gap={"size-100"}>
-      <RootSpanMessage
-        role={"HUMAN"}
-        value={rootSpan.input?.value}
-      />
-      <RootSpanMessage
-        role={"AI"}
-        value={rootSpan.output?.value}
-      />
+      <RootSpanMessage role={"HUMAN"} value={rootSpan.input?.value} />
+      <RootSpanMessage role={"AI"} value={rootSpan.output?.value} />
     </Flex>
   );
 }


### PR DESCRIPTION
Summary
- switch the session trace list to use the shared `DynamicContent` helper for human/AI messages so JSON vs text rendering is handled consistently
- drop the old MIME type parsing logic now covered by the reusable component

Testing
- Not run (not requested)