### PR TITLE
docs(js): simplify OTel changeset description

### DIFF
--- a/js/.changeset/chore-ai-sdk-v6-otel-alignment.md
+++ b/js/.changeset/chore-ai-sdk-v6-otel-alignment.md
@@ -2,4 +2,4 @@
 "@arizeai/phoenix-otel": patch
 ---
 
-Align OpenTelemetry dependencies in `@arizeai/phoenix-otel` to a compatible v2 set and update tests to assert observable span processor behavior instead of internal provider fields.
+Align OpenTelemetry dependencies in `@arizeai/phoenix-otel` to a compatible v2 set.


### PR DESCRIPTION
## Summary
- Remove internal test refactor detail from the `@arizeai/phoenix-otel` changeset description, keeping only the consumer-facing information.

## Test plan
- No code changes; changeset text only.