### PR TITLE
fix(auth): replace fetchQuery with loadQuery in resetPasswordLoader

### DIFF
--- a/app/src/pages/auth/ResetPasswordPage.tsx
+++ b/app/src/pages/auth/ResetPasswordPage.tsx
@@ -1,14 +1,21 @@
+import { usePreloadedQuery } from "react-relay";
 import { useLoaderData } from "react-router";
 
 import { Flex, View } from "@phoenix/components";
 
+import type { resetPasswordLoaderQuery as resetPasswordLoaderQueryType } from "./__generated__/resetPasswordLoaderQuery.graphql";
 import { AuthLayout } from "./AuthLayout";
 import { PhoenixLogo } from "./PhoenixLogo";
 import { ResetPasswordForm } from "./ResetPasswordForm";
-import type { resetPasswordLoader } from "./resetPasswordLoader";
+import type { ResetPasswordLoaderData } from "./resetPasswordLoader";
+import { resetPasswordLoaderQuery } from "./resetPasswordLoader";
 
 export function ResetPasswordPage() {
-  const loaderData = useLoaderData<typeof resetPasswordLoader>();
+  const loaderData = useLoaderData() as ResetPasswordLoaderData;
+  const data = usePreloadedQuery<resetPasswordLoaderQueryType>(
+    resetPasswordLoaderQuery,
+    loaderData.queryRef
+  );
   return (
     <AuthLayout>
       <Flex direction="column" gap="size-200" alignItems="center">
@@ -16,7 +23,7 @@ export function ResetPasswordPage() {
           <PhoenixLogo />
         </View>
       </Flex>
-      <ResetPasswordForm query={loaderData} />
+      <ResetPasswordForm query={data} />
     </AuthLayout>
   );
 }

--- a/app/src/pages/auth/resetPasswordLoader.ts
+++ b/app/src/pages/auth/resetPasswordLoader.ts
@@ -1,32 +1,48 @@
-import { fetchQuery, graphql } from "react-relay";
+import { fetchQuery, graphql, loadQuery } from "react-relay";
 import { redirect } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
-import type { resetPasswordLoaderQuery } from "./__generated__/resetPasswordLoaderQuery.graphql";
+import type { resetPasswordLoaderQuery as resetPasswordLoaderQueryType } from "./__generated__/resetPasswordLoaderQuery.graphql";
+
+/**
+ * The loadQuery graphql query node to be used for render-as-you-fetch.
+ */
+export const resetPasswordLoaderQuery = graphql`
+  query resetPasswordLoaderQuery {
+    viewer {
+      id
+      email
+    }
+    ...ResetPasswordFormQuery
+  }
+`;
 
 /**
  * Makes sure the user is logged in
  */
 export async function resetPasswordLoader() {
-  const loaderData = await fetchQuery<resetPasswordLoaderQuery>(
+  const queryRef = loadQuery<resetPasswordLoaderQueryType>(
     RelayEnvironment,
-    graphql`
-      query resetPasswordLoaderQuery {
-        viewer {
-          id
-          email
-        }
-        ...ResetPasswordFormQuery
-      }
-    `,
+    resetPasswordLoaderQuery,
+    {}
+  );
+
+  // Fetch scalar fields needed for the redirect check
+  const data = await fetchQuery<resetPasswordLoaderQueryType>(
+    RelayEnvironment,
+    resetPasswordLoaderQuery,
     {}
   ).toPromise();
 
-  if (!loaderData?.viewer) {
+  if (!data?.viewer) {
     // Should never happen but just in case
     return redirect("/login");
   }
 
-  return loaderData;
+  return { queryRef };
 }
+
+export type ResetPasswordLoaderData = {
+  queryRef: ReturnType<typeof loadQuery<resetPasswordLoaderQueryType>>;
+};


### PR DESCRIPTION
## Summary

- Replaces `fetchQuery` with `loadQuery` + `usePreloadedQuery` in `resetPasswordLoader` / `ResetPasswordPage`, fixing a Relay GC cache eviction bug (Relay cannot associate `fetchQuery` results with a mounted component, so its GC can evict the data while the page is still rendered)
- Exports the `resetPasswordLoaderQuery` node from the loader so `ResetPasswordPage` can pass it to `usePreloadedQuery`
- Keeps a small `fetchQuery` call in the loader solely for the redirect check (`viewer` presence), following the same pattern as `promptLoader.tsx`
- Exports `ResetPasswordLoaderData` type to work around React Router's `useLoaderData` inference limitations when the loader can also return a `redirect`

Closes #12216
Part of #12209

## Test plan

- [ ] Navigate to the reset-password page while logged in — form renders and pre-fills email correctly
- [ ] Navigate to the reset-password page while logged out — redirects to `/login`
- [ ] Submit a valid password change — succeeds and redirects to `/login?message=password_reset`
- [ ] Submit with wrong current password — shows error notification
- [ ] Leave the page mounted for an extended session — data remains available (no GC eviction)
- [ ] `cd app && pnpm tsc --noEmit` passes (only pre-existing `vite.config.mts` errors present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)