### PR TITLE
chore: Fix missing type annotations in test_main.py

### DIFF
--- a/tests/unit/server/test_main.py
+++ b/tests/unit/server/test_main.py
@@ -1,15 +1,17 @@
 from argparse import Namespace
 
+import pytest
+
 from phoenix.server.main import _resolve_grpc_port
 
 
-def test_resolve_grpc_port_uses_cli_flag(monkeypatch) -> None:
+def test_resolve_grpc_port_uses_cli_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_GRPC_PORT", "4318")
 
     assert _resolve_grpc_port(Namespace(grpc_port=9000)) == 9000
 
 
-def test_resolve_grpc_port_uses_env_when_cli_flag_missing(monkeypatch) -> None:
+def test_resolve_grpc_port_uses_env_when_cli_flag_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHOENIX_GRPC_PORT", "4318")
 
     assert _resolve_grpc_port(Namespace(grpc_port=None)) == 4318


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only typing changes with no production code or behavior changes.
> 
> **Overview**
> Adds missing type annotations to `tests/unit/server/test_main.py` by importing `pytest` and annotating the `monkeypatch` fixture parameters as `pytest.MonkeyPatch` in the `_resolve_grpc_port` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a400e8d5faa3ae51e88ff9e7c2ebea25d05e5253. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->