### PR TITLE
fix: restore height: 100% on DialogContent to re-enable scrolling

### DIFF
--- a/app/src/components/core/dialog/Dialog.tsx
+++ b/app/src/components/core/dialog/Dialog.tsx
@@ -47,6 +47,7 @@ const dialogContentCSS = css`
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
+  height: 100%;
 `;
 
 export const DialogContent = ({ children, ...props }: DialogContentProps) => {


### PR DESCRIPTION
DialogContent was changed in #11960 from a Flex with height="100%" to a
div with flex: 1 1 auto. Since react-aria-Dialog renders as a <section>
with no flex display, flex: 1 1 auto has no effect and DialogContent grows to its full content height. This breaks every scroll container inside the dialog (e.g. the span details info panel) because they never see a constrained height and scrollHeight always equals clientHeight.

Restoring height: 100% re-establishes the height constraint and makes
overflow-y: auto containers inside the dialog scrollable again.