### PR TITLE
fix: make name non-nullable for output configs

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -388,6 +388,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: phoenix
         options: >-
+          --name postgres
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -405,6 +406,12 @@ jobs:
             tests/integration/
             tests/__generated__/
             tests/__init__.py
+      - name: Increase PostgreSQL max_connections
+        if: matrix.db == 'postgresql'
+        run: |
+          docker exec postgres sed -i 's/^max_connections = .*/max_connections = 300/' /var/lib/postgresql/data/postgresql.conf
+          docker restart postgres
+          until docker exec postgres pg_isready -U postgres; do sleep 1; done
       - name: Set up Python ${{ matrix.py }}
         uses: actions/setup-python@v5
         with:
@@ -415,7 +422,7 @@ jobs:
           version: "0.9.18"
       - name: Run integration tests
         timeout-minutes: 30
-        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 8
+        run: uvx tox run -e integration_tests -- -ra --reruns 5 -n 16
 
   test-migrations:
     name: DB Migration Continuity (${{ matrix.db }}${{ matrix.concurrently == true && ', concurrently' || '' }})

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -58,6 +58,11 @@ from phoenix.db.types.annotation_configs import (
 )
 from phoenix.db.types.annotation_configs import (
     AnnotationConfigType,
+    CategoricalOutputConfig,
+    OutputConfigType,
+)
+from phoenix.db.types.annotation_configs import (
+    OutputConfig as OutputConfigModel,
 )
 from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
@@ -425,24 +430,54 @@ class _AnnotationConfig(TypeDecorator[AnnotationConfigType]):
         return AnnotationConfigModel.model_validate(value).root if value is not None else None
 
 
-class _AnnotationConfigList(TypeDecorator[list[AnnotationConfigType]]):
+class _OutputConfigList(TypeDecorator[list[OutputConfigType]]):
     # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
     cache_ok = True
     impl = JSON_
 
     def process_bind_param(
-        self, value: Optional[list[AnnotationConfigType]], _: Dialect
+        self, value: Optional[list[OutputConfigType]], _: Dialect
     ) -> Optional[list[dict[str, Any]]]:
         if value is None:
             return None
-        return [AnnotationConfigModel(root=config).model_dump() for config in value]
+        seen = set()
+        for config in value:
+            if config.name in seen:
+                raise ValueError(f"Duplicate name: {config.name}")
+            seen.add(config.name)
+        return [OutputConfigModel(root=config).model_dump() for config in value]
 
     def process_result_value(
         self, value: Optional[list[dict[str, Any]]], _: Dialect
-    ) -> Optional[list[AnnotationConfigType]]:
+    ) -> Optional[list[OutputConfigType]]:
         if value is None:
             return None
-        return [AnnotationConfigModel.model_validate(config).root for config in value]
+        return [OutputConfigModel.model_validate(config).root for config in value]
+
+
+class _CategoricalOutputConfigList(TypeDecorator[list[CategoricalOutputConfig]]):
+    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
+    cache_ok = True
+    impl = JSON_
+
+    def process_bind_param(
+        self, value: Optional[list[CategoricalOutputConfig]], _: Dialect
+    ) -> Optional[list[dict[str, Any]]]:
+        if value is None:
+            return None
+        seen = set()
+        for config in value:
+            if config.name in seen:
+                raise ValueError(f"Duplicate name: {config.name}")
+            seen.add(config.name)
+        return [config.model_dump() for config in value]
+
+    def process_result_value(
+        self, value: Optional[list[dict[str, Any]]], _: Dialect
+    ) -> Optional[list[CategoricalOutputConfig]]:
+        if value is None:
+            return None
+        return [CategoricalOutputConfig.model_validate(config) for config in value]
 
 
 class _TokenCustomization(TypeDecorator[TokenPriceCustomization]):
@@ -2298,8 +2333,8 @@ class LLMEvaluator(Evaluator):
         ForeignKey("prompt_version_tags.id", ondelete="SET NULL"),
         index=True,
     )
-    output_configs: Mapped[list[AnnotationConfigType]] = mapped_column(
-        _AnnotationConfigList, nullable=False
+    output_configs: Mapped[list[CategoricalOutputConfig]] = mapped_column(
+        _CategoricalOutputConfigList, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         UtcTimeStamp, server_default=func.now(), onupdate=func.now()
@@ -2367,8 +2402,8 @@ class BuiltinEvaluator(Evaluator):
 
     key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     input_schema: Mapped[dict[str, Any]] = mapped_column(JSON_, nullable=False)
-    output_configs: Mapped[list[AnnotationConfigType]] = mapped_column(
-        _AnnotationConfigList, nullable=False
+    output_configs: Mapped[list[OutputConfigType]] = mapped_column(
+        _OutputConfigList, nullable=False
     )
 
     # Track when this was last synced from the registry
@@ -2403,8 +2438,8 @@ class DatasetEvaluators(HasId):
     )
     name: Mapped[Identifier] = mapped_column(_Identifier, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    output_configs: Mapped[Optional[list[AnnotationConfigType]]] = mapped_column(
-        _AnnotationConfigList, nullable=True
+    output_configs: Mapped[Optional[list[OutputConfigType]]] = mapped_column(
+        _OutputConfigList, nullable=True
     )
     input_mapping: Mapped[InputMapping] = mapped_column(_InputMapping, nullable=False)
     user_id: Mapped[Optional[int]] = mapped_column(

--- a/src/phoenix/db/types/annotation_configs.py
+++ b/src/phoenix/db/types/annotation_configs.py
@@ -96,3 +96,21 @@ AnnotationConfigType: TypeAlias = Annotated[
 
 class AnnotationConfig(RootModel[AnnotationConfigType]):
     root: AnnotationConfigType
+
+
+class CategoricalOutputConfig(CategoricalAnnotationConfig):
+    name: str
+
+
+class ContinuousOutputConfig(ContinuousAnnotationConfig):
+    name: str
+
+
+OutputConfigType: TypeAlias = Annotated[
+    Union[CategoricalOutputConfig, ContinuousOutputConfig],
+    Field(..., discriminator="type"),
+]
+
+
+class OutputConfig(RootModel[OutputConfigType]):
+    root: OutputConfigType

--- a/src/phoenix/server/api/builtin_evaluator_sync.py
+++ b/src/phoenix/server/api/builtin_evaluator_sync.py
@@ -14,7 +14,7 @@ import logging
 from sqlalchemy import delete, select
 
 from phoenix.db import models
-from phoenix.db.types.annotation_configs import AnnotationConfigType
+from phoenix.db.types.annotation_configs import OutputConfigType
 from phoenix.db.types.identifier import Identifier
 from phoenix.server.api.evaluators import get_builtin_evaluators
 from phoenix.server.types import DbSessionFactory
@@ -40,9 +40,8 @@ async def sync_builtin_evaluators(db: DbSessionFactory) -> None:
             current_keys.add(key)
 
             evaluator = evaluator_cls()
-            # Cast to the broader AnnotationConfigType since EvaluatorOutputConfig
-            # is a subset (excludes FreeformAnnotationConfig)
-            output_cfgs: list[AnnotationConfigType] = list(evaluator.output_configs)
+            # Evaluator output_configs are WithName (categorical/continuous only for built-ins)
+            output_cfgs: list[OutputConfigType] = list(evaluator.output_configs)
 
             # Check if this evaluator already exists by key
             existing = await session.scalar(

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -22,10 +22,11 @@ from typing_extensions import TypedDict, assert_never
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
-    ContinuousAnnotationConfig,
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
     OptimizationDirection,
+    OutputConfigType,
 )
 from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.model_provider import (
@@ -91,9 +92,6 @@ class EvaluationResult(TypedDict):
     end_time: datetime
 
 
-EvaluatorOutputConfig: TypeAlias = CategoricalAnnotationConfig | ContinuousAnnotationConfig
-
-
 class BaseEvaluator(ABC):
     """
     Base interface for all evaluators that attach annotations to tasks.
@@ -122,7 +120,7 @@ class BaseEvaluator(ABC):
 
     @property
     @abstractmethod
-    def output_configs(self) -> Sequence[EvaluatorOutputConfig]:
+    def output_configs(self) -> Sequence[OutputConfigType]:
         """Returns the output configurations for this evaluator."""
         ...
 
@@ -133,7 +131,7 @@ class BaseEvaluator(ABC):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_configs: Sequence[EvaluatorOutputConfig],
+        output_configs: Sequence[OutputConfigType],
         tracer: Optional[Tracer] = None,
     ) -> list[EvaluationResult]:
         """
@@ -170,7 +168,7 @@ class LLMEvaluator(BaseEvaluator):
         invocation_parameters: PromptInvocationParameters,
         model_provider: ModelProvider,
         llm_client: PlaygroundStreamingClient[Any],
-        output_configs: Sequence[EvaluatorOutputConfig],
+        output_configs: Sequence[OutputConfigType],
         prompt_name: str,
     ):
         self._name = name
@@ -193,7 +191,7 @@ class LLMEvaluator(BaseEvaluator):
         return self._description
 
     @property
-    def output_configs(self) -> Sequence[EvaluatorOutputConfig]:
+    def output_configs(self) -> Sequence[OutputConfigType]:
         return self._output_configs
 
     @property
@@ -238,24 +236,24 @@ class LLMEvaluator(BaseEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_configs: Sequence[EvaluatorOutputConfig],
+        output_configs: Sequence[OutputConfigType],
         tracer: Optional[Tracer] = None,
     ) -> list[EvaluationResult]:
         start_time = datetime.now(timezone.utc)
 
         # LLMEvaluator only supports categorical output configs
-        categorical_configs: list[CategoricalAnnotationConfig] = []
+        categorical_configs: list[CategoricalOutputConfig] = []
         for config in output_configs:
-            if not isinstance(config, CategoricalAnnotationConfig):
+            if not isinstance(config, CategoricalOutputConfig):
                 raise ValueError(
-                    f"LLMEvaluator only supports CategoricalAnnotationConfig, "
+                    f"LLMEvaluator only supports CategoricalOutputConfig, "
                     f"got {type(config).__name__}"
                 )
             categorical_configs.append(config)
 
         multi_output = len(categorical_configs) > 1
-        configs_by_name: dict[str, CategoricalAnnotationConfig] = {
-            config.name or "": config for config in categorical_configs
+        configs_by_name: dict[str, CategoricalOutputConfig] = {
+            config.name: config for config in categorical_configs
         }
 
         tracer_ = tracer or NoOpTracer()
@@ -528,7 +526,7 @@ class BuiltInEvaluator(BaseEvaluator):
 
     @property
     @abstractmethod
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         """Returns the output configurations for this evaluator."""
         ...
 
@@ -538,7 +536,7 @@ class BuiltInEvaluator(BaseEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_configs: Sequence[EvaluatorOutputConfig],
+        output_configs: Sequence[OutputConfigType],
         tracer: Optional[Tracer] = None,
     ) -> list[EvaluationResult]:
         multi_output = len(output_configs) > 1
@@ -562,14 +560,14 @@ class BuiltInEvaluator(BaseEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult: ...
 
     def _map_boolean_to_label_and_score(
         self,
         matched: bool,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
     ) -> tuple[Optional[str], Optional[float]]:
         """
         Map a boolean result to a label and score using the output config.
@@ -577,7 +575,7 @@ class BuiltInEvaluator(BaseEvaluator):
         - values[0] is the "matched/pass" case
         - values[1] is the "not matched/fail" case
         """
-        if isinstance(output_config, CategoricalAnnotationConfig):
+        if isinstance(output_config, CategoricalOutputConfig):
             index = 0 if matched else 1
             if index < len(output_config.values):
                 value = output_config.values[index]
@@ -775,7 +773,7 @@ async def _get_llm_evaluators(
             output_configs=[
                 cfg
                 for cfg in llm_evaluator_orm.output_configs
-                if isinstance(cfg, (CategoricalAnnotationConfig, ContinuousAnnotationConfig))
+                if isinstance(cfg, (CategoricalOutputConfig, ContinuousOutputConfig))
             ],
             prompt_name=prompt.name.root,
         )
@@ -1129,7 +1127,7 @@ def create_llm_evaluator_from_inline(
     *,
     prompt_version_orm: models.PromptVersion,
     llm_client: "PlaygroundStreamingClient[Any]",
-    output_configs: Sequence[EvaluatorOutputConfig],
+    output_configs: Sequence[OutputConfigType],
     name: str,
     description: Optional[str] = None,
 ) -> LLMEvaluator:
@@ -1193,9 +1191,9 @@ class ContainsEvaluator(BuiltInEvaluator):
         }
 
     @property
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         return [
-            CategoricalAnnotationConfig(
+            CategoricalOutputConfig(
                 type="CATEGORICAL",
                 name="contains",
                 optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1212,7 +1210,7 @@ class ContainsEvaluator(BuiltInEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult:
         start_time = datetime.now(timezone.utc)
@@ -1441,9 +1439,9 @@ class ExactMatchEvaluator(BuiltInEvaluator):
         }
 
     @property
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         return [
-            CategoricalAnnotationConfig(
+            CategoricalOutputConfig(
                 type="CATEGORICAL",
                 name="exact_match",
                 optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1460,7 +1458,7 @@ class ExactMatchEvaluator(BuiltInEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult:
         start_time = datetime.now(timezone.utc)
@@ -1643,9 +1641,9 @@ class RegexEvaluator(BuiltInEvaluator):
         }
 
     @property
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         return [
-            CategoricalAnnotationConfig(
+            CategoricalOutputConfig(
                 type="CATEGORICAL",
                 name="regex",
                 optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1662,7 +1660,7 @@ class RegexEvaluator(BuiltInEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult:
         start_time = datetime.now(timezone.utc)
@@ -1872,9 +1870,9 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
         }
 
     @property
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         return [
-            ContinuousAnnotationConfig(
+            ContinuousOutputConfig(
                 type="CONTINUOUS",
                 name="levenshtein_distance",
                 optimization_direction=OptimizationDirection.MINIMIZE,
@@ -1888,7 +1886,7 @@ class LevenshteinDistanceEvaluator(BuiltInEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult:
         start_time = datetime.now(timezone.utc)
@@ -2092,9 +2090,9 @@ class JSONDistanceEvaluator(BuiltInEvaluator):
         }
 
     @property
-    def output_configs(self) -> list[EvaluatorOutputConfig]:
+    def output_configs(self) -> list[OutputConfigType]:
         return [
-            ContinuousAnnotationConfig(
+            ContinuousOutputConfig(
                 type="CONTINUOUS",
                 name="json_distance",
                 optimization_direction=OptimizationDirection.MINIMIZE,
@@ -2108,7 +2106,7 @@ class JSONDistanceEvaluator(BuiltInEvaluator):
         context: dict[str, Any],
         input_mapping: InputMapping,
         name: str,
-        output_config: EvaluatorOutputConfig,
+        output_config: OutputConfigType,
         tracer: Optional[Tracer] = None,
     ) -> EvaluationResult:
         start_time = datetime.now(timezone.utc)

--- a/src/phoenix/server/api/helpers/evaluators.py
+++ b/src/phoenix/server/api/helpers/evaluators.py
@@ -11,9 +11,8 @@ from typing_extensions import Self, assert_never
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    AnnotationConfigType,
-    CategoricalAnnotationConfig,
-    ContinuousAnnotationConfig,
+    CategoricalOutputConfig,
+    OutputConfigType,
 )
 from phoenix.server.api.helpers.prompts.models import (
     PromptResponseFormat,
@@ -35,7 +34,7 @@ def validate_evaluator_prompt_and_configs(
     *,
     prompt_tools: Optional[PromptTools],
     prompt_response_format: Optional[PromptResponseFormat],
-    evaluator_output_configs: list[CategoricalAnnotationConfig],
+    evaluator_output_configs: list[CategoricalOutputConfig],
     evaluator_description: Optional[str] = None,
 ) -> None:
     """
@@ -70,7 +69,7 @@ def validate_evaluator_prompt_and_configs(
 
     # Validate each config against its matched tool
     for config in evaluator_output_configs:
-        config_name = config.name or ""
+        config_name = config.name
         prompt_tool = tools_by_name.get(config_name)
         if prompt_tool is None:
             raise ValueError(
@@ -88,7 +87,7 @@ def _validate_tool_and_config(
     *,
     prompt_tool: PromptToolFunction,
     evaluator_annotation_name: str,
-    evaluator_output_config: CategoricalAnnotationConfig,
+    evaluator_output_config: CategoricalOutputConfig,
     evaluator_description: Optional[str] = None,
 ) -> None:
     """Validate a single tool definition against its matched output config."""
@@ -153,9 +152,9 @@ def validate_consistent_llm_evaluator_and_prompt_version(
     if not output_configs:
         raise ValueError("LLM evaluator must have at least one output config")
     # Validate all configs are categorical
-    categorical_configs: list[CategoricalAnnotationConfig] = []
+    categorical_configs: list[CategoricalOutputConfig] = []
     for output_config in output_configs:
-        if not isinstance(output_config, CategoricalAnnotationConfig):
+        if not isinstance(output_config, CategoricalOutputConfig):
             raise ValueError("LLM evaluator output config must be a CategoricalAnnotationConfig")
         categorical_configs.append(output_config)
     validate_evaluator_prompt_and_configs(
@@ -308,13 +307,13 @@ def validate_unique_config_names(
 class LLMEvaluatorOutputConfigs(BaseModel):
     """Validated output configs for LLM evaluators (categorical only)."""
 
-    configs: list[CategoricalAnnotationConfig] = Field(min_length=1)
+    configs: list[CategoricalOutputConfig] = Field(min_length=1)
 
     @field_validator("configs")
     @classmethod
     def check_unique_names(
-        cls, configs: list[CategoricalAnnotationConfig]
-    ) -> list[CategoricalAnnotationConfig]:
+        cls, configs: list[CategoricalOutputConfig]
+    ) -> list[CategoricalOutputConfig]:
         names = [c.name for c in configs]
         if len(names) != len(set(names)):
             duplicates = [n for n in names if names.count(n) > 1]
@@ -331,12 +330,12 @@ class LLMEvaluatorOutputConfigs(BaseModel):
             CategoricalAnnotationValue,
         )
 
-        configs: list[CategoricalAnnotationConfig] = []
+        configs: list[CategoricalOutputConfig] = []
         for input_ in inputs:
             if input_.categorical is not None and input_.categorical is not strawberry.UNSET:
                 cat = input_.categorical
                 configs.append(
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type=AnnotationType.CATEGORICAL.value,
                         name=cat.name,
                         description=cat.description,
@@ -358,17 +357,15 @@ class LLMEvaluatorOutputConfigs(BaseModel):
 def get_evaluator_output_configs(
     evaluator_input: "PlaygroundEvaluatorInput",
     evaluator: "BaseEvaluator",
-) -> list[CategoricalAnnotationConfig | ContinuousAnnotationConfig]:
+) -> list[OutputConfigType]:
     """
     Get the output configs for an evaluator run. Uses configs from the evaluator input
     if provided, otherwise falls back to the base evaluator's stored output configs.
 
     Returns only categorical or continuous configs (the types supported by evaluators).
-    Raises ValueError if any freeform configs are encountered.
     """
-    from phoenix.db.types.annotation_configs import FreeformAnnotationConfig
 
-    configs: list[AnnotationConfigType]
+    configs: list[OutputConfigType]
     if evaluator_input.output_configs:
         from phoenix.server.api.mutations.evaluator_mutations import (
             _convert_output_config_inputs_to_pydantic,
@@ -378,11 +375,4 @@ def get_evaluator_output_configs(
     else:
         configs = list(evaluator.output_configs)
 
-    narrowed: list[CategoricalAnnotationConfig | ContinuousAnnotationConfig] = []
-    for config in configs:
-        if isinstance(config, FreeformAnnotationConfig):
-            raise ValueError(
-                "Freeform annotation configs are not supported as evaluator output configs"
-            )
-        narrowed.append(config)
-    return narrowed
+    return configs

--- a/src/phoenix/server/api/input_types/AnnotationConfigInput.py
+++ b/src/phoenix/server/api/input_types/AnnotationConfigInput.py
@@ -19,6 +19,11 @@ class CategoricalAnnotationConfigInput:
     optimization_direction: OptimizationDirection
     values: list[CategoricalAnnotationConfigValueInput]
 
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise BadRequest("Name cannot be empty")
+        self.name = self.name.strip()
+
 
 @strawberry.input
 class ContinuousAnnotationConfigInput:
@@ -28,11 +33,21 @@ class ContinuousAnnotationConfigInput:
     lower_bound: Optional[float] = None
     upper_bound: Optional[float] = None
 
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise BadRequest("Name cannot be empty")
+        self.name = self.name.strip()
+
 
 @strawberry.input
 class FreeformAnnotationConfigInput:
     name: str
     description: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise BadRequest("Name cannot be empty")
+        self.name = self.name.strip()
 
 
 @strawberry.input(one_of=True)

--- a/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
+++ b/src/phoenix/server/api/input_types/GenerativeModelCustomerProviderConfigInput.py
@@ -22,6 +22,7 @@ from phoenix.db.types.model_provider import (
     OpenAIClientKwargs,
     OpenAICustomProviderConfig,
 )
+from phoenix.server.api.exceptions import BadRequest
 from phoenix.server.api.input_types.GenerativeModelInput import OpenAIApiType
 
 
@@ -319,7 +320,7 @@ class GenerativeModelCustomerProviderConfigInput:
             )
             != 1
         ):
-            raise ValueError(
+            raise BadRequest(
                 "Exactly one of openai, azure_openai, anthropic, aws_bedrock, "
                 "google_genai must be provided"
             )

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -19,9 +19,7 @@ from phoenix.db.helpers import (
     get_dataset_example_revisions,
     insert_experiment_with_examples_snapshot,
 )
-from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
-)
+from phoenix.db.types.annotation_configs import CategoricalOutputConfig
 from phoenix.db.types.model_provider import (
     is_sdk_compatible_with_model_provider,
 )
@@ -671,9 +669,9 @@ class ChatCompletionMutationMixin:
                 all_configs = _convert_output_config_inputs_to_pydantic(
                     inline_llm_evaluator.output_configs
                 )
-                categorical_configs: list[CategoricalAnnotationConfig] = []
+                categorical_configs: list[CategoricalOutputConfig] = []
                 for config in all_configs:
-                    if not isinstance(config, CategoricalAnnotationConfig):
+                    if not isinstance(config, CategoricalOutputConfig):
                         raise BadRequest(
                             "Only categorical annotation configs "
                             "are supported for LLM evaluator previews"

--- a/src/phoenix/server/api/mutations/evaluator_mutations.py
+++ b/src/phoenix/server/api/mutations/evaluator_mutations.py
@@ -15,7 +15,11 @@ from strawberry.types import Info
 
 from phoenix.db import models
 from phoenix.db.models import EvaluatorKind
-from phoenix.db.types.annotation_configs import AnnotationConfigType
+from phoenix.db.types.annotation_configs import (
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
+    OutputConfigType,
+)
 from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier as IdentifierModel
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly, IsNotViewer
@@ -46,22 +50,19 @@ from phoenix.server.api.types.PromptVersion import PromptVersion
 from phoenix.server.bearer_auth import PhoenixUser
 
 
-def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> AnnotationConfigType:
+def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> OutputConfigType:
     """
     Convert AnnotationConfigInput to pydantic for evaluator output configs.
     Always includes name.
     """
     from phoenix.db.types.annotation_configs import (
         AnnotationType,
-        CategoricalAnnotationConfig,
         CategoricalAnnotationValue,
-        ContinuousAnnotationConfig,
-        FreeformAnnotationConfig,
     )
 
     if input.categorical is not None and input.categorical is not UNSET:
         cat = input.categorical
-        return CategoricalAnnotationConfig(
+        return CategoricalOutputConfig(
             type=AnnotationType.CATEGORICAL.value,
             name=cat.name,
             description=cat.description,
@@ -70,7 +71,7 @@ def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> Annotation
         )
     elif input.continuous is not None and input.continuous is not UNSET:
         cont = input.continuous
-        return ContinuousAnnotationConfig(
+        return ContinuousOutputConfig(
             type=AnnotationType.CONTINUOUS.value,
             name=cont.name,
             description=cont.description,
@@ -78,20 +79,12 @@ def _output_config_input_to_pydantic(input: AnnotationConfigInput) -> Annotation
             lower_bound=cont.lower_bound,
             upper_bound=cont.upper_bound,
         )
-    elif input.freeform is not None and input.freeform is not UNSET:
-        ff = input.freeform
-        return FreeformAnnotationConfig(
-            type=AnnotationType.FREEFORM.value,
-            name=ff.name,
-            description=ff.description,
-        )
-    else:
-        raise BadRequest("No annotation config provided in output config input")
+    raise BadRequest("Invalid output config input")
 
 
 def _convert_output_config_inputs_to_pydantic(
     configs: list[AnnotationConfigInput],
-) -> list[AnnotationConfigType]:
+) -> list[OutputConfigType]:
     """Convert a list of AnnotationConfigInput to pydantic models for evaluator output configs."""
     return [_output_config_input_to_pydantic(c) for c in configs]
 
@@ -303,7 +296,7 @@ class EvaluatorMutationMixin:
             validated_configs = LLMEvaluatorOutputConfigs.from_inputs(input.output_configs)
         except (ValueError, ValidationError) as e:
             raise BadRequest(str(e))
-        output_configs: list[AnnotationConfigType] = list(validated_configs.configs)
+        output_configs: list[CategoricalOutputConfig] = list(validated_configs.configs)
         try:
             validated_name = IdentifierModel.model_validate(input.name)
         except ValidationError as error:
@@ -451,7 +444,7 @@ class EvaluatorMutationMixin:
             validated_configs = LLMEvaluatorOutputConfigs.from_inputs(input.output_configs)
         except (ValueError, ValidationError) as e:
             raise BadRequest(str(e))
-        output_configs: list[AnnotationConfigType] = list(validated_configs.configs)
+        output_configs: list[CategoricalOutputConfig] = list(validated_configs.configs)
 
         try:
             prompt_version = input.prompt_version.to_orm_prompt_version(user_id)
@@ -552,7 +545,7 @@ class EvaluatorMutationMixin:
             dataset_evaluator.description = (
                 input.description if isinstance(input.description, str) else None
             )
-            dataset_evaluator.output_configs = output_configs
+            dataset_evaluator.output_configs = list(output_configs)
             dataset_evaluator.input_mapping = (
                 input.input_mapping.to_orm()
                 if input.input_mapping is not None
@@ -563,7 +556,7 @@ class EvaluatorMutationMixin:
             llm_evaluator.description = (
                 input.description if isinstance(input.description, str) else None
             )
-            llm_evaluator.output_configs = output_configs
+            llm_evaluator.output_configs = list(output_configs)
             llm_evaluator.updated_at = datetime.now(timezone.utc)
             llm_evaluator.user_id = user_id
 
@@ -790,7 +783,7 @@ class EvaluatorMutationMixin:
 
                 # If output_configs provided, convert them; otherwise store None
                 # (resolver falls back to base evaluator configs at runtime)
-                output_configs: Optional[list[AnnotationConfigType]] = None
+                output_configs: Optional[list[OutputConfigType]] = None
                 if input.output_configs is not None:
                     output_configs = _convert_output_config_inputs_to_pydantic(input.output_configs)
 

--- a/src/phoenix/server/api/types/Evaluator.py
+++ b/src/phoenix/server/api/types/Evaluator.py
@@ -13,10 +13,9 @@ from typing_extensions import TypeAlias
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig as CategoricalAnnotationConfigModel,
-)
-from phoenix.db.types.annotation_configs import (
-    ContinuousAnnotationConfig as ContinuousAnnotationConfigModel,
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
+    OutputConfigType,
 )
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import NotFound
@@ -303,14 +302,12 @@ class LLMEvaluator(Evaluator, Node):
         return [
             _to_gql_output_config(
                 config=config,
-                annotation_name=config.name or "",
+                annotation_name=config.name,
                 id_prefix="Evaluator",
                 evaluator_id=self.id,
             )
             for config in configs
-            if isinstance(
-                config, (CategoricalAnnotationConfigModel, ContinuousAnnotationConfigModel)
-            )
+            if isinstance(config, (CategoricalOutputConfig, ContinuousOutputConfig))
         ]
 
     @strawberry.field
@@ -539,14 +536,12 @@ class BuiltInEvaluator(Evaluator, Node):
         return [
             _to_gql_output_config(
                 config,
-                config.name or evaluator_class.name,  # type: ignore[attr-defined]
+                config.name,
                 id_prefix="BuiltInEvaluator",
                 evaluator_id=self.id,
             )
             for config in base_configs
-            if isinstance(
-                config, (CategoricalAnnotationConfigModel, ContinuousAnnotationConfigModel)
-            )
+            if isinstance(config, (CategoricalOutputConfig, ContinuousOutputConfig))
         ]
 
 
@@ -562,7 +557,7 @@ def _generate_output_config_id(id_prefix: str, evaluator_id: int, config_name: s
 
 
 def _to_gql_categorical_annotation_config(
-    config: CategoricalAnnotationConfigModel,
+    config: CategoricalOutputConfig,
     annotation_name: str,
     id_prefix: str,
     evaluator_id: int,
@@ -585,7 +580,7 @@ def _to_gql_categorical_annotation_config(
 
 
 def _to_gql_continuous_annotation_config(
-    config: ContinuousAnnotationConfigModel,
+    config: ContinuousOutputConfig,
     annotation_name: str,
     id_prefix: str,
     evaluator_id: int,
@@ -602,12 +597,12 @@ def _to_gql_continuous_annotation_config(
 
 
 def _to_gql_output_config(
-    config: Union[CategoricalAnnotationConfigModel, ContinuousAnnotationConfigModel],
+    config: OutputConfigType,
     annotation_name: str,
     id_prefix: str,
     evaluator_id: int,
 ) -> BuiltInEvaluatorOutputConfig:
-    if isinstance(config, CategoricalAnnotationConfigModel):
+    if isinstance(config, CategoricalOutputConfig):
         return _to_gql_categorical_annotation_config(
             config, annotation_name, id_prefix, evaluator_id
         )
@@ -724,7 +719,7 @@ class DatasetEvaluator(Node):
                 if evaluator is None:
                     return []
                 if isinstance(evaluator, models.LLMEvaluator):
-                    configs = evaluator.output_configs
+                    configs = list(evaluator.output_configs)
                 elif isinstance(evaluator, models.BuiltinEvaluator):
                     builtin = get_builtin_evaluator_by_key(evaluator.key)
                     if builtin is None:
@@ -732,17 +727,16 @@ class DatasetEvaluator(Node):
                     configs = list(builtin().output_configs)
                 else:
                     return []
+        configs_list: list[OutputConfigType] = configs if configs is not None else []
         return [
             _to_gql_output_config(
                 config,
-                config.name or "",
+                config.name,
                 id_prefix="DatasetEvaluator",
                 evaluator_id=self.id,
             )
-            for config in configs
-            if isinstance(
-                config, (CategoricalAnnotationConfigModel, ContinuousAnnotationConfigModel)
-            )
+            for config in configs_list
+            if isinstance(config, (CategoricalOutputConfig, ContinuousOutputConfig))
         ]
 
     @strawberry.field

--- a/tests/unit/db/test_models.py
+++ b/tests/unit/db/test_models.py
@@ -16,7 +16,10 @@ from phoenix.db.types.annotation_configs import (
     AnnotationConfigType,
     CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
     OptimizationDirection,
+    OutputConfigType,
 )
 from phoenix.db.types.evaluators import InputMapping
 from phoenix.db.types.identifier import Identifier
@@ -834,7 +837,7 @@ class TestEvaluatorPolymorphism:
                 description="First evaluator",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="goodness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -853,7 +856,7 @@ class TestEvaluatorPolymorphism:
                 description="Second evaluator",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="correctness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1019,7 +1022,7 @@ class TestEvaluatorPolymorphism:
                 description="Third evaluator",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="hallucination",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1262,11 +1265,11 @@ class TestPromptVersion:
 class TestAnnotationConfigTypeDecorators:
     """Test serialization/deserialization of annotation config TypeDecorators.
 
-    Validates _AnnotationConfigList works correctly for multi-output evaluator support.
+    Validates _OutputConfigList works correctly for multi-output evaluator support.
     """
 
     async def test_annotation_config_list_serialization(self, db: DbSessionFactory) -> None:
-        """Test _AnnotationConfigList serializes and deserializes correctly."""
+        """Test _OutputConfigList serializes and deserializes correctly."""
         async with db() as session:
             # Create prompt dependencies for evaluator
             prompt = models.Prompt(
@@ -1302,7 +1305,7 @@ class TestAnnotationConfigTypeDecorators:
 
             # Create evaluator with multiple output configs
             multi_output_configs: list[AnnotationConfigType] = [
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="quality",
                     description="Quality assessment",
@@ -1312,7 +1315,7 @@ class TestAnnotationConfigTypeDecorators:
                         CategoricalAnnotationValue(label="low", score=0.0),
                     ],
                 ),
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="relevance",
                     description="Relevance assessment",
@@ -1360,47 +1363,16 @@ class TestAnnotationConfigTypeDecorators:
             assert config_2.description == "Relevance assessment"
 
     async def test_continuous_annotation_config_list_round_trip(self, db: DbSessionFactory) -> None:
-        """Test ContinuousAnnotationConfig round-trip through _AnnotationConfigList.
+        """Test ContinuousAnnotationConfig round-trip through _OutputConfigList.
 
         Verifies all fields (name, description, optimization_direction,
         lower_bound, upper_bound) survive serialization and deserialization.
+        Uses BuiltinEvaluator since it uses _OutputConfigList (categorical + continuous);
+        LLMEvaluator only accepts categorical configs.
         """
-        from phoenix.db.types.annotation_configs import ContinuousAnnotationConfig
-
         async with db() as session:
-            prompt = models.Prompt(
-                name=Identifier(root=f"test-prompt-{token_hex(4)}"),
-                description="Test prompt",
-                metadata_={},
-            )
-            session.add(prompt)
-            await session.flush()
-
-            prompt_version = models.PromptVersion(
-                prompt_id=prompt.id,
-                template_type=PromptTemplateType.STRING,
-                template_format=PromptTemplateFormat.F_STRING,
-                template=PromptStringTemplate(type="string", template="Test: {input}"),
-                invocation_parameters=PromptOpenAIInvocationParameters(
-                    type="openai", openai=PromptOpenAIInvocationParametersContent()
-                ),
-                model_provider=ModelProvider.OPENAI,
-                model_name="gpt-4",
-                metadata_={},
-            )
-            session.add(prompt_version)
-            await session.flush()
-
-            prompt_tag = models.PromptVersionTag(
-                name=Identifier(root=f"v1-{token_hex(4)}"),
-                prompt_id=prompt.id,
-                prompt_version_id=prompt_version.id,
-            )
-            session.add(prompt_tag)
-            await session.flush()
-
-            continuous_configs: list[AnnotationConfigType] = [
-                ContinuousAnnotationConfig(
+            continuous_configs: list[OutputConfigType] = [
+                ContinuousOutputConfig(
                     type="CONTINUOUS",
                     name="similarity_score",
                     description="Measures semantic similarity",
@@ -1408,7 +1380,7 @@ class TestAnnotationConfigTypeDecorators:
                     lower_bound=0.0,
                     upper_bound=1.0,
                 ),
-                ContinuousAnnotationConfig(
+                ContinuousOutputConfig(
                     type="CONTINUOUS",
                     name="latency",
                     description="Response latency in seconds",
@@ -1418,38 +1390,34 @@ class TestAnnotationConfigTypeDecorators:
                 ),
             ]
 
-            evaluator = models.LLMEvaluator(
-                name=Identifier(root=f"continuous-eval-{token_hex(4)}"),
-                description="Continuous config evaluator",
-                kind="LLM",
+            builtin_eval = models.BuiltinEvaluator(
+                name=Identifier(root=f"continuous-round-trip-{token_hex(4)}"),
+                description="Continuous config round-trip test",
+                metadata_={},
+                key=f"continuous_round_trip_{token_hex(4)}",
+                input_schema={"type": "object"},
                 output_configs=continuous_configs,
-                prompt_id=prompt.id,
-                prompt_version_tag_id=prompt_tag.id,
             )
-            session.add(evaluator)
+            session.add(builtin_eval)
             await session.flush()
-            evaluator_id = evaluator.id
+            evaluator_id = builtin_eval.id
 
         async with db() as session:
-            loaded_eval = await session.get(models.LLMEvaluator, evaluator_id)
+            loaded_eval = await session.get(models.BuiltinEvaluator, evaluator_id)
             assert loaded_eval is not None
             assert len(loaded_eval.output_configs) == 2
 
-            # Verify first continuous config
             config_1 = loaded_eval.output_configs[0]
-            assert isinstance(config_1, ContinuousAnnotationConfig)
+            assert isinstance(config_1, ContinuousOutputConfig)
             assert config_1.name == "similarity_score"
             assert config_1.description == "Measures semantic similarity"
-            assert str(config_1.optimization_direction) == OptimizationDirection.MAXIMIZE.value
             assert config_1.lower_bound == 0.0
             assert config_1.upper_bound == 1.0
 
-            # Verify second continuous config
             config_2 = loaded_eval.output_configs[1]
-            assert isinstance(config_2, ContinuousAnnotationConfig)
+            assert isinstance(config_2, ContinuousOutputConfig)
             assert config_2.name == "latency"
             assert config_2.description == "Response latency in seconds"
-            assert str(config_2.optimization_direction) == OptimizationDirection.MINIMIZE.value
             assert config_2.lower_bound == 0.0
             assert config_2.upper_bound is None
 
@@ -1501,7 +1469,7 @@ class TestAnnotationConfigTypeDecorators:
                 description="Test evaluator",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="quality",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1518,8 +1486,8 @@ class TestAnnotationConfigTypeDecorators:
             await session.flush()
 
             # Create dataset evaluator with output configs
-            configs: list[AnnotationConfigType] = [
-                CategoricalAnnotationConfig(
+            configs: list[OutputConfigType] = [
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="quality",
                     optimization_direction=OptimizationDirection.MINIMIZE,
@@ -1553,7 +1521,7 @@ class TestAnnotationConfigTypeDecorators:
             assert len(loaded.output_configs) == 1
 
             config = loaded.output_configs[0]
-            assert isinstance(config, CategoricalAnnotationConfig)
+            assert isinstance(config, CategoricalOutputConfig)
             assert config.name == "quality"
             # Note: DBBaseModel uses use_enum_values=True, so enums are stored as values
             assert str(config.optimization_direction) == OptimizationDirection.MINIMIZE.value
@@ -1608,7 +1576,7 @@ class TestAnnotationConfigTypeDecorators:
                 description="Test evaluator",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="quality",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1654,8 +1622,8 @@ class TestBuiltinEvaluatorMultiOutput:
         """Test BuiltinEvaluator correctly stores and retrieves list of output configs."""
         async with db() as session:
             # Create a builtin evaluator with multiple output configs
-            multi_output_configs: list[AnnotationConfigType] = [
-                CategoricalAnnotationConfig(
+            multi_output_configs: list[OutputConfigType] = [
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="hallucination",
                     description="Detects hallucinations",
@@ -1665,7 +1633,7 @@ class TestBuiltinEvaluatorMultiOutput:
                         CategoricalAnnotationValue(label="factual", score=0.0),
                     ],
                 ),
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="confidence",
                     description="Confidence level",
@@ -1698,14 +1666,14 @@ class TestBuiltinEvaluatorMultiOutput:
 
             # Verify first config
             config_1 = loaded.output_configs[0]
-            assert isinstance(config_1, CategoricalAnnotationConfig)
+            assert isinstance(config_1, CategoricalOutputConfig)
             assert config_1.name == "hallucination"
             # Note: DBBaseModel uses use_enum_values=True, so enums are stored as values
             assert str(config_1.optimization_direction) == OptimizationDirection.MINIMIZE.value
 
             # Verify second config
             config_2 = loaded.output_configs[1]
-            assert isinstance(config_2, CategoricalAnnotationConfig)
+            assert isinstance(config_2, CategoricalOutputConfig)
             assert config_2.name == "confidence"
             assert len(config_2.values) == 3
 
@@ -1727,7 +1695,7 @@ class TestBuiltinEvaluatorMultiOutput:
                 key=f"BUILTIN_{token_hex(4)}",
                 input_schema={"type": "object", "properties": {"input": {"type": "string"}}},
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="quality",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1748,7 +1716,7 @@ class TestBuiltinEvaluatorMultiOutput:
                 name=builtin_eval.name,
                 input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="quality",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -1775,7 +1743,7 @@ class TestBuiltinEvaluatorMultiOutput:
             assert len(loaded.output_configs) == 1
 
             config = loaded.output_configs[0]
-            assert isinstance(config, CategoricalAnnotationConfig)
+            assert isinstance(config, CategoricalOutputConfig)
             assert config.name == "quality"
             # Note: DBBaseModel uses use_enum_values=True, so enums are stored as values
             assert str(config.optimization_direction) == OptimizationDirection.MINIMIZE.value

--- a/tests/unit/server/api/conftest.py
+++ b/tests/unit/server/api/conftest.py
@@ -6,8 +6,8 @@ from sqlalchemy import insert, select
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
     OptimizationDirection,
 )
 from phoenix.db.types.evaluators import InputMapping
@@ -891,7 +891,7 @@ async def correctness_llm_evaluator(db: DbSessionFactory) -> models.LLMEvaluator
             description="evaluates the correctness of the output",
             kind="LLM",
             output_configs=[
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="correctness",
                     optimization_direction=OptimizationDirection.MAXIMIZE,

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -19,8 +19,8 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
     OptimizationDirection,
 )
 from phoenix.db.types.db_helper_types import UNDEFINED
@@ -76,7 +76,7 @@ from tests.unit.vcr import CustomVCR
 
 def validate_consistent_llm_evaluator_and_prompt_version(
     prompt_version: models.PromptVersion,
-    output_config: CategoricalAnnotationConfig,
+    output_config: CategoricalOutputConfig,
     description: Optional[str] = None,
 ) -> None:
     """Test helper that wraps validate_evaluator_prompt_and_configs."""
@@ -91,7 +91,7 @@ def validate_consistent_llm_evaluator_and_prompt_version(
 class TestValidateConsistentLLMEvaluatorAndPromptVersion:
     def test_both_descriptions_null_does_not_raise(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         validate_consistent_llm_evaluator_and_prompt_version(
@@ -100,7 +100,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_both_descriptions_strings_do_not_raise(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         description = "evaluates the correctness of the output"
@@ -112,7 +112,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_string_evaluator_description_and_null_function_description_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         with pytest.raises(
@@ -127,7 +127,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_null_evaluator_description_and_string_function_description_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -144,7 +144,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_non_null_response_format_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         prompt_version.response_format = PromptResponseFormatJSONSchema(
@@ -162,7 +162,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_null_tools_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         prompt_version.tools = None
@@ -174,7 +174,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_empty_tools_list_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -189,7 +189,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_multiple_tools_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -221,7 +221,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_null_tool_choice_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -234,7 +234,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_zero_or_more_tool_choice_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -247,7 +247,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_specific_function_tool_choice_with_matching_name_does_not_raise(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -258,7 +258,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_specific_function_tool_choice_with_mismatched_name_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -273,7 +273,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_function_parameters_type_not_object_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -286,7 +286,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_empty_function_parameters_properties_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -299,7 +299,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_missing_label_property_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -322,7 +322,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_property_type_not_string_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -345,7 +345,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_enum_less_than_two_items_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -368,7 +368,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_missing_enum_field_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -390,7 +390,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_missing_description_field_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -412,7 +412,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_duplicate_function_parameters_required_values_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -428,7 +428,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_defined_but_not_required_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -453,7 +453,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_and_explanation_defined_but_only_label_required_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -482,7 +482,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_unexpected_required_property_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -505,7 +505,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_label_description_mismatch_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -528,7 +528,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_choices_mismatch_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -543,7 +543,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_with_explanation_property_does_not_raise(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -566,7 +566,7 @@ class TestValidateConsistentLLMEvaluatorAndPromptVersion:
 
     def test_explanation_property_explicitly_set_to_none_raises(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         assert prompt_version.tools is not None
@@ -599,7 +599,7 @@ class TestMultiConfigValidation:
 
     def test_multi_config_with_matching_tools_does_not_raise(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         """When each config has a matching tool definition (by name), validation
@@ -609,7 +609,7 @@ class TestMultiConfigValidation:
         )
 
         # Build a second config that matches a second tool
-        second_config = CategoricalAnnotationConfig(
+        second_config = CategoricalOutputConfig(
             type="CATEGORICAL",
             name="hallucination",
             optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -652,17 +652,17 @@ class TestMultiConfigValidation:
 
     def test_multi_config_all_categorical_required(
         self,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         prompt_version: models.PromptVersion,
     ) -> None:
         """All configs must be CategoricalAnnotationConfig, even if only the primary
         config is validated against the prompt tool."""
-        from phoenix.db.types.annotation_configs import ContinuousAnnotationConfig
+        from phoenix.db.types.annotation_configs import ContinuousOutputConfig
         from phoenix.server.api.helpers.evaluators import (
             validate_consistent_llm_evaluator_and_prompt_version as validate_fn,
         )
 
-        non_categorical_config = ContinuousAnnotationConfig(
+        non_categorical_config = ContinuousOutputConfig(
             type="CONTINUOUS",
             name="score",
             optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -2046,7 +2046,7 @@ class TestBuiltInEvaluatorOutputConfigUsage:
 
         evaluator = ExactMatchEvaluator()
         # Create a custom output config with different labels
-        custom_config = CategoricalAnnotationConfig(
+        custom_config = CategoricalOutputConfig(
             type="CATEGORICAL",
             name="exact",
             optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -2075,7 +2075,7 @@ class TestBuiltInEvaluatorOutputConfigUsage:
 
         evaluator = RegexEvaluator()
         # Create a custom output config with different labels
-        custom_config = CategoricalAnnotationConfig(
+        custom_config = CategoricalOutputConfig(
             type="CATEGORICAL",
             name="regex",
             optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -2103,7 +2103,7 @@ class TestBuiltInEvaluatorOutputConfigUsage:
         from phoenix.server.api.evaluators import ContainsEvaluator
 
         evaluator = ContainsEvaluator()
-        custom_config = CategoricalAnnotationConfig(
+        custom_config = CategoricalOutputConfig(
             type="CATEGORICAL",
             name="contains_custom_scores",
             optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -2315,7 +2315,7 @@ class TestLLMEvaluator:
     def llm_evaluator(
         self,
         llm_evaluator_prompt_version: models.PromptVersion,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         openai_streaming_client: "OpenAIStreamingClient",
     ) -> LLMEvaluator:
         template = llm_evaluator_prompt_version.template
@@ -2418,7 +2418,7 @@ class TestLLMEvaluator:
     def multipart_llm_evaluator(
         self,
         multipart_llm_evaluator_prompt_version: models.PromptVersion,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         openai_streaming_client: "OpenAIStreamingClient",
     ) -> LLMEvaluator:
         template = multipart_llm_evaluator_prompt_version.template
@@ -2445,7 +2445,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
         custom_vcr: CustomVCR,
         gpt_4o_mini_generative_model: models.GenerativeModel,
@@ -2800,7 +2800,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
     ) -> None:
         # Invalid JSONPath expressions are now validated at construction time
         with pytest.raises(BadRequest) as exc_info:
@@ -2816,7 +2816,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
     ) -> None:
         # Valid JSONPath syntax but path doesn't exist in context
         input_mapping = EvaluatorInputMappingInput(
@@ -2923,7 +2923,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
         custom_vcr: CustomVCR,
     ) -> None:
@@ -3144,7 +3144,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
         text_response_body = (
@@ -3312,7 +3312,7 @@ class TestLLMEvaluator:
         project: models.Project,
         tracer: Tracer,
         llm_evaluator: LLMEvaluator,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
         tool_call_response_body = (
@@ -3372,7 +3372,7 @@ class TestLLMEvaluator:
         db: DbSessionFactory,
         project: models.Project,
         tracer: Tracer,
-        output_config: CategoricalAnnotationConfig,
+        output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
         multipart_llm_evaluator: LLMEvaluator,
         custom_vcr: CustomVCR,
@@ -3655,8 +3655,8 @@ class TestGetEvaluators:
 
 
 @pytest.fixture
-def output_config() -> CategoricalAnnotationConfig:
-    return CategoricalAnnotationConfig(
+def output_config() -> CategoricalOutputConfig:
+    return CategoricalOutputConfig(
         type="CATEGORICAL",
         name="correctness",
         optimization_direction=OptimizationDirection.MAXIMIZE,

--- a/tests/unit/server/api/mutations/test_evaluator_mutations.py
+++ b/tests/unit/server/api/mutations/test_evaluator_mutations.py
@@ -11,6 +11,7 @@ from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
     CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
     FreeformAnnotationConfig,
     OptimizationDirection,
 )
@@ -2629,7 +2630,7 @@ class TestUpdateDatasetBuiltinEvaluatorMutation:
             description="test llm evaluator",
             kind="LLM",
             output_configs=[
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="test",
                     optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -2893,7 +2894,7 @@ async def llm_evaluator(
         description=evaluator_description,
         kind="LLM",
         output_configs=[
-            CategoricalAnnotationConfig(
+            CategoricalOutputConfig(
                 type="CATEGORICAL",
                 name=annotation_name,
                 optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -3054,7 +3055,7 @@ class TestDeleteDatasetEvaluators:
                 description="test llm evaluator for deletion",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="correctness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -3180,7 +3181,7 @@ class TestDeleteDatasetEvaluators:
                 description="test llm evaluator for batch deletion",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="correctness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -3341,7 +3342,7 @@ class TestDeleteDatasetEvaluators:
                 description="test llm evaluator for prompt deletion",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="correctness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -3453,7 +3454,7 @@ class TestDeleteDatasetEvaluators:
                 description="test llm evaluator to keep prompt",
                 kind="LLM",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="correctness",
                         optimization_direction=OptimizationDirection.MAXIMIZE,

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -9,8 +9,8 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
     OptimizationDirection,
 )
 from phoenix.db.types.evaluators import InputMapping
@@ -2303,8 +2303,9 @@ async def evaluators_for_querying(
             metadata_={},
             prompt_id=prompt.id,
             output_configs=[
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
+                    name="result",
                     optimization_direction=OptimizationDirection.MAXIMIZE,
                     values=[
                         CategoricalAnnotationValue(label="good", score=1.0),
@@ -2393,11 +2394,12 @@ class TestEvaluatorsQuery:
                 key="orphan_key",
                 input_schema={"type": "object"},
                 output_configs=[
-                    {
-                        "type": "CATEGORICAL",
-                        "optimization_direction": "MAXIMIZE",
-                        "values": [{"label": "a"}],
-                    }
+                    CategoricalOutputConfig(
+                        type="CATEGORICAL",
+                        name="a",
+                        optimization_direction=OptimizationDirection.MAXIMIZE,
+                        values=[CategoricalAnnotationValue(label="a", score=1.0)],
+                    )
                 ],
             )
             session.add(orphan_builtin)

--- a/tests/unit/server/api/types/test_Dataset.py
+++ b/tests/unit/server/api/types/test_Dataset.py
@@ -9,8 +9,8 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
     OptimizationDirection,
 )
 from phoenix.db.types.evaluators import InputMapping
@@ -970,7 +970,7 @@ async def dataset_with_evaluators(db: DbSessionFactory) -> None:
             name=Identifier("evaluator-1"),
             description="First evaluator",
             output_configs=[
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="goodness",
                     optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -987,7 +987,7 @@ async def dataset_with_evaluators(db: DbSessionFactory) -> None:
             name=Identifier("evaluator-2"),
             description="Second evaluator",
             output_configs=[
-                CategoricalAnnotationConfig(
+                CategoricalOutputConfig(
                     type="CATEGORICAL",
                     name="correctness",
                     optimization_direction=OptimizationDirection.MAXIMIZE,

--- a/tests/unit/server/api/types/test_Evaluator.py
+++ b/tests/unit/server/api/types/test_Evaluator.py
@@ -6,8 +6,9 @@ from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.types.annotation_configs import (
-    CategoricalAnnotationConfig,
     CategoricalAnnotationValue,
+    CategoricalOutputConfig,
+    ContinuousOutputConfig,
     OptimizationDirection,
 )
 from phoenix.db.types.evaluators import InputMapping
@@ -228,7 +229,7 @@ class TestDatasetEvaluatorDescriptionFallback:
                 prompt_id=prompt.id,
                 description="Base evaluator description",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="result",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -275,7 +276,7 @@ class TestDatasetEvaluatorDescriptionFallback:
                 prompt_id=prompt.id,
                 description=None,
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="result2",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -492,10 +493,6 @@ class TestDatasetEvaluatorBuiltinOutputConfig:
         """Create test data: dataset with builtin evaluator assignments."""
         from sqlalchemy import select
 
-        from phoenix.db.types.annotation_configs import (
-            ContinuousAnnotationConfig,
-        )
-
         async with db() as session:
             project = models.Project(name=f"test-project-{token_hex(4)}")
             session.add(project)
@@ -537,7 +534,7 @@ class TestDatasetEvaluatorBuiltinOutputConfig:
                 name=Identifier("contains_with_override"),
                 input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="contains",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -570,7 +567,7 @@ class TestDatasetEvaluatorBuiltinOutputConfig:
                 name=Identifier("levenshtein_with_override"),
                 input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
                 output_configs=[
-                    ContinuousAnnotationConfig(
+                    ContinuousOutputConfig(
                         type="CONTINUOUS",
                         name="levenshtein_distance",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -867,10 +864,6 @@ class TestBuiltInEvaluatorMultiOutput:
         """Verify output_configs are correctly stored for builtin evaluators."""
         from sqlalchemy import select
 
-        from phoenix.db.types.annotation_configs import (
-            ContinuousAnnotationConfig,
-        )
-
         async with db() as session:
             # Create dataset
             dataset = models.Dataset(
@@ -906,7 +899,7 @@ class TestBuiltInEvaluatorMultiOutput:
                 name=Identifier("contains_overridden"),
                 input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="contains",
                         optimization_direction=OptimizationDirection.MINIMIZE,
@@ -933,7 +926,7 @@ class TestBuiltInEvaluatorMultiOutput:
                 name=Identifier("levenshtein_overridden"),
                 input_mapping=InputMapping(literal_mapping={}, path_mapping={}),
                 output_configs=[
-                    ContinuousAnnotationConfig(
+                    ContinuousOutputConfig(
                         type="CONTINUOUS",
                         name="levenshtein_distance",
                         optimization_direction=OptimizationDirection.MAXIMIZE,
@@ -1106,7 +1099,7 @@ class TestLLMEvaluatorOutputConfigs:
                 prompt_id=prompt.id,
                 description="Multi-output LLM evaluator",
                 output_configs=[
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="quality",
                         description="Quality assessment",
@@ -1116,7 +1109,7 @@ class TestLLMEvaluatorOutputConfigs:
                             CategoricalAnnotationValue(label="low", score=0.0),
                         ],
                     ),
-                    CategoricalAnnotationConfig(
+                    CategoricalOutputConfig(
                         type="CATEGORICAL",
                         name="relevance",
                         description="Relevance assessment",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches evaluator persistence/serialization and GraphQL/API typing, adding stricter validation (required names, unique names) that could surface errors for existing/invalid stored configs. Also increases integration test parallelism and tweaks Postgres container settings, which may affect CI stability.
> 
> **Overview**
> **Evaluator output configs are now modeled as a separate, name-required type.** Introduces `CategoricalOutputConfig`/`ContinuousOutputConfig` and `OutputConfigType`, and updates evaluator codepaths to use these instead of the broader `AnnotationConfigType` (removing freeform output configs from evaluator outputs and eliminating `name or ""` fallbacks).
> 
> **DB storage and API/GraphQL plumbing were updated to enforce uniqueness and proper serialization.** Replaces the old list type decorator with `_OutputConfigList`/`_CategoricalOutputConfigList` that validate unique config names and serialize via the new root models; updates `LLMEvaluator`, `BuiltinEvaluator`, and `DatasetEvaluators` columns and the built-in evaluator sync and mutations/helpers accordingly.
> 
> **CI tweaks for faster/stabler integration tests.** Names the Postgres service container, bumps `max_connections`, and increases integration test parallelism from `-n 8` to `-n 16`.
> 
> Separately, invalid generative model provider input now raises `BadRequest` (API-level error) instead of `ValueError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 450f75b407a545e7df42d61935c00cfcb96ec950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/arizeai-433a7140/arizeai-433a7140/editor/fix%2Fmake-name-not-nullable?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->