### PR TITLE
docs: add release notes for brute force login protection

### DIFF
--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -54,6 +54,13 @@ Span queries now support filtering by trace ID and parent relationships, enablin
 The Playground now displays evaluation metrics, cost, and latency aggregates in real-time as dataset experiments run. Metrics update incrementally every ~2 seconds, providing immediate feedback on experiment performance without waiting for completion.
 </Update>
 
+<Update label="03.04.2026">
+## [03.04.2026: Brute Force Login Protection](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
+**Available in arize-phoenix 13.8.0+**
+
+Phoenix now automatically protects login endpoints against brute force attacks. After 5 consecutive failed attempts, the account is temporarily locked for 5 minutes. Enabled by default with configurable thresholds via `PHOENIX_BRUTE_FORCE_LOGIN_PROTECTION_MAX_ATTEMPTS`.
+</Update>
+
 <Update label="03.07.2026">
 ## [03.07.2026: Unified Dataset Upload with Drag-and-Drop](/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api)
 **Available in arize-phoenix 13.9.0+**

--- a/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api.mdx
+++ b/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api.mdx
@@ -144,6 +144,19 @@ March 4, 2026
 
 The Playground now displays evaluation metrics, cost, and latency aggregates in real-time as dataset experiments run. Metrics update incrementally every ~2 seconds, providing immediate feedback on experiment performance without waiting for completion.
 
+# Brute Force Login Protection
+
+March 4, 2026
+
+**Available in arize-phoenix 13.8.0+**
+
+Phoenix now automatically protects login endpoints against brute force attacks. After 5 consecutive failed login attempts within a 5-minute window, the account is temporarily locked for 5 minutes. This applies to both basic auth and LDAP login endpoints.
+
+- **Enabled by default** — no configuration required
+- **Configurable attempt threshold** via `PHOENIX_BRUTE_FORCE_LOGIN_PROTECTION_MAX_ATTEMPTS` (default: 5)
+- **Disable if needed** by setting `PHOENIX_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION=true`
+- **Automatic recovery** — the lockout resets after the 5-minute window expires, and clears immediately on successful login or password reset
+
 # Unified Dataset Upload with Drag-and-Drop
 
 March 7, 2026


### PR DESCRIPTION
## Summary

- Adds release note entry for the brute force login protection feature shipped in arize-phoenix v13.8.0 (March 4, 2026)
- This was the only undocumented user-facing feature across the last 30 GitHub releases
- Documents the `PHOENIX_BRUTE_FORCE_LOGIN_PROTECTION_MAX_ATTEMPTS` and `PHOENIX_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION` environment variables

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm aggregate file link resolves to the correct section