### PR TITLE
feat: Add opt-in pre-upgrade migration Job to Helm chart

### DIFF
--- a/docs/phoenix/self-hosting/upgrade/migrations.mdx
+++ b/docs/phoenix/self-hosting/upgrade/migrations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migrations"
-description: Migrations are run at boot
+description: How Phoenix manages database migrations and how to run them safely in production
 ---
 
 New major versions of Phoenix may contain database migrations that run automatically upon the start of the application. This process is intended to be seamless and should not require manual intervention except in exceptional circumstances.
@@ -22,4 +22,59 @@ In the case that you may need to manually apply migration, debug builds are prov
 
 </Warning>
 
+## Kubernetes Rolling Upgrades
+
+On large PostgreSQL databases, migrations can take long enough during a rolling upgrade that Kubernetes liveness probes time out and kill the new pod before it finishes — causing a `CrashLoopBackoff` loop. The recommended solution is to run migrations in an **initContainer** before the main Phoenix container starts.
+
+An initContainer runs to completion before Kubernetes starts the main container or begins evaluating its liveness probe. If the initContainer fails, Kubernetes retries it automatically. The server pod does not start until migrations have succeeded.
+
+Add the following `initContainers` entry to your Phoenix pod spec:
+
+```yaml
+initContainers:
+  - name: run-migrations
+    image: arizephoenix/phoenix:latest  # match your Phoenix version
+    command: ["phoenix", "db", "migrate"]
+    env:
+      - name: PHOENIX_SQL_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: phoenix-db-secret
+            key: url
+containers:
+  - name: phoenix
+    image: arizephoenix/phoenix:latest
+    command: ["phoenix", "serve"]
+    env:
+      - name: PHOENIX_SQL_DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: phoenix-db-secret
+            key: url
+```
+
+When the server starts and the database is already at the latest version, Phoenix's built-in migration check is a no-op — it detects that no migrations are pending and proceeds immediately.
+
+<Info>
+**Concurrent migrations during rolling upgrades**: In a multi-replica deployment, multiple pods may run the initContainer at the same time. Phoenix's migrations are designed to be safe under concurrent execution — if two pods race, one will fail with a transient error, retry, find the database already at head, and exit cleanly. No data is at risk, but you may see one extra pod restart in your logs. If you prefer a clean, restart-free rollout, there are a few options:
+
+- **Roll one pod at a time** (simplest): set `maxSurge: 0, maxUnavailable: 1` on the Deployment. Kubernetes will tear down one old pod before starting its replacement, so only one initContainer ever runs at a time. There will be a brief reduction in capacity during the rollout.
+- **Run migrations before the rollout**: run `phoenix db migrate` manually (or in CI) before triggering the Deployment update. By the time pods start rolling, the database is already at head and the initContainer is a no-op.
+- **Use a pre-upgrade Job**: run migrations as a Kubernetes `Job` via a Helm `pre-upgrade` hook. The Job completes before the rollout begins, and no initContainer is needed.
+</Info>
+
+## Zero-Downtime Index Migrations on PostgreSQL
+
+Some migrations create new indexes on large tables. By default, PostgreSQL's `CREATE INDEX` acquires a `SHARE` lock that **blocks writes** for the duration of the index build. During a rolling upgrade, this means the old Phoenix instance will be unable to ingest traces while the new instance is building the index.
+
+Set `PHOENIX_MIGRATE_INDEX_CONCURRENTLY=true` to use `CREATE INDEX CONCURRENTLY` instead. This builds the index without holding a write lock, so the old instance continues ingesting traces uninterrupted. Add the env var to the initContainer from the previous section:
+
+```yaml
+      - name: PHOENIX_MIGRATE_INDEX_CONCURRENTLY
+        value: "true"
+```
+
+<Warning>
+`CONCURRENTLY` does not make migrations faster — it is roughly 2–3x slower than the default, and the initContainer (and therefore the new pod) still waits for the index build to complete before starting the server. For very large tables, consider pre-creating indexes manually before upgrading. See [MIGRATION.md](https://github.com/Arize-ai/phoenix/blob/main/MIGRATION.md) for version-specific guidance. This setting is ignored for SQLite.
+</Warning>
 

--- a/helm/templates/phoenix/migration-job.yaml
+++ b/helm/templates/phoenix/migration-job.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "phoenix.fullname" . }}-migrate
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "phoenix.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ include "phoenix.fullname" . }}-migrate
+    spec:
+      restartPolicy: OnFailure
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "phoenix.fullname" .) }}
+      {{- end }}
+      {{- if .Values.securityContext.pod.enabled }}
+      securityContext: {{- omit .Values.securityContext.pod "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ .Values.image.registry }}/{{ .Values.image.repository | default "arizephoenix/phoenix" }}:{{ .Values.image.tag | default "latest" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          command: ["phoenix", "db", "migrate"]
+          {{- if .Values.securityContext.container.enabled }}
+          securityContext: {{- omit .Values.securityContext.container "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.migrations.resources }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "phoenix.fullname" . }}-configmap
+          {{- if or .Values.auth.secret .Values.migrations.migrateIndexConcurrently (and .Values.additionalEnv (gt (len .Values.additionalEnv) 0)) }}
+          env:
+          {{- if .Values.auth.secret }}
+          {{- range $authSecrets := .Values.auth.secret }}
+            - name: {{ $authSecrets.key }}
+              valueFrom:
+              {{- if $authSecrets.valueFrom }}
+                {{- $authSecrets.valueFrom | toYaml | nindent 16 }}
+              {{- else }}
+                secretKeyRef:
+                  name: {{ $.Values.auth.name }}
+                  key: {{ $authSecrets.key }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.migrations.migrateIndexConcurrently }}
+            - name: PHOENIX_MIGRATE_INDEX_CONCURRENTLY
+              value: "true"
+          {{- end }}
+          {{- if and .Values.additionalEnv (gt (len .Values.additionalEnv) 0) }}
+          {{- .Values.additionalEnv | toYaml | nindent 12 }}
+          {{- end }}
+          {{- end }}
+      {{- if .Values.serviceAccount.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.serviceAccount.imagePullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,30 @@ deployment:
   nodeSelector: {}
   affinity: {}
 
+# Migration Job configuration
+migrations:
+  # -- Run database migrations as a Helm hook Job before the Deployment rollout.
+  # When enabled, a Kubernetes Job runs `phoenix db migrate` as a pre-upgrade and
+  # post-install hook, guaranteeing the database schema is up to date before any
+  # server pod starts. Recommended for multi-replica deployments with large PostgreSQL
+  # databases where migrations can take long enough to trigger liveness probe failures.
+  enabled: false
+
+  # -- Use CREATE INDEX CONCURRENTLY for index-creation migrations on PostgreSQL.
+  # Avoids acquiring a write lock on the table during the index build, so an existing
+  # Phoenix instance can continue ingesting traces while the migration runs.
+  # Note: CONCURRENTLY is roughly 2-3x slower than the default. Ignored for SQLite.
+  migrateIndexConcurrently: false
+
+  # -- Resource requests and limits for the migration Job container.
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+
 # -- Additional environment variables to add to the deployments pod spec
 # For supported environment variables see https://arize.com/docs/phoenix/self-hosting/configuration#environment-variables
 # Should only be used for capabilities not exposed via the helm chart directly

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -155,6 +155,35 @@ def _resolve_grpc_port(args: Namespace) -> int:
     return args.grpc_port if args.grpc_port is not None else get_env_grpc_port()
 
 
+def _run_db_migrate(db_connection_str: str) -> None:
+    """Run database migrations as a standalone operation, then exit.
+
+    Always runs migrations regardless of PHOENIX_DISABLE_MIGRATIONS, and always
+    logs migration output so progress is visible (e.g. in a K8s initContainer).
+    Exits with code 0 on success and 1 on failure.
+    """
+    from phoenix.db.engines import create_engine as create_db_engine
+    from phoenix.exceptions import PhoenixMigrationError
+
+    Settings.disable_migrations = False
+    Settings.log_migrations = True
+
+    try:
+        engine = create_db_engine(
+            connection_str=db_connection_str,
+            migrate=True,
+            log_to_stdout=False,
+        )
+        engine.dispose()
+        sys.exit(0)
+    except PhoenixMigrationError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Migration error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def main() -> None:
     initialize_settings()
     setup_logging()
@@ -237,10 +266,23 @@ def main() -> None:
     )
     trace_fixture_parser.add_argument("--simulate-streaming", action="store_true")
 
+    db_parser = subparsers.add_parser("db", help=SUPPRESS)
+    db_subparsers = db_parser.add_subparsers(dest="db_command", required=True, help=SUPPRESS)
+    db_subparsers.add_parser(
+        "migrate",
+        help="Run database migrations and exit. Suitable for use as a Kubernetes initContainer.",
+    )
+
     args = parser.parse_args()
     db_connection_str = (
         args.database_url if args.database_url else get_env_database_connection_str()
     )
+
+    if args.command == "db":
+        if args.db_command == "migrate":
+            _run_db_migrate(db_connection_str)
+        return  # unreachable; subcommand handlers exit
+
     force_fixture_ingestion = False
     scaffold_datasets = False
     tracing_fixture_names = set()

--- a/src/phoenix/server/main.py
+++ b/src/phoenix/server/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import codecs
 import os
@@ -174,7 +175,7 @@ def _run_db_migrate(db_connection_str: str) -> None:
             migrate=True,
             log_to_stdout=False,
         )
-        engine.dispose()
+        asyncio.run(engine.dispose())
         sys.exit(0)
     except PhoenixMigrationError as e:
         print(str(e), file=sys.stderr)

--- a/tests/integration/server/test_launch_app.py
+++ b/tests/integration/server/test_launch_app.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+import sys
 from datetime import datetime, timezone
 from itertools import chain
 from secrets import token_hex
@@ -66,6 +69,61 @@ def _no_auth_app(
 ) -> Iterator[_AppInfo]:
     with _server(_AppInfo(_env)) as app:
         yield app
+
+
+class TestDbMigrate:
+    def test_db_migrate(self, _env_sql_database: dict[str, str]) -> None:
+        from pathlib import Path
+
+        import sqlalchemy
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        import phoenix.db as _phoenix_db
+
+        raw_url = _env_sql_database["PHOENIX_SQL_DATABASE_URL"]
+        schema = _env_sql_database.get("PHOENIX_SQL_DATABASE_SCHEMA") or None
+        url = sqlalchemy.make_url(raw_url)
+        if url.get_backend_name() == "postgresql":
+            url = url.set(drivername="postgresql+psycopg")
+
+        engine = sqlalchemy.create_engine(url)
+        try:
+            # Verify the database is fresh: alembic_version must not exist yet.
+            inspector = sqlalchemy.inspect(engine)
+            assert "alembic_version" not in inspector.get_table_names(schema=schema), (
+                "alembic_version already exists before migration ran"
+            )
+        finally:
+            engine.dispose()
+
+        command = [sys.executable, "-m", "phoenix.server.main", "db", "migrate"]
+        env = (
+            {**os.environ, **_env_sql_database}
+            if sys.platform == "win32"
+            else dict(_env_sql_database)
+        )
+        result = subprocess.run(command, env=env, capture_output=True, text=True)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        # Confirm alembic_version now matches the current head revision.
+        engine = sqlalchemy.create_engine(url)
+        try:
+            with engine.connect() as conn:
+                if schema:
+                    conn.execute(sqlalchemy.text(f'SET search_path TO "{schema}"'))
+                actual = conn.execute(
+                    sqlalchemy.text("SELECT version_num FROM alembic_version")
+                ).scalar()
+        finally:
+            engine.dispose()
+
+        scripts_dir = str(Path(_phoenix_db.__file__).parent / "migrations")
+        cfg = Config()
+        cfg.set_main_option("script_location", scripts_dir)
+        expected = ScriptDirectory.from_config(cfg).get_current_head()
+
+        assert actual == expected, f"DB is at {actual!r}, expected head {expected!r}"
 
 
 class TestLaunchApp:


### PR DESCRIPTION
Adds a helm.sh/hook: pre-upgrade,post-install Job that runs `phoenix db migrate` before the Deployment rollout, eliminating concurrent migration races in multi-replica deployments. Controlled via migrations.enabled in values.yaml.