### PR TITLE
Fix tool parameter mapping in chat completion API

### DIFF
--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -2243,7 +2243,14 @@ class GoogleStreamingClient(PlaygroundStreamingClient["GoogleAsyncClient"]):
             config_dict["system_instruction"] = system_prompt
 
         if tools:
-            function_declarations = [types.FunctionDeclaration(**tool) for tool in tools]
+            function_declarations = [
+                types.FunctionDeclaration(
+                    name=tool["name"],
+                    description=tool.get("description"),
+                    parameters_json_schema=tool.get("parameters"),
+                )
+                for tool in tools
+            ]
             config_dict["tools"] = [types.Tool(function_declarations=function_declarations)]
 
         config = types.GenerateContentConfig.model_validate(config_dict)


### PR DESCRIPTION
## Summary
Updated the tool function declaration construction to explicitly map tool dictionary fields to the correct parameter names expected by the `FunctionDeclaration` type.

## Key Changes
- Changed from unpacking tool dictionary directly (`**tool`) to explicit field mapping
- Maps `tool["name"]` to the `name` parameter
- Maps `tool.get("description")` to the `description` parameter
- Maps `tool.get("parameters")` to the `parameters_json_schema` parameter

## Implementation Details
The previous implementation used dictionary unpacking which assumed the tool dictionary keys matched the `FunctionDeclaration` constructor parameter names exactly. The updated approach explicitly maps the incoming tool structure to the expected parameter names, providing better clarity and handling potential key mismatches between the API input format and the underlying type definition.

https://claude.ai/code/session_017rTS8BWEMU1e7nVo9mfnYN