### PR TITLE
docs: add openapi spec reference to docs.json for Mintlify v2

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
+  "openapi": "docs/openapi.json",
   "theme": "mint",
   "name": "Phoenix",
   "colors": {


### PR DESCRIPTION
The `docs.json` (Mintlify v2 config) was missing the `openapi` key pointing to the OpenAPI spec file. Without this, Mintlify cannot render the API playground on pages using `openapi:` frontmatter, causing pages like `list-spans-with-simple-filters-no-dsl` to not display the interactive endpoint documentation properly.

Fixes #11708

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation-config change that only affects docs rendering; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds an `openapi` reference to `docs.json`, pointing Mintlify v2 at `docs/openapi.json` so pages that use `openapi:` frontmatter can render interactive API reference/playground content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0bd866f4c1522163bef83b18de83a5610b4f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->