### PR TITLE
ci: dispatch package version updates from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,7 @@ name: Publish Python packages
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   list-python-packages:
@@ -137,6 +138,8 @@ jobs:
             exit 1
           fi
           echo "ref=refs/tags/${NAME}-v${VERSION}" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}
@@ -151,6 +154,17 @@ jobs:
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Trigger dependency update workflow
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE="${{ steps.ref.outputs.name }}"
+          VERSION="${{ steps.ref.outputs.version }}"
+          gh workflow run update-phoenix-package-versions.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --field package="$PACKAGE" \
+            --field version="$VERSION"
 
   slack:
     name: Slack notification

--- a/.github/workflows/update-phoenix-package-versions.yml
+++ b/.github/workflows/update-phoenix-package-versions.yml
@@ -5,18 +5,16 @@ permissions:
   pull-requests: write
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package name (client, evals, or otel)'
+        description: 'Package name to update'
         required: true
         type: choice
         options:
-          - client
-          - evals
-          - otel
+          - arize-phoenix-client
+          - arize-phoenix-evals
+          - arize-phoenix-otel
       version:
         description: 'Version to update to (e.g., 1.23.0)'
         required: true
@@ -26,14 +24,9 @@ jobs:
   update-package-version:
     name: Update Phoenix Package Version in pyproject.toml
     runs-on: ubuntu-latest
-    # Only run if this is a package release or manual trigger
-    # Note: If this workflow doesn't trigger (GitHub may prevent workflows triggered by
-    # other workflows to avoid recursion), use workflow_dispatch to trigger manually.
-    if: |
-      github.event_name == 'workflow_dispatch' || 
-      startsWith(github.event.release.tag_name, 'arize-phoenix-client-v') ||
-      startsWith(github.event.release.tag_name, 'arize-phoenix-evals-v') ||
-      startsWith(github.event.release.tag_name, 'arize-phoenix-otel-v')
+    env:
+      PACKAGE_NAME: ${{ inputs.package }}
+      PACKAGE_VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,64 +34,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
 
-      - name: Determine package and extract version
-        id: extract-version
+      - name: Validate version input
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger - use inputs
-            PACKAGE="${{ inputs.package }}"
-            VERSION="${{ inputs.version }}"
-            TRIGGER="manual"
-            echo "Manual trigger: arize-phoenix-$PACKAGE $VERSION"
-          else
-            # Release trigger - extract from tag
-            TAG_NAME="${{ github.event.release.tag_name }}"
-            
-            # Determine which package from tag (using case for clarity and POSIX compatibility)
-            case "$TAG_NAME" in
-              arize-phoenix-client-v*)
-                PACKAGE="client"
-                VERSION=${TAG_NAME#arize-phoenix-client-v}
-                ;;
-              arize-phoenix-evals-v*)
-                PACKAGE="evals"
-                VERSION=${TAG_NAME#arize-phoenix-evals-v}
-                ;;
-              arize-phoenix-otel-v*)
-                PACKAGE="otel"
-                VERSION=${TAG_NAME#arize-phoenix-otel-v}
-                ;;
-              *)
-                echo "❌ Error: Unknown package from tag $TAG_NAME"
-                exit 1
-                ;;
-            esac
-            
-            TRIGGER="automatic"
-            echo "Release tag: $TAG_NAME"
-            echo "Package: arize-phoenix-$PACKAGE"
-            echo "Extracted version: $VERSION"
-          fi
+          echo "Dispatch trigger: $PACKAGE_NAME $PACKAGE_VERSION"
           
           # Validate version format (basic semver check)
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
-            echo "❌ Error: Invalid version format: $VERSION"
+          if ! echo "$PACKAGE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+            echo "❌ Error: Invalid version format: $PACKAGE_VERSION"
             echo "Expected semantic version (e.g., 1.2.3, 1.2.3-alpha.1, 1.2.3+build.1)"
             exit 1
           fi
-          
-          echo "package=$PACKAGE" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "trigger=$TRIGGER" >> $GITHUB_OUTPUT
-          echo "tag_name=${TAG_NAME:-manual}" >> $GITHUB_OUTPUT
 
       - name: Check if update is needed
         id: check-update
         run: |
-          PACKAGE="${{ steps.extract-version.outputs.package }}"
-          NEW_VERSION="${{ steps.extract-version.outputs.version }}"
-          PACKAGE_NAME="arize-phoenix-$PACKAGE"
-          
           # Extract current version from pyproject.toml
           CURRENT_VERSION=$(grep -E "^\s*\"$PACKAGE_NAME>=" pyproject.toml | head -n 1 | sed -n "s/.*$PACKAGE_NAME>=\([0-9.]*\).*/\1/p")
           
@@ -108,9 +57,9 @@ jobs:
             exit 0
           fi
           
-          if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
+          if [ "$CURRENT_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "📦 Update needed for $PACKAGE_NAME: $CURRENT_VERSION → $NEW_VERSION"
+            echo "📦 Update needed for $PACKAGE_NAME: $CURRENT_VERSION → $PACKAGE_VERSION"
           else
             echo "needs_update=false" >> $GITHUB_OUTPUT
             echo "✓ Versions already match for $PACKAGE_NAME: $CURRENT_VERSION"
@@ -119,13 +68,9 @@ jobs:
       - name: Update pyproject.toml
         if: steps.check-update.outputs.needs_update == 'true'
         run: |
-          PACKAGE="${{ steps.extract-version.outputs.package }}"
-          NEW_VERSION="${{ steps.extract-version.outputs.version }}"
-          PACKAGE_NAME="arize-phoenix-$PACKAGE"
-          
           # Surgically replace only the version number, preserving all formatting
           # Escape special chars in version for sed (periods, forward slashes, etc.)
-          ESCAPED_VERSION=$(printf '%s\n' "$NEW_VERSION" | sed 's/[.[\*^$/]/\\&/g')
+          ESCAPED_VERSION=$(printf '%s\n' "$PACKAGE_VERSION" | sed 's/[.[\*^$/]/\\&/g')
           
           if ! sed -i.bak "s/\($PACKAGE_NAME>=\)[0-9.]*/\1$ESCAPED_VERSION/" pyproject.toml; then
             echo "❌ Error: Failed to update pyproject.toml"
@@ -133,7 +78,7 @@ jobs:
           fi
           rm pyproject.toml.bak
           
-          echo "✓ Updated $PACKAGE_NAME to $NEW_VERSION"
+          echo "✓ Updated $PACKAGE_NAME to $PACKAGE_VERSION"
           grep "$PACKAGE_NAME" pyproject.toml
 
       - name: Verify changes
@@ -155,19 +100,17 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          commit-message: "fix(deps): update arize-phoenix-${{ steps.extract-version.outputs.package }} to ${{ steps.extract-version.outputs.version }}"
-          title: "fix(deps): update arize-phoenix-${{ steps.extract-version.outputs.package }} to ${{ steps.extract-version.outputs.version }}"
+          commit-message: "fix(deps): update ${{ env.PACKAGE_NAME }} to ${{ env.PACKAGE_VERSION }}"
+          title: "fix(deps): update ${{ env.PACKAGE_NAME }} to ${{ env.PACKAGE_VERSION }}"
           body: |
             ## 📦 Dependency Update
             
-            Updates `arize-phoenix-${{ steps.extract-version.outputs.package }}` to version **${{ steps.extract-version.outputs.version }}**
-            
-            **Trigger:** ${{ steps.extract-version.outputs.trigger == 'manual' && 'Manual workflow dispatch' || format('Release {0}', steps.extract-version.outputs.tag_name) }}
+            Updates `${{ env.PACKAGE_NAME }}` to version **${{ env.PACKAGE_VERSION }}**
             
             ---
             
             <sub>This PR was automatically generated by the `update-phoenix-package-versions` workflow.</sub>
-          branch: update-phoenix-${{ steps.extract-version.outputs.package }}-${{ steps.extract-version.outputs.version }}
+          branch: update-phoenix-${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}
           base: main
           delete-branch: true
 


### PR DESCRIPTION
Move package-version updates to explicit workflow dispatches from publish and align inputs to package names from release metadata, while keeping publish resilient if dispatch fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI automation and permissions (adds `actions: write`) and introduces cross-workflow dispatching that could fail or misfire, affecting dependency update PR creation but not runtime code.
> 
> **Overview**
> After successfully publishing each non-root Python package, `publish.yaml` now triggers `update-phoenix-package-versions.yml` via `gh workflow run`, passing the released package name/version from the release manifest, and grants the workflow `actions: write` to allow dispatch.
> 
> `update-phoenix-package-versions.yml` is simplified to **dispatch-only** (removes release-event triggering and tag parsing), aligns `package` inputs to full package names (e.g., `arize-phoenix-client`), and updates PR/branch naming and messages to use the dispatched `PACKAGE_NAME`/`PACKAGE_VERSION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64241674df200a5fa54dbf5abf660d5a29104e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->