### PR TITLE
chore: Rename "Projects" to "Tracing" in left nav

### DIFF
--- a/app/src/components/core/counter/Counter.tsx
+++ b/app/src/components/core/counter/Counter.tsx
@@ -6,7 +6,7 @@ export type CounterProps = PropsWithChildren<{
    * The color of the counter
    * @default 'default'
    **/
-  variant?: "default" | "danger";
+  variant?: "default" | "danger" | "quiet";
 }>;
 
 const counterCSS = css`
@@ -20,8 +20,14 @@ const counterCSS = css`
   line-height: var(--global-line-height-xs);
   text-align: center;
   color: var(--global-text-color-900);
+  font-family: "Geist Mono", monospace;
   &[data-variant="danger"] {
     background-color: var(--global-background-color-danger);
+  }
+  &[data-variant="quiet"] {
+    border: none;
+    background: transparent;
+    color: var(--global-text-color-500);
   }
 `;
 

--- a/app/src/pages/Layout.tsx
+++ b/app/src/pages/Layout.tsx
@@ -108,7 +108,7 @@ function SideNav() {
               leadingVisual={<Icon svg={<Icons.Trace />} />}
               trailingVisual={
                 loaderData?.projectCount != null ? (
-                  <Counter>{loaderData.projectCount}</Counter>
+                  <Counter variant="quiet">{loaderData.projectCount}</Counter>
                 ) : undefined
               }
               isExpanded={isSideNavExpanded}
@@ -121,7 +121,7 @@ function SideNav() {
               leadingVisual={<Icon svg={<Icons.DatabaseOutline />} />}
               trailingVisual={
                 loaderData?.datasetCount != null ? (
-                  <Counter>{loaderData.datasetCount}</Counter>
+                  <Counter variant="quiet">{loaderData.datasetCount}</Counter>
                 ) : undefined
               }
               isExpanded={isSideNavExpanded}
@@ -142,7 +142,7 @@ function SideNav() {
               leadingVisual={<Icon svg={<Icons.Scale />} />}
               trailingVisual={
                 loaderData?.evaluatorCount != null ? (
-                  <Counter>{loaderData.evaluatorCount}</Counter>
+                  <Counter variant="quiet">{loaderData.evaluatorCount}</Counter>
                 ) : undefined
               }
               isExpanded={isSideNavExpanded}
@@ -155,7 +155,7 @@ function SideNav() {
               leadingVisual={<Icon svg={<Icons.MessageSquareOutline />} />}
               trailingVisual={
                 loaderData?.promptCount != null ? (
-                  <Counter>{loaderData.promptCount}</Counter>
+                  <Counter variant="quiet">{loaderData.promptCount}</Counter>
                 ) : undefined
               }
               isExpanded={isSideNavExpanded}

--- a/app/stories/Counter.stories.tsx
+++ b/app/stories/Counter.stories.tsx
@@ -32,3 +32,13 @@ Danger.args = {
   children: "12,000",
   variant: "danger",
 };
+
+/**
+ * The `quiet` variant removes the border and background
+ */
+export const Quiet = Template.bind({});
+
+Quiet.args = {
+  children: "1.2k",
+  variant: "quiet",
+};


### PR DESCRIPTION
## Summary
- Renames the "Projects" nav item to "Tracing" in the left sidebar
- Updates the icon from `GridOutline` to `Trace`
- URL (`/projects`) remains unchanged

## Test plan
- [ ] Visual check: left nav shows "Tracing" with the trace icon
- [ ] Clicking it still navigates to `/projects`