### PR TITLE
fix(filter): raise SyntaxError when comparing string field to numeric value

### DIFF
--- a/src/phoenix/trace/dsl/filter.py
+++ b/src/phoenix/trace/dsl/filter.py
@@ -400,6 +400,10 @@ def _cast_as(
     )
 
 
+def _is_string_name(node: typing.Any) -> bool:
+    return isinstance(node, ast.Name) and node.id in _STRING_NAMES
+
+
 def _is_string(node: typing.Any) -> TypeGuard[ast.Call]:
     return (
         isinstance(node, ast.Name)
@@ -487,8 +491,18 @@ class _FilterTranslator(_ProjectionTranslator):
                 _as_bool_attribute(right) if _is_bool_constant(left) else _cast_as("String", right)
             )
         if _is_float(left) and not _is_float(right):
+            if _is_string_name(right):
+                raise SyntaxError(
+                    f"type mismatch: string field '{ast.unparse(right)}'"
+                    " cannot be compared to a numeric value"
+                )
             right = _cast_as("Float", right)
         elif not _is_float(left) and _is_float(right):
+            if _is_string_name(left):
+                raise SyntaxError(
+                    f"type mismatch: string field '{ast.unparse(left)}'"
+                    " cannot be compared to a numeric value"
+                )
             left = _cast_as("Float", left)
         if isinstance(op, (ast.In, ast.NotIn)):
             if _is_string_attribute(right) or ast.unparse(right) in _NAMES:

--- a/tests/unit/trace/dsl/test_filter.py
+++ b/tests/unit/trace/dsl/test_filter.py
@@ -185,6 +185,22 @@ async def test_filter_translated(
 
 
 @pytest.mark.parametrize(
+    "expression",
+    [
+        pytest.param("name == 1", id="string-field-eq-int"),
+        pytest.param("name == 1.5", id="string-field-eq-float"),
+        pytest.param("1 == name", id="int-eq-string-field"),
+        pytest.param("span_id == 42", id="span_id-eq-int"),
+        pytest.param("status_code == 0", id="status_code-eq-int"),
+        pytest.param("latency_ms == name", id="float-field-eq-string-field"),
+    ],
+)
+def test_filter_raises_on_string_numeric_type_mismatch(expression: str) -> None:
+    with pytest.raises(SyntaxError, match="type mismatch"):
+        SpanFilter(expression)
+
+
+@pytest.mark.parametrize(
     "filter_condition,expected",
     [
         pytest.param(


### PR DESCRIPTION
## Summary

Closes #12209 (second issue — invalid PostgreSQL query when filtering spans with a numeric value against a string field).

When a filter condition like `name == 1` was submitted, the span filter translator blindly emitted `CAST(spans.name AS FLOAT) = 1`. On SQLite this silently returns zero rows; on PostgreSQL it raises:

```
asyncpg.exceptions.InvalidTextRepresentationError: invalid input syntax for type double precision: "common agent graph"
```

- Add `_is_string_name` helper to detect AST nodes that refer to known string-typed columns (`name`, `span_id`, `status_code`, etc.)
- Guard both branches of the float-cast logic in `_FilterTranslator.visit_Compare` — if either operand is a known string column and the other is numeric, raise a descriptive `SyntaxError` before any SQL is generated
- Add 6 parametrized unit tests covering `name == 1`, `1 == name`, `span_id == 42`, `status_code == 0`, `name == 1.5`, and `latency_ms == name`

## Test plan

- [ ] `uv run pytest tests/unit/trace/dsl/test_filter.py` — all pass
- [ ] Filter condition `name == 1` via GraphQL now returns a structured error instead of a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)