### PR TITLE
fix: command syntax for adding phoenix MCP

### DIFF
--- a/docs/phoenix/integrations/phoenix-mcp-server.mdx
+++ b/docs/phoenix/integrations/phoenix-mcp-server.mdx
@@ -181,7 +181,7 @@ The Phoenix MCP Server (`@arizeai/phoenix-mcp`) connects AI assistants directly 
   <Tab title="Connect via Claude Code CLI">
 
     ```bash
-    claude mcp add phoenix npx -y @arizeai/phoenix-mcp@latest \
+    claude mcp add phoenix -- npx -y @arizeai/phoenix-mcp@latest \
     --baseUrl https://my-phoenix.com \
     --apiKey your-api-key
     ```


### PR DESCRIPTION
Before I see `error: unknown option '--baseUrl'` when using zsh because `claude mcp add` interprets `--baseUrl` as its own option rather than passing it through to the `npx` command.