### PR TITLE
docs(cli): add agent-friendly patterns to CLI development skill

### DIFF
--- a/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
+++ b/js/packages/phoenix-cli/.agents/skills/phoenix-cli-development/SKILL.md
@@ -162,29 +162,28 @@ interface StructuredError {
   "code": "FAILURE",
   "hint": "px project list --format raw"
 }
+```
 
 ### Progressive help discovery
 
 Every subcommand MUST include a `--help` with at least one concrete example. Use Commander's `.addHelpText('after', ...)` to append an `Examples:` block:
 
 ```
-
 $ px project create --help
 Usage: px project create [options]
 
 Create a new Phoenix project.
 
 Options:
---name <name> Project name (required)
---description <d> Project description
---format <format> Output format (pretty|json|raw) (default: "pretty")
--h, --help Display help
+  --name <name>       Project name (required)
+  --description <d>   Project description
+  --format <format>   Output format (pretty|json|raw) (default: "pretty")
+  -h, --help          Display help
 
 Examples:
-px project create --name my-project
-px project create --name my-project --format raw
-
-````
+  px project create --name my-project
+  px project create --name my-project --format raw
+```
 
 Agents discover capabilities incrementally: `px` → `px project` → `px project create --help`. Each level MUST provide enough information to navigate deeper.
 
@@ -202,7 +201,7 @@ interface CommonOptions {
   format?: OutputFormat; // --format: Output format (pretty/json/raw)
   progress?: boolean; // --no-progress: Suppress progress indicators
 }
-````
+```
 
 Commands that prompt for input or confirmation MUST support non-interactive mode:
 


### PR DESCRIPTION
## Summary
- Adds 6 new agent-friendly design sections to the `phoenix-cli-development` skill: non-interactive mode (`--no-input`), idempotent commands, structured data on success, actionable errors with `StructuredError` interface, and progressive help discovery
- Consolidates interactive behavior into a single `--no-input` flag (replaces separate `--yes`/`--ci` concepts) with automatic TTY detection
- Extends the new-command checklist with 4 items covering `--no-input`, `--help` examples, structured output, and agent verification
- Fixes frontmatter to match `phoenix-skill-development` conventions (`license`, `metadata`)

Informed by Railway CLI, [Anthropic skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), and [@ericzakariasson's thread on agent-friendly CLI design](https://x.com/ericzakariasson/status/2036762680401223946).

## Test plan
- [ ] Read through the updated SKILL.md and verify conventions are clear and consistent
- [ ] Verify the skill triggers correctly when working on CLI commands in a fresh conversation
- [ ] Confirm line count stays under 500 (currently 310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)