### PR TITLE
ci: move non-linux integration tests to cron job

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -521,10 +521,7 @@ jobs:
       matrix:
         py: ["3.10", "3.13"]
         db: [sqlite, postgresql]
-        os: [oss-4-core-runner, windows-latest]
-        exclude:
-          - db: postgresql
-            os: windows-latest
+        os: [oss-4-core-runner]
     env:
       CI_TEST_DB_BACKEND: ${{ matrix.db }}
     services:
@@ -567,7 +564,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n auto
+        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }})

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -25,7 +25,7 @@ jobs:
           branches=$(gh api repos/${{ github.repository }}/branches --paginate | jq -c -s '[.[][] | select(.name == "main" or (.name | startswith("version-"))) | .name]')
           echo "branches=$branches" >> $GITHUB_OUTPUT
 
-  unit-tests-all-platforms:
+  unit-tests-non-linux:
     name: Unit Tests (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.db }}, ${{ matrix.py }})
     runs-on: ${{ matrix.os }}
     needs: discover-branches
@@ -73,10 +73,51 @@ jobs:
         timeout-minutes: 60
         run: uvx tox run -e unit_tests -- -ra --reruns 5 --db postgresql -n 4 --dist loadscope
 
+  integration-tests-non-linux:
+    name: Integration Tests (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.py }})
+    runs-on: ${{ matrix.os }}
+    needs: discover-branches
+    if: ${{ needs.discover-branches.outputs.branches != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
+        py: ["3.10", "3.13"]
+        os: [windows-latest, macos-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          sparse-checkout: |
+            requirements/
+            src/phoenix/
+            packages/phoenix-client/
+            tests/integration/
+            tests/__generated__/
+            tests/__init__.py
+      - name: Set up Python ${{ matrix.py }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Set up `uv`
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            requirements/ci.txt
+            requirements/integration-tests.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run integration tests
+        timeout-minutes: 30
+        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
+  
   slack-notification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [discover-branches, unit-tests-all-platforms]
+    needs: [discover-branches, unit-tests-non-linux, integration-tests-non-linux]
     if: failure()
     steps:
       - uses: slackapi/slack-github-action@v1


### PR DESCRIPTION
Move Windows integration tests out of the main CI matrix into the all-platforms workflow alongside macOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; main risk is reduced/shifted platform coverage (Windows integration tests move from PR-time to nightly) and potential changes in test runtime/flake behavior due to fixed parallelism.
> 
> **Overview**
> Removes Windows from the `python-CI.yml` integration-test matrix (leaving Linux-only) and caps test parallelism to `-n 4`.
> 
> Adds a new `integration-tests-non-linux` job to the scheduled `python-all-platforms.yml` workflow to run integration tests on Windows and macOS across `main`/`version-*` branches, and updates Slack failure notifications to depend on both the non-Linux unit and integration jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d0840ef16c629fd393a6f4333cf0ef8ea88260c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->