### PR TITLE
chore: link opencode skills to .agents source

### DIFF
--- a/.opencode/skills/mintlify
+++ b/.opencode/skills/mintlify
@@ -1,0 +1,1 @@
+../../.agents/skills/mintlify

--- a/.opencode/skills/phoenix-playwright-tests
+++ b/.opencode/skills/phoenix-playwright-tests
@@ -1,0 +1,1 @@
+../../.agents/skills/phoenix-playwright-tests

--- a/.opencode/skills/phoenix-skill-development
+++ b/.opencode/skills/phoenix-skill-development
@@ -1,0 +1,1 @@
+../../.agents/skills/phoenix-skill-development

--- a/.opencode/skills/rewrite-as-clean-branch.md
+++ b/.opencode/skills/rewrite-as-clean-branch.md
@@ -1,0 +1,1 @@
+../../.agents/skills/rewrite-as-clean-branch.md

--- a/.opencode/skills/vercel-react-best-practices
+++ b/.opencode/skills/vercel-react-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/vercel-react-best-practices


### PR DESCRIPTION

<img width="1294" height="966" alt="Screenshot 2026-02-17 at 10 25 39 AM" src="https://github.com/user-attachments/assets/c3884bd8-bc41-4284-85c5-cbeafdb5c2ea" />
## Summary
- add .opencode/skills symlinks that point to .agents/skills
- keep .agents/skills as the source of truth for skill content