### PR TITLE
fix(ci): give each merge gate a unique status check name

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -96,7 +96,7 @@ jobs:
           retention-days: 30
 
   ci-required:
-    name: CI Required
+    name: Playwright CI Required
     needs:
       - changes
       - e2e-test

--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -526,7 +526,7 @@ jobs:
         run: uvx tox run -e phoenix_client_canary_tests_sdk_${{ matrix.pkg }} -- -ra -x
 
   ci-required:
-    name: CI Required
+    name: Python CI Required
     needs:
       - format-and-lint
       - changes

--- a/.github/workflows/typescript-CI.yml
+++ b/.github/workflows/typescript-CI.yml
@@ -75,7 +75,7 @@ jobs:
           pnpm run test
 
   ci-required:
-    name: CI Required
+    name: TypeScript CI Required
     needs:
       - changes
       - ci

--- a/.github/workflows/typescript-packages-CI.yml
+++ b/.github/workflows/typescript-packages-CI.yml
@@ -74,7 +74,7 @@ jobs:
           pnpm run lint
 
   ci-required:
-    name: CI Required
+    name: TypeScript Packages CI Required
     needs:
       - changes
       - ci


### PR DESCRIPTION
## Summary
- Rename all 4 `CI Required` merge gate jobs to unique names (`Python CI Required`, `TypeScript CI Required`, `TypeScript Packages CI Required`, `Playwright CI Required`)
- Enables identifying which gate is failing and independently configuring them in GitHub branch protection rules

## Post-merge action
Update GitHub branch protection rules to reference the new check names instead of the old `CI Required`.

## Test plan
- [ ] Verify the new names appear as distinct status checks on this PR