### PR TITLE
ci: generate sitemap pr

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -36,7 +36,7 @@ jobs:
           commit-message: "chore: update sitemap.xml"
           branch: update-sitemap
           title: "chore: update sitemap.xml"
-          body: "Auto-generated sitemap update
+          body: "Auto-generated sitemap update"
           add-paths: |
             sitemap.xml
             docs/phoenix/sitemap.xml


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the sitemap automation to run on `main` pushes and open/update a PR using a write-enabled secret token, which can affect CI behavior and repository write operations if misconfigured.
> 
> **Overview**
> Updates the `Generate Sitemap` GitHub Actions workflow to run on pushes to `main` (and manual dispatch) instead of on pull requests.
> 
> Switches execution to `uv run` (removing explicit Python setup), and replaces the inline commit/push + PR-comment failure handling with `peter-evans/create-pull-request` to open/update an `update-sitemap` PR containing updated `sitemap.xml` files using `MY_RELEASE_PLEASE_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 412f09e630baa0d7d9ef45566d135cbea4375de4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->