### PR TITLE
ci: remove macos for integration tests

### DIFF
--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
         py: ["3.10", "3.13"]
-        os: [windows-latest, macos-latest]
+        os: [windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It's timing out at 30 minutes for unknown reasons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that reduces platform coverage for integration tests but does not affect runtime code or production behavior.
> 
> **Overview**
> Removes macOS from the OS matrix for `integration-tests-non-linux` in `.github/workflows/python-all-platforms.yml`, so integration tests now run only on `windows-latest` for the nightly all-platforms workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f1748b18c825a2ac4c2468e75372247cec568e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->