### PR TITLE
revert: "feat(evaluators): add strict mode to evaluator tool definitions"

### DIFF
--- a/app/src/components/evaluators/utils.ts
+++ b/app/src/components/evaluators/utils.ts
@@ -65,7 +65,6 @@ const createPromptVersionInput = ({
         function: {
           name: config.name,
           description,
-          strict: true,
           parameters: {
             type: "object",
             properties: {
@@ -83,7 +82,6 @@ const createPromptVersionInput = ({
                   }
                 : {}),
             },
-            additionalProperties: false,
             required: ["label", ...(includeExplanation ? ["explanation"] : [])],
           },
         },

--- a/app/src/schemas/phoenixToolTypeSchemas.ts
+++ b/app/src/schemas/phoenixToolTypeSchemas.ts
@@ -36,7 +36,6 @@ export const CategoricalChoiceToolTypeSchema =
           ])
         ),
         required: z.array(z.string()),
-        additionalProperties: z.boolean().optional(),
       }),
     }),
   });

--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -62,15 +62,16 @@ export const openAIToolDefinitionSchema = z.looseObject({
         .string()
         .optional()
         .describe("A description of the function"),
-      strict: z
-        .boolean()
-        .optional()
-        .describe(
-          "Whether or not the arguments should exactly match the function definition"
-        ),
-      parameters: jsonSchemaZodSchema.describe(
-        "The parameters that the function accepts"
-      ),
+      parameters: jsonSchemaZodSchema
+        .extend({
+          strict: z
+            .boolean()
+            .optional()
+            .describe(
+              "Whether or not the arguments should exactly match the function definition, only supported for OpenAI models"
+            ),
+        })
+        .describe("The parameters that the function accepts"),
     })
     .describe("The function definition"),
 });
@@ -134,7 +135,6 @@ export type OpenAIResponsesToolDefinition = z.infer<
 export const anthropicToolDefinitionSchema = z.object({
   name: z.string(),
   description: z.string(),
-  strict: z.boolean().optional(),
   input_schema: jsonSchemaZodSchema,
 });
 
@@ -156,7 +156,6 @@ export const awsToolDefinitionSchema = z.object({
   toolSpec: z.object({
     name: z.string(),
     description: z.string().min(1),
-    strict: z.boolean().optional(),
     inputSchema: z.object({
       json: jsonSchemaZodSchema,
     }),
@@ -205,7 +204,6 @@ export const awsToolToOpenAI = awsToolDefinitionSchema.transform(
     function: {
       name: aws.toolSpec.name,
       description: aws.toolSpec.description,
-      ...(aws.toolSpec.strict != null && { strict: aws.toolSpec.strict }),
       parameters: aws.toolSpec.inputSchema.json,
     },
   })
@@ -216,7 +214,6 @@ export const openAIToolToAws = openAIToolDefinitionSchema.transform(
     toolSpec: {
       name: openai.function.name,
       description: openai.function.description ?? openai.function.name,
-      ...(openai.function.strict != null && { strict: openai.function.strict }),
       inputSchema: {
         json: openai.function.parameters,
       },
@@ -233,7 +230,6 @@ export const anthropicToolToOpenAI = anthropicToolDefinitionSchema.transform(
     function: {
       name: anthropic.name,
       description: anthropic.description,
-      ...(anthropic.strict != null && { strict: anthropic.strict }),
       parameters: anthropic.input_schema,
     },
   })
@@ -246,7 +242,6 @@ export const openAIToolToAnthropic = openAIToolDefinitionSchema.transform(
   (openai): AnthropicToolDefinition => ({
     name: openai.function.name,
     description: openai.function.description ?? "",
-    ...(openai.function.strict != null && { strict: openai.function.strict }),
     input_schema: openai.function.parameters,
   })
 );

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -310,7 +310,6 @@ class AnthropicToolDefinition(DBBaseModel):
     name: str
     cache_control: Optional[AnthropicCacheControlParam] = UNDEFINED
     description: str = UNDEFINED
-    strict: Optional[bool] = UNDEFINED
 
 
 class BedrockToolDefinition(DBBaseModel):
@@ -806,14 +805,12 @@ def _prompt_to_openai_tool(
 def _bedrock_to_prompt_tool(
     tool: BedrockToolDefinition,
 ) -> PromptToolFunction:
-    strict = tool.toolSpec.get("strict")
     return PromptToolFunction(
         type="function",
         function=PromptToolFunctionDefinition(
             name=tool.toolSpec["name"],
             description=tool.toolSpec["description"],
             parameters=tool.toolSpec["inputSchema"]["json"],
-            strict=strict if isinstance(strict, bool) else UNDEFINED,
         ),
     )
 
@@ -827,7 +824,6 @@ def _anthropic_to_prompt_tool(
             name=tool.name,
             description=tool.description,
             parameters=tool.input_schema,
-            strict=tool.strict if isinstance(tool.strict, bool) else UNDEFINED,
         ),
     )
 
@@ -840,7 +836,6 @@ def _prompt_to_anthropic_tool(
         input_schema=function.parameters if function.parameters is not UNDEFINED else {},
         name=function.name,
         description=function.description,
-        strict=function.strict if isinstance(function.strict, bool) else UNDEFINED,
     )
 
 
@@ -848,16 +843,15 @@ def _prompt_to_bedrock_tool(
     tool: PromptToolFunction,
 ) -> BedrockToolDefinition:
     function = tool.function
-    tool_spec: dict[str, Any] = {
-        "name": function.name,
-        "description": function.description,
-        "inputSchema": {
-            "json": function.parameters,
-        },
-    }
-    if isinstance(function.strict, bool):
-        tool_spec["strict"] = function.strict
-    return BedrockToolDefinition(toolSpec=tool_spec)
+    return BedrockToolDefinition(
+        toolSpec={
+            "name": function.name,
+            "description": function.description,
+            "inputSchema": {
+                "json": function.parameters,
+            },
+        }
+    )
 
 
 def _gemini_to_prompt_tool(


### PR DESCRIPTION
Reverts Arize-ai/phoenix#12068

> 400 Bad Request. {'message': '{\n "error": {\n "code": 400,\n "message": "Invalid JSON payload received. Unknown name \\"additional_properties\\" at \'tools[0].function_declarations[0].parameters\': Cannot find field.",\n "status": "INVALID_ARGUMENT",\n "details": [\n {\n "@type": "type.googleapis.com/google.rpc.BadRequest",\n "fieldViolations": [\n {\n "field": "tools[0].function_declarations[0].parameters",\n "description": "Invalid JSON payload received. Unknown name \\"additional_properties\\" at \'tools[0].function_declarations[0].parameters\': Cannot find field."\n }\n ]\n }\n ]\n }\n}\n', 'status': 'Bad Request'}