### PR TITLE
ci: Add Claude agent workflow for automated issue implementation

### DIFF
--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -74,13 +74,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           prompt: |
             Read and implement GitHub issue #${{ github.event.issue.number }}.
-
-            ${{ github.event.issue.body }}
-
+            Use `gh issue view ${{ github.event.issue.number }}` to read the issue details.
             Create commits referencing #${{ github.event.issue.number }}, then push and open a PR with `gh pr create`.
-          claude_args: '--max-turns 30'
+          claude_args: '--allowedTools Read,Write,Edit,Glob,Grep,Agent,"Bash(git:*)","Bash(make:*)","Bash(gh:*)","Bash(uv:*)","Bash(pnpm:*)"'
 
       - name: Cleanup
         if: always() && env.READY == 'true'


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that automatically implements issues labeled `good-agent-issue` using Claude Code
- Includes guard logic to skip already-assigned issues or issues with existing PRs
- Claims the issue during work, cleans up labels/assignees on both success and failure
- Uses job-level env vars to avoid script injection and reduce repetition, sets a 60-minute timeout

## Test plan
- [ ] Add `good-agent-issue` label to a test issue and verify the workflow triggers
- [ ] Verify guard step skips issues that are already assigned or have linked PRs
- [ ] Verify cleanup runs on both success and failure paths