### PR TITLE
ci: resolve IPython get_ipython mypy errors

### DIFF
--- a/src/phoenix/session/session.py
+++ b/src/phoenix/session/session.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 # type workaround
 # https://github.com/python/mypy/issues/5264#issuecomment-399407428
 if TYPE_CHECKING:
-    from IPython.display import IFrame  # type: ignore[import-not-found]
+    from IPython.display import IFrame
 
     _BaseList = UserList[pd.DataFrame]
 else:
@@ -570,10 +570,10 @@ def _is_colab() -> bool:
     except ImportError:
         return False
     try:
-        from IPython.core.getipython import get_ipython  # type: ignore
+        from IPython.core.getipython import get_ipython
     except ImportError:
         return False
-    return get_ipython() is not None
+    return get_ipython() is not None  # type: ignore[no-untyped-call]
 
 
 def _is_sagemaker() -> bool:
@@ -588,16 +588,16 @@ def _is_sagemaker() -> bool:
         from IPython.core.getipython import get_ipython
     except ImportError:
         return False
-    return get_ipython() is not None
+    return get_ipython() is not None  # type: ignore[no-untyped-call]
 
 
 def _is_databricks() -> bool:
     """Determines whether this is in a Databricks notebook"""
     try:
-        import IPython  # type: ignore
+        from IPython.core.getipython import get_ipython
     except ImportError:
         return False
-    if (shell := IPython.get_ipython()) is None:
+    if (shell := get_ipython()) is None:  # type: ignore[no-untyped-call]
         return False
     try:
         dbutils = shell.user_ns["dbutils"]
@@ -666,9 +666,9 @@ def _get_databricks_context() -> DatabricksContext:
     Returns the databricks context for constructing the base url
     and the root_path for the app
     """
-    import IPython
+    from IPython.core.getipython import get_ipython
 
-    shell = IPython.get_ipython()
+    shell = get_ipython()  # type: ignore[no-untyped-call]
     dbutils = shell.user_ns["dbutils"]
     notebook_context = json.loads(
         dbutils.entry_point.getDbutils().notebook().getContext().toJson()


### PR DESCRIPTION
This change will not break users with older IPython installations. We’re just importing from the defining module instead of via the package’s re-export; runtime behavior and supported versions are the same. `IPython.get_ipython` is not defined on the top-level package; it’s re-exported from the core module.
```python
# IPython/__init__.py
from .core.getipython import get_ipython
```
<img width="782" height="43" alt="Screenshot 2026-02-25 at 12 37 38 PM" src="https://github.com/user-attachments/assets/abe3bc61-7026-4c19-a6f0-d43750769faa" />


   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-checking-only adjustments to IPython imports and mypy suppressions; runtime logic is effectively unchanged aside from import paths.
> 
> **Overview**
> Fixes notebook-environment detection typing issues by importing `get_ipython` directly from `IPython.core.getipython` instead of relying on top-level `IPython` re-exports.
> 
> Updates Colab/SageMaker/Databricks checks (and Databricks context retrieval) to add targeted `# type: ignore[no-untyped-call]` annotations and removes an unnecessary `import-not-found` ignore for `IPython.display.IFrame`, without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf9c782305dc46a3a82c9c679c7886bcee61fe26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->