### PR TITLE
ci: implement merge gate pattern for required status checks

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -7,22 +7,34 @@ on:
     branches:
       - main
       - version-13
-    paths:
-      - "src/**"
-      - "app/**"
-      - ".github/workflows/playwright.yaml"
   pull_request:
     branches:
       - main
       - version-13
-    paths:
-      - "src/**"
-      - "app/**"
-      - ".github/workflows/playwright.yaml"
+
 jobs:
+  changes:
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - "src/**"
+              - "app/**"
+              - ".github/workflows/playwright.yaml"
+
+
   e2e-test:
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.e2e == 'true' }}
     defaults:
       run:
         working-directory: ./app
@@ -87,3 +99,23 @@ jobs:
           name: playwright-report-py${{ matrix.py }}-${{ matrix.os }}
           path: app/playwright-report/
           retention-days: 30
+
+  ci-required:
+    name: CI Required
+    needs:
+      - changes
+      - e2e-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -8,16 +8,6 @@ on:
       - main
       - version-*
   pull_request:
-    paths:
-      - "**/*.py"
-      - "**/*.ipynb"
-      - "src/**"
-      - "tests/**"
-      - "tutorials/**"
-      - "**/pyproject.toml"
-      - "packages/**"
-      - "tox.ini"
-      - "uv.lock"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -676,3 +666,39 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run canary tests for ${{ matrix.pkg }}
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
+
+  ci-required:
+    name: CI Required
+    needs:
+      - ruff
+      - changes
+      - phoenix-client
+      - phoenix-evals
+      - phoenix-otel
+      - clean-jupyter-notebooks
+      - build-graphql-schema
+      - build-openapi-schema
+      - compile-protobuf
+      - compile-prompts
+      - check-lockfile
+      - type-check
+      - type-check-unit-tests
+      - unit-tests
+      - type-check-integration-tests
+      - integration-tests
+      - test-migrations
+      - phoenix-client-canary-tests-sdk
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -7,11 +7,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - "app/**"
-      - ".oxlintrc.json"
-      - ".oxfmtrc.jsonc"
-      - ".nvmrc"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -20,9 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - "app/**"
+              - ".oxlintrc.json"
+              - ".oxfmtrc.jsonc"
+              - ".nvmrc"
+
   ci:
     name: CI Typescript
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -59,3 +73,23 @@ jobs:
         working-directory: ./app
         run: |
           pnpm run test
+
+  ci-required:
+    name: CI Required
+    needs:
+      - changes
+      - ci
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -7,12 +7,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - "js/**"
-      - "schemas/**"
-      - ".oxlintrc.json"
-      - ".oxfmtrc.jsonc"
-      - ".nvmrc"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -21,9 +15,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            packages:
+              - "js/**"
+              - "schemas/**"
+              - ".oxlintrc.json"
+              - ".oxfmtrc.jsonc"
+              - ".nvmrc"
+
   ci:
     name: CI Typescript
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.packages == 'true' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -58,3 +72,23 @@ jobs:
         working-directory: ./js
         run: |
           pnpm run lint
+
+  ci-required:
+    name: CI Required
+    needs:
+      - changes
+      - ci
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
## Summary

- Removes trigger-level `paths:` filters from `pull_request` triggers on all four CI workflows so every PR always produces a status check (previously, absent checks blocked merges under branch protection)
- Adds job-level path filtering via `dorny/paths-filter` where missing (`typescript-CI.yml`, `typescript-packages-CI.yml`, `playwright.yaml`) so individual jobs still skip when irrelevant paths haven't changed
- Adds a `ci-required` gate job to each workflow that runs `if: always()`, depends on all substantive jobs, and fails only if any job failed or was cancelled

## Gate checks to enable in branch protection

| Required Status Check | Workflow |
|---|---|
| `Python CI / CI Required` | `python-CI.yml` |
| `Typescript CI / CI Required` | `typescript-CI.yml` |
| `Typescript Packages CI / CI Required` | `typescript-packages-CI.yml` |
| `Playwright Tests / CI Required` | `playwright.yaml` |

## Branch protection setup (after merge)

**Location:** GitHub → Settings → Branches → Branch protection rules → `main` → Edit

Under **"Require status checks to pass before merging"**, enable **"Require branches to be up to date before merging"** and add these status checks by name:

```
Python CI / CI Required
Typescript CI / CI Required
Typescript Packages CI / CI Required
Playwright Tests / CI Required
```

> **Note:** GitHub's status check search only surfaces checks that have run at least once. Merge this PR first (or trigger the workflows manually), then search for the names above in the branch protection UI.

## Test plan

- [ ] Open a TypeScript-only PR → `Python CI / CI Required` appears and passes (all jobs skipped)
- [ ] Open a Python-only PR → `Typescript CI / CI Required` appears and passes (ci job skipped)
- [ ] Verify gate checks appear consistently before enabling branch protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)