### PR TITLE
fix(prompts): replace fetchQuery with loadQuery in promptVersionLoader

### DIFF
--- a/app/src/pages/prompt/PromptVersionDetailsPage.tsx
+++ b/app/src/pages/prompt/PromptVersionDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { usePreloadedQuery } from "react-relay";
 import { useLoaderData, useParams } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -18,18 +19,24 @@ import {
 import { PromptChatMessagesCard } from "@phoenix/components/prompt/PromptChatMessagesCard";
 import { PromptModelConfigurationCard } from "@phoenix/pages/prompt/PromptModelConfigurationCard";
 import type { promptVersionLoader } from "@phoenix/pages/prompt/promptVersionLoader";
+import { promptVersionLoaderQueryNode } from "@phoenix/pages/prompt/promptVersionLoader";
 
 import { TagPromptVersionButton } from "../../components/prompt/TagPromptVersionButton";
-import type { promptVersionLoaderQuery$data } from "./__generated__/promptVersionLoaderQuery.graphql";
+import type {
+  promptVersionLoaderQuery,
+  promptVersionLoaderQuery$data,
+} from "./__generated__/promptVersionLoaderQuery.graphql";
 import { PromptCodeExportCard } from "./PromptCodeExportCard";
 import { PromptVersionTagsList } from "./PromptVersionTagsList";
 
 export function PromptVersionDetailsPage() {
   const loaderData = useLoaderData<typeof promptVersionLoader>();
   invariant(loaderData, "loaderData is required");
-  return (
-    <PromptVersionDetailsPageContent promptVersion={loaderData.promptVersion} />
+  const data = usePreloadedQuery<promptVersionLoaderQuery>(
+    promptVersionLoaderQueryNode,
+    loaderData.queryRef
   );
+  return <PromptVersionDetailsPageContent promptVersion={data.promptVersion} />;
 }
 
 function PromptVersionDetailsPageContent({

--- a/app/src/pages/prompt/promptVersionLoader.tsx
+++ b/app/src/pages/prompt/promptVersionLoader.tsx
@@ -1,4 +1,4 @@
-import { fetchQuery, graphql } from "react-relay";
+import { graphql, loadQuery } from "react-relay";
 import type { LoaderFunctionArgs } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
@@ -6,46 +6,46 @@ import RelayEnvironment from "@phoenix/RelayEnvironment";
 import type { promptVersionLoaderQuery } from "./__generated__/promptVersionLoaderQuery.graphql";
 
 /**
+ * The loadQuery graphql query node to be used for render-as-you-fetch.
+ */
+export const promptVersionLoaderQueryNode = graphql`
+  query promptVersionLoaderQuery($id: ID!) {
+    promptVersion: node(id: $id) {
+      __typename
+      id
+      ... on PromptVersion {
+        ...PromptInvocationParameters__main
+        ...PromptChatMessagesCard__main
+        ...PromptCodeExportCard__main
+        ...PromptModelConfigurationCard__main
+        ...PromptVersionTagsList_data
+        description
+        invocationParameters
+        modelName
+
+        tags {
+          name
+        }
+      }
+    }
+  }
+`;
+
+/**
  * Loads in the necessary page data for the prompt/:promptId/versions/:versionId page
  *
  * In other words, the data required to render a specific version of a prompt
  */
-export async function promptVersionLoader(args: LoaderFunctionArgs) {
+export function promptVersionLoader(args: LoaderFunctionArgs) {
   const { versionId } = args.params;
-  return await fetchQuery<promptVersionLoaderQuery>(
+  const queryRef = loadQuery<promptVersionLoaderQuery>(
     RelayEnvironment,
-    graphql`
-      query promptVersionLoaderQuery($id: ID!) {
-        promptVersion: node(id: $id) {
-          __typename
-          id
-          ... on PromptVersion {
-            ...PromptInvocationParameters__main
-            ...PromptChatMessagesCard__main
-            ...PromptCodeExportCard__main
-            ...PromptModelConfigurationCard__main
-            ...PromptVersionTagsList_data
-            description
-            invocationParameters
-            modelName
-
-            tags {
-              name
-            }
-          }
-        }
-      }
-    `,
+    promptVersionLoaderQueryNode,
     {
       id: versionId as string,
     }
-  )
-    .toPromise()
-    .catch(() => {
-      throw new Error("Prompt version not found");
-    });
+  );
+  return { queryRef };
 }
 
-export type PromptVersionLoaderData = Awaited<
-  ReturnType<typeof promptVersionLoader>
->;
+export type PromptVersionLoaderData = ReturnType<typeof promptVersionLoader>;


### PR DESCRIPTION
## Summary

- Replaces `fetchQuery` + `.toPromise()` with `loadQuery` in `promptVersionLoader`, returning `{ queryRef }` instead of the raw query result
- Updates `PromptVersionDetailsPage` to call `usePreloadedQuery(promptVersionLoaderQueryNode, loaderData.queryRef)` and destructure `.promptVersion` from the result
- Exports `promptVersionLoaderQueryNode` so the component can reference the query node for `usePreloadedQuery`

This fixes a Relay GC cache eviction bug: `fetchQuery` has no mounted component to anchor the cached data, so Relay's garbage collector can evict it while the page is still rendered. Using `loadQuery` + `usePreloadedQuery` ties the query's cache lifetime to the component tree.

Closes #12220
Part of #12209

## Test plan

- [ ] Navigate to a prompt version detail page and verify it renders correctly
- [ ] Navigate away and back to confirm no stale/missing data
- [ ] Confirm `pnpm tsc --noEmit` passes in `app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)