### PR TITLE
refactor(db): remove psycopg dependency, use asyncpg for migrations

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,6 +31,18 @@ python -m phoenix.server.main db migrate --database-url "postgresql://..."
 
 Top-level `--help` only shows global usage; use `phoenix serve --help`, or `phoenix db migrate --help` for subcommand options.
 
+### PostgreSQL Driver: `psycopg` Removed
+
+The `psycopg` driver has been removed. Phoenix now uses `asyncpg` as the sole PostgreSQL driver for both runtime queries and migrations. If you have `psycopg` installed only for Phoenix, it can be uninstalled.
+
+The `pg` extra no longer includes `psycopg`:
+
+```shell
+pip install arize-phoenix[pg]  # only installs asyncpg
+```
+
+No configuration changes are needed — `PHOENIX_SQL_DATABASE_URL` continues to work with the same `postgresql://` connection strings.
+
 ### Legacy Client Removed
 
 The legacy `phoenix.session.client.Client` (accessed via `px.Client()`) has been removed. All client interactions now go through the `arize-phoenix-client` package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ dev = [
   "portpicker",
   "prometheus_client",
   "psutil",
-  "psycopg[binary,pool]",
   "py-grpc-prometheus",
   "pyarrow-stubs",
   "pydantic>=1.0,!=2.0.*,<3",
@@ -177,7 +176,6 @@ evals = []
 experimental = []
 pg = [
   "asyncpg",
-  "psycopg[binary,pool]",
 ]
 aws = [
   "aioboto3",

--- a/src/phoenix/db/engines.py
+++ b/src/phoenix/db/engines.py
@@ -2,21 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
 from enum import Enum
 from sqlite3 import Connection
-from typing import Any, Optional
+from typing import Any
 
 import aiosqlite
 import numpy as np
 import orjson
-import sqlalchemy
 import sqlean
-from sqlalchemy import URL, StaticPool, event, make_url
+from sqlalchemy import URL, NullPool, StaticPool, event, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from typing_extensions import assert_never
 
-from phoenix.config import get_env_database_schema
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.migrate import migrate_in_thread
 from phoenix.db.models import init_models
@@ -138,23 +135,15 @@ def aio_sqlite_engine(
         else:
             asyncio.create_task(init_models(engine))
     else:
-        sync_engine = sqlalchemy.create_engine(
-            url=url.set(drivername="sqlite"),
-            echo=log_migrations,
+        migration_engine = create_async_engine(
+            url=url,
             json_serializer=_dumps,
-            creator=lambda: sqlean.connect(f"file:{database}", uri=True),
+            async_creator=async_creator,
+            poolclass=NullPool,
+            echo=log_migrations,
         )
-        migrate_in_thread(sync_engine, log_migrations=log_migrations)
+        migrate_in_thread(migration_engine, log_migrations=log_migrations)
     return engine
-
-
-def set_postgresql_search_path(schema: str) -> Callable[[Connection, Any], None]:
-    def _(connection: Connection, _: Any) -> None:
-        cursor = connection.cursor()
-        cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {schema};")
-        cursor.execute(f"SET search_path TO {schema};")
-
-    return _
 
 
 def aio_postgresql_engine(
@@ -169,46 +158,37 @@ def aio_postgresql_engine(
     )
 
     use_iam_auth = get_env_postgres_use_iam_auth()
+    asyncpg_url, asyncpg_args = get_pg_config(url, enforce_ssl=use_iam_auth)
 
-    asyncpg_url, asyncpg_args = get_pg_config(url, "asyncpg", enforce_ssl=use_iam_auth)
-
-    iam_config: Optional[dict[str, Any]] = None
-    token_lifetime: int = 0
     if use_iam_auth:
-        iam_config = _extract_iam_config_from_url(url)
-        token_lifetime = get_env_postgres_iam_token_lifetime()
+        if not (host := url.host):
+            raise ValueError("Database host is required for IAM authentication")
+        if not (user := url.username):
+            raise ValueError("Database user is required for IAM authentication")
+        port = url.port or 5432
+        database = url.database or "postgres"
 
         async def iam_async_creator() -> Any:
             import asyncpg  # type: ignore
 
             from phoenix.db.iam_auth import generate_aws_rds_token
 
-            assert iam_config is not None
-            token = generate_aws_rds_token(
-                host=iam_config["host"],
-                port=iam_config["port"],
-                user=iam_config["user"],
+            token = generate_aws_rds_token(host=host, port=port, user=user)
+            return await asyncpg.connect(
+                host=host,
+                port=port,
+                user=user,
+                password=token,
+                database=database,
+                **asyncpg_args,
             )
-
-            conn_kwargs = {
-                "host": iam_config["host"],
-                "port": iam_config["port"],
-                "user": iam_config["user"],
-                "password": token,
-                "database": iam_config["database"],
-            }
-
-            if asyncpg_args:
-                conn_kwargs.update(asyncpg_args)
-
-            return await asyncpg.connect(**conn_kwargs)
 
         engine = create_async_engine(
             url=asyncpg_url,
             async_creator=iam_async_creator,
             echo=log_to_stdout,
             json_serializer=_dumps,
-            pool_recycle=token_lifetime,
+            pool_recycle=get_env_postgres_iam_token_lifetime(),
         )
     else:
         engine = create_async_engine(
@@ -221,82 +201,25 @@ def aio_postgresql_engine(
     if not migrate:
         return engine
 
-    psycopg_url, psycopg_args = get_pg_config(url, "psycopg", enforce_ssl=use_iam_auth)
-
     if use_iam_auth:
-        assert iam_config is not None
-
-        def iam_sync_creator() -> Any:
-            import psycopg
-
-            from phoenix.db.iam_auth import generate_aws_rds_token
-
-            token = generate_aws_rds_token(
-                host=iam_config["host"],
-                port=iam_config["port"],
-                user=iam_config["user"],
-            )
-
-            conn_kwargs = {
-                "host": iam_config["host"],
-                "port": iam_config["port"],
-                "user": iam_config["user"],
-                "password": token,
-                "dbname": iam_config["database"],
-            }
-
-            if psycopg_args:
-                conn_kwargs.update(psycopg_args)
-
-            return psycopg.connect(**conn_kwargs)
-
-        sync_engine = sqlalchemy.create_engine(
-            url=psycopg_url,
-            creator=iam_sync_creator,
+        migration_engine = create_async_engine(
+            url=asyncpg_url,
+            async_creator=iam_async_creator,
             echo=log_migrations,
             json_serializer=_dumps,
-            pool_recycle=token_lifetime,
+            poolclass=NullPool,
+            pool_recycle=get_env_postgres_iam_token_lifetime(),
         )
     else:
-        sync_engine = sqlalchemy.create_engine(
-            url=psycopg_url,
-            connect_args=psycopg_args,
+        migration_engine = create_async_engine(
+            url=asyncpg_url,
+            connect_args=asyncpg_args,
             echo=log_migrations,
             json_serializer=_dumps,
+            poolclass=NullPool,
         )
-
-    if schema := get_env_database_schema():
-        event.listen(sync_engine, "connect", set_postgresql_search_path(schema))
-    migrate_in_thread(sync_engine, log_migrations=log_migrations)
+    migrate_in_thread(migration_engine, log_migrations=log_migrations)
     return engine
-
-
-def _extract_iam_config_from_url(url: URL) -> dict[str, Any]:
-    """Extract connection parameters needed for IAM authentication from a SQLAlchemy URL.
-
-    Args:
-        url: SQLAlchemy database URL
-
-    Returns:
-        Dictionary with host, port, user, and database
-    """
-    host = url.host
-    if not host:
-        raise ValueError("Database host is required for IAM authentication")
-
-    port = url.port or 5432
-    user = url.username
-    if not user:
-        raise ValueError("Database user is required for IAM authentication")
-
-    database = url.database or "postgres"
-
-    return {
-        "host": host,
-        "port": port,
-        "user": user,
-        "database": database,
-    }
 
 
 def _dumps(obj: Any) -> str:

--- a/src/phoenix/db/migrate.py
+++ b/src/phoenix/db/migrate.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from phoenix.exceptions import PhoenixMigrationError
 from phoenix.utilities import no_emojis_on_windows
@@ -35,34 +35,37 @@ def printif(condition: bool, text: str) -> None:
 
 
 def migrate(
-    engine: Engine,
+    engine: AsyncEngine,
     error_queue: Optional["SimpleQueue[BaseException]"] = None,
     log_migrations: bool = True,
 ) -> None:
     """
     Runs migrations on the database.
-    NB: Migrate only works on non-memory databases.
 
-    Args:
-        url: The database URL.
+    The caller must provide a disposable engine (e.g. with NullPool) — this
+    function disposes it after use. Do not pass the server's main engine.
     """
+    import asyncio
+
     try:
         printif(log_migrations, "🏃‍♀️‍➡️ Running migrations on the database.")
         printif(log_migrations, "---------------------------")
         config_path = str(Path(__file__).parent.resolve() / "alembic.ini")
         alembic_cfg = Config(config_path)
 
-        # Explicitly set the migration directory
         scripts_location = str(Path(__file__).parent.resolve() / "migrations")
         alembic_cfg.set_main_option("script_location", scripts_location)
         url = str(engine.url).replace("%", "%%")
         alembic_cfg.set_main_option("sqlalchemy.url", url)
         start_time = perf_counter()
-        with engine.connect() as conn:
-            alembic_cfg.attributes["connection"] = conn
-            command.upgrade(alembic_cfg, "head")
+
+        async def run() -> None:
+            async with engine.connect() as conn:
+                await conn.run_sync(_run_alembic_upgrade, alembic_cfg)
+            await engine.dispose()
+
+        asyncio.run(run())
         elapsed_time = perf_counter() - start_time
-        engine.dispose()
         printif(log_migrations, "---------------------------")
         printif(log_migrations, f"✅ Migrations completed in {elapsed_time:.3f} seconds.")
     except BaseException as e:
@@ -72,7 +75,12 @@ def migrate(
         raise
 
 
-def migrate_in_thread(engine: Engine, log_migrations: bool = True) -> None:
+def _run_alembic_upgrade(connection, alembic_cfg: Config) -> None:  # type: ignore[no-untyped-def]
+    alembic_cfg.attributes["connection"] = connection
+    command.upgrade(alembic_cfg, "head")
+
+
+def migrate_in_thread(engine: AsyncEngine, log_migrations: bool = True) -> None:
     """
     Runs migrations on the database in a separate thread.
     This is needed because depending on the context (notebook)

--- a/src/phoenix/db/migrations/data_migration_scripts/populate_project_sessions.py
+++ b/src/phoenix/db/migrations/data_migration_scripts/populate_project_sessions.py
@@ -13,151 +13,132 @@ Environment variables.
 """
 
 import os
-from datetime import datetime
 from time import perf_counter
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import sqlean
-from openinference.semconv.trace import SpanAttributes
 from sqlalchemy import (
-    JSON,
+    Connection,
     Engine,
     NullPool,
     create_engine,
-    event,
-    func,
-    insert,
     make_url,
-    select,
-    update,
+    text,
 )
-from sqlalchemy.dialects import postgresql
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
 
 from phoenix.config import ENV_PHOENIX_SQL_DATABASE_SCHEMA, get_env_database_connection_str
-from phoenix.db.engines import set_postgresql_search_path
 
+_SQLITE_INSERT_SESSIONS = text("""
+    INSERT INTO project_sessions (session_id, project_id, start_time, end_time)
+    SELECT
+        sub.session_id,
+        sub.project_id,
+        sub.start_time,
+        sub.end_time
+    FROM (
+        SELECT
+            CAST(JSON_EXTRACT(s.attributes, '$.session.id') AS VARCHAR) AS session_id,
+            t.project_rowid AS project_id,
+            t.start_time AS start_time,
+            ROW_NUMBER() OVER (
+                PARTITION BY JSON_EXTRACT(s.attributes, '$.session.id')
+                ORDER BY t.start_time, t.id, s.id
+            ) AS rank,
+            MAX(t.end_time) OVER (
+                PARTITION BY JSON_EXTRACT(s.attributes, '$.session.id')
+            ) AS end_time
+        FROM spans s
+        JOIN traces t ON s.trace_rowid = t.id
+        WHERE s.parent_id IS NULL
+        AND CAST(JSON_EXTRACT(s.attributes, '$.session.id') AS VARCHAR) != ''
+    ) sub
+    WHERE sub.rank = 1
+""")
 
-class JSONB(JSON):
-    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
-    __visit_name__ = "JSONB"
-
-
-@compiles(JSONB, "sqlite")
-def _(*args: Any, **kwargs: Any) -> str:
-    # See https://docs.sqlalchemy.org/en/20/core/custom_types.html
-    return "JSONB"
-
-
-JSON_ = (
-    JSON()
-    .with_variant(
-        postgresql.JSONB(),  # type: ignore
-        "postgresql",
+_SQLITE_UPDATE_TRACES = text("""
+    UPDATE traces
+    SET project_session_rowid = (
+        SELECT ps.id
+        FROM project_sessions ps
+        JOIN spans s ON CAST(JSON_EXTRACT(s.attributes, '$.session.id') AS VARCHAR) = ps.session_id
+        WHERE s.trace_rowid = traces.id
+        AND s.parent_id IS NULL
+        AND CAST(JSON_EXTRACT(s.attributes, '$.session.id') AS VARCHAR) != ''
     )
-    .with_variant(
-        JSONB(),
-        "sqlite",
+    WHERE EXISTS (
+        SELECT 1
+        FROM spans s
+        WHERE s.trace_rowid = traces.id
+        AND s.parent_id IS NULL
+        AND CAST(JSON_EXTRACT(s.attributes, '$.session.id') AS VARCHAR) != ''
     )
-)
+""")
 
+_PG_INSERT_SESSIONS = text("""
+    INSERT INTO project_sessions (session_id, project_id, start_time, end_time)
+    SELECT
+        sub.session_id,
+        sub.project_id,
+        sub.start_time,
+        sub.end_time
+    FROM (
+        SELECT
+            CAST(s.attributes #>> '{session,id}' AS VARCHAR) AS session_id,
+            t.project_rowid AS project_id,
+            t.start_time AS start_time,
+            ROW_NUMBER() OVER (
+                PARTITION BY s.attributes #> '{session,id}'
+                ORDER BY t.start_time, t.id, s.id
+            ) AS rank,
+            MAX(t.end_time) OVER (
+                PARTITION BY s.attributes #> '{session,id}'
+            ) AS end_time
+        FROM spans s
+        JOIN traces t ON s.trace_rowid = t.id
+        WHERE s.parent_id IS NULL
+        AND CAST(s.attributes #>> '{session,id}' AS VARCHAR) != ''
+    ) sub
+    WHERE sub.rank = 1
+""")
 
-class Base(DeclarativeBase): ...
-
-
-class ProjectSession(Base):
-    __tablename__ = "project_sessions"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    session_id: Mapped[str]
-    project_id: Mapped[int]
-    start_time: Mapped[datetime]
-    end_time: Mapped[datetime]
-
-
-class Trace(Base):
-    __tablename__ = "traces"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    project_session_rowid: Mapped[Union[int, None]]
-    project_rowid: Mapped[int]
-    start_time: Mapped[datetime]
-    end_time: Mapped[datetime]
-
-
-class Span(Base):
-    __tablename__ = "spans"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    trace_rowid: Mapped[int]
-    parent_id: Mapped[Optional[str]]
-    attributes: Mapped[dict[str, Any]] = mapped_column(JSON_, nullable=False)
-
-
-SESSION_ID = SpanAttributes.SESSION_ID.split(".")
-USER_ID = SpanAttributes.USER_ID.split(".")
+_PG_UPDATE_TRACES = text("""
+    UPDATE traces
+    SET project_session_rowid = sub.project_session_rowid
+    FROM (
+        SELECT
+            s.trace_rowid,
+            ps.id AS project_session_rowid
+        FROM spans s
+        JOIN project_sessions ps
+            ON CAST(s.attributes #>> '{session,id}' AS VARCHAR) = ps.session_id
+        WHERE s.parent_id IS NULL
+        AND CAST(s.attributes #>> '{session,id}' AS VARCHAR) != ''
+    ) sub
+    WHERE traces.id = sub.trace_rowid
+""")
 
 
 def populate_project_sessions(
-    engine: Engine,
+    engine_or_connection: Union[Engine, Connection],
 ) -> None:
-    sessions_from_span = (
-        select(
-            Span.attributes[SESSION_ID].as_string().label("session_id"),
-            Trace.project_rowid.label("project_id"),
-            Trace.start_time.label("start_time"),
-            func.row_number()
-            .over(
-                partition_by=Span.attributes[SESSION_ID],
-                order_by=[Trace.start_time, Trace.id, Span.id],
-            )
-            .label("rank"),
-            func.max(Trace.end_time)
-            .over(partition_by=Span.attributes[SESSION_ID])
-            .label("end_time"),
-        )
-        .join_from(Span, Trace, Span.trace_rowid == Trace.id)
-        .where(Span.parent_id.is_(None))
-        .where(Span.attributes[SESSION_ID].as_string() != "")
-        .subquery()
-    )
-    sessions_for_trace_id = (
-        select(
-            Span.trace_rowid,
-            ProjectSession.id.label("project_session_rowid"),
-        )
-        .join_from(
-            Span,
-            ProjectSession,
-            Span.attributes[SESSION_ID].as_string() == ProjectSession.session_id,
-        )
-        .where(Span.parent_id.is_(None))
-        .where(Span.attributes[SESSION_ID].as_string() != "")
-        .subquery()
-    )
     start_time = perf_counter()
-    with sessionmaker(engine).begin() as session:
-        session.execute(
-            insert(ProjectSession).from_select(
-                [
-                    "session_id",
-                    "project_id",
-                    "start_time",
-                    "end_time",
-                ],
-                select(
-                    sessions_from_span.c.session_id,
-                    sessions_from_span.c.project_id,
-                    sessions_from_span.c.start_time,
-                    sessions_from_span.c.end_time,
-                ).where(sessions_from_span.c.rank == 1),
-            )
-        )
-        session.execute(
-            (
-                update(Trace)
-                .values(project_session_rowid=sessions_for_trace_id.c.project_session_rowid)
-                .where(Trace.id == sessions_for_trace_id.c.trace_rowid)
-            )
-        )
+    if isinstance(engine_or_connection, Connection):
+        conn = engine_or_connection
+        dialect = conn.engine.dialect.name
+        insert_stmt = _PG_INSERT_SESSIONS if dialect == "postgresql" else _SQLITE_INSERT_SESSIONS
+        update_stmt = _PG_UPDATE_TRACES if dialect == "postgresql" else _SQLITE_UPDATE_TRACES
+        conn.execute(insert_stmt)
+        conn.execute(update_stmt)
+        conn.commit()
+    else:
+        engine = engine_or_connection
+        dialect = engine.dialect.name
+        insert_stmt = _PG_INSERT_SESSIONS if dialect == "postgresql" else _SQLITE_INSERT_SESSIONS
+        update_stmt = _PG_UPDATE_TRACES if dialect == "postgresql" else _SQLITE_UPDATE_TRACES
+        with engine.connect() as conn:
+            conn.execute(insert_stmt)
+            conn.execute(update_stmt)
+            conn.commit()
     elapsed_time = perf_counter() - start_time
     print(f"✅ Populated project_sessions in {elapsed_time:.3f} seconds.")
 
@@ -178,7 +159,14 @@ if __name__ == "__main__":
             poolclass=NullPool,
             echo=True,
         )
+        populate_project_sessions(engine)
     elif backend == "postgresql":
+        import asyncio
+
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from phoenix.db.engines import get_async_db_url
+
         schema = os.getenv(ENV_PHOENIX_SQL_DATABASE_SCHEMA)
         if schema:
             print(f"Using schema: {schema}")
@@ -187,13 +175,21 @@ if __name__ == "__main__":
         ans = input("Is that correct? [y]/n: ")
         if ans.lower().startswith("n"):
             schema = input("Please enter the correct schema: ")
-        engine = create_engine(
-            url=sql_database_url.set(drivername="postgresql+psycopg"),
-            poolclass=NullPool,
-            echo=True,
-        )
-        if schema:
-            event.listen(engine, "connect", set_postgresql_search_path(schema))
+        async_url = get_async_db_url(sql_database_url.render_as_string(hide_password=False))
+        async_engine = create_async_engine(url=async_url, poolclass=NullPool, echo=True)
+
+        def _run_with_schema(connection: Any) -> None:
+            if schema:
+                connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
+                connection.execute(text(f"SET search_path TO {schema}"))
+                connection.commit()
+            populate_project_sessions(connection)
+
+        async def _run() -> None:
+            async with async_engine.connect() as conn:
+                await conn.run_sync(_run_with_schema)
+            await async_engine.dispose()
+
+        asyncio.run(_run())
     else:
         raise ValueError(f"Unknown database backend: {backend}")
-    populate_project_sessions(engine)

--- a/src/phoenix/db/migrations/env.py
+++ b/src/phoenix/db/migrations/env.py
@@ -1,10 +1,10 @@
 import asyncio
 
 from alembic import context
-from sqlalchemy import Connection, engine_from_config, pool
+from sqlalchemy import Connection, engine_from_config, pool, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from phoenix.config import get_env_database_connection_str
+from phoenix.config import get_env_database_connection_str, get_env_database_schema
 from phoenix.db.engines import get_async_db_url
 from phoenix.db.models import Base
 from phoenix.settings import Settings
@@ -21,6 +21,9 @@ target_metadata = Base.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
+
+_schema = get_env_database_schema()
 
 
 def run_migrations_offline() -> None:
@@ -42,6 +45,7 @@ def run_migrations_offline() -> None:
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
         transaction_per_migration=True,
+        version_table_schema=_schema,
     )
 
     with context.begin_transaction():
@@ -90,6 +94,11 @@ async def run_async_migrations(connectable: AsyncEngine) -> None:
 
 
 def run_migrations(connection: Connection) -> None:
+    if _schema:
+        connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {_schema}"))
+        connection.execute(text(f"SET search_path TO {_schema}"))
+    if connection.in_transaction():
+        connection.commit()
     transaction = connection.begin()
     try:
         context.configure(
@@ -98,14 +107,13 @@ def run_migrations(connection: Connection) -> None:
             compare_type=True,
             transactional_ddl=True,
             transaction_per_migration=True,
+            version_table_schema=_schema,
         )
         context.run_migrations()
         transaction.commit()
     except Exception:
         transaction.rollback()
         raise
-    finally:
-        connection.close()
 
 
 if context.is_offline_mode():

--- a/src/phoenix/db/pg_config.py
+++ b/src/phoenix/db/pg_config.py
@@ -1,30 +1,26 @@
 from __future__ import annotations
 
 import ssl
-from typing import Any, Container, Final, Literal, Mapping, TypedDict, get_type_hints
+from typing import Any, Container, Final, Mapping, TypedDict, get_type_hints
 
 from sqlalchemy import URL
-from typing_extensions import assert_never
 
 
 def get_pg_config(
     url: URL,
-    driver: Literal["psycopg", "asyncpg"],
     enforce_ssl: bool = False,
 ) -> tuple[URL, dict[str, Any]]:
-    """Convert SQLAlchemy URL to driver-specific configuration.
+    """Convert SQLAlchemy URL to asyncpg-specific configuration.
 
     Args:
         url: SQLAlchemy URL
-        driver: "psycopg" or "asyncpg"
         enforce_ssl: If True, ensure SSL is enabled (required for AWS RDS IAM auth)
 
     Returns:
         Tuple of (base_url, connect_args):
         - base_url: URL with driver prefix and non-SSL parameters
-        - connect_args: SSL configuration for the driver
+        - connect_args: SSL configuration for asyncpg
     """
-    # Create new URL with appropriate driver
     query = url.query
     ssl_args = _get_ssl_args(query)
 
@@ -36,25 +32,16 @@ def get_pg_config(
             "Remove 'sslmode=disable' from the connection string."
         )
 
-    # Create base URL without SSL parameters
     base_url = url.set(
-        drivername=f"postgresql+{driver}",
+        drivername="postgresql+asyncpg",
         query={k: v for k, v in query.items() if k not in _SSL_KEYS},
     )
 
-    # Get appropriate SSL configuration based on driver
-    if driver == "psycopg":
-        connect_args = dict(ssl_args)
-        # Remove asyncpg-specific parameters from base URL
-        base_url = base_url.set(query=_remove_asyncpg_only_params(base_url.query))
-    elif driver == "asyncpg":
-        # Only create SSL context if we have SSL parameters and sslmode is not disable
-        if ssl_args and ssl_args.get("sslmode") != "disable":
-            connect_args = {"ssl": _get_ssl_context(ssl_args)}
-        else:
-            connect_args = {}
+    if ssl_args and ssl_args.get("sslmode") != "disable":
+        connect_args = {"ssl": _get_ssl_context(ssl_args)}
     else:
-        assert_never(driver)
+        connect_args = {}
+
     return base_url, connect_args
 
 
@@ -184,24 +171,3 @@ def _get_ssl_context(ssl_args: _SSLArgs) -> ssl.SSLContext:
         ssl_context.verify_mode = ssl.CERT_NONE
 
     return ssl_context
-
-
-def _remove_asyncpg_only_params(
-    query: Mapping[str, str | tuple[str, ...]],
-) -> dict[str, str | tuple[str, ...]]:
-    """Remove asyncpg-specific parameters from a SQLAlchemy URL query.
-
-    Args:
-        query: SQLAlchemy URL query parameters
-
-    Returns:
-        Dictionary of query parameters with asyncpg-specific parameters removed
-    """
-    return {k: v for k, v in query.items() if k not in _ASYNCPG_ONLY_KEYS}
-
-
-# Asyncpg-specific parameter keys
-_ASYNCPG_ONLY_KEYS: Final[tuple[str, ...]] = (
-    "prepared_statement_cache_size",
-    # Add other asyncpg-specific parameters here if needed
-)

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from base64 import b64decode, urlsafe_b64encode
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import AbstractContextManager, contextmanager, nullcontext
+from contextlib import AbstractContextManager, asynccontextmanager, contextmanager, nullcontext
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -62,8 +62,10 @@ from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.trace import Span, Tracer, format_span_id
 from opentelemetry.util.types import AttributeValue
 from psutil import STATUS_ZOMBIE, Popen
-from sqlalchemy import URL, create_engine, text
+from sqlalchemy import URL, text
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
 from strawberry.relay import GlobalID
@@ -83,6 +85,7 @@ from phoenix.config import (
     ENV_PHOENIX_SQL_DATABASE_SCHEMA,
     ENV_PHOENIX_SQL_DATABASE_URL,
 )
+from phoenix.db.engines import get_async_db_url
 from phoenix.server.api.auth import IsAdmin
 from phoenix.server.api.exceptions import Unauthorized
 from phoenix.server.api.input_types.UserRoleInput import UserRoleInput
@@ -803,28 +806,33 @@ def _capture_stdout(
                 log.append(line)
 
 
-@contextmanager
-def _random_schema(
+@asynccontextmanager
+async def _random_schema(
     url: URL,
-) -> Iterator[str]:
-    engine = create_engine(url.set(drivername="postgresql+psycopg"))
-    engine.connect().close()
-    engine.dispose()
+) -> AsyncIterator[str]:
+    async_url = get_async_db_url(url.render_as_string(hide_password=False))
+    async_engine = create_async_engine(async_url, poolclass=NullPool)
+
     schema = f"{_SCHEMA_PREFIX}{token_hex(16)}"[:63]
+    async with async_engine.connect() as conn:
+        await conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema}"))
+        await conn.commit()
+
     yield schema
+
     time_limit = time() + 30
     while time() < time_limit:
         try:
-            with engine.connect() as conn:
-                conn.execute(text(f"DROP SCHEMA {schema} CASCADE;"))
-                conn.commit()
+            async with async_engine.connect() as conn:
+                await conn.execute(text(f"DROP SCHEMA {schema} CASCADE;"))
+                await conn.commit()
         except OperationalError as exc:
             if "too many clients" in str(exc):
-                sleep(1)
+                await asyncio.sleep(1)
                 continue
             raise
         break
-    engine.dispose()
+    await async_engine.dispose()
 
 
 def _gql(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -253,12 +253,20 @@ def _env_database(
     _sql_database_url: URL,
 ) -> Iterator[dict[str, str]]:
     """Configure database environment variables for testing."""
+    import asyncio
+
     env = {"PHOENIX_SQL_DATABASE_URL": _sql_database_url.render_as_string()}
     if not _sql_database_url.get_backend_name().startswith("postgresql"):
         yield env
     else:
-        with _random_schema(_sql_database_url) as schema:
+        loop = asyncio.new_event_loop()
+        ctx = _random_schema(_sql_database_url)
+        schema = loop.run_until_complete(ctx.__aenter__())
+        try:
             yield {**env, "PHOENIX_SQL_DATABASE_SCHEMA": schema}
+        finally:
+            loop.run_until_complete(ctx.__aexit__(None, None, None))
+            loop.close()
 
 
 @pytest.fixture(scope="package")

--- a/tests/integration/db_migrations/__init__.py
+++ b/tests/integration/db_migrations/__init__.py
@@ -1,43 +1,66 @@
 from __future__ import annotations
 
 import re
-from typing import Literal, Optional, TypedDict
+from typing import Callable, Literal, Optional, TypedDict, TypeVar, Union
 
 import pytest
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import Connection, Engine, Row, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 from typing_extensions import TypeAlias, assert_never
 
 _DBBackend: TypeAlias = Literal["sqlite", "postgresql"]
+_AnyEngine: TypeAlias = Union[Engine, AsyncEngine]
+
+T = TypeVar("T")
 
 
-def _up(engine: Engine, alembic_config: Config, revision: str, schema: str) -> None:
-    with engine.connect() as conn:
+async def _run_async(engine: _AnyEngine, fn: Callable[[Connection], T]) -> T:
+    """Run a sync function against either a sync or async engine."""
+    if isinstance(engine, AsyncEngine):
+        async with engine.connect() as conn:
+            return await conn.run_sync(fn)
+    else:
+        with engine.connect() as conn:
+            return fn(conn)
+
+
+async def _up(engine: _AnyEngine, alembic_config: Config, revision: str, schema: str) -> None:
+    def _do(conn: Connection) -> None:
         alembic_config.attributes["connection"] = conn
         command.upgrade(alembic_config, revision)
-    engine.dispose()
+
+    await _run_async(engine, _do)
+    if isinstance(engine, Engine):
+        engine.dispose()
     if revision == "head":
         return
-    actual = _version_num(engine, schema)
+    actual = await _version_num(engine, schema)
     assert actual == (revision,)
 
 
-def _down(engine: Engine, alembic_config: Config, revision: str, schema: str) -> None:
-    with engine.connect() as conn:
+async def _down(engine: _AnyEngine, alembic_config: Config, revision: str, schema: str) -> None:
+    def _do(conn: Connection) -> None:
         alembic_config.attributes["connection"] = conn
         command.downgrade(alembic_config, revision)
-    engine.dispose()
-    assert _version_num(engine, schema) == (None if revision == "base" else (revision,))
+
+    await _run_async(engine, _do)
+    if isinstance(engine, Engine):
+        engine.dispose()
+    assert (await _version_num(engine, schema)) == (None if revision == "base" else (revision,))
 
 
-def _version_num(engine: Engine, schema: str) -> Optional[Row[tuple[str]]]:
+async def _version_num(engine: _AnyEngine, schema: str) -> Optional[Row[tuple[str]]]:
     table, column = "alembic_version", "version_num"
     if schema:
         table = f"{schema}.{table}"
     stmt = text(f"SELECT {column} FROM {table}")
-    with engine.connect() as conn:
+
+    def _do(conn: Connection) -> Optional[Row[tuple[str]]]:
         return conn.execute(stmt).first()
+
+    return await _run_async(engine, _do)
 
 
 class _TableSchemaInfo(TypedDict):
@@ -244,7 +267,7 @@ def _get_table_schema_info(
     )
 
 
-def _verify_clean_state(engine: Engine, schema: str) -> None:
+async def _verify_clean_state(engine: AsyncEngine, schema: str) -> None:
     """Verify that the database is in a clean state before running migrations.
 
     This function checks that the alembic_version table does not exist, indicating
@@ -259,4 +282,4 @@ def _verify_clean_state(engine: Engine, schema: str) -> None:
             alembic_version table exists)
     """
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(engine, schema)
+        await _version_num(engine, schema)

--- a/tests/integration/db_migrations/conftest.py
+++ b/tests/integration/db_migrations/conftest.py
@@ -1,15 +1,17 @@
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from pathlib import Path
 from secrets import token_hex
 
+import aiosqlite
 import pytest
 import sqlean
 from alembic.config import Config
 from pytest import TempPathFactory
-from sqlalchemy import URL, Engine, NullPool, create_engine, event
+from sqlalchemy import URL, NullPool, event
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 import phoenix
-from phoenix.db.engines import set_postgresql_search_path
+from phoenix.db.engines import get_async_db_url
 
 from .._helpers import _SCHEMA_PREFIX, _random_schema
 
@@ -23,43 +25,61 @@ def _alembic_config() -> Config:
 
 
 @pytest.fixture
-def _schema(
+async def _schema(
     _sql_database_url: URL,
-) -> Iterator[str]:
+) -> AsyncIterator[str]:
     if not _sql_database_url.get_backend_name().startswith("postgresql"):
         yield ""
     else:
-        with _random_schema(_sql_database_url) as schema:
+        async with _random_schema(_sql_database_url) as schema:
             yield schema
 
 
 @pytest.fixture
-def _engine(
+async def _engine(
     _sql_database_url: URL,
     _schema: str,
     tmp_path_factory: TempPathFactory,
-) -> Iterator[Engine]:
+) -> AsyncIterator[AsyncEngine]:
     backend = _sql_database_url.get_backend_name()
     if backend == "sqlite":
         assert not _schema, "SQLite does not support schemas"
         tmp = tmp_path_factory.getbasetemp() / Path(__file__).parent.name
         tmp.mkdir(parents=True, exist_ok=True)
         file = tmp / f".{token_hex(16)}.db"
-        engine = create_engine(
-            url=_sql_database_url.set(database=str(file)),
-            creator=lambda: sqlean.connect(f"file:///{file}", uri=True),
+
+        def async_creator() -> aiosqlite.Connection:
+            conn = aiosqlite.Connection(
+                lambda: sqlean.connect(f"file:{file}", uri=True),
+                iter_chunk_size=64,
+            )
+            conn.daemon = True
+            return conn
+
+        engine = create_async_engine(
+            url=_sql_database_url.set(drivername="sqlite+aiosqlite", database=str(file)),
+            async_creator=async_creator,
             poolclass=NullPool,
             echo=True,
         )
+        # Don't set foreign_keys pragma on the migration engine — PRAGMA
+        # foreign_keys = ON causes batch_alter_table's DROP TABLE to cascade
+        # and delete child rows. The runtime server engine sets this pragma;
+        # the migration engine should not.
+        yield engine
+        await engine.dispose()
     elif backend == "postgresql":
         assert _schema.startswith(_SCHEMA_PREFIX), "PostgreSQL requires a schema"
-        engine = create_engine(
-            url=_sql_database_url.set(drivername="postgresql+psycopg"),
-            poolclass=NullPool,
-            echo=True,
-        )
-        event.listen(engine, "connect", set_postgresql_search_path(_schema))
+        async_url = get_async_db_url(_sql_database_url.render_as_string(hide_password=False))
+        engine = create_async_engine(url=async_url, poolclass=NullPool, echo=True)
+        schema = _schema
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _set_search_path(dbapi_conn, _):  # type: ignore[no-untyped-def]
+            cursor = dbapi_conn.cursor()
+            cursor.execute(f"SET search_path TO {schema};")
+
+        yield engine
+        await engine.dispose()
     else:
         pytest.fail(f"Unknown backend: {backend}")
-    yield engine
-    engine.dispose()

--- a/tests/integration/db_migrations/test_autoincrement_primary_keys.py
+++ b/tests/integration/db_migrations/test_autoincrement_primary_keys.py
@@ -19,8 +19,8 @@ from secrets import token_hex
 from typing import Callable, Type
 
 from alembic.config import Config
-from sqlalchemy import Engine, select, text
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import Connection, select, text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
@@ -31,22 +31,25 @@ from phoenix.db.types.prompts import (
     PromptOpenAIInvocationParametersContent,
 )
 
-from . import _up
+from . import _run_async, _up
 
 
-def _create_user_role(engine: Engine, name: str) -> int:
+async def _create_user_role(engine: AsyncEngine, name: str) -> int:
     """Create a user role and return its ID."""
-    with engine.connect() as conn:
+
+    def _do(conn: Connection) -> int:
         role_id = conn.execute(
             text(f"INSERT INTO user_roles (name) VALUES ('{name}') RETURNING id")
         ).scalar()
         conn.commit()
-    assert isinstance(role_id, int)
-    return role_id
+        assert isinstance(role_id, int)
+        return role_id
+
+    return await _run_async(engine, _do)
 
 
-def _assert_autoincrement_preserved(
-    db: "sessionmaker[Session]",
+async def _assert_autoincrement_preserved(
+    db: async_sessionmaker[AsyncSession],
     model_class: Type[models.HasId],
     create_instance: Callable[[], models.HasId],
     id_attr: str = "id",
@@ -57,7 +60,7 @@ def _assert_autoincrement_preserved(
     Creates an instance, deletes it, creates another, and verifies the new ID is greater.
     """
     # Create first instance
-    with db.begin() as session:
+    async with db.begin() as session:
         instance1 = create_instance()
         assert getattr(instance1, id_attr) is None
         session.add(instance1)
@@ -65,25 +68,25 @@ def _assert_autoincrement_preserved(
     assert id1 is not None
 
     # Verify it exists
-    with db.begin() as session:
+    async with db.begin() as session:
         assert (
-            session.scalar(select(getattr(model_class, id_attr)).filter_by(**{id_attr: id1}))
+            await session.scalar(select(getattr(model_class, id_attr)).filter_by(**{id_attr: id1}))
             is not None
         )
 
     # Delete it
-    with db.begin() as session:
-        session.delete(instance1)
+    async with db.begin() as session:
+        await session.delete(instance1)
 
     # Verify it's gone
-    with db.begin() as session:
+    async with db.begin() as session:
         assert (
-            session.scalar(select(getattr(model_class, id_attr)).filter_by(**{id_attr: id1}))
+            await session.scalar(select(getattr(model_class, id_attr)).filter_by(**{id_attr: id1}))
             is None
         )
 
     # Create second instance
-    with db.begin() as session:
+    async with db.begin() as session:
         instance2 = create_instance()
         assert getattr(instance2, id_attr) is None
         session.add(instance2)
@@ -96,17 +99,17 @@ def _assert_autoincrement_preserved(
     )
 
 
-def test_users_autoincrement(
-    _engine: Engine,
+async def test_users_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     """Test that users table preserves autoincrement behavior."""
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create admin role (migrations don't seed user_roles)
-    role_id = _create_user_role(_engine, "ADMIN")
+    role_id = await _create_user_role(_engine, "ADMIN")
 
     counter = [0]
 
@@ -120,21 +123,21 @@ def test_users_autoincrement(
             user_role_id=role_id,
         )
 
-    _assert_autoincrement_preserved(db, models.User, create_user)
+    await _assert_autoincrement_preserved(db, models.User, create_user)
 
 
-def test_password_reset_tokens_autoincrement(
-    _engine: Engine,
+async def test_password_reset_tokens_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     """Test that password_reset_tokens table preserves autoincrement behavior."""
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create admin role and user for the tokens
-    role_id = _create_user_role(_engine, "ADMIN")
-    with db.begin() as session:
+    role_id = await _create_user_role(_engine, "ADMIN")
+    async with db.begin() as session:
         user = models.LocalUser(
             email=f"prt_test_{token_hex(8)}@example.com",
             username=f"prt_user_{token_hex(8)}",
@@ -151,21 +154,21 @@ def test_password_reset_tokens_autoincrement(
             expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
-    _assert_autoincrement_preserved(db, models.PasswordResetToken, create_token)
+    await _assert_autoincrement_preserved(db, models.PasswordResetToken, create_token)
 
 
-def test_refresh_tokens_autoincrement(
-    _engine: Engine,
+async def test_refresh_tokens_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     """Test that refresh_tokens table preserves autoincrement behavior."""
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create admin role and user for the tokens
-    role_id = _create_user_role(_engine, "ADMIN")
-    with db.begin() as session:
+    role_id = await _create_user_role(_engine, "ADMIN")
+    async with db.begin() as session:
         user = models.LocalUser(
             email=f"rt_test_{token_hex(8)}@example.com",
             username=f"rt_user_{token_hex(8)}",
@@ -182,21 +185,21 @@ def test_refresh_tokens_autoincrement(
             expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
-    _assert_autoincrement_preserved(db, models.RefreshToken, create_token)
+    await _assert_autoincrement_preserved(db, models.RefreshToken, create_token)
 
 
-def test_access_tokens_autoincrement(
-    _engine: Engine,
+async def test_access_tokens_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     """Test that access_tokens table preserves autoincrement behavior."""
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create admin role and user for the access tokens
-    role_id = _create_user_role(_engine, "ADMIN")
-    with db.begin() as session:
+    role_id = await _create_user_role(_engine, "ADMIN")
+    async with db.begin() as session:
         user = models.LocalUser(
             email=f"at_test_{token_hex(8)}@example.com",
             username=f"at_user_{token_hex(8)}",
@@ -210,7 +213,7 @@ def test_access_tokens_autoincrement(
     # Need a new refresh token for each access token (unique constraint)
     refresh_token_ids = []
     for _ in range(2):
-        with db.begin() as session:
+        async with db.begin() as session:
             refresh_token = models.RefreshToken(
                 user_id=user_id,
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
@@ -229,21 +232,21 @@ def test_access_tokens_autoincrement(
             expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
-    _assert_autoincrement_preserved(db, models.AccessToken, create_token)
+    await _assert_autoincrement_preserved(db, models.AccessToken, create_token)
 
 
-def test_api_keys_autoincrement(
-    _engine: Engine,
+async def test_api_keys_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     """Test that api_keys table preserves autoincrement behavior."""
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create admin role and user for the API keys
-    role_id = _create_user_role(_engine, "ADMIN")
-    with db.begin() as session:
+    role_id = await _create_user_role(_engine, "ADMIN")
+    async with db.begin() as session:
         user = models.LocalUser(
             email=f"ak_test_{token_hex(8)}@example.com",
             username=f"ak_user_{token_hex(8)}",
@@ -263,11 +266,11 @@ def test_api_keys_autoincrement(
             name=f"test_key_{counter[0]}_{token_hex(8)}",
         )
 
-    _assert_autoincrement_preserved(db, models.ApiKey, create_api_key)
+    await _assert_autoincrement_preserved(db, models.ApiKey, create_api_key)
 
 
-def test_prompt_versions_autoincrement(
-    _engine: Engine,
+async def test_prompt_versions_autoincrement(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
@@ -277,11 +280,11 @@ def test_prompt_versions_autoincrement(
     Note: prompt_versions gained sqlite_autoincrement=True in migration 02463bd83119
     to ensure batch_alter_table operations preserve ID monotonicity.
     """
-    _up(_engine, _alembic_config, "head", _schema)
-    db = sessionmaker(bind=_engine, expire_on_commit=False)
+    await _up(_engine, _alembic_config, "head", _schema)
+    db = async_sessionmaker(bind=_engine, expire_on_commit=False)
 
     # Create a prompt for the versions
-    with db.begin() as session:
+    async with db.begin() as session:
         name = Identifier.model_validate(token_hex(16))
         prompt = models.Prompt(name=name)
         session.add(prompt)
@@ -303,4 +306,4 @@ def test_prompt_versions_autoincrement(
             ),
         )
 
-    _assert_autoincrement_preserved(db, models.PromptVersion, create_prompt_version)
+    await _assert_autoincrement_preserved(db, models.PromptVersion, create_prompt_version)

--- a/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
+++ b/tests/integration/db_migrations/test_change_jsonb_to_json_for_prompts.py
@@ -1,16 +1,17 @@
 import json
 import re
-from typing import Literal
+from typing import Any, Literal, Tuple
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Engine, text
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 
-def test_change_jsonb_to_json_for_prompts(
-    _engine: Engine,
+async def test_change_jsonb_to_json_for_prompts(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _db_backend: Literal["sqlite", "postgresql"],
     _schema: str,
@@ -28,10 +29,10 @@ def test_change_jsonb_to_json_for_prompts(
     """
     # Verify we're starting from a clean state
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
     # Run the migration that creates the prompt_versions table
-    _up(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
+    await _up(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
 
     # Sample data for testing - intentionally using keys in arbitrary order
     # to demonstrate the difference between JSONB and JSON in PostgreSQL
@@ -39,7 +40,7 @@ def test_change_jsonb_to_json_for_prompts(
     response_format_data = {"ZZZ": 3, "Z": 1, "ZZ": 2}
 
     # Insert test data with JSONB columns
-    with _engine.connect() as conn:
+    def _insert_test_data(conn: Connection) -> Tuple[Any, Any]:
         # Create a prompt to reference
         prompt_id = conn.execute(
             text(
@@ -75,9 +76,12 @@ def test_change_jsonb_to_json_for_prompts(
             },
         ).scalar()
         conn.commit()  # Commit to ensure data is visible to subsequent connections
+        return prompt_id, prompt_version_id
+
+    _, prompt_version_id = await _run_async(_engine, _insert_test_data)
 
     # STEP 1: Verify initial state with JSONB columns
-    with _engine.connect() as conn:
+    def _verify_initial_state(conn: Connection) -> None:
         # Check column types based on database backend
         if _db_backend == "postgresql":
             # PostgreSQL: Use pg_typeof to check column types
@@ -139,11 +143,13 @@ def test_change_jsonb_to_json_for_prompts(
             assert result[0] != json.dumps(tools_data)
             assert result[1] != json.dumps(response_format_data)
 
+    await _run_async(_engine, _verify_initial_state)
+
     # STEP 2: Run the migration to change JSONB to JSON
-    _up(_engine, _alembic_config, "8a3764fe7f1a", _schema)
+    await _up(_engine, _alembic_config, "8a3764fe7f1a", _schema)
 
     # Verify the migration worked correctly
-    with _engine.connect() as conn:
+    def _verify_after_upgrade(conn: Connection) -> None:
         # Check data is still accessible
         result = conn.execute(
             text("SELECT tools, response_format FROM prompt_versions WHERE id = :id"),
@@ -189,11 +195,13 @@ def test_change_jsonb_to_json_for_prompts(
             assert re.search(r"\btools\s+JSON\b", table_def) is not None
             assert re.search(r"\bresponse_format\s+JSON\b", table_def) is not None
 
+    await _run_async(_engine, _verify_after_upgrade)
+
     # STEP 3: Test downgrade back to JSONB
-    _down(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
+    await _down(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
 
     # Verify the downgrade worked correctly
-    with _engine.connect() as conn:
+    def _verify_after_downgrade(conn: Connection) -> None:
         # Check data is still accessible
         result = conn.execute(
             text("SELECT tools, response_format FROM prompt_versions WHERE id = :id"),
@@ -237,3 +245,5 @@ def test_change_jsonb_to_json_for_prompts(
             assert table_def is not None
             assert re.search(r"\btools\s+JSONB\b", table_def) is not None
             assert re.search(r"\bresponse_format\s+JSONB\b", table_def) is not None
+
+    await _run_async(_engine, _verify_after_downgrade)

--- a/tests/integration/db_migrations/test_data_migration_2f9d1a65945f_annotation_config_migration.py
+++ b/tests/integration/db_migrations/test_data_migration_2f9d1a65945f_annotation_config_migration.py
@@ -1,30 +1,32 @@
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import Any, Literal, Tuple
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Connection, Engine, text
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 from typing_extensions import assert_never
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 
-def test_annotation_config_migration(
-    _engine: Engine,
+async def test_annotation_config_migration(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _db_backend: Literal["sqlite", "postgresql"],
     _schema: str,
 ) -> None:
     # no migrations applied yet
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
     # apply migrations up to right before annotation config migration
-    _up(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
+    await _up(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
 
     # insert entities to be annotated
     now = datetime.now(timezone.utc)
-    with _engine.connect() as conn:
+
+    def _insert_entities(conn: Connection) -> Tuple[int, int]:
         # create a project
         project_id = conn.execute(
             text(
@@ -96,10 +98,13 @@ def test_annotation_config_migration(
         ).scalar()
         assert isinstance(span_rowid, int)
         conn.commit()
+        return trace_rowid, span_rowid
+
+    trace_rowid, span_rowid = await _run_async(_engine, _insert_entities)
 
     for iteration_index in range(2):
         # test behavior before up migration
-        with _engine.connect() as conn:
+        def _verify_pre_migration(conn: Connection) -> Tuple[int, int, int, int, int, int]:
             # verify columns
             if _db_backend == "sqlite":
                 trace_annotations_table_def = _get_sqlite_table_info(conn, "trace_annotations")
@@ -343,7 +348,25 @@ def test_annotation_config_migration(
             )
             conn.commit()
 
-        with _engine.connect() as conn:
+            return (
+                trace_annotation_from_llm_id,
+                trace_annotation_from_human_id,
+                span_annotation_from_llm_id,
+                span_annotation_from_human_id,
+                document_annotation_from_llm_id,
+                document_annotation_from_human_id,
+            )
+
+        (
+            trace_annotation_from_llm_id,
+            trace_annotation_from_human_id,
+            span_annotation_from_llm_id,
+            span_annotation_from_human_id,
+            document_annotation_from_llm_id,
+            document_annotation_from_human_id,
+        ) = await _run_async(_engine, _verify_pre_migration)
+
+        def _test_code_not_allowed_trace(conn: Connection) -> None:
             # verify that 'CODE' annotator_kind is not allowed for trace annotations before migration
             with pytest.raises(Exception) as exc_info:
                 _create_trace_annotation_pre_migration(
@@ -359,7 +382,9 @@ def test_annotation_config_migration(
                 # conn.commit()
             assert "valid_annotator_kind" in str(exc_info.value)
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_code_not_allowed_trace)
+
+        def _test_code_not_allowed_span(conn: Connection) -> None:
             # verify that 'CODE' annotator_kind is not allowed for span annotations before migration
             with pytest.raises(Exception) as exc_info:
                 _create_span_annotation_pre_migration(
@@ -375,7 +400,9 @@ def test_annotation_config_migration(
                 conn.commit()
             assert "valid_annotator_kind" in str(exc_info.value)
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_code_not_allowed_span)
+
+        def _test_code_not_allowed_document(conn: Connection) -> None:
             # Verify that 'CODE' annotator_kind is not allowed for document annotations before migration
             with pytest.raises(Exception) as exc_info:
                 _create_document_annotation_pre_migration(
@@ -392,11 +419,13 @@ def test_annotation_config_migration(
                 conn.commit()
             assert "valid_annotator_kind" in str(exc_info.value)
 
+        await _run_async(_engine, _test_code_not_allowed_document)
+
         # run the annotation config migration
-        _up(_engine, _alembic_config, "2f9d1a65945f", _schema)
+        await _up(_engine, _alembic_config, "2f9d1a65945f", _schema)
 
         # verify new columns exist and have been backfilled
-        with _engine.connect() as conn:
+        def _verify_post_migration(conn: Connection) -> None:
             # verify expected columns and constraints exist
             if _db_backend == "sqlite":
                 trace_annotations_table_def = _get_sqlite_table_info(conn, "trace_annotations")
@@ -499,9 +528,9 @@ def test_annotation_config_migration(
 
             elif _db_backend == "postgresql":
                 # Get table information for all three tables
-                trace_annotations_info = _get_postgres_table_info(conn, "trace_annotations")
-                span_annotations_info = _get_postgres_table_info(conn, "span_annotations")
-                document_annotations_info = _get_postgres_table_info(conn, "document_annotations")
+                _get_postgres_table_info(conn, "trace_annotations")
+                _get_postgres_table_info(conn, "span_annotations")
+                _get_postgres_table_info(conn, "document_annotations")
             else:
                 assert_never(_db_backend)
 
@@ -607,7 +636,9 @@ def test_annotation_config_migration(
             assert source == "APP"
             assert user_id is None
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _verify_post_migration)
+
+        def _test_source_nonnull_trace(conn: Connection) -> None:
             # verify source is non-nullable for trace annotations
             with pytest.raises(Exception) as exc_info:
                 _create_trace_annotation_post_migration(
@@ -631,7 +662,9 @@ def test_annotation_config_migration(
             )
             assert "source" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_source_nonnull_trace)
+
+        def _test_source_nonnull_span(conn: Connection) -> None:
             # verify source is non-nullable for span annotations
             with pytest.raises(Exception) as exc_info:
                 _create_span_annotation_post_migration(
@@ -655,7 +688,9 @@ def test_annotation_config_migration(
             )
             assert "source" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_source_nonnull_span)
+
+        def _test_source_nonnull_document(conn: Connection) -> None:
             # verify source is non-nullable for document annotations
             with pytest.raises(Exception) as exc_info:
                 _create_document_annotation_post_migration(
@@ -680,7 +715,9 @@ def test_annotation_config_migration(
             )
             assert "source" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_source_nonnull_document)
+
+        def _test_identifier_nonnull_trace(conn: Connection) -> None:
             # verify identifier is non-nullable for trace annotations
             with pytest.raises(Exception) as exc_info:
                 _create_trace_annotation_post_migration(
@@ -704,7 +741,9 @@ def test_annotation_config_migration(
             )
             assert "identifier" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_identifier_nonnull_trace)
+
+        def _test_identifier_nonnull_span(conn: Connection) -> None:
             # verify identifier is non-nullable for span annotations
             with pytest.raises(Exception) as exc_info:
                 _create_span_annotation_post_migration(
@@ -728,7 +767,9 @@ def test_annotation_config_migration(
             )
             assert "identifier" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_identifier_nonnull_span)
+
+        def _test_identifier_nonnull_document(conn: Connection) -> None:
             # verify identifier is non-nullable for document annotations
             with pytest.raises(Exception) as exc_info:
                 _create_document_annotation_post_migration(
@@ -753,7 +794,9 @@ def test_annotation_config_migration(
             )
             assert "identifier" in error_message
 
-        with _engine.connect() as conn:
+        await _run_async(_engine, _test_identifier_nonnull_document)
+
+        def _test_code_allowed_and_cleanup(conn: Connection) -> None:
             # verify that after migration, 'CODE' is allowed
             trace_annotation_from_code_id = _create_trace_annotation_post_migration(
                 conn=conn,
@@ -818,7 +861,9 @@ def test_annotation_config_migration(
             )
             conn.commit()
 
-        _down(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
+        await _run_async(_engine, _test_code_allowed_and_cleanup)
+
+        await _down(_engine, _alembic_config, "bc8fea3c2bc8", _schema)
 
 
 def _create_trace_annotation_pre_migration(

--- a/tests/integration/db_migrations/test_data_migration_4ded9e43755f_create_project_sessions_table.py
+++ b/tests/integration/db_migrations/test_data_migration_4ded9e43755f_create_project_sessions_table.py
@@ -7,37 +7,42 @@ from typing import Any, Iterable, Iterator, Sequence, Union, cast
 import pandas as pd
 import pytest
 from alembic.config import Config
-from sqlalchemy import Column, Engine, MetaData, Table, insert
+from sqlalchemy import Column, Connection, MetaData, Table, insert
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from phoenix.db.migrations.data_migration_scripts.populate_project_sessions import (
     populate_project_sessions,
 )
 from phoenix.db.models import JSON_
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 
-def test_data_migration_for_project_sessions(
-    _engine: Engine,
+async def test_data_migration_for_project_sessions(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
 ) -> None:
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
-    _up(_engine, _alembic_config, "cd164e83824f", _schema)
+    await _up(_engine, _alembic_config, "cd164e83824f", _schema)
 
-    metadata = MetaData()
-    metadata.reflect(bind=_engine)
-    table_projects = metadata.tables["projects"]
-    table_traces = metadata.tables["traces"]
-    table_spans = Table(
-        "spans",
-        MetaData(),
-        Column("attributes", JSON_),
-        Column("events", JSON_),
-        autoload_with=_engine,
-    )
+    def _reflect_tables(conn: Connection) -> tuple[Table, Table, Table]:
+        metadata = MetaData()
+        metadata.reflect(bind=conn)
+        t_projects = metadata.tables["projects"]
+        t_traces = metadata.tables["traces"]
+        t_spans = Table(
+            "spans",
+            MetaData(),
+            Column("attributes", JSON_),
+            Column("events", JSON_),
+            autoload_with=conn,
+        )
+        return t_projects, t_traces, t_spans
+
+    table_projects, table_traces, table_spans = await _run_async(_engine, _reflect_tables)
 
     def time_gen(
         t: datetime,
@@ -93,7 +98,7 @@ def test_data_migration_for_project_sessions(
                 }
                 parent_id = span_id
 
-    with _engine.connect() as conn:
+    def _insert_data(conn: Connection) -> None:
         project_rowids = conn.scalars(
             insert(table_projects).returning(table_projects.c.id),
             [{"name": token_urlsafe(16)} for _ in range(num_projects)],
@@ -120,18 +125,36 @@ def test_data_migration_for_project_sessions(
         conn.execute(insert(table_spans), list(get_spans(traces)))
         conn.commit()
 
-    for _ in range(2):
-        _down(_engine, _alembic_config, "cd164e83824f", _schema)
-        metadata = MetaData()
-        metadata.reflect(bind=_engine)
-        assert metadata.tables.get("project_sessions") is None
-        _up(_engine, _alembic_config, "4ded9e43755f", _schema)
-        populate_project_sessions(_engine)
+    await _run_async(_engine, _insert_data)
 
-        with _engine.connect() as conn:
-            df_spans = pd.read_sql_table("spans", conn, index_col="id")
-            df_traces = pd.read_sql_table("traces", conn, index_col="id")
-            df_project_sessions = pd.read_sql_table("project_sessions", conn, index_col="id")
+    for _ in range(2):
+        await _down(_engine, _alembic_config, "cd164e83824f", _schema)
+
+        def _check_no_project_sessions(conn: Connection) -> None:
+            metadata = MetaData()
+            metadata.reflect(bind=conn)
+            assert metadata.tables.get("project_sessions") is None
+
+        await _run_async(_engine, _check_no_project_sessions)
+        await _up(_engine, _alembic_config, "4ded9e43755f", _schema)
+
+        def _populate(conn: Connection) -> None:
+            populate_project_sessions(conn)
+
+        await _run_async(_engine, _populate)
+
+        def _read_tables(conn: Connection) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+            df_spans = pd.read_sql_table("spans", conn)
+            df_traces = pd.read_sql_table("traces", conn)
+            df_project_sessions = pd.read_sql_table("project_sessions", conn)
+            return df_spans, df_traces, df_project_sessions
+
+        df_spans, df_traces, df_project_sessions = await _run_async(_engine, _read_tables)
+        # Set index after reading since read_sql_table with index_col
+        # may not work consistently across sync/async
+        df_spans = df_spans.set_index("id")
+        df_traces = df_traces.set_index("id")
+        df_project_sessions = df_project_sessions.set_index("id")
 
         assert len(df_project_sessions) == num_project_sessions
         assert len(df_traces) == num_projects * num_traces_per_project

--- a/tests/integration/db_migrations/test_data_migration_6a88424799fe_update_users_with_auth_method.py
+++ b/tests/integration/db_migrations/test_data_migration_6a88424799fe_update_users_with_auth_method.py
@@ -3,13 +3,14 @@ from typing import Literal
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Connection, Engine, text
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 
-def test_user_auth_method_migration(
-    _engine: Engine,
+async def test_user_auth_method_migration(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _db_backend: Literal["sqlite", "postgresql"],
     _schema: str,
@@ -51,13 +52,13 @@ def test_user_auth_method_migration(
     """
     # no migrations applied yet
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
     # apply migrations up to right before auth method migration
-    _up(_engine, _alembic_config, "8a3764fe7f1a", _schema)
+    await _up(_engine, _alembic_config, "8a3764fe7f1a", _schema)
 
     # Create test users
-    with _engine.connect() as conn:
+    def _create_test_users(conn: Connection) -> tuple[int, int, int]:
         # Create a user role
         role_id = conn.execute(
             text(
@@ -120,12 +121,15 @@ def test_user_auth_method_migration(
         ).scalar()
         assert isinstance(oauth_user_id, int)
         conn.commit()
+        return role_id, local_user_id, oauth_user_id
+
+    role_id, local_user_id, oauth_user_id = await _run_async(_engine, _create_test_users)
 
     # Run the auth method migration
-    _up(_engine, _alembic_config, "6a88424799fe", _schema)
+    await _up(_engine, _alembic_config, "6a88424799fe", _schema)
 
     # Test post-migration constraints
-    with _engine.connect() as conn:
+    def _test_invalid_auth_method(conn: Connection) -> None:
         # Test invalid auth_method value
         with pytest.raises(Exception) as exc_info:
             conn.execute(
@@ -150,7 +154,9 @@ def test_user_auth_method_migration(
             "Expected valid_auth_method constraint violation"
         )
 
-    with _engine.connect() as conn:
+    await _run_async(_engine, _test_invalid_auth_method)
+
+    def _test_local_with_oauth(conn: Connection) -> None:
         # Test LOCAL auth with OAuth2 credentials
         with pytest.raises(Exception) as exc_info:
             conn.execute(
@@ -183,7 +189,9 @@ def test_user_auth_method_migration(
             "Expected local_auth_has_password_no_oauth constraint violation"
         )
 
-    with _engine.connect() as conn:
+    await _run_async(_engine, _test_local_with_oauth)
+
+    def _test_oauth_with_password(conn: Connection) -> None:
         # Test OAUTH2 auth with password credentials
         with pytest.raises(Exception) as exc_info:
             conn.execute(
@@ -216,11 +224,13 @@ def test_user_auth_method_migration(
             "Expected non_local_auth_has_no_password constraint violation"
         )
 
+    await _run_async(_engine, _test_oauth_with_password)
+
     # Test downgrade
-    _down(_engine, _alembic_config, "8a3764fe7f1a", _schema)
+    await _down(_engine, _alembic_config, "8a3764fe7f1a", _schema)
 
     # Verify downgrade state
-    with _engine.connect() as conn:
+    def _verify_local_user(conn: Connection) -> None:
         # Verify users still exist and have correct data
         local_user = conn.execute(
             text(
@@ -241,7 +251,9 @@ def test_user_auth_method_migration(
         assert not bool(local_user[2]), "Local user should still not have oauth2_client_id"
         assert not bool(local_user[3]), "Local user should still not have oauth2_user_id"
 
-    with _engine.connect() as conn:
+    await _run_async(_engine, _verify_local_user)
+
+    def _verify_oauth_user(conn: Connection) -> None:
         oauth_user = conn.execute(
             text(
                 """
@@ -260,6 +272,8 @@ def test_user_auth_method_migration(
         assert not bool(oauth_user[1]), "OAuth2 user should still not have password_salt"
         assert bool(oauth_user[2]), "OAuth2 user should still have oauth2_client_id"
         assert bool(oauth_user[3]), "OAuth2 user should still have oauth2_user_id"
+
+    await _run_async(_engine, _verify_oauth_user)
 
 
 def _create_local_user(

--- a/tests/integration/db_migrations/test_data_migration_a1b2c3d4e5f6_ldap_schema_migration.py
+++ b/tests/integration/db_migrations/test_data_migration_a1b2c3d4e5f6_ldap_schema_migration.py
@@ -13,13 +13,14 @@ This test verifies the migration that:
 
 from hashlib import md5
 from secrets import token_hex
-from typing import Literal
+from typing import Literal, Tuple
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Engine, text
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 # Legacy markers used before this migration
 LDAP_CLIENT_ID_MARKER = "\ue000LDAP(stopgap)"
@@ -31,8 +32,8 @@ def _generate_null_email_marker(unique_id: str) -> str:
     return f"{NULL_EMAIL_MARKER_PREFIX}{md5(unique_id.lower().encode()).hexdigest()}"
 
 
-def test_ldap_schema_migration(
-    _engine: Engine,
+async def test_ldap_schema_migration(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _db_backend: Literal["sqlite", "postgresql"],
     _schema: str,
@@ -49,13 +50,15 @@ def test_ldap_schema_migration(
     """
     # No migrations applied yet
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
     # Apply migrations up to right before our migration
-    _up(_engine, _alembic_config, "3f53d82a1b7e", _schema)
+    await _up(_engine, _alembic_config, "3f53d82a1b7e", _schema)
 
     # Create test data in legacy format
-    with _engine.connect() as conn:
+    def _create_test_data(
+        conn: Connection,
+    ) -> Tuple[int, int, int, int, int, str, str]:
         # Create a user role
         role_id = conn.execute(
             text(
@@ -172,12 +175,31 @@ def test_ldap_schema_migration(
         assert isinstance(ldap_user_null_email_id, int)
 
         conn.commit()
+        return (
+            role_id,
+            local_user_id,
+            oauth_user_id,
+            ldap_user_with_email_id,
+            ldap_user_null_email_id,
+            ldap_unique_id,
+            ldap_unique_id_2,
+        )
+
+    (
+        role_id,
+        local_user_id,
+        oauth_user_id,
+        ldap_user_with_email_id,
+        ldap_user_null_email_id,
+        ldap_unique_id,
+        ldap_unique_id_2,
+    ) = await _run_async(_engine, _create_test_data)
 
     # Run the LDAP schema migration
-    _up(_engine, _alembic_config, "a1b2c3d4e5f6", _schema)
+    await _up(_engine, _alembic_config, "a1b2c3d4e5f6", _schema)
 
     # Verify migration results
-    with _engine.connect() as conn:
+    def _verify_migration(conn: Connection) -> None:
         # Verify LOCAL user is unchanged
         local_user = conn.execute(
             text(
@@ -247,35 +269,14 @@ def test_ldap_schema_migration(
         assert ldap_user_null[3] == ldap_unique_id_2, "LDAP user ldap_unique_id should be preserved"
         assert ldap_user_null[4] is None, "Null email marker should be converted to NULL"
 
+    await _run_async(_engine, _verify_migration)
+
     # ==========================================================================
     # TEST ALL CONSTRAINTS
     # ==========================================================================
-    #
-    # Constraint summary (R = Required, N = Must be NULL, O = Optional):
-    #
-    # | Field            | LOCAL | OAUTH2 | LDAP |
-    # |------------------|-------|--------|------|
-    # | email            |   R   |   R    |  *   |
-    # | password         |   R   |   N    |  N   |
-    # | ldap_unique_id   |   N   |   N    |  *   |
-    # | oauth2_client_id |   N   |   O    |  N   |
-    # | oauth2_user_id   |   N   |   O    |  N   |
-    #
-    # *: LDAP users must have email OR ldap_unique_id (or both).
-    #
-    # Constraints:
-    # - valid_auth_method: auth_method IN ('LOCAL', 'OAUTH2', 'LDAP')
-    # - local_auth_has_password_no_oauth: LOCAL must have password, no oauth2/ldap fields
-    # - non_local_auth_has_no_password: OAUTH2/LDAP must NOT have password
-    # - ldap_auth_valid: LDAP must have no oauth2 fields, must have email OR ldap_unique_id
-    # - oauth2_auth_no_ldap_fields: OAUTH2 must NOT have ldap_unique_id
-    # - non_ldap_auth_has_email: LOCAL/OAUTH2 must have email
-    # ==========================================================================
 
-    # -------------------------------------------------------------------------
     # Test ldap_auth_valid: LDAP user with oauth2_client_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_ldap_with_oauth_client(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -302,10 +303,10 @@ def test_ldap_schema_migration(
             "Expected ldap_auth_valid constraint violation for LDAP with oauth2_client_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_ldap_with_oauth_client)
+
     # Test ldap_auth_valid: LDAP user with oauth2_user_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_ldap_with_oauth_user(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -332,11 +333,10 @@ def test_ldap_schema_migration(
             "Expected ldap_auth_valid constraint violation for LDAP with oauth2_user_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_ldap_with_oauth_user)
+
     # Test ldap_auth_valid: LDAP orphan (NULL email AND NULL ldap_unique_id) should fail
-    # This is the critical bug we're preventing!
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_ldap_orphan(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -362,10 +362,10 @@ def test_ldap_schema_migration(
             "(NULL email AND NULL ldap_unique_id)"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_ldap_orphan)
+
     # Test non_ldap_auth_has_email: LOCAL user with NULL email should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_local_null_email(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -394,10 +394,10 @@ def test_ldap_schema_migration(
             "Expected non_ldap_auth_has_email constraint violation for LOCAL with NULL email"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_local_null_email)
+
     # Test non_ldap_auth_has_email: OAUTH2 user with NULL email should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_oauth_null_email(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -424,10 +424,10 @@ def test_ldap_schema_migration(
             "Expected non_ldap_auth_has_email constraint violation for OAUTH2 with NULL email"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_oauth_null_email)
+
     # Test oauth2_auth_no_ldap_fields: OAUTH2 user with ldap_unique_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_oauth_with_ldap(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -456,10 +456,10 @@ def test_ldap_schema_migration(
             "Expected oauth2_auth_no_ldap_fields constraint violation"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_oauth_with_ldap)
+
     # Test local_auth_has_password_no_oauth: LOCAL user with ldap_unique_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_local_with_ldap(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -490,10 +490,10 @@ def test_ldap_schema_migration(
             "Expected local_auth_has_password_no_oauth constraint violation for LOCAL with ldap_unique_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_local_with_ldap)
+
     # Test local_auth_has_password_no_oauth: LOCAL user with oauth2_client_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_local_with_oauth_client(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -524,10 +524,10 @@ def test_ldap_schema_migration(
             "Expected local_auth_has_password_no_oauth constraint violation for LOCAL with oauth2_client_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_local_with_oauth_client)
+
     # Test non_local_auth_has_no_password: LDAP user with password should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_ldap_with_password(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -558,10 +558,10 @@ def test_ldap_schema_migration(
             "Expected non_local_auth_has_no_password constraint violation for LDAP with password"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_ldap_with_password)
+
     # Test non_local_auth_has_no_password: OAUTH2 user with password should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_oauth_with_password(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -593,12 +593,11 @@ def test_ldap_schema_migration(
             "Expected non_local_auth_has_no_password constraint violation for OAUTH2 with password"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_oauth_with_password)
+
     # Test unique index: Duplicate ldap_unique_id should fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _create_first_ldap_dup(conn: Connection) -> str:
         duplicate_ldap_id = f"duplicate-ldap-guid-{token_hex(4)}"
-        # Create first LDAP user
         conn.execute(
             text(
                 """
@@ -620,8 +619,11 @@ def test_ldap_schema_migration(
             },
         )
         conn.commit()
+        return duplicate_ldap_id
 
-    with _engine.connect() as conn:
+    duplicate_ldap_id = await _run_async(_engine, _create_first_ldap_dup)
+
+    def _test_dup_ldap_id(conn: Connection) -> None:
         # Try to create second LDAP user with same ldap_unique_id
         with pytest.raises(Exception) as exc_info:
             conn.execute(
@@ -649,14 +651,14 @@ def test_ldap_schema_migration(
             "Expected unique constraint violation for duplicate ldap_unique_id"
         )
 
+    await _run_async(_engine, _test_dup_ldap_id)
+
     # ==========================================================================
     # TEST VALID EDGE CASES
     # ==========================================================================
 
-    # -------------------------------------------------------------------------
     # Valid: LDAP user with ldap_unique_id but NULL email (null email mode)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_valid_ldap_null_email(conn: Connection) -> None:
         new_ldap_id = conn.execute(
             text(
                 """
@@ -680,10 +682,10 @@ def test_ldap_schema_migration(
         conn.commit()
         assert isinstance(new_ldap_id, int), "Should be able to create LDAP user with NULL email"
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_valid_ldap_null_email)
+
     # Valid: LDAP user with email but NULL ldap_unique_id (simple mode)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_valid_ldap_email_only(conn: Connection) -> None:
         ldap_email_only_id = conn.execute(
             text(
                 """
@@ -709,10 +711,10 @@ def test_ldap_schema_migration(
             "Should be able to create LDAP user with email but NULL ldap_unique_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_valid_ldap_email_only)
+
     # Valid: LDAP user with both email and ldap_unique_id (enterprise mode)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_valid_ldap_both(conn: Connection) -> None:
         ldap_both_id = conn.execute(
             text(
                 """
@@ -739,10 +741,10 @@ def test_ldap_schema_migration(
             "Should be able to create LDAP user with both email and ldap_unique_id"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_valid_ldap_both)
+
     # Valid: OAUTH2 user with NULL oauth2 fields (pre-provisioned)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_valid_oauth_preprovisioned(conn: Connection) -> None:
         oauth_preprovisioned_id = conn.execute(
             text(
                 """
@@ -768,11 +770,13 @@ def test_ldap_schema_migration(
             "Should be able to create OAUTH2 user with NULL oauth2 fields (pre-provisioned)"
         )
 
+    await _run_async(_engine, _test_valid_oauth_preprovisioned)
+
     # Test downgrade
-    _down(_engine, _alembic_config, "3f53d82a1b7e", _schema)
+    await _down(_engine, _alembic_config, "3f53d82a1b7e", _schema)
 
     # Verify downgrade state
-    with _engine.connect() as conn:
+    def _verify_downgrade(conn: Connection) -> None:
         # Verify LDAP users are reverted to legacy format
         ldap_user_reverted = conn.execute(
             text(
@@ -817,22 +821,14 @@ def test_ldap_schema_migration(
             "Email should start with null marker prefix"
         )
 
+    await _run_async(_engine, _verify_downgrade)
+
     # ==========================================================================
     # TEST DOWNGRADE CONSTRAINTS
     # ==========================================================================
-    #
-    # After downgrade, the old constraints should be restored:
-    # - valid_auth_method: only 'LOCAL' and 'OAUTH2' (no 'LDAP')
-    # - email is NOT NULL (required for all users)
-    # - ldap_unique_id column does not exist
-    # - local_auth_has_password_no_oauth: LOCAL must have password, no oauth2 fields
-    # - non_local_auth_has_no_password: OAUTH2 must NOT have password
-    # ==========================================================================
 
-    # -------------------------------------------------------------------------
     # Downgrade: Verify ldap_unique_id column was dropped
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_no_ldap_column(conn: Connection) -> None:
         # Try to select ldap_unique_id - should fail because column doesn't exist
         with pytest.raises(Exception) as exc_info:
             conn.execute(text("SELECT ldap_unique_id FROM users LIMIT 1"))
@@ -841,10 +837,10 @@ def test_ldap_schema_migration(
             "Expected error mentioning ldap_unique_id column (should not exist after downgrade)"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_downgrade_no_ldap_column)
+
     # Downgrade: auth_method='LDAP' should fail (not in valid_auth_method)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_no_ldap_auth(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -870,10 +866,10 @@ def test_ldap_schema_migration(
             "Expected valid_auth_method constraint violation for 'LDAP' after downgrade"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_downgrade_no_ldap_auth)
+
     # Downgrade: NULL email should fail (email is NOT NULL after downgrade)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_null_email(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -900,10 +896,10 @@ def test_ldap_schema_migration(
             "Expected NOT NULL constraint violation for NULL email after downgrade"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_downgrade_null_email)
+
     # Downgrade: LOCAL user with oauth2_client_id should still fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_local_with_oauth(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -934,10 +930,10 @@ def test_ldap_schema_migration(
             "Expected local_auth_has_password_no_oauth constraint after downgrade"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_downgrade_local_with_oauth)
+
     # Downgrade: OAUTH2 user with password should still fail
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_oauth_with_password(conn: Connection) -> None:
         with pytest.raises(Exception) as exc_info:
             conn.execute(
                 text(
@@ -969,10 +965,10 @@ def test_ldap_schema_migration(
             "Expected non_local_auth_has_no_password constraint after downgrade"
         )
 
-    # -------------------------------------------------------------------------
+    await _run_async(_engine, _test_downgrade_oauth_with_password)
+
     # Downgrade: Valid LDAP user creation (using legacy marker format)
-    # -------------------------------------------------------------------------
-    with _engine.connect() as conn:
+    def _test_downgrade_valid_legacy_ldap(conn: Connection) -> None:
         legacy_ldap_id = conn.execute(
             text(
                 """
@@ -999,3 +995,5 @@ def test_ldap_schema_migration(
         assert isinstance(legacy_ldap_id, int), (
             "Should be able to create legacy LDAP user with marker after downgrade"
         )
+
+    await _run_async(_engine, _test_downgrade_valid_legacy_ldap)

--- a/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
+++ b/tests/integration/db_migrations/test_data_migration_e76cbd66ffc3_add_experiments_dataset_examples.py
@@ -13,13 +13,14 @@ from typing import Any, Dict, Literal
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Engine, MetaData, text
+from sqlalchemy import Connection, MetaData, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from . import _down, _up, _version_num
+from . import _down, _run_async, _up, _version_num
 
 
-def test_experiments_dataset_examples_backfill_migration(
-    _engine: Engine,
+async def test_experiments_dataset_examples_backfill_migration(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _db_backend: Literal["sqlite", "postgresql"],
     _schema: str,
@@ -43,37 +44,37 @@ def test_experiments_dataset_examples_backfill_migration(
 
     # Verify clean state
     with pytest.raises(BaseException, match="alembic_version"):
-        _version_num(_engine, _schema)
+        await _version_num(_engine, _schema)
 
     # Migrate to the revision before our target migration
-    _up(_engine, _alembic_config, "58228d933c91", _schema)
+    await _up(_engine, _alembic_config, "58228d933c91", _schema)
 
     # Set up test data before migration
-    test_data = _setup_test_data(_engine)
+    test_data = await _setup_test_data(_engine)
 
     # Verify pre-migration state
-    _verify_pre_migration_state(_engine, test_data)
+    await _verify_pre_migration_state(_engine, test_data)
 
     # Run the target migration
-    _up(_engine, _alembic_config, "e76cbd66ffc3", _schema)
+    await _up(_engine, _alembic_config, "e76cbd66ffc3", _schema)
 
     # Verify post-migration state
-    _verify_post_migration_state(_engine, test_data)
+    await _verify_post_migration_state(_engine, test_data)
 
     # Test downgrade
-    _down(_engine, _alembic_config, "58228d933c91", _schema)
+    await _down(_engine, _alembic_config, "58228d933c91", _schema)
 
     # Verify table is dropped
-    _verify_downgrade_state(_engine)
+    await _verify_downgrade_state(_engine)
 
 
-def _setup_test_data(_engine: Engine) -> Dict[str, Any]:
+async def _setup_test_data(_engine: AsyncEngine) -> Dict[str, Any]:
     """Set up test data before migration."""
 
     # Use current timestamp for cross-database compatibility
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc)
 
-    with _engine.connect() as conn:
+    def _do(conn: Connection) -> Dict[str, Any]:
         # Create test datasets
         dataset1_id = conn.execute(
             text("""
@@ -249,12 +250,14 @@ def _setup_test_data(_engine: Engine) -> Dict[str, Any]:
             "experiments": [experiment1_id, experiment2_id, experiment3_id],
         }
 
+    return await _run_async(_engine, _do)
 
-def _verify_pre_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> None:
+
+async def _verify_pre_migration_state(_engine: AsyncEngine, test_data: Dict[str, Any]) -> None:
     """Verify state before migration."""
 
     # Check junction table doesn't exist (use separate transaction for PostgreSQL)
-    with _engine.connect() as conn:
+    def _check_no_junction(conn: Connection) -> None:
         try:
             conn.execute(text("SELECT 1 FROM experiments_dataset_examples LIMIT 1"))
             assert False, "Junction table should not exist before migration"
@@ -262,8 +265,10 @@ def _verify_pre_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> N
             # Expected - table doesn't exist (different backends raise different exceptions)
             pass
 
+    await _run_async(_engine, _check_no_junction)
+
     # Verify other tables exist (separate transaction)
-    with _engine.connect() as conn:
+    def _check_tables(conn: Connection) -> None:
         # Verify experiments exist
         result = conn.execute(text("SELECT COUNT(*) FROM experiments"))
         assert result.scalar() == 3, "Should have 3 experiments"
@@ -275,14 +280,16 @@ def _verify_pre_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> N
         result = conn.execute(text("SELECT COUNT(*) FROM dataset_example_revisions"))
         assert result.scalar() == 5, "Should have 5 revisions (including DELETE)"
 
+    await _run_async(_engine, _check_tables)
 
-def _verify_post_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> None:
+
+async def _verify_post_migration_state(_engine: AsyncEngine, test_data: Dict[str, Any]) -> None:
     """Verify state after migration and backfill."""
 
-    with _engine.connect() as conn:
+    def _do(conn: Connection) -> None:
         # Verify junction table exists with correct schema
         metadata = MetaData()
-        metadata.reflect(bind=_engine)
+        metadata.reflect(bind=conn)
 
         assert "experiments_dataset_examples" in metadata.tables, "Junction table should exist"
 
@@ -349,12 +356,14 @@ def _verify_post_migration_state(_engine: Engine, test_data: Dict[str, Any]) -> 
         )
         assert result.scalar() == 0, "No DELETE revisions should be in junction table"
 
+    await _run_async(_engine, _do)
 
-def _verify_downgrade_state(_engine: Engine) -> None:
+
+async def _verify_downgrade_state(_engine: AsyncEngine) -> None:
     """Verify state after downgrade."""
 
     # Check junction table is dropped (use separate transaction for PostgreSQL)
-    with _engine.connect() as conn:
+    def _check_no_junction(conn: Connection) -> None:
         try:
             conn.execute(text("SELECT 1 FROM experiments_dataset_examples LIMIT 1"))
             assert False, "Junction table should be dropped after downgrade"
@@ -362,7 +371,11 @@ def _verify_downgrade_state(_engine: Engine) -> None:
             # Expected - table doesn't exist (different backends raise different exceptions)
             pass
 
+    await _run_async(_engine, _check_no_junction)
+
     # Verify other tables still exist (separate transaction)
-    with _engine.connect() as conn:
+    def _check_experiments(conn: Connection) -> None:
         result = conn.execute(text("SELECT COUNT(*) FROM experiments"))
         assert result.scalar() == 3, "Experiments should still exist after downgrade"
+
+    await _run_async(_engine, _check_experiments)

--- a/tests/integration/db_migrations/test_db_schema_6a88424799fe_update_users_with_auth_method.py
+++ b/tests/integration/db_migrations/test_db_schema_6a88424799fe_update_users_with_auth_method.py
@@ -1,10 +1,20 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from alembic.config import Config
-from sqlalchemy import Engine
+from sqlalchemy import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
 from typing_extensions import assert_never
 
-from . import _DBBackend, _down, _get_table_schema_info, _TableSchemaInfo, _up, _verify_clean_state
+from . import (
+    _DBBackend,
+    _down,
+    _get_table_schema_info,
+    _run_async,
+    _TableSchemaInfo,
+    _up,
+    _verify_clean_state,
+)
 
 _DOWN = "8a3764fe7f1a"
 _UP = "6a88424799fe"
@@ -27,38 +37,44 @@ class DBSchemaComparisonTest(ABC):
         db_backend: _DBBackend,
     ) -> _TableSchemaInfo: ...
 
-    def _test_db_schema(
+    async def _test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        _verify_clean_state(_engine, _schema)
+        await _verify_clean_state(_engine, _schema)
 
-        _up(_engine, _alembic_config, _DOWN, _schema)
+        await _up(_engine, _alembic_config, _DOWN, _schema)
 
         current_info = self._get_current_schema_info(_db_backend)
         upgraded_info = self._get_upgraded_schema_info(_db_backend)
 
-        with _engine.connect() as conn:
-            initial_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_initial(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        initial_info = await _run_async(_engine, _get_initial)
         assert initial_info == current_info, (
             "Initial schema info does not match expected current schema info"
         )
 
-        _up(_engine, _alembic_config, _UP, _schema)
+        await _up(_engine, _alembic_config, _UP, _schema)
 
-        with _engine.connect() as conn:
-            final_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_final(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        final_info = await _run_async(_engine, _get_final)
         assert final_info == upgraded_info, (
             "Final schema info does not match expected upgraded schema info"
         )
 
-        _down(_engine, _alembic_config, _DOWN, _schema)
+        await _down(_engine, _alembic_config, _DOWN, _schema)
 
-        with _engine.connect() as conn:
-            downgraded_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_downgraded(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        downgraded_info = await _run_async(_engine, _get_downgraded)
         assert downgraded_info == current_info, (
             "Downgraded schema info does not match expected current schema info"
         )
@@ -196,11 +212,11 @@ class TestUsers(DBSchemaComparisonTest):
             ),  # These columns are nullable
         )
 
-    def test_db_schema(
+    async def test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
+        await self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)

--- a/tests/integration/db_migrations/test_db_schema_a20694b15f82_cost.py
+++ b/tests/integration/db_migrations/test_db_schema_a20694b15f82_cost.py
@@ -2,10 +2,19 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from alembic.config import Config
-from sqlalchemy import Engine
+from sqlalchemy import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
 from typing_extensions import assert_never, override
 
-from . import _DBBackend, _down, _get_table_schema_info, _TableSchemaInfo, _up, _verify_clean_state
+from . import (
+    _DBBackend,
+    _down,
+    _get_table_schema_info,
+    _run_async,
+    _TableSchemaInfo,
+    _up,
+    _verify_clean_state,
+)
 
 _DOWN = "6a88424799fe"
 _UP = "a20694b15f82"
@@ -28,38 +37,44 @@ class DBSchemaComparisonTest(ABC):
         db_backend: _DBBackend,
     ) -> Optional[_TableSchemaInfo]: ...
 
-    def _test_db_schema(
+    async def _test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        _verify_clean_state(_engine, _schema)
+        await _verify_clean_state(_engine, _schema)
 
-        _up(_engine, _alembic_config, _DOWN, _schema)
+        await _up(_engine, _alembic_config, _DOWN, _schema)
 
         current_info = self._get_current_schema_info(_db_backend)
         upgraded_info = self._get_upgraded_schema_info(_db_backend)
 
-        with _engine.connect() as conn:
-            initial_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_initial(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        initial_info = await _run_async(_engine, _get_initial)
         assert initial_info == current_info, (
             "Initial schema info does not match expected current schema info"
         )
 
-        _up(_engine, _alembic_config, _UP, _schema)
+        await _up(_engine, _alembic_config, _UP, _schema)
 
-        with _engine.connect() as conn:
-            final_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_final(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        final_info = await _run_async(_engine, _get_final)
         assert final_info == upgraded_info, (
             "Final schema info does not match expected upgraded schema info"
         )
 
-        _down(_engine, _alembic_config, _DOWN, _schema)
+        await _down(_engine, _alembic_config, _DOWN, _schema)
 
-        with _engine.connect() as conn:
-            downgraded_info = _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+        def _get_downgraded(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, self.table_name, _db_backend, _schema)
+
+        downgraded_info = await _run_async(_engine, _get_downgraded)
         assert downgraded_info == current_info, (
             "Downgraded schema info does not match expected current schema info"
         )
@@ -124,14 +139,14 @@ class TestGenerativeModel(DBSchemaComparisonTest):
             ),  # These columns are nullable
         )
 
-    def test_db_schema(
+    async def test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
+        await self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
 
 
 class TestTokenPrices(DBSchemaComparisonTest):
@@ -190,14 +205,14 @@ class TestTokenPrices(DBSchemaComparisonTest):
             nullable_column_names=frozenset(["customization"]),  # This column is nullable
         )
 
-    def test_db_schema(
+    async def test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
+        await self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
 
 
 class TestSpanCosts(DBSchemaComparisonTest):
@@ -274,14 +289,14 @@ class TestSpanCosts(DBSchemaComparisonTest):
             ),  # These columns are nullable
         )
 
-    def test_db_schema(
+    async def test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
+        await self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
 
 
 class TestSpanCostDetails(DBSchemaComparisonTest):
@@ -344,11 +359,11 @@ class TestSpanCostDetails(DBSchemaComparisonTest):
             ),  # These columns are nullable
         )
 
-    def test_db_schema(
+    async def test_db_schema(
         self,
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
     ) -> None:
-        self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)
+        await self._test_db_schema(_engine, _alembic_config, _db_backend, _schema)

--- a/tests/integration/db_migrations/test_db_schema_for_annotations.py
+++ b/tests/integration/db_migrations/test_db_schema_for_annotations.py
@@ -17,14 +17,15 @@ Supported annotation tables:
 - document_annotations: Annotations for document positions (includes additional document_position column)
 """
 
-from typing import Literal, Sequence
+from typing import Literal, Optional, Sequence
 
 import pytest
 from alembic.config import Config
-from sqlalchemy import Engine
+from sqlalchemy import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
 from typing_extensions import assert_never
 
-from . import _DBBackend, _get_table_schema_info, _TableSchemaInfo, _up
+from . import _DBBackend, _get_table_schema_info, _run_async, _TableSchemaInfo, _up
 
 # Define the supported annotation table names as a Literal type for type safety
 AnnotationTableName = Literal[
@@ -351,13 +352,13 @@ class TestDBSchema:
             ),
         ],
     )
-    def test_annotation_table_schema(
+    async def test_annotation_table_schema(
         self,
         table_name: AnnotationTableName,
         foreign_key_column: str,
         additional_columns: list[str],
         additional_nullable_columns: list[str],
-        _engine: Engine,
+        _engine: AsyncEngine,
         _alembic_config: Config,
         _db_backend: _DBBackend,
         _schema: str,
@@ -381,7 +382,7 @@ class TestDBSchema:
             _schema: Database schema name (pytest fixture)
         """
         # Apply all migrations to get the final schema
-        _up(_engine, _alembic_config, "head", _schema)
+        await _up(_engine, _alembic_config, "head", _schema)
 
         # Build expected schema using helper functions
         expected = _get_expected_schema_info(
@@ -393,8 +394,10 @@ class TestDBSchema:
         )
 
         # Get actual schema from database
-        with _engine.connect() as conn:
-            actual = _get_table_schema_info(conn, table_name, _db_backend, _schema)
+        def _do(conn: Connection) -> Optional[_TableSchemaInfo]:
+            return _get_table_schema_info(conn, table_name, _db_backend, _schema)
+
+        actual = await _run_async(_engine, _do)
 
         # Verify schemas match exactly
         assert actual == expected

--- a/tests/integration/db_migrations/test_up_and_down_migrations.py
+++ b/tests/integration/db_migrations/test_up_and_down_migrations.py
@@ -9,7 +9,7 @@ across SQLite and PostgreSQL backends using Alembic.
 import pytest
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from . import _down, _up, _verify_clean_state
 
@@ -28,8 +28,8 @@ from . import _down, _up, _verify_clean_state
         ),
     ],
 )
-def test_up_and_down_migrations(
-    _engine: Engine,
+async def test_up_and_down_migrations(
+    _engine: AsyncEngine,
     _alembic_config: Config,
     _schema: str,
     migrate_index_concurrently: bool,
@@ -60,9 +60,9 @@ def test_up_and_down_migrations(
         monkeypatch.delenv("PHOENIX_MIGRATE_INDEX_CONCURRENTLY", raising=False)
 
     # Verify clean state and test full migration cycle
-    _verify_clean_state(_engine, _schema)
-    _up(_engine, _alembic_config, "head", _schema)
-    _down(_engine, _alembic_config, "base", _schema)
+    await _verify_clean_state(_engine, _schema)
+    await _up(_engine, _alembic_config, "head", _schema)
+    await _down(_engine, _alembic_config, "base", _schema)
 
     # Get migration history and test each step individually
     script = ScriptDirectory.from_config(_alembic_config)
@@ -76,5 +76,5 @@ def test_up_and_down_migrations(
 
         # Test each migration step twice for reliability
         for _ in range(2):
-            _up(_engine, _alembic_config, b.revision, _schema)
-            _down(_engine, _alembic_config, a.revision, _schema)
+            await _up(_engine, _alembic_config, b.revision, _schema)
+            await _down(_engine, _alembic_config, a.revision, _schema)

--- a/tests/integration/server/test_launch_app.py
+++ b/tests/integration/server/test_launch_app.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from itertools import chain
 from secrets import token_hex
@@ -34,10 +35,10 @@ from .._helpers import (
 
 
 @pytest.fixture
-def _env_sql_database(
+async def _env_sql_database(
     _sql_database_url: URL,
     tmp_path_factory: TempPathFactory,
-) -> Iterator[dict[str, str]]:
+) -> AsyncIterator[dict[str, str]]:
     if _sql_database_url.get_backend_name() == "sqlite":
         tmp = tmp_path_factory.mktemp(token_hex(8))
         database = str(tmp / "phoenix.db")
@@ -46,7 +47,7 @@ def _env_sql_database(
     if not _sql_database_url.get_backend_name().startswith("postgresql"):
         yield env
     else:
-        with _random_schema(_sql_database_url) as schema:
+        async with _random_schema(_sql_database_url) as schema:
             yield {**env, "PHOENIX_SQL_DATABASE_SCHEMA": schema}
 
 
@@ -71,30 +72,39 @@ def _no_auth_app(
 
 
 class TestDbMigrate:
-    def test_db_migrate(self, _env_sql_database: dict[str, str]) -> None:
+    async def test_db_migrate(self, _env_sql_database: dict[str, str]) -> None:
         from pathlib import Path
 
         import sqlalchemy
         from alembic.config import Config
         from alembic.script import ScriptDirectory
+        from sqlalchemy.ext.asyncio import create_async_engine
+        from sqlalchemy.pool import NullPool
 
         import phoenix.db as _phoenix_db
+        from phoenix.db.engines import get_async_db_url
 
         raw_url = _env_sql_database["PHOENIX_SQL_DATABASE_URL"]
         schema = _env_sql_database.get("PHOENIX_SQL_DATABASE_SCHEMA") or None
         url = sqlalchemy.make_url(raw_url)
         if url.get_backend_name() == "postgresql":
-            url = url.set(drivername="postgresql+psycopg")
+            async_url = get_async_db_url(url.render_as_string(hide_password=False))
+            async_engine = create_async_engine(async_url, poolclass=NullPool)
+        else:
+            async_engine = create_async_engine(
+                url.set(drivername="sqlite+aiosqlite"), poolclass=NullPool
+            )
 
-        engine = sqlalchemy.create_engine(url)
-        try:
-            # Verify the database is fresh: alembic_version must not exist yet.
-            inspector = sqlalchemy.inspect(engine)
+        # Verify the database is fresh: alembic_version must not exist yet.
+        def _check_fresh(conn: sqlalchemy.Connection) -> None:
+            inspector = sqlalchemy.inspect(conn)
             assert "alembic_version" not in inspector.get_table_names(schema=schema), (
                 "alembic_version already exists before migration ran"
             )
-        finally:
-            engine.dispose()
+
+        async with async_engine.connect() as conn:
+            await conn.run_sync(_check_fresh)
+        await async_engine.dispose()
 
         command = [sys.executable, "-m", "phoenix.server.main", "db", "migrate"]
         env = (
@@ -106,16 +116,23 @@ class TestDbMigrate:
         assert result.returncode == 0, result.stdout + result.stderr
 
         # Confirm alembic_version now matches the current head revision.
-        engine = sqlalchemy.create_engine(url)
-        try:
-            with engine.connect() as conn:
-                if schema:
-                    conn.execute(sqlalchemy.text(f'SET search_path TO "{schema}"'))
-                actual = conn.execute(
-                    sqlalchemy.text("SELECT version_num FROM alembic_version")
-                ).scalar()
-        finally:
-            engine.dispose()
+        if url.get_backend_name() == "postgresql":
+            async_engine = create_async_engine(
+                get_async_db_url(url.render_as_string(hide_password=False)), poolclass=NullPool
+            )
+        else:
+            async_engine = create_async_engine(
+                url.set(drivername="sqlite+aiosqlite"), poolclass=NullPool
+            )
+
+        def _get_version(conn: sqlalchemy.Connection) -> Any:
+            if schema:
+                conn.execute(sqlalchemy.text(f'SET search_path TO "{schema}"'))
+            return conn.execute(sqlalchemy.text("SELECT version_num FROM alembic_version")).scalar()
+
+        async with async_engine.connect() as conn:
+            actual = await conn.run_sync(_get_version)
+        await async_engine.dispose()
 
         scripts_dir = str(Path(_phoenix_db.__file__).parent / "migrations")
         cfg = Config()

--- a/tests/unit/db/test_pg_config.py
+++ b/tests/unit/db/test_pg_config.py
@@ -1,5 +1,4 @@
 import ssl
-from typing import Literal
 
 import pytest
 from smtpdfix.certs import Cert, _generate_certs
@@ -56,7 +55,6 @@ class TestPgConfig:
             "sslsni": f"{BASE}?sslmode=require&sslsni=0",
         }
 
-    @pytest.mark.parametrize("driver", ["psycopg", "asyncpg"])
     @pytest.mark.parametrize(
         "dsn_key",
         [
@@ -73,18 +71,17 @@ class TestPgConfig:
     )
     def test_get_pg_config(
         self,
-        driver: Literal["asyncpg", "psycopg"],
         dsn_key: str,
         _dsns: dict[str, str],
         _tls_certs_client: Cert,
         _tls_certs_server: Cert,
     ) -> None:
         dsn = _dsns[dsn_key]
-        base_url, connect_args = get_pg_config(make_url(dsn), driver=driver)
+        base_url, connect_args = get_pg_config(make_url(dsn))
 
         # Verify base URL preserves non-SSL parameters
         expected_url = BASE.set(
-            drivername=f"postgresql+{driver}",
+            drivername="postgresql+asyncpg",
             query={"application_name": "test", "statement_timeout": "1000"}
             if dsn_key == "non-ssl"
             else {},
@@ -97,30 +94,16 @@ class TestPgConfig:
         assert base_url.database == expected_url.database
         assert dict(base_url.query) == dict(expected_url.query)
 
-        # Verify SSL configuration
-        if driver == "psycopg":
-            expected = {}
-            if dsn_key in ["verify-full", "verify-ca", "require", "prefer", "disable", "allow"]:
-                expected["sslmode"] = dsn_key
-            if dsn_key in ["verify-full", "verify-ca"]:
-                expected["sslrootcert"] = str(_tls_certs_server.cert.resolve())
-            if dsn_key == "verify-full":
-                expected["sslcert"] = str(_tls_certs_client.cert.resolve())
-                expected["sslkey"] = str(_tls_certs_client.key[0].resolve())
-            if dsn_key == "sslsni":
-                expected["sslmode"] = "require"
-                expected["sslsni"] = "0"
-            assert connect_args == expected
-        else:  # asyncpg
-            if dsn_key in ["verify-full", "verify-ca"]:
-                assert isinstance(connect_args["ssl"], ssl.SSLContext)
-                ssl_context = connect_args["ssl"]
-                assert ssl_context.verify_mode == ssl.CERT_REQUIRED
-                assert ssl_context.check_hostname == (dsn_key == "verify-full")
-            elif dsn_key in ["require", "prefer", "allow", "sslsni"]:
-                assert isinstance(connect_args["ssl"], ssl.SSLContext)
-                ssl_context = connect_args["ssl"]
-                assert ssl_context.verify_mode == ssl.CERT_NONE
-                assert ssl_context.check_hostname is False
-            elif dsn_key in ["disable", "base", "non-ssl"]:
-                assert connect_args == {}
+        # Verify SSL configuration for asyncpg
+        if dsn_key in ["verify-full", "verify-ca"]:
+            assert isinstance(connect_args["ssl"], ssl.SSLContext)
+            ssl_context = connect_args["ssl"]
+            assert ssl_context.verify_mode == ssl.CERT_REQUIRED
+            assert ssl_context.check_hostname == (dsn_key == "verify-full")
+        elif dsn_key in ["require", "prefer", "allow", "sslsni"]:
+            assert isinstance(connect_args["ssl"], ssl.SSLContext)
+            ssl_context = connect_args["ssl"]
+            assert ssl_context.verify_mode == ssl.CERT_NONE
+            assert ssl_context.check_hostname is False
+        elif dsn_key in ["disable", "base", "non-ssl"]:
+            assert connect_args == {}

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,6 @@ container = [
 ]
 pg = [
     { name = "asyncpg" },
-    { name = "psycopg", extra = ["binary", "pool"] },
 ]
 
 [package.dev-dependencies]
@@ -505,7 +504,6 @@ dev = [
     { name = "portpicker" },
     { name = "prometheus-client" },
     { name = "psutil" },
-    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "py-grpc-prometheus" },
     { name = "pyarrow-stubs" },
     { name = "pydantic" },
@@ -598,7 +596,6 @@ requires-dist = [
     { name = "prometheus-client", marker = "extra == 'container'" },
     { name = "protobuf", specifier = ">=4.25.8" },
     { name = "psutil" },
-    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'pg'" },
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
@@ -675,7 +672,6 @@ dev = [
     { name = "portpicker" },
     { name = "prometheus-client" },
     { name = "psutil" },
-    { name = "psycopg", extras = ["binary", "pool"] },
     { name = "py-grpc-prometheus" },
     { name = "pyarrow-stubs" },
     { name = "pydantic", specifier = ">=1.0,!=2.0.*,<3" },
@@ -4871,77 +4867,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
-]
-
-[package.optional-dependencies]
-binary = [
-    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
-]
-pool = [
-    { name = "psycopg-pool" },
-]
-
-[[package]]
-name = "psycopg-binary"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/d8/a763308a41e2ecfb6256ba0877d340c2f2b124c8b2746401863d96fa2c7a/psycopg_binary-3.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b3385b58b2fe408a13d084c14b8dcf468cd36cbbe774408250facc128f9fa75c", size = 4609758, upload-time = "2026-02-18T16:46:33.132Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a9/f8a683e85400c1208685e7c895abc049dc13aa0b6ea989e6adf0a3681fe0/psycopg_binary-3.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1bef235a50a80f6aba05147002bc354559657cb6386dbd04d8e1c97d1d7cbe84", size = 4676740, upload-time = "2026-02-18T16:46:42.904Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7d/03512c4aaac8a58fc3b1221f38293aa517a1950d10ef8646c72c49addc7d/psycopg_binary-3.3.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:97c839717bf8c8df3f6d983a20949c4fb22e2a34ee172e3e427ede363feda27b", size = 5496335, upload-time = "2026-02-18T16:46:51.517Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/bc/23319b4b1c2c0b810d225e1b6f16efbb16150074fc0ea96bfcabdf59ee09/psycopg_binary-3.3.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48e500cf1c0984dacf1f28ea482c3cdbb4c2288d51c336c04bc64198ab21fc51", size = 5172032, upload-time = "2026-02-18T16:47:00.878Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c8/6d61dc0a56654c558a37b2d9b2094e470aa12621305cc7935fd769122e32/psycopg_binary-3.3.3-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb36a08859b9432d94ea6b26ec41a2f98f83f14868c91321d0c1e11f672eeae7", size = 6763107, upload-time = "2026-02-18T16:47:11.784Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b5/e2a3c90aa1059f5b5f593379caad7be3cc3c2ce1ddfc7730e39854e174fe/psycopg_binary-3.3.3-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0dde92cfde09293fb63b3f547919ba7d73bd2654573c03502b3263dd0218e44e", size = 5006494, upload-time = "2026-02-18T16:47:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/3e/bf126e0a1f864e191b7f3eeea667ee2ce13d582b036255fb8b12946d1f7a/psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:78c9ce98caaf82ac8484d269791c1b403d7598633e0e4e2fa1097baae244e2f1", size = 4533850, upload-time = "2026-02-18T16:47:21.673Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/d8/bb5e8d395deb945629aa0c65d12ab90ec3bfcbdf56be89e2a84d001864c9/psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d593612758d0041cb13cb0003f7f8d3fabb7ad9319e651e78afae49b1cf5860e", size = 4223316, upload-time = "2026-02-18T16:47:25.82Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/70/33eef61b0f0fd41ebf93b9699f44067313a45016827f67b3c8cc41f0a7ab/psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f24e8e17035200a465c178e9ea945527ad0738118694184c450f1192a452ff25", size = 3954515, upload-time = "2026-02-18T16:47:30.434Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/db/27c2b3b9698e713e83e11e8540daa27516f9e90390ec21a41091cb15fcaf/psycopg_binary-3.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e7b607f0e14f2a4cf7e78a05ebd13df6144acfba87cb90842e70d3f125d9f53f", size = 4260274, upload-time = "2026-02-18T16:47:36.128Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/3b/71e5d603059bf5474215f573a3e2d357a4e95672b26e04d41674400d4862/psycopg_binary-3.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:b27d3a23c79fa59557d2cc63a7e8bb4c7e022c018558eda36f9d7c4e6b99a6e0", size = 3557375, upload-time = "2026-02-18T16:47:42.799Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c0/b389119dd754483d316805260f3e73cdcad97925839107cc7a296f6132b1/psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048", size = 4609740, upload-time = "2026-02-18T16:47:51.093Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e3/9976eef20f61840285174d360da4c820a311ab39d6b82fa09fbb545be825/psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181", size = 4676837, upload-time = "2026-02-18T16:47:55.523Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f2/d28ba2f7404fd7f68d41e8a11df86313bd646258244cb12a8dd83b868a97/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:90eecd93073922f085967f3ed3a98ba8c325cbbc8c1a204e300282abd2369e13", size = 5497070, upload-time = "2026-02-18T16:47:59.929Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/6c5c54b815edeb30a281cfcea96dc93b3bb6be939aea022f00cab7aa1420/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dac7ee2f88b4d7bb12837989ca354c38d400eeb21bce3b73dac02622f0a3c8d6", size = 5172410, upload-time = "2026-02-18T16:48:05.665Z" },
-    { url = "https://files.pythonhosted.org/packages/51/75/8206c7008b57de03c1ada46bd3110cc3743f3fd9ed52031c4601401d766d/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62cf8784eb6d35beaee1056d54caf94ec6ecf2b7552395e305518ab61eb8fd2", size = 6763408, upload-time = "2026-02-18T16:48:13.541Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5a/ea1641a1e6c8c8b3454b0fcb43c3045133a8b703e6e824fae134088e63bd/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a39f34c9b18e8f6794cca17bfbcd64572ca2482318db644268049f8c738f35a6", size = 5006255, upload-time = "2026-02-18T16:48:22.176Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/fb/538df099bf55ae1637d52d7ccb6b9620b535a40f4c733897ac2b7bb9e14c/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:883d68d48ca9ff3cb3d10c5fdebea02c79b48eecacdddbf7cce6e7cdbdc216b8", size = 4532694, upload-time = "2026-02-18T16:48:27.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/d1/00780c0e187ea3c13dfc53bd7060654b2232cd30df562aac91a5f1c545ac/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cab7bc3d288d37a80aa8c0820033250c95e40b1c2b5c57cf59827b19c2a8b69d", size = 4222833, upload-time = "2026-02-18T16:48:31.221Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/34/a07f1ff713c51d64dc9f19f2c32be80299a2055d5d109d5853662b922cb4/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:56c767007ca959ca32f796b42379fc7e1ae2ed085d29f20b05b3fc394f3715cc", size = 3952818, upload-time = "2026-02-18T16:48:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/67/d33f268a7759b4445f3c9b5a181039b01af8c8263c865c1be7a6444d4749/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:da2f331a01af232259a21573a01338530c6016dcfad74626c01330535bcd8628", size = 4258061, upload-time = "2026-02-18T16:48:41.365Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/3b/0d8d2c5e8e29ccc07d28c8af38445d9d9abcd238d590186cac82ee71fc84/psycopg_binary-3.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:19f93235ece6dbfc4036b5e4f6d8b13f0b8f2b3eeb8b0bd2936d406991bcdd40", size = 3558915, upload-time = "2026-02-18T16:48:46.679Z" },
-    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
-    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
-    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
-    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
-    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
-    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
-]
-
-[[package]]
-name = "psycopg-pool"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidate on asyncpg as the sole PostgreSQL driver. Previously, migrations used a separate sync psycopg engine while the server used asyncpg. Now both paths use asyncpg via SQLAlchemy's run_sync bridge.

Key changes:
- migrate.py: create a disposable AsyncEngine with NullPool for migrations to avoid cross-event-loop pool contamination
- engines.py: remove sync psycopg engine creation and set_postgresql_search_path (schema setup handled by env.py)
- env.py: add `if connection.in_transaction(): connection.commit()` before explicit begin() to handle run_sync's auto-begun transaction, preserving Mode 3 (external transaction) semantics
- pg_config.py: remove psycopg branch, simplify to asyncpg-only
- pyproject.toml: remove psycopg[binary,pool] from deps