### PR TITLE
feat(ts): add @arizeai/phoenix-logger and clean up experiment terminal output

### DIFF
--- a/js/.changeset/phoenix-client-logger-summary.md
+++ b/js/.changeset/phoenix-client-logger-summary.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Use PhoenixLogger as default logger in experiment functions, gate per-run logs behind verbose mode, add always-visible summary block with experiment and project traces URLs, export Logger and OutputMode from @arizeai/phoenix-client/experiments

--- a/js/.changeset/phoenix-config-output-mode.md
+++ b/js/.changeset/phoenix-config-output-mode.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-config": minor
+---
+
+Add PHOENIX_OUTPUT_MODE and PHOENIX_NO_PROGRESS environment variable constants

--- a/js/.changeset/phoenix-logger-initial.md
+++ b/js/.changeset/phoenix-logger-initial.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-logger": patch
+---
+
+Add new @arizeai/phoenix-logger package with Logger class supporting quiet/default/verbose output modes, TTY-aware in-place progress counter, and summary method for always-visible output

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -78,6 +78,7 @@
     "@arizeai/openinference-semantic-conventions": "^1.1.0",
     "@arizeai/openinference-vercel": "^2.7.0",
     "@arizeai/phoenix-config": "workspace:*",
+    "@arizeai/phoenix-logger": "workspace:*",
     "@arizeai/phoenix-otel": "workspace:*",
     "async": "^3.2.6",
     "openapi-fetch": "^0.12.5",

--- a/js/packages/phoenix-client/src/experiments/gatedLogger.ts
+++ b/js/packages/phoenix-client/src/experiments/gatedLogger.ts
@@ -1,0 +1,37 @@
+import { type Logger } from "../types/logger";
+
+/**
+ * Internal type for extended logger with gated methods.
+ * Supports verbose/summary methods and optional progress tracking.
+ * @internal
+ */
+export type GatedLogger = {
+  verbose(msg: string): void;
+  info(msg: string): void;
+  error(msg: string): void;
+  summary(msg: string): void;
+  startProgress?(total: number, label: string): void;
+  tickProgress?(): void;
+  stopProgress?(): void;
+};
+
+/**
+ * Wraps a Logger into a GatedLogger.
+ *
+ * If the logger has `verbose` and `summary` methods (i.e. it is a full-featured
+ * Logger class instance), use it directly — it manages verbosity internally.
+ * Otherwise (plain console or custom logger), create a wrapper where verbose is
+ * a no-op and summary delegates to info.
+ * @internal
+ */
+export function toGatedLogger(logger: Logger): GatedLogger {
+  if ("verbose" in logger && "summary" in logger) {
+    return logger as unknown as GatedLogger;
+  }
+  return {
+    verbose: () => {},
+    info: (msg) => logger.info(msg),
+    error: (msg) => logger.error(msg),
+    summary: (msg) => logger.info(msg),
+  };
+}

--- a/js/packages/phoenix-client/src/experiments/index.ts
+++ b/js/packages/phoenix-client/src/experiments/index.ts
@@ -8,3 +8,5 @@ export * from "./deleteExperiment";
 export * from "./resumeExperiment";
 export * from "./resumeEvaluation";
 export * from "./helpers";
+export { Logger } from "@arizeai/phoenix-logger";
+export type { OutputMode } from "@arizeai/phoenix-logger";

--- a/js/packages/phoenix-client/src/utils/urlUtils.ts
+++ b/js/packages/phoenix-client/src/utils/urlUtils.ts
@@ -77,3 +77,24 @@ export function getDatasetUrl({
   const url = new URL(`datasets/${datasetId}/examples`, getWebBaseUrl(baseUrl));
   return url.toString();
 }
+
+/**
+ * Get the URL to view project traces in the Phoenix web UI
+ * @param params - The parameters for generating the project traces URL
+ * @param params.baseUrl - The base URL of the Phoenix API
+ * @param params.projectName - The name of the project
+ * @returns The URL to view the project traces
+ */
+export function getProjectTracesUrl({
+  baseUrl,
+  projectName,
+}: {
+  baseUrl: string;
+  projectName: string;
+}): string {
+  const url = new URL(
+    `projects/${encodeURIComponent(projectName)}`,
+    getWebBaseUrl(baseUrl)
+  );
+  return url.toString();
+}

--- a/js/packages/phoenix-config/src/env.ts
+++ b/js/packages/phoenix-config/src/env.ts
@@ -49,6 +49,21 @@ export const ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT";
 export const ENV_PHOENIX_API_KEY = "PHOENIX_API_KEY";
 
 /**
+ * Controls terminal output verbosity for Phoenix loggers.
+ * Accepted values: "quiet" | "default" | "verbose"
+ * @example
+ * process.env[ENV_PHOENIX_OUTPUT_MODE] = "verbose";
+ */
+export const ENV_PHOENIX_OUTPUT_MODE = "PHOENIX_OUTPUT_MODE";
+
+/**
+ * Disables TTY in-place progress when set to "1".
+ * @example
+ * process.env[ENV_PHOENIX_NO_PROGRESS] = "1";
+ */
+export const ENV_PHOENIX_NO_PROGRESS = "PHOENIX_NO_PROGRESS";
+
+/**
  * Retrieves an integer value from an environment variable.
  *
  * @param envKey - The name of the environment variable to read
@@ -147,6 +162,8 @@ export function getEnvironmentConfig() {
       ENV_PHOENIX_COLLECTOR_ENDPOINT
     ),
     [ENV_PHOENIX_API_KEY]: getStrFromEnvironment(ENV_PHOENIX_API_KEY),
+    [ENV_PHOENIX_OUTPUT_MODE]: getStrFromEnvironment(ENV_PHOENIX_OUTPUT_MODE),
+    [ENV_PHOENIX_NO_PROGRESS]: getStrFromEnvironment(ENV_PHOENIX_NO_PROGRESS),
   };
 }
 

--- a/js/packages/phoenix-logger/package.json
+++ b/js/packages/phoenix-logger/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@arizeai/phoenix-logger",
+  "version": "0.1.0",
+  "description": "Shared logger for Phoenix packages",
+  "keywords": [
+    "arize",
+    "phoenix"
+  ],
+  "homepage": "https://github.com/Arize-ai/phoenix/tree/main/js/packages/phoenix-logger",
+  "bugs": {
+    "url": "https://github.com/Arize-ai/phoenix/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "oss@arize.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Arize-ai/phoenix.git"
+  },
+  "files": [
+    "dist",
+    "src",
+    "package.json"
+  ],
+  "main": "dist/src/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build tsconfig.json tsconfig.esm.json && tsc-alias -p tsconfig.esm.json",
+    "clean": "rimraf dist",
+    "postbuild": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@arizeai/phoenix-config": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.22",
+    "vitest": "^4.0.10"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/js/packages/phoenix-logger/src/Logger.ts
+++ b/js/packages/phoenix-logger/src/Logger.ts
@@ -1,0 +1,129 @@
+import { Console } from "console";
+import {
+  ENV_PHOENIX_NO_PROGRESS,
+  ENV_PHOENIX_OUTPUT_MODE,
+  getEnvironmentConfig,
+} from "@arizeai/phoenix-config";
+
+import type { LoggerOptions, OutputMode } from "./types";
+
+const ESC = "\x1B[";
+const HIDE_CURSOR = `${ESC}?25l`;
+const SHOW_CURSOR = `${ESC}?25h`;
+
+function resolveOutputMode(mode?: OutputMode): OutputMode {
+  if (mode) return mode;
+  const env = getEnvironmentConfig()[ENV_PHOENIX_OUTPUT_MODE];
+  if (env === "quiet" || env === "default" || env === "verbose") return env;
+  return "default";
+}
+
+function resolveNoProgress(noProgress?: boolean): boolean {
+  if (noProgress !== undefined) return noProgress;
+  return getEnvironmentConfig()[ENV_PHOENIX_NO_PROGRESS] === "1";
+}
+
+export class Logger {
+  private readonly mode: OutputMode;
+  private readonly outputStream: NodeJS.WritableStream;
+  private readonly errorStream: NodeJS.WritableStream;
+  private readonly noProgress: boolean;
+  private readonly _console: Console;
+
+  private _progressTotal = 0;
+  private _progressCurrent = 0;
+  private _progressLabel = "";
+  private _progressActive = false;
+
+  constructor({
+    outputMode,
+    outputStream = process.stdout,
+    errorStream = process.stderr,
+    noProgress,
+  }: LoggerOptions = {}) {
+    this.mode = resolveOutputMode(outputMode);
+    this.outputStream = outputStream;
+    this.errorStream = errorStream;
+    this.noProgress = resolveNoProgress(noProgress);
+    this._console = new Console({
+      stdout: this.outputStream,
+      stderr: this.errorStream,
+    });
+
+    if (this.isTTY) {
+      const cleanup = () => {
+        (this.outputStream as NodeJS.WriteStream).write(SHOW_CURSOR);
+      };
+      process.once("exit", cleanup);
+      process.once("SIGINT", cleanup);
+      process.once("SIGTERM", cleanup);
+    }
+  }
+
+  get isTTY(): boolean {
+    return (
+      "isTTY" in this.outputStream &&
+      Boolean((this.outputStream as NodeJS.WriteStream).isTTY)
+    );
+  }
+
+  log(msg: string): void {
+    this.info(msg);
+  }
+
+  info(msg: string): void {
+    if (this.mode === "quiet") return;
+    this._console.log(msg);
+  }
+
+  error(msg: string): void {
+    this._console.error(msg);
+  }
+
+  verbose(msg: string): void {
+    if (this.mode !== "verbose") return;
+    this._console.log(msg);
+  }
+
+  summary(msg: string): void {
+    this._console.log(msg);
+  }
+
+  startProgress(total: number, label: string): void {
+    this._progressTotal = total;
+    this._progressCurrent = 0;
+    this._progressLabel = label;
+    this._progressActive = true;
+    if (this.isTTY && !this.noProgress) {
+      (this.outputStream as NodeJS.WriteStream).write(HIDE_CURSOR);
+    }
+  }
+
+  tickProgress(): void {
+    if (!this._progressActive) return;
+    this._progressCurrent++;
+    const n = this._progressCurrent;
+    const m = this._progressTotal;
+    const label = this._progressLabel;
+    if (this.isTTY && !this.noProgress) {
+      (this.outputStream as NodeJS.WriteStream).write(`\r[${n}/${m}] ${label}`);
+    } else {
+      // Non-TTY: milestone logs at 25/50/75/100%
+      const pct = m > 0 ? Math.round((n / m) * 100) : 100;
+      const isMilestone = n === m || pct === 25 || pct === 50 || pct === 75;
+      if (isMilestone) {
+        this._console.log(`[${label}] ${n}/${m} (${pct}%)`);
+      }
+    }
+  }
+
+  stopProgress(): void {
+    if (!this._progressActive) return;
+    this._progressActive = false;
+    if (this.isTTY && !this.noProgress) {
+      const spaces = " ".repeat(30);
+      (this.outputStream as NodeJS.WriteStream).write(`\r${spaces}\r`);
+      (this.outputStream as NodeJS.WriteStream).write(SHOW_CURSOR);
+    }
+  }
+}

--- a/js/packages/phoenix-logger/src/index.ts
+++ b/js/packages/phoenix-logger/src/index.ts
@@ -1,0 +1,2 @@
+export { Logger } from "./Logger";
+export type { OutputMode, LoggerOptions } from "./types";

--- a/js/packages/phoenix-logger/src/types.ts
+++ b/js/packages/phoenix-logger/src/types.ts
@@ -1,0 +1,8 @@
+export type OutputMode = "quiet" | "default" | "verbose";
+
+export type LoggerOptions = {
+  outputMode?: OutputMode;
+  outputStream?: NodeJS.WritableStream;
+  errorStream?: NodeJS.WritableStream;
+  noProgress?: boolean;
+};

--- a/js/packages/phoenix-logger/tsconfig.esm.json
+++ b/js/packages/phoenix-logger/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/esm/tsconfig.esm.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/js/packages/phoenix-logger/tsconfig.json
+++ b/js/packages/phoenix-logger/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"],
+    "noUncheckedIndexedAccess": true
+  },
+  "files": [],
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@arizeai/phoenix-config':
         specifier: workspace:*
         version: link:../phoenix-config
+      '@arizeai/phoenix-logger':
+        specifier: workspace:*
+        version: link:../phoenix-logger
       '@arizeai/phoenix-otel':
         specifier: workspace:*
         version: link:../phoenix-otel
@@ -303,6 +306,19 @@ importers:
       vitest:
         specifier: ^4.0.10
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(msw@2.12.10(@types/node@24.10.13)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/phoenix-logger:
+    dependencies:
+      '@arizeai/phoenix-config':
+        specifier: workspace:*
+        version: link:../phoenix-config
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.22
+        version: 20.19.33
+      vitest:
+        specifier: ^4.0.10
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   packages/phoenix-mcp:
     dependencies:


### PR DESCRIPTION
## Summary

- Add new `@arizeai/phoenix-logger` package with a `Logger` class supporting `quiet`/`default`/`verbose` output modes, TTY-aware in-place progress counter (`[N/M] label`), and a `summary()` method that is never suppressed
- Add `PHOENIX_OUTPUT_MODE` and `PHOENIX_NO_PROGRESS` env var constants to `@arizeai/phoenix-config`
- Change default logger in `runExperiment`, `resumeExperiment`, and `resumeEvaluation` from `console` to `new Logger()` — per-run logs are now gated to verbose mode by default, eliminating noise
- Remove all emojis from experiment log messages; replace with structured `[category]` prefixes (e.g. `[experiment]`, `[tasks]`, `[eval]`, `[error]`)
- Add an always-visible summary block at the end of every run with experiment URL and project traces URL (emitted via `summary()`, shown even in `quiet` mode)
- Add `getProjectTracesUrl()` to `phoenix-client` URL utilities
- Export `Logger` and `OutputMode` from `@arizeai/phoenix-client/experiments` for convenient user access

## Verbosity control

| Mode | `verbose()` | `info()` | `error()` | `summary()` |
|------|-------------|----------|-----------|-------------|
| `verbose` | ✓ | ✓ | ✓ | ✓ |
| `default` (new default) | — | ✓ | ✓ | ✓ |
| `quiet` | — | — | ✓ | ✓ |

Users can opt in to the old verbose behavior via `new Logger({ outputMode: 'verbose' })` or `PHOENIX_OUTPUT_MODE=verbose`.

## Test plan

- [ ] All existing unit tests pass (`pnpm --filter @arizeai/phoenix-client run test`)
- [ ] All packages build cleanly (`pnpm run -r build`)
- [ ] Lint passes (`pnpm --dir js run lint:fix`)
- [ ] Default run: no per-run log spam, clean summary block at end
- [ ] `new Logger({ outputMode: 'verbose' })`: per-run logs visible
- [ ] `new Logger({ outputMode: 'quiet' })`: only summary + errors shown
- [ ] TTY terminal: `[N/M]` in-place progress updates during task phase
- [ ] Non-TTY (piped output): milestone logs at 25/50/75/100%
- [ ] `PHOENIX_OUTPUT_MODE=verbose` env var respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)