### PR TITLE
ci: run publish-packages steps from repo root, only uv build in package dir

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,14 +98,10 @@ jobs:
       fail-fast: false
       matrix:
         path: ${{ fromJSON(needs.list-python-packages.outputs.package_paths) }}
-    defaults:
-      run:
-        working-directory: ${{ matrix.path }}
     steps:
       - uses: actions/checkout@v6
       - name: Resolve ref from manifest
         id: ref
-        working-directory: .
         run: |
           VERSION=$(jq -r --arg p "${{ matrix.path }}" '.[$p] // empty' .release-please-manifest.json)
           NAME=$(jq -r --arg p "${{ matrix.path }}" '.packages[$p]["package-name"] // empty' release-please-config.json)
@@ -122,6 +118,7 @@ jobs:
           python-version: "3.10"
           version: "0.9.18"
       - run: uv build
+        working-directory: ${{ matrix.path }}
       - run: uv run --with check-wheel-contents check-wheel-contents dist/*.whl
       - run: uv run --with twine twine upload --skip-existing --verbose dist/*
         env:


### PR DESCRIPTION
- Remove job-level working-directory so steps default to repo root
- Set working-directory on uv build step only so wheels are built from package dir
- Fixes 'Path dist/*.whl does not exist' (uv writes to repo root dist/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts GitHub Actions working directories; main risk is breaking the package publish workflow if artifacts land in an unexpected `dist/` location.
> 
> **Overview**
> Fixes `publish-packages` in `.github/workflows/publish.yaml` to run steps from the repo root (removing the job-level `working-directory`) and applies `working-directory: ${{ matrix.path }}` only to the `uv build` step.
> 
> This aligns where `dist/` is produced/consumed to avoid missing wheel artifacts during `check-wheel-contents`/`twine upload`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e1bf79c9fe0a3ca93c16c8e47cf183075021b87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->