### PR TITLE
fix(playground): prevent OTel context leak causing duplicate trace_id in dataset runs

### DIFF
--- a/packages/phoenix-evals/pyproject.toml
+++ b/packages/phoenix-evals/pyproject.toml
@@ -51,7 +51,7 @@ test = [
   "boto3",
   "litellm>=1.28.9",
   "openai>=1.0.0",
-  "mistralai>=1.0.0",
+  "mistralai>=1.0.0,<2",
   "vertexai",
   "respx",
   "nest_asyncio",

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -365,7 +365,7 @@ class LLMEvaluator(BaseEvaluator):
                     messages=messages,
                     tools=denormalized_tools,
                     tracer=tracer_,
-                    **invocation_parameters,
+                    invocation_parameters=invocation_parameters,
                 ):
                     if isinstance(chunk, ToolCallChunk):
                         if chunk.id not in tool_call_by_id:

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -12,6 +12,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from functools import wraps
 from itertools import chain
 from secrets import token_hex
+from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -50,6 +51,7 @@ from openinference.semconv.trace import (
     ToolAttributes,
     ToolCallAttributes,
 )
+from opentelemetry.context import Context as OtelContext
 from opentelemetry.semconv.attributes.url_attributes import URL_FULL, URL_PATH
 from opentelemetry.trace import NoOpTracer, Status, StatusCode, Tracer
 from opentelemetry.trace import Span as OTelSpan
@@ -391,10 +393,12 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
 
     async def chat_completion_create(
         self,
+        *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         tracer: Tracer | None = None,
-        **invocation_parameters: Any,
+        otel_context: OtelContext | None = None,
     ) -> AsyncIterator[ChatCompletionChunk]:
         tracer_ = tracer or NoOpTracer()
         attributes = dict(
@@ -423,8 +427,11 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
         # Use start_span (not start_as_current_span) and span.end() in finally so we never
         # attach contextvars in the generator. Avoids "Failed to detach context" /
         # "Token was created in a different Context" when the generator is closed in another task.
+        # otel_context can be passed as OtelContext() by callers that want to prevent the
+        # ambient OTel context from leaking its trace_id into the playground span.
         span = tracer_.start_span(
             "ChatCompletion",
+            context=otel_context,
             attributes=attributes,
             set_status_on_exception=False,  # we set status manually
         )
@@ -433,7 +440,10 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
         auto_accumulating = self.response_attributes_are_auto_accumulating
         try:
             async for chunk in self._chat_completion_create(
-                messages=messages, tools=tools, span=span, **invocation_parameters
+                messages=messages,
+                tools=tools,
+                invocation_parameters=invocation_parameters,
+                span=span,
             ):
                 if isinstance(chunk, TextChunk):
                     if not auto_accumulating:
@@ -462,8 +472,8 @@ class PlaygroundStreamingClient(ABC, Generic[ClientT]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]: ...
 
     @classmethod
@@ -594,8 +604,8 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         from openai import omit
         from openai.types import chat
@@ -724,8 +734,8 @@ class OpenAIBaseStreamingClient(PlaygroundStreamingClient["AsyncOpenAI"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         """
         OpenAI Responses API (responses.create) streaming. Yields TextChunk and
@@ -1275,8 +1285,8 @@ class BedrockStreamingClient(PlaygroundStreamingClient["BedrockRuntimeClient"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         async for chunk in self._handle_converse_api(
             messages=messages,
@@ -1291,8 +1301,8 @@ class BedrockStreamingClient(PlaygroundStreamingClient["BedrockRuntimeClient"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any],
         span: OTelSpan,
-        invocation_parameters: dict[str, Any],
     ) -> AsyncIterator[ChatCompletionChunk]:
         """
         Handle the converse API.
@@ -1646,14 +1656,14 @@ class OpenAIResponsesAPIStreamingClient(
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         async for chunk in self._responses_create(
             messages=messages,
             tools=tools,
+            invocation_parameters=invocation_parameters,
             span=span,
-            **invocation_parameters,
         ):
             yield chunk
 
@@ -1759,14 +1769,14 @@ class AzureOpenAIResponsesAPIStreamingClient(
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         async for chunk in self._responses_create(
             messages=messages,
             tools=tools,
+            invocation_parameters=invocation_parameters,
             span=span,
-            **invocation_parameters,
         ):
             yield chunk
 
@@ -1785,8 +1795,8 @@ class AzureOpenAIReasoningNonStreamingClient(
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         from openai import omit
         from openai.types import chat
@@ -1965,8 +1975,8 @@ class AnthropicStreamingClient(PlaygroundStreamingClient["AsyncAnthropic"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         anthropic_messages, system_prompt = self._build_anthropic_messages(messages)
         anthropic_params = {
@@ -2220,14 +2230,14 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
         *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         span: OTelSpan,
-        **invocation_parameters: Any,
     ) -> AsyncIterator[ChatCompletionChunk]:
         from google.genai import types
 
         contents, system_prompt = self._build_google_messages(messages)
 
-        config_dict = invocation_parameters.copy()
+        config_dict = dict(invocation_parameters)
 
         if system_prompt:
             config_dict["system_instruction"] = system_prompt
@@ -2421,13 +2431,16 @@ class Gemini3GoogleStreamingClient(Gemini25GoogleStreamingClient):
 
     async def chat_completion_create(
         self,
+        *,
         messages: list[PlaygroundMessage],
         tools: list[JSONScalarType],
+        invocation_parameters: Mapping[str, Any] = MappingProxyType({}),
         tracer: Tracer | None = None,
-        **invocation_parameters: Any,
+        otel_context: OtelContext | None = None,
     ) -> AsyncIterator[ChatCompletionChunk]:
         # Extract thinking_level and construct thinking_config
-        thinking_level = invocation_parameters.pop("thinking_level", None)
+        parameters = dict(invocation_parameters)
+        thinking_level = parameters.pop("thinking_level", None)
 
         if thinking_level:
             try:
@@ -2446,13 +2459,17 @@ class Gemini3GoogleStreamingClient(Gemini25GoogleStreamingClient):
             # but will eventually be added in a future version
             # we are purposefully allowing users to select medium knowing
             # it does not work.
-            invocation_parameters["thinking_config"] = {
+            parameters["thinking_config"] = {
                 "include_thoughts": True,
                 "thinking_level": thinking_level.upper(),
             }
 
         async for chunk in super().chat_completion_create(
-            messages, tools, tracer=tracer, **invocation_parameters
+            messages=messages,
+            tools=tools,
+            invocation_parameters=parameters,
+            tracer=tracer,
+            otel_context=otel_context,
         ):
             yield chunk
 

--- a/src/phoenix/server/api/mutations/chat_mutations.py
+++ b/src/phoenix/server/api/mutations/chat_mutations.py
@@ -750,7 +750,7 @@ class ChatCompletionMutationMixin:
                 messages=messages,
                 tools=input.tools or [],
                 tracer=tracer,
-                **invocation_parameters,
+                invocation_parameters=invocation_parameters,
             ):
                 if isinstance(chunk, TextChunk):
                     text_content += chunk.content

--- a/src/phoenix/server/api/subscriptions.py
+++ b/src/phoenix/server/api/subscriptions.py
@@ -17,6 +17,7 @@ from typing import (
 
 import strawberry
 from openinference.semconv.trace import SpanAttributes
+from opentelemetry.context import Context as OtelContext
 from sqlalchemy import and_, insert, select
 from sqlalchemy.orm import load_only
 from strawberry.relay.types import GlobalID
@@ -137,7 +138,7 @@ async def _stream_single_chat_completion(
             messages=messages,
             tools=input.tools or [],
             tracer=tracer,
-            **invocation_parameters,
+            invocation_parameters=invocation_parameters,
         ):
             chunk.repetition_number = repetition_number
             yield chunk
@@ -646,7 +647,15 @@ async def _stream_chat_completion_over_dataset_example(
             messages=messages,
             tools=input.tools or [],
             tracer=tracer,
-            **invocation_parameters,
+            # Pass an empty OTel context so the LLM span starts as a fresh root
+            # span and does not inherit the ambient context from server-side
+            # instrumentation (e.g. Strawberry's OpenTelemetryExtension).
+            # Without this, every dataset-example call within the same
+            # subscription would share the subscription span's trace_id, causing
+            # a duplicate-key violation on uq_traces_trace_id when more than one
+            # example is flushed.
+            otel_context=OtelContext(),
+            invocation_parameters=invocation_parameters,
         ):
             chunk.dataset_example_id = example_id
             chunk.repetition_number = repetition_number

--- a/tests/unit/server/api/helpers/test_playground_clients.py
+++ b/tests/unit/server/api/helpers/test_playground_clients.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -68,7 +69,7 @@ class TestOpenAIBaseStreamingClient:
             )
         ]
 
-        invocation_parameters = {"temperature": 0.1}
+        invocation_parameters: Mapping[str, Any] = {"temperature": 0.1}
 
         with custom_vcr.use_cassette():
             text_chunks = []
@@ -76,7 +77,7 @@ class TestOpenAIBaseStreamingClient:
                 messages=messages,
                 tools=[],
                 tracer=tracer,
-                **invocation_parameters,
+                invocation_parameters=invocation_parameters,
             ):
                 if isinstance(chunk, TextChunk):
                     text_chunks.append(chunk.content)
@@ -194,7 +195,7 @@ class TestOpenAIBaseStreamingClient:
             )
         ]
 
-        invocation_parameters = {"tool_choice": "auto"}
+        invocation_parameters: Mapping[str, Any] = {"tool_choice": "auto"}
 
         with custom_vcr.use_cassette():
             tool_call_chunks = []
@@ -202,7 +203,7 @@ class TestOpenAIBaseStreamingClient:
                 messages=messages,
                 tools=[get_current_weather_tool_schema],
                 tracer=tracer,
-                **invocation_parameters,
+                invocation_parameters=invocation_parameters,
             ):
                 tool_call_chunks.append(chunk)
 
@@ -317,7 +318,7 @@ class TestOpenAIBaseStreamingClient:
             )
         ]
 
-        invocation_parameters = {"temperature": 0.1}
+        invocation_parameters: Mapping[str, Any] = {"temperature": 0.1}
 
         with custom_vcr.use_cassette():
             with pytest.raises(AuthenticationError) as exc_info:
@@ -325,7 +326,7 @@ class TestOpenAIBaseStreamingClient:
                     messages=messages,
                     tools=[],
                     tracer=tracer,
-                    **invocation_parameters,
+                    invocation_parameters=invocation_parameters,
                 ):
                     pass
 

--- a/uv.lock
+++ b/uv.lock
@@ -796,7 +796,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'dev'", specifier = ">=1.28.9" },
     { name = "litellm", marker = "extra == 'test'", specifier = ">=1.28.9" },
     { name = "mistralai", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "mistralai", marker = "extra == 'test'", specifier = ">=1.0.0" },
+    { name = "mistralai", marker = "extra == 'test'", specifier = ">=1.0.0,<2" },
     { name = "nest-asyncio", marker = "extra == 'test'" },
     { name = "openai", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'test'", specifier = ">=1.0.0" },


### PR DESCRIPTION
When PHOENIX_SERVER_INSTRUMENTATION_OTLP_TRACE_COLLECTOR_HTTP_ENDPOINT is set, Strawberry's OpenTelemetryExtension injects a subscription-level span into the ambient OTel context. chat_completion_create called start_span without an explicit context, so every dataset example's LLM call inherited the subscription span's trace_id. The first example to flush succeeded; all subsequent examples failed with a unique constraint violation on uq_traces_trace_id, and their ExperimentRuns were also lost in the rollback.