### PR TITLE
chore: fix missing quote in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ help: ## Show this help message
 	@echo -e "  test-python            - Run Python tests (unit + integration)"
 	@echo -e "  test-frontend          - Run frontend tests (app/)"
 	@echo -e "  test-ts                - Run TypeScript package tests (js/)"
-	@echo -e "  test-helm              - Run Helm chart tests
+	@echo -e "  test-helm              - Run Helm chart tests"
 	@echo -e "  typecheck              - Type check all code (Python + frontend + TypeScript)"
 	@echo -e "  typecheck-python       - Type check Python only"
 	@echo -e "  typecheck-python-ty    - Type check Python with ty (verify expected errors only)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line documentation/help output fix in the `Makefile` with no impact on build/test execution logic.
> 
> **Overview**
> Fixes the `Makefile` `help` target output by adding the missing closing quote on the `test-helm` description line, preventing malformed `echo` output when listing make targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04dc7baf5006e613f9b8616c3ce1d6b45fc8d1a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->