### PR TITLE
fix: fix double dollar sign in token costs cell

### DIFF
--- a/app/src/components/trace/TokenCosts.tsx
+++ b/app/src/components/trace/TokenCosts.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, Ref } from "react";
 import { forwardRef } from "react";
 
 import type { TextProps } from "@phoenix/components";
-import { Icon, Icons, Text } from "@phoenix/components";
+import { Text } from "@phoenix/components";
 import { costFormatter } from "@phoenix/utils/numberFormatUtils";
 
 const tokenCostsItemCSS = css`
@@ -37,12 +37,6 @@ function TokenCosts(props: TokenCostsProps, ref: Ref<HTMLDivElement>) {
       ref={ref}
       {...otherProps}
     >
-      <Icon
-        svg={<Icons.DollarSignOutline />}
-        css={css`
-          color: var(--global-text-color-900);
-        `}
-      />
       <Text size={props.size} fontFamily="mono">
         {text}
       </Text>


### PR DESCRIPTION
Removes dollar sign icon from token costs cell, since `costFormatter` already adds a dollar sign.

before:
<img width="278" height="331" alt="image" src="https://github.com/user-attachments/assets/bd5015e0-07e7-456b-aab1-6c76d863f1d4" />


after:
<img width="278" height="331" alt="image" src="https://github.com/user-attachments/assets/ff920367-5ca9-449e-bebb-77d7f8de6bd0" />
