### PR TITLE
ci: use personal token for creating PR

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           commit-message: "chore: update phoenix version to ${{ needs.push_to_registry.outputs.version }} in kustomize and helm"
           title: "chore: update phoenix version to ${{ needs.push_to_registry.outputs.version }} in kustomize and helm"
           body: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk workflow change limited to how the release automation authenticates when opening PRs; main risk is the workflow failing if the new secret/token is missing or lacks permissions.
> 
> **Overview**
> Updates the `docker-build-release` GitHub Actions workflow to pass `secrets.MY_RELEASE_PLEASE_TOKEN` to `peter-evans/create-pull-request`, so the automated kustomize/Helm version-bump PRs are created using a dedicated token instead of the default auth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b16dd2927caf3d2500aed3602e40c9eb93e32be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->