### PR TITLE
fix(ci): use PAT for checkout in changeset action

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.MY_CHANGESET_TOKEN }}
       - name: setup node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- Adds `MY_CHANGESET_TOKEN` to the `actions/checkout` step in the changeset publish workflow
- Without this, `actions/checkout` persists the default `GITHUB_TOKEN` git credentials, so commits pushed by the changeset action don't trigger subsequent CI workflows

## Test plan
- [ ] Verify next changeset PR merge triggers CI workflows on push