### PR TITLE
ci: add uv sync to type check make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ test: test-python test-frontend test-ts ## Run all tests (Python + frontend + Ty
 	@echo -e "$(GREEN)✓ All tests complete$(NC)"
 
 typecheck-python: ## Type check Python code
+	@$(UV) sync
 	@echo -e "$(CYAN)Type checking Python...$(NC)"
 	@$(UV) run mypy
 	@echo -e "$(GREEN)✓ Type check complete$(NC)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Makefile-only change that just adds a dependency sync step before type checking; minimal functional impact beyond slightly longer runtime and potential dependency resolution failures.
> 
> **Overview**
> Ensures Python type checking runs against a synchronized `uv` environment by adding `uv sync` to the `typecheck-python` Make target before invoking `mypy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6405bab36ca4850e49df05a878e0ce7223198c7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->