### PR TITLE
fix: Improve JSONDistanceEvaluator error messages

### DIFF
--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -2192,7 +2192,7 @@ class JSONDistanceEvaluator(BuiltInEvaluator):
                     expected: Any = expected_raw
                     actual: Any = actual_raw
 
-                    if error is None and parse_strings and isinstance(expected_raw, str):
+                    if parse_strings and isinstance(expected_raw, str):
                         try:
                             expected = json.loads(expected_raw)
                         except json.JSONDecodeError as e:


### PR DESCRIPTION
resolves #11432 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to evaluator error messaging and control flow with no new external I/O or data mutations; main risk is slight behavior change in error text/when parsing of `actual` is attempted.
> 
> **Overview**
> Improves `JSONDistanceEvaluator` JSON parsing failure handling by validating `expected` and `actual` independently and returning field-specific errors (`Invalid JSON in 'expected'` vs `Invalid JSON in 'actual'`).
> 
> When parsing fails, the evaluator now includes a more actionable explanation (including guidance to set `parse_strings=False` for non-JSON Python objects) while preserving the existing `distance=-1`/`score=None` error behavior; successful parses still compute `json_diff_count` as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e61c09ddccd9fcd1b6ca5dfa61c3f323ba5d63c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->