### PR TITLE
chore: add structured prompt and acceptance criteria to implement-issue workflow

### DIFF
--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -76,43 +76,46 @@ jobs:
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end. Deliver a complete, merge-ready PR.
 
+            The keywords MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, and OPTIONAL
+            follow RFC 2119 conventions when they appear in all capitals.
+
             ## 1. Understand
-            - Run `gh issue view ${{ github.event.issue.number }}` to read the full issue and comments.
-            - Read CLAUDE.md and run `make help` to learn project tooling.
-            - Explore relevant code, patterns, and conventions before writing anything.
+            - You MUST run `gh issue view ${{ github.event.issue.number }}` to read the full issue and comments.
+            - You MUST read CLAUDE.md and run `make help` to learn project tooling.
+            - You MUST explore relevant code, patterns, and conventions before writing anything.
 
             ## 2. Plan
-            - Outline your implementation approach before coding.
-            - Identify affected files, tests, and documentation.
+            - You MUST outline your implementation approach before coding.
+            - You SHOULD identify affected files, tests, and documentation.
 
             ## 3. Implement
-            - Follow existing codebase patterns and conventions.
-            - Add clear docstrings to new public functions, classes, and modules.
-            - Keep changes focused on the issue.
-            - If you modify any JS/TS packages under `js/`, create a changeset via `pnpm changeset`.
+            - You MUST follow existing codebase patterns and conventions.
+            - You MUST add clear docstrings to new public functions, classes, and modules.
+            - You MUST keep changes focused on the issue.
+            - You MUST create a changeset via `pnpm changeset` if you modify any JS/TS packages under `js/`.
 
             ## 4. Validate
-            - Run /simplify and fix any issues.
-            - Run tests, linting, and formatting via `make` targets. Fix all failures.
-            - Update docs and skills/ files if affected. Ground all documentation in real code — verify examples and references against the actual implementation, never hallucinate.
+            - You MUST run /simplify and fix any issues found.
+            - You MUST run tests, linting, and formatting via `make` targets. All failures MUST be fixed.
+            - You MUST update docs and skills/ files if affected by your changes. Documentation MUST be grounded in real code — verify examples and references against the actual implementation. You MUST NOT hallucinate documentation.
 
             ## 5. Ship
-            - Commit referencing #${{ github.event.issue.number }}, push, and open a PR via `gh pr create`.
-            - Write a clear PR description covering what changed, why, and how to verify.
-            - Include screenshots or examples when applicable.
+            - You MUST commit referencing #${{ github.event.issue.number }}, push, and open a PR via `gh pr create`.
+            - You MUST write a clear PR description covering what changed, why, and how to verify.
+            - You SHOULD include screenshots or examples when applicable.
 
             ## Acceptance Criteria
-            Every item must be complete before opening the PR:
-            - [ ] Implementation plan reviewed
-            - [ ] Code reviewed with /simplify — no issues remaining
-            - [ ] Tests pass and validate the change
-            - [ ] Docstrings added to new public APIs
-            - [ ] Documentation updated and grounded in real code
-            - [ ] Changeset created (`pnpm changeset`) if JS/TS packages were modified
-            - [ ] Relevant skills updated under skills/ directory
-            - [ ] Linting and formatting pass
-            - [ ] PR created with a clear description
-            - [ ] Screenshots or examples included when applicable
+            All REQUIRED items MUST be satisfied before opening the PR. The PR MUST NOT be opened if any item is incomplete.
+            - [ ] REQUIRED: Implementation plan reviewed
+            - [ ] REQUIRED: Code reviewed with /simplify — no issues remaining
+            - [ ] REQUIRED: Tests pass and validate the change
+            - [ ] REQUIRED: Docstrings added to new public APIs
+            - [ ] REQUIRED: Documentation updated and grounded in real code
+            - [ ] REQUIRED: Changeset created (`pnpm changeset`) if JS/TS packages were modified
+            - [ ] RECOMMENDED: Relevant skills updated under skills/ directory
+            - [ ] REQUIRED: Linting and formatting pass
+            - [ ] REQUIRED: PR created with a clear description
+            - [ ] RECOMMENDED: Screenshots or examples included when applicable
           claude_args: '--allowedTools Read,Write,Edit,Glob,Grep,Agent,"Bash(git:*)","Bash(make:*)","Bash(gh:*)","Bash(uv:*)","Bash(pnpm:*)","Bash(npx:*)"'
 
       - name: Cleanup


### PR DESCRIPTION
## Summary
- Replaces the minimal 3-line prompt in `claude-implement-issue.yml` with a structured, phased workflow (Understand → Implement → Validate → Ship)
- Adds an acceptance criteria checklist that must be completed before opening a PR
- Goal: improve the quality and completeness of PRs created by the automated issue implementation workflow

## Test plan
- [x] YAML validates successfully
- [ ] Trigger workflow on a test issue with the `good-agent-issue` label and verify the agent follows the new prompt structure