### PR TITLE
feat(cli): add sessions and session commands

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-cli.mdx
@@ -131,6 +131,49 @@ px trace abc123def456 --format raw | jq      # Pipe to jq
 | `--api-key <key>` | Phoenix API key | From env |
 | `--no-progress` | Disable progress indicators | — |
 
+### `px sessions`
+
+List sessions (multi-turn conversations) for a project.
+
+```bash
+px sessions                                       # List recent sessions
+px sessions --limit 20                            # More sessions
+px sessions --order asc                           # Oldest first
+px sessions --format raw --no-progress | jq       # Pipe to jq
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --limit <number>` | Maximum number of sessions to return | 10 |
+| `--order <order>` | Sort order: `asc` or `desc` | `desc` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--project <name>` | Project name or ID | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--no-progress` | Disable progress indicators | — |
+
+### `px session <session-id>`
+
+View a session's conversation flow, including all traces (turns) in the session.
+
+```bash
+px session my-chat-session-001                              # By session_id
+px session UHJvamVjdFNlc3Npb24...                           # By GlobalID
+px session my-chat-session-001 --include-annotations        # With annotations
+px session my-chat-session-001 --file session.json          # Save to file
+px session my-chat-session-001 --format raw | jq            # Pipe to jq
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--include-annotations` | Include session annotations | Off |
+| `--file <path>` | Save to file instead of stdout | stdout |
+| `--format <format>` | `pretty`, `json`, or `raw` | `pretty` |
+| `--endpoint <url>` | Phoenix API endpoint | From env |
+| `--project <name>` | Project name or ID | From env |
+| `--api-key <key>` | Phoenix API key | From env |
+| `--no-progress` | Disable progress indicators | — |
+
 ### `px datasets`
 
 List all available datasets.

--- a/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli.mdx
@@ -114,6 +114,8 @@ Phoenix CLI provides the following commands:
 | `projects` | List of all projects | stdout |
 | `trace <id>` | A specific trace by ID | stdout (or to a file with `--file`) |
 | `traces [directory]` | Recent traces from the project | Saves each trace as a JSON file in the given directory, or prints to stdout if no directory is provided |
+| `sessions` | List sessions for a project | stdout |
+| `session <id>` | A specific session with its traces | stdout (or to a file with `--file`) |
 
 <Note>
 Traces are fetched chronologically with most recent first.
@@ -243,6 +245,27 @@ This command retrieves traces that occurred since January 1, 2026, saving each a
 - Building regression test datasets
 - Offline analysis and debugging
 - Creating evaluation datasets for experiments
+
+## Sessions
+
+Sessions group multiple traces into a single multi-turn conversation. Use the `sessions` and `session` commands to explore them.
+
+### List Sessions
+
+```bash
+px sessions --limit 10
+px sessions --format raw --no-progress | jq '.[].session_id'
+```
+
+### View a Session
+
+```bash
+px session my-chat-session-001
+px session my-chat-session-001 --include-annotations
+px session my-chat-session-001 --format raw | jq '.session.traces[].trace_id'
+```
+
+To drill into a specific turn's input/output, use `px trace <trace-id>` with the trace ID from the session output.
 
 ## Trace Output Structure
 

--- a/js/.changeset/add-sessions-commands.md
+++ b/js/.changeset/add-sessions-commands.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `px sessions` and `px session` commands for browsing multi-turn conversation sessions via the REST API.

--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -12,6 +12,8 @@ import {
   createProjectsCommand,
   createPromptCommand,
   createPromptsCommand,
+  createSessionCommand,
+  createSessionsCommand,
   createTraceCommand,
   createTracesCommand,
 } from "./commands";
@@ -32,6 +34,8 @@ export function main() {
   program.addCommand(createTraceCommand());
   program.addCommand(createDatasetsCommand());
   program.addCommand(createDatasetCommand());
+  program.addCommand(createSessionsCommand());
+  program.addCommand(createSessionCommand());
   program.addCommand(createExperimentsCommand());
   program.addCommand(createExperimentCommand());
   program.addCommand(createPromptsCommand());

--- a/js/packages/phoenix-cli/src/commands/formatSessions.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSessions.ts
@@ -1,0 +1,177 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+export type OutputFormat = "pretty" | "json" | "raw";
+
+type SessionData = componentsV1["schemas"]["SessionData"];
+type SessionAnnotation = componentsV1["schemas"]["SessionAnnotation"];
+
+export interface FormatSessionsOutputOptions {
+  sessions: SessionData[];
+  format?: OutputFormat;
+}
+
+export function formatSessionsOutput({
+  sessions,
+  format,
+}: FormatSessionsOutputOptions): string {
+  const selected = format || "pretty";
+  if (selected === "raw") {
+    return JSON.stringify(sessions);
+  }
+  if (selected === "json") {
+    return JSON.stringify(sessions, null, 2);
+  }
+  return formatSessionsPretty(sessions);
+}
+
+export interface FormatSessionOutputOptions {
+  session: SessionData;
+  annotations?: SessionAnnotation[];
+  format?: OutputFormat;
+}
+
+export function formatSessionOutput({
+  session,
+  annotations,
+  format,
+}: FormatSessionOutputOptions): string {
+  const selected = format || "pretty";
+  if (selected === "raw") {
+    return JSON.stringify({ session, annotations });
+  }
+  if (selected === "json") {
+    return JSON.stringify({ session, annotations }, null, 2);
+  }
+  return formatSessionPretty(session, annotations);
+}
+
+function formatSessionsPretty(sessions: SessionData[]): string {
+  if (sessions.length === 0) {
+    return "No sessions found";
+  }
+
+  const lines: string[] = [];
+  lines.push("Sessions:");
+  lines.push("");
+
+  for (const session of sessions) {
+    lines.push(`┌─ ${session.session_id}`);
+    lines.push(`│  ID: ${session.id}`);
+    lines.push(`│  Traces: ${session.traces.length}`);
+    lines.push(`│  Started: ${formatDate(session.start_time)}`);
+    lines.push(`│  Ended: ${formatDate(session.end_time)}`);
+    lines.push(
+      `│  Duration: ${formatDuration(session.start_time, session.end_time)}`
+    );
+    lines.push(`└─`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function formatSessionPretty(
+  session: SessionData,
+  annotations?: SessionAnnotation[]
+): string {
+  const lines: string[] = [];
+
+  lines.push(`┌─ Session: ${session.session_id}`);
+  lines.push(`│  ID: ${session.id}`);
+  lines.push(`│  Project: ${session.project_id}`);
+  lines.push(`│  Started: ${formatDate(session.start_time)}`);
+  lines.push(`│  Ended: ${formatDate(session.end_time)}`);
+  lines.push(`│  Turns: ${session.traces.length}`);
+  lines.push(`│`);
+
+  if (session.traces.length > 0) {
+    // Sort traces by start_time ascending (chronological order)
+    const sortedTraces = [...session.traces].sort(
+      (a, b) =>
+        new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+    );
+
+    lines.push(`│  Traces:`);
+
+    for (let i = 0; i < sortedTraces.length; i++) {
+      const trace = sortedTraces[i]!;
+      const isLast = i === sortedTraces.length - 1;
+      const connector = isLast ? "└─" : "├─";
+      const continuation = isLast ? "  " : "│ ";
+
+      const startTime = formatTime(trace.start_time);
+      const endTime = formatTime(trace.end_time);
+      const duration = formatDuration(trace.start_time, trace.end_time);
+
+      lines.push(
+        `│  ${connector} [Turn ${i + 1}] ${startTime} - ${endTime} (${duration})`
+      );
+      lines.push(`│  ${continuation} trace: ${trace.trace_id}`);
+    }
+  }
+
+  if (annotations && annotations.length > 0) {
+    lines.push(`│`);
+    lines.push(`│  Annotations:`);
+    for (const annotation of annotations) {
+      const parts: string[] = [];
+      if (annotation.result?.score != null) {
+        parts.push(`score=${annotation.result.score}`);
+      }
+      if (annotation.result?.label) {
+        parts.push(`label="${annotation.result.label}"`);
+      }
+      const detail = parts.length > 0 ? `: ${parts.join(", ")}` : "";
+      lines.push(
+        `│    - ${annotation.name} (${annotation.annotator_kind})${detail}`
+      );
+    }
+  }
+
+  lines.push(`└─`);
+
+  return lines.join("\n");
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    const date = new Date(dateStr);
+    return date.toLocaleString();
+  } catch {
+    return dateStr;
+  }
+}
+
+function formatTime(dateStr: string): string {
+  try {
+    const date = new Date(dateStr);
+    return date.toLocaleTimeString();
+  } catch {
+    return dateStr;
+  }
+}
+
+function formatDuration(startStr: string, endStr: string): string {
+  const startMs = Date.parse(startStr);
+  const endMs = Date.parse(endStr);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+    return "n/a";
+  }
+  const diffMs = Math.max(0, endMs - startMs);
+  const totalSeconds = Math.floor(diffMs / 1000);
+
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes < 60) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m ${seconds}s`;
+}

--- a/js/packages/phoenix-cli/src/commands/index.ts
+++ b/js/packages/phoenix-cli/src/commands/index.ts
@@ -6,6 +6,8 @@ export * from "./datasets";
 export * from "./dataset";
 export * from "./experiments";
 export * from "./experiment";
+export * from "./sessions";
+export * from "./session";
 export * from "./prompts";
 export * from "./prompt";
 export * from "./api";

--- a/js/packages/phoenix-cli/src/commands/session.ts
+++ b/js/packages/phoenix-cli/src/commands/session.ts
@@ -1,0 +1,211 @@
+import * as fs from "fs";
+import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { Command } from "commander";
+
+import { createPhoenixClient } from "../client";
+import { getConfigErrorMessage, resolveConfig } from "../config";
+import { writeError, writeOutput, writeProgress } from "../io";
+import { formatSessionOutput, type OutputFormat } from "./formatSessions";
+
+type SessionData = componentsV1["schemas"]["SessionData"];
+type SessionAnnotation = componentsV1["schemas"]["SessionAnnotation"];
+
+interface SessionOptions {
+  endpoint?: string;
+  project?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  file?: string;
+  includeAnnotations?: boolean;
+}
+
+/**
+ * Fetch a single session by identifier
+ */
+async function fetchSession(
+  client: PhoenixClient,
+  sessionIdentifier: string
+): Promise<SessionData> {
+  const response = await client.GET("/v1/sessions/{session_identifier}", {
+    params: {
+      path: {
+        session_identifier: sessionIdentifier,
+      },
+    },
+  });
+
+  if (response.error || !response.data) {
+    throw new Error(`Failed to fetch session: ${response.error}`);
+  }
+
+  return response.data.data;
+}
+
+/**
+ * Fetch annotations for a session
+ */
+async function fetchSessionAnnotations(
+  client: PhoenixClient,
+  projectIdentifier: string,
+  sessionId: string
+): Promise<SessionAnnotation[]> {
+  const allAnnotations: SessionAnnotation[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await client.GET(
+      "/v1/projects/{project_identifier}/session_annotations",
+      {
+        params: {
+          path: {
+            project_identifier: projectIdentifier,
+          },
+          query: {
+            session_ids: [sessionId],
+            cursor,
+            limit: 100,
+          },
+        },
+      }
+    );
+
+    if (response.error || !response.data) {
+      throw new Error(`Failed to fetch session annotations: ${response.error}`);
+    }
+
+    allAnnotations.push(...response.data.data);
+    cursor = response.data.next_cursor || undefined;
+  } while (cursor);
+
+  return allAnnotations;
+}
+
+/**
+ * Session command handler
+ */
+async function sessionHandler(
+  sessionId: string,
+  options: SessionOptions
+): Promise<void> {
+  try {
+    const userSpecifiedFormat =
+      process.argv.includes("--format") ||
+      process.argv.some((arg) => arg.startsWith("--format="));
+
+    // Resolve configuration
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        project: options.project,
+        apiKey: options.apiKey,
+      },
+    });
+
+    // Validate that we have endpoint
+    if (!config.endpoint) {
+      const errors = [
+        "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
+      ];
+      writeError({ message: getConfigErrorMessage({ errors }) });
+      process.exit(1);
+    }
+
+    // Create client
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Fetching session ${sessionId}...`,
+      noProgress: !options.progress,
+    });
+
+    // Fetch session
+    const session = await fetchSession(client, sessionId);
+
+    writeProgress({
+      message: `Fetched session with ${session.traces.length} trace(s)`,
+      noProgress: !options.progress,
+    });
+
+    // Optionally fetch annotations
+    let annotations: SessionAnnotation[] | undefined;
+    if (options.includeAnnotations) {
+      writeProgress({
+        message: "Fetching session annotations...",
+        noProgress: !options.progress,
+      });
+
+      annotations = await fetchSessionAnnotations(
+        client,
+        session.project_id,
+        session.session_id
+      );
+
+      writeProgress({
+        message: `Found ${annotations.length} annotation(s)`,
+        noProgress: !options.progress,
+      });
+    }
+
+    // Determine output format
+    const outputFormat: OutputFormat = options.file
+      ? "json"
+      : options.format || "pretty";
+
+    if (options.file && userSpecifiedFormat && options.format !== "json") {
+      writeError({
+        message: `Warning: --format is ignored when writing to a file; writing JSON to ${options.file}`,
+      });
+    }
+
+    // Format output
+    const output = formatSessionOutput({
+      session,
+      annotations,
+      format: outputFormat,
+    });
+
+    if (options.file) {
+      fs.writeFileSync(options.file, output, "utf-8");
+      writeProgress({
+        message: `Wrote session to ${options.file}`,
+        noProgress: !options.progress,
+      });
+    } else {
+      writeOutput({ message: output });
+    }
+  } catch (error) {
+    writeError({
+      message: `Error fetching session: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(1);
+  }
+}
+
+/**
+ * Create the session command
+ */
+export function createSessionCommand(): Command {
+  const command = new Command("session");
+
+  command
+    .description("View a session's conversation flow")
+    .argument(
+      "<session-id>",
+      "Session identifier (GlobalID or user-provided session_id)"
+    )
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--project <name>", "Project name or ID")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .option("--file <path>", "Save session to file instead of stdout")
+    .option("--include-annotations", "Include session annotations")
+    .action(sessionHandler);
+
+  return command;
+}

--- a/js/packages/phoenix-cli/src/commands/sessions.ts
+++ b/js/packages/phoenix-cli/src/commands/sessions.ts
@@ -1,0 +1,179 @@
+import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { Command } from "commander";
+
+import { createPhoenixClient, resolveProjectId } from "../client";
+import {
+  getConfigErrorMessage,
+  resolveConfig,
+  validateConfig,
+} from "../config";
+import { writeError, writeOutput, writeProgress } from "../io";
+import { formatSessionsOutput, type OutputFormat } from "./formatSessions";
+
+type SessionData = componentsV1["schemas"]["SessionData"];
+
+interface SessionsOptions {
+  endpoint?: string;
+  project?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  limit?: number;
+  order?: "asc" | "desc";
+}
+
+/**
+ * Fetch sessions for a project from Phoenix
+ */
+async function fetchSessions(
+  client: PhoenixClient,
+  projectIdentifier: string,
+  options: { limit?: number; order?: "asc" | "desc" } = {}
+): Promise<SessionData[]> {
+  const allSessions: SessionData[] = [];
+  let cursor: string | undefined;
+  const targetLimit = options.limit || 10;
+
+  do {
+    const response = await client.GET(
+      "/v1/projects/{project_identifier}/sessions",
+      {
+        params: {
+          path: {
+            project_identifier: projectIdentifier,
+          },
+          query: {
+            cursor,
+            limit: Math.min(targetLimit - allSessions.length, 100),
+            order: options.order,
+          },
+        },
+      }
+    );
+
+    if (response.error || !response.data) {
+      throw new Error(`Failed to fetch sessions: ${response.error}`);
+    }
+
+    allSessions.push(...response.data.data);
+    cursor = response.data.next_cursor || undefined;
+
+    if (allSessions.length >= targetLimit) {
+      break;
+    }
+  } while (cursor);
+
+  return allSessions.slice(0, targetLimit);
+}
+
+/**
+ * Sessions command handler
+ */
+async function sessionsHandler(options: SessionsOptions): Promise<void> {
+  try {
+    // Resolve configuration
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        project: options.project,
+        apiKey: options.apiKey,
+      },
+    });
+
+    // Validate configuration
+    const validation = validateConfig({ config });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(1);
+    }
+
+    // Create client
+    const client = createPhoenixClient({ config });
+
+    // Resolve project ID
+    const projectIdentifier = config.project;
+    if (!projectIdentifier) {
+      writeError({ message: "Project not configured" });
+      process.exit(1);
+    }
+
+    writeProgress({
+      message: `Resolving project: ${projectIdentifier}`,
+      noProgress: !options.progress,
+    });
+
+    const projectId = await resolveProjectId({
+      client,
+      projectIdentifier,
+    });
+
+    const limit = options.limit || 10;
+
+    writeProgress({
+      message: `Fetching sessions for project ${projectId}...`,
+      noProgress: !options.progress,
+    });
+
+    // Fetch sessions
+    const sessions = await fetchSessions(client, projectId, {
+      limit,
+      order: options.order,
+    });
+
+    if (sessions.length === 0) {
+      writeProgress({
+        message: "No sessions found",
+        noProgress: !options.progress,
+      });
+      return;
+    }
+
+    writeProgress({
+      message: `Found ${sessions.length} session(s)`,
+      noProgress: !options.progress,
+    });
+
+    // Output sessions
+    const output = formatSessionsOutput({
+      sessions,
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error fetching sessions: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(1);
+  }
+}
+
+/**
+ * Create the sessions command
+ */
+export function createSessionsCommand(): Command {
+  const command = new Command("sessions");
+
+  command
+    .description("List sessions for a project")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--project <name>", "Project name or ID")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .option(
+      "-n, --limit <number>",
+      "Maximum number of sessions to return",
+      parseInt,
+      10
+    )
+    .option("--order <order>", "Sort order: asc or desc", "desc")
+    .action(sessionsHandler);
+
+  return command;
+}

--- a/skills/phoenix-cli/SKILL.md
+++ b/skills/phoenix-cli/SKILL.md
@@ -57,6 +57,30 @@ Trace
       exception.message                  — set if span errored
 ```
 
+## Sessions
+
+```bash
+px sessions --limit 10 --format raw --no-progress | jq .
+px sessions --order asc --format raw --no-progress | jq '.[].session_id'
+px session <session-id> --format raw | jq .
+px session <session-id> --include-annotations --format raw | jq '.annotations'
+```
+
+### Session JSON shape
+
+```
+SessionData
+  id, session_id, project_id
+  start_time, end_time
+  traces[]
+    id, trace_id, start_time, end_time
+
+SessionAnnotation (with --include-annotations)
+  id, name, annotator_kind ("LLM"|"CODE"|"HUMAN"), session_id
+  result { label, score, explanation }
+  metadata, identifier, source, created_at, updated_at
+```
+
 ## Datasets / Experiments / Prompts
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `px sessions` command to list multi-turn conversation sessions for a project with cursor pagination, `--limit`, and `--order` options
- Adds `px session <id>` command to view a single session's conversation flow with traces and optional `--include-annotations` support
- Fixes session annotations fetch to use user-facing `session_id` instead of internal GlobalID
- Updates SKILL.md, CLI reference docs, and retrieve-traces-via-cli docs

Closes #11792

## Test plan
- [x] `pnpm run build` compiles successfully
- [x] All 84 existing tests pass (`pnpm test`)
- [x] `px --help` shows both new commands
- [x] `px sessions --endpoint http://localhost:6006 --project SESSIONS-DEMO`
- [x] `px session <session-id> --endpoint http://localhost:6006`
- [x] `px session <session-id> --include-annotations`
- [x] `px session <session-id> --format json --file out.json`
- [x] `px sessions --format raw --no-progress | jq .`