### PR TITLE
feat(cli): add px annotation-config list command

### DIFF
--- a/js/.changeset/annotation-config-list-cli.md
+++ b/js/.changeset/annotation-config-list-cli.md
@@ -1,0 +1,7 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `px annotation-config list` command to list all annotation configurations.
+
+The new command fetches annotation configs from `GET /v1/annotation_configs` with cursor-based pagination and supports `--format pretty|json|raw`, `--limit`, `--endpoint`, `--api-key`, and `--no-progress` options.

--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander";
 
 import {
+  createAnnotationConfigCommand,
   createApiCommand,
   createAuthCommand,
   createDatasetCommand,
@@ -28,6 +29,7 @@ export function main() {
     .version("0.0.4");
 
   // Register commands
+  program.addCommand(createAnnotationConfigCommand());
   program.addCommand(createAuthCommand());
   program.addCommand(createProjectsCommand());
   program.addCommand(createTracesCommand());

--- a/js/packages/phoenix-cli/src/commands/annotationConfig.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationConfig.ts
@@ -1,0 +1,142 @@
+import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { Command } from "commander";
+
+import { createPhoenixClient } from "../client";
+import { getConfigErrorMessage, resolveConfig } from "../config";
+import { ExitCode, getExitCodeForError } from "../exitCodes";
+import { writeError, writeOutput, writeProgress } from "../io";
+import {
+  formatAnnotationConfigsOutput,
+  type OutputFormat,
+} from "./formatAnnotationConfigs";
+
+type AnnotationConfig =
+  | componentsV1["schemas"]["CategoricalAnnotationConfig"]
+  | componentsV1["schemas"]["ContinuousAnnotationConfig"]
+  | componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+interface AnnotationConfigListOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: OutputFormat;
+  progress?: boolean;
+  limit?: number;
+}
+
+/**
+ * Fetch all annotation configs from Phoenix
+ */
+async function fetchAnnotationConfigs(
+  client: PhoenixClient,
+  options: { limit?: number } = {}
+): Promise<AnnotationConfig[]> {
+  const allConfigs: AnnotationConfig[] = [];
+  let cursor: string | undefined;
+  const pageLimit = options.limit || 100;
+
+  do {
+    const response = await client.GET("/v1/annotation_configs", {
+      params: {
+        query: {
+          cursor,
+          limit: pageLimit,
+        },
+      },
+    });
+
+    if (response.error || !response.data) {
+      throw new Error(`Failed to fetch annotation configs: ${response.error}`);
+    }
+
+    allConfigs.push(...response.data.data);
+    cursor = response.data.next_cursor || undefined;
+
+    // If we've fetched enough for the requested limit, stop
+    if (options.limit && allConfigs.length >= options.limit) {
+      break;
+    }
+  } while (cursor);
+
+  return allConfigs;
+}
+
+/**
+ * Handler for `annotation-config list`
+ */
+async function annotationConfigListHandler(
+  options: AnnotationConfigListOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    if (!config.endpoint) {
+      const errors = [
+        "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
+      ];
+      writeError({ message: getConfigErrorMessage({ errors }) });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: "Fetching annotation configs...",
+      noProgress: !options.progress,
+    });
+
+    const configs = await fetchAnnotationConfigs(client, {
+      limit: options.limit,
+    });
+
+    writeProgress({
+      message: `Found ${configs.length} annotation config(s)`,
+      noProgress: !options.progress,
+    });
+
+    const output = formatAnnotationConfigsOutput({
+      configs,
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error fetching annotation configs: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+/**
+ * Create the `annotation-config` command with subcommands
+ */
+export function createAnnotationConfigCommand(): Command {
+  const command = new Command("annotation-config");
+  command.description("Manage Phoenix annotation configurations");
+
+  const listCommand = new Command("list");
+  listCommand
+    .description("List all annotation configurations")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .option(
+      "--limit <number>",
+      "Maximum number of annotation configs to fetch",
+      parseInt
+    )
+    .action(annotationConfigListHandler);
+
+  command.addCommand(listCommand);
+
+  return command;
+}

--- a/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
+++ b/js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts
@@ -1,0 +1,62 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+
+export type OutputFormat = "pretty" | "json" | "raw";
+
+type AnnotationConfig =
+  | componentsV1["schemas"]["CategoricalAnnotationConfig"]
+  | componentsV1["schemas"]["ContinuousAnnotationConfig"]
+  | componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+export interface FormatAnnotationConfigsOutputOptions {
+  /**
+   * Annotation configs to format.
+   */
+  configs: AnnotationConfig[];
+  /**
+   * Output format. Defaults to `"pretty"`.
+   */
+  format?: OutputFormat;
+}
+
+export function formatAnnotationConfigsOutput({
+  configs,
+  format,
+}: FormatAnnotationConfigsOutputOptions): string {
+  const selected = format || "pretty";
+  if (selected === "raw") {
+    return JSON.stringify(configs);
+  }
+  if (selected === "json") {
+    return JSON.stringify(configs, null, 2);
+  }
+  return formatAnnotationConfigsPretty(configs);
+}
+
+function formatAnnotationConfigsPretty(configs: AnnotationConfig[]): string {
+  if (configs.length === 0) {
+    return "No annotation configs found";
+  }
+
+  const lines: string[] = [];
+  lines.push("Annotation Configs:");
+  lines.push("");
+
+  for (const config of configs) {
+    const desc =
+      config.description === null ||
+      config.description === undefined ||
+      config.description === ""
+        ? ""
+        : ` — ${config.description}`;
+
+    lines.push(`┌─ ${config.name} (${config.id})`);
+    lines.push(`│  Type: ${config.type}`);
+    if (desc) {
+      lines.push(`│  Description:${desc}`);
+    }
+    lines.push(`└─`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/js/packages/phoenix-cli/src/commands/index.ts
+++ b/js/packages/phoenix-cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+export * from "./annotationConfig";
 export * from "./auth";
 export * from "./projects";
 export * from "./traces";

--- a/js/packages/phoenix-cli/test/annotationConfigs.test.ts
+++ b/js/packages/phoenix-cli/test/annotationConfigs.test.ts
@@ -1,0 +1,151 @@
+import type { componentsV1 } from "@arizeai/phoenix-client";
+import { describe, expect, it } from "vitest";
+
+import { formatAnnotationConfigsOutput } from "../src/commands/formatAnnotationConfigs";
+
+type CategoricalAnnotationConfig =
+  componentsV1["schemas"]["CategoricalAnnotationConfig"];
+type ContinuousAnnotationConfig =
+  componentsV1["schemas"]["ContinuousAnnotationConfig"];
+type FreeformAnnotationConfig =
+  componentsV1["schemas"]["FreeformAnnotationConfig"];
+
+const mockCategorical: CategoricalAnnotationConfig = {
+  id: "cat-id-001",
+  name: "quality",
+  type: "CATEGORICAL",
+  description: "Quality rating",
+  optimization_direction: "MAXIMIZE",
+  values: [
+    { label: "good", score: 1 },
+    { label: "bad", score: 0 },
+  ],
+};
+
+const mockContinuous: ContinuousAnnotationConfig = {
+  id: "cont-id-002",
+  name: "score",
+  type: "CONTINUOUS",
+  description: null,
+  optimization_direction: "MAXIMIZE",
+  lower_bound: 0,
+  upper_bound: 1,
+};
+
+const mockFreeform: FreeformAnnotationConfig = {
+  id: "free-id-003",
+  name: "notes",
+  type: "FREEFORM",
+  description: "Free-text notes",
+};
+
+describe("Annotation Config Formatting", () => {
+  describe("formatAnnotationConfigsOutput - raw", () => {
+    it("should format as compact JSON", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "raw",
+      });
+
+      expect(output).toBe(JSON.stringify([mockCategorical]));
+      expect(output).not.toContain("\n");
+    });
+
+    it("should handle empty array", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [],
+        format: "raw",
+      });
+
+      expect(output).toBe("[]");
+    });
+  });
+
+  describe("formatAnnotationConfigsOutput - json", () => {
+    it("should format as pretty JSON", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "json",
+      });
+
+      expect(output).toBe(JSON.stringify([mockCategorical], null, 2));
+      expect(output).toContain("\n");
+      expect(output).toContain("  ");
+    });
+
+    it("should handle multiple configs", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical, mockContinuous, mockFreeform],
+        format: "json",
+      });
+
+      expect(output).toBe(
+        JSON.stringify([mockCategorical, mockContinuous, mockFreeform], null, 2)
+      );
+    });
+  });
+
+  describe("formatAnnotationConfigsOutput - pretty", () => {
+    it("should show header and config name with id", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+        format: "pretty",
+      });
+
+      expect(output).toContain("Annotation Configs:");
+      expect(output).toContain("┌─ quality (cat-id-001)");
+      expect(output).toContain("│  Type: CATEGORICAL");
+      expect(output).toContain("│  Description: — Quality rating");
+      expect(output).toContain("└─");
+    });
+
+    it("should omit description line when description is null", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockContinuous],
+        format: "pretty",
+      });
+
+      expect(output).toContain("┌─ score (cont-id-002)");
+      expect(output).toContain("│  Type: CONTINUOUS");
+      expect(output).not.toContain("Description:");
+    });
+
+    it("should render freeform type", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockFreeform],
+        format: "pretty",
+      });
+
+      expect(output).toContain("┌─ notes (free-id-003)");
+      expect(output).toContain("│  Type: FREEFORM");
+      expect(output).toContain("│  Description: — Free-text notes");
+    });
+
+    it("should return empty message when no configs", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [],
+        format: "pretty",
+      });
+
+      expect(output).toBe("No annotation configs found");
+    });
+
+    it("should format multiple configs", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical, mockFreeform],
+        format: "pretty",
+      });
+
+      expect(output).toContain("┌─ quality (cat-id-001)");
+      expect(output).toContain("┌─ notes (free-id-003)");
+    });
+
+    it("should default to pretty format when format is undefined", () => {
+      const output = formatAnnotationConfigsOutput({
+        configs: [mockCategorical],
+      });
+
+      expect(output).toContain("Annotation Configs:");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #12021

Implements `px annotation-config list` to list all annotation configurations via `GET /v1/annotation_configs`.

- Adds `annotation-config` parent command with `list` subcommand, following the design for future CRUD operations
- Fetches all configs with cursor-based pagination
- Pretty-prints name, type, and description for each config
- Supports `--format pretty|json|raw`, `--limit`, `--endpoint`, `--api-key`, and `--no-progress` options
- Uses semantic exit codes (`ExitCode.INVALID_ARGUMENT`, `getExitCodeForError`) added in the latest main

## Files changed

- `js/packages/phoenix-cli/src/commands/annotationConfig.ts` — New command file with `annotation-config list` handler
- `js/packages/phoenix-cli/src/commands/formatAnnotationConfigs.ts` — Pretty/JSON/raw formatter for annotation configs
- `js/packages/phoenix-cli/src/commands/index.ts` — Export new command
- `js/packages/phoenix-cli/src/cli.ts` — Register `annotation-config` command
- `js/packages/phoenix-cli/test/annotationConfigs.test.ts` — 10 unit tests covering all output formats
- `js/.changeset/annotation-config-list-cli.md` — Changeset for minor version bump

## How to verify

```bash
px annotation-config list
px annotation-config list --format json
px annotation-config list --limit 10
```

Example pretty output:
```
Annotation Configs:

┌─ quality (CategoricalAnnotationConfig:1)
│  Type: CATEGORICAL
│  Description: — Quality rating
└─
```

## Test plan

- [x] Unit tests pass: `pnpm test` in `js/packages/phoenix-cli` (107 tests)
- [x] TypeScript typecheck passes
- [x] Lists configs in pretty format
- [x] Outputs JSON with `--format json`
- [x] Caps results with `--limit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
