### PR TITLE
fix(app): include credentials for dataset uploads

### DIFF
--- a/app/src/pages/datasets/DatasetFromCSVForm.tsx
+++ b/app/src/pages/datasets/DatasetFromCSVForm.tsx
@@ -84,6 +84,7 @@ export function DatasetFromCSVForm(props: CreateDatasetFromCSVFormProps) {
       });
       return fetch(prependBasename("/v1/datasets/upload?sync=true"), {
         method: "POST",
+        credentials: "include",
         body: formData,
       })
         .then((response) => {

--- a/app/src/pages/datasets/DatasetFromJSONLForm.tsx
+++ b/app/src/pages/datasets/DatasetFromJSONLForm.tsx
@@ -95,6 +95,7 @@ export function DatasetFromJSONLForm(props: CreateDatasetFromJSONLFormProps) {
       });
       return fetch(prependBasename("/v1/datasets/upload?sync=true"), {
         method: "POST",
+        credentials: "include",
         body: formData,
       })
         .then((response) => {


### PR DESCRIPTION
fixes #9910\n\nDataset upload requests from the app now include cookies explicitly so authenticated sessions are preserved when uploading CSV/JSONL files.\n\n### What changed\n- add  to CSV dataset upload request\n- add  to JSONL dataset upload request\n\n### Validation\n-  (app)\n-  (app)\n- 
> phoenix-ui@0.0.1 fmt /home/openclaw/.openclaw/workspace/agents/charlie/repos/phoenix/app
> oxfmt --config ../.oxfmtrc.jsonc\n-  (app) **fails in current main checkout due to missing  module in  (pre-existing, unrelated to this change)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, scoped change to include cookies on two upload requests; primary risk is unintended cookie inclusion if the endpoint is cross-origin/misconfigured.
> 
> **Overview**
> Dataset uploads from the UI now explicitly include browser credentials (cookies) by adding `credentials: "include"` to the `fetch` calls used by the CSV and JSONL upload forms. This preserves authenticated sessions during multipart uploads to `/v1/datasets/upload?sync=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2b6a509ed328670773f09ad0e05db1d36eabf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->