### PR TITLE
fix(docs): fix python quickstart notebook and docs

### DIFF
--- a/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
+++ b/docs/phoenix/get-started/get-started-datasets-and-experiments.mdx
@@ -135,7 +135,7 @@ dataset = client.datasets.get_dataset(dataset="python quickstart fails")
 Now we can run our experiment!
 
 ```python
-experiment = client.experiments.run_experiment(dataset, my_task, evaluators=evaluators)
+experiment = client.experiments.run_experiment(dataset=dataset, task=my_task, evaluators=evaluators)
 ```
 
 Once this completes, Phoenix logs the experiment results automatically.

--- a/tutorials/quickstarts/python_quickstart.ipynb
+++ b/tutorials/quickstarts/python_quickstart.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -qqqqq arize-phoenix crewai crewai-tools openinference-instrumentation-crewai openai getpass"
+    "%pip install -qqqqq arize-phoenix crewai crewai-tools openinference-instrumentation-crewai openinference-instrumentation-openai openai"
    ]
   },
   {
@@ -151,7 +151,7 @@
     "crew = Crew(\n",
     "    agents=[researcher, writer],\n",
     "    tasks=[task1, task2],\n",
-    "    verbose=1,\n",
+    "    verbose=True,\n",
     "    process=Process.sequential,\n",
     ")"
    ]
@@ -380,7 +380,7 @@
     "updated_crew = Crew(\n",
     "    agents=[researcher, writer],\n",
     "    tasks=[task1, task2],\n",
-    "    verbose=1,\n",
+    "    verbose=True,\n",
     "    process=Process.sequential,\n",
     ")"
    ]
@@ -424,6 +424,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0ef1981c",
+   "metadata": {},
+   "source": [
+    "**Before running the next cell**, you need to create a dataset in the Phoenix UI from your failed traces:\n",
+    "\n",
+    "1. Go to your Phoenix instance and open the **crewai-tracing-quickstart** project.\n",
+    "2. Click the **Traces** tab. In the filter bar, enter: `evals['completeness'].label == 'incomplete'`\n",
+    "3. Select all the filtered traces, then click **Add to Dataset** and name it **\"python quickstart fails\"**.\n",
+    "\n",
+    "This dataset captures the inputs that your agent struggled with, so you can re-run them through the improved agent and measure whether the changes actually help."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b63e9e8a",
@@ -441,7 +455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = client.experiments.run_experiment(dataset, my_task, evaluators=evaluators)"
+    "experiment = client.experiments.run_experiment(dataset=dataset, task=my_task, evaluators=evaluators)"
    ]
   }
  ],


### PR DESCRIPTION
  Summary

  - Fix pip install: remove getpass (no PyPI package) and add missing openinference-instrumentation-openai
  - Fix verbose=1 to verbose=True in both Crew() constructors
  - Fix run_experiment() to use keyword args (dataset=, task=) as required by the client API
  - Add markdown cell with instructions to create the dataset in Phoenix UI before running experiments

  Test plan

  - Tested full notebook end-to-end locally with Python 3.11
  - Tested on Google Colab — all cells pass
  - Verified docs page change matches notebook