### PR TITLE
fix(js): fix oxfmt formatting in example apps

### DIFF
--- a/js/examples/apps/experiments-quickstart/package.json
+++ b/js/examples/apps/experiments-quickstart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "experiments-quickstart",
-  "private": true,
   "version": "1.0.0",
+  "private": true,
   "description": "Phoenix Datasets & Experiments Tutorial - TypeScript",
   "type": "module",
   "scripts": {

--- a/js/examples/apps/langchain-quickstart/package.json
+++ b/js/examples/apps/langchain-quickstart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langchain-quickstart",
-  "private": true,
   "version": "1.0.0",
+  "private": true,
   "description": "Simple LangChain TypeScript application with Phoenix tracing",
   "type": "module",
   "scripts": {

--- a/js/examples/apps/mastra-agent/package.json
+++ b/js/examples/apps/mastra-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mastra-agent",
-  "private": true,
   "version": "1.0.0",
+  "private": true,
   "description": "Simple Mastra agent with Arize Phoenix tracing",
   "type": "module",
   "scripts": {

--- a/js/examples/apps/mastra-quickstart/package.json
+++ b/js/examples/apps/mastra-quickstart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mastra-quickstart",
-  "private": true,
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "keywords": [],
   "license": "ISC",

--- a/js/examples/apps/tracing-tutorial/package.json
+++ b/js/examples/apps/tracing-tutorial/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tracing-tutorial",
-  "private": true,
   "version": "1.0.0",
+  "private": true,
   "description": "Phoenix Tracing Tutorial - Learn to trace LLM applications with Phoenix",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fix oxfmt formatting issues in 5 example app `package.json` files
- The `experimentalSortPackageJson` option reorders `private` after `version`

## Test plan
- [x] `pnpm fmt:check` passes in CI