### PR TITLE
docs: add append messages video to playground docs

### DIFF
--- a/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
+++ b/docs/phoenix/prompt-engineering/how-to-prompts/using-the-playground.mdx
@@ -86,6 +86,10 @@ You can use template variables like `{input.question}` and `{output.response}` i
 
 ## Appending Conversation History
 
+<video controls autoPlay={false} loop={false} width="100%">
+  <source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/append_messages_on_playground.mp4" type="video/mp4" />
+</video>
+
 When running experiments over datasets, you can append conversation messages from your dataset examples to the prompt. This is useful for:
 
 - **A/B testing models**: Compare how different models respond to the same conversation history

--- a/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments.mdx
+++ b/docs/phoenix/release-notes/01-2026/01-05-2026-appended-messages-for-playground-experiments.mdx
@@ -7,6 +7,10 @@ description: Available in Phoenix 13.0+
 
 ## Appended Messages for A/B Testing
 
+<video controls autoPlay={false} loop={false} width="100%">
+  <source src="https://storage.googleapis.com/arize-phoenix-assets/assets/videos/append_messages_on_playground.mp4" type="video/mp4" />
+</video>
+
 The Prompt Playground now supports appending conversation history from dataset examples to your prompts, enabling powerful A/B testing workflows for models and system prompts.
 
 ### Key Features


### PR DESCRIPTION
## Summary
- Adds a demo video showing how append messages works in the playground
- Video added to the main how-to guide (`using-the-playground.mdx`) under "Appending Conversation History"
- Video added to the Jan 2026 release notes (`01-05-2026-appended-messages-for-playground-experiments.mdx`)

## Test plan
- [ ] Verify video renders correctly on the docs site
- [ ] Confirm video plays in both the how-to guide and release notes pages