### PR TITLE
fix(evals): accept optional prompt_template in CorrectnessEvaluator, FaithfulnessEvaluator, and ToolSelectionEvaluator

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/metrics/correctness.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/correctness.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import Optional, Union
+
 from pydantic import BaseModel, Field
 
 from ..__generated__.classification_evaluator_configs import (
     CORRECTNESS_CLASSIFICATION_EVALUATOR_CONFIG,
 )
 from ..evaluators import ClassificationEvaluator
-from ..llm import LLM
+from ..llm import LLM, PromptLike, Template
 from ..llm.prompts import PromptTemplate
 
 
@@ -54,11 +58,12 @@ class CorrectnessEvaluator(ClassificationEvaluator):
     def __init__(
         self,
         llm: LLM,
+        prompt_template: Union[PromptLike, PromptTemplate, Template, None] = None,
     ):
         super().__init__(
             name=self.NAME,
             llm=llm,
-            prompt_template=self.PROMPT.template,
+            prompt_template=prompt_template if prompt_template is not None else self.PROMPT.template,
             choices=self.CHOICES,
             direction=self.DIRECTION,
             input_schema=self.CorrectnessInputSchema,

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/faithfulness.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/faithfulness.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import Union
+
 from pydantic import BaseModel, Field
 
 from ..__generated__.classification_evaluator_configs import (
     FAITHFULNESS_CLASSIFICATION_EVALUATOR_CONFIG,
 )
 from ..evaluators import ClassificationEvaluator
-from ..llm import LLM
+from ..llm import LLM, PromptLike, Template
 from ..llm.prompts import PromptTemplate
 
 
@@ -57,11 +61,12 @@ class FaithfulnessEvaluator(ClassificationEvaluator):
     def __init__(
         self,
         llm: LLM,
+        prompt_template: Union[PromptLike, PromptTemplate, Template, None] = None,
     ):
         super().__init__(
             name=self.NAME,
             llm=llm,
-            prompt_template=self.PROMPT.template,
+            prompt_template=prompt_template if prompt_template is not None else self.PROMPT.template,
             choices=self.CHOICES,
             direction=self.DIRECTION,
             input_schema=self.FaithfulnessInputSchema,

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/tool_selection.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/tool_selection.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import Union
+
 from pydantic import BaseModel, Field
 
 from ..__generated__.classification_evaluator_configs import (
     TOOL_SELECTION_CLASSIFICATION_EVALUATOR_CONFIG,
 )
 from ..evaluators import ClassificationEvaluator
-from ..llm import LLM
+from ..llm import LLM, PromptLike, Template
 from ..llm.prompts import PromptTemplate
 
 
@@ -61,11 +65,12 @@ class ToolSelectionEvaluator(ClassificationEvaluator):
     def __init__(
         self,
         llm: LLM,
+        prompt_template: Union[PromptLike, PromptTemplate, Template, None] = None,
     ):
         super().__init__(
             name=self.NAME,
             llm=llm,
-            prompt_template=self.PROMPT.template,
+            prompt_template=prompt_template if prompt_template is not None else self.PROMPT.template,
             choices=self.CHOICES,
             direction=self.DIRECTION,
             input_schema=self.ToolSelectionInputSchema,


### PR DESCRIPTION
## Problem

`CorrectnessEvaluator`, `FaithfulnessEvaluator`, and `ToolSelectionEvaluator` all inherit from `ClassificationEvaluator` which accepts `prompt_template` as a parameter. However, the concrete subclasses hard-coded the class-level default template and did not expose `prompt_template` in their own `__init__`, so callers who tried to pass a custom template received:

```
TypeError: CorrectnessEvaluator.__init__() got an unexpected keyword argument 'prompt_template'
```

This is documented in the Arize tutorial at https://arize.com/docs/phoenix/evaluation/how-to-evals/configuring-the-llm, which shows `prompt_template` being passed to these evaluators.

## Fix

Added `prompt_template: Union[PromptLike, PromptTemplate, Template, None] = None` to the `__init__` of all three evaluators. When provided, the custom template is forwarded to `ClassificationEvaluator`; when omitted (`None`), the class-level default is used as before.

The change is backwards-compatible: existing code that instantiates `CorrectnessEvaluator(llm=llm)` without `prompt_template` continues to work identically.

## Testing

```python
from phoenix.evals import LLM
from phoenix.evals.metrics import CorrectnessEvaluator

llm = LLM(provider="openai", model="gpt-4o-mini", api_key="...")

# Was: TypeError
evaluator = CorrectnessEvaluator(llm=llm, prompt_template="Classify: {input} {output}")

# Still works
evaluator_default = CorrectnessEvaluator(llm=llm)
```

Closes #11858