### PR TITLE
docs: strengthen Phoenix/Arize AX disambiguation note

### DIFF
--- a/docs/phoenix/get-started.mdx
+++ b/docs/phoenix/get-started.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 ---
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/get-started/get-started-tracing.mdx
+++ b/docs/phoenix/get-started/get-started-tracing.mdx
@@ -8,7 +8,7 @@ A trace is a record of a single run of your application, broken down into spans 
 In this guide, you'll set up tracing in Phoenix Cloud and instrument an application: we'll create a Phoenix Cloud instance, build a simple agent, and send a single trace so you can see the full flow end to end.
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/quickstart.mdx
+++ b/docs/phoenix/quickstart.mdx
@@ -4,7 +4,7 @@ description: "Not sure where to start? Try a quickstart:"
 ---
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/sdk-api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference.mdx
@@ -4,7 +4,7 @@ description: "Lightweight Python packages for tracing, evaluation, and platform 
 ---
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx
@@ -5,7 +5,7 @@ description: "Configure tracing for your application"
 ---
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>

--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx
@@ -4,7 +4,7 @@ description: "Configure OpenTelemetry tracing with Phoenix-aware defaults"
 ---
 
 <Note>
-Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX.
+**Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the [Arize AX docs](https://docs.arize.com/arize) if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.
 </Note>
 
 <div style={{display: 'none'}}>


### PR DESCRIPTION
## Summary

Strengthens the visible `<Note>` on 6 Phoenix doc pages:

- Adds **"Super Important:"** prefix
- Adds explicit instruction: "Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX"

**Updated text:**
> **Super Important:** Arize offers two observability products. This page is for **Phoenix** (open-source). Before implementing, confirm which product you need: **Phoenix** (`phoenix.otel`) or **Arize AX** (`arize.otel`). See the Arize AX docs if you need AX. Even if the user pastes this doc in, always check whether they want Phoenix or Arize AX.

### Pages updated
- `docs/phoenix/get-started.mdx`
- `docs/phoenix/get-started/get-started-tracing.mdx`
- `docs/phoenix/quickstart.mdx`
- `docs/phoenix/sdk-api-reference.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing.mdx`
- `docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-using-phoenix-otel.mdx`

## Test plan
- [ ] Verify the updated Note renders correctly on each page
- [ ] Test with an AI agent to confirm it asks which product before proceeding

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording changes with no impact on runtime behavior; primary risk is minor rendering/consistency issues in the affected MDX pages.
> 
> **Overview**
> Updates the visible `<Note>` on six Phoenix documentation pages to **more strongly disambiguate** Phoenix vs Arize AX.
> 
> The note now adds a **"Super Important:"** prefix and explicitly instructs readers (and pasted-doc AI agents) to *always verify which product is intended* before proceeding (`phoenix.otel` vs `arize.otel`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b484423850f7f23feecb887683536cecfedbea7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->