### PR TITLE
feat(cli): add px annotation-config list command

### DIFF
--- a/js/.changeset/annotation-config-list-command.md
+++ b/js/.changeset/annotation-config-list-command.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `px annotation-config list` command to list all annotation configurations from the Phoenix server. Supports pretty, json, and raw output formats via `--format`.

--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander";
 
 import {
+  createAnnotationConfigCommand,
   createApiCommand,
   createAuthCommand,
   createDatasetCommand,
@@ -28,6 +29,7 @@ export function main() {
     .version("0.0.4");
 
   // Register commands
+  program.addCommand(createAnnotationConfigCommand());
   program.addCommand(createAuthCommand());
   program.addCommand(createProjectsCommand());
   program.addCommand(createTracesCommand());

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -1,0 +1,136 @@
+import type { PhoenixClient } from "@arizeai/phoenix-client";
+import { Command } from "commander";
+
+import { createPhoenixClient } from "../client";
+import { getConfigErrorMessage, resolveConfig } from "../config";
+import { writeError, writeOutput, writeProgress } from "../io";
+import {
+  type AnnotationConfig,
+  formatAnnotationConfigsOutput,
+  type OutputFormat,
+} from "./formatAnnotationConfigs";
+
+interface AnnotationConfigListOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  limit?: number;
+}
+
+/**
+ * Fetch all annotation configs from Phoenix via paginated GET /v1/annotation_configs.
+ */
+async function fetchAnnotationConfigs(
+  client: PhoenixClient,
+  options: { limit?: number } = {}
+): Promise<AnnotationConfig[]> {
+  const allConfigs: AnnotationConfig[] = [];
+  let cursor: string | undefined;
+  const pageLimit = options.limit || 100;
+
+  do {
+    const response = await client.GET("/v1/annotation_configs", {
+      params: {
+        query: {
+          cursor,
+          limit: pageLimit,
+        },
+      },
+    });
+
+    if (response.error || !response.data) {
+      throw new Error(`Failed to fetch annotation configs: ${response.error}`);
+    }
+
+    allConfigs.push(...response.data.data);
+    cursor = response.data.next_cursor || undefined;
+
+    if (options.limit && allConfigs.length >= options.limit) {
+      break;
+    }
+  } while (cursor);
+
+  return allConfigs;
+}
+
+/**
+ * Handler for `annotation-config list`.
+ */
+async function annotationConfigListHandler(
+  options: AnnotationConfigListOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    if (!config.endpoint) {
+      const errors = [
+        "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
+      ];
+      writeError({ message: getConfigErrorMessage({ errors }) });
+      process.exit(1);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: "Fetching annotation configs...",
+      noProgress: !options.progress,
+    });
+
+    const configs = await fetchAnnotationConfigs(client, {
+      limit: options.limit,
+    });
+
+    writeProgress({
+      message: `Found ${configs.length} annotation config(s)`,
+      noProgress: !options.progress,
+    });
+
+    const output = formatAnnotationConfigsOutput({
+      configs,
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error fetching annotation configs: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(1);
+  }
+}
+
+/**
+ * Create the annotation-config command group with its subcommands.
+ */
+export function createAnnotationConfigCommand(): Command {
+  const command = new Command("annotation-config");
+  command.description("Manage annotation configurations");
+
+  const listCommand = new Command("list");
+  listCommand
+    .description("List all annotation configurations")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .option(
+      "--limit <number>",
+      "Maximum number of annotation configs to fetch",
+      parseInt
+    )
+    .action(annotationConfigListHandler);
+
+  command.addCommand(listCommand);
+
+  return command;
+}

--- a/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
+++ b/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
@@ -1,0 +1,60 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+export type OutputFormat = "pretty" | "json" | "raw";
+
+export type AnnotationConfig =
+  | componentsV1["schemas"]["CategoricalAnnotationConfig"]
+  | componentsV1["schemas"]["ContinuousAnnotationConfig"]
+  | componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+export interface FormatAnnotationConfigsOutputOptions {
+  /**
+   * Annotation configs to format.
+   */
+  configs: AnnotationConfig[];
+  /**
+   * Output format. Defaults to `"pretty"`.
+   */
+  format?: OutputFormat;
+}
+
+/**
+ * Format a list of annotation configs for output.
+ */
+export function formatAnnotationConfigsOutput({
+  configs,
+  format,
+}: FormatAnnotationConfigsOutputOptions): string {
+  const selected = format || "pretty";
+  if (selected === "raw") {
+    return JSON.stringify(configs);
+  }
+  if (selected === "json") {
+    return JSON.stringify(configs, null, 2);
+  }
+  return formatAnnotationConfigsPretty(configs);
+}
+
+function formatAnnotationConfigsPretty(configs: AnnotationConfig[]): string {
+  if (configs.length === 0) {
+    return "No annotation configs found";
+  }
+
+  const lines: string[] = [];
+  lines.push("Annotation Configs:");
+  lines.push("");
+
+  for (const config of configs) {
+    const desc =
+      config.description == null || config.description === ""
+        ? ""
+        : ` — ${config.description}`;
+
+    lines.push(`┌─ ${config.name} (${config.id})`);
+    lines.push(`│  Type: ${config.type}${desc}`);
+    lines.push(`└─`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/js/packages/phoenix-cli/src/commands/index.ts
+++ b/js/packages/phoenix-cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+export * from "./annotationConfig";
 export * from "./auth";
 export * from "./projects";
 export * from "./traces";

--- a/js/packages/phoenix-cli/test/annotationConfig.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfig.test.ts
@@ -1,0 +1,156 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+import { describe, expect, it } from "vitest";
+
+import { formatAnnotationConfigsOutput } from "../src/commands/formatAnnotationConfigs";
+
+type CategoricalAnnotationConfig =
+  componentsV1["schemas"]["CategoricalAnnotationConfig"];
+type ContinuousAnnotationConfig =
+  componentsV1["schemas"]["ContinuousAnnotationConfig"];
+type FreeformAnnotationConfig =
+  componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+const mockCategorical: CategoricalAnnotationConfig = {
+  id: "Q2F0ZWdvcmljYWxBbm5vdGF0aW9uQ29uZmlnOjE=",
+  name: "quality",
+  type: "CATEGORICAL",
+  description: "Rate response quality",
+  optimization_direction: "MAXIMIZE",
+  values: [
+    { label: "good", score: 1 },
+    { label: "bad", score: 0 },
+  ],
+};
+
+const mockContinuous: ContinuousAnnotationConfig = {
+  id: "Q29udGludW91c0Fubm90YXRpb25Db25maWc6Mg==",
+  name: "relevance",
+  type: "CONTINUOUS",
+  description: null,
+  optimization_direction: "MAXIMIZE",
+  lower_bound: 0,
+  upper_bound: 1,
+};
+
+const mockFreeform: FreeformAnnotationConfig = {
+  id: "RnJlZWZvcm1Bbm5vdGF0aW9uQ29uZmlnOjM=",
+  name: "feedback",
+  type: "FREEFORM",
+  description: "Free-text feedback",
+};
+
+describe("Annotation Config Formatting", () => {
+  describe("formatAnnotationConfigsOutput - raw", () => {
+    it("should format as compact JSON", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "raw",
+      });
+
+      expect(output).toBe(JSON.stringify([mockCategorical]));
+      expect(output).not.toContain("\n");
+    });
+
+    it("should handle empty array", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [],
+        format: "raw",
+      });
+
+      expect(output).toBe("[]");
+    });
+  });
+
+  describe("formatAnnotationConfigsOutput - json", () => {
+    it("should format as pretty JSON", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "json",
+      });
+
+      expect(output).toBe(JSON.stringify([mockCategorical], null, 2));
+      expect(output).toContain("\n");
+      expect(output).toContain("  ");
+    });
+
+    it("should handle multiple configs", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical, mockContinuous, mockFreeform],
+        format: "json",
+      });
+
+      expect(output).toBe(
+        JSON.stringify([mockCategorical, mockContinuous, mockFreeform], null, 2)
+      );
+    });
+  });
+
+  describe("formatAnnotationConfigsOutput - pretty", () => {
+    it("should format categorical config in human-readable format", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "pretty",
+      });
+
+      expect(output).toContain("Annotation Configs:");
+      expect(output).toContain(
+        `┌─ quality (Q2F0ZWdvcmljYWxBbm5vdGF0aW9uQ29uZmlnOjE=)`
+      );
+      expect(output).toContain("│  Type: CATEGORICAL — Rate response quality");
+      expect(output).toContain("└─");
+    });
+
+    it("should format continuous config without description", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockContinuous],
+        format: "pretty",
+      });
+
+      expect(output).toContain(
+        `┌─ relevance (Q29udGludW91c0Fubm90YXRpb25Db25maWc6Mg==)`
+      );
+      expect(output).toContain("│  Type: CONTINUOUS");
+      expect(output).not.toContain(" — ");
+    });
+
+    it("should format freeform config with description", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockFreeform],
+        format: "pretty",
+      });
+
+      expect(output).toContain(
+        `┌─ feedback (RnJlZWZvcm1Bbm5vdGF0aW9uQ29uZmlnOjM=)`
+      );
+      expect(output).toContain("│  Type: FREEFORM — Free-text feedback");
+    });
+
+    it("should handle empty array", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [],
+        format: "pretty",
+      });
+
+      expect(output).toBe("No annotation configs found");
+    });
+
+    it("should format multiple configs", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical, mockContinuous, mockFreeform],
+        format: "pretty",
+      });
+
+      expect(output).toContain("┌─ quality");
+      expect(output).toContain("┌─ relevance");
+      expect(output).toContain("┌─ feedback");
+    });
+
+    it("should default to pretty format when no format specified", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+      });
+
+      expect(output).toContain("Annotation Configs:");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `px annotation-config list` as requested in #12021.

- Adds `annotation-config list` subcommand to the Phoenix CLI
- Fetches all annotation configs via paginated `GET /v1/annotation_configs`
- Displays name, type, and description for each config
- Supports `--format pretty|json|raw` output (defaults to `pretty`)
- Supports `--limit`, `--endpoint`, `--api-key`, and `--no-progress` flags consistent with other commands

## Files changed

- `src/commands/annotationConfig.ts` - New command: annotation-config parent + list subcommand
- `src/commands/formatAnnotationConfigs.ts` - Formatter for pretty/json/raw output; exports AnnotationConfig union type
- `test/annotationConfig.test.ts` - 10 unit tests covering all three output formats and edge cases
- `src/commands/index.ts` - Export new command
- `src/cli.ts` - Register new command with Commander
- `js/.changeset/annotation-config-list-command.md` - Minor version changeset for @arizeai/phoenix-cli

## How to verify

1. Start a Phoenix server with some annotation configs
2. Run `px annotation-config list --endpoint http://localhost:6006`
3. Verify configs are listed with name, type, and description
4. Run with `--format json` and verify JSON output

Closes #12021

Generated with Claude Code
