### PR TITLE
fix(app): prevent browser caching of dev server assets

### DIFF
--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -52,6 +52,11 @@ export default defineConfig(() => {
     publicDir: resolve(__dirname, "static"),
     server: {
       port: parseInt(process.env.VITE_PORT || "5173"),
+      headers: {
+        // Prevent browser caching during development to ensure fresh assets
+        // after code changes. This fixes 304 responses causing stale files.
+        "Cache-Control": "no-store",
+      },
     },
     preview: {
       port: 6006,


### PR DESCRIPTION
Add Cache-Control: no-store header to Vite dev server config to prevent browser caching during development. This fixes issues where 304 responses cause stale bundled assets to be served after code changes, requiring hard refresh to see updates.

Slack thread: https://arize-ai.slack.com/archives/C04QMRADE1L/p1771889097601239?thread_ts=1771887377.527449&cid=C04QMRADE1L

https://claude.ai/code/session_01JK1TfbV2igSjcGavGZJig1