### PR TITLE
Add --curl preview to px api graphql

### DIFF
--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -184,6 +184,22 @@ Make authenticated GraphQL queries against the Phoenix API. Output is `{"data": 
 px api graphql '<query>' [--endpoint <url>] [--api-key <key>]
 ```
 
+Preview the exact HTTP request as `curl` without executing it:
+
+```bash
+px api graphql '{ projects { edges { node { name } } } }' --curl
+px api graphql '{ projects { edges { node { name } } } }' --curl --show-token
+```
+
+`--curl` prints the equivalent request to stdout and exits without making a network call. Authorization headers are masked by default, including values supplied through `PHOENIX_API_KEY` or `PHOENIX_CLIENT_HEADERS`. Use `--show-token` only when you explicitly need the raw credential in the generated command.
+
+Current scope and behavior:
+
+- `--curl` is currently implemented for `px api graphql` only.
+- `--curl` prints the request without executing it.
+- `--show-token` is only valid with `--curl`.
+- Authorization masking and header normalization are designed to match the live request behavior used by `fetch`.
+
 Use introspection to discover what fields are available:
 
 ```bash

--- a/js/packages/phoenix-cli/src/commands/api.ts
+++ b/js/packages/phoenix-cli/src/commands/api.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 
+import type { PhoenixConfig } from "../config";
 import { getConfigErrorMessage, resolveConfig } from "../config";
+import { renderCurlCommand } from "../curl";
 import { writeError, writeOutput } from "../io";
 
 /**
@@ -15,6 +17,42 @@ export function isNonQuery({ query }: { query: string }): boolean {
 interface ApiGraphqlOptions {
   endpoint?: string;
   apiKey?: string;
+  curl?: boolean;
+  showToken?: boolean;
+}
+
+export interface ApiGraphqlRequest {
+  url: string;
+  method: "POST";
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Builds the exact outbound GraphQL request used by both live execution and
+ * `--curl` preview mode so the two paths cannot drift apart.
+ */
+export function buildGraphqlRequest({
+  query,
+  config,
+}: {
+  query: string;
+  config: PhoenixConfig;
+}): ApiGraphqlRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(config.headers ?? {}),
+  };
+  if (config.apiKey) {
+    headers["Authorization"] = `Bearer ${config.apiKey}`;
+  }
+
+  return {
+    url: `${config.endpoint?.replace(/\/$/, "")}/graphql`,
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query }),
+  };
 }
 
 async function apiGraphqlHandler(
@@ -22,6 +60,13 @@ async function apiGraphqlHandler(
   options: ApiGraphqlOptions
 ): Promise<void> {
   try {
+    if (options.showToken && !options.curl) {
+      writeError({
+        message: "Error: --show-token can only be used with --curl.",
+      });
+      process.exit(1);
+    }
+
     // 1. Reject mutations and subscriptions
     if (isNonQuery({ query })) {
       writeError({
@@ -47,26 +92,34 @@ async function apiGraphqlHandler(
       process.exit(1);
     }
 
-    // 3. Build URL and auth headers
-    const graphqlUrl = `${config.endpoint.replace(/\/$/, "")}/graphql`;
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      ...(config.headers ?? {}),
-    };
-    if (config.apiKey) {
-      headers["Authorization"] = `Bearer ${config.apiKey}`;
+    const request = buildGraphqlRequest({
+      query,
+      config,
+    });
+
+    if (options.curl) {
+      writeOutput({
+        message: renderCurlCommand({
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          body: request.body,
+          maskTokens: !options.showToken,
+        }),
+      });
+      return;
     }
 
     // 4. POST using Node 22 built-in fetch
-    const response = await fetch(graphqlUrl, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ query }),
+    const response = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
     });
 
     if (!response.ok) {
       writeError({
-        message: `Error: HTTP ${response.status} ${response.statusText} from ${graphqlUrl}`,
+        message: `Error: HTTP ${response.status} ${response.statusText} from ${request.url}`,
       });
       process.exit(1);
     }
@@ -113,11 +166,25 @@ function createApiGraphqlCommand(): Command {
         "\n" +
         "    # Pipe to jq to extract fields\n" +
         "    px api graphql '{ projects { edges { node { name } } } }' | \\\n" +
-        "      jq '.data.projects.edges[].node.name'"
+        "      jq '.data.projects.edges[].node.name'\n" +
+        "\n" +
+        "    # Print the equivalent curl command without executing it\n" +
+        "    px api graphql '{ projects { edges { node { name } } } }' --curl\n" +
+        "\n" +
+        "    # Reveal the raw token in curl output\n" +
+        "    px api graphql '{ projects { edges { node { name } } } }' --curl --show-token\n" +
+        "\n" +
+        "  Curl mode prints the request without executing it.\n" +
+        "  Auth tokens are masked by default. Use --show-token with --curl to reveal them."
     )
     .argument("<query>", "GraphQL query string")
     .option("--endpoint <url>", "Phoenix API endpoint (or set PHOENIX_HOST)")
     .option("--api-key <key>", "Phoenix API key (or set PHOENIX_API_KEY)")
+    .option("--curl", "Print the equivalent curl command instead of executing the request")
+    .option(
+      "--show-token",
+      "Show the raw Authorization token in curl output (requires --curl)"
+    )
     .action(apiGraphqlHandler);
 }
 

--- a/js/packages/phoenix-cli/src/curl.ts
+++ b/js/packages/phoenix-cli/src/curl.ts
@@ -1,0 +1,85 @@
+import { obscureApiKey } from "./commands/auth";
+
+export interface RenderCurlCommandOptions {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  maskTokens: boolean;
+}
+
+function shellEscape(value: string): string {
+  return "'" + value.replace(/'/g, "'\"'\"'") + "'";
+}
+
+/**
+ * Normalize headers through the platform `Headers` implementation so curl
+ * output mirrors how `fetch` combines duplicate logical headers such as
+ * `authorization` + `Authorization`.
+ */
+function normalizeHeaders(headers: Record<string, string>): Array<[string, string]> {
+  const normalizedHeaders = new Headers();
+  const headerNames = new Map<string, string>();
+
+  for (const [key, value] of Object.entries(headers)) {
+    normalizedHeaders.append(key, value);
+    headerNames.set(key.toLowerCase(), headerNames.get(key.toLowerCase()) ?? key);
+  }
+
+  return Array.from(normalizedHeaders.entries()).map(([key, value]) => [
+    headerNames.get(key) ?? key,
+    value,
+  ]);
+}
+
+function maskHeaderValue({
+  key,
+  value,
+  maskTokens,
+}: {
+  key: string;
+  value: string;
+  maskTokens: boolean;
+}): string {
+  if (!maskTokens || key.toLowerCase() !== "authorization") {
+    return value;
+  }
+
+  const match = value.match(/^(\S+)\s+(.+)$/);
+  if (match) {
+    const [, prefix, token] = match;
+    return `${prefix} ${obscureApiKey(token)}`;
+  }
+
+  return obscureApiKey(value);
+}
+
+/**
+ * Renders a pipe-friendly multiline curl command that matches the request
+ * Phoenix CLI would send over `fetch`.
+ */
+export function renderCurlCommand({
+  method,
+  url,
+  headers,
+  body,
+  maskTokens,
+}: RenderCurlCommandOptions): string {
+  const lines = ["curl \\"];
+
+  lines.push(`  -X ${method.toUpperCase()} \\`);
+
+  for (const [key, value] of normalizeHeaders(headers)) {
+    lines.push(
+      `  -H ${shellEscape(`${key}: ${maskHeaderValue({ key, value, maskTokens })}`)} \\`
+    );
+  }
+
+  if (body !== undefined) {
+    lines.push(`  --data-raw ${shellEscape(body)} \\`);
+  }
+
+  lines.push(`  ${shellEscape(url)}`);
+
+  return lines.join("\n");
+}

--- a/js/packages/phoenix-cli/test/api.test.ts
+++ b/js/packages/phoenix-cli/test/api.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isNonQuery } from "../src/commands/api";
+import {
+  buildGraphqlRequest,
+  createApiCommand,
+  isNonQuery,
+} from "../src/commands/api";
+import { renderCurlCommand } from "../src/curl";
 
 describe("isNonQuery", () => {
   it("returns false for an anonymous shorthand query", () => {
@@ -79,5 +84,273 @@ describe("isNonQuery", () => {
 
   it("returns true for subscription with leading whitespace", () => {
     expect(isNonQuery({ query: "  subscription { x }" })).toBe(true);
+  });
+});
+
+describe("buildGraphqlRequest", () => {
+  it("builds the same request shape used by the live command", () => {
+    const request = buildGraphqlRequest({
+      query: "{ projects { edges { node { name } } } }",
+      config: {
+        endpoint: "http://localhost:6006/",
+        apiKey: "secret-token",
+        headers: {
+          "X-Trace": "enabled",
+        },
+      },
+    });
+
+    expect(request).toEqual({
+      url: "http://localhost:6006/graphql",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Trace": "enabled",
+        Authorization: "Bearer secret-token",
+      },
+      body: JSON.stringify({
+        query: "{ projects { edges { node { name } } } }",
+      }),
+    });
+  });
+});
+
+describe("renderCurlCommand", () => {
+  it("renders multiline curl output with masked auth by default", () => {
+    const command = renderCurlCommand({
+      method: "POST",
+      url: "http://localhost:6006/graphql",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer secret-token",
+      },
+      body: JSON.stringify({
+        query: "{ project(name: \"Bob's\") { name } }",
+      }),
+      maskTokens: true,
+    });
+
+    expect(command).toContain("curl \\");
+    expect(command).toContain("  -X POST \\");
+    expect(command).toContain(
+      "  -H 'Authorization: Bearer ************************************' \\"
+    );
+    expect(command).toContain("Bob'\"'\"'s");
+    expect(command).toContain("  'http://localhost:6006/graphql'");
+  });
+
+  it("reveals the raw token when masking is disabled", () => {
+    const command = renderCurlCommand({
+      method: "POST",
+      url: "http://localhost:6006/graphql",
+      headers: {
+        Authorization: "Bearer secret-token",
+      },
+      maskTokens: false,
+    });
+
+    expect(command).toContain("Authorization: Bearer secret-token");
+  });
+
+  it("masks non-bearer authorization headers too", () => {
+    const command = renderCurlCommand({
+      method: "POST",
+      url: "http://localhost:6006/graphql",
+      headers: {
+        Authorization: "Basic abc123",
+      },
+      maskTokens: true,
+    });
+
+    expect(command).toContain(
+      "  -H 'Authorization: Basic ************************************' \\"
+    );
+    expect(command).not.toContain("Basic abc123");
+  });
+
+  it("normalizes mixed-case duplicate headers the same way fetch does", () => {
+    const command = renderCurlCommand({
+      method: "POST",
+      url: "http://localhost:6006/graphql",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer env-secret",
+        Authorization: "Bearer cli-secret",
+        "content-type": "application/custom+json",
+      },
+      maskTokens: false,
+    });
+
+    expect(command).toContain(
+      "  -H 'authorization: Bearer env-secret, Bearer cli-secret' \\"
+    );
+    expect(command).toContain(
+      "  -H 'Content-Type: application/json, application/custom+json' \\"
+    );
+    expect(command).not.toContain("  -H 'Authorization: Bearer cli-secret' \\");
+    expect(command).not.toContain(
+      "  -H 'content-type: application/custom+json' \\"
+    );
+  });
+});
+
+describe("api graphql command", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("executes fetch in normal mode", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: {
+          projects: {
+            edges: [],
+          },
+        },
+      }),
+    });
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApiCommand().parseAsync(
+      [
+        "graphql",
+        "{ projects { edges { node { name } } } }",
+        "--endpoint",
+        "http://localhost:6006",
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          data: {
+            projects: {
+              edges: [],
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints curl and does not execute fetch when --curl is set", async () => {
+    const fetchMock = vi.fn();
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApiCommand().parseAsync(
+      [
+        "graphql",
+        "{ projects { edges { node { name } } } }",
+        "--endpoint",
+        "http://localhost:6006",
+        "--api-key",
+        "secret-token",
+        "--curl",
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("curl \\"));
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining("  -X POST \\")
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "  -H 'Content-Type: application/json' \\\n"
+      )
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "  -H 'Authorization: Bearer ************************************' \\\n"
+      )
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `  --data-raw '${JSON.stringify({
+          query: "{ projects { edges { node { name } } } }",
+        })}' \\`
+      )
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining("  'http://localhost:6006/graphql'")
+    );
+  });
+
+  it("rejects --show-token when --curl is not set", async () => {
+    const fetchMock = vi.fn();
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createApiCommand().parseAsync(
+        [
+          "graphql",
+          "{ projects { edges { node { name } } } }",
+          "--endpoint",
+          "http://localhost:6006",
+          "--show-token",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow("process.exit:1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Error: --show-token can only be used with --curl."
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("still rejects mutations in curl mode", async () => {
+    const fetchMock = vi.fn();
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createApiCommand().parseAsync(
+        [
+          "graphql",
+          'mutation { createProject(name: "x") { id } }',
+          "--endpoint",
+          "http://localhost:6006",
+          "--curl",
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow("process.exit:1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Error: Only queries are permitted. Mutations and subscriptions are not allowed."
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
Refs #12044

## Summary
- add `--curl` to `px api graphql` to print the equivalent curl command instead of executing the request
- add `--show-token` as a curl-only flag to reveal the raw authorization token when explicitly requested
- keep request construction shared between live execution and curl rendering so the two paths do not drift

## Scope
- implements `--curl` for `px api graphql` only
- does not broaden the feature to other CLI commands that may map to multiple HTTP requests

## Behavior
- prints method, headers, body, and URL
- masks authorization values by default, including values from `PHOENIX_API_KEY` and `PHOENIX_CLIENT_HEADERS`
- does not execute the request when `--curl` is set
- rejects `--show-token` unless `--curl` is also present
- normalizes duplicate logical headers to match live `fetch` behavior

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- manual smoke tests against a local Phoenix server for normal execution, `--curl`, `--curl --show-token`, and error paths
- transport-level check confirming curl mode performs no network request
