### PR TITLE
chore(phoenix-evals): update Python lower bound to 3.10

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -174,7 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
         os: [windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-evals"
 description = "LLM Evaluations"
 readme = "README.md"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.10, <3.14"
 license = {text="Elastic-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,8 +15,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -81,7 +79,7 @@ only-packages = true
 exclude = [".git", "__pycache__", ".tox", "dist"]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]


### PR DESCRIPTION
## Summary
- Bumps `requires-python` from `>=3.8` to `>=3.10` in `arize-phoenix-evals`
- Removes Python 3.8 and 3.9 classifiers
- Updates `ruff` target version to `py310`
- Updates CI matrices to test on Python 3.10 instead of 3.9

## Test plan
- [ ] CI passes on Python 3.10 and 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it drops Python 3.8/3.9 support for `arize-phoenix-evals`, which can be a breaking change for downstream users and CI environments. No runtime logic changes, but packaging/CI constraints may cause installation/test failures on older interpreters.
> 
> **Overview**
> **Drops Python 3.8/3.9 support for `arize-phoenix-evals`.** The package metadata in `packages/phoenix-evals/pyproject.toml` now requires Python `>=3.10` and removes the 3.8/3.9 trove classifiers, and `ruff` is retargeted from `py38` to `py310`.
> 
> CI coverage for Phoenix Evals is updated to test `3.10` and `3.12` (replacing `3.9`) in both `python-CI.yml` and the non-Linux matrix in `python-all-platforms.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d64c1e0ec7c0ce03853818baeedf829018e04a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->