### PR TITLE
feat: ability to show sql in stdout

### DIFF
--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -106,17 +106,16 @@ Phoenix supports two types of database URLs:
 Note that if you plan on using SQLite, it's advised to to use a persistent volume
 and simply point the PHOENIX_WORKING_DIR to that volume.
 """
-ENV_PHOENIX_SQL_DATABASE_ECHO = "PHOENIX_SQL_DATABASE_ECHO"
+ENV_PHOENIX_LOG_SQL = "PHOENIX_LOG_SQL"
 """
-Whether to echo all SQL statements issued by SQLAlchemy to stdout.
-This is equivalent to passing ``echo=True`` to SQLAlchemy's ``create_engine()``.
+Whether to log all SQL statements to stdout.
 Useful for debugging database queries during development.
 
 Set to ``true`` to enable SQL logging, ``false`` (default) to disable it.
 
 Example::
 
-    PHOENIX_SQL_DATABASE_ECHO=true
+    PHOENIX_LOG_SQL=true
 """
 ENV_PHOENIX_POSTGRES_HOST = "PHOENIX_POSTGRES_HOST"
 """
@@ -2791,8 +2790,8 @@ def get_env_database_connection_str() -> str:
     return f"sqlite:///{working_dir}/phoenix.db"
 
 
-def get_env_database_sql_echo() -> bool:
-    return _bool_val(ENV_PHOENIX_SQL_DATABASE_ECHO, False)
+def get_env_log_sql() -> bool:
+    return _bool_val(ENV_PHOENIX_LOG_SQL, False)
 
 
 def get_env_database_schema() -> Optional[str]:

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -63,12 +63,12 @@ from phoenix.config import (
     get_env_csrf_trusted_origins,
     get_env_database_allocated_storage_capacity_gibibytes,
     get_env_database_usage_insertion_blocking_threshold_percentage,
-    get_env_database_sql_echo,
     get_env_fastapi_middleware_paths,
     get_env_gql_extension_paths,
     get_env_grpc_interceptor_paths,
     get_env_grpc_port,
     get_env_host,
+    get_env_log_sql,
     get_env_max_spans_queue_size,
     get_env_port,
     get_env_support_email,
@@ -918,7 +918,7 @@ def create_engine_and_run_migrations(
         return create_engine(
             connection_str=database_url,
             migrate=not Settings.disable_migrations,
-            log_to_stdout=get_env_database_sql_echo(),
+            log_to_stdout=get_env_log_sql(),
         )
     except PhoenixMigrationError as e:
         msg = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds an opt-in logging toggle; default behavior remains unchanged aside from potential performance/log-volume impact when explicitly enabled.
> 
> **Overview**
> Adds a new `PHOENIX_LOG_SQL` environment flag to optionally enable SQLAlchemy `echo` logging to stdout for easier database query debugging.
> 
> Wires this flag into server startup by passing `log_to_stdout=get_env_log_sql()` when creating the DB engine during `create_engine_and_run_migrations`, changing behavior from always-disabled SQL stdout logging to configurable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062d958c99b778596d65feefcd29a083f0de4da7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->