### PR TITLE
feat(evaluators): add strict mode to evaluator tool definitions

### DIFF
--- a/app/src/components/evaluators/utils.ts
+++ b/app/src/components/evaluators/utils.ts
@@ -65,6 +65,7 @@ const createPromptVersionInput = ({
         function: {
           name: config.name,
           description,
+          strict: true,
           parameters: {
             type: "object",
             properties: {
@@ -82,6 +83,7 @@ const createPromptVersionInput = ({
                   }
                 : {}),
             },
+            additionalProperties: false,
             required: ["label", ...(includeExplanation ? ["explanation"] : [])],
           },
         },

--- a/app/src/schemas/phoenixToolTypeSchemas.ts
+++ b/app/src/schemas/phoenixToolTypeSchemas.ts
@@ -36,6 +36,7 @@ export const CategoricalChoiceToolTypeSchema =
           ])
         ),
         required: z.array(z.string()),
+        additionalProperties: z.boolean().optional(),
       }),
     }),
   });

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -62,16 +62,15 @@ export const openAIToolDefinitionSchema = z.looseObject({
         .string()
         .optional()
         .describe("A description of the function"),
-      parameters: jsonSchemaZodSchema
-        .extend({
-          strict: z
-            .boolean()
-            .optional()
-            .describe(
-              "Whether or not the arguments should exactly match the function definition, only supported for OpenAI models"
-            ),
-        })
-        .describe("The parameters that the function accepts"),
+      strict: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether or not the arguments should exactly match the function definition"
+        ),
+      parameters: jsonSchemaZodSchema.describe(
+        "The parameters that the function accepts"
+      ),
     })
     .describe("The function definition"),
 });
@@ -135,6 +134,7 @@ export type OpenAIResponsesToolDefinition = z.infer<
 export const anthropicToolDefinitionSchema = z.object({
   name: z.string(),
   description: z.string(),
+  strict: z.boolean().optional(),
   input_schema: jsonSchemaZodSchema,
 });
 
@@ -156,6 +156,7 @@ export const awsToolDefinitionSchema = z.object({
   toolSpec: z.object({
     name: z.string(),
     description: z.string().min(1),
+    strict: z.boolean().optional(),
     inputSchema: z.object({
       json: jsonSchemaZodSchema,
     }),
@@ -204,6 +205,7 @@ export const awsToolToOpenAI = awsToolDefinitionSchema.transform(
     function: {
       name: aws.toolSpec.name,
       description: aws.toolSpec.description,
+      ...(aws.toolSpec.strict != null && { strict: aws.toolSpec.strict }),
       parameters: aws.toolSpec.inputSchema.json,
     },
   })
@@ -214,6 +216,7 @@ export const openAIToolToAws = openAIToolDefinitionSchema.transform(
     toolSpec: {
       name: openai.function.name,
       description: openai.function.description ?? openai.function.name,
+      ...(openai.function.strict != null && { strict: openai.function.strict }),
       inputSchema: {
         json: openai.function.parameters,
       },
@@ -230,6 +233,7 @@ export const anthropicToolToOpenAI = anthropicToolDefinitionSchema.transform(
     function: {
       name: anthropic.name,
       description: anthropic.description,
+      ...(anthropic.strict != null && { strict: anthropic.strict }),
       parameters: anthropic.input_schema,
     },
   })
@@ -242,6 +246,7 @@ export const openAIToolToAnthropic = openAIToolDefinitionSchema.transform(
   (openai): AnthropicToolDefinition => ({
     name: openai.function.name,
     description: openai.function.description ?? "",
+    ...(openai.function.strict != null && { strict: openai.function.strict }),
     input_schema: openai.function.parameters,
   })
 );

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -310,6 +310,7 @@ class AnthropicToolDefinition(DBBaseModel):
     name: str
     cache_control: Optional[AnthropicCacheControlParam] = UNDEFINED
     description: str = UNDEFINED
+    strict: Optional[bool] = UNDEFINED
 
 
 class BedrockToolDefinition(DBBaseModel):
@@ -805,12 +806,14 @@ def _prompt_to_openai_tool(
 def _bedrock_to_prompt_tool(
     tool: BedrockToolDefinition,
 ) -> PromptToolFunction:
+    strict = tool.toolSpec.get("strict")
     return PromptToolFunction(
         type="function",
         function=PromptToolFunctionDefinition(
             name=tool.toolSpec["name"],
             description=tool.toolSpec["description"],
             parameters=tool.toolSpec["inputSchema"]["json"],
+            strict=strict if isinstance(strict, bool) else UNDEFINED,
         ),
     )
 
@@ -824,6 +827,7 @@ def _anthropic_to_prompt_tool(
             name=tool.name,
             description=tool.description,
             parameters=tool.input_schema,
+            strict=tool.strict if isinstance(tool.strict, bool) else UNDEFINED,
         ),
     )
 
@@ -836,6 +840,7 @@ def _prompt_to_anthropic_tool(
         input_schema=function.parameters if function.parameters is not UNDEFINED else {},
         name=function.name,
         description=function.description,
+        strict=function.strict if isinstance(function.strict, bool) else UNDEFINED,
     )
 
 
@@ -843,15 +848,16 @@ def _prompt_to_bedrock_tool(
     tool: PromptToolFunction,
 ) -> BedrockToolDefinition:
     function = tool.function
-    return BedrockToolDefinition(
-        toolSpec={
-            "name": function.name,
-            "description": function.description,
-            "inputSchema": {
-                "json": function.parameters,
-            },
-        }
-    )
+    tool_spec: dict[str, Any] = {
+        "name": function.name,
+        "description": function.description,
+        "inputSchema": {
+            "json": function.parameters,
+        },
+    }
+    if isinstance(function.strict, bool):
+        tool_spec["strict"] = function.strict
+    return BedrockToolDefinition(toolSpec=tool_spec)
 
 
 def _gemini_to_prompt_tool(


### PR DESCRIPTION
Sets strict: true and additionalProperties: false on evaluator function tool schemas, and extends CategoricalChoiceToolTypeSchema to accept these fields.