### PR TITLE
chore: enable TypeScript LSP and Pyright LSP Claude plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "enabledPlugins": {
-    "github@claude-plugins-official": true
-  },
   "hooks": {
     "PostToolUse": [
       {
@@ -50,5 +47,9 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Removes `github@claude-plugins-official` plugin
- Adds `typescript-lsp@claude-plugins-official` and `pyright-lsp@claude-plugins-official` plugins to `.claude/settings.json`

## Test plan
- [ ] Verify LSP plugins work as expected in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)