### PR TITLE
fix(deps): pin fastapi>=0.135.2 to prevent 204 route assertion error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "python-multipart",  # see https://www.starlette.io/#dependencies
   "arize-phoenix-evals>=2.12.0",
   "arize-phoenix-otel>=0.15.0",
-  "fastapi",
+  "fastapi>=0.135.2",  # older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
   "authlib",
   "arize-phoenix-client>=2.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'container'" },
     { name = "cachetools" },
     { name = "email-validator" },
-    { name = "fastapi" },
+    { name = "fastapi", specifier = ">=0.135.2" },
     { name = "google-genai", marker = "python_full_version >= '3.10' and extra == 'container'", specifier = ">=1.50.0" },
     { name = "google-genai", marker = "python_full_version < '3.10' and extra == 'container'" },
     { name = "grpc-interceptor" },


### PR DESCRIPTION
## Summary
- Adds a lower bound `fastapi>=0.135.2` to prevent import-time `AssertionError: Status code 204 must not have a response body` that occurs with older FastAPI versions (e.g. 0.115.14)
- Previously `fastapi` had no version constraint, so fresh installs could resolve to a version that crashes on Phoenix's 204 routes

Closes #12384

## Test plan
- [x] Reproduced locally by pinning `fastapi==0.115.14` — confirmed `from phoenix.otel import register` and server startup both crash with `AssertionError`
- [x] `uv sync` passes cleanly with the new lower bound
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)