### PR TITLE
Strengthen Playwright auth path handling

### DIFF
--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, devices, Project } from "@playwright/test";
+import path from "path";
+import { ADMIN_STORAGE_STATE_PATH } from "./tests/constants";
 
 /**
  * Read environment variables from file.
@@ -10,6 +12,7 @@ import { defineConfig, devices, Project } from "@playwright/test";
 // Skip WebKit for CI because of recurring issues with caching binaries.
 const isCI = !!process.env.CI;
 const skipWebKit = process.env.CI_PLAYWRIGHT_SKIP_WEBKIT === "true";
+const appDir = __dirname;
 
 const projects: Project[] = [
   {
@@ -20,7 +23,7 @@ const projects: Project[] = [
     name: "chromium",
     use: {
       ...devices["Desktop Chrome"],
-      storageState: "playwright/.auth/admin.json",
+      storageState: ADMIN_STORAGE_STATE_PATH,
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
@@ -30,7 +33,7 @@ const projects: Project[] = [
     name: "firefox",
     use: {
       ...devices["Desktop Firefox"],
-      storageState: "playwright/.auth/admin.json",
+      storageState: ADMIN_STORAGE_STATE_PATH,
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
@@ -43,7 +46,7 @@ if (!skipWebKit) {
     name: "webkit",
     use: {
       ...devices["Desktop Safari"],
-      storageState: "playwright/.auth/admin.json",
+      storageState: ADMIN_STORAGE_STATE_PATH,
     },
     dependencies: ["setup"],
     // The test below runs last in the 'rate limit' project so that we don't lock ourselves out
@@ -72,7 +75,7 @@ export default defineConfig({
   // Use default workers (cpu count)
   workers: undefined,
   fullyParallel: true,
-  testDir: "./tests",
+  testDir: path.resolve(appDir, "tests"),
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -96,7 +99,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm run dev:server:test",
+    command: `pnpm --dir "${appDir}" run dev:server:test`,
     url: "http://localhost:6006",
     reuseExistingServer: !isCI,
     timeout: isCI ? 240_000 : 120_000,

--- a/app/tests/auth.setup.ts
+++ b/app/tests/auth.setup.ts
@@ -1,10 +1,11 @@
 import fs from "fs/promises";
 import { expect, Page, test as setup } from "@playwright/test";
-
-const AUTH_DIR = "playwright/.auth";
-const ADMIN_STORAGE_STATE = `${AUTH_DIR}/admin.json`;
-const MEMBER_STORAGE_STATE = `${AUTH_DIR}/member.json`;
-const VIEWER_STORAGE_STATE = `${AUTH_DIR}/viewer.json`;
+import {
+  ADMIN_STORAGE_STATE_PATH,
+  AUTH_DIR,
+  MEMBER_STORAGE_STATE_PATH,
+  VIEWER_STORAGE_STATE_PATH,
+} from "./constants";
 
 async function login({
   page,
@@ -179,17 +180,17 @@ setup(
     await saveStorageStateForUser({
       email: "admin@localhost",
       password: "admin123",
-      storageStatePath: ADMIN_STORAGE_STATE,
+      storageStatePath: ADMIN_STORAGE_STATE_PATH,
     });
     await saveStorageStateForUser({
       email: "member@localhost.com",
       password: "member123",
-      storageStatePath: MEMBER_STORAGE_STATE,
+      storageStatePath: MEMBER_STORAGE_STATE_PATH,
     });
     await saveStorageStateForUser({
       email: "viewer@localhost.com",
       password: "viewer123",
-      storageStatePath: VIEWER_STORAGE_STATE,
+      storageStatePath: VIEWER_STORAGE_STATE_PATH,
     });
   }
 );

--- a/app/tests/constants.ts
+++ b/app/tests/constants.ts
@@ -1,0 +1,8 @@
+import path from "path";
+
+const APP_DIR = path.resolve(__dirname, "../..");
+
+export const AUTH_DIR = path.resolve(APP_DIR, "playwright/.auth");
+export const ADMIN_STORAGE_STATE_PATH = path.join(AUTH_DIR, "admin.json");
+export const MEMBER_STORAGE_STATE_PATH = path.join(AUTH_DIR, "member.json");
+export const VIEWER_STORAGE_STATE_PATH = path.join(AUTH_DIR, "viewer.json");

--- a/app/tests/constants.ts
+++ b/app/tests/constants.ts
@@ -1,6 +1,6 @@
 import path from "path";
 
-const APP_DIR = path.resolve(__dirname, "../..");
+const APP_DIR = path.resolve(__dirname, "..");
 
 export const AUTH_DIR = path.resolve(APP_DIR, "playwright/.auth");
 export const ADMIN_STORAGE_STATE_PATH = path.join(AUTH_DIR, "admin.json");

--- a/app/tests/member-access.spec.ts
+++ b/app/tests/member-access.spec.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { expect, test } from "@playwright/test";
+import { MEMBER_STORAGE_STATE_PATH } from "./constants";
 
-test.use({ storageState: "playwright/.auth/member.json" });
+test.use({ storageState: MEMBER_STORAGE_STATE_PATH });
 
 test("can create user key", async ({ page }) => {
   // Navigate to profile page

--- a/app/tests/viewer-access.spec.ts
+++ b/app/tests/viewer-access.spec.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { expect, test } from "@playwright/test";
+import { VIEWER_STORAGE_STATE_PATH } from "./constants";
 
-test.use({ storageState: "playwright/.auth/viewer.json" });
+test.use({ storageState: VIEWER_STORAGE_STATE_PATH });
 
 test("can create user key", async ({ page }) => {
   // Navigate to profile page


### PR DESCRIPTION
Summary
- centralize the Playwright auth constants in `app/tests/constants.ts` and expose uppercase snake case paths so all scripts reuse the same values
- make the Playwright config aware of its true directory, resolve the `tests` dir and storage state from that location, and run the dev server command via `pnpm --dir` so tests can execute from anywhere
- update `auth.setup.ts`, `member-access.spec.ts`, and `viewer-access.spec.ts` to import the shared constants instead of hard-coding paths

Testing
- Not run (not requested)