### PR TITLE
fix(examples): bump langchain-core to fix CVE-2025-68664

### DIFF
--- a/examples/computer_use_agent/requirements.txt
+++ b/examples/computer_use_agent/requirements.txt
@@ -2,10 +2,10 @@ arize-phoenix
 arize-phoenix-evals
 arize-phoenix-otel
 beautifulsoup4==4.12.3
-langchain==0.3.14
-langchain-anthropic==0.3.0
-langchain-core>=0.3.29,<0.3.72
-langgraph==0.2.62
+langchain>=0.3.14
+langchain-anthropic>=0.3.0
+langchain-core>=0.3.81
+langgraph>=0.2.62
 loguru==0.7.2
 pandas==2.2.3
 python-dotenv==1.0.1

--- a/examples/rag_agent/requirements.txt
+++ b/examples/rag_agent/requirements.txt
@@ -3,12 +3,12 @@ arize-phoenix-evals
 arize-phoenix-otel
 beautifulsoup4==4.12.3
 duckduckgo_search==7.2.1
-langchain==0.3.14
+langchain>=0.3.14
 langchain-community
-langchain-core>=0.3.29,<0.3.72
-langchain-openai==0.2.11
+langchain-core>=0.3.81
+langchain-openai>=0.2.11
 langchain-text-splitters
-langgraph==0.2.62
+langgraph>=0.2.62
 loguru==0.7.2
 pandas==2.2.3
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Bumps `langchain-core` minimum to `>=0.3.81` in `examples/rag_agent` and `examples/computer_use_agent` to patch CVE-2025-68664 (CVSS 9.3)
- The serialization injection vulnerability in `dumps()`/`loads()` APIs allows secret extraction from environment variables
- Removes the `<0.3.72` upper bound that excluded the patched version and relaxes related langchain pins for compatibility

## Test plan
- [ ] Verify CI passes (no code changes, only dependency version bumps in example apps)