### PR TITLE
docs(cli): add changeset and docs for px docs fetch

### DIFF
--- a/js/.changeset/cli-docs-fetch.md
+++ b/js/.changeset/cli-docs-fetch.md
@@ -1,0 +1,6 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add `px docs fetch` command to download Phoenix documentation markdown for coding agents.
+Fetches from the llms.txt index with workflow filtering, concurrent downloads, and auto-generated index files.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -256,6 +256,29 @@ $ px api graphql '{ projectCount datasetCount promptCount evaluatorCount }'
 
 ---
 
+### `px docs fetch`
+
+Download Phoenix documentation markdown files for use by coding agents. Fetches pages from the [llms.txt](https://arize.com/docs/phoenix/llms.txt) index, filtered by workflow category, and writes them to a local directory with auto-generated index files.
+
+```bash
+px docs fetch                                # fetch default workflows
+px docs fetch --workflow tracing             # fetch only tracing docs
+px docs fetch --workflow tracing --workflow evaluation
+px docs fetch --dry-run                      # preview without downloading
+px docs fetch --refresh                      # clear output dir and re-download
+```
+
+| Option                | Description                                                                                       | Default                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `--workflow <name>`   | Filter by workflow category (repeatable). Values: `tracing`, `evaluation`, `datasets`, `prompts`, `integrations`, `sdk`, `self-hosting`, `all` | `tracing`, `evaluation`, `datasets`, `prompts`, `integrations` |
+| `--output-dir <dir>`  | Output directory for downloaded docs                                                              | `.px/docs`                                               |
+| `--dry-run`           | Discover links only; do not write files                                                           | `false`                                                  |
+| `--refresh`           | Clear output directory before downloading                                                         | `false`                                                  |
+| `--strict`            | Fail command if any page download fails                                                           | `false`                                                  |
+| `--workers <n>`       | Number of concurrent download workers                                                             | `10`                                                     |
+
+---
+
 ## JSON output shape
 
 All commands output JSON. Use `--format raw` for compact JSON and `--no-progress` to suppress stderr when piping:

--- a/skills/phoenix-cli/SKILL.md
+++ b/skills/phoenix-cli/SKILL.md
@@ -107,3 +107,18 @@ px api graphql '{ __type(name: "Project") { fields { name type { name } } } }' |
 ```
 
 Key root fields: `projects`, `datasets`, `prompts`, `evaluators`, `projectCount`, `datasetCount`, `promptCount`, `evaluatorCount`, `viewer`.
+
+## Docs
+
+Download Phoenix documentation markdown for local use by coding agents.
+
+```bash
+px docs fetch                                # fetch default workflow docs to .px/docs
+px docs fetch --workflow tracing             # fetch only tracing docs
+px docs fetch --workflow tracing --workflow evaluation
+px docs fetch --dry-run                      # preview what would be downloaded
+px docs fetch --refresh                      # clear .px/docs and re-download
+px docs fetch --output-dir ./my-docs         # custom output directory
+```
+
+Key options: `--workflow` (repeatable, values: `tracing`, `evaluation`, `datasets`, `prompts`, `integrations`, `sdk`, `self-hosting`, `all`), `--dry-run`, `--refresh`, `--output-dir` (default `.px/docs`), `--workers` (default 10).


### PR DESCRIPTION
## Summary
- Add minor changeset for `@arizeai/phoenix-cli` covering the new `px docs fetch` command
- Add `px docs fetch` section to the CLI README with usage examples and options table
- Add `## Docs` section to the `phoenix-cli` skill with command examples and key options

Follow-up to ce9ee48f0 (`feat(cli): add px docs fetch command`), which shipped without a changeset or documentation.

## Test plan
- [ ] Verify changeset format matches existing changesets
- [ ] Confirm README renders properly on GitHub
- [ ] Confirm SKILL.md option names match `src/commands/docs.ts`