### PR TITLE
docs: document SDK session retrieval methods

### DIFF
--- a/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval.mdx
+++ b/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval.mdx
@@ -1,0 +1,58 @@
+---
+title: "03.05.2026 SDK Session Retrieval"
+description: "Get and list sessions programmatically from Python and TypeScript."
+---
+
+Session retrieval is now available in both the Python and TypeScript client SDKs. You can fetch individual sessions by ID or list all sessions for a project — with automatic pagination, async support, and DataFrame export built in.
+
+## Python
+
+The `client.sessions` resource adds three methods:
+
+- **`get(session_id)`** — Fetch a single session with all its traces
+- **`list(project_name, limit)`** — List sessions for a project with automatic pagination
+- **`get_sessions_dataframe(project_name)`** — Return sessions as a pandas DataFrame
+
+```python
+from phoenix.client import Client
+
+client = Client()
+
+# Get a session
+session = client.sessions.get(session_id="my-session-id")
+
+# List recent sessions
+sessions = client.sessions.list(project_name="my-chatbot", limit=10)
+
+# Analyze in pandas
+df = client.sessions.get_sessions_dataframe(project_name="my-chatbot")
+```
+
+Async variants are available on `AsyncClient` with the same interface.
+
+## TypeScript
+
+Two new functions are exported from `@arizeai/phoenix-client/sessions`:
+
+- **`getSession({ sessionId })`** — Fetch a single session with all its traces
+- **`listSessions({ projectName })`** — List all sessions for a project with automatic pagination
+
+```javascript
+import { getSession, listSessions } from "@arizeai/phoenix-client/sessions";
+
+const session = await getSession({ sessionId: "my-session-id" });
+const sessions = await listSessions({ projectName: "my-chatbot" });
+```
+
+## Return Types
+
+Both SDKs return the same shape: each session includes `sessionId`, `projectId`, `startTime`, `endTime`, and a `traces` array. Each trace contains `traceId`, `startTime`, and `endTime`.
+
+<CardGroup cols={2}>
+  <Card title="Python SDK Reference" icon="python" href="/docs/phoenix/sdk-api-reference/python/arize-phoenix-client">
+    Full Python client documentation
+  </Card>
+  <Card title="TypeScript SDK Reference" icon="js" href="/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client">
+    Full TypeScript client documentation
+  </Card>
+</CardGroup>

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval" arrow="true" title="03.05.2026" icon="calendar" description="SDK session retrieval for Python and TypeScript"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api" arrow="true" title="02.27.2026" icon="calendar" description="Sessions API and CLI support"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-14-2026-phoenix-13-0" arrow="true" title="02.14.2026" icon="calendar" description="Phoenix 13.0"/>
     <Card href="/docs/phoenix/release-notes/02-2026/02-12-2026-openai-responses-api-support" arrow="true" title="02.12.2026" icon="calendar" description="OpenAI Responses API type support"/>

--- a/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
+++ b/docs/phoenix/sdk-api-reference/python/arize-phoenix-client.mdx
@@ -19,6 +19,7 @@ Phoenix Client provides a interface for interacting with the Phoenix platform vi
 - **Experiments** - Run evaluations and track experiment results
 - **Spans** - Query and analyze traces with powerful filtering
 - **Annotations** - Add human feedback and automated evaluations
+- **Sessions** - Retrieve and list multi-turn conversation sessions
 
 ## Installation
 
@@ -261,10 +262,44 @@ new_project = client.projects.create(
 print(f"Created project with ID: {new_project['id']}")
 ```
 
+## Sessions
+
+Retrieve session data for multi-turn conversations. Sessions group related traces from a conversation into a single timeline.
+
+```python
+# Get a specific session by ID
+session = client.sessions.get(session_id="my-session-id")
+print(f"Session: {session['session_id']}, Traces: {len(session['traces'])}")
+
+# List sessions for a project
+sessions = client.sessions.list(project_name="my-chatbot")
+for s in sessions:
+    print(f"{s['session_id']}: {len(s['traces'])} traces")
+
+# List with a limit
+recent = client.sessions.list(project_name="my-chatbot", limit=10)
+
+# Get sessions as a pandas DataFrame
+df = client.sessions.get_sessions_dataframe(project_name="my-chatbot")
+print(df[["session_id", "start_time", "end_time", "num_traces"]])
+```
+
+### Async Usage
+
+```python
+from phoenix.client import AsyncClient
+
+async_client = AsyncClient()
+
+session = await async_client.sessions.get(session_id="my-session-id")
+sessions = await async_client.sessions.list(project_name="my-chatbot", limit=10)
+df = await async_client.sessions.get_sessions_dataframe(project_name="my-chatbot")
+```
+
 ---
 
 ## Reference Documentation
 
 <Card title="Full API Reference" icon="arrow-up-right-from-square" href="https://arize-phoenix.readthedocs.io/projects/client/">
-  Complete API documentation for datasets, experiments, prompts, spans, and annotations
+  Complete API documentation for datasets, experiments, prompts, spans, sessions, and annotations
 </Card>

--- a/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/arizeai-phoenix-client.mdx
@@ -259,6 +259,43 @@ const experiment = await runExperiment({
 
 </Note>
 
+## Sessions
+
+Retrieve session data for multi-turn conversations. Sessions group related traces from a conversation into a single timeline.
+
+### Get a Session
+
+```javascript
+import { getSession } from "@arizeai/phoenix-client/sessions";
+
+const session = await getSession({ sessionId: "my-session-id" });
+console.log(`Session: ${session.sessionId}, Traces: ${session.traces.length}`);
+
+// Each trace includes traceId, startTime, and endTime
+for (const trace of session.traces) {
+  console.log(`  Turn: ${trace.traceId} (${trace.startTime} - ${trace.endTime})`);
+}
+```
+
+### List Sessions
+
+```javascript
+import { listSessions } from "@arizeai/phoenix-client/sessions";
+
+// By project name
+const sessions = await listSessions({ projectName: "my-chatbot" });
+
+// By project ID
+const sessionsById = await listSessions({ projectId: "project-abc-123" });
+
+// Using the shorthand `project` identifier
+const sessionsByProject = await listSessions({ project: "my-chatbot" });
+
+for (const session of sessions) {
+  console.log(`${session.sessionId}: ${session.traces.length} traces`);
+}
+```
+
 ## Compatibility
 
 This package utilizes [openapi-ts](https://openapi-ts.pages.dev/) to generate types from the Phoenix OpenAPI spec.


### PR DESCRIPTION
## Summary

- Add **Sessions** section to the Python SDK reference page (`arize-phoenix-client.mdx`) with examples for `get`, `list`, `get_sessions_dataframe`, and async usage
- Add **Sessions** section to the TypeScript SDK reference page (`@arizeai/phoenix-client.mdx`) with examples for `getSession` and `listSessions` (all three `ProjectIdentifier` variants)
- Create new release note (`03-05-2026-sdk-session-retrieval.mdx`) covering both SDKs
- Add card to the 2026 release notes overview page

## Test plan

- [ ] Verify MDX renders correctly in Mintlify preview
- [ ] Confirm code examples match actual API signatures from source
- [ ] Check navigation links between release note and SDK reference pages