### PR TITLE
chore: mark phoenix-release-notes skill as internal

### DIFF
--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -5,6 +5,7 @@ description: >
   user asks to write release notes, document a release, update release documentation, or mentions
   undocumented releases. Also trigger when the user wants to update GitHub release descriptions,
   add entries to the release notes page, or asks what changed in a recent Phoenix version.
+internal: true
 ---
 
 # Release Notes

--- a/.claude/skills/phoenix-release-notes
+++ b/.claude/skills/phoenix-release-notes
@@ -1,0 +1,1 @@
+../../.agents/skills/phoenix-release-notes


### PR DESCRIPTION
## Summary
- Adds `internal: true` to the phoenix-release-notes skill frontmatter so it doesn't appear as a user-invocable slash command
- Adds the `.claude/skills/phoenix-release-notes` symlink (matching existing skill pattern)

## Test plan
- [ ] Verify skill is no longer listed as a slash command
- [ ] Verify skill still triggers correctly when release notes tasks are requested