### PR TITLE
feat(cli): add px experiment export subcommand

### DIFF
--- a/js/packages/phoenix-cli/src/commands/experiment.ts
+++ b/js/packages/phoenix-cli/src/commands/experiment.ts
@@ -5,11 +5,11 @@ import { Command } from "commander";
 import { createPhoenixClient } from "../client";
 import { getConfigErrorMessage, resolveConfig } from "../config";
 import { writeError, writeOutput, writeProgress } from "../io";
+import { createExperimentExportCommand } from "./experimentExport";
 import {
   formatExperimentJsonOutput,
   type OutputFormat,
 } from "./formatExperiment";
-import { createExperimentExportCommand } from "./experimentExport";
 
 interface ExperimentOptions {
   endpoint?: string;

--- a/js/packages/phoenix-cli/src/commands/experiment.ts
+++ b/js/packages/phoenix-cli/src/commands/experiment.ts
@@ -9,6 +9,7 @@ import {
   formatExperimentJsonOutput,
   type OutputFormat,
 } from "./formatExperiment";
+import { createExperimentExportCommand } from "./experimentExport";
 
 interface ExperimentOptions {
   endpoint?: string;
@@ -139,6 +140,8 @@ export function createExperimentCommand(): Command {
     .option("--no-progress", "Disable progress indicators")
     .option("--file <path>", "Save experiment to file instead of stdout")
     .action(experimentHandler);
+
+  command.addCommand(createExperimentExportCommand());
 
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/experimentExport.ts
+++ b/js/packages/phoenix-cli/src/commands/experimentExport.ts
@@ -1,0 +1,131 @@
+import * as fs from "fs";
+import type { PhoenixClient } from "@arizeai/phoenix-client";
+import { Command } from "commander";
+
+import { createPhoenixClient } from "../client";
+import { getConfigErrorMessage, resolveConfig } from "../config";
+import { writeError, writeOutput, writeProgress } from "../io";
+
+export type ExportFormat = "csv" | "json";
+
+interface ExperimentExportOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: ExportFormat;
+  output?: string;
+  progress?: boolean;
+}
+
+/**
+ * Download experiment data in the specified format
+ */
+async function downloadExperimentData(
+  client: PhoenixClient,
+  experimentId: string,
+  format: ExportFormat
+): Promise<string> {
+  const path =
+    format === "csv"
+      ? "/v1/experiments/{experiment_id}/csv"
+      : "/v1/experiments/{experiment_id}/json";
+
+  const response = await client.GET(path, {
+    params: {
+      path: {
+        experiment_id: experimentId,
+      },
+    },
+    parseAs: "text",
+  });
+
+  if (response.error || response.data === undefined) {
+    throw new Error(
+      `Failed to download experiment ${format.toUpperCase()}: ${response.error}`
+    );
+  }
+
+  return response.data as string;
+}
+
+/**
+ * Experiment export command handler
+ */
+async function experimentExportHandler(
+  experimentId: string,
+  options: ExperimentExportOptions
+): Promise<void> {
+  try {
+    const format: ExportFormat = options.format || "json";
+
+    // Resolve configuration
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    // Validate that we have endpoint
+    if (!config.endpoint) {
+      const errors = [
+        "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
+      ];
+      writeError({ message: getConfigErrorMessage({ errors }) });
+      process.exit(1);
+    }
+
+    // Create client
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Exporting experiment ${experimentId} as ${format.toUpperCase()}...`,
+      noProgress: !options.progress,
+    });
+
+    // Download experiment data in requested format
+    const data = await downloadExperimentData(client, experimentId, format);
+
+    writeProgress({
+      message: `Downloaded experiment data`,
+      noProgress: !options.progress,
+    });
+
+    if (options.output) {
+      fs.writeFileSync(options.output, data, "utf-8");
+      writeProgress({
+        message: `Wrote experiment to ${options.output}`,
+        noProgress: !options.progress,
+      });
+    } else {
+      writeOutput({ message: data });
+    }
+  } catch (error) {
+    writeError({
+      message: `Error exporting experiment: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(1);
+  }
+}
+
+/**
+ * Create the experiment export subcommand
+ */
+export function createExperimentExportCommand(): Command {
+  const command = new Command("export");
+
+  command
+    .description("Export experiment runs in CSV or JSON format")
+    .argument("<experiment-id>", "Experiment identifier")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Export format: csv or json (default: json)",
+      "json"
+    )
+    .option("--output <file>", "Write output to file instead of stdout")
+    .option("--no-progress", "Disable progress indicators")
+    .action(experimentExportHandler);
+
+  return command;
+}

--- a/js/packages/phoenix-cli/src/commands/index.ts
+++ b/js/packages/phoenix-cli/src/commands/index.ts
@@ -6,6 +6,7 @@ export * from "./datasets";
 export * from "./dataset";
 export * from "./experiments";
 export * from "./experiment";
+export * from "./experimentExport";
 export * from "./sessions";
 export * from "./session";
 export * from "./prompts";

--- a/js/packages/phoenix-cli/test/experimentExport.test.ts
+++ b/js/packages/phoenix-cli/test/experimentExport.test.ts
@@ -24,18 +24,14 @@ describe("Experiment Export Command", () => {
 
   it("should have --format option defaulting to json", () => {
     const command = createExperimentExportCommand();
-    const formatOption = command.options.find(
-      (opt) => opt.long === "--format"
-    );
+    const formatOption = command.options.find((opt) => opt.long === "--format");
     expect(formatOption).toBeDefined();
     expect(formatOption?.defaultValue).toBe("json");
   });
 
   it("should have --output option", () => {
     const command = createExperimentExportCommand();
-    const outputOption = command.options.find(
-      (opt) => opt.long === "--output"
-    );
+    const outputOption = command.options.find((opt) => opt.long === "--output");
     expect(outputOption).toBeDefined();
   });
 

--- a/js/packages/phoenix-cli/test/experimentExport.test.ts
+++ b/js/packages/phoenix-cli/test/experimentExport.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { createExperimentExportCommand } from "../src/commands/experimentExport";
+
+describe("Experiment Export Command", () => {
+  it("should create a command named 'export'", () => {
+    const command = createExperimentExportCommand();
+    expect(command.name()).toBe("export");
+  });
+
+  it("should have the correct description", () => {
+    const command = createExperimentExportCommand();
+    expect(command.description()).toBe(
+      "Export experiment runs in CSV or JSON format"
+    );
+  });
+
+  it("should accept experiment-id as a required argument", () => {
+    const command = createExperimentExportCommand();
+    const args = command.registeredArguments;
+    expect(args).toHaveLength(1);
+    expect(args[0].name()).toBe("experiment-id");
+  });
+
+  it("should have --format option defaulting to json", () => {
+    const command = createExperimentExportCommand();
+    const formatOption = command.options.find(
+      (opt) => opt.long === "--format"
+    );
+    expect(formatOption).toBeDefined();
+    expect(formatOption?.defaultValue).toBe("json");
+  });
+
+  it("should have --output option", () => {
+    const command = createExperimentExportCommand();
+    const outputOption = command.options.find(
+      (opt) => opt.long === "--output"
+    );
+    expect(outputOption).toBeDefined();
+  });
+
+  it("should have --endpoint option", () => {
+    const command = createExperimentExportCommand();
+    const option = command.options.find((opt) => opt.long === "--endpoint");
+    expect(option).toBeDefined();
+  });
+
+  it("should have --api-key option", () => {
+    const command = createExperimentExportCommand();
+    const option = command.options.find((opt) => opt.long === "--api-key");
+    expect(option).toBeDefined();
+  });
+
+  it("should have --no-progress option", () => {
+    const command = createExperimentExportCommand();
+    const option = command.options.find(
+      (opt) => opt.long === "--no-progress" || opt.long === "--progress"
+    );
+    expect(option).toBeDefined();
+  });
+});
+
+describe("Experiment command has export subcommand", () => {
+  it("should register export as a subcommand of experiment", async () => {
+    const { createExperimentCommand } = await import(
+      "../src/commands/experiment"
+    );
+    const command = createExperimentCommand();
+    const subcommands = command.commands;
+    const exportCmd = subcommands.find((cmd) => cmd.name() === "export");
+    expect(exportCmd).toBeDefined();
+  });
+});

--- a/skills/phoenix-cli/SKILL.md
+++ b/skills/phoenix-cli/SKILL.md
@@ -88,6 +88,10 @@ px datasets --format raw --no-progress | jq '.[].name'
 px dataset <name> --format raw | jq '.examples[] | {input, output: .expected_output}'
 px experiments --dataset <name> --format raw --no-progress | jq '.[] | {id, name, failed_run_count}'
 px experiment <id> --format raw --no-progress | jq '.[] | select(.error != null) | {input, error}'
+px experiment export <id>                             # export JSON to stdout (default)
+px experiment export <id> --format csv                # export CSV to stdout
+px experiment export <id> --format json --output out.json  # write JSON to file
+px experiment export <id> --format csv --output out.csv    # write CSV to file
 px prompts --format raw --no-progress | jq '.[].name'
 px prompt <name> --format text --no-progress   # plain text, ideal for piping to AI
 ```


### PR DESCRIPTION
## Summary

Implements `px experiment export <id> --format csv|json` as requested in #12037.

- Adds a new `export` subcommand under `px experiment` that calls the existing API endpoints:
  - `GET /v1/experiments/{id}/json` for JSON format (default)
  - `GET /v1/experiments/{id}/csv` for CSV format
- `--format csv|json` selects export format (default: `json`)
- `--output <file>` writes output to a file instead of stdout
- Outputs raw data to stdout by default (suitable for piping)

## Test plan

- [ ] `px experiment export <id>` outputs JSON to stdout
- [ ] `px experiment export <id> --format csv` outputs CSV to stdout
- [ ] `px experiment export <id> --format json` outputs JSON to stdout
- [ ] `px experiment export <id> --output out.json` writes JSON to file
- [ ] `px experiment export <id> --format csv --output out.csv` writes CSV to file
- [ ] Unit tests in `test/experimentExport.test.ts` verify command structure and options

Closes #12037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
