### PR TITLE
fix(evals): handle litellm 1.81.16 usage=None behavior change

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/models/litellm.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/models/litellm.py
@@ -150,7 +150,7 @@ class LiteLLMModel(BaseModel):
             return str(choice.message.content)
         return ""
 
-    def _extract_usage(self, response: "ModelResponse") -> Optional[Usage]:
+    def _extract_usage(self, response: "ModelResponse") -> Usage:
         from litellm.types.utils import Usage as ResponseUsage
 
         if isinstance(response_usage := response.get("usage"), ResponseUsage):  # type: ignore[no-untyped-call]
@@ -159,7 +159,7 @@ class LiteLLMModel(BaseModel):
                 completion_tokens=response_usage.completion_tokens,
                 total_tokens=response_usage.total_tokens,
             )
-        return None
+        return Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
     def _parse_output(self, response: "ModelResponse") -> Tuple[str, ExtraInfo]:
         text = self._extract_text(response)


### PR DESCRIPTION
## Summary

- In litellm >=1.81.16, `ModelResponse(usage=None)` no longer auto-converts the `usage` field to `Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)` — it now keeps it as `None`
- This caused `_extract_usage` to return `None` (the `isinstance(..., ResponseUsage)` check fails for `None`), breaking `test_parse_output_without_usage` across all platforms and Python versions
- Fix: explicitly return `Usage(0, 0, 0)` as the fallback instead of `None`, removing the implicit dependency on litellm's internal behavior

## Root cause

Daily CI started failing today (2026-02-26) with `litellm==1.81.16` being pulled in (unpinned in requirements). The test `TestParseOutput::test_parse_output_without_usage` failed with:
```
AttributeError: 'NoneType' object has no attribute 'prompt_tokens'
```

## Test plan
- [x] All `test_parse_output` tests pass locally (`40 passed`)
- [x] `mypy` passes with no issues
- CI should pass with the explicit `Usage(0, 0, 0)` fallback, regardless of litellm version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to usage parsing that replaces a `None` fallback with a zeroed `Usage`, affecting only token accounting when LiteLLM omits `usage`.
> 
> **Overview**
> Fixes `LiteLLMModel` output parsing to handle LiteLLM responses where `usage` is `None` (newer LiteLLM behavior).
> 
> `_extract_usage` now always returns a `Usage` object, defaulting to `Usage(0, 0, 0)` instead of `None`, and updates the return type accordingly so `_parse_output` consistently attaches usage data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2642704db11e1f2b5ecf5b139f255f7d88be99cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->