### PR TITLE
docs: Add Phoenix release notes for 03-22-2026 through 03-24-2026

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1099,6 +1099,8 @@
               {
                 "group": "03.2026",
                 "pages": [
+                  "docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates",
+                  "docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api",
                   "docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements",
                   "docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api",
                   "docs/phoenix/release-notes/03-2026/03-08-2026-new-playground-providers-and-project-settings",

--- a/docs/phoenix/release-notes.mdx
+++ b/docs/phoenix/release-notes.mdx
@@ -10,6 +10,50 @@ GitHub
 
 
 
+<Update label="03.24.2026">
+## [03.24.2026: Prompt Version Diff View](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
+**Available in arize-phoenix 13.18.0+**
+
+The Prompts UI now shows a line-by-line diff between any two prompt versions. See exactly what changed — message content, tool call arguments, and tool results — without leaving Phoenix.
+
+- **Side-by-side diff** across the full chat template, including all content part types
+</Update>
+
+<Update label="03.24.2026">
+## [03.24.2026: Evals Accept Structured Data Inputs](/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates)
+**Available in arize-phoenix-evals 2.12.0+**
+
+Evaluators now accept dicts and lists as template variable values, JSON-serializing them automatically. Built-in evaluators also accept `**kwargs` forwarded to the LLM on every call (e.g., `temperature=0.0`).
+
+- **Structured inputs** (dicts, lists) are JSON-serialized before prompt rendering — no manual `json.dumps()` needed
+- **LLM invocation kwargs** accepted by all built-in evaluators (`FaithfulnessEvaluator`, `CorrectnessEvaluator`, etc.)
+</Update>
+
+<Update label="03.23.2026">
+## [03.23.2026: `px auth status` Shows Username and Role](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+**Available in arize-phoenix 13.17.0+ and @arizeai/phoenix-cli 0.12.0+**
+
+`px auth status` now verifies credentials against the server and displays the authenticated username and role alongside the endpoint and token info.
+</Update>
+
+<Update label="03.22.2026">
+## [03.22.2026: `px spans` — Fetch and Filter Spans from the CLI](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+**Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
+
+`px spans` fetches spans for a project with filtering by kind, status code, name, trace ID, and time window. Output to the terminal or save to JSON for offline use.
+
+- **`--span-kind`**, **`--status-code`**, **`--name`**, **`--trace-id`** filters
+- **`--last-n-minutes`** / **`--since`** time range controls
+- **`--include-annotations`** to attach span annotations to the output
+</Update>
+
+<Update label="03.22.2026">
+## [03.22.2026: `px self update` and `GET /v1/user`](/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api)
+**Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
+
+`px self update` upgrades the installed CLI to the latest version, detecting npm, pnpm, bun, or Deno automatically. `GET /v1/user` returns the authenticated user's profile (username, email, role) or an anonymous representation when auth is disabled.
+</Update>
+
 <Update label="03.18.2026">
 ## [03.18.2026: Span Filters — Name, Kind, and Status Code](/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements)
 **Available in arize-phoenix 13.15.0+ (server), arize-phoenix-client 2.1.0+ (Python), @arizeai/phoenix-client 6.5.1+ (TypeScript)**

--- a/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api.mdx
+++ b/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api.mdx
@@ -1,0 +1,111 @@
+---
+title: "Release Notes"
+---
+
+# `px spans` — Fetch and Filter Spans from the CLI
+
+March 22, 2026
+
+**Available in arize-phoenix 13.16.0+ and @arizeai/phoenix-cli 0.12.0+**
+
+The Phoenix CLI (`px`) now has a `spans` command that fetches spans for a project with full filtering support. Pipe the output to other tools, save it to a file for offline analysis, or use it in scripts and CI pipelines.
+
+```bash
+# Fetch the 100 most recent spans (default)
+px spans
+
+# Fetch LLM spans with errors from the last hour
+px spans --span-kind LLM --status-code ERROR --last-n-minutes 60
+
+# Save spans to a JSON file
+px spans output.json --limit 500
+
+# Filter by span name or trace ID
+px spans --name my_chain_step --trace-id abc123
+
+# Include span annotations in output
+px spans --include-annotations
+
+# Root spans only (no parent)
+px spans --parent-id null
+```
+
+- **`--span-kind`** filters by span kind (`LLM`, `CHAIN`, `TOOL`, `RETRIEVER`, `EMBEDDING`, `AGENT`, `RERANKER`, `GUARDRAIL`, `EVALUATOR`, `UNKNOWN`); accepts multiple values
+- **`--status-code`** filters by status (`OK`, `ERROR`, `UNSET`); accepts multiple values
+- **`--name`** matches one or more span names
+- **`--trace-id`** narrows to specific traces; accepts multiple values
+- **`--last-n-minutes`** and **`--since`** control the time window
+- **`--format pretty|json|raw`** controls terminal output; file output is always JSON
+- **`--include-annotations`** attaches span annotations to each span in the output
+
+# `px self update` — Self-Update the CLI
+
+March 22, 2026
+
+**Available in @arizeai/phoenix-cli 0.12.0+**
+
+`px self update` upgrades the installed CLI to the latest published version. It detects how `px` was installed (npm, pnpm, bun, or Deno) and runs the appropriate update command automatically.
+
+```bash
+# Check if an update is available without installing
+px self update --check
+
+# Update to the latest version
+px self update
+```
+
+# `GET /v1/user` — Authenticated User Endpoint
+
+March 22, 2026
+
+**Available in arize-phoenix 13.16.0+**
+
+A new `GET /v1/user` endpoint returns the profile of the currently authenticated user, including their username, email, and role. When authentication is disabled, the endpoint returns an anonymous user representation instead of an error.
+
+```bash
+# Get the authenticated user's profile
+GET /v1/user
+```
+
+Response (authenticated):
+```json
+{
+  "data": {
+    "auth_method": "LOCAL",
+    "id": "VXNlcjox",
+    "username": "alice",
+    "email": "alice@example.com",
+    "role": "ADMIN",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+    "password_needs_reset": false
+  }
+}
+```
+
+Response (authentication disabled):
+```json
+{
+  "data": {
+    "auth_method": "ANONYMOUS"
+  }
+}
+```
+
+# `px auth status` Shows Username and Role
+
+March 23, 2026
+
+**Available in arize-phoenix 13.17.0+ and @arizeai/phoenix-cli 0.12.0+**
+
+`px auth status` now displays the authenticated username and role alongside the endpoint and token info. This uses the new `GET /v1/user` endpoint to verify credentials and surface identity at a glance.
+
+```bash
+px auth status
+# https://my-phoenix.example.com
+#   ✓ Logged in as alice (api key)
+#   - Role: ADMIN
+#   - Token: ************************************
+```
+
+When the server does not support the `/v1/user` endpoint (older versions), the command falls back gracefully and reports that verification is unavailable without failing.

--- a/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates.mdx
+++ b/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates.mdx
@@ -1,0 +1,70 @@
+---
+title: "Release Notes"
+---
+
+# Prompt Version Diff View
+
+March 24, 2026
+
+**Available in arize-phoenix 13.18.0+**
+
+The Prompts UI now includes a diff view for comparing two versions of a prompt side by side. Open any prompt version and select a baseline to see exactly what changed between versions — message roles, content additions, tool call arguments, and tool results are all diffed line by line.
+
+- **Side-by-side diff** highlights added and removed lines across the full chat template
+- **Works with all template types**: chat templates (with multi-part messages including tool calls and tool results) and string templates
+- **Supports all content parts**: text, tool calls, and tool results are each rendered and diffed
+
+# Evals Now Accept Structured Data as Inputs
+
+March 24, 2026
+
+**Available in arize-phoenix-evals 2.12.0+**
+
+Evaluators now accept dicts, lists, and other structured data as template variable values. Previously, non-string inputs were coerced via Python `str()`, which produced invalid JSON for nested objects. Now, structured values are JSON-serialized automatically before being inserted into the prompt.
+
+```python
+from phoenix.evals.metrics.faithfulness import FaithfulnessEvaluator
+from phoenix.evals import LLM
+
+llm = LLM(provider="openai", model="gpt-4o-mini")
+evaluator = FaithfulnessEvaluator(llm=llm)
+
+# Structured data is now accepted directly — no manual serialization needed
+scores = evaluator.evaluate({
+    "input": {"query": "What is the capital of France?", "language": "en"},
+    "output": "Paris is the capital of France.",
+    "context": ["Paris is the capital of France.", "France is in Western Europe."],
+})
+```
+
+- **Dicts and lists** are serialized to valid JSON strings (e.g., `{"key": "value"}`) before prompt rendering
+- **Plain strings** pass through unchanged — existing evaluator code continues to work without modification
+- **Section variables** (`{{#var}}`, `{{^var}}`) in Mustache templates still receive the raw value so pystache can iterate lists and evaluate conditionals
+
+# Built-in Classification Evaluators Accept LLM Invocation Parameters
+
+March 24, 2026
+
+**Available in arize-phoenix-evals 2.12.0+**
+
+Built-in classification evaluators (`FaithfulnessEvaluator`, `CorrectnessEvaluator`, `HallucinationEvaluator`, and others) now accept arbitrary `**kwargs` that are forwarded to the LLM on every evaluation call. Use this to control generation behavior without needing to subclass.
+
+```python
+from phoenix.evals.metrics.faithfulness import FaithfulnessEvaluator
+from phoenix.evals import LLM
+
+llm = LLM(provider="openai", model="gpt-4o-mini")
+
+# Pass LLM invocation parameters directly (e.g., temperature, max_tokens)
+evaluator = FaithfulnessEvaluator(llm=llm, temperature=0.0, max_tokens=256)
+
+eval_input = {
+    "input": "What is the capital of France?",
+    "output": "Paris is the capital of France.",
+    "context": "Paris is the capital and largest city of France.",
+}
+scores = evaluator.evaluate(eval_input)
+```
+
+- **Any keyword argument** beyond `llm` is stored as an invocation parameter and forwarded to the underlying LLM client on each call
+- Applies to all built-in evaluators: `FaithfulnessEvaluator`, `CorrectnessEvaluator`, `DocumentRelevanceEvaluator`, `RefusalEvaluator`, `ConcisenessEvaluator`, `ToolSelectionEvaluator`, `ToolInvocationEvaluator`, and `ToolResponseHandlingEvaluator`

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/03-2026/03-24-2026-prompt-version-diff-and-evals-updates" arrow="true" title="03.24.2026" icon="calendar" description="Prompt version diff view; structured eval inputs; LLM kwargs for built-in evaluators"/>
+    <Card href="/docs/phoenix/release-notes/03-2026/03-22-2026-cli-and-user-api" arrow="true" title="03.22.2026" icon="calendar" description="px spans command, px self update, GET /v1/user endpoint, px auth status enrichment"/>
     <Card href="/docs/phoenix/release-notes/03-2026/03-13-2026-rest-api-improvements" arrow="true" title="03.18.2026" icon="calendar" description="Span filters by name, kind, and status code; list traces by project"/>
     <Card href="/docs/phoenix/release-notes/03-2026/03-11-2026-session-turns-api" arrow="true" title="03.11.2026"/>
     <Card href="/docs/phoenix/release-notes/03-2026/03-08-2026-new-playground-providers-and-project-settings" arrow="true" title="03.08.2026" icon="calendar" description="New playground providers and editable project settings"/>


### PR DESCRIPTION
## Summary

- Documents arize-phoenix 13.16.0–13.18.0 and arize-phoenix-evals 2.12.0 releases
- New file: `03-22-2026-cli-and-user-api.mdx` — `px spans` command, `px self update`, `GET /v1/user` endpoint, `px auth status` user info
- New file: `03-24-2026-prompt-version-diff-and-evals-updates.mdx` — prompt version diff view, structured eval inputs, LLM kwargs for built-in evaluators
- Updated aggregate file (`release-notes.mdx`), year overview (`2026.mdx`), and navigation (`docs.json`)

## Test plan

- [ ] Verify all links in `release-notes.mdx` resolve to real MDX files
- [ ] Check navigation entries in `docs.json` match new file paths
- [ ] Review MDX formatting and frontmatter validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)