### PR TITLE
fix: support boolean values in metadata/attributes filters

### DIFF
--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -143,6 +143,26 @@ def test_get_attribute_keys_list(expression: str, expected: Optional[list[str]])
             if sys.version_info >= (3, 9)
             else "and_((attributes[['attributes']].as_string() == attributes[['attributes']].as_string()), (attributes[['attributes']].as_string() != attributes[['attributes', 'attributes']].as_string()))",
         ),
+        (
+            "metadata['is_empty'] == True",
+            "attributes[['metadata', 'is_empty']] == True",
+        ),
+        (
+            "metadata['is_empty'] == False",
+            "attributes[['metadata', 'is_empty']] == False",
+        ),
+        (
+            "True == metadata['is_empty']",
+            "True == attributes[['metadata', 'is_empty']]",
+        ),
+        (
+            "metadata['is_empty'] is True",
+            "attributes[['metadata', 'is_empty']] == True",
+        ),
+        (
+            "metadata['is_empty'] is not False",
+            "attributes[['metadata', 'is_empty']] != False",
+        ),
     ],
 )
 async def test_filter_translated(


### PR DESCRIPTION
Fixes #11743

Filters like `metadata['is_empty'] == True` previously caused an "unexpected error" because Python booleans were incorrectly treated as float constants, causing PostgreSQL to fail when trying to cast the JSON string 'true' to a float.

Generaged with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the AST-to-SQL translation for span filters, which can change query semantics; risk is limited to boolean comparisons against JSON `attributes`/`metadata` and is covered by new unit tests.
> 
> **Overview**
> Fixes filter translation for boolean literals in JSON-backed `metadata`/`attributes` expressions so comparisons like `metadata['is_empty'] == True` no longer get treated as float casts and fail on PostgreSQL.
> 
> Updates `_FilterTranslator.visit_Compare` to detect boolean constants and compare against the raw JSON subscript (also mapping `is`/`is not` to `==`/`!=`), and adds unit tests covering `True`/`False` comparisons in both operand orders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ab72ecb44b5eb32022743737672b1e460a225d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->