### PR TITLE
fix(ui): resolve additional jsx-a11y violations

### DIFF
--- a/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCosts.tsx
@@ -36,9 +36,7 @@ export function ExperimentRepeatedRunGroupTokenCosts(
   return (
     <TooltipTrigger isDisabled={props.costTotal == null}>
       <Pressable>
-        <TokenCosts size={props.size} aria-role="button">
-          {props.costTotal}
-        </TokenCosts>
+        <TokenCosts size={props.size}>{props.costTotal}</TokenCosts>
       </Pressable>
       <RichTooltip>
         <TooltipArrow />

--- a/app/src/components/experiment/ExperimentRunTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentRunTokenCosts.tsx
@@ -34,9 +34,7 @@ export function ExperimentRunTokenCosts(props: ExperimentRunTokenCostsProps) {
   return (
     <TooltipTrigger isDisabled={props.costTotal == null}>
       <Pressable>
-        <TokenCosts size={props.size} aria-role="button">
-          {props.costTotal}
-        </TokenCosts>
+        <TokenCosts size={props.size}>{props.costTotal}</TokenCosts>
       </Pressable>
       <RichTooltip>
         <TooltipArrow />

--- a/app/src/components/generative/ModelMenu.tsx
+++ b/app/src/components/generative/ModelMenu.tsx
@@ -401,7 +401,6 @@ function ModelsByProviderMenu({
   return (
     <Menu
       css={menuWidthCSS}
-      autoFocus={false}
       onAction={(key) => {
         const modelInfo = decodeMenuKey(String(key));
         if (!modelInfo) {
@@ -536,7 +535,7 @@ function ProviderMenu({
   onChange,
 }: ProviderMenuProps) {
   return (
-    <Menu css={menuWidthCSS} autoFocus={false}>
+    <Menu css={menuWidthCSS}>
       {/* Custom providers */}
       {customProviders.map((customProvider) => {
         const providerKey = SDK_TO_PROVIDER_KEY[customProvider.sdk];

--- a/app/src/components/user/UserPicture.tsx
+++ b/app/src/components/user/UserPicture.tsx
@@ -67,7 +67,11 @@ export function UserPicture({
 
   return (
     <div css={styles} data-theme={theme}>
-      {profilePictureUrl ? <img src={profilePictureUrl} /> : firstLetter}
+      {profilePictureUrl ? (
+        <img src={profilePictureUrl} alt={`${name} profile picture`} />
+      ) : (
+        firstLetter
+      )}
     </div>
   );
 }

--- a/app/src/pages/apis/APIsPage.tsx
+++ b/app/src/pages/apis/APIsPage.tsx
@@ -44,10 +44,18 @@ export function APIsPage() {
           <Tab id="graphql">GraphQL</Tab>
         </TabList>
         <LazyTabPanel id="rest">
-          <iframe src={`${basename}/docs`} style={iframeStyle} />
+          <iframe
+            title="REST API documentation"
+            src={`${basename}/docs`}
+            style={iframeStyle}
+          />
         </LazyTabPanel>
         <LazyTabPanel id="graphql">
-          <iframe src={`${basename}/graphql`} style={iframeStyle} />
+          <iframe
+            title="GraphQL API documentation"
+            src={`${basename}/graphql`}
+            style={iframeStyle}
+          />
         </LazyTabPanel>
       </Tabs>
     </div>

--- a/app/src/pages/trace/SpanImage.tsx
+++ b/app/src/pages/trace/SpanImage.tsx
@@ -67,7 +67,7 @@ export function SpanImage(props: SpanImageProps) {
   if (isRedacted) {
     content = <RedactedImageSVG />;
   } else {
-    content = <img src={props.url} />;
+    content = <img src={props.url} alt="Span image" />;
   }
   return (
     <div


### PR DESCRIPTION
refs #11614

## Summary
Second small pass on issue #11614 to reduce a11y lint violations with low-risk, focused fixes.

## What changed
- Added missing iframe titles on APIs page
- Added missing img alt text in UserPicture and SpanImage
- Removed invalid aria-role usage from experiment token cost components
- Removed explicit autoFocus={false} props in ModelMenu

## Validation
- cd app && pnpm fmt:check
- cd app && pnpm lint
- cd app && pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only accessibility attribute changes with minimal behavioral impact (possible minor focus behavior differences in menus).
> 
> **Overview**
> Addresses additional `jsx-a11y` violations across the UI.
> 
> Adds missing accessible labels by providing `title` on the REST/GraphQL docs iframes and `alt` text on user avatar and span image `<img>` elements. Removes invalid `aria-role` usage from experiment token cost displays and drops redundant `autoFocus={false}` props from model selection menus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da09b48162ade35b2aeac06e5467ec250a8d339e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->