### PR TITLE
docs: clean up Claude Agent SDK sidebar nav titles

### DIFF
--- a/docs/phoenix/integrations/python/claude-agent-sdk.mdx
+++ b/docs/phoenix/integrations/python/claude-agent-sdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Claude Agent SDK (Python)"
+sidebarTitle: "Claude Agent SDK"
 description: Trace Anthropic's Claude Agent SDK applications in Python with Phoenix
 ---
 

--- a/docs/phoenix/integrations/typescript/claude-agent-sdk.mdx
+++ b/docs/phoenix/integrations/typescript/claude-agent-sdk.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Claude Agent SDK (TypeScript)"
+sidebarTitle: "Claude Agent SDK"
 description: Trace Anthropic's Claude Agent SDK applications in TypeScript/Node.js with Phoenix
 ---
 


### PR DESCRIPTION
## Summary
- Adds `sidebarTitle: "Claude Agent SDK"` to both the Python and TypeScript Claude Agent SDK integration pages
- The sidebar nav now shows "Claude Agent SDK" without the language suffix, while page titles retain "(Python)" / "(TypeScript)"

## Test plan
- [ ] Verify sidebar nav shows "Claude Agent SDK" under both Python and TypeScript sections
- [ ] Verify page titles still show the language parenthetical