### PR TITLE
ci: remove sparse checkout

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,11 +64,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            .release-please-manifest.json
-            release-please-config.json
-          sparse-checkout-cone-mode: false
       - name: Read version from manifest
         id: version
         run: |
@@ -108,11 +103,6 @@ jobs:
         working-directory: ${{ matrix.path }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            .release-please-manifest.json
-            release-please-config.json
-          sparse-checkout-cone-mode: false
       - name: Resolve ref from manifest
         id: ref
         working-directory: .


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk CI tweak that only changes how the repo is checked out during PyPI publishing; main impact is slightly longer checkout times and reduced chance of missing files during release steps.
> 
> **Overview**
> Removes `sparse-checkout` from the initial `actions/checkout` steps in the `publish-phoenix` and `publish-packages` jobs, switching them to full repository checkouts before resolving versions/refs.
> 
> This simplifies the PyPI publish workflow by avoiding partial checkouts when reading `.release-please-manifest.json`/`release-please-config.json` and preparing tag-based builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8354308a7c71b587d323d6499919e02e7d99405d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->