### PR TITLE
docs: make Phoenix/Arize AX disambiguation note actionable

### DIFF
--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 ---
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -8,7 +8,7 @@ A trace is a record of a single run of your application, broken down into spans 
 In this guide, you'll set up tracing in Phoenix Cloud and instrument an application: we'll create a Phoenix Cloud instance, build a simple agent, and send a single trace so you can see the full flow end to end.
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/quickstart.mdx
+++ b/docs/phoenix/quickstart.mdx
@@ -4,7 +4,7 @@ description: "Not sure where to start? Try a quickstart:"
 ---
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -4,7 +4,7 @@ description: "Lightweight Python packages for tracing, evaluation, and platform 
 ---
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
@@ -5,7 +5,7 @@ description: "Configure tracing for your application"
 ---
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -4,7 +4,7 @@ description: "Configure OpenTelemetry tracing with Phoenix-aware defaults"
 ---
 
 <Note>
-This page covers **Phoenix**, the open-source observability platform. Looking for the **Arize AX** cloud platform instead? See the [Arize AX docs](https://docs.arize.com/arize).
+Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
 </Note>
 
 <div style={{display: 'none'}}>


### PR DESCRIPTION
## Summary

Updates the visible `<Note>` on 6 Phoenix doc pages to be more direct and actionable for both humans and AI agents:

**Before:**
> This page covers Phoenix (open-source). Looking for the Arize AX cloud platform instead? See the Arize AX docs.

**After:**
> Arize offers two observability products. This page is for Phoenix (open-source). Before implementing, confirm which product you need: Phoenix (`phoenix.otel`) or Arize AX (`arize.otel`). See the Arize AX docs if you need AX.

The hidden agent instruction `<div>` remains unchanged.

### Pages updated
- `docs/phoenix/get-started.mdx`
- `docs/phoenix/get-started/get-started-tracing.mdx`
- `docs/phoenix/quickstart.mdx`
- `docs/phoenix/sdk-api-reference.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx`

## Test plan
- [ ] Verify the updated Note renders correctly on each page
- [ ] Test with an AI agent: ask it to "implement Arize tracing" using one of these pages and confirm it asks which product

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy updates to a repeated note block; no product logic or APIs changed, with minimal risk beyond potential wording/rendering issues.
> 
> **Overview**
> Updates the visible `<Note>` banner across six Phoenix documentation pages to make Phoenix vs Arize AX disambiguation more actionable, explicitly naming the two SDK namespaces (`phoenix.otel` vs `arize.otel`) and prompting readers to confirm the intended product before implementing.
> 
> The hidden AI-agent instruction block remains unchanged; only the user-facing note text is rewritten for clarity and consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c3486eef890f0ca44379317f014d44a66391102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->