### PR TITLE
chore(js): mark example apps as private to exclude from publish

### DIFF
--- a/js/examples/apps/experiments-quickstart/package.json
+++ b/js/examples/apps/experiments-quickstart/package.json
@@ -1,5 +1,6 @@
 {
   "name": "experiments-quickstart",
+  "private": true,
   "version": "1.0.0",
   "description": "Phoenix Datasets & Experiments Tutorial - TypeScript",
   "type": "module",

--- a/js/examples/apps/langchain-quickstart/package.json
+++ b/js/examples/apps/langchain-quickstart/package.json
@@ -1,5 +1,6 @@
 {
   "name": "langchain-quickstart",
+  "private": true,
   "version": "1.0.0",
   "description": "Simple LangChain TypeScript application with Phoenix tracing",
   "type": "module",

--- a/js/examples/apps/mastra-agent/package.json
+++ b/js/examples/apps/mastra-agent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mastra-agent",
+  "private": true,
   "version": "1.0.0",
   "description": "Simple Mastra agent with Arize Phoenix tracing",
   "type": "module",

--- a/js/examples/apps/mastra-quickstart/package.json
+++ b/js/examples/apps/mastra-quickstart/package.json
@@ -1,5 +1,6 @@
 {
   "name": "mastra-quickstart",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "keywords": [],

--- a/js/examples/apps/tracing-tutorial/package.json
+++ b/js/examples/apps/tracing-tutorial/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tracing-tutorial",
+  "private": true,
   "version": "1.0.0",
   "description": "Phoenix Tracing Tutorial - Learn to trace LLM applications with Phoenix",
   "type": "module",


### PR DESCRIPTION
## Summary
- Adds `"private": true` to five example app `package.json` files that were missing it, preventing them from being included in `pnpm publish -r` during CI releases
- Affected apps: `experiments-quickstart`, `langchain-quickstart`, `mastra-agent`, `mastra-quickstart`, `tracing-tutorial`
- Matches the pattern already used by other example apps (`cli-agent-starter-kit`, `demo-document-relevancy-experiment`, `phoenix-experiment-runner`)

## Test plan
- [x] Verified with `pnpm publish -r --dry-run` that none of the example apps appear in publish output