### PR TITLE
feat: Enable React Compiler by default

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -42,7 +42,6 @@ pnpm run prod
 
 The following environment variables can be configured in your `.env` file:
 
-- **`PHOENIX_ENABLE_REACT_COMPILER`**: Enable or disable the React Compiler for improved performance. Set to `True` (capital T) to enable, or omit/leave unset to disable. The React Compiler can improve performance but may introduce new errors, so proceed with caution when enabling it.
 - **`PHOENIX_ENABLE_SOURCE_MAP`**: This enables source maps during Vite builds. It's useful for when you want a production build but still have debug capabilities for the JS bundles.
 
 ### Authentication

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "dev:server:offline": "python -m phoenix.server.main --dev --dev-vite-port ${VITE_PORT:-5173} serve",
     "dev:server:test": "node ./tests/utils/testServer.mjs",
     "dev:ui": "source ./.env && pnpm run build:static && pnpm run build:relay && vite",
-    "ensure:env": "test -f .env || printf 'export PHOENIX_ENABLE_REACT_COMPILER=True\nexport PHOENIX_TELEMETRY_ENABLED=False\nexport PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True\n' > .env",
+    "ensure:env": "test -f .env || printf 'export PHOENIX_TELEMETRY_ENABLED=False\nexport PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True\n' > .env",
     "fmt": "oxfmt --config ../.oxfmtrc.jsonc",
     "fmt:check": "oxfmt --check --config ../.oxfmtrc.jsonc",
     "lint": "oxlint",

--- a/app/vite.config.mts
+++ b/app/vite.config.mts
@@ -9,37 +9,20 @@ import circleDependency from "vite-plugin-circular-dependency";
 import reactFallbackThrottlePlugin from "vite-plugin-react-fallback-throttle";
 import relay from "vite-plugin-relay";
 
-const useReactCompiler = process.env.PHOENIX_ENABLE_REACT_COMPILER === "True";
-
 // We default to not exporting source maps since the JS bundle gets added to the python package.
 // We however want to enable source maps on the containers for debugging purposes.
 const enableSourceMap = process.env.PHOENIX_ENABLE_SOURCE_MAP === "True";
 
-if (useReactCompiler) {
-  // eslint-disable-next-line no-console
-  console.log(
-    "🔥 Using React Compiler. This will improve performance but also may introduce new errors. Proceed with caution."
-  );
-} else {
-  // eslint-disable-next-line no-console
-  console.log("⏼ React compiler is disabled.");
-}
 export default defineConfig(() => {
   const plugins = [
     // disable react's built-in 300ms suspense fallback timer
     // without this build plugin we see a 300ms delay on most UI interactions
     reactFallbackThrottlePlugin(),
-    react(
-      useReactCompiler
-        ? {
-            babel: {
-              plugins: [
-                ["babel-plugin-react-compiler", { panicThreshold: "none" }],
-              ],
-            },
-          }
-        : {}
-    ),
+    react({
+      babel: {
+        plugins: [["babel-plugin-react-compiler", { panicThreshold: "none" }]],
+      },
+    }),
     relay,
     lezer(),
     circleDependency({ circleImportThrowErr: true }),


### PR DESCRIPTION
Resolves #11463 

## Summary
Enables React Compiler by default across the app and removes the old feature flag path.

## Changes

1. App always uses React Compiler
- Removed `PHOENIX_ENABLE_REACT_COMPILER` gating in Vite.
- Always applies `babel-plugin-react-compiler`.

2. Removed obsolete env/docs
- Dropped `PHOENIX_ENABLE_REACT_COMPILER` from `ensure:env`.
- Removed README documentation for that env var.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Always enabling `babel-plugin-react-compiler` changes the frontend build pipeline and could introduce new runtime or build-time regressions in React rendering/performance. Scope is limited to Vite config and local env/docs wiring.
> 
> **Overview**
> **React Compiler is now always enabled** in `vite.config.mts` by removing the `PHOENIX_ENABLE_REACT_COMPILER` gating/console messaging and unconditionally applying `babel-plugin-react-compiler`.
> 
> Cleans up local setup/docs by removing `PHOENIX_ENABLE_REACT_COMPILER` from `package.json`’s `ensure:env` default `.env` template and from `app/README.md` environment variable documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e9d69ee181c7b1cb4b377b31174a3e6aea7d00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->