### PR TITLE
fix(prompts): replace fetchQuery with loadQuery in promptConfigLoader

### DIFF
--- a/app/src/pages/prompt/PromptConfigPage.tsx
+++ b/app/src/pages/prompt/PromptConfigPage.tsx
@@ -1,14 +1,21 @@
+import { usePreloadedQuery } from "react-relay";
 import { useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Flex, View } from "@phoenix/components";
 import type { promptConfigLoader } from "@phoenix/pages/prompt/promptConfigLoader";
+import { promptConfigLoaderQueryNode } from "@phoenix/pages/prompt/promptConfigLoader";
 
+import type { promptConfigLoaderQuery } from "./__generated__/promptConfigLoaderQuery.graphql";
 import { PromptVersionTagsConfigCard } from "./PromptVersionTagsConfigCard";
 
 export function PromptConfigPage() {
   const loaderData = useLoaderData<typeof promptConfigLoader>();
   invariant(loaderData, "loaderData is required");
+  const data = usePreloadedQuery<promptConfigLoaderQuery>(
+    promptConfigLoaderQueryNode,
+    loaderData.queryRef
+  );
 
   return (
     <Flex direction="row" height="100%">
@@ -26,7 +33,7 @@ export function PromptConfigPage() {
             marginEnd="auto"
             maxWidth={900}
           >
-            <PromptVersionTagsConfigCard prompt={loaderData.prompt} />
+            <PromptVersionTagsConfigCard prompt={data.prompt} />
           </Flex>
         </View>
       </View>

--- a/app/src/pages/prompt/promptConfigLoader.ts
+++ b/app/src/pages/prompt/promptConfigLoader.ts
@@ -1,27 +1,31 @@
-import { fetchQuery, graphql } from "react-relay";
+import { graphql, loadQuery } from "react-relay";
 import type { LoaderFunctionArgs } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
 import type { promptConfigLoaderQuery } from "./__generated__/promptConfigLoaderQuery.graphql";
 
-export const promptConfigLoader = async ({ params }: LoaderFunctionArgs) => {
+export const promptConfigLoaderQueryNode = graphql`
+  query promptConfigLoaderQuery($id: ID!) {
+    prompt: node(id: $id) {
+      ... on Prompt {
+        ...PromptVersionTagsConfigCard_data
+      }
+    }
+  }
+`;
+
+export const promptConfigLoader = ({ params }: LoaderFunctionArgs) => {
   const promptId = params.promptId;
   if (!promptId) {
     throw new Error("Prompt ID is required");
   }
 
-  return await fetchQuery<promptConfigLoaderQuery>(
+  const queryRef = loadQuery<promptConfigLoaderQuery>(
     RelayEnvironment,
-    graphql`
-      query promptConfigLoaderQuery($id: ID!) {
-        prompt: node(id: $id) {
-          ... on Prompt {
-            ...PromptVersionTagsConfigCard_data
-          }
-        }
-      }
-    `,
+    promptConfigLoaderQueryNode,
     { id: promptId }
-  ).toPromise();
+  );
+
+  return { queryRef };
 };


### PR DESCRIPTION
## Summary

- Fixes a Relay cache eviction bug in `promptConfigLoader` where `fetchQuery` was used inside a React Router route loader
- Relay cannot associate queries fetched via `fetchQuery` with any mounted component, so its GC eventually evicts the cached data while the component relying on it is still mounted — breaking the page
- Replaces `fetchQuery` with `loadQuery` + `usePreloadedQuery` so the query's cache lifetime is tied to the component

Closes #12219
Part of #12209

## Changes

- `promptConfigLoader.ts`: export the `graphql` query node as `promptConfigLoaderQueryNode`, replace `fetchQuery(...).toPromise()` with `loadQuery(...)`, return `{ queryRef }` instead of the raw data
- `PromptConfigPage.tsx`: import the query node, call `usePreloadedQuery` to get the data, pass `data.prompt` (instead of `loaderData.prompt`) to `<PromptVersionTagsConfigCard>`

## Test plan

- [ ] Navigate to a prompt's Config tab — the tags table should load and display correctly
- [ ] Verify no TypeScript errors: `cd app && pnpm tsc --noEmit` (only pre-existing `vite.config.mts` errors remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)