### PR TITLE
fix: use store-and-network fetch policy for ModelMenu query

### DIFF
--- a/app/src/components/generative/ModelMenu.tsx
+++ b/app/src/components/generative/ModelMenu.tsx
@@ -180,7 +180,8 @@ export function ModelMenu({ value, onChange }: ModelMenuProps) {
         }
       }
     `,
-    {}
+    {},
+    { fetchPolicy: "store-and-network" }
   );
 
   // Group models by provider


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized data-fetch policy change; main risk is subtle UI behavior changes due to cached data showing briefly before the network response.
> 
> **Overview**
> Updates `ModelMenu`’s Relay `useLazyLoadQuery` to use `fetchPolicy: "store-and-network"`, returning cached model/provider data immediately while also revalidating in the background to keep the menu list fresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45d507299edf82258c37aad861a8211ac9ea18dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->