### PR TITLE
chore: use claude-opus-4-6 for implement-issue workflow

### DIFF
--- a/.github/workflows/claude-implement-issue.yml
+++ b/.github/workflows/claude-implement-issue.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          model: claude-opus-4-6
           prompt: |
             Implement GitHub issue #${{ github.event.issue.number }} end-to-end. Deliver a complete, merge-ready PR.
 


### PR DESCRIPTION
## Summary
- Updates the `claude-implement-issue` workflow to use `claude-opus-4-6` model instead of the default

## Test plan
- [ ] Verify workflow triggers correctly on `good-agent-issue` label