### PR TITLE
fix: pin litellm <1.82.7 in requirements files

### DIFF
--- a/requirements/packages/phoenix-evals.txt
+++ b/requirements/packages/phoenix-evals.txt
@@ -1,7 +1,7 @@
 -r ../ci.txt
 anthropic
 google-genai
-litellm
+litellm<1.82.7
 mistralai
 mypy-boto3-bedrock-runtime
 openai

--- a/requirements/type-check.txt
+++ b/requirements/type-check.txt
@@ -1,7 +1,7 @@
 -r ci.txt
 asyncpg
 grpcio
-litellm>=1.0.3
+litellm>=1.0.3,<1.82.7
 aioboto3
 # Note: OpenTelemetry packages must use versions released on the same date to ensure compatibility
 opentelemetry-exporter-otlp==1.39.1

--- a/requirements/unit-tests.txt
+++ b/requirements/unit-tests.txt
@@ -8,7 +8,7 @@ google-genai>=1.0.0
 grpc-interceptor[testing]
 httpx
 httpx-ws
-litellm>1.61.15
+litellm>1.61.15,<1.82.7
 nest-asyncio # for executor testing
 numpy
 pandas-stubs==2.0.3.230814


### PR DESCRIPTION
## Summary
- Pin `litellm<1.82.7` in `requirements/unit-tests.txt`, `requirements/type-check.txt`, and `requirements/packages/phoenix-evals.txt`
- The `pyproject.toml` files were already pinned; these requirements files were missed
- Versions 1.82.7+ are compromised via supply chain attack: https://github.com/BerriAI/litellm/issues/24518

## Test plan
- [ ] CI passes with the pinned versions