### PR TITLE
feat(cli): implement semantic exit codes

### DIFF
--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -24,7 +24,14 @@ export function main() {
 
   program
     .name("px")
-    .description("Phoenix CLI - AI observability from the command line")
+    .description(
+      "Phoenix CLI - AI observability from the command line\n\n" +
+        "Exit codes:\n" +
+        "  0  Success\n" +
+        "  1  General failure (configuration error, API error, unexpected condition)\n" +
+        "  2  Cancelled (user declined a confirmation prompt)\n" +
+        "  4  Authentication required or insufficient permissions (HTTP 401/403)"
+    )
     .version("0.0.4");
 
   // Register commands

--- a/js/packages/phoenix-cli/src/client.ts
+++ b/js/packages/phoenix-cli/src/client.ts
@@ -1,6 +1,7 @@
 import { createClient, type PhoenixClient } from "@arizeai/phoenix-client";
 
 import type { PhoenixConfig } from "./config";
+import { AuthRequiredError, throwIfAuthError } from "./errors";
 
 export interface CreatePhoenixClientOptions {
   /**
@@ -83,6 +84,7 @@ export async function resolveProjectId({
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(
         `Failed to resolve project "${projectIdentifier}": ${response.error}`
       );
@@ -90,6 +92,9 @@ export async function resolveProjectId({
 
     return response.data.data.id;
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      throw error;
+    }
     throw new Error(
       `Failed to resolve project "${projectIdentifier}": ${error instanceof Error ? error.message : String(error)}`
     );
@@ -143,6 +148,7 @@ export async function resolveDatasetId({
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(
         `Failed to resolve dataset "${datasetIdentifier}": ${response.error}`
       );
@@ -155,6 +161,9 @@ export async function resolveDatasetId({
 
     return datasets[0].id;
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      throw error;
+    }
     throw new Error(
       `Failed to resolve dataset "${datasetIdentifier}": ${error instanceof Error ? error.message : String(error)}`
     );

--- a/js/packages/phoenix-cli/src/commands/api.ts
+++ b/js/packages/phoenix-cli/src/commands/api.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 
 /**
@@ -28,7 +30,7 @@ async function apiGraphqlHandler(
         message:
           "Error: Only queries are permitted. Mutations and subscriptions are not allowed.",
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // 2. Resolve config (endpoint only — no project required)
@@ -44,7 +46,7 @@ async function apiGraphqlHandler(
           ],
         }),
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // 3. Build URL and auth headers
@@ -65,10 +67,16 @@ async function apiGraphqlHandler(
     });
 
     if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        writeError({
+          message: `Authentication required (HTTP ${response.status}). Configure PHOENIX_API_KEY or use --api-key.`,
+        });
+        process.exit(EXIT_CODES.AUTH_REQUIRED);
+      }
       writeError({
         message: `Error: HTTP ${response.status} ${response.statusText} from ${graphqlUrl}`,
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // 5. Parse and output response
@@ -86,13 +94,17 @@ async function apiGraphqlHandler(
     writeOutput({ message: JSON.stringify(json, null, 2) });
 
     if (json.errors && json.errors.length > 0 && json.data == null) {
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/auth.ts
+++ b/js/packages/phoenix-cli/src/commands/auth.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 
 import { resolveConfig } from "../config";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 
 interface AuthStatusOptions {
@@ -36,7 +37,7 @@ async function authStatusHandler(options: AuthStatusOptions): Promise<void> {
     writeError({
       message: "Configuration Error:\n  - Phoenix endpoint not configured",
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 
   const lines: string[] = [];

--- a/js/packages/phoenix-cli/src/commands/dataset.ts
+++ b/js/packages/phoenix-cli/src/commands/dataset.ts
@@ -4,6 +4,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient, resolveDatasetId } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import {
   type DatasetExamplesData,
@@ -45,6 +47,7 @@ async function fetchDatasetExamples(
   });
 
   if (response.error || !response.data) {
+    throwIfAuthError(response.response);
     throw new Error(`Failed to fetch dataset examples: ${response.error}`);
   }
 
@@ -103,7 +106,7 @@ async function datasetHandler(
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -167,10 +170,14 @@ async function datasetHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching dataset: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/datasets.ts
+++ b/js/packages/phoenix-cli/src/commands/datasets.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { formatDatasetsOutput, type OutputFormat } from "./formatDatasets";
 
@@ -38,6 +40,7 @@ async function fetchDatasets(
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch datasets: ${response.error}`);
     }
 
@@ -72,7 +75,7 @@ async function datasetsHandler(options: DatasetsOptions): Promise<void> {
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -100,10 +103,14 @@ async function datasetsHandler(options: DatasetsOptions): Promise<void> {
     });
     writeOutput({ message: output });
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching datasets: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/experiment.ts
+++ b/js/packages/phoenix-cli/src/commands/experiment.ts
@@ -4,6 +4,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import {
   formatExperimentJsonOutput,
@@ -35,6 +37,7 @@ async function downloadExperimentJson(
   });
 
   if (response.error || response.data === undefined) {
+    throwIfAuthError(response.response);
     throw new Error(`Failed to download experiment: ${response.error}`);
   }
 
@@ -67,7 +70,7 @@ async function experimentHandler(
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -113,10 +116,14 @@ async function experimentHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching experiment: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/experiments.ts
+++ b/js/packages/phoenix-cli/src/commands/experiments.ts
@@ -5,6 +5,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient, resolveDatasetId } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import {
   formatExperimentsOutput,
@@ -48,6 +50,7 @@ async function fetchExperiments(
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch experiments: ${response.error}`);
     }
 
@@ -80,6 +83,7 @@ async function downloadExperimentJson(
   });
 
   if (response.error || response.data === undefined) {
+    throwIfAuthError(response.response);
     throw new Error(`Failed to download experiment: ${response.error}`);
   }
 
@@ -157,7 +161,7 @@ async function experimentsHandler(
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Validate that we have dataset
@@ -166,7 +170,7 @@ async function experimentsHandler(
         message:
           "Dataset not specified. Use --dataset <name-or-id> to specify a dataset.",
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -237,10 +241,14 @@ async function experimentsHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching experiments: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/projects.ts
+++ b/js/packages/phoenix-cli/src/commands/projects.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput } from "../io";
 import { formatProjectsOutput, type OutputFormat } from "./formatProjects";
 
@@ -38,6 +40,7 @@ async function fetchProjects(
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch projects: ${response.error}`);
     }
 
@@ -68,7 +71,7 @@ async function projectsHandler(options: ProjectsOptions): Promise<void> {
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -90,10 +93,14 @@ async function projectsHandler(options: ProjectsOptions): Promise<void> {
     });
     writeOutput({ message: output });
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching projects: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/prompt.ts
+++ b/js/packages/phoenix-cli/src/commands/prompt.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { formatPromptOutput, type OutputFormat } from "./formatPrompt";
 
@@ -35,6 +37,7 @@ async function fetchPromptVersion(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(
         `Failed to fetch prompt version: ${response.error || "Unknown error"}`
       );
@@ -55,6 +58,7 @@ async function fetchPromptVersion(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(
         `Failed to fetch prompt with tag "${options.tag}": ${response.error || "Unknown error"}`
       );
@@ -71,6 +75,7 @@ async function fetchPromptVersion(
   });
 
   if (response.error || !response.data) {
+    throwIfAuthError(response.response);
     throw new Error(
       `Failed to fetch prompt "${promptIdentifier}": ${response.error || "Unknown error"}`
     );
@@ -101,7 +106,7 @@ async function promptHandler(
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -130,10 +135,14 @@ async function promptHandler(
     });
     writeOutput({ message: output });
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching prompt: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/prompts.ts
+++ b/js/packages/phoenix-cli/src/commands/prompts.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { formatPromptsOutput, type OutputFormat } from "./formatPrompts";
 
@@ -38,6 +40,7 @@ async function fetchPrompts(
     });
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch prompts: ${response.error}`);
     }
 
@@ -72,7 +75,7 @@ async function promptsHandler(options: PromptsOptions): Promise<void> {
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -100,10 +103,14 @@ async function promptsHandler(options: PromptsOptions): Promise<void> {
     });
     writeOutput({ message: output });
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching prompts: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/session.ts
+++ b/js/packages/phoenix-cli/src/commands/session.ts
@@ -4,6 +4,8 @@ import { Command } from "commander";
 
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { formatSessionOutput, type OutputFormat } from "./formatSessions";
 
@@ -36,6 +38,7 @@ async function fetchSession(
   });
 
   if (response.error || !response.data) {
+    throwIfAuthError(response.response);
     throw new Error(`Failed to fetch session: ${response.error}`);
   }
 
@@ -71,6 +74,7 @@ async function fetchSessionAnnotations(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch session annotations: ${response.error}`);
     }
 
@@ -108,7 +112,7 @@ async function sessionHandler(
         "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
       ];
       writeError({ message: getConfigErrorMessage({ errors }) });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -175,10 +179,14 @@ async function sessionHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching session: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/sessions.ts
+++ b/js/packages/phoenix-cli/src/commands/sessions.ts
@@ -7,6 +7,8 @@ import {
   resolveConfig,
   validateConfig,
 } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { formatSessionsOutput, type OutputFormat } from "./formatSessions";
 
@@ -52,6 +54,7 @@ async function fetchSessions(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch sessions: ${response.error}`);
     }
 
@@ -86,7 +89,7 @@ async function sessionsHandler(options: SessionsOptions): Promise<void> {
       writeError({
         message: getConfigErrorMessage({ errors: validation.errors }),
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -96,7 +99,7 @@ async function sessionsHandler(options: SessionsOptions): Promise<void> {
     const projectIdentifier = config.project;
     if (!projectIdentifier) {
       writeError({ message: "Project not configured" });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     writeProgress({
@@ -142,10 +145,14 @@ async function sessionsHandler(options: SessionsOptions): Promise<void> {
     });
     writeOutput({ message: output });
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching sessions: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/spanAnnotations.ts
+++ b/js/packages/phoenix-cli/src/commands/spanAnnotations.ts
@@ -1,5 +1,7 @@
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
 
+import { throwIfAuthError } from "../errors";
+
 export type SpanAnnotation = componentsV1["schemas"]["SpanAnnotation"];
 
 const DEFAULT_PAGE_LIMIT = 1000;
@@ -62,6 +64,7 @@ async function fetchSpanAnnotationsForChunk({
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(
         `Failed to fetch span annotations: ${String(response.error)}`
       );

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -8,6 +8,8 @@ import {
   resolveConfig,
   validateConfig,
 } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { buildTrace } from "../trace";
 import { formatTraceOutput, type OutputFormat } from "./formatTraces";
@@ -55,6 +57,7 @@ async function fetchTraceSpans(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch spans: ${response.error}`);
     }
 
@@ -105,7 +108,7 @@ async function traceHandler(
       writeError({
         message: getConfigErrorMessage({ errors: validation.errors }),
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -115,7 +118,7 @@ async function traceHandler(
     const projectIdentifier = config.project;
     if (!projectIdentifier) {
       writeError({ message: "Project not configured" });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     writeProgress({
@@ -138,7 +141,7 @@ async function traceHandler(
 
     if (spans.length === 0) {
       writeError({ message: `Trace not found: ${traceId}` });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     writeProgress({
@@ -203,10 +206,14 @@ async function traceHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching trace: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/commands/traces.ts
+++ b/js/packages/phoenix-cli/src/commands/traces.ts
@@ -9,6 +9,8 @@ import {
   resolveConfig,
   validateConfig,
 } from "../config";
+import { AuthRequiredError, throwIfAuthError } from "../errors";
+import { EXIT_CODES } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { buildTrace, groupSpansByTrace, type Trace } from "../trace";
 import { formatTracesOutput, type OutputFormat } from "./formatTraces";
@@ -66,6 +68,7 @@ async function fetchSpans(
     );
 
     if (response.error || !response.data) {
+      throwIfAuthError(response.response);
       throw new Error(`Failed to fetch spans: ${response.error}`);
     }
 
@@ -217,7 +220,7 @@ async function tracesHandler(
       writeError({
         message: getConfigErrorMessage({ errors: validation.errors }),
       });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     // Create client
@@ -227,7 +230,7 @@ async function tracesHandler(
     const projectIdentifier = config.project;
     if (!projectIdentifier) {
       writeError({ message: "Project not configured" });
-      process.exit(1);
+      process.exit(EXIT_CODES.FAILURE);
     }
 
     writeProgress({
@@ -336,10 +339,14 @@ async function tracesHandler(
       writeOutput({ message: output });
     }
   } catch (error) {
+    if (error instanceof AuthRequiredError) {
+      writeError({ message: error.message });
+      process.exit(EXIT_CODES.AUTH_REQUIRED);
+    }
     writeError({
       message: `Error fetching traces: ${error instanceof Error ? error.message : String(error)}`,
     });
-    process.exit(1);
+    process.exit(EXIT_CODES.FAILURE);
   }
 }
 

--- a/js/packages/phoenix-cli/src/errors.ts
+++ b/js/packages/phoenix-cli/src/errors.ts
@@ -1,0 +1,36 @@
+/**
+ * Thrown when the server returns HTTP 401 or 403.
+ * Commands should catch this and exit with EXIT_CODES.AUTH_REQUIRED (4).
+ */
+export class AuthRequiredError extends Error {
+  constructor(message?: string) {
+    super(
+      message ??
+        "Authentication required or insufficient permissions. Set PHOENIX_API_KEY or use --api-key."
+    );
+    this.name = "AuthRequiredError";
+  }
+}
+
+/**
+ * Thrown when the user cancels an interactive prompt.
+ * Commands should catch this and exit with EXIT_CODES.CANCELLED (2).
+ */
+export class UserCancelledError extends Error {
+  constructor(message?: string) {
+    super(message ?? "Operation cancelled by user.");
+    this.name = "UserCancelledError";
+  }
+}
+
+/**
+ * Check an HTTP Response for 401/403 and throw AuthRequiredError if found.
+ * Call this before throwing a generic error so callers can distinguish auth failures.
+ */
+export function throwIfAuthError(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new AuthRequiredError(
+      `Authentication required (HTTP ${response.status}). Configure PHOENIX_API_KEY or use --api-key.`
+    );
+  }
+}

--- a/js/packages/phoenix-cli/src/exitCodes.ts
+++ b/js/packages/phoenix-cli/src/exitCodes.ts
@@ -1,0 +1,18 @@
+/**
+ * Semantic exit codes for the Phoenix CLI.
+ *
+ * These codes enable scripting and CI integration by providing
+ * machine-readable signals for different outcomes.
+ */
+export const EXIT_CODES = {
+  /** Command completed successfully. */
+  SUCCESS: 0,
+  /** General failure (configuration errors, API errors, unexpected conditions). */
+  FAILURE: 1,
+  /** Operation cancelled by the user (e.g., declined a confirmation prompt). */
+  CANCELLED: 2,
+  /** Authentication required or insufficient permissions (HTTP 401/403). */
+  AUTH_REQUIRED: 4,
+} as const;
+
+export type ExitCode = (typeof EXIT_CODES)[keyof typeof EXIT_CODES];

--- a/js/packages/phoenix-cli/test/exitCodes.test.ts
+++ b/js/packages/phoenix-cli/test/exitCodes.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { AuthRequiredError, UserCancelledError, throwIfAuthError } from "../src/errors";
+import { EXIT_CODES } from "../src/exitCodes";
+
+describe("EXIT_CODES", () => {
+  it("defines success as 0", () => {
+    expect(EXIT_CODES.SUCCESS).toBe(0);
+  });
+
+  it("defines failure as 1", () => {
+    expect(EXIT_CODES.FAILURE).toBe(1);
+  });
+
+  it("defines cancelled as 2", () => {
+    expect(EXIT_CODES.CANCELLED).toBe(2);
+  });
+
+  it("defines auth_required as 4", () => {
+    expect(EXIT_CODES.AUTH_REQUIRED).toBe(4);
+  });
+
+  it("has no duplicate values", () => {
+    const values = Object.values(EXIT_CODES);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+  });
+});
+
+describe("AuthRequiredError", () => {
+  it("has name AuthRequiredError", () => {
+    const err = new AuthRequiredError();
+    expect(err.name).toBe("AuthRequiredError");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new AuthRequiredError();
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("uses a default message when none provided", () => {
+    const err = new AuthRequiredError();
+    expect(err.message).toContain("Authentication required");
+  });
+
+  it("uses a custom message when provided", () => {
+    const err = new AuthRequiredError("Custom auth error");
+    expect(err.message).toBe("Custom auth error");
+  });
+});
+
+describe("UserCancelledError", () => {
+  it("has name UserCancelledError", () => {
+    const err = new UserCancelledError();
+    expect(err.name).toBe("UserCancelledError");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new UserCancelledError();
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("uses a default message when none provided", () => {
+    const err = new UserCancelledError();
+    expect(err.message).toContain("cancelled");
+  });
+
+  it("uses a custom message when provided", () => {
+    const err = new UserCancelledError("Aborted by user");
+    expect(err.message).toBe("Aborted by user");
+  });
+});
+
+describe("throwIfAuthError", () => {
+  const makeResponse = (status: number): Response =>
+    new Response(null, { status });
+
+  it("throws AuthRequiredError for HTTP 401", () => {
+    expect(() => throwIfAuthError(makeResponse(401))).toThrow(AuthRequiredError);
+  });
+
+  it("throws AuthRequiredError for HTTP 403", () => {
+    expect(() => throwIfAuthError(makeResponse(403))).toThrow(AuthRequiredError);
+  });
+
+  it("includes the HTTP status in the error message", () => {
+    try {
+      throwIfAuthError(makeResponse(401));
+    } catch (err) {
+      expect((err as Error).message).toContain("401");
+    }
+  });
+
+  it("does not throw for HTTP 200", () => {
+    expect(() => throwIfAuthError(makeResponse(200))).not.toThrow();
+  });
+
+  it("does not throw for HTTP 404", () => {
+    expect(() => throwIfAuthError(makeResponse(404))).not.toThrow();
+  });
+
+  it("does not throw for HTTP 500", () => {
+    expect(() => throwIfAuthError(makeResponse(500))).not.toThrow();
+  });
+});


### PR DESCRIPTION
Implements semantic exit codes for the px CLI as specified in issue 12046.

Exit codes: 0=success, 1=general failure, 2=cancelled, 4=auth required (HTTP 401/403).

Changes:
- Add src/exitCodes.ts with EXIT_CODES constant and ExitCode type
- Add src/errors.ts with AuthRequiredError, UserCancelledError, and throwIfAuthError helper
- Update cli.ts to document exit codes in px --help output
- Update client.ts to propagate AuthRequiredError from resolveProjectId/resolveDatasetId
- Update all command files to use EXIT_CODES constants and handle AuthRequiredError with exit code 4
- Add test/exitCodes.test.ts with unit tests

Closes #12046

🤖 Generated with [Claude Code](https://claude.com/claude-code)