### PR TITLE
chore(phoenix-client): update Python lower bound to 3.10

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -85,7 +85,7 @@ jobs:
     if: ${{ needs.changes.outputs.phoenix_client == 'true' }}
     strategy:
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -512,7 +512,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.9]
+        py: ["3.10"]
         pkg: [openai, google_generativeai] # NOTE: bypass Anthropic check while types are changing
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
         os: [windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/packages/phoenix-client/pyproject.toml
+++ b/packages/phoenix-client/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-client"
 description = "LLM Observability"
 readme = "README.md"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.10, <3.14"
 license = {text="Apache-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,7 +15,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -53,7 +52,7 @@ exclude = [
 ]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
@@ -83,7 +82,7 @@ exclude = [
 
 [tool.pyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportUnusedFunction = false
 exclude = [
   "dist/",


### PR DESCRIPTION
## Summary
- Bumps `requires-python` from `>=3.9` to `>=3.10` in `arize-phoenix-client`
- Removes Python 3.9 classifier
- Updates `ruff` target version and `pyright` pythonVersion to `py310`/`3.10`
- Updates CI matrices to test on Python 3.10 instead of 3.9

## Test plan
- [ ] CI passes on Python 3.10 and 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops Python 3.9 support for `arize-phoenix-client`, which can break consumers and reduces backward-compatibility. CI/lint/typecheck baselines shift to 3.10, so any remaining 3.9-only issues will no longer be caught.
> 
> **Overview**
> **Raises the Python floor for `arize-phoenix-client` to 3.10.** Updates `packages/phoenix-client/pyproject.toml` to require `>=3.10`, removes the Python 3.9 classifier, and aligns `ruff`/`pyright` target versions to 3.10.
> 
> **CI coverage is adjusted accordingly.** Workflow matrices in `python-CI.yml` and `python-all-platforms.yml` switch `phoenix-client` (including canary and non-Linux jobs) from Python 3.9 to 3.10.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f862753b72aeec00c27c4ba9296b1e860bb8a9a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->