### PR TITLE
docs: update MCP documentation for expanded tool coverage

### DIFF
--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -71,7 +71,7 @@ MCP has two different Phoenix integrations, and they serve different goals.
 | MCP Integration | Purpose | When to use |
 |---|---|---|
 | `Phoenix Docs MCP` | Search Phoenix documentation from your coding agent | Recommended for all users |
-| `Phoenix MCP Server` | Operate directly on your Phoenix instance (prompts, datasets, experiments) | Use when you want agent-driven Phoenix data operations |
+| `Phoenix MCP Server` | Operate directly on your Phoenix instance (projects, traces, sessions, prompts, datasets, experiments, and more) | Use when you want agent-driven Phoenix data operations |
 
 ### Phoenix Docs MCP (Documentation Access)
 
@@ -156,7 +156,7 @@ Reference docs: [Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code
 
 ### Phoenix MCP Server (Direct Phoenix Operations)
 
-For prompt, dataset, and experiment operations against your Phoenix instance, use the dedicated setup guide:
+For direct operations against your Phoenix instance (traces, sessions, prompts, datasets, experiments, and more), use the dedicated setup guide:
 
 - [/docs/phoenix/integrations/phoenix-mcp-server](/docs/phoenix/integrations/phoenix-mcp-server)
 
@@ -232,6 +232,6 @@ npx skills add Arize-ai/phoenix --skill phoenix-cli --skill phoenix-tracing
     Detailed guide for fetching traces from Phoenix.
   </Card>
   <Card title="Phoenix MCP Server" icon="plug" href="/docs/phoenix/integrations/phoenix-mcp-server">
-    Manage prompts, datasets, and experiments via the Phoenix MCP Server.
+    Interact with projects, traces, sessions, prompts, datasets, and experiments via the Phoenix MCP Server.
   </Card>
 </CardGroup>

--- a/docs/phoenix/sdk-api-reference/typescript/mcp-server.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/mcp-server.mdx
@@ -18,9 +18,15 @@ Phoenix MCP Server is an implementation of the Model Context Protocol for the Ar
 
 You can use Phoenix MCP Server for:
 
+* **Projects Management**: List and explore projects that organize your observability data
+
+* **Traces, Spans & Annotations**: Retrieve traces, spans, and annotation configs for analysis and debugging
+
+* **Sessions**: Explore conversation flows and session-level annotations
+
 * **Prompts Management**: Create, list, update, and iterate on prompts
 
-* **Datasets**: Explore datasets, and synthesize new examples
+* **Datasets**: Explore datasets and synthesize new examples
 
 * **Experiments**: Pull experiment results and visualize them with the help of an LLM
 
@@ -96,9 +102,33 @@ When developing, the server requires the following environment variables:
 
 * `PHOENIX_API_KEY`: Your Phoenix API key
 
-* `PHOENIX_BASE_URL`: The base URL for Phoenix
+* `PHOENIX_HOST`: The base URL for Phoenix
+
+* `PHOENIX_PROJECT`: Optional default project for project-scoped tools
+
+* `PHOENIX_CLIENT_HEADERS`: Optional JSON-encoded request headers
 
 Make sure to set these in a `.env` file. See `.env.example`.
+
+## Tool Coverage
+
+The MCP server covers the main operational Phoenix workflows:
+
+**Prompts** — `list-prompts`, `get-prompt`, `get-latest-prompt`, `get-prompt-by-identifier`, `get-prompt-version`, `list-prompt-versions`, `get-prompt-version-by-tag`, `list-prompt-version-tags`, `add-prompt-version-tag`, `upsert-prompt`
+
+**Projects** — `list-projects`, `get-project`
+
+**Traces** — `list-traces`, `get-trace`
+
+**Spans** — `get-spans`, `get-span-annotations`
+
+**Sessions** — `list-sessions`, `get-session`
+
+**Annotation Configs** — `list-annotation-configs`
+
+**Datasets** — `list-datasets`, `get-dataset`, `get-dataset-examples`, `get-dataset-experiments`, `add-dataset-examples`
+
+**Experiments** — `list-experiments-for-dataset`, `get-experiment-by-id`
 
 ## License
 


### PR DESCRIPTION
## Summary
- Updates the SDK API reference page (`mcp-server.mdx`) to reflect the full set of 23+ MCP tools — previously only listed prompts, datasets, and experiments
- Fixes stale env var name (`PHOENIX_BASE_URL` → `PHOENIX_HOST`) and adds missing env vars (`PHOENIX_PROJECT`, `PHOENIX_CLIENT_HEADERS`)
- Adds a Tool Coverage section to the API reference matching the README
- Updates the coding agents guide to reference the broader MCP capability set in 3 places

## Test plan
- [ ] Verify docs render correctly on the Mintlify preview
- [ ] Confirm tool names in the Tool Coverage section match the actual MCP server implementation