### PR TITLE
feat: add expectedRunCount experiment field and experiments table fraction

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1431,6 +1431,11 @@ type Experiment implements Node {
   sequenceNumber: Int!
   runs(first: Int = 50, after: String, sort: ExperimentRunSort): ExperimentRunConnection!
   runCount: Int!
+
+  """
+  Expected number of experiment runs: dataset examples in scope times repetitions.
+  """
+  expectedRunCount: Int!
   annotationSummaries: [ExperimentAnnotationSummary!]!
   errorRate: Float
   averageRunLatencyMs: Float

--- a/app/src/pages/experiments/ExperimentsTable.tsx
+++ b/app/src/pages/experiments/ExperimentsTable.tsx
@@ -53,6 +53,7 @@ import { calculateAnnotationScorePercentile } from "@phoenix/pages/experiment/ut
 import {
   floatFormatter,
   formatPercent,
+  intFormatter,
 } from "@phoenix/utils/numberFormatUtils";
 import { makeSafeColumnId } from "@phoenix/utils/tableUtils";
 
@@ -66,6 +67,10 @@ import { ErrorRateCell } from "./ErrorRateCell";
 import { ExperimentSelectionToolbar } from "./ExperimentSelectionToolbar";
 
 const PAGE_SIZE = 100;
+
+const runCountFractionCellCSS = css`
+  float: right;
+`;
 
 const defaultColumnSettings = {
   minSize: 100,
@@ -168,6 +173,7 @@ export function ExperimentsTable({
                 metadata
                 errorRate
                 runCount
+                expectedRunCount
                 repetitions
                 averageRunLatencyMs
                 project {
@@ -402,7 +408,18 @@ export function ExperimentsTable({
       meta: {
         textAlign: "right",
       },
-      cell: IntCell,
+      cell: ({ row }) => {
+        const { runCount, expectedRunCount } = row.original;
+        return (
+          <span
+            className="font-mono"
+            css={runCountFractionCellCSS}
+            title={`${runCount} / ${expectedRunCount}`}
+          >
+            {intFormatter(runCount)} / {intFormatter(expectedRunCount)}
+          </span>
+        );
+      },
     },
     {
       header: "avg latency",

--- a/app/src/pages/experiments/__generated__/ExperimentsPageQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fc562c231891f448b40587a916c93188>>
+ * @generated SignedSource<<acb87dc78122f2a2ca9aa6597d0f5a2a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -252,6 +252,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "expectedRunCount",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "repetitions",
                             "storageKey": null
                           },
@@ -489,12 +496,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8882b98e1c23ac0119d6016b51710f23",
+    "cacheID": "861f9953e296c10d7753797a4f3477ae",
     "id": null,
     "metadata": {},
     "name": "ExperimentsPageQuery",
     "operationKind": "query",
-    "text": "query ExperimentsPageQuery(\n  $datasetId: ID!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experimentCount\n    }\n    ...ExperimentsTableFragment\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  id\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        repetitions\n        averageRunLatencyMs\n        project {\n          id\n        }\n        datasetSplits {\n          edges {\n            node {\n              id\n              name\n              color\n            }\n          }\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n          count\n          errorCount\n        }\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ExperimentsPageQuery(\n  $datasetId: ID!\n) {\n  dataset: node(id: $datasetId) {\n    __typename\n    id\n    ... on Dataset {\n      experimentCount\n    }\n    ...ExperimentsTableFragment\n  }\n}\n\nfragment ExperimentsTableFragment on Dataset {\n  id\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: 100) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        expectedRunCount\n        repetitions\n        averageRunLatencyMs\n        project {\n          id\n        }\n        datasetSplits {\n          edges {\n            node {\n              id\n              name\n              color\n            }\n          }\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n          count\n          errorCount\n        }\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<931982f6ea3501f36738c2a82159e8dd>>
+ * @generated SignedSource<<538e5664123c54d17bc25bb4eeab5feb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -52,6 +52,7 @@ export type ExperimentsTableFragment$data = {
         };
         readonly description: string | null;
         readonly errorRate: number | null;
+        readonly expectedRunCount: number;
         readonly id: string;
         readonly metadata: any;
         readonly name: string;
@@ -256,6 +257,13 @@ return {
                   "args": null,
                   "kind": "ScalarField",
                   "name": "runCount",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "expectedRunCount",
                   "storageKey": null
                 },
                 {
@@ -490,6 +498,6 @@ return {
 };
 })();
 
-(node as any).hash = "6cce0a41bae9977df42516a14da8cf7d";
+(node as any).hash = "abc1e770a13dc312089a3c1276f1c99c";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a4238943097d1f41da0a35d1391caa1>>
+ * @generated SignedSource<<b41378b9c55ec7cbc3a5086ea1087fc7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -250,6 +250,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "expectedRunCount",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "repetitions",
                             "storageKey": null
                           },
@@ -487,16 +494,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "875aedb45181537dc7bc54a137d612bf",
+    "cacheID": "260c7df5a8c10d510790817f1ebb5ad5",
     "id": null,
     "metadata": {},
     "name": "ExperimentsTableQuery",
     "operationKind": "query",
-    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  id\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        repetitions\n        averageRunLatencyMs\n        project {\n          id\n        }\n        datasetSplits {\n          edges {\n            node {\n              id\n              name\n              color\n            }\n          }\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n          count\n          errorCount\n        }\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ExperimentsTableQuery(\n  $after: String = null\n  $first: Int = 100\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentsTableFragment_2HEEH6\n    id\n  }\n}\n\nfragment ExperimentsTableFragment_2HEEH6 on Dataset {\n  id\n  experimentAnnotationSummaries {\n    annotationName\n    minScore\n    maxScore\n  }\n  experiments(first: $first, after: $after) {\n    edges {\n      experiment: node {\n        id\n        name\n        sequenceNumber\n        description\n        createdAt\n        metadata\n        errorRate\n        runCount\n        expectedRunCount\n        repetitions\n        averageRunLatencyMs\n        project {\n          id\n        }\n        datasetSplits {\n          edges {\n            node {\n              id\n              name\n              color\n            }\n          }\n        }\n        costSummary {\n          total {\n            tokens\n            cost\n          }\n          prompt {\n            tokens\n            cost\n          }\n          completion {\n            tokens\n            cost\n          }\n        }\n        annotationSummaries {\n          annotationName\n          meanScore\n          count\n          errorCount\n        }\n        user {\n          username\n          profilePictureUrl\n          id\n        }\n      }\n      cursor\n      node {\n        __typename\n        id\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6cce0a41bae9977df42516a14da8cf7d";
+(node as any).hash = "abc1e770a13dc312089a3c1276f1c99c";
 
 export default node;

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -31,6 +31,7 @@ from phoenix.server.api.dataloaders import (
     ExperimentAnnotationSummaryDataLoader,
     ExperimentDatasetSplitsDataLoader,
     ExperimentErrorRatesDataLoader,
+    ExperimentExpectedRunCountsDataLoader,
     ExperimentRepeatedRunGroupAnnotationSummariesDataLoader,
     ExperimentRepeatedRunGroupsDataLoader,
     ExperimentRunAnnotations,
@@ -133,6 +134,7 @@ class DataLoaders:
     experiment_annotation_summaries: ExperimentAnnotationSummaryDataLoader
     experiment_dataset_splits: ExperimentDatasetSplitsDataLoader
     experiment_error_rates: ExperimentErrorRatesDataLoader
+    experiment_expected_run_counts: ExperimentExpectedRunCountsDataLoader
     experiment_fields: TableFieldsDataLoader
     experiment_repeated_run_group_annotation_summaries: (
         ExperimentRepeatedRunGroupAnnotationSummariesDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -31,6 +31,7 @@ from .document_retrieval_metrics import DocumentRetrievalMetricsDataLoader
 from .experiment_annotation_summaries import ExperimentAnnotationSummaryDataLoader
 from .experiment_dataset_splits import ExperimentDatasetSplitsDataLoader
 from .experiment_error_rates import ExperimentErrorRatesDataLoader
+from .experiment_expected_run_counts import ExperimentExpectedRunCountsDataLoader
 from .experiment_repeated_run_group_annotation_summaries import (
     ExperimentRepeatedRunGroupAnnotationSummariesDataLoader,
 )
@@ -112,6 +113,7 @@ __all__ = [
     "DocumentRetrievalMetricsDataLoader",
     "ExperimentAnnotationSummaryDataLoader",
     "ExperimentErrorRatesDataLoader",
+    "ExperimentExpectedRunCountsDataLoader",
     "ExperimentRepeatedRunGroupsDataLoader",
     "ExperimentRepeatedRunGroupAnnotationSummariesDataLoader",
     "ExperimentRunAnnotations",

--- a/src/phoenix/server/api/dataloaders/experiment_expected_run_counts.py
+++ b/src/phoenix/server/api/dataloaders/experiment_expected_run_counts.py
@@ -1,0 +1,54 @@
+from sqlalchemy import func, select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+ExperimentID: TypeAlias = int
+ExpectedRunCount: TypeAlias = int
+Key: TypeAlias = ExperimentID
+Result: TypeAlias = ExpectedRunCount
+
+
+class ExperimentExpectedRunCountsDataLoader(DataLoader[Key, Result]):
+    def __init__(
+        self,
+        db: DbSessionFactory,
+    ) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        experiment_ids = keys
+        resolved_experiment_ids = (
+            select(models.Experiment.id)
+            .where(models.Experiment.id.in_(set(experiment_ids)))
+            .subquery()
+        )
+        query = (
+            select(
+                resolved_experiment_ids.c.id,
+                func.count(models.ExperimentDatasetExample.dataset_example_id)
+                * models.Experiment.repetitions,
+            )
+            .select_from(resolved_experiment_ids)
+            .join(
+                models.Experiment,
+                resolved_experiment_ids.c.id == models.Experiment.id,
+            )
+            .outerjoin(
+                models.ExperimentDatasetExample,
+                models.ExperimentDatasetExample.experiment_id == resolved_experiment_ids.c.id,
+            )
+            .group_by(resolved_experiment_ids.c.id, models.Experiment.repetitions)
+        )
+        async with self._db() as session:
+            expected_counts = {
+                experiment_id: expected_count
+                async for experiment_id, expected_count in await session.stream(query)
+            }
+        return [
+            expected_counts.get(experiment_id, ValueError(f"Unknown experiment: {experiment_id}"))
+            for experiment_id in keys
+        ]

--- a/src/phoenix/server/api/types/Experiment.py
+++ b/src/phoenix/server/api/types/Experiment.py
@@ -244,6 +244,14 @@ class Experiment(Node):
     async def run_count(self, info: Info[Context, None]) -> int:
         return await info.context.data_loaders.experiment_run_counts.load(self.id)
 
+    @strawberry.field(
+        description=(
+            "Expected number of experiment runs: dataset examples in scope times repetitions."
+        )
+    )  # type: ignore
+    async def expected_run_count(self, info: Info[Context, None]) -> int:
+        return await info.context.data_loaders.experiment_expected_run_counts.load(self.id)
+
     @strawberry.field
     async def annotation_summaries(
         self, info: Info[Context, None]

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -103,6 +103,7 @@ from phoenix.server.api.dataloaders import (
     ExperimentAnnotationSummaryDataLoader,
     ExperimentDatasetSplitsDataLoader,
     ExperimentErrorRatesDataLoader,
+    ExperimentExpectedRunCountsDataLoader,
     ExperimentRepeatedRunGroupAnnotationSummariesDataLoader,
     ExperimentRepeatedRunGroupsDataLoader,
     ExperimentRunAnnotations,
@@ -768,6 +769,7 @@ def create_graphql_router(
                 experiment_annotation_summaries=ExperimentAnnotationSummaryDataLoader(db),
                 experiment_dataset_splits=ExperimentDatasetSplitsDataLoader(db),
                 experiment_error_rates=ExperimentErrorRatesDataLoader(db),
+                experiment_expected_run_counts=ExperimentExpectedRunCountsDataLoader(db),
                 experiment_fields=TableFieldsDataLoader(db, models.Experiment),
                 experiment_repeated_run_group_annotation_summaries=ExperimentRepeatedRunGroupAnnotationSummariesDataLoader(
                     db

--- a/tests/unit/server/api/types/test_Experiment.py
+++ b/tests/unit/server/api/types/test_Experiment.py
@@ -381,6 +381,101 @@ async def test_run_count_resolver_returns_correct_counts(
     }
 
 
+@pytest.fixture
+async def experiment_with_expected_run_count(db: DbSessionFactory) -> int:
+    """One experiment, two dataset examples in scope, repetitions=2 → expected_run_count 4."""
+    async with db() as session:
+        dataset = models.Dataset(
+            name="dataset-name",
+            description="dataset-description",
+            metadata_={},
+        )
+        session.add(dataset)
+        await session.flush()
+
+        examples = [
+            models.DatasetExample(
+                dataset_id=dataset.id,
+                created_at=datetime(
+                    year=2020, month=1, day=1, hour=0, minute=0, tzinfo=timezone.utc
+                ),
+            )
+            for _ in range(4)
+        ]
+        session.add_all(examples)
+        await session.flush()
+
+        version = models.DatasetVersion(
+            dataset_id=dataset.id,
+            description="version-description",
+            metadata_={},
+        )
+        session.add(version)
+        await session.flush()
+
+        revisions = [
+            models.DatasetExampleRevision(
+                dataset_example_id=example.id,
+                dataset_version_id=version.id,
+                input={"input": "input"},
+                output={"output": "output"},
+                metadata_={},
+                revision_kind="CREATE",
+            )
+            for example in examples
+        ]
+        session.add_all(revisions)
+        await session.flush()
+
+        experiment = models.Experiment(
+            dataset_id=dataset.id,
+            dataset_version_id=version.id,
+            name="experiment-name",
+            description="experiment-description",
+            repetitions=2,
+            metadata_={},
+        )
+        session.add(experiment)
+        await session.flush()
+
+        session.add_all(
+            [
+                models.ExperimentDatasetExample(
+                    experiment_id=experiment.id,
+                    dataset_example_id=example.id,
+                    dataset_example_revision_id=revision.id,
+                )
+                for example, revision in zip(examples, revisions)
+            ][:-1]
+        )
+    return experiment.id
+
+
+async def test_expected_run_count_resolver(
+    gql_client: AsyncGraphQLClient,
+    experiment_with_expected_run_count: int,
+) -> None:
+    query = """
+      query ($experimentId: ID!) {
+        experiment: node(id: $experimentId) {
+          ... on Experiment {
+            expectedRunCount
+          }
+        }
+      }
+    """
+    response = await gql_client.execute(
+        query=query,
+        variables={
+            "experimentId": str(
+                GlobalID(type_name="Experiment", node_id=str(experiment_with_expected_run_count))
+            ),
+        },
+    )
+    assert not response.errors
+    assert response.data == {"experiment": {"expectedRunCount": 6}}
+
+
 async def test_average_run_latency_resolver_returns_correct_values(
     gql_client: AsyncGraphQLClient,
     experiments_with_runs_and_annotations: Any,


### PR DESCRIPTION
- Add ExperimentExpectedRunCountsDataLoader (examples × repetitions)
- Expose expectedRunCount on GraphQL Experiment
- Show run count as actual/expected in ExperimentsTable
- Add unit test for expected_run_count resolver

<img width="464" height="220" src="https://github.com/user-attachments/assets/428a5361-343a-4b25-a43b-b5561101e36e" />
