### PR TITLE
feat: add OpenAI web_search tool definition schema

### DIFF
--- a/app/src/pages/playground/PlaygroundTool.tsx
+++ b/app/src/pages/playground/PlaygroundTool.tsx
@@ -18,9 +18,11 @@ import {
   awsToolDefinitionJSONSchema,
   geminiToolDefinitionJSONSchema,
   openAIToolDefinitionJSONSchema,
+  openAIWebSearchToolDefinitionJSONSchema,
 } from "@phoenix/schemas";
 import { findToolChoiceName } from "@phoenix/schemas/toolChoiceSchemas";
 import { Tool } from "@phoenix/store";
+import { isObject } from "@phoenix/typeUtils";
 
 import { getToolName } from "./playgroundUtils";
 import { PlaygroundInstanceProps } from "./types";
@@ -136,7 +138,16 @@ export function PlaygroundTool({
   const toolDefinitionJSONSchema = useMemo((): JSONSchema7 | null => {
     switch (instanceProvider) {
       case "OPENAI":
-      case "AZURE_OPENAI":
+      case "AZURE_OPENAI": {
+        const isWebSearch =
+          isObject(tool.definition) &&
+          (tool.definition as { type?: string }).type === "web_search";
+        return (
+          isWebSearch
+            ? openAIWebSearchToolDefinitionJSONSchema
+            : openAIToolDefinitionJSONSchema
+        ) as JSONSchema7;
+      }
       case "DEEPSEEK":
       case "XAI":
       case "OLLAMA":
@@ -148,7 +159,7 @@ export function PlaygroundTool({
       case "GOOGLE":
         return geminiToolDefinitionJSONSchema as JSONSchema7;
     }
-  }, [instanceProvider]);
+  }, [instanceProvider, tool.definition]);
 
   return (
     <Card

--- a/app/src/schemas/__tests__/toolSchemas.test.ts
+++ b/app/src/schemas/__tests__/toolSchemas.test.ts
@@ -154,17 +154,6 @@ describe("toolSchemas", () => {
       expect(parsed.success).toBe(true);
     });
 
-    it("should accept web_search with filters.blocked_domains only (OpenAI API alternative)", () => {
-      const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
-        type: "web_search",
-        filters: { blocked_domains: ["example.com"] },
-      });
-      expect(parsed.success).toBe(true);
-      if (parsed.success) {
-        expect(parsed.data.filters?.blocked_domains).toEqual(["example.com"]);
-      }
-    });
-
     it("should accept web_search with user_location (docs example)", () => {
       const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
         type: "web_search",

--- a/app/src/schemas/__tests__/toolSchemas.test.ts
+++ b/app/src/schemas/__tests__/toolSchemas.test.ts
@@ -154,6 +154,17 @@ describe("toolSchemas", () => {
       expect(parsed.success).toBe(true);
     });
 
+    it("should accept web_search with filters.blocked_domains only (OpenAI API alternative)", () => {
+      const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
+        type: "web_search",
+        filters: { blocked_domains: ["example.com"] },
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.filters?.blocked_domains).toEqual(["example.com"]);
+      }
+    });
+
     it("should accept web_search with user_location (docs example)", () => {
       const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
         type: "web_search",

--- a/app/src/schemas/__tests__/toolSchemas.test.ts
+++ b/app/src/schemas/__tests__/toolSchemas.test.ts
@@ -4,7 +4,9 @@ import {
   createOpenAIToolDefinition,
   detectToolDefinitionProvider,
   fromOpenAIToolDefinition,
+  llmProviderToolDefinitionSchema,
   openAIToolDefinitionSchema,
+  openAIWebSearchToolDefinitionSchema,
   toOpenAIToolDefinition,
 } from "../toolSchemas";
 
@@ -133,6 +135,46 @@ describe("toolSchemas", () => {
       const parsed = anthropicToolDefinitionSchema.safeParse(anthropicTool);
       expect(parsed.success).toBe(true);
       expect(anthropicTool.name).toBe(`new_function_${toolNumber}`);
+    });
+  });
+
+  describe("openAIWebSearchToolDefinitionSchema", () => {
+    it("should accept minimal web_search tool (docs example)", () => {
+      const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
+        type: "web_search",
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it("should accept web_search with filters.allowed_domains (docs example)", () => {
+      const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
+        type: "web_search",
+        filters: { allowed_domains: ["pubmed.ncbi.nlm.nih.gov", "who.int"] },
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it("should accept web_search with user_location (docs example)", () => {
+      const parsed = openAIWebSearchToolDefinitionSchema.safeParse({
+        type: "web_search",
+        user_location: {
+          type: "approximate",
+          country: "GB",
+          city: "London",
+          region: "London",
+        },
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.user_location?.country).toBe("GB");
+      }
+    });
+
+    it("should be accepted by llmProviderToolDefinitionSchema union", () => {
+      expect(
+        llmProviderToolDefinitionSchema.safeParse({ type: "web_search" })
+          .success
+      ).toBe(true);
     });
   });
 });

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -157,7 +157,6 @@ export const openAIWebSearchToolDefinitionSchema = z
     filters: z
       .object({
         allowed_domains: z.array(z.string()).optional(),
-        blocked_domains: z.array(z.string()).optional(),
       })
       .passthrough()
       .nullable()

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -155,11 +155,16 @@ export const openAIWebSearchToolDefinitionSchema = z
   .object({
     type: z.literal("web_search"),
     filters: z
-      .object({ allowed_domains: z.array(z.string()) })
+      .object({
+        allowed_domains: z.array(z.string()).optional(),
+        blocked_domains: z.array(z.string()).optional(),
+      })
       .passthrough()
       .nullable()
       .optional()
-      .describe("Domain allow-list (omit protocol, e.g. openai.com)."),
+      .describe(
+        "Domain allow-list and/or block-list (omit protocol, e.g. openai.com)."
+      ),
     user_location: z
       .object({
         type: z.enum(["approximate", "precise"]).optional(),

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -167,7 +167,7 @@ export const openAIWebSearchToolDefinitionSchema = z
       ),
     user_location: z
       .object({
-        type: z.enum(["approximate", "precise"]).optional(),
+        type: z.literal("approximate").optional(),
         country: z.string().optional(),
         city: z.string().optional(),
         region: z.string().optional(),

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -148,6 +148,53 @@ export type OpenAIResponsesToolDefinition = z.infer<
 >;
 
 /**
+ * The zod schema for the OpenAI Responses API built-in web_search tool.
+ * @see https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses
+ */
+export const openAIWebSearchToolDefinitionSchema = z
+  .object({
+    type: z.literal("web_search"),
+    filters: z
+      .object({ allowed_domains: z.array(z.string()) })
+      .passthrough()
+      .nullable()
+      .optional()
+      .describe("Domain allow-list (omit protocol, e.g. openai.com)."),
+    user_location: z
+      .object({
+        type: z.enum(["approximate", "precise"]).optional(),
+        country: z.string().optional(),
+        city: z.string().optional(),
+        region: z.string().optional(),
+        timezone: z.string().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional()
+      .describe("Refine results by geography (e.g. country, city)."),
+    external_web_access: z
+      .boolean()
+      .optional()
+      .describe("false = cache-only. Default true (live access)."),
+  })
+  .passthrough();
+
+/**
+ * The type of the OpenAI Responses API web_search tool definition
+ */
+export type OpenAIResponsesWebSearchToolDefinition = z.infer<
+  typeof openAIWebSearchToolDefinitionSchema
+>;
+
+/**
+ * JSON schema for the Responses API web_search tool (playground editor when tool is web_search).
+ */
+export const openAIWebSearchToolDefinitionJSONSchema = zodToJsonSchema(
+  openAIWebSearchToolDefinitionSchema,
+  { removeAdditionalStrategy: "passthrough" }
+);
+
+/**
  * The zod schema for an anthropic tool definition
  */
 export const anthropicToolDefinitionSchema = z.object({
@@ -330,6 +377,7 @@ export const llmProviderToolDefinitionSchema = z.union([
   // Responses API must come before Gemini: both have top-level name + parameters,
   // but only Responses API requires type: "function", which Gemini tools lack.
   openAIResponsesToolDefinitionSchema,
+  openAIWebSearchToolDefinitionSchema,
   anthropicToolDefinitionSchema,
   awsToolDefinitionSchema,
   geminiToolDefinitionSchema,


### PR DESCRIPTION
Closes #11548
- Introduced `openAIWebSearchToolDefinitionSchema` and its corresponding JSON schema for the OpenAI Responses API web_search tool.
- Updated `PlaygroundTool` to handle the new web_search tool type, allowing for conditional schema selection based on tool definition.
- Added tests to validate the new schema and its integration within the existing tool definitions.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and editor-selection changes only; no auth/data persistence logic changes, but could affect tool definition validation/parsing for OpenAI playground users.
> 
> **Overview**
> Adds support for OpenAI Responses API built-in `web_search` tools by introducing `openAIWebSearchToolDefinitionSchema` plus a generated JSON schema, and including it in the `llmProviderToolDefinitionSchema` union.
> 
> Updates the Playground tool editor to detect `type: "web_search"` for OpenAI/Azure OpenAI tools and switch the JSON schema used for validation/editing accordingly. Adds unit tests covering minimal and optioned `web_search` definitions and ensuring the new schema is accepted by the provider-union parser.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 711629f68016ee61cffda7cb49bb7518b5f36190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->