### PR TITLE
feat(cli): add px session-delete command

### DIFF
--- a/js/packages/phoenix-cli/src/cli.ts
+++ b/js/packages/phoenix-cli/src/cli.ts
@@ -15,6 +15,7 @@ import {
   createPromptCommand,
   createPromptsCommand,
   createSessionCommand,
+  createSessionDeleteCommand,
   createSessionsCommand,
   createTraceCommand,
   createTracesCommand,
@@ -36,6 +37,7 @@ export function main() {
   program.addCommand(createDatasetCommand());
   program.addCommand(createSessionsCommand());
   program.addCommand(createSessionCommand());
+  program.addCommand(createSessionDeleteCommand());
   program.addCommand(createExperimentsCommand());
   program.addCommand(createExperimentCommand());
   program.addCommand(createPromptsCommand());

--- a/js/packages/phoenix-cli/src/commands/index.ts
+++ b/js/packages/phoenix-cli/src/commands/index.ts
@@ -9,6 +9,7 @@ export * from "./experiments";
 export * from "./experiment";
 export * from "./sessions";
 export * from "./session";
+export * from "./sessionDelete";
 export * from "./prompts";
 export * from "./prompt";
 export * from "./api";

--- a/js/packages/phoenix-cli/src/commands/sessionDelete.ts
+++ b/js/packages/phoenix-cli/src/commands/sessionDelete.ts
@@ -1,0 +1,118 @@
+import * as readline from "readline";
+import { Command } from "commander";
+
+import { createPhoenixClient } from "../client";
+import { getConfigErrorMessage, resolveConfig } from "../config";
+import { ExitCode, getExitCodeForError } from "../exitCodes";
+import { writeError, writeOutput, writeProgress } from "../io";
+
+interface SessionDeleteOptions {
+  endpoint?: string;
+  apiKey?: string;
+  progress?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Prompt the user for confirmation via stdin.
+ * Returns true if the user types "y" or "yes" (case-insensitive).
+ */
+function confirm(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  return new Promise((resolve) => {
+    rl.question(`${message} [y/N] `, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+/**
+ * Session delete command handler
+ */
+async function sessionDeleteHandler(
+  sessionIdentifier: string,
+  options: SessionDeleteOptions,
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    if (!config.endpoint) {
+      const errors = [
+        "Phoenix endpoint not configured. Set PHOENIX_HOST environment variable or use --endpoint flag.",
+      ];
+      writeError({ message: getConfigErrorMessage({ errors }) });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    if (!options.yes) {
+      const confirmed = await confirm(
+        `Delete session "${sessionIdentifier}" and all associated traces? This cannot be undone.`,
+      );
+      if (!confirmed) {
+        writeOutput({ message: "Cancelled." });
+        process.exit(ExitCode.CANCELLED);
+      }
+    }
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Deleting session ${sessionIdentifier}...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.DELETE(
+      "/v1/sessions/{session_identifier}",
+      {
+        params: {
+          path: {
+            session_identifier: sessionIdentifier,
+          },
+        },
+      },
+    );
+
+    if (response.error) {
+      throw new Error(
+        `Failed to delete session: ${JSON.stringify(response.error)}`,
+      );
+    }
+
+    writeOutput({ message: `Session "${sessionIdentifier}" deleted.` });
+  } catch (error) {
+    writeError({
+      message: `Error deleting session: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+/**
+ * Create the session-delete command
+ */
+export function createSessionDeleteCommand(): Command {
+  const command = new Command("session-delete");
+
+  command
+    .description("Delete a session and its associated traces")
+    .argument(
+      "<session-identifier>",
+      "Session identifier (GlobalID or user-provided session_id)",
+    )
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--no-progress", "Disable progress indicators")
+    .option("--yes", "Skip confirmation prompt")
+    .action(sessionDeleteHandler);
+
+  return command;
+}


### PR DESCRIPTION
fixes #12038

## Summary

Adds `px session-delete <identifier>` command to delete a session and its associated traces via `DELETE /v1/sessions/{session_identifier}`.

## Details

The implementation follows the patterns established in `session.ts` and `dataset.ts`:

- Accepts session identifier as a positional argument (GlobalID or user-provided session_id)
- Prompts for confirmation before deletion since it cascades to traces/spans
- `--yes` flag skips the confirmation prompt for scripting/CI use
- Standard options: `--endpoint`, `--api-key`, `--no-progress`
- Uses `ExitCode.CANCELLED` (2) when user declines confirmation
- Uses Node.js built-in `readline` for the confirmation prompt (no new dependencies)

### Usage

```bash
# Interactive (prompts for confirmation)
px session-delete my-session-id

# Non-interactive (skips confirmation)
px session-delete my-session-id --yes

# With explicit endpoint
px session-delete my-session-id --endpoint http://localhost:6006 --yes
```

## Shortcomings

- Uses `readline` for confirmation instead of a richer prompt library — keeps dependencies minimal but the UX is basic. Can be upgraded later if the team adds an interactive prompt dependency.
- Named `session-delete` (hyphenated) rather than `session delete` (subcommand) to match the existing flat command structure.

## Checklist

- [x] The purpose of the PR: Implement `px session delete` per #12038
- [x] Test plan: TypeScript compiles cleanly (`pnpm run typecheck`), `oxlint` passes with 0 warnings
- [x] Test results: Build succeeds across the full JS workspace (`pnpm run -r build`)