### PR TITLE
fix(js): re-export suppressTracing from phoenix-otel

### DIFF
--- a/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
+++ b/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument.mdx
@@ -1116,9 +1116,8 @@ with suppress_tracing():
 
 <Tab title="TypeScript" icon="js">
 ```typescript
-import { suppressTracing } from "@opentelemetry/core";
 import { withSpan } from "@arizeai/openinference-core";
-import { trace, context } from "@arizeai/phoenix-otel";
+import { trace, context, suppressTracing } from "@arizeai/phoenix-otel";
 
 await context.with(suppressTracing(context.active()), async () => {
   // this trace will not be recorded

--- a/js/packages/phoenix-otel/src/index.ts
+++ b/js/packages/phoenix-otel/src/index.ts
@@ -5,6 +5,7 @@ export {
   type Tracer,
   SpanStatusCode,
 } from "@opentelemetry/api";
+export { suppressTracing } from "@opentelemetry/core";
 export { registerInstrumentations } from "@opentelemetry/instrumentation";
 export { type Instrumentation } from "@opentelemetry/instrumentation";
 export { type NodeTracerProvider } from "@opentelemetry/sdk-trace-node";

--- a/js/packages/phoenix-otel/test/suppressTracing.test.ts
+++ b/js/packages/phoenix-otel/test/suppressTracing.test.ts
@@ -1,0 +1,15 @@
+import { suppressTracing as originalSuppressTracing } from "@opentelemetry/core";
+import { describe, expect, test } from "vitest";
+
+import { suppressTracing } from "../src";
+
+describe("suppressTracing re-export", () => {
+  test("should be re-exported from the package", () => {
+    expect(suppressTracing).toBeDefined();
+    expect(typeof suppressTracing).toBe("function");
+  });
+
+  test("should be the same function as @opentelemetry/core suppressTracing", () => {
+    expect(suppressTracing).toBe(originalSuppressTracing);
+  });
+});


### PR DESCRIPTION
## Summary

- Re-exports `suppressTracing` from `@opentelemetry/core` in `@arizeai/phoenix-otel` so users can import it alongside `trace`, `context`, and `SpanStatusCode` without needing a separate `@opentelemetry/core` dependency
- Updates the docs example in `instrument.mdx` to show the simplified single-package import
- Adds a test verifying `suppressTracing` is referentially identical to the original from `@opentelemetry/core`

Resolves #10137

## Test plan

- [x] Existing tests pass (`pnpm test` in `js/packages/phoenix-otel`)
- [x] New `suppressTracing.test.ts` verifies the re-export is defined, is a function, and is referentially equal to `@opentelemetry/core`'s `suppressTracing`