### PR TITLE
chore: reorganize Storybook sidebar navigation

### DIFF
--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -194,6 +194,33 @@ const preview: Preview = {
     docs: {
       container: ThemedDocsContainer,
     },
+    options: {
+      storySort: {
+        order: [
+          "Reference",
+          "Core",
+          [
+            "Content",
+            "Actions",
+            "Forms",
+            "Feedback",
+            "Overlays",
+            "Layout",
+            "Navigation",
+            "Media",
+          ],
+          "Charting",
+          "DateTime",
+          "Table",
+          "Annotation",
+          "Chat",
+          "Experiment",
+          "Prompt",
+          "Tokens",
+          "Trace",
+        ],
+      },
+    },
   },
   //👇 Enables auto-generated documentation for all stories
   tags: ["autodocs"],

--- a/app/stories/Alert.stories.tsx
+++ b/app/stories/Alert.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Alert, Button, Icon, Icons } from "@phoenix/components";
 
 const meta: Meta<typeof Alert> = {
-  title: "Core/Alert",
+  title: "Core/Feedback/Alert",
   component: Alert,
   parameters: {
     layout: "centered",

--- a/app/stories/AnnotationInputs.stories.tsx
+++ b/app/stories/AnnotationInputs.stories.tsx
@@ -19,7 +19,7 @@ import type {
  * Components are wrapped in \<AnnotationFocusProvider \\> to provide focus management.
  */
 const meta = {
-  title: "AnnotationInputs",
+  title: "Annotation/Annotation Inputs",
   parameters: {
     layout: "centered",
   },

--- a/app/stories/Breadcrumbs.stories.tsx
+++ b/app/stories/Breadcrumbs.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Breadcrumb, Breadcrumbs } from "@phoenix/components";
 
 const meta: Meta<typeof Breadcrumbs> = {
-  title: "Core/Breadcrumbs",
+  title: "Core/Navigation/Breadcrumbs",
   component: Breadcrumbs,
   parameters: {
     layout: "centered",

--- a/app/stories/Button.stories.tsx
+++ b/app/stories/Button.stories.tsx
@@ -5,7 +5,7 @@ import type { ButtonProps } from "@phoenix/components";
 import { Button } from "@phoenix/components";
 import { Keyboard, VisuallyHidden } from "@phoenix/components/core/content";
 const meta: Meta = {
-  title: "Core/Button",
+  title: "Core/Actions/Button",
   component: Button,
   parameters: {
     layout: "centered",

--- a/app/stories/Card.stories.tsx
+++ b/app/stories/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import { Button, Card, Text, Token } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Card",
+  title: "Core/Layout/Card",
   component: Card,
   parameters: {
     layout: "centered",

--- a/app/stories/CategoricalChartColors.stories.tsx
+++ b/app/stories/CategoricalChartColors.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "@phoenix/components/core/tooltip";
 
 const meta: Meta = {
-  title: "charting/CategoricalChartColors",
+  title: "Charting/Categorical Chart Colors",
 };
 
 export default meta;

--- a/app/stories/ChatUI.stories.tsx
+++ b/app/stories/ChatUI.stories.tsx
@@ -144,7 +144,7 @@ function ChatUI() {
 }
 
 const meta = {
-  title: "Chat/ChatUI",
+  title: "Chat/Chat UI",
   component: ChatUI,
   decorators: [
     (Story) => (

--- a/app/stories/Checkbox.stories.tsx
+++ b/app/stories/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import { Checkbox } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Checkbox",
+  title: "Core/Forms/Checkbox",
   component: Checkbox,
   parameters: {
     layout: "centered",

--- a/app/stories/Colors.stories.tsx
+++ b/app/stories/Colors.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { GLOBAL_COLORS } from "./constants/colorConstants";
 
 const meta: Meta = {
-  title: "Colors",
+  title: "Reference/Colors",
 };
 
 export default meta;

--- a/app/stories/ComboBox.stories.tsx
+++ b/app/stories/ComboBox.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@phoenix/components/core/combobox/ComboBox";
 
 const meta: Meta = {
-  title: "Core/ComboBox",
+  title: "Core/Forms/Combo Box",
   component: ComboBox,
   argTypes: {
     label: {

--- a/app/stories/Counter.stories.tsx
+++ b/app/stories/Counter.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import type { CounterProps } from "@phoenix/components";
 import { Counter } from "@phoenix/components";
 const meta: Meta = {
-  title: "Core/Counter",
+  title: "Core/Content/Counter",
   component: Counter,
   parameters: {
     layout: "centered",

--- a/app/stories/CredentialField.stories.tsx
+++ b/app/stories/CredentialField.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/CredentialField",
+  title: "Core/Forms/Credential Field",
   component: CredentialField,
 
   parameters: {

--- a/app/stories/DateField.stories.tsx
+++ b/app/stories/DateField.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/DateField",
+  title: "Core/Forms/Date Field",
   component: DateField,
   parameters: {
     layout: "centered",

--- a/app/stories/Dialog.stories.tsx
+++ b/app/stories/Dialog.stories.tsx
@@ -20,7 +20,7 @@ import {
 } from "@phoenix/components/core/dialog";
 
 const meta: Meta = {
-  title: "Core/Dialog",
+  title: "Core/Overlays/Dialog",
   component: Dialog,
   parameters: {
     layout: "centered",

--- a/app/stories/Disclosure.stories.tsx
+++ b/app/stories/Disclosure.stories.tsx
@@ -16,7 +16,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Disclosure",
+  title: "Core/Layout/Disclosure",
   component: DisclosureGroup,
   parameters: {
     layout: "centered",

--- a/app/stories/ExperimentItem.stories.tsx
+++ b/app/stories/ExperimentItem.stories.tsx
@@ -200,7 +200,7 @@ const mockAnnotationSummaries: AnnotationSummaries = [
 ];
 
 const meta: Meta<typeof ExperimentItem> = {
-  title: "Experiment/ExperimentItem",
+  title: "Experiment/Experiment Item",
   component: ExperimentItem,
   parameters: {
     layout: "centered",

--- a/app/stories/ExperimentRunAnnotations.stories.tsx
+++ b/app/stories/ExperimentRunAnnotations.stories.tsx
@@ -121,7 +121,7 @@ const mockAnnotationSummaries: AnnotationSummaries = [
 ];
 
 const meta: Meta<StoryArgs> = {
-  title: "Experiment/ExperimentRunAnnotations",
+  title: "Experiment/Run Annotations",
   component: ExperimentRunAnnotations,
   parameters: {
     layout: "centered",

--- a/app/stories/ExperimentRunOutputs.stories.tsx
+++ b/app/stories/ExperimentRunOutputs.stories.tsx
@@ -344,7 +344,7 @@ const mockReferenceOutput: ReferenceOutput = {
 };
 
 const meta: Meta<StoryArgs> = {
-  title: "Experiment/ExperimentRunOutputs",
+  title: "Experiment/Run Outputs",
   component: ExperimentRunOutputs,
   parameters: {
     layout: "fullscreen",

--- a/app/stories/ExperimentTable.stories.tsx
+++ b/app/stories/ExperimentTable.stories.tsx
@@ -608,7 +608,7 @@ function PaddedCell({ children }: { children: React.ReactNode }) {
 
 // Storybook Configuration
 const meta: Meta<typeof SimpleExperimentTable> = {
-  title: "Table/ExperimentTable",
+  title: "Table/Experiment Table",
   component: SimpleExperimentTable,
   parameters: {
     docs: {

--- a/app/stories/FileDropZone.stories.tsx
+++ b/app/stories/FileDropZone.stories.tsx
@@ -36,7 +36,7 @@ const fileChipRemoveButtonCSS = css`
 `;
 
 const meta: Meta<typeof FileDropZone> = {
-  title: "Core/FileDropZone",
+  title: "Core/Media/File Drop Zone",
   component: FileDropZone,
   parameters: {
     layout: "centered",

--- a/app/stories/Gallery.stories.tsx
+++ b/app/stories/Gallery.stories.tsx
@@ -36,7 +36,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Gallery",
+  title: "Reference/Gallery",
 
   parameters: {
     layout: "fullscreen",

--- a/app/stories/GridList.stories.tsx
+++ b/app/stories/GridList.stories.tsx
@@ -17,7 +17,7 @@ import { AnnotationNameAndValue } from "@phoenix/components/annotation/Annotatio
 import type { Annotation } from "@phoenix/components/annotation/types";
 
 const meta: Meta = {
-  title: "Core/GridList",
+  title: "Core/Navigation/Grid List",
   component: GridList,
 };
 

--- a/app/stories/Heading.stories.tsx
+++ b/app/stories/Heading.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta } from "@storybook/react";
 import { Flex, Heading, View } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Heading",
+  title: "Core/Content/Heading",
   component: Heading,
 
   parameters: {

--- a/app/stories/IconButton.stories.tsx
+++ b/app/stories/IconButton.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from "../src/components/core/icon/Icons";
 
 const meta: Meta = {
-  title: "Core/IconButton",
+  title: "Core/Actions/Icon Button",
   component: IconButton,
   parameters: {
     layout: "centered",

--- a/app/stories/Icons.stories.tsx
+++ b/app/stories/Icons.stories.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from "react";
 import { Icon, Icons } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Icons",
+  title: "Core/Content/Icons",
   component: Icon,
 };
 

--- a/app/stories/KeyboardToken.stories.tsx
+++ b/app/stories/KeyboardToken.stories.tsx
@@ -19,7 +19,7 @@ import { KeyboardToken } from "../src/components/core/KeyboardToken";
  * - Can be used inline with text
  */
 const meta: Meta<typeof KeyboardToken> = {
-  title: "Core/Content/KeyboardToken",
+  title: "Core/Content/Keyboard Token",
   component: KeyboardToken,
   parameters: {
     layout: "centered",

--- a/app/stories/LatencyText.stories.tsx
+++ b/app/stories/LatencyText.stories.tsx
@@ -4,7 +4,7 @@ import type { LatencyThresholds } from "@phoenix/components/trace/LatencyText";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 
 const meta: Meta = {
-  title: "Trace/LatencyText",
+  title: "Trace/Latency Text",
   component: LatencyText,
   parameters: {
     layout: "centered",

--- a/app/stories/LinkButton.stories.tsx
+++ b/app/stories/LinkButton.stories.tsx
@@ -4,7 +4,7 @@ import type { LinkButtonProps } from "@phoenix/components";
 import { LinkButton } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/LinkButton",
+  title: "Core/Actions/Link Button",
   component: LinkButton,
   parameters: {
     layout: "centered",

--- a/app/stories/List.stories.tsx
+++ b/app/stories/List.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { List, ListItem } from "@phoenix/components";
 
 const meta: Meta<typeof List> = {
-  title: "Core/List",
+  title: "Core/Navigation/List",
   component: List,
   parameters: {
     layout: "centered",

--- a/app/stories/ListBox.stories.tsx
+++ b/app/stories/ListBox.stories.tsx
@@ -4,7 +4,7 @@ import type { ListBoxProps } from "@phoenix/components";
 import { ListBox, ListBoxItem } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/ListBox",
+  title: "Core/Navigation/List Box",
   component: ListBox,
 };
 

--- a/app/stories/Loading.stories.tsx
+++ b/app/stories/Loading.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Loading } from "@phoenix/components";
 
 const meta: Meta<typeof Loading> = {
-  title: "Core/Loading",
+  title: "Core/Feedback/Loading",
   component: Loading,
   parameters: {
     layout: "centered",

--- a/app/stories/Menu.stories.tsx
+++ b/app/stories/Menu.stories.tsx
@@ -33,7 +33,7 @@ import {
 import { Truncate } from "@phoenix/components/core/utility/Truncate";
 
 const meta: Meta<typeof Menu> = {
-  title: "Core/Menu",
+  title: "Core/Actions/Menu",
   component: Menu,
   parameters: {
     layout: "centered",

--- a/app/stories/Modal.stories.tsx
+++ b/app/stories/Modal.stories.tsx
@@ -20,7 +20,7 @@ import {
 } from "@phoenix/components/core/dialog";
 
 const meta: Meta = {
-  title: "Core/Modal",
+  title: "Core/Overlays/Modal",
   component: Modal,
 };
 

--- a/app/stories/NumberField.stories.tsx
+++ b/app/stories/NumberField.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/NumberField",
+  title: "Core/Forms/Number Field",
   component: NumberField,
 
   parameters: {

--- a/app/stories/OverflowCell.stories.tsx
+++ b/app/stories/OverflowCell.stories.tsx
@@ -8,7 +8,7 @@ import { JSONBlock } from "@phoenix/components/code";
 import { OverflowCell } from "../src/components/table/OverflowCell";
 
 const meta: Meta<typeof OverflowCell> = {
-  title: "Table/OverflowCell",
+  title: "Table/Overflow Cell",
   component: OverflowCell,
   parameters: {
     layout: "centered",

--- a/app/stories/PageHeader.stories.tsx
+++ b/app/stories/PageHeader.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/PageHeader",
+  title: "Core/Layout/Page Header",
   component: PageHeader,
   parameters: {
     controls: { expanded: true },

--- a/app/stories/Popover.stories.tsx
+++ b/app/stories/Popover.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Popover",
+  title: "Core/Overlays/Popover",
   component: Popover,
   parameters: {
     layout: "centered",

--- a/app/stories/ProgressBar.stories.tsx
+++ b/app/stories/ProgressBar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ProgressBar } from "@phoenix/components";
 
 const meta: Meta<typeof ProgressBar> = {
-  title: "Core/ProgressBar",
+  title: "Core/Feedback/Progress Bar",
   component: ProgressBar,
   parameters: {
     layout: "centered",

--- a/app/stories/ProgressCircle.stories.tsx
+++ b/app/stories/ProgressCircle.stories.tsx
@@ -4,7 +4,7 @@ import { ProgressCircle } from "../src/components/core/progress/ProgressCircle";
 import type { ProgressCircleProps } from "../src/components/core/progress/types";
 
 const meta: Meta<typeof ProgressCircle> = {
-  title: "Core/ProgressCircle",
+  title: "Core/Feedback/Progress Circle",
   component: ProgressCircle,
   parameters: {
     layout: "centered",

--- a/app/stories/PromptMenu.stories.tsx
+++ b/app/stories/PromptMenu.stories.tsx
@@ -25,7 +25,7 @@ const promptMenuContainerCSS = css`
 `;
 
 const meta: Meta = {
-  title: "PromptMenu",
+  title: "Prompt/Prompt Menu",
   parameters: {
     layout: "centered",
   },

--- a/app/stories/ProviderAndIntegrationIcons.stories.tsx
+++ b/app/stories/ProviderAndIntegrationIcons.stories.tsx
@@ -31,7 +31,7 @@ import {
 import { ModelProviders } from "@phoenix/constants/generativeConstants";
 
 const meta: Meta = {
-  title: "Provider & Integration Icons",
+  title: "Reference/Provider & Integration Icons",
 };
 export default meta;
 

--- a/app/stories/RadioGroup.stories.tsx
+++ b/app/stories/RadioGroup.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/RadioGroup",
+  title: "Core/Forms/Radio Group",
   component: RadioGroup,
   parameters: {
     layout: "centered",

--- a/app/stories/RecordIcon.stories.tsx
+++ b/app/stories/RecordIcon.stories.tsx
@@ -6,7 +6,7 @@ import type { RecordIconProps } from "@phoenix/components/core/icon/RecordIcon";
 import { RecordIcon } from "@phoenix/components/core/icon/RecordIcon";
 
 const meta: Meta = {
-  title: "Core/RecordIcon",
+  title: "Core/Content/Record Icon",
   component: RecordIcon,
   argTypes: {
     isActive: { control: "boolean" },

--- a/app/stories/RichTooltip.stories.tsx
+++ b/app/stories/RichTooltip.stories.tsx
@@ -17,7 +17,7 @@ import {
  * Unlike regular tooltips, rich tooltips can contain formatted content and interactive elements using composition.
  */
 const meta = {
-  title: "Core/RichTooltip",
+  title: "Core/Overlays/Rich Tooltip",
   component: RichTooltip,
   parameters: {
     layout: "centered",

--- a/app/stories/SearchField.stories.tsx
+++ b/app/stories/SearchField.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { SearchIcon } from "@phoenix/components/core/field";
 
 const meta: Meta = {
-  title: "Core/SearchField",
+  title: "Core/Forms/Search Field",
   component: SearchField,
   parameters: {
     controls: { expanded: true },

--- a/app/stories/Select.stories.tsx
+++ b/app/stories/Select.stories.tsx
@@ -17,7 +17,7 @@ import {
  * It supports different sizes, is fully accessible, and follows the design system's styling.
  */
 const meta = {
-  title: "Core/Select",
+  title: "Core/Forms/Select",
   component: Select,
   parameters: {
     layout: "centered",

--- a/app/stories/SemanticChartColors.stories.tsx
+++ b/app/stories/SemanticChartColors.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "@phoenix/components/core/tooltip";
 
 const meta: Meta = {
-  title: "charting/SemanticChartColors",
+  title: "Charting/Semantic Chart Colors",
 };
 
 export default meta;

--- a/app/stories/Skeleton.stories.tsx
+++ b/app/stories/Skeleton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ContentSkeleton, Flex, Skeleton } from "@phoenix/components";
 
 const meta: Meta<typeof Skeleton> = {
-  title: "Core/Skeleton",
+  title: "Core/Feedback/Skeleton",
   component: Skeleton,
   parameters: {
     layout: "centered",

--- a/app/stories/Slider.stories.tsx
+++ b/app/stories/Slider.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Card, Slider, SliderNumberField, View } from "@phoenix/components";
 
 const meta: Meta<typeof Slider> = {
-  title: "Core/Slider",
+  title: "Core/Forms/Slider",
   component: Slider,
   parameters: {
     layout: "centered",

--- a/app/stories/SpanKindIcon.stories.tsx
+++ b/app/stories/SpanKindIcon.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import { SpanKindIcon } from "@phoenix/components/trace";
 
 const meta: Meta = {
-  title: "SpanKindIcon",
+  title: "Trace/Span Kind Icon",
   component: SpanKindIcon,
   parameters: {
     docs: {

--- a/app/stories/StackedTimeSeriesBarChart.stories.tsx
+++ b/app/stories/StackedTimeSeriesBarChart.stories.tsx
@@ -270,7 +270,7 @@ function StackedBarChart({
 }
 
 const meta: Meta<typeof StackedBarChart> = {
-  title: "Charting/StackedTimeSeriesBarChart",
+  title: "Charting/Stacked Time Series Bar Chart",
   component: StackedBarChart,
   decorators: [
     (Story) => (

--- a/app/stories/Switch.stories.tsx
+++ b/app/stories/Switch.stories.tsx
@@ -5,7 +5,7 @@ import type { SwitchProps } from "@phoenix/components";
 import { Flex, Switch } from "@phoenix/components";
 
 const meta: Meta<SwitchProps> = {
-  title: "Core/Switch",
+  title: "Core/Forms/Switch",
   component: Switch,
   parameters: {
     controls: { expanded: true },

--- a/app/stories/Tabs.stories.tsx
+++ b/app/stories/Tabs.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Tabs",
+  title: "Core/Navigation/Tabs",
   component: Tabs,
   parameters: {
     layout: "centered",

--- a/app/stories/TagGroup.stories.tsx
+++ b/app/stories/TagGroup.stories.tsx
@@ -4,7 +4,7 @@ import type { TagGroupProps } from "@phoenix/components";
 import { Label, Tag, TagGroup, TagList } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/TagGroup",
+  title: "Core/Forms/Tag Group",
   component: TagGroup,
   parameters: {
     controls: { expanded: true },

--- a/app/stories/Text.stories.tsx
+++ b/app/stories/Text.stories.tsx
@@ -7,7 +7,7 @@ import { Flex, Text } from "@phoenix/components";
 import { GLOBAL_COLORS } from "./constants/colorConstants";
 
 const meta: Meta = {
-  title: "Core/Text",
+  title: "Core/Content/Text",
   component: Text,
 
   parameters: {

--- a/app/stories/TextField.stories.tsx
+++ b/app/stories/TextField.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from "@phoenix/components/core/field";
 
 const meta: Meta = {
-  title: "Core/TextField",
+  title: "Core/Forms/Text Field",
   component: TextField,
   parameters: {
     controls: { expanded: true },

--- a/app/stories/TimeField.stories.tsx
+++ b/app/stories/TimeField.stories.tsx
@@ -4,7 +4,7 @@ import type { TimeFieldProps, TimeValue } from "@phoenix/components";
 import { DateInput, DateSegment, Label, TimeField } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/TimeField",
+  title: "Core/Forms/Time Field",
   component: TimeField,
   parameters: {
     layout: "centered",

--- a/app/stories/TimeRangeForm.stories.tsx
+++ b/app/stories/TimeRangeForm.stories.tsx
@@ -16,7 +16,7 @@ import {
 import { createTimeRangeFormatter } from "@phoenix/utils/timeFormatUtils";
 
 const meta: Meta = {
-  title: "Core/TimeRangeForm",
+  title: "Core/Forms/Time Range Form",
   component: TimeRangeForm,
   parameters: {
     layout: "centered",

--- a/app/stories/TimeRangeSelector.stories.tsx
+++ b/app/stories/TimeRangeSelector.stories.tsx
@@ -10,7 +10,7 @@ import { PreferencesProvider } from "@phoenix/contexts";
 import { createTimeRangeFormatter } from "@phoenix/utils/timeFormatUtils";
 
 const meta: Meta = {
-  title: "TimeRangeSelector",
+  title: "DateTime/Time Range Selector",
   component: TimeRangeSelector,
   parameters: {
     layout: "centered",

--- a/app/stories/Timer.stories.tsx
+++ b/app/stories/Timer.stories.tsx
@@ -5,7 +5,7 @@ import type { TimerProps } from "@phoenix/components";
 import { Timer } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Timer",
+  title: "Core/Feedback/Timer",
   component: Timer,
   parameters: {
     layout: "centered",

--- a/app/stories/TimezonePreferences.stories.tsx
+++ b/app/stories/TimezonePreferences.stories.tsx
@@ -15,7 +15,7 @@ import { useTimeFormatters } from "@phoenix/hooks/useTimeFormatters";
 import { ViewerPreferences } from "@phoenix/pages/profile/ViewerPreferences";
 
 const meta: Meta = {
-  title: "Timezone Preferences",
+  title: "DateTime/Timezone Preferences",
   parameters: {
     layout: "centered",
   },

--- a/app/stories/TitledPanel.stories.tsx
+++ b/app/stories/TitledPanel.stories.tsx
@@ -5,7 +5,7 @@ import { Card, Text, Token, View } from "@phoenix/components";
 import { TitledPanel } from "@phoenix/components/react-resizable-panels";
 
 const meta: Meta = {
-  title: "TitledPanel",
+  title: "Core/Layout/Titled Panel",
   component: TitledPanel,
   parameters: {
     layout: "centered",

--- a/app/stories/Toast.stories.tsx
+++ b/app/stories/Toast.stories.tsx
@@ -6,7 +6,7 @@ import { Toast } from "@phoenix/components";
 import type { NotificationParams } from "@phoenix/contexts";
 
 const meta: Meta = {
-  title: "Core/Toast",
+  title: "Core/Feedback/Toast",
   component: Toast,
   parameters: {
     layout: "centered",

--- a/app/stories/ToastRegion.stories.tsx
+++ b/app/stories/ToastRegion.stories.tsx
@@ -9,7 +9,7 @@ import { useNotify, useNotifyError, useNotifySuccess } from "@phoenix/contexts";
  * ToastRegion manages the display of one or more queued toasts
  */
 const meta: Meta = {
-  title: "Core/ToastRegion",
+  title: "Core/Feedback/Toast Region",
   component: ToastRegion,
   parameters: {
     layout: "centered",

--- a/app/stories/ToggleButton.stories.tsx
+++ b/app/stories/ToggleButton.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Icon, Icons, ToggleButton } from "@phoenix/components";
 
 export default {
-  title: "Core/ToggleButton",
+  title: "Core/Actions/Toggle Button",
   component: ToggleButton,
   parameters: {
     layout: "centered",

--- a/app/stories/ToggleButtonGroup.stories.tsx
+++ b/app/stories/ToggleButtonGroup.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/ToggleButtonGroup",
+  title: "Core/Actions/Toggle Button Group",
   component: ToggleButtonGroup,
   parameters: {
     layout: "centered",

--- a/app/stories/Token.stories.tsx
+++ b/app/stories/Token.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from "@phoenix/components";
 
 const meta: Meta = {
-  title: "Core/Token",
+  title: "Core/Content/Token",
   component: Token,
   parameters: {
     layout: "centered",

--- a/app/stories/TokenCosts.stories.tsx
+++ b/app/stories/TokenCosts.stories.tsx
@@ -11,7 +11,7 @@ import { TokenCostsDetails } from "@phoenix/components/trace/TokenCostsDetails";
  * it can show detailed breakdowns of cost usage by token type and prompt/completion.
  */
 const meta = {
-  title: "TokenCosts",
+  title: "Tokens/Token Costs",
   component: TokenCosts,
   parameters: {
     layout: "centered",

--- a/app/stories/TokenCount.stories.tsx
+++ b/app/stories/TokenCount.stories.tsx
@@ -11,7 +11,7 @@ import { TokenCountDetails } from "@phoenix/components/trace/TokenCountDetails";
  * it can show detailed breakdowns of token usage.
  */
 const meta = {
-  title: "TokenCount",
+  title: "Tokens/Token Count",
   component: TokenCount,
   parameters: {
     layout: "centered",

--- a/app/stories/Toolbar.stories.tsx
+++ b/app/stories/Toolbar.stories.tsx
@@ -22,7 +22,7 @@ import {
  */
 
 const meta: Meta<typeof Toolbar> = {
-  title: "Core/Toolbar",
+  title: "Core/Actions/Toolbar",
   component: Toolbar,
   subcomponents: { Separator },
   parameters: {

--- a/app/stories/Tooltip.stories.tsx
+++ b/app/stories/Tooltip.stories.tsx
@@ -14,7 +14,7 @@ import {
  * The tooltip component wraps react-aria-components' Tooltip with Phoenix design system styling.
  */
 const meta = {
-  title: "Core/Tooltip",
+  title: "Core/Overlays/Tooltip",
   component: Tooltip,
   parameters: {
     layout: "centered",


### PR DESCRIPTION
## Summary
- Reorganize all 72 Storybook story titles for a cleaner, more navigable sidebar hierarchy
- Move 11 root-level orphan stories into proper categories (Reference, Annotation, DateTime, Tokens, Trace, Prompt)
- Add subcategories to the flat Core/ group: Content, Actions, Forms, Feedback, Overlays, Layout, Navigation, Media
- Fix inconsistent `charting/` → `Charting/` casing and add spaces to PascalCase names
- Add `storySort` config to `preview.tsx` for logical sidebar ordering

## Test plan
- [ ] Run `pnpm --filter app storybook` and verify sidebar shows the new hierarchy
- [ ] Verify no root-level orphan stories remain
- [ ] Verify all Core stories are in subcategories
- [ ] Verify charting stories all use `Charting/` (uppercase)
- [ ] Verify spaces in all multi-word names