### PR TITLE
fix: Update all-platforms test schedule

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -35,12 +35,6 @@ jobs:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
         py: ["3.10", "3.13"]
         os: [windows-latest, macos-latest]
-        db: [sqlite, postgresql]
-        exclude:
-          - db: postgresql
-            os: windows-latest
-          - db: postgresql
-            os: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow tweaks (schedule and matrix reduction) with no product/runtime code changes; main risk is reduced test coverage and missed platform/DB regressions.
> 
> **Overview**
> Renames the GitHub Actions workflow from *Nightly* to `Python All Platforms` and changes its scheduled trigger from a daily run to weekdays-only at `0 19 * * 1-5`.
> 
> Simplifies the test matrix by dropping the database dimension (and its PostgreSQL install/test steps) and no longer running on the custom Linux runner, leaving only Windows and macOS runs across the configured Python versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b558cda832421481f2c76c547be4f8982df2548. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->