### PR TITLE
docs: add GTM tag to Mintlify config

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,6 +24,9 @@
   "integrations": {
     "ga4": {
       "measurementId": "G-V9Z9MCPE84"
+    },
+    "gtm": {
+      "tagId": "GTM-W96XM35"
     }
   },
   "favicon": "/docs/favicon.png",


### PR DESCRIPTION
## Summary
- Adds Google Tag Manager integration (`GTM-W96XM35`) to the Mintlify docs configuration

## Test plan
- [ ] Verify GTM tag fires correctly on docs site after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change to enable analytics tracking; no application logic or data handling code is modified.
> 
> **Overview**
> Adds Google Tag Manager support to the Mintlify `docs.json` config by introducing a new `integrations.gtm` entry with tag ID `GTM-W96XM35`, alongside the existing GA4 integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 471994b6f6da7f000824ae6b1ced52208e5c0c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->