### PR TITLE
docs: add missing release note entries for session retrieval

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -9,6 +9,16 @@ GitHub
 
 
 
+<Update label="03.05.2026">
+## [03.05.2026: SDK Session Retrieval](/docs/phoenix/release-notes/03-2026/03-05-2026-sdk-session-retrieval)
+Session retrieval is now available in the Python client (`client.sessions.get()`, `client.sessions.list()`, `get_sessions_dataframe()`) and the TypeScript client (`getSession()`, `listSessions()`). Both SDKs support automatic pagination and async usage for working with multi-turn conversation data.
+</Update>
+
+<Update label="02.27.2026">
+## [02.27.2026: Sessions API and CLI Support](/docs/phoenix/release-notes/02-2026/02-27-2026-cli-sessions-and-rest-api)
+REST API endpoints for listing and getting sessions (`GET /v1/sessions`, `GET /v1/sessions/{id}`) and CLI commands (`px sessions`, `px session <id>`) for exploring multi-turn conversations from the terminal.
+</Update>
+
 <Update label="02.24.2026">
 ## 02.24.2026: Claude Agent SDK Integration
 


### PR DESCRIPTION
## Summary
- Adds two missing `<Update>` entries to the main `release-notes.mdx` timeline:
  - **03.05.2026: SDK Session Retrieval** — Python and TypeScript session retrieval methods
  - **02.27.2026: Sessions API and CLI Support** — REST API endpoints and CLI commands for sessions
- The individual release note pages already exist; only the main timeline was missing these entries

## Test plan
- [ ] Verify the two new entries appear at the top of the release notes timeline
- [ ] Confirm links navigate to the correct detail pages