### PR TITLE
fix: prevent text overflow in table columns with long unbroken strings

### DIFF
--- a/app/src/pages/examples/ExamplesTable.tsx
+++ b/app/src/pages/examples/ExamplesTable.tsx
@@ -431,6 +431,7 @@ export function ExamplesTable({
                         ...getCommonPinningStyles(cell.column),
                         width: `calc(var(${colSizeVar}) * 1px)`,
                         maxWidth: `calc(var(${colSizeVar}) * 1px)`,
+                        overflowWrap: "anywhere",
                         // prevent text selection on the select cell
                         userSelect:
                           cell.column.columnDef.id === "select"

--- a/app/src/pages/experiment/ExperimentCompareListPage.tsx
+++ b/app/src/pages/experiment/ExperimentCompareListPage.tsx
@@ -1470,6 +1470,7 @@ function TableBody<T>({
                   padding:
                     "var(--global-dimension-size-175) var(--global-dimension-size-200)",
                   verticalAlign: "middle",
+                  overflowWrap: "anywhere",
                 }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/src/pages/experiment/ExperimentCompareTable.tsx
+++ b/app/src/pages/experiment/ExperimentCompareTable.tsx
@@ -784,6 +784,7 @@ function TableBody<T>({
                     width: `calc(var(--col-${makeSafeColumnId(cell.column.id)}-size) * 1px)`,
                     maxWidth: `calc(var(--col-${makeSafeColumnId(cell.column.id)}-size) * 1px)`,
                     padding: 0,
+                    overflowWrap: "anywhere",
                   }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/app/tests/dataset-examples-overflow.spec.ts
+++ b/app/tests/dataset-examples-overflow.spec.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "crypto";
+import { expect, test } from "@playwright/test";
+
+/**
+ * Test for issue #11923: Output column allows visual overflow if contents are very wide
+ * This test verifies that long text without spaces wraps properly in the dataset Examples tab
+ */
+test.describe("Dataset Examples Table Overflow", () => {
+  // Long string without spaces that would overflow without proper CSS handling
+  const LONG_OUTPUT_NO_SPACES =
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  test("long text without spaces wraps in dataset examples output column", async ({
+    page,
+    request,
+  }) => {
+    const datasetName = `overflow-test-${randomUUID().slice(0, 8)}`;
+
+    // 1. Create a dataset with examples that have long output text (no spaces)
+    const createDatasetResponse = await request.post(
+      "/v1/datasets/upload?sync=true",
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        data: {
+          action: "create",
+          name: datasetName,
+          inputs: [
+            { question: "What is 2+2?" },
+            { question: "What is the capital of France?" },
+          ],
+          outputs: [
+            { answer: LONG_OUTPUT_NO_SPACES },
+            { answer: "Paris is the capital" },
+          ],
+        },
+      }
+    );
+    expect(createDatasetResponse.ok()).toBeTruthy();
+
+    const datasetData = await createDatasetResponse.json();
+    const datasetId = datasetData.data.dataset_id;
+    expect(datasetId).toBeTruthy();
+
+    // 2. Navigate to the dataset Examples tab
+    await page.goto(`/datasets/${datasetId}/examples`);
+    await page.waitForURL(`**/datasets/**/examples`);
+
+    // 3. Wait for the table to load and verify content is visible
+    await expect(page.getByText("What is 2+2?").first()).toBeVisible();
+
+    // 4. Check that the long output text is visible (it gets truncated in the cell)
+    // The text should be present in the output column
+    const outputCell = page.locator("td").filter({
+      hasText: LONG_OUTPUT_NO_SPACES.substring(0, 50),
+    });
+    await expect(outputCell.first()).toBeVisible();
+
+    // 5. Verify overflow handling by checking the cell's computed style
+    // Get the bounding box of the output cell and its parent table
+    const table = page.locator("table").first();
+    const tableBox = await table.boundingBox();
+    const cellBox = await outputCell.first().boundingBox();
+
+    // The cell should not extend beyond the table boundaries
+    // (this would happen if overflow wasn't properly handled)
+    expect(tableBox).toBeTruthy();
+    expect(cellBox).toBeTruthy();
+    if (tableBox && cellBox) {
+      // Cell's right edge should not exceed table's right edge
+      const tableRightEdge = tableBox.x + tableBox.width;
+      const cellRightEdge = cellBox.x + cellBox.width;
+      expect(cellRightEdge).toBeLessThanOrEqual(tableRightEdge + 1); // +1 for rounding
+    }
+  });
+});


### PR DESCRIPTION

<img width="1728" height="685" alt="Screenshot 2026-03-09 at 11 29 26 AM" src="https://github.com/user-attachments/assets/608e3a04-4b6b-4da6-85d9-695ec0b2d97e" />


## Summary
- Fixes #11923 - Output column allows visual overflow if contents are very wide
- Adds `overflowWrap: "anywhere"` CSS property to table cells so long text without spaces wraps properly instead of overflowing into neighboring columns

## Changes
- **ExamplesTable.tsx** - Dataset Examples tab (primary fix)
- **ExperimentCompareTable.tsx** - Experiment comparison grid view (preventive fix)
- **ExperimentCompareListPage.tsx** - Experiment comparison list view (preventive fix)
- **dataset-examples-overflow.spec.ts** - New Playwright E2E test

## Testing
- Added Playwright test that creates a dataset with long unbroken strings and verifies cells don't overflow table boundaries
- Manually verified fix on local Phoenix server