### PR TITLE
chore: use correct access token

### DIFF
--- a/.github/workflows/sync-lockfile-release-pr.yml
+++ b/.github/workflows/sync-lockfile-release-pr.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a one-line CI change swapping the checkout token; main risk is misconfigured secret causing the workflow to fail to push updates.
> 
> **Overview**
> Updates the `sync-lockfile-release-pr.yml` GitHub Action to use `secrets.MY_RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN` when checking out the release PR branch, ensuring the workflow can commit/push `uv.lock` updates from that branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d7947b720ec1f116cd9afda6e2f7ea0087e6765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->