### PR TITLE
feat: REST API PUT /prompt_versions/{id}/tags/{tag_name} — upsert tag

### DIFF
--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4266,6 +4266,93 @@
         }
       }
     },
+    "/v1/prompt_versions/{prompt_version_id}/tags/{tag_name}": {
+      "put": {
+        "tags": [
+          "prompts"
+        ],
+        "summary": "Upsert tag on prompt version",
+        "description": "Create or move a named tag to a specific prompt version. If the tag already exists on another version of the same prompt, it will be moved to this version. Tag names are unique per prompt.",
+        "operationId": "upsertPromptVersionTag",
+        "parameters": [
+          {
+            "name": "prompt_version_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the prompt version.",
+              "title": "Prompt Version Id"
+            },
+            "description": "The ID of the prompt version."
+          },
+          {
+            "name": "tag_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The name of the tag to create or move to this version.",
+              "title": "Tag Name"
+            },
+            "description": "The name of the tag to create or move to this version."
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/UpsertPromptVersionTagRequestBody"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Request Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No content returned on successful tag upsert"
+          },
+          "403": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        }
+      }
+    },
     "/v1/projects": {
       "get": {
         "tags": [
@@ -11254,6 +11341,23 @@
           "id"
         ],
         "title": "UpsertExperimentEvaluationResponseBodyData"
+      },
+      "UpsertPromptVersionTagRequestBody": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "title": "UpsertPromptVersionTagRequestBody"
       },
       "ValidationError": {
         "properties": {

--- a/src/phoenix/server/api/routers/v1/prompts.py
+++ b/src/phoenix/server/api/routers/v1/prompts.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from pydantic import ValidationError, model_validator
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
@@ -670,6 +670,96 @@ async def create_prompt_version_tag(
         values = dict(
             name=request_body.name,
             description=request_body.description,
+            prompt_id=prompt_id,
+            prompt_version_id=id_,
+            user_id=user_id,
+        )
+        await session.execute(
+            insert_on_conflict(
+                values,
+                dialect=dialect,
+                table=models.PromptVersionTag,
+                unique_by=("name", "prompt_id"),
+                on_conflict=OnConflict.DO_UPDATE,
+            )
+        )
+    return None
+
+
+class UpsertPromptVersionTagRequestBody(V1RoutesBaseModel):
+    description: Optional[str] = None
+
+
+@router.put(
+    "/prompt_versions/{prompt_version_id}/tags/{tag_name}",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="upsertPromptVersionTag",
+    summary="Upsert tag on prompt version",
+    description="Create or move a named tag to a specific prompt version. If the tag already "
+    "exists on another version of the same prompt, it will be moved to this version. "
+    "Tag names are unique per prompt.",
+    response_description="No content returned on successful tag upsert",
+    status_code=204,
+    responses=add_errors_to_responses(
+        [
+            404,
+            422,
+        ]
+    ),
+    response_model_by_alias=True,
+    response_model_exclude_defaults=True,
+    response_model_exclude_unset=True,
+)
+async def upsert_prompt_version_tag(
+    request: Request,
+    prompt_version_id: str = Path(description="The ID of the prompt version."),
+    tag_name: str = Path(description="The name of the tag to create or move to this version."),
+    request_body: Optional[UpsertPromptVersionTagRequestBody] = Body(default=None),
+) -> None:
+    """
+    Upsert a tag on a specific prompt version.
+
+    Creates the tag if it does not exist, or moves it to this version if it already exists
+    on another version of the same prompt. Tag names are unique within a prompt.
+
+    Args:
+        request (Request): The FastAPI request object.
+        prompt_version_id (str): The ID of the prompt version to tag.
+        tag_name (str): The name of the tag to create or move.
+        request_body (Optional[UpsertPromptVersionTagRequestBody]): Optional body with
+            description to associate with the tag.
+
+    Returns:
+        None: Returns a 204 No Content response on success.
+
+    Raises:
+        HTTPException: If the prompt version ID is invalid, the tag name is invalid,
+            or the prompt version is not found.
+    """
+    try:
+        id_ = from_global_id_with_expected_type(
+            GlobalID.from_id(prompt_version_id),
+            PromptVersionNodeType.__name__,
+        )
+    except ValueError:
+        raise HTTPException(422, "Invalid prompt version ID")
+    try:
+        validated_tag_name = Identifier.model_validate(tag_name)
+    except ValidationError:
+        raise HTTPException(422, "Invalid tag name")
+    user_id: Optional[int] = None
+    if request.app.state.authentication_enabled:
+        assert isinstance(user := request.user, PhoenixUser)
+        user_id = int(user.identity)
+    description = request_body.description if request_body is not None else None
+    async with request.app.state.db() as session:
+        prompt_id = await session.scalar(select(models.PromptVersion.prompt_id).filter_by(id=id_))
+        if prompt_id is None:
+            raise HTTPException(404)
+        dialect = SupportedSQLDialect(session.bind.dialect.name)
+        values = dict(
+            name=validated_tag_name,
+            description=description,
             prompt_id=prompt_id,
             prompt_version_id=id_,
             user_id=user_id,

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2242,6 +2242,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (415, "POST", "v1/traces"),
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),
+    (422, "PUT", "v1/prompt_versions/fake-id-{}/tags/production"),
     # DELETE routes
     (422, "DELETE", "v1/annotation_configs/fake-id-{}"),
     (422, "DELETE", "v1/datasets/fake-id-{}"),

--- a/tests/unit/server/api/routers/v1/test_prompts.py
+++ b/tests/unit/server/api/routers/v1/test_prompts.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 from deepdiff.diff import DeepDiff
 from faker import Faker
+from sqlalchemy import select
 from openai import pydantic_function_tool
 from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, ValidationError, create_model
@@ -125,6 +126,111 @@ class TestPrompts:
             assert (response := await httpx_client.get(url)).is_success
             assert isinstance((data := response.json()["data"]), dict)
             self._compare_prompt_version(data, prompt_version)
+
+    async def test_upsert_prompt_version_tag_creates_new_tag(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, prompt_versions = await self._insert_prompt_versions(db)
+        prompt_version = prompt_versions[0]
+        prompt_version_id = str(GlobalID(PromptVersion.__name__, str(prompt_version.id)))
+        tag_name = "production"
+        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags/{tag_name}"
+        response = await httpx_client.put(url, json={"description": "prod tag"})
+        assert response.status_code == 204
+        async with db() as session:
+            tag = await session.scalar(
+                select(models.PromptVersionTag).filter_by(
+                    name=tag_name, prompt_version_id=prompt_version.id
+                )
+            )
+        assert tag is not None
+        assert tag.description == "prod tag"
+
+    async def test_upsert_prompt_version_tag_moves_existing_tag(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, prompt_versions = await self._insert_prompt_versions(db)
+        version_a = prompt_versions[0]
+        version_b = prompt_versions[1]
+        tag_name = "production"
+        # Create the tag on version_a first
+        await self._tag_prompt_version(
+            db, version_a, tag_name=Identifier.model_validate(tag_name)
+        )
+        # Upsert the tag onto version_b — it should move from version_a
+        prompt_version_b_id = str(GlobalID(PromptVersion.__name__, str(version_b.id)))
+        url = f"v1/prompt_versions/{quote_plus(prompt_version_b_id)}/tags/{tag_name}"
+        response = await httpx_client.put(url, json={})
+        assert response.status_code == 204
+        async with db() as session:
+            tag = await session.scalar(
+                select(models.PromptVersionTag).filter_by(
+                    name=tag_name, prompt_id=version_b.prompt_id
+                )
+            )
+        assert tag is not None
+        assert tag.prompt_version_id == version_b.id
+        # Tag must no longer be associated with version_a
+        async with db() as session:
+            old_tag = await session.scalar(
+                select(models.PromptVersionTag).filter_by(
+                    name=tag_name, prompt_version_id=version_a.id
+                )
+            )
+        assert old_tag is None
+
+    async def test_upsert_prompt_version_tag_no_body(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, prompt_versions = await self._insert_prompt_versions(db)
+        prompt_version = prompt_versions[0]
+        prompt_version_id = str(GlobalID(PromptVersion.__name__, str(prompt_version.id)))
+        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags/staging"
+        response = await httpx_client.put(url)
+        assert response.status_code == 204
+        async with db() as session:
+            tag = await session.scalar(
+                select(models.PromptVersionTag).filter_by(
+                    name="staging", prompt_version_id=prompt_version.id
+                )
+            )
+        assert tag is not None
+        assert tag.description is None
+
+    async def test_upsert_prompt_version_tag_invalid_version_id(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        url = "v1/prompt_versions/not-a-valid-id/tags/production"
+        response = await httpx_client.put(url)
+        assert response.status_code == 422
+
+    async def test_upsert_prompt_version_tag_version_not_found(
+        self,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        nonexistent_id = str(GlobalID(PromptVersion.__name__, "999999"))
+        url = f"v1/prompt_versions/{quote_plus(nonexistent_id)}/tags/production"
+        response = await httpx_client.put(url)
+        assert response.status_code == 404
+
+    async def test_upsert_prompt_version_tag_invalid_tag_name(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        _, prompt_versions = await self._insert_prompt_versions(db)
+        prompt_version = prompt_versions[0]
+        prompt_version_id = str(GlobalID(PromptVersion.__name__, str(prompt_version.id)))
+        url = f"v1/prompt_versions/{quote_plus(prompt_version_id)}/tags/invalid%20name"
+        response = await httpx_client.put(url)
+        assert response.status_code == 422
 
     @pytest.mark.parametrize(
         "name",

--- a/tests/unit/server/api/routers/v1/test_prompts.py
+++ b/tests/unit/server/api/routers/v1/test_prompts.py
@@ -11,10 +11,10 @@ import httpx
 import pytest
 from deepdiff.diff import DeepDiff
 from faker import Faker
-from sqlalchemy import select
 from openai import pydantic_function_tool
 from openai.lib._pydantic import to_strict_json_schema
 from pydantic import BaseModel, ValidationError, create_model
+from sqlalchemy import select
 from strawberry.relay import GlobalID
 from typing_extensions import assert_never
 
@@ -142,7 +142,7 @@ class TestPrompts:
         async with db() as session:
             tag = await session.scalar(
                 select(models.PromptVersionTag).filter_by(
-                    name=tag_name, prompt_version_id=prompt_version.id
+                    name=Identifier.model_validate(tag_name), prompt_version_id=prompt_version.id
                 )
             )
         assert tag is not None
@@ -158,9 +158,7 @@ class TestPrompts:
         version_b = prompt_versions[1]
         tag_name = "production"
         # Create the tag on version_a first
-        await self._tag_prompt_version(
-            db, version_a, tag_name=Identifier.model_validate(tag_name)
-        )
+        await self._tag_prompt_version(db, version_a, tag_name=Identifier.model_validate(tag_name))
         # Upsert the tag onto version_b — it should move from version_a
         prompt_version_b_id = str(GlobalID(PromptVersion.__name__, str(version_b.id)))
         url = f"v1/prompt_versions/{quote_plus(prompt_version_b_id)}/tags/{tag_name}"
@@ -169,7 +167,7 @@ class TestPrompts:
         async with db() as session:
             tag = await session.scalar(
                 select(models.PromptVersionTag).filter_by(
-                    name=tag_name, prompt_id=version_b.prompt_id
+                    name=Identifier.model_validate(tag_name), prompt_id=version_b.prompt_id
                 )
             )
         assert tag is not None
@@ -178,7 +176,7 @@ class TestPrompts:
         async with db() as session:
             old_tag = await session.scalar(
                 select(models.PromptVersionTag).filter_by(
-                    name=tag_name, prompt_version_id=version_a.id
+                    name=Identifier.model_validate(tag_name), prompt_version_id=version_a.id
                 )
             )
         assert old_tag is None
@@ -197,7 +195,7 @@ class TestPrompts:
         async with db() as session:
             tag = await session.scalar(
                 select(models.PromptVersionTag).filter_by(
-                    name="staging", prompt_version_id=prompt_version.id
+                    name=Identifier.model_validate("staging"), prompt_version_id=prompt_version.id
                 )
             )
         assert tag is not None


### PR DESCRIPTION
## Summary

Implements `PUT /prompt_versions/{prompt_version_id}/tags/{tag_name}` — the upsert endpoint for prompt version tags, as specified in #12424.

- **Creates** the tag if it doesn't exist on any version of the prompt
- **Moves** the tag to this version if it already exists on another version of the same prompt (upsert semantics via `ON CONFLICT DO UPDATE` on the unique `(name, prompt_id)` constraint)
- Returns `204 No Content` on success
- Requires `MEMBER+` write access (via `Depends(is_not_locked)`)
- Optional JSON body: `{"description": "..."}` — all fields optional, body may be omitted entirely

## What changed

- **`src/phoenix/server/api/routers/v1/prompts.py`**: Added `UpsertPromptVersionTagRequestBody` model and `PUT /prompt_versions/{prompt_version_id}/tags/{tag_name}` endpoint
- **`schemas/openapi.json`**: Added new path and `UpsertPromptVersionTagRequestBody` schema component
- **`tests/unit/server/api/routers/v1/test_prompts.py`**: Six new unit tests covering create, move, no-body, invalid version ID, version not found, and invalid tag name cases
- **`tests/integration/_helpers.py`**: Registered the new PUT endpoint in `_VIEWER_BLOCKED_WRITE_OPERATIONS` to ensure viewer-role access control coverage

## How to verify

```bash
# Create a prompt version, then tag it:
PUT /v1/prompt_versions/<version_id>/tags/production
Content-Type: application/json

{"description": "Current production version"}
# 204 No Content

# Move the same tag to a different version:
PUT /v1/prompt_versions/<other_version_id>/tags/production
# 204 No Content (tag moved from first version to this one)
```

## Checklist

- [x] Implementation follows existing codebase patterns (mirrors `createPromptVersionTag` POST endpoint)
- [x] `except ValidationError` used (consistent with other Identifier validation in file)
- [x] `Depends(is_not_locked)` applied
- [x] 6 unit tests covering happy path, upsert/move, no-body, 404, and 422 cases
- [x] Viewer-blocked write operations list updated in integration test helpers
- [x] OpenAPI schema updated
- [x] No JS/TS packages modified — no changeset needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
