### PR TITLE
ci: remove sparse checkout

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -78,9 +78,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: refs/tags/arize-phoenix-v${{ steps.version.outputs.version }}
-          sparse-checkout: |
-            src/phoenix/
-            app/
       - uses: pnpm/action-setup@v4
         with:
           package_json_file: app/package.json
@@ -96,16 +93,6 @@ jobs:
       - name: Check wheel contents
         run: uv run --with check-wheel-contents check-wheel-contents --ignore W004 dist/*.whl
       - uses: pypa/gh-action-pypi-publish@release/v1
-      - run: echo "NAME=phoenix" >> $GITHUB_ENV
-        if: failure()
-      - run: touch ${{ runner.temp }}/${{ env.NAME }}
-        if: failure()
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: ${{ env.NAME }}
-          path: ${{ runner.temp }}/${{ env.NAME }}
-          retention-days: 1
 
   publish-packages:
     name: Publish Python packages
@@ -140,7 +127,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}
-          sparse-checkout: ${{ matrix.path }}
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.10"
@@ -151,16 +137,6 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      - run: echo "NAME=package-$(basename ${{ matrix.path }})" >> $GITHUB_ENV
-        if: failure()
-      - run: touch ${{ runner.temp }}/${{ env.NAME }}
-        if: failure()
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: ${{ env.NAME }}
-          path: ${{ runner.temp }}/${{ env.NAME }}
-          retention-days: 1
 
   slack:
     name: Slack notification
@@ -168,54 +144,27 @@ jobs:
     if: always() && (needs.publish-phoenix.result != 'skipped' || needs.publish-packages.result != 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            .release-please-manifest.json
-            release-please-config.json
-          sparse-checkout-cone-mode: false
-      - uses: actions/download-artifact@v8
-        continue-on-error: true
       - name: Set notification content
         id: notify
         env:
           PHOENIX_RESULT: ${{ needs.publish-phoenix.result }}
           PACKAGES_RESULT: ${{ needs.publish-packages.result }}
-          PACKAGE_PATHS: ${{ needs.list-python-packages.outputs.package_paths }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          NL=$'\n'
-          PARTS=""
-          if [ "$PHOENIX_RESULT" = "success" ]; then
-            PHOENIX_VER=$(jq -r '.["."] // "unknown"' .release-please-manifest.json)
-            PARTS="Published successfully:${NL}  - arize-phoenix: https://pypi.org/project/arize-phoenix/${PHOENIX_VER}/${NL}"
-          fi
-          if [ "$PACKAGES_RESULT" = "success" ] && [ "$PACKAGE_PATHS" != "[]" ]; then
-            if [ -n "$PARTS" ]; then
-              PARTS="${PARTS}${NL}"
-            else
-              PARTS="Published successfully:${NL}"
-            fi
-            for path in $(echo "$PACKAGE_PATHS" | jq -r '.[]'); do
-              name="arize-$(echo "$path" | sed 's|^packages/||')"
-              ver=$(jq -r --arg p "$path" '.[$p] // "unknown"' .release-please-manifest.json)
-              PARTS="${PARTS}  - ${name}: https://pypi.org/project/${name}/${ver}/${NL}"
-            done
-          fi
-          if [ -n "$PARTS" ]; then
-            PARTS="${PARTS}${NL}"
-          fi
-          FAIL_DIRS=$(find . -maxdepth 1 -type d ! -name '.' ! -name '.*' 2>/dev/null | sed 's|^\./||' | nl -w2 -s'. ' || true)
-          if [ -n "$FAIL_DIRS" ]; then
-            PARTS="${PARTS}🚨🚨🚨 Publication failed for the following packages 🚨🚨🚨${NL}${FAIL_DIRS}${NL}${NL}${RUN_URL}"
-          fi
-          if [ -n "$PARTS" ]; then
+          if [ "$PHOENIX_RESULT" = "failure" ] || [ "$PACKAGES_RESULT" = "failure" ]; then
             {
-              echo "text<<END_NOTIFY_TEXT"
-              printf '%s' "$PARTS"
-              echo ""
-              echo "END_NOTIFY_TEXT"
-            } >> "$GITHUB_OUTPUT"
+              echo "text<<EOF"
+              echo "🚨🚨🚨 PYPI Publication Failed 🚨🚨🚨"
+              echo "$RUN_URL"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          elif [ "$PHOENIX_RESULT" = "success" ] || [ "$PACKAGES_RESULT" = "success" ]; then
+            {
+              echo "text<<EOF"
+              echo "PYPI Publication Succeeded"
+              echo "$RUN_URL"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           fi
       - name: Send message to Slack
         if: steps.notify.outputs.text != ''


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the PyPI publishing GitHub Actions workflow (checkout strategy and notification logic), which could impact release runs if the new full checkouts or simplified messaging behave unexpectedly. No product/runtime code is affected.
> 
> **Overview**
> Updates the `publish.yaml` release workflow to **stop using sparse checkout** for tag-based publishing steps, switching to full repository checkouts for Phoenix and package builds.
> 
> Removes failure artifact upload/download plumbing and replaces the Slack step’s detailed per-package success/failure reporting with a **simple success/failure message** that links to the workflow run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c596f264209512c70d02dcb313c6f82d8d0b526b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->