### PR TITLE
perf(db): use bulk inserts for dataset example creation

### DIFF
--- a/src/phoenix/db/insertion/dataset.py
+++ b/src/phoenix/db/insertion/dataset.py
@@ -88,24 +88,6 @@ async def insert_dataset_version(
     return cast(DatasetVersionId, id_)
 
 
-async def insert_dataset_example(
-    session: AsyncSession,
-    dataset_id: DatasetId,
-    span_rowid: Optional[SpanRowId] = None,
-    created_at: Optional[datetime] = None,
-) -> DatasetExampleId:
-    id_ = await session.scalar(
-        insert(models.DatasetExample)
-        .values(
-            dataset_id=dataset_id,
-            span_rowid=span_rowid,
-            created_at=created_at,
-        )
-        .returning(models.DatasetExample.id)
-    )
-    return cast(DatasetExampleId, id_)
-
-
 class RevisionKind(Enum):
     CREATE = "CREATE"
     PATCH = "PATCH"
@@ -116,32 +98,6 @@ class RevisionKind(Enum):
         if isinstance(v, str) and v and v.isascii() and not v.isupper():
             return cls(v.upper())
         raise ValueError(f"Invalid revision kind: {v}")
-
-
-async def insert_dataset_example_revision(
-    session: AsyncSession,
-    dataset_version_id: DatasetVersionId,
-    dataset_example_id: DatasetExampleId,
-    input: Mapping[str, Any],
-    output: Mapping[str, Any],
-    metadata: Optional[Mapping[str, Any]] = None,
-    revision_kind: RevisionKind = RevisionKind.CREATE,
-    created_at: Optional[datetime] = None,
-) -> DatasetExampleRevisionId:
-    id_ = await session.scalar(
-        insert(models.DatasetExampleRevision)
-        .values(
-            dataset_version_id=dataset_version_id,
-            dataset_example_id=dataset_example_id,
-            input=input,
-            output=output,
-            metadata_=metadata,
-            revision_kind=revision_kind.value,
-            created_at=created_at,
-        )
-        .returning(models.DatasetExampleRevision.id)
-    )
-    return cast(DatasetExampleRevisionId, id_)
 
 
 async def bulk_insert_dataset_examples(
@@ -257,34 +213,45 @@ async def bulk_insert_dataset_example_revisions(
 async def resolve_span_ids_to_rowids(
     session: AsyncSession,
     span_ids: list[Optional[str]],
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> dict[str, int]:
     """
     Batch resolve span_id strings to database row IDs.
 
     Args:
         session: Database session
-        span_ids: List of OTEL span ID strings
+        span_ids: List of OTEL span ID strings (duplicates are handled efficiently)
+        batch_size: Number of span IDs per query batch (default: DEFAULT_BATCH_SIZE)
 
     Returns:
         Dictionary mapping span_id to Span.id (database row ID)
     """
-    # Filter out None and empty strings
-    valid_span_ids = [sid for sid in span_ids if sid]
-    if not valid_span_ids:
+    # Filter out None and empty strings, then deduplicate
+    # Deduplication is critical: 10,000 examples referencing the same 5 span IDs
+    # should only use 5 query parameters, not 10,000
+    unique_span_ids = {sid for sid in span_ids if sid}
+    if not unique_span_ids:
         return {}
-
-    # Query spans table for matching span_ids
-    result = await session.execute(
-        select(models.Span.span_id, models.Span.id).where(models.Span.span_id.in_(valid_span_ids))
-    )
 
     # Build mapping of span_id (string) to span row ID (int)
     span_id_to_rowid: dict[str, int] = {}
-    for span_id, row_id in result.all():
-        span_id_to_rowid[span_id] = row_id
+
+    # Process in batches to avoid exceeding database parameter limits
+    # (e.g., SQLite's 32,767 limit for bound parameters)
+    unique_span_ids_list = list(unique_span_ids)
+    for i in range(0, len(unique_span_ids_list), batch_size):
+        batch = unique_span_ids_list[i : i + batch_size]
+
+        # Query spans table for matching span_ids in this batch
+        result = await session.execute(
+            select(models.Span.span_id, models.Span.id).where(models.Span.span_id.in_(batch))
+        )
+
+        for span_id, row_id in result.all():
+            span_id_to_rowid[span_id] = row_id
 
     # Log warnings for span IDs that couldn't be resolved
-    missing_span_ids = set(valid_span_ids) - set(span_id_to_rowid.keys())
+    missing_span_ids = unique_span_ids - set(span_id_to_rowid.keys())
     if missing_span_ids:
         logger.warning(
             f"Could not resolve {len(missing_span_ids)} span IDs to database records. "
@@ -339,10 +306,16 @@ async def bulk_create_dataset_splits(
 async def bulk_assign_examples_to_splits(
     session: AsyncSession,
     assignments: list[tuple[DatasetExampleId, int]],
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> None:
     """
     Bulk assign examples to splits.
     assignments is a list of (dataset_example_id, dataset_split_id) tuples.
+
+    Args:
+        session: Database session
+        assignments: List of (dataset_example_id, dataset_split_id) tuples
+        batch_size: Number of records per batch insert (default: DEFAULT_BATCH_SIZE)
     """
     if not assignments:
         return
@@ -352,32 +325,37 @@ async def bulk_assign_examples_to_splits(
     from typing_extensions import assert_never
 
     dialect = SupportedSQLDialect(session.bind.dialect.name)
-    records = [
-        {
-            "dataset_example_id": example_id,
-            "dataset_split_id": split_id,
-        }
-        for example_id, split_id in assignments
-    ]
 
-    # Use index_elements instead of constraint name because the table uses
-    # a PrimaryKeyConstraint, not a unique constraint
-    if dialect is SupportedSQLDialect.POSTGRESQL:
-        pg_stmt = pg_insert(models.DatasetSplitDatasetExample).values(records)
-        await session.execute(
-            pg_stmt.on_conflict_do_nothing(
-                index_elements=["dataset_split_id", "dataset_example_id"]
+    # Process in batches to avoid exceeding database parameter limits
+    # (e.g., SQLite's 32,767 limit, PostgreSQL's similar constraints)
+    for i in range(0, len(assignments), batch_size):
+        batch = assignments[i : i + batch_size]
+        records = [
+            {
+                "dataset_example_id": example_id,
+                "dataset_split_id": split_id,
+            }
+            for example_id, split_id in batch
+        ]
+
+        # Use index_elements instead of constraint name because the table uses
+        # a PrimaryKeyConstraint, not a unique constraint
+        if dialect is SupportedSQLDialect.POSTGRESQL:
+            pg_stmt = pg_insert(models.DatasetSplitDatasetExample).values(records)
+            await session.execute(
+                pg_stmt.on_conflict_do_nothing(
+                    index_elements=["dataset_split_id", "dataset_example_id"]
+                )
             )
-        )
-    elif dialect is SupportedSQLDialect.SQLITE:
-        sqlite_stmt = sqlite_insert(models.DatasetSplitDatasetExample).values(records)
-        await session.execute(
-            sqlite_stmt.on_conflict_do_nothing(
-                index_elements=["dataset_split_id", "dataset_example_id"]
+        elif dialect is SupportedSQLDialect.SQLITE:
+            sqlite_stmt = sqlite_insert(models.DatasetSplitDatasetExample).values(records)
+            await session.execute(
+                sqlite_stmt.on_conflict_do_nothing(
+                    index_elements=["dataset_split_id", "dataset_example_id"]
+                )
             )
-        )
-    else:
-        assert_never(dialect)
+        else:
+            assert_never(dialect)
 
 
 class DatasetAction(Enum):

--- a/tests/unit/db/insertion/test_dataset.py
+++ b/tests/unit/db/insertion/test_dataset.py
@@ -1,9 +1,16 @@
 from datetime import datetime, timezone
 
+import pytest
 from sqlalchemy import insert, select
 
 from phoenix.db import models
-from phoenix.db.insertion.dataset import ExampleContent, add_dataset_examples
+from phoenix.db.insertion.dataset import (
+    ExampleContent,
+    add_dataset_examples,
+    bulk_assign_examples_to_splits,
+    bulk_create_dataset_splits,
+    resolve_span_ids_to_rowids,
+)
 from phoenix.server.types import DbSessionFactory
 
 
@@ -159,3 +166,359 @@ async def test_create_dataset_with_span_links(
 
         # Fourth example should have no link (no span_id provided)
         assert examples_list[3].span_rowid is None
+
+
+async def test_resolve_span_ids_to_rowids_deduplicates_input(
+    db: DbSessionFactory,
+) -> None:
+    """Test that resolve_span_ids_to_rowids deduplicates span IDs before querying.
+
+    This is critical for performance: 10,000 examples referencing the same 5 span IDs
+    should only consume 5 query parameters, not 10,000.
+    """
+    # Create a trace and span
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="dedup-test-project").returning(models.Project.id)
+        )
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                project_rowid=project_id,
+                trace_id="dedup-test-trace",
+                start_time=datetime.now(timezone.utc),
+                end_time=datetime.now(timezone.utc),
+            )
+            .returning(models.Trace.id)
+        )
+        span_rowid = await session.scalar(
+            insert(models.Span)
+            .values(
+                trace_rowid=trace_id,
+                span_id="duplicate-span-id",
+                name="test_span",
+                span_kind="INTERNAL",
+                start_time=datetime.now(timezone.utc),
+                end_time=datetime.now(timezone.utc),
+                attributes={},
+                events=[],
+                status_code="OK",
+                status_message="",
+                cumulative_error_count=0,
+                cumulative_llm_token_count_prompt=0,
+                cumulative_llm_token_count_completion=0,
+            )
+            .returning(models.Span.id)
+        )
+        await session.commit()
+
+    # Pass many duplicates of the same span ID
+    span_ids_with_duplicates: list[str | None] = (
+        ["duplicate-span-id"] * 100 + [None] * 50 + [""] * 25
+    )
+
+    async with db() as session:
+        result = await resolve_span_ids_to_rowids(session, span_ids_with_duplicates)
+
+    # Should still resolve correctly
+    assert len(result) == 1
+    assert result["duplicate-span-id"] == span_rowid
+
+
+async def test_resolve_span_ids_to_rowids_batches_large_inputs(
+    db: DbSessionFactory,
+) -> None:
+    """Test that resolve_span_ids_to_rowids processes large inputs in batches.
+
+    With a small batch_size, we can verify batching works without creating
+    thousands of spans.
+    """
+    # Create multiple spans
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project).values(name="batch-test-project").returning(models.Project.id)
+        )
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                project_rowid=project_id,
+                trace_id="batch-test-trace",
+                start_time=datetime.now(timezone.utc),
+                end_time=datetime.now(timezone.utc),
+            )
+            .returning(models.Trace.id)
+        )
+
+        # Create 10 spans
+        span_id_strs = [f"span-batch-{i}" for i in range(10)]
+        span_rowids: dict[str, int] = {}
+        for span_id in span_id_strs:
+            rowid = await session.scalar(
+                insert(models.Span)
+                .values(
+                    trace_rowid=trace_id,
+                    span_id=span_id,
+                    name=f"test_span_{span_id}",
+                    span_kind="INTERNAL",
+                    start_time=datetime.now(timezone.utc),
+                    end_time=datetime.now(timezone.utc),
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+                .returning(models.Span.id)
+            )
+            assert rowid is not None
+            span_rowids[span_id] = rowid
+        await session.commit()
+
+    # Resolve with a small batch size to force multiple batches
+    # Cast to list[str | None] as required by the function signature
+    span_ids_input: list[str | None] = list(span_id_strs)
+    async with db() as session:
+        result = await resolve_span_ids_to_rowids(session, span_ids_input, batch_size=3)
+
+    # All 10 spans should be resolved correctly
+    assert len(result) == 10
+    for span_id in span_id_strs:
+        assert result[span_id] == span_rowids[span_id]
+
+
+async def test_bulk_assign_examples_to_splits_batches_large_inputs(
+    db: DbSessionFactory,
+) -> None:
+    """Test that bulk_assign_examples_to_splits processes large inputs in batches.
+
+    With 2 params per row, large datasets with multiple splits can easily exceed
+    the 32,767 parameter limit. This test verifies batching works correctly.
+    """
+    # Create a dataset with examples
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=[ExampleContent(input={"x": i}, output={"z": i * 2}) for i in range(10)],
+            name="batch-split-test",
+        )
+
+    # Get the example IDs
+    async with db() as session:
+        examples = await session.scalars(
+            select(models.DatasetExample)
+            .join(models.Dataset)
+            .where(models.Dataset.name == "batch-split-test")
+        )
+        example_ids = [e.id for e in examples]
+
+        # Create multiple splits
+        split_name_to_id = await bulk_create_dataset_splits(
+            session, {"split-a", "split-b", "split-c"}
+        )
+
+        # Create assignments (every example to every split = 30 assignments)
+        assignments = [
+            (example_id, split_id)
+            for example_id in example_ids
+            for split_id in split_name_to_id.values()
+        ]
+
+        # Use small batch_size to verify batching
+        await bulk_assign_examples_to_splits(session, assignments, batch_size=5)
+        await session.commit()
+
+    # Verify all assignments were made
+    async with db() as session:
+        result = await session.execute(select(models.DatasetSplitDatasetExample))
+        all_assignments = result.scalars().all()
+        assert len(all_assignments) == 30  # 10 examples x 3 splits
+
+
+async def test_bulk_assign_examples_to_splits_handles_duplicates(
+    db: DbSessionFactory,
+) -> None:
+    """Test that bulk_assign_examples_to_splits handles duplicate assignments gracefully.
+
+    The ON CONFLICT DO NOTHING clause should prevent errors from duplicates.
+    """
+    # Create a dataset with examples
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=[
+                ExampleContent(input={"x": 1}, output={"z": 2}),
+            ],
+            name="duplicate-split-test",
+        )
+
+    async with db() as session:
+        examples = await session.scalars(
+            select(models.DatasetExample)
+            .join(models.Dataset)
+            .where(models.Dataset.name == "duplicate-split-test")
+        )
+        example_id = next(iter(examples)).id
+
+        split_name_to_id = await bulk_create_dataset_splits(session, {"test-split"})
+        split_id = split_name_to_id["test-split"]
+
+        # Assign the same example-split pair multiple times
+        duplicate_assignments = [(example_id, split_id)] * 5
+
+        # Should not raise an error
+        await bulk_assign_examples_to_splits(session, duplicate_assignments)
+        await session.commit()
+
+    # Verify only one assignment exists
+    async with db() as session:
+        result = await session.execute(
+            select(models.DatasetSplitDatasetExample).where(
+                models.DatasetSplitDatasetExample.dataset_example_id == example_id
+            )
+        )
+        all_assignments = result.scalars().all()
+        assert len(all_assignments) == 1
+
+
+async def test_add_dataset_examples_with_many_splits(
+    db: DbSessionFactory,
+) -> None:
+    """Test end-to-end that creating examples with splits works correctly with batching.
+
+    This tests the full flow through add_dataset_examples -> bulk_assign_examples_to_splits.
+    """
+    # Create 15 examples each belonging to 3 different splits
+    examples = [
+        ExampleContent(
+            input={"x": i},
+            output={"z": i * 2},
+            splits=frozenset(["train", "eval", "test"]),
+        )
+        for i in range(15)
+    ]
+
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=examples,
+            name="many-splits-dataset",
+        )
+
+    # Verify all examples have all splits assigned
+    async with db() as session:
+        result = await session.execute(
+            select(models.DatasetSplitDatasetExample)
+            .join(models.DatasetExample)
+            .join(models.Dataset)
+            .where(models.Dataset.name == "many-splits-dataset")
+        )
+        all_assignments = result.scalars().all()
+        # 15 examples x 3 splits = 45 assignments
+        assert len(all_assignments) == 45
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7, 100])
+async def test_resolve_span_ids_to_rowids_various_batch_sizes(
+    db: DbSessionFactory,
+    batch_size: int,
+) -> None:
+    """Test that resolve_span_ids_to_rowids works correctly with various batch sizes."""
+    # Create spans
+    async with db() as session:
+        project_id = await session.scalar(
+            insert(models.Project)
+            .values(name=f"batch-size-{batch_size}-project")
+            .returning(models.Project.id)
+        )
+        trace_id = await session.scalar(
+            insert(models.Trace)
+            .values(
+                project_rowid=project_id,
+                trace_id=f"batch-size-{batch_size}-trace",
+                start_time=datetime.now(timezone.utc),
+                end_time=datetime.now(timezone.utc),
+            )
+            .returning(models.Trace.id)
+        )
+
+        # Create 10 spans
+        expected_mappings: dict[str, int] = {}
+        for i in range(10):
+            span_id = f"span-size-{batch_size}-{i}"
+            rowid = await session.scalar(
+                insert(models.Span)
+                .values(
+                    trace_rowid=trace_id,
+                    span_id=span_id,
+                    name=f"test_span_{i}",
+                    span_kind="INTERNAL",
+                    start_time=datetime.now(timezone.utc),
+                    end_time=datetime.now(timezone.utc),
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+                .returning(models.Span.id)
+            )
+            assert rowid is not None
+            expected_mappings[span_id] = rowid
+        await session.commit()
+
+    # Resolve with parameterized batch size
+    async with db() as session:
+        span_ids: list[str | None] = list(expected_mappings.keys())
+        result = await resolve_span_ids_to_rowids(session, span_ids, batch_size=batch_size)
+
+    assert result == expected_mappings
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7, 100])
+async def test_bulk_assign_examples_to_splits_various_batch_sizes(
+    db: DbSessionFactory,
+    batch_size: int,
+) -> None:
+    """Test that bulk_assign_examples_to_splits works correctly with various batch sizes."""
+    # Create a dataset with examples
+    async with db() as session:
+        await add_dataset_examples(
+            session=session,
+            examples=[ExampleContent(input={"x": i}, output={"z": i}) for i in range(5)],
+            name=f"batch-size-{batch_size}-split-test",
+        )
+
+    async with db() as session:
+        examples = await session.scalars(
+            select(models.DatasetExample)
+            .join(models.Dataset)
+            .where(models.Dataset.name == f"batch-size-{batch_size}-split-test")
+        )
+        example_ids = [e.id for e in examples]
+
+        split_name_to_id = await bulk_create_dataset_splits(session, {"split-x", "split-y"})
+
+        # Create assignments (5 examples x 2 splits = 10 assignments)
+        assignments = [
+            (example_id, split_id)
+            for example_id in example_ids
+            for split_id in split_name_to_id.values()
+        ]
+
+        await bulk_assign_examples_to_splits(session, assignments, batch_size=batch_size)
+        await session.commit()
+
+    # Verify all assignments were made
+    async with db() as session:
+        result = await session.execute(
+            select(models.DatasetSplitDatasetExample)
+            .join(models.DatasetExample)
+            .join(models.Dataset)
+            .where(models.Dataset.name == f"batch-size-{batch_size}-split-test")
+        )
+        all_assignments = result.scalars().all()
+        assert len(all_assignments) == 10


### PR DESCRIPTION
## Summary

Anecdotally improves performance of dataset uploads for a 5MB dataset from around 17s to 3s (10,000 rows)

- Replace sequential single-row inserts with batched bulk inserts when adding examples to datasets
- Dramatically reduces database round trips for large dataset uploads
- Add `bulk_insert_dataset_examples()` and `bulk_insert_dataset_example_revisions()` functions
- Use configurable batch size (default 1000) to balance performance and memory

## Performance Impact

| Examples | Before (round trips) | After (round trips) | Speedup |
|----------|---------------------|---------------------|---------|
| 100      | 200                 | 2                   | ~100x   |
| 1,000    | 2,000               | 2                   | ~1000x  |
| 10,000   | 20,000              | 20                  | ~1000x  |
| 100,000  | 200,000             | 200                 | ~1000x  |

## Details

The original code inserted dataset examples one at a time in a loop:
- For N examples, this required 2N database round trips (one for `DatasetExample`, one for `DatasetExampleRevision`)

The new code uses `INSERT ... VALUES (...), (...), ... RETURNING id` to insert up to 1000 rows at a time, reducing round trips by ~1000x.

## Test Plan

- All existing dataset tests pass (288 tests)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dataset ingestion write paths and relies on bulk `RETURNING` ordering and batching behavior across SQLite/Postgres, which could affect correctness/performance under different dialects despite added test coverage.
> 
> **Overview**
> Switches `add_dataset_examples` from per-row inserts to batched `INSERT ... RETURNING` flows via new `bulk_insert_dataset_examples` and `bulk_insert_dataset_example_revisions`, plus an early return for empty example lists.
> 
> Improves large-upload robustness by **deduplicating and batching** span ID resolution in `resolve_span_ids_to_rowids` and by batching split-assignment inserts in `bulk_assign_examples_to_splits` to stay under DB parameter limits; adds extensive unit tests covering deduping, batching, and duplicate split assignments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b569b096d015b8a788cc78c8defd5f0433dca4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->