### PR TITLE
refactor: extract semantic table color tokens and add tooltip arrows

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -992,6 +992,13 @@ export const derivedCSS = (theme: ThemeContextType["theme"]) => css`
 
     // Table tokens
     --global-table-pinned-column-background-color: var(--global-color-gray-75);
+    --global-table-header-background-color: var(--global-color-gray-75);
+    --global-table-row-border-color: var(--global-color-gray-200);
+    --global-table-row-selected-background-color: var(
+      --global-color-primary-100
+    );
+    --global-table-bordered-cell-border-color: var(--global-color-gray-100);
+    --global-table-pagination-border-color: var(--global-color-gray-300);
 
     --global-border-size-thin: var(--global-dimension-static-size-10);
     --global-border-size-thick: var(--global-dimension-static-size-25);

--- a/app/src/components/table/styles.ts
+++ b/app/src/components/table/styles.ts
@@ -14,6 +14,7 @@ export const tableCSS = css`
     position: sticky;
     top: 0;
     z-index: 2;
+    background-color: var(--global-table-header-background-color);
     tr {
       th {
         padding: var(--global-dimension-size-100)
@@ -78,7 +79,7 @@ export const tableCSS = css`
       height: 100%;
       &:not(:last-of-type) {
         & > td {
-          border-bottom: 1px solid var(--global-color-gray-200);
+          border-bottom: 1px solid var(--global-table-row-border-color);
         }
       }
       & > td {
@@ -86,7 +87,7 @@ export const tableCSS = css`
           var(--global-dimension-size-200);
       }
       &[data-selected="true"] {
-        background-color: var(--global-color-primary-100);
+        background-color: var(--global-table-row-selected-background-color);
       }
     }
   }
@@ -96,10 +97,10 @@ export const borderedTableCSS = css`
   tbody:not(.is-empty) {
     tr {
       & > td {
-        border-bottom: 1px solid var(--global-color-gray-100);
+        border-bottom: 1px solid var(--global-table-bordered-cell-border-color);
       }
       & > td:not(:last-of-type) {
-        border-right: 1px solid var(--global-color-gray-100);
+        border-right: 1px solid var(--global-table-bordered-cell-border-color);
       }
     }
   }
@@ -133,7 +134,7 @@ export const paginationCSS = css`
   align-items: center;
   padding: var(--global-dimension-size-100);
   gap: var(--global-dimension-size-50);
-  border-top: 1px solid var(--global-color-gray-300);
+  border-top: 1px solid var(--global-table-pagination-border-color);
 `;
 
 //These are the important styles to make sticky column pinning work!

--- a/app/src/pages/experiment/ExampleDetailsPaginator.tsx
+++ b/app/src/pages/experiment/ExampleDetailsPaginator.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/react";
 import { startTransition } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -9,6 +8,7 @@ import {
   Icons,
   KeyboardToken,
   Tooltip,
+  TooltipArrow,
   TooltipTrigger,
 } from "@phoenix/components";
 
@@ -60,14 +60,8 @@ export const ExampleDetailsPaginator = ({
           onPress={handleNext}
           leadingVisual={<Icon svg={<Icons.ArrowDownwardOutline />} />}
         ></Button>
-        <Tooltip
-          offset={4}
-          css={css`
-            border-color: var(--global-border-color-default);
-            border-radius: var(--global-rounding-medium);
-            padding: var(--global-dimension-static-size-100);
-          `}
-        >
+        <Tooltip offset={4}>
+          <TooltipArrow />
           <Flex direction="row" gap="size-100" alignItems="center">
             <span>Next</span>
             <KeyboardToken>{NEXT_EXAMPLE_HOTKEY}</KeyboardToken>
@@ -82,14 +76,8 @@ export const ExampleDetailsPaginator = ({
           onPress={handlePrevious}
           leadingVisual={<Icon svg={<Icons.ArrowUpwardOutline />} />}
         ></Button>
-        <Tooltip
-          offset={4}
-          css={css`
-            border-color: var(--global-border-color-default);
-            border-radius: var(--global-rounding-medium);
-            padding: var(--global-dimension-static-size-100);
-          `}
-        >
+        <Tooltip offset={4}>
+          <TooltipArrow />
           <Flex direction="row" gap="size-100" alignItems="center">
             <span>Previous</span>
             <KeyboardToken>{PREVIOUS_EXAMPLE_HOTKEY}</KeyboardToken>

--- a/app/src/pages/trace/TraceDetailsPaginator.tsx
+++ b/app/src/pages/trace/TraceDetailsPaginator.tsx
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import { startTransition } from "react";
-import { Tooltip, TooltipTrigger } from "react-aria-components";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import {
@@ -9,7 +8,9 @@ import {
   Icon,
   Icons,
   KeyboardToken,
-  View,
+  Tooltip,
+  TooltipArrow,
+  TooltipTrigger,
 } from "@phoenix/components";
 import {
   getNeighbors,
@@ -76,17 +77,11 @@ export const TraceDetailsPaginator = ({
             }}
           />
           <Tooltip offset={4}>
-            <View
-              borderWidth="thin"
-              borderColor="default"
-              borderRadius="medium"
-              padding="size-100"
-            >
-              <Flex direction="row" gap="size-100" alignItems="center">
-                <span>Next trace</span>
-                <KeyboardToken>{NEXT_TRACE_HOTKEY}</KeyboardToken>
-              </Flex>
-            </View>
+            <TooltipArrow />
+            <Flex direction="row" gap="size-100" alignItems="center">
+              <span>Next trace</span>
+              <KeyboardToken>{NEXT_TRACE_HOTKEY}</KeyboardToken>
+            </Flex>
           </Tooltip>
         </TooltipTrigger>
         <TooltipTrigger delay={100}>
@@ -103,17 +98,11 @@ export const TraceDetailsPaginator = ({
             }}
           />
           <Tooltip offset={4}>
-            <View
-              borderWidth="thin"
-              borderColor="default"
-              borderRadius="medium"
-              padding="size-100"
-            >
-              <Flex direction="row" gap="size-100" alignItems="center">
-                <span>Previous trace</span>
-                <KeyboardToken>{PREVIOUS_TRACE_HOTKEY}</KeyboardToken>
-              </Flex>
-            </View>
+            <TooltipArrow />
+            <Flex direction="row" gap="size-100" alignItems="center">
+              <span>Previous trace</span>
+              <KeyboardToken>{PREVIOUS_TRACE_HOTKEY}</KeyboardToken>
+            </Flex>
           </Tooltip>
         </TooltipTrigger>
       </Flex>


### PR DESCRIPTION
## Summary
- Extract hardcoded color tokens from table styles into semantic CSS variables in GlobalStyles: `--global-table-header-background-color`, `--global-table-row-border-color`, `--global-table-row-selected-background-color`, `--global-table-bordered-cell-border-color`, `--global-table-pagination-border-color`
- Add `TooltipArrow` to `ExampleDetailsPaginator` and `TraceDetailsPaginator` tooltips, replacing inline CSS overrides and `View` wrappers

## Test plan
- [ ] Verify table header, row borders, selected rows, bordered cells, and pagination borders render correctly in both light and dark themes
- [ ] Verify tooltip arrows appear on paginator buttons in trace detail and experiment example detail views