### PR TITLE
fix(settings): replace fetchQuery with loadQuery in settingsAIProvidersPageLoader

### DIFF
--- a/app/src/pages/settings/SettingsAIProvidersPage.tsx
+++ b/app/src/pages/settings/SettingsAIProvidersPage.tsx
@@ -1,18 +1,30 @@
+import { usePreloadedQuery } from "react-relay";
 import { useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
 
 import { Flex } from "@phoenix/components";
 import { CustomProvidersCard } from "@phoenix/pages/settings/CustomProvidersCard";
 import { GenerativeProvidersCard } from "@phoenix/pages/settings/GenerativeProvidersCard";
-import type { settingsAIProvidersPageLoader } from "@phoenix/pages/settings/settingsAIProvidersPageLoader";
+import {
+  settingsAIProvidersPageLoaderQuery,
+  type SettingsAIProvidersLoaderData,
+} from "@phoenix/pages/settings/settingsAIProvidersPageLoader";
+
+import type { settingsAIProvidersPageLoaderQuery as settingsAIProvidersPageLoaderQueryType } from "./__generated__/settingsAIProvidersPageLoaderQuery.graphql";
 
 export function SettingsAIProvidersPage() {
-  const loaderData = useLoaderData<typeof settingsAIProvidersPageLoader>();
+  const loaderData = useLoaderData() as
+    | SettingsAIProvidersLoaderData
+    | undefined;
   invariant(loaderData, "loaderData is required");
+  const data = usePreloadedQuery<settingsAIProvidersPageLoaderQueryType>(
+    settingsAIProvidersPageLoaderQuery,
+    loaderData.queryRef
+  );
   return (
     <Flex direction="column" gap="size-200">
-      <GenerativeProvidersCard query={loaderData} />
-      <CustomProvidersCard query={loaderData} />
+      <GenerativeProvidersCard query={data} />
+      <CustomProvidersCard query={data} />
     </Flex>
   );
 }

--- a/app/src/pages/settings/settingsAIProvidersPageLoader.ts
+++ b/app/src/pages/settings/settingsAIProvidersPageLoader.ts
@@ -1,18 +1,25 @@
-import { fetchQuery, graphql } from "react-relay";
+import { graphql, loadQuery } from "react-relay";
 
 import RelayEnvironment from "@phoenix/RelayEnvironment";
 
-import type { settingsAIProvidersPageLoaderQuery } from "./__generated__/settingsAIProvidersPageLoaderQuery.graphql";
+import type { settingsAIProvidersPageLoaderQuery as settingsAIProvidersPageLoaderQueryType } from "./__generated__/settingsAIProvidersPageLoaderQuery.graphql";
 
-export async function settingsAIProvidersPageLoader() {
-  return await fetchQuery<settingsAIProvidersPageLoaderQuery>(
+export const settingsAIProvidersPageLoaderQuery = graphql`
+  query settingsAIProvidersPageLoaderQuery {
+    ...GenerativeProvidersCard_data
+    ...CustomProvidersCard_data
+  }
+`;
+
+export function settingsAIProvidersPageLoader() {
+  const queryRef = loadQuery<settingsAIProvidersPageLoaderQueryType>(
     RelayEnvironment,
-    graphql`
-      query settingsAIProvidersPageLoaderQuery {
-        ...GenerativeProvidersCard_data
-        ...CustomProvidersCard_data
-      }
-    `,
+    settingsAIProvidersPageLoaderQuery,
     {}
-  ).toPromise();
+  );
+  return { queryRef };
 }
+
+export type SettingsAIProvidersLoaderData = ReturnType<
+  typeof settingsAIProvidersPageLoader
+>;


### PR DESCRIPTION
## Summary

- Fixes Relay GC cache eviction bug in `settingsAIProvidersPageLoader` where `fetchQuery` was used inside a React Router route loader
- Relay cannot associate queries fetched via `fetchQuery` with any mounted component, so its GC can evict the cached data while the component is still mounted — breaking the page
- Replaces `fetchQuery` + inline `graphql` tag with `loadQuery` + exported query node, and updates `SettingsAIProvidersPage` to call `usePreloadedQuery` before passing data to `GenerativeProvidersCard` and `CustomProvidersCard`

Closes #12217. Part of #12209.

## Test plan

- [ ] Navigate to the Settings > AI Providers page and verify it loads correctly
- [ ] Verify no TypeScript errors: `cd app && pnpm tsc --noEmit`
- [ ] Leave the page mounted for a while and confirm the data doesn't disappear due to Relay GC eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)