### PR TITLE
chore: Update Agent Spec logo to greyscale SVG

### DIFF
--- a/docs/phoenix/integrations.mdx
+++ b/docs/phoenix/integrations.mdx
@@ -85,7 +85,7 @@ Phoenix captures detailed traces from your AI applications, giving you visibilit
       <Card title="Graphite" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/graphite-logo.png" href="/docs/phoenix/integrations/python/graphite" />
       <Card title="NVIDIA" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/nvidia-logo.png" href="/docs/phoenix/integrations/python/nvidia" />
       <Card title="MCP" href="/docs/phoenix/integrations/python/mcp-tracing" icon="plug" description="MCP tracing integration"/>
-      <Card title="Agent Spec" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-logo.png" href="/docs/phoenix/integrations/python/agentspec" />
+      <Card title="Agent Spec" img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-greyscale-logo.svg" href="/docs/phoenix/integrations/python/agentspec" />
     </CardGroup>
   </Tab>
   <Tab title="TypeScript" icon="js">

--- a/docs/phoenix/integrations/python/agentspec.mdx
+++ b/docs/phoenix/integrations/python/agentspec.mdx
@@ -9,5 +9,5 @@ description: Open Agent Spec (Agent Spec) is a portable language for defining ag
 
 <Columns cols={2}>
 
-  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-logo.png" horizontal title="Agent Spec Tracing" href="/docs/phoenix/integrations/python/agentspec/agentspec-tracing"/>
+  <Card img="https://storage.googleapis.com/arize-phoenix-assets/assets/images/agentspec-greyscale-logo.svg" horizontal title="Agent Spec Tracing" href="/docs/phoenix/integrations/python/agentspec/agentspec-tracing"/>
 </Columns>


### PR DESCRIPTION
## Summary
- Replace (nonexistent) Agent Spec logo PNG with greyscale SVG in both integration card locations

## Test plan
- [x] Verify logo renders correctly on the integrations page
- [x] Verify logo renders correctly on the Agent Spec sub-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is cosmetic (broken/incorrect image URL or rendering differences for SVG).
> 
> **Overview**
> Updates the **Agent Spec** integration branding by replacing the logo asset reference from the previous PNG to a greyscale SVG in both the main `Integrations` page card and the `Agent Spec` integration overview page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6239ffbffa15b5896e73b38e97196b291763d1f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->