### PR TITLE
ci: use personal access token for creating PR

### DIFF
--- a/.github/workflows/cost-sync.yml
+++ b/.github/workflows/cost-sync.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.verify-changed-files.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           commit-message: "fix(cost): update built-in model token prices"
           title: "fix(cost): update built-in model token prices"
           body: |

--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -154,7 +154,7 @@ jobs:
         if: steps.check-update.outputs.needs_update == 'true' && steps.verify-changed-files.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           commit-message: "fix(deps): update arize-phoenix-${{ steps.extract-version.outputs.package }} to ${{ steps.extract-version.outputs.version }}"
           title: "fix(deps): update arize-phoenix-${{ steps.extract-version.outputs.package }} to ${{ steps.extract-version.outputs.version }}"
           body: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which GitHub credential is used to open automated PRs; misconfiguration or missing secret could break these automations or broaden token permissions beyond `GITHUB_TOKEN` if not scoped correctly.
> 
> **Overview**
> Updates the `cost-sync` and `update-phoenix-package-versions` GitHub Actions workflows to create automated PRs using `secrets.MY_RELEASE_PLEASE_TOKEN` instead of the default `secrets.GITHUB_TOKEN`.
> 
> This affects only the `peter-evans/create-pull-request` steps, changing the authentication used when opening and pushing branches for these bot-generated PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25416a4e659bbb629bc4f0f50df3f059bfd676e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->