### PR TITLE
fix: add gemini-3.1-pro-preview model name

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2287,6 +2287,7 @@ class Gemini25GoogleStreamingClient(GoogleStreamingClient):
 
 
 GEMINI_3_MODELS = [
+    "gemini-3.1-pro-preview",
     "gemini-3-pro-preview",
     "gemini-3-flash-preview",
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-string allowlist change to enable selecting an additional model; no behavior changes beyond model availability.
> 
> **Overview**
> Adds Google Gemini model support for `gemini-3.1-pro-preview` by including it in the `GEMINI_3_MODELS` list used to register `Gemini3GoogleStreamingClient`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5bfbf33dad9160d77fa57fd9f735e221e56f625. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->