### PR TITLE
chore: drop Python 3.9 support for packages

### DIFF
--- a/.github/workflows/python-CI.yml
+++ b/.github/workflows/python-CI.yml
@@ -85,7 +85,7 @@ jobs:
     if: ${{ needs.changes.outputs.phoenix_client == 'true' }}
     strategy:
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -512,7 +512,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.9]
+        py: ["3.10"]
         pkg: [openai, google_generativeai] # NOTE: bypass Anthropic check while types are changing
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-all-platforms.yml
+++ b/.github/workflows/python-all-platforms.yml
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
         os: [windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
-        py: [3.9, 3.12]
+        py: ["3.10", "3.12"]
         os: [windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/packages/phoenix-client/pyproject.toml
+++ b/packages/phoenix-client/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-client"
 description = "LLM Observability"
 readme = "README.md"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.10, <3.14"
 license = {text="Apache-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,7 +15,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -53,7 +52,7 @@ exclude = [
 ]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
@@ -83,7 +82,7 @@ exclude = [
 
 [tool.pyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportUnusedFunction = false
 exclude = [
   "dist/",

--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -2,7 +2,7 @@
 name = "arize-phoenix-evals"
 description = "LLM Evaluations"
 readme = "README.md"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.10, <3.14"
 license = {text="Elastic-2.0"}
 license-files = { paths = ["LICENSE", "IP_NOTICE"] }
 keywords = [
@@ -15,8 +15,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -81,7 +79,7 @@ only-packages = true
 exclude = [".git", "__pycache__", ".tox", "dist"]
 extend-include = ["*.ipynb"]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]


### PR DESCRIPTION
Drop support for Python 3.9 from phoenix-client and phoenix-evals packages. Also drop Python 3.8 from phoenix-evals. Update CI workflows to run on Python 3.10 instead of 3.9.

- phoenix-client: requires-python >=3.10, <3.14
- phoenix-evals: requires-python >=3.10, <3.14
- phoenix-otel: already at >=3.10 (no change)

https://claude.ai/code/session_01DQD9anXrgipcrQjHNQTdPT