### PR TITLE
ci: prevent httpx.ReadTimeout in experiment integration tests

### DIFF
--- a/tests/integration/_mock_llm_server.py
+++ b/tests/integration/_mock_llm_server.py
@@ -1652,7 +1652,6 @@ class _LLMRequestHandler(BaseHTTPRequestHandler):
                 model_version=model_id,
             )
             self._send_genai_chunk(response)
-            time.sleep(0.01)
 
         # Final chunk with finish_reason
         output_tokens = _estimate_tokens(response_text)

--- a/tests/integration/experiments/test_playground.py
+++ b/tests/integration/experiments/test_playground.py
@@ -436,7 +436,8 @@ class TestChatCompletionOverDataset:
         and attaches evaluators using all 4 custom providers (OpenAI, Anthropic,
         Google GenAI, Bedrock).
         """
-        async with httpx.AsyncClient(base_url=_app.base_url) as client:
+        # Long timeout so stream() read doesn't hit default 5s during slow CI
+        async with httpx.AsyncClient(base_url=_app.base_url, timeout=120.0) as client:
             # Run subscription with all evaluators
             experiment_id = await _run_subscription_with_evaluators(
                 client,
@@ -571,7 +572,8 @@ class TestChatCompletionOverDataset:
         # Look up provider ID from the fixture
         provider_id = getattr(_custom_providers, provider_key)
 
-        async with httpx.AsyncClient(base_url=_app.base_url) as client:
+        # Long timeout so stream() read doesn't hit default 5s during slow CI
+        async with httpx.AsyncClient(base_url=_app.base_url, timeout=60.0) as client:
             # Run subscription without evaluators
             experiment_id = await _run_subscription_without_evaluators(
                 client,


### PR DESCRIPTION
- Set httpx.AsyncClient timeout=120s in test_experiment_with_evaluators and timeout=60s in test_provider_without_evaluators so stream() read does not hit default 5s during slow CI
- Remove time.sleep(0.01) per chunk in mock LLM GenAI text streaming so mock server runs as fast as other providers