### PR TITLE
chore(phoenix-client): deprecate ProjectSelector type

### DIFF
--- a/js/.changeset/deprecate-project-selector.md
+++ b/js/.changeset/deprecate-project-selector.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Deprecated `ProjectSelector` type in favor of `ProjectIdentifier`. `ProjectSelector` remains available as a type alias but will be removed in a future major release.


### PR DESCRIPTION
## Summary
- Adds a changeset (`patch`) documenting that `ProjectSelector` is deprecated in favor of `ProjectIdentifier`
- The type alias and `@deprecated` JSDoc tag already exist in `js/packages/phoenix-client/src/types/projects.ts`

## Test plan
- [x] `pnpm typecheck` confirms no new type errors (pre-existing errors are unrelated sibling workspace issues)