### PR TITLE
fix(playground): handle eval exceptions and include repetition_number in errors

### DIFF
--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -701,8 +701,9 @@ async def _stream_chat_completion_over_dataset_example(
                     repetition_number=repetition_number,
                 )
                 continue
-            if eval_tracer is not None:
-                all_db_traces.extend(eval_tracer.get_db_traces(project_id=eval_project_id))
+            finally:
+                if eval_tracer is not None:
+                    all_db_traces.extend(eval_tracer.get_db_traces(project_id=eval_project_id))
             db_run.annotations.extend([evaluation_result_to_model(r) for r in eval_results])
     # Capture annotation objects from the in-memory collections before the session takes
     # ownership and expires them on flush/close, making lazy loads impossible afterward.


### PR DESCRIPTION
fixes #10955
fixes #10956

## Summary

- **Eval exception handling (#10956):** Wrap `evaluator.evaluate()` calls in `_stream_chat_completion_over_dataset_example` with try/except. When an evaluator throws an unexpected exception (e.g., network error, JSON parsing error), emit an `EvaluationChunk` with the error message and `continue` processing remaining evaluators, instead of crashing the entire subscription.

- **Missing repetition_number (#10955):** Add `repetition_number` to the `not_started` and `in_progress` tuple structures in `chat_completion_over_dataset`, and include it in `ChatCompletionSubscriptionError` emissions for timeout and exception errors. This allows the frontend to correctly associate errors with specific repetitions.

## Changes

All changes are in `src/phoenix/server/api/subscriptions.py`:

1. **`_cleanup_chat_completion_over_dataset_resources`** — Updated tuple type signatures to include `RepetitionNumber` and adjusted unpacking in all cleanup loops.

2. **`chat_completion_over_dataset`** — Changed `not_started` from `list[tuple[DatasetExampleNodeID, ChatStream]]` to `list[tuple[DatasetExampleNodeID, RepetitionNumber, ChatStream]]` and `in_progress` from 3-tuple to 4-tuple. Updated the scheduling loop to unpack `repetition_number` and pass it to error yields.

3. **`_stream_chat_completion_over_dataset_example`** — Added try/except around `evaluator.evaluate()` call. On exception, logs the error and yields an `EvaluationChunk(error=...)` with the evaluator name, dataset example ID, and repetition number, then continues to the next evaluator.

## Test plan

- [ ] Verify subscription continues after an evaluator throws an exception
- [ ] Verify timeout errors include `repetition_number` in the payload
- [ ] Verify exception errors include `repetition_number` in the payload
- [ ] Verify normal (non-error) flow is unaffected
- [ ] Run existing unit tests: `tox run -e unit_tests -- -k test_subscription`