### PR TITLE
fix: Reset invocation params dirty flag when switching providers

### DIFF
--- a/app/src/store/playground/playgroundStore.tsx
+++ b/app/src/store/playground/playgroundStore.tsx
@@ -535,9 +535,18 @@ export const createPlaygroundStore = (props: InitialPlaygroundState) => {
             openaiApiType: null,
           };
 
+          // Clear the dirty flag on invocation parameters when switching providers
+          // to prevent incompatible parameters from being preserved
+          const invocationParametersWithoutDirty =
+            baseModel.invocationParameters.map((param) => ({
+              ...param,
+              dirty: undefined,
+            }));
+
           // Build final model config
           const finalModel = {
             ...baseModel,
+            invocationParameters: invocationParametersWithoutDirty,
             ...resetFields,
             ...(savedProviderConfig || {}),
             // Only override invocation parameters if we have saved config


### PR DESCRIPTION
## Description

Fixes #11959

When switching providers in the Playground (e.g., OpenAI → Anthropic), invocation parameters with `dirty=true` were being preserved even when incompatible with the new provider's valid ranges.

## Changes

- Clear the `dirty` flag on all invocation parameters when the provider changes in `updateProvider`
- This ensures that user-modified parameters from the old provider don't incorrectly carry over to the new provider

## Testing

The fix clears the `dirty` flag by mapping over all invocation parameters and setting `dirty: undefined` before building the final model config. This allows the new provider's supported invocation parameters to properly control which parameters are valid.

## Related Issue

Fixes #11959