### PR TITLE
docs(evals): add TypeScript custom LLM evaluator example

### DIFF
--- a/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators.mdx
+++ b/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators.mdx
@@ -52,6 +52,9 @@ There is no limit to the number of label choices you can provide, and you can sp
 
 For the relevance evaluation, we define the evaluator as follows:
 
+<Tabs>
+  <Tab title="Python" icon="python">
+
 ```python
 from phoenix.evals import ClassificationEvaluator
 from phoenix.evals.llm import LLM
@@ -66,6 +69,43 @@ relevance_classifier = ClassificationEvaluator(
 )
 results = relevance_classifier.evaluate({"query": "input query goes here", "reference": "document text goes here"})
 ```
+
+  </Tab>
+
+  <Tab title="TypeScript" icon="js">
+
+```typescript
+import { createClassificationEvaluator } from "@arizeai/phoenix-evals";
+import { openai } from "@ai-sdk/openai";
+
+const relevanceClassifier = createClassificationEvaluator({
+  name: "relevance",
+  model: openai("gpt-4o"),
+  promptTemplate: `You are comparing a reference text to a question and trying to determine if the reference text
+contains information relevant to answering the question. Here is the data:
+    [BEGIN DATA]
+    ************
+    [Question]: {{query}}
+    ************
+    [Reference text]: {{reference}}
+    [END DATA]
+
+Compare the Question above to the Reference text. You must determine whether the Reference text
+contains information that can answer the Question. Please focus on whether the very specific
+question can be answered by the information in the Reference text.
+"irrelevant" means that the reference text does not contain an answer to the Question.
+"relevant" means the reference text contains an answer to the Question.`,
+  choices: { irrelevant: 0, relevant: 1 },
+});
+
+const result = await relevanceClassifier.evaluate({
+  query: "input query goes here",
+  reference: "document text goes here",
+});
+```
+
+  </Tab>
+</Tabs>
 
 ### Custom Numeric Rating LLM Evaluator
 


### PR DESCRIPTION
fixes #11788

Adds a TypeScript example to the **Custom LLM Evaluators** docs page so Python and TypeScript users have parallel guidance in the core "Putting it together" section.

### What changed
- Wrapped the existing Python example in language tabs
- Added a matching TypeScript example using createClassificationEvaluator

### Validation
- Docs-only change; no repo-defined local docs check target was found in this checkout
- Verified markdown structure remains consistent with existing eval docs tabs