### PR TITLE
fix: sync lockfile as part of release pr

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -238,7 +238,7 @@ async def _cleanup_chat_completion_resources(
             return_exceptions=True,
         )
 
-    # 3. Now safe to close generators
+    # 3. Now it's safe to close generators
     if in_progress:
         await asyncio.gather(
             *[stream.aclose() for _, stream, _ in in_progress if inspect.isasyncgen(stream)],


### PR DESCRIPTION
""

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in subscription cleanup logic; no runtime behavior is modified.
> 
> **Overview**
> Clarifies wording in `subscriptions.py` around the cancellation/cleanup sequence by updating the step 3 comment to explicitly state it is *safe* to close async generators after awaiting task cancellation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7db6b7330d40b22fded8381703d9957e83a244e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->