### PR TITLE
fix(playground): preserve prompt invocation parameters when loading

### DIFF
--- a/app/src/pages/playground/__tests__/fetchPlaygroundPrompt.test.ts
+++ b/app/src/pages/playground/__tests__/fetchPlaygroundPrompt.test.ts
@@ -37,11 +37,13 @@ describe("objectToInvocationParameters", () => {
         invocationName: "temperature",
         canonicalName: "TEMPERATURE",
         valueFloat: 0.7,
+        dirty: true,
       },
       {
         invocationName: "max_tokens",
         canonicalName: "MAX_COMPLETION_TOKENS",
         valueInt: 100,
+        dirty: true,
       },
     ]);
   });
@@ -60,12 +62,43 @@ describe("objectToInvocationParameters", () => {
       {
         invocationName: "unknownParam",
         valueJson: "test",
+        dirty: true,
       },
       {
         invocationName: "maxTokens",
         valueJson: 100,
+        dirty: true,
       },
     ]);
+  });
+
+  it("should mark all parameters as dirty to preserve them during model updates", () => {
+    // This test verifies that prompt invocation parameters are marked as dirty
+    // so they are preserved when updateModelSupportedInvocationParameters runs
+    const params = {
+      temperature: 0,
+      max_tokens: 4096,
+    };
+
+    const supportedParams = [
+      {
+        __typename: "FloatInvocationParameter",
+        invocationName: "temperature",
+        canonicalName: "TEMPERATURE",
+        invocationInputField: "value_float",
+      },
+      {
+        __typename: "IntInvocationParameter",
+        invocationName: "max_tokens",
+        canonicalName: "MAX_COMPLETION_TOKENS",
+        invocationInputField: "value_int",
+      },
+    ] satisfies SupportedParamsType;
+
+    const result = objectToInvocationParameters(params, supportedParams);
+
+    // All parameters should have dirty: true so they are preserved
+    expect(result.every((param) => param.dirty === true)).toBe(true);
   });
 });
 

--- a/app/src/pages/playground/fetchPlaygroundPrompt.ts
+++ b/app/src/pages/playground/fetchPlaygroundPrompt.ts
@@ -104,18 +104,22 @@ export const objectToInvocationParameters = (
       : {};
   // now we'll map the incoming invocation parameters to the supported invocation parameters
   // we'll use the invocation name as the key
+  // we mark all parameters as dirty: true because these are explicitly saved values from the prompt
+  // that should be preserved when updateModelSupportedInvocationParameters runs
   return Object.entries(invocationParameters).map(([key, value]) => {
     const definition = invocationParameterDefinitionMap[key];
     if (!definition || !definition.invocationInputField) {
       return {
         invocationName: key,
         valueJson: value,
+        dirty: true,
       };
     }
     return {
       invocationName: key,
       canonicalName: definition.canonicalName,
       [toCamelCase(definition.invocationInputField)]: value,
+      dirty: true,
     };
   });
 };


### PR DESCRIPTION
## Summary
- Mark prompt invocation parameters as `dirty: true` when loading a prompt in the Playground
- This ensures saved prompt values (temperature, max_tokens, etc.) are preserved when `updateModelSupportedInvocationParameters` runs

## Problem
When opening an existing prompt in the Playground, the invocation parameters (temperature, max tokens) were being reset to default values instead of using the prompt's saved configuration.

**Root cause:** Prompt invocation parameters were converted via `objectToInvocationParameters()` without the `dirty: true` flag. When `ModelSupportedParamsFetcher` ran and called `updateModelSupportedInvocationParameters()`, only parameters with `dirty: true` were preserved - the rest were replaced with server defaults.

## Solution
Add `dirty: true` to all invocation parameters in `objectToInvocationParameters()`. These are explicitly saved values from the prompt that should be preserved.

This change only affects the prompt loading flow - other flows (fresh playground, user-saved defaults, model switching without a prompt) are unaffected.

Fixes #11925