### PR TITLE
fix(phoenix-client): remove deprecated ProjectSelector type

### DIFF
--- a/js/.changeset/deprecate-project-selector.md
+++ b/js/.changeset/deprecate-project-selector.md
@@ -2,4 +2,4 @@
 "@arizeai/phoenix-client": patch
 ---
 
-Deprecated `ProjectSelector` type in favor of `ProjectIdentifier`. `ProjectSelector` remains available as a type alias but will be removed in a future major release.
+Removed deprecated `ProjectSelector` type alias. Use `ProjectIdentifier` instead.

--- a/js/packages/phoenix-client/src/types/projects.ts
+++ b/js/packages/phoenix-client/src/types/projects.ts
@@ -10,11 +10,6 @@ export type ProjectIdentifier =
   | { projectName: string };
 
 /**
- * @deprecated Use {@link ProjectIdentifier} instead.
- */
-export type ProjectSelector = ProjectIdentifier;
-
-/**
  * Resolves a {@link ProjectIdentifier} union to a plain string
  * suitable for the REST `project_identifier` path parameter.
  */


### PR DESCRIPTION
## Summary
- Removes the deprecated `ProjectSelector` type alias from `phoenix-client`
- All internal usages already reference `ProjectIdentifier` directly
- Includes a `patch` changeset for `@arizeai/phoenix-client`

## Test plan
- [x] Confirmed no remaining references to `ProjectSelector` in the codebase
- [x] `pnpm typecheck` passes (pre-existing errors are unrelated sibling workspace issues)