### PR TITLE
fix(ui): force text/csv MIME type on CSV upload to handle Windows browser behavior

### DIFF
--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { useCallback, useRef, useState } from "react";
 import type { DropItem, FileDropItem } from "react-aria-components";
 import { Controller, useForm } from "react-hook-form";
+import invariant from "tiny-invariant";
 
 import {
   Button,
@@ -221,13 +222,23 @@ export function DatasetFromFileForm(props: DatasetFromFileFormProps) {
       setIsSubmitting(true);
       const formData = new FormData();
 
-      if (fileType === "jsonl") {
-        const jsonlFile = new File([data.file], data.file.name, {
-          type: "application/jsonl",
-        });
-        formData.append("file", jsonlFile);
-      } else {
-        formData.append("file", data.file);
+      switch (fileType) {
+        case "jsonl": {
+          const jsonlFile = new File([data.file], data.file.name, {
+            type: "application/jsonl",
+          });
+          formData.append("file", jsonlFile);
+          break;
+        }
+        case "csv": {
+          const csvFile = new File([data.file], data.file.name, {
+            type: "text/csv",
+          });
+          formData.append("file", csvFile);
+          break;
+        }
+        default:
+          invariant(false, `Invalid file type: ${fileType}`);
       }
 
       formData.append("name", data.name);


### PR DESCRIPTION
On Windows, .csv files are registered as application/vnd.ms-excel in the OS registry, causing browsers to send that MIME type in multipart uploads. The server only accepts text/csv and would reject the file with a 422. Fix by wrapping the CSV file in a new File object with an explicit type before appending to FormData, matching the existing pattern already used for JSONL.