### PR TITLE
fix: re-export supress tracing from phoenix-otel

### DIFF
--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -1116,9 +1116,8 @@ with suppress_tracing():
 
 <Tab title="TypeScript" icon="js">
 ```typescript
-import { suppressTracing } from "@opentelemetry/core";
 import { withSpan } from "@arizeai/openinference-core";
-import { trace, context } from "@arizeai/phoenix-otel";
+import { trace, context, suppressTracing } from "@arizeai/phoenix-otel";
 
 await context.with(suppressTracing(context.active()), async () => {
   // this trace will not be recorded

--- a/js/packages/phoenix-otel/src/index.ts
+++ b/js/packages/phoenix-otel/src/index.ts
@@ -5,6 +5,7 @@ export {
   type Tracer,
   SpanStatusCode,
 } from "@opentelemetry/api";
+export { suppressTracing } from "@opentelemetry/core";
 export { registerInstrumentations } from "@opentelemetry/instrumentation";
 export { type Instrumentation } from "@opentelemetry/instrumentation";
 export { type NodeTracerProvider } from "@opentelemetry/sdk-trace-node";

--- a/js/packages/phoenix-otel/test/register.test.ts
+++ b/js/packages/phoenix-otel/test/register.test.ts
@@ -1,8 +1,9 @@
 import { context } from "@opentelemetry/api";
+import { suppressTracing as originalSuppressTracing } from "@opentelemetry/core";
 import type { Span, SpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { describe, expect, test } from "vitest";
 
-import { DiagLogLevel } from "../src";
+import { DiagLogLevel, suppressTracing } from "../src";
 import { ensureCollectorEndpoint, register } from "../src/register";
 
 describe("register", () => {
@@ -43,6 +44,11 @@ describe("register", () => {
 test("should export DiagLogLevel as a runtime value", () => {
   expect(DiagLogLevel.DEBUG).toBeDefined();
   expect(typeof DiagLogLevel.DEBUG).toBe("number");
+});
+
+test("should re-export suppressTracing from @opentelemetry/core", () => {
+  expect(suppressTracing).toBe(originalSuppressTracing);
+  expect(typeof suppressTracing).toBe("function");
 });
 
 test.each([


### PR DESCRIPTION
Resolves #10137

**Problem**: Users who needed `suppressTracing` had to import it separately from `@opentelemetry/core`, while other OpenTelemetry utilities like `trace`, `context`, and `SpanStatusCode` were already re-exported from `@arizeai/phoenix-otel`.

**Solution**: I added `export { suppressTracing } from "@opentelemetry/core"` in `js/packages/phoenix-otel/src/index.ts` alongside the existing `@opentelemetry/api` re-exports. Previously users needed two package imports (`@opentelemetry/core` and `@arizeai/phoenix-otel`). Now `suppressTracing` comes directly from `@arizeai/phoenix-otel`, matching the pattern already established for `trace`, `context`, and `SpanStatusCode`. Updated the docs example in `instrument.mdx` to show the simplified single-package import, and added a test that verifies the re-exported `suppressTracing` is referentially identical to `originalSuppressTracing` from `@opentelemetry/core`.