### PR TITLE
chore(js): ignore CHANGELOG.md files in oxfmt

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -11,6 +11,7 @@
     "js/**/dist/**",
     "js/**/build/**",
     "js/docs/**",
+    "**/CHANGELOG.md",
   ],
   "experimentalSortImports": {
     "newlinesBetween": false,


### PR DESCRIPTION
## Summary
- Add `**/CHANGELOG.md` to `ignorePatterns` in `.oxfmtrc.jsonc` to exclude auto-generated changelog files from oxfmt formatting checks

## Test plan
- [ ] Verify `pnpm run fmt:check` passes in `js/` without errors on CHANGELOG.md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)