### PR TITLE
ci: make python-CI linux-only, move windows/macos to all-platforms

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -94,13 +94,12 @@ jobs:
 
   phoenix-client:
     name: Phoenix Client
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.phoenix_client == 'true' }}
     strategy:
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,14 +116,13 @@ jobs:
 
   phoenix-evals:
     name: Phoenix Evals
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.phoenix_evals == 'true' }}
     strategy:
       fail-fast: false
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -141,13 +139,12 @@ jobs:
 
   phoenix-otel:
     name: Phoenix OTel
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.phoenix_otel == 'true' }}
     strategy:
       matrix:
         py: [3.9, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -114,10 +114,85 @@ jobs:
         timeout-minutes: 30
         run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 4
   
+  phoenix-client-non-linux:
+    name: Phoenix Client (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.py }})
+    runs-on: ${{ matrix.os }}
+    needs: discover-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
+        py: [3.9, 3.12]
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          sparse-checkout: |
+            requirements/
+            packages/phoenix-client/
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+      - run: uvx tox run -e phoenix_client -- -ra -x
+
+  phoenix-evals-non-linux:
+    name: Phoenix Evals (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.py }})
+    runs-on: ${{ matrix.os }}
+    needs: discover-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
+        py: [3.9, 3.12]
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          sparse-checkout: |
+            requirements/
+            packages/phoenix-evals/
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+      - run: uvx tox run -e phoenix_evals -- -ra -x
+
+  phoenix-otel-non-linux:
+    name: Phoenix OTel (${{ matrix.branch }}, ${{ matrix.os }}, ${{ matrix.py }})
+    runs-on: ${{ matrix.os }}
+    needs: discover-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
+        py: [3.9, 3.12]
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          sparse-checkout: |
+            requirements/
+            packages/phoenix-otel/
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+      - run: uvx tox run -e phoenix_otel -- -ra -x
+
   slack-notification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [discover-branches, unit-tests-non-linux, integration-tests-non-linux]
+    needs: [discover-branches, unit-tests-non-linux, integration-tests-non-linux, phoenix-client-non-linux, phoenix-evals-non-linux, phoenix-otel-non-linux]
     if: failure()
     steps:
       - uses: slackapi/slack-github-action@v1


### PR DESCRIPTION
Move phoenix-client, phoenix-evals, and phoenix-otel jobs off the windows/macos matrix in python-CI.yml. Add corresponding non-linux variants to python-all-platforms.yml so they still run on the nightly schedule across all maintained branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow-only changes that shift when/where tests run; main risk is reduced non-Linux signal on PRs if nightly coverage is missed or delayed.
> 
> **Overview**
> `python-CI.yml` now runs `phoenix-client`, `phoenix-evals`, and `phoenix-otel` tox jobs on `ubuntu-latest` only, removing the Windows/macOS matrix from PR/push CI.
> 
> `python-all-platforms.yml` adds new `*-non-linux` jobs for those three packages to run on Windows and macOS (Python 3.9/3.12) across `main` and `version-*` branches, and updates the Slack failure notification to wait on these jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 015ee3b6faafcb42d9b86f7fb509d856bfbb4684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->