### PR TITLE
fix(js): add tabIndex to TokenCount/TokenCosts Pressable call sites

### DIFF
--- a/app/src/components/experiment/ExperimentAverageRunTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentAverageRunTokenCosts.tsx
@@ -36,7 +36,7 @@ export function ExperimentAverageRunTokenCosts(
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCosts size={props.size} role="button">
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
           {props.averageRunCostTotal}
         </TokenCosts>
       </Pressable>

--- a/app/src/components/experiment/ExperimentAverageRunTokenCount.tsx
+++ b/app/src/components/experiment/ExperimentAverageRunTokenCount.tsx
@@ -40,7 +40,7 @@ export function ExperimentAverageRunTokenCount(
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.averageRunTokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCosts.tsx
@@ -36,7 +36,9 @@ export function ExperimentRepeatedRunGroupTokenCosts(
   return (
     <TooltipTrigger isDisabled={props.costTotal == null}>
       <Pressable>
-        <TokenCosts size={props.size}>{props.costTotal}</TokenCosts>
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
+          {props.costTotal}
+        </TokenCosts>
       </Pressable>
       <RichTooltip>
         <TooltipArrow />

--- a/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCount.tsx
+++ b/app/src/components/experiment/ExperimentRepeatedRunGroupTokenCount.tsx
@@ -36,7 +36,7 @@ export function ExperimentRepeatedRunGroupTokenCount(
   return (
     <TooltipTrigger isDisabled={props.tokenCountTotal == null}>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/experiment/ExperimentRunTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentRunTokenCosts.tsx
@@ -34,7 +34,9 @@ export function ExperimentRunTokenCosts(props: ExperimentRunTokenCostsProps) {
   return (
     <TooltipTrigger isDisabled={props.costTotal == null}>
       <Pressable>
-        <TokenCosts size={props.size}>{props.costTotal}</TokenCosts>
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
+          {props.costTotal}
+        </TokenCosts>
       </Pressable>
       <RichTooltip>
         <TooltipArrow />

--- a/app/src/components/experiment/ExperimentRunTokenCount.tsx
+++ b/app/src/components/experiment/ExperimentRunTokenCount.tsx
@@ -34,7 +34,7 @@ export function ExperimentRunTokenCount(props: ExperimentRunTokenCountProps) {
   return (
     <TooltipTrigger isDisabled={props.tokenCountTotal == null}>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/experiment/ExperimentTokenCosts.tsx
+++ b/app/src/components/experiment/ExperimentTokenCosts.tsx
@@ -34,7 +34,7 @@ export function ExperimentTokenCosts(props: ExperimentTokenCostsProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCosts size={props.size} role="button">
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
           {props.totalCost}
         </TokenCosts>
       </Pressable>

--- a/app/src/components/experiment/ExperimentTokenCount.tsx
+++ b/app/src/components/experiment/ExperimentTokenCount.tsx
@@ -38,7 +38,7 @@ export function ExperimentTokenCount(props: ExperimentTokenCountProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/trace/SessionTokenCosts.tsx
+++ b/app/src/components/trace/SessionTokenCosts.tsx
@@ -34,7 +34,7 @@ export function SessionTokenCosts(props: SessionTokenCostsProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCosts size={props.size} role="button">
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
           {props.totalCost}
         </TokenCosts>
       </Pressable>

--- a/app/src/components/trace/SessionTokenCount.tsx
+++ b/app/src/components/trace/SessionTokenCount.tsx
@@ -34,7 +34,7 @@ export function SessionTokenCount(props: SessionTokenCountProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/trace/SpanCumulativeTokenCount.tsx
+++ b/app/src/components/trace/SpanCumulativeTokenCount.tsx
@@ -34,7 +34,7 @@ export function SpanCumulativeTokenCount(props: SpanCumulativeTokenCountProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/trace/SpanTokenCosts.tsx
+++ b/app/src/components/trace/SpanTokenCosts.tsx
@@ -34,7 +34,7 @@ export function SpanTokenCosts(props: SpanTokenCostsProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCosts size={props.size} role="button">
+        <TokenCosts size={props.size} role="button" tabIndex={0}>
           {props.totalCost}
         </TokenCosts>
       </Pressable>

--- a/app/src/components/trace/SpanTokenCount.tsx
+++ b/app/src/components/trace/SpanTokenCount.tsx
@@ -40,7 +40,7 @@ export function SpanTokenCount(props: SpanTokenCountProps) {
   return (
     <TooltipTrigger>
       <Pressable onPress={handlePress}>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>

--- a/app/src/components/trace/TraceTokenCount.tsx
+++ b/app/src/components/trace/TraceTokenCount.tsx
@@ -34,7 +34,7 @@ export function TraceTokenCount(props: TraceTokenCountProps) {
   return (
     <TooltipTrigger>
       <Pressable>
-        <TokenCount size={props.size} role="button">
+        <TokenCount size={props.size} role="button" tabIndex={0}>
           {props.tokenCountTotal}
         </TokenCount>
       </Pressable>


### PR DESCRIPTION
## Summary
- Adds `tabIndex={0}` to all 14 `TokenCount`/`TokenCosts` usages wrapped in `<Pressable>`, fixing the react-aria warning: *"Pressable child must be focusable"*
- Adds missing `role="button"` to `ExperimentRunTokenCosts` and `ExperimentRepeatedRunGroupTokenCosts`
- Non-interactive display usages (placeholders, null-data cases) are left unchanged so they don't pollute the tab order

## Test plan
- [ ] `npx tsc --noEmit` passes in `app/`
- [ ] Open a trace with token counts — console warning is gone
- [ ] Token count/cost elements are keyboard-focusable via Tab key
- [ ] Placeholder elements (e.g. `ExperimentRunMetadataEmpty`) are **not** focusable