### PR TITLE
fix(auth): replace fetchQuery with loadQuery in authenticatedRootLoader

### DIFF
--- a/app/src/pages/AuthenticatedRoot.tsx
+++ b/app/src/pages/AuthenticatedRoot.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { usePreloadedQuery } from "react-relay";
 import { Outlet, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
@@ -6,16 +7,25 @@ import { isFullStoryEnabled, setIdentity } from "@phoenix/analytics/fullstory";
 import { AgentChatWidget } from "@phoenix/components/agent";
 import { AgentProvider } from "@phoenix/contexts/AgentContext";
 import { ViewerProvider } from "@phoenix/contexts/ViewerContext";
-import type { authenticatedRootLoader } from "@phoenix/pages/authenticatedRootLoader";
+import type { AuthenticatedRootLoaderDataResolved } from "@phoenix/pages/authenticatedRootLoader";
+import { authenticatedRootLoaderQuery } from "@phoenix/pages/authenticatedRootLoader";
 
+import type { authenticatedRootLoaderQuery as AuthenticatedRootLoaderQueryType } from "./__generated__/authenticatedRootLoaderQuery.graphql";
 import { AppAlerts } from "./AppAlerts";
 
 /**
  * The root of the authenticated application. Note that authentication might be entirely disabled
  */
 export function AuthenticatedRoot() {
-  const loaderData = useLoaderData<typeof authenticatedRootLoader>();
+  // Redirects are handled by React Router before the component mounts, so the
+  // loader data here is always the non-redirect branch.
+  const loaderData = useLoaderData() as AuthenticatedRootLoaderDataResolved;
   invariant(loaderData, "loaderData is required");
+
+  const queryData = usePreloadedQuery<AuthenticatedRootLoaderQueryType>(
+    authenticatedRootLoaderQuery,
+    loaderData.queryRef
+  );
 
   // Set analytics if enabled
   useEffect(() => {
@@ -30,7 +40,7 @@ export function AuthenticatedRoot() {
   }, [loaderData]);
 
   return (
-    <ViewerProvider query={loaderData}>
+    <ViewerProvider query={queryData}>
       <AgentProvider>
         <AgentChatWidget />
         <AppAlerts />

--- a/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<73dcc2ae818d192736ef34f5a0c4dba6>>
+ * @generated SignedSource<<584d585fe36ff78c236ac766f33cec0b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,12 +12,6 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type authenticatedRootLoaderQuery$variables = Record<PropertyKey, never>;
 export type authenticatedRootLoaderQuery$data = {
-  readonly viewer: {
-    readonly email: string | null;
-    readonly id: string;
-    readonly passwordNeedsReset: boolean;
-    readonly username: string;
-  } | null;
   readonly " $fragmentSpreads": FragmentRefs<"ViewerContext_viewer">;
 };
 export type authenticatedRootLoaderQuery = {
@@ -37,27 +31,6 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "username",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "email",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "passwordNeedsReset",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 };
@@ -72,21 +45,6 @@ return {
         "args": null,
         "kind": "FragmentSpread",
         "name": "ViewerContext_viewer"
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "User",
-        "kind": "LinkedField",
-        "name": "viewer",
-        "plural": false,
-        "selections": [
-          (v0/*: any*/),
-          (v1/*: any*/),
-          (v2/*: any*/),
-          (v3/*: any*/)
-        ],
-        "storageKey": null
       }
     ],
     "type": "Query",
@@ -107,8 +65,20 @@ return {
         "plural": false,
         "selections": [
           (v0/*: any*/),
-          (v1/*: any*/),
-          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "username",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -131,7 +101,7 @@ return {
             "name": "role",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
+              (v1/*: any*/),
               (v0/*: any*/)
             ],
             "storageKey": null
@@ -152,7 +122,7 @@ return {
             "plural": true,
             "selections": [
               (v0/*: any*/),
-              (v4/*: any*/),
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -176,24 +146,23 @@ return {
               }
             ],
             "storageKey": null
-          },
-          (v3/*: any*/)
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "909f2b392805d784bcac384c6d208692",
+    "cacheID": "f39ce3ad306b5daa3e40a2e851ca2e9d",
     "id": null,
     "metadata": {},
     "name": "authenticatedRootLoaderQuery",
     "operationKind": "query",
-    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
+    "text": "query authenticatedRootLoaderQuery {\n  ...ViewerContext_viewer\n}\n\nfragment APIKeysTableFragment on User {\n  apiKeys {\n    id\n    name\n    description\n    createdAt\n    expiresAt\n  }\n  id\n}\n\nfragment ViewerContext_viewer on Query {\n  viewer {\n    id\n    username\n    email\n    profilePictureUrl\n    isManagementUser\n    role {\n      name\n      id\n    }\n    authMethod\n    ...APIKeysTableFragment\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7df3b0168622116913f7d14b4a0a6a0a";
+(node as any).hash = "26f018608f21da07f218dbd5e9f3a989";
 
 export default node;

--- a/app/src/pages/__generated__/authenticatedRootLoader_viewerQuery.graphql.ts
+++ b/app/src/pages/__generated__/authenticatedRootLoader_viewerQuery.graphql.ts
@@ -1,0 +1,98 @@
+/**
+ * @generated SignedSource<<03328136b479268126f8665940941f68>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type authenticatedRootLoader_viewerQuery$variables = Record<PropertyKey, never>;
+export type authenticatedRootLoader_viewerQuery$data = {
+  readonly viewer: {
+    readonly email: string | null;
+    readonly id: string;
+    readonly passwordNeedsReset: boolean;
+    readonly username: string;
+  } | null;
+};
+export type authenticatedRootLoader_viewerQuery = {
+  response: authenticatedRootLoader_viewerQuery$data;
+  variables: authenticatedRootLoader_viewerQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "User",
+    "kind": "LinkedField",
+    "name": "viewer",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "username",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "email",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "passwordNeedsReset",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "authenticatedRootLoader_viewerQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "authenticatedRootLoader_viewerQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "95ea890b5bfc0d438f83baa48f6980f4",
+    "id": null,
+    "metadata": {},
+    "name": "authenticatedRootLoader_viewerQuery",
+    "operationKind": "query",
+    "text": "query authenticatedRootLoader_viewerQuery {\n  viewer {\n    id\n    username\n    email\n    passwordNeedsReset\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "39590abe880df809f08308e4ed40604f";
+
+export default node;

--- a/app/src/pages/authenticatedRootLoader.ts
+++ b/app/src/pages/authenticatedRootLoader.ts
@@ -1,20 +1,32 @@
-import { fetchQuery, graphql } from "react-relay";
+import { fetchQuery, graphql, loadQuery } from "react-relay";
 import { redirect } from "react-router";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 import { createRedirectUrlWithReturn } from "@phoenix/utils/routingUtils";
 
-import type { authenticatedRootLoaderQuery } from "./__generated__/authenticatedRootLoaderQuery.graphql";
+import type { authenticatedRootLoader_viewerQuery } from "./__generated__/authenticatedRootLoader_viewerQuery.graphql";
+import type { authenticatedRootLoaderQuery as AuthenticatedRootLoaderQueryType } from "./__generated__/authenticatedRootLoaderQuery.graphql";
+
+/**
+ * The loadQuery graphql query node for the authenticated root.
+ * Exported so AuthenticatedRoot can reference it in usePreloadedQuery.
+ */
+export const authenticatedRootLoaderQuery = graphql`
+  query authenticatedRootLoaderQuery {
+    ...ViewerContext_viewer
+  }
+`;
 
 /**
  * Loads in the necessary data at the root of the authenticated application
  */
 export async function authenticatedRootLoader() {
-  const loaderData = await fetchQuery<authenticatedRootLoaderQuery>(
+  // Small separate fetch for the scalar needed to check the redirect condition
+  // before the component mounts.
+  const viewerData = await fetchQuery<authenticatedRootLoader_viewerQuery>(
     RelayEnvironment,
     graphql`
-      query authenticatedRootLoaderQuery {
-        ...ViewerContext_viewer
+      query authenticatedRootLoader_viewerQuery {
         viewer {
           id
           username
@@ -26,12 +38,36 @@ export async function authenticatedRootLoader() {
     {}
   ).toPromise();
 
-  if (loaderData?.viewer?.passwordNeedsReset) {
+  if (viewerData?.viewer?.passwordNeedsReset) {
     const redirectUrl = createRedirectUrlWithReturn({
       path: "/reset-password",
     });
     return redirect(redirectUrl);
   }
 
-  return loaderData;
+  // Use loadQuery so Relay ties the query's lifetime to the mounted component,
+  // preventing GC from evicting the cache while the component is still rendered.
+  const queryRef = loadQuery<AuthenticatedRootLoaderQueryType>(
+    RelayEnvironment,
+    authenticatedRootLoaderQuery,
+    {}
+  );
+
+  return {
+    queryRef,
+    viewer: viewerData?.viewer,
+  };
 }
+
+export type AuthenticatedRootLoaderData = Awaited<
+  ReturnType<typeof authenticatedRootLoader>
+>;
+
+/**
+ * The non-redirect branch of the loader data — what the component receives
+ * at render time (redirects are handled by React Router before mounting).
+ */
+export type AuthenticatedRootLoaderDataResolved = Extract<
+  AuthenticatedRootLoaderData,
+  { queryRef: unknown }
+>;


### PR DESCRIPTION
## Summary

- Fixes a Relay cache eviction bug where `fetchQuery` in `authenticatedRootLoader` returned data that Relay GC could evict while `AuthenticatedRoot` was still mounted (since `fetchQuery` results aren't tied to any component)
- Switches to `loadQuery` + `usePreloadedQuery` so the query's cache lifetime is tied to the mounted `AuthenticatedRoot` component
- Keeps a small separate `fetchQuery` solely for the `passwordNeedsReset` scalar needed for the pre-render redirect check (matching the pattern in `promptLoader.tsx`)
- Exports `authenticatedRootLoaderQuery` node and `AuthenticatedRootLoaderDataResolved` type so the component can call `usePreloadedQuery` and pass the result as a fragment ref to `ViewerProvider`

Closes #12215. Part of #12209.

## Test plan

- [ ] Log in as a user with `passwordNeedsReset = true` — should redirect to `/reset-password`
- [ ] Log in as a normal user — app loads correctly, viewer context is populated
- [ ] Navigate between pages and leave the app idle; viewer data should not disappear due to GC eviction
- [ ] Verify no TypeScript errors: `cd app && pnpm tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)