### PR TITLE
fix: add sonnet 4.6 for aws model names

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -1094,6 +1094,7 @@ class OllamaStreamingClient(OpenAIBaseStreamingClient):
     model_names=[
         PROVIDER_DEFAULT,
         "anthropic.claude-opus-4-6-v1",
+        "anthropic.claude-sonnet-4-6",
         "anthropic.claude-opus-4-5-20251101-v1:0",
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "anthropic.claude-haiku-4-5-20251001-v1:0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single string-list update to model registration; low chance of impact beyond enabling selection of the new model name.
> 
> **Overview**
> Adds AWS Bedrock support for Anthropic’s `claude-sonnet-4-6` by including it in the `BedrockStreamingClient` registered `model_names` list in `playground_clients.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca07eed1f0b204b007127ae62274c95fa4d6600f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->