### PR TITLE
feat(api): add trace_id filter to GET spans REST endpoints

### DIFF
--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -4635,6 +4635,8 @@ export interface operations {
                 start_time?: string | null;
                 /** @description Exclusive upper bound time */
                 end_time?: string | null;
+                /** @description Filter by one or more trace IDs */
+                trace_id?: string[] | null;
             };
             header?: never;
             path: {
@@ -4694,6 +4696,8 @@ export interface operations {
                 start_time?: string | null;
                 /** @description Exclusive upper bound time */
                 end_time?: string | null;
+                /** @description Filter by one or more trace IDs */
+                trace_id?: string[] | null;
             };
             header?: never;
             path: {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2666,6 +2666,27 @@
               "title": "End Time"
             },
             "description": "Exclusive upper bound time"
+          },
+          {
+            "name": "trace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by one or more trace IDs",
+              "title": "Trace Id"
+            },
+            "description": "Filter by one or more trace IDs"
           }
         ],
         "responses": {
@@ -2801,6 +2822,27 @@
               "title": "End Time"
             },
             "description": "Exclusive upper bound time"
+          },
+          {
+            "name": "trace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by one or more trace IDs",
+              "title": "Trace Id"
+            },
+            "description": "Filter by one or more trace IDs"
           }
         ],
         "responses": {

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -603,6 +603,10 @@ async def span_search_otlpv1(
     limit: int = Query(default=100, gt=0, le=1000, description="Maximum number of spans to return"),
     start_time: Optional[datetime] = Query(default=None, description="Inclusive lower bound time"),
     end_time: Optional[datetime] = Query(default=None, description="Exclusive upper bound time"),
+    trace_id: Optional[list[str]] = Query(
+        default=None,
+        description="Filter by one or more trace IDs",
+    ),
 ) -> OtlpSpansResponseBody:
     """Search spans with minimal filters instead of the old SpanQuery DSL."""
 
@@ -626,6 +630,8 @@ async def span_search_otlpv1(
         stmt = stmt.where(models.Span.start_time >= normalize_datetime(start_time, timezone.utc))
     if end_time:
         stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
+    if trace_id:
+        stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
 
     if cursor:
         try:
@@ -650,7 +656,7 @@ async def span_search_otlpv1(
 
     # Convert ORM rows -> OTLP-style spans
     result_spans: list[OtlpSpan] = []
-    for span_orm, trace_id in rows:
+    for span_orm, span_trace_id in rows:
         try:
             status_code_enum = StatusCode(span_orm.status_code or "UNSET")
         except ValueError:
@@ -703,7 +709,7 @@ async def span_search_otlpv1(
 
         result_spans.append(
             OtlpSpan(
-                trace_id=trace_id,
+                trace_id=span_trace_id,
                 span_id=span_orm.span_id,
                 parent_span_id=span_orm.parent_id,
                 name=span_orm.name,
@@ -740,6 +746,10 @@ async def span_search(
     limit: int = Query(default=100, gt=0, le=1000, description="Maximum number of spans to return"),
     start_time: Optional[datetime] = Query(default=None, description="Inclusive lower bound time"),
     end_time: Optional[datetime] = Query(default=None, description="Exclusive upper bound time"),
+    trace_id: Optional[list[str]] = Query(
+        default=None,
+        description="Filter by one or more trace IDs",
+    ),
 ) -> SpansResponseBody:
     async with request.app.state.db() as session:
         project = await get_project_by_identifier(session, project_identifier)
@@ -761,6 +771,8 @@ async def span_search(
         stmt = stmt.where(models.Span.start_time >= normalize_datetime(start_time, timezone.utc))
     if end_time:
         stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
+    if trace_id:
+        stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
 
     if cursor:
         try:
@@ -785,7 +797,7 @@ async def span_search(
 
     # Convert ORM rows -> Phoenix spans
     result_spans: list[Span] = []
-    for span_orm, trace_id in rows:
+    for span_orm, span_trace_id in rows:
         # Convert events to Phoenix Event list
         events: list[SpanEvent] = []
         for event in span_orm.events:
@@ -837,7 +849,7 @@ async def span_search(
                 id=str(GlobalID("Span", str(span_orm.id))),
                 name=span_orm.name or "",
                 context=SpanContext(
-                    trace_id=trace_id,
+                    trace_id=span_trace_id,
                     span_id=span_orm.span_id or "",
                 ),
                 span_kind=openinference_span_kind,

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -1106,3 +1106,116 @@ async def test_phoenix_openinference_span_kind_extraction(
     span = spans[0]
     assert span.span_kind == "LLM"
     assert "openinference.span.kind" not in span.attributes
+
+
+@pytest.fixture
+async def multi_trace_project(db: DbSessionFactory) -> None:
+    """Insert a project with two traces, each containing spans."""
+    async with db() as session:
+        project = models.Project(name="multi-trace")
+        session.add(project)
+        await session.flush()
+
+        base_time = datetime.fromisoformat("2021-01-01T00:00:00+00:00")
+
+        trace_a = models.Trace(
+            project_rowid=project.id,
+            trace_id="traceaaa00000000",
+            start_time=base_time,
+            end_time=base_time + timedelta(minutes=1),
+        )
+        trace_b = models.Trace(
+            project_rowid=project.id,
+            trace_id="tracebbb00000000",
+            start_time=base_time,
+            end_time=base_time + timedelta(minutes=1),
+        )
+        session.add_all([trace_a, trace_b])
+        await session.flush()
+
+        span_ids = [
+            ["aaa00000", "aaa00001"],
+            ["bbb00000", "bbb00001"],
+        ]
+        for i, trace in enumerate([trace_a, trace_b]):
+            for j in range(2):
+                session.add(
+                    models.Span(
+                        trace_rowid=trace.id,
+                        span_id=span_ids[i][j],
+                        parent_id=None,
+                        name=f"span-t{i}-{j}",
+                        span_kind="CHAIN",
+                        start_time=base_time + timedelta(minutes=j),
+                        end_time=base_time + timedelta(minutes=j, seconds=30),
+                        attributes={},
+                        events=[],
+                        status_code="OK",
+                        status_message="",
+                        cumulative_error_count=0,
+                        cumulative_llm_token_count_prompt=0,
+                        cumulative_llm_token_count_completion=0,
+                    )
+                )
+        await session.flush()
+
+
+async def test_span_search_filter_by_single_trace_id(
+    httpx_client: httpx.AsyncClient, multi_trace_project: None
+) -> None:
+    resp = await httpx_client.get(
+        "v1/projects/multi-trace/spans",
+        params={"trace_id": "traceaaa00000000"},
+    )
+    assert resp.is_success
+    spans = [Span.model_validate(s) for s in resp.json()["data"]]
+    assert len(spans) == 2
+    assert all(s.context.trace_id == "traceaaa00000000" for s in spans)
+
+
+async def test_span_search_filter_by_multiple_trace_ids(
+    httpx_client: httpx.AsyncClient, multi_trace_project: None
+) -> None:
+    resp = await httpx_client.get(
+        "v1/projects/multi-trace/spans",
+        params=[("trace_id", "traceaaa00000000"), ("trace_id", "tracebbb00000000")],
+    )
+    assert resp.is_success
+    spans = [Span.model_validate(s) for s in resp.json()["data"]]
+    assert len(spans) == 4
+
+
+async def test_span_search_filter_by_nonexistent_trace_id(
+    httpx_client: httpx.AsyncClient, multi_trace_project: None
+) -> None:
+    resp = await httpx_client.get(
+        "v1/projects/multi-trace/spans",
+        params={"trace_id": "does-not-exist"},
+    )
+    assert resp.is_success
+    assert resp.json()["data"] == []
+
+
+async def test_otlp_span_search_filter_by_single_trace_id(
+    httpx_client: httpx.AsyncClient, multi_trace_project: None
+) -> None:
+    resp = await httpx_client.get(
+        "v1/projects/multi-trace/spans/otlpv1",
+        params={"trace_id": "tracebbb00000000"},
+    )
+    assert resp.is_success
+    spans = [OtlpSpan.model_validate(s) for s in resp.json()["data"]]
+    assert len(spans) == 2
+    assert all(s.trace_id == "tracebbb00000000" for s in spans)
+
+
+async def test_otlp_span_search_filter_by_multiple_trace_ids(
+    httpx_client: httpx.AsyncClient, multi_trace_project: None
+) -> None:
+    resp = await httpx_client.get(
+        "v1/projects/multi-trace/spans/otlpv1",
+        params=[("trace_id", "traceaaa00000000"), ("trace_id", "tracebbb00000000")],
+    )
+    assert resp.is_success
+    spans = [OtlpSpan.model_validate(s) for s in resp.json()["data"]]
+    assert len(spans) == 4


### PR DESCRIPTION
## Summary
- Adds optional `trace_id` query parameter to both `GET /v1/projects/{id}/spans` and `GET /v1/projects/{id}/spans/otlpv1` endpoints
- Supports filtering by multiple trace IDs via repeated query params (`?trace_id=abc&trace_id=def`)
- Composable with existing `start_time`, `end_time`, `limit`, and `cursor` parameters

Closes #11882

## Test plan
- [x] Added 5 new unit tests covering single trace ID, multiple trace IDs, nonexistent trace ID, and both endpoints
- [x] All 32 existing + new tests pass