### PR TITLE
fix: make tool description optional for Anthropic and AWS Bedrock providers

### DIFF
--- a/app/src/schemas/toolSchemas.ts
+++ b/app/src/schemas/toolSchemas.ts
@@ -134,7 +134,7 @@ export type OpenAIResponsesToolDefinition = z.infer<
  */
 export const anthropicToolDefinitionSchema = z.object({
   name: z.string(),
-  description: z.string(),
+  description: z.string().optional(),
   input_schema: jsonSchemaZodSchema,
 });
 
@@ -155,7 +155,7 @@ export const anthropicToolDefinitionJSONSchema = z.toJSONSchema(
 export const awsToolDefinitionSchema = z.object({
   toolSpec: z.object({
     name: z.string(),
-    description: z.string().min(1),
+    description: z.string().min(1).optional(),
     inputSchema: z.object({
       json: jsonSchemaZodSchema,
     }),
@@ -203,7 +203,9 @@ export const awsToolToOpenAI = awsToolDefinitionSchema.transform(
     type: "function",
     function: {
       name: aws.toolSpec.name,
-      description: aws.toolSpec.description,
+      ...(aws.toolSpec.description != null && {
+        description: aws.toolSpec.description,
+      }),
       parameters: aws.toolSpec.inputSchema.json,
     },
   })
@@ -213,7 +215,9 @@ export const openAIToolToAws = openAIToolDefinitionSchema.transform(
   (openai): AwsToolDefinition => ({
     toolSpec: {
       name: openai.function.name,
-      description: openai.function.description ?? openai.function.name,
+      ...(openai.function.description != null && {
+        description: openai.function.description,
+      }),
       inputSchema: {
         json: openai.function.parameters,
       },
@@ -229,7 +233,9 @@ export const anthropicToolToOpenAI = anthropicToolDefinitionSchema.transform(
     type: "function",
     function: {
       name: anthropic.name,
-      description: anthropic.description,
+      ...(anthropic.description != null && {
+        description: anthropic.description,
+      }),
       parameters: anthropic.input_schema,
     },
   })
@@ -241,7 +247,9 @@ export const anthropicToolToOpenAI = anthropicToolDefinitionSchema.transform(
 export const openAIToolToAnthropic = openAIToolDefinitionSchema.transform(
   (openai): AnthropicToolDefinition => ({
     name: openai.function.name,
-    description: openai.function.description ?? "",
+    ...(openai.function.description != null && {
+      description: openai.function.description,
+    }),
     input_schema: openai.function.parameters,
   })
 );

--- a/src/phoenix/server/api/helpers/prompts/models.py
+++ b/src/phoenix/server/api/helpers/prompts/models.py
@@ -805,11 +805,12 @@ def _prompt_to_openai_tool(
 def _bedrock_to_prompt_tool(
     tool: BedrockToolDefinition,
 ) -> PromptToolFunction:
+    description = tool.toolSpec.get("description")
     return PromptToolFunction(
         type="function",
         function=PromptToolFunctionDefinition(
             name=tool.toolSpec["name"],
-            description=tool.toolSpec["description"],
+            description=description if isinstance(description, str) else UNDEFINED,
             parameters=tool.toolSpec["inputSchema"]["json"],
         ),
     )
@@ -843,15 +844,15 @@ def _prompt_to_bedrock_tool(
     tool: PromptToolFunction,
 ) -> BedrockToolDefinition:
     function = tool.function
-    return BedrockToolDefinition(
-        toolSpec={
-            "name": function.name,
-            "description": function.description,
-            "inputSchema": {
-                "json": function.parameters,
-            },
-        }
-    )
+    tool_spec: dict[str, Any] = {
+        "name": function.name,
+        "inputSchema": {
+            "json": function.parameters,
+        },
+    }
+    if isinstance(function.description, str):
+        tool_spec["description"] = function.description
+    return BedrockToolDefinition(toolSpec=tool_spec)
 
 
 def _gemini_to_prompt_tool(


### PR DESCRIPTION
description is optional per both the Anthropic and Bedrock Converse APIs. AWS ToolSpecification docs specify Required: No with min length 1 if present.

- anthropicToolDefinitionSchema: description z.string() -> z.string().optional()
- awsToolDefinitionSchema: description z.string().min(1) -> z.string().min(1).optional()
- All conversion transforms (anthropicToolToOpenAI, openAIToolToAnthropic, awsToolToOpenAI, openAIToolToAws): omit description key when absent instead of falling back to empty string or function name
- _bedrock_to_prompt_tool: use .get() to avoid KeyError when description absent
- _prompt_to_bedrock_tool: only write description to toolSpec when it is a str