### PR TITLE
feat(ui): add compound Message component for AI chat interfaces

### DIFF
--- a/app/src/GlobalStyles.tsx
+++ b/app/src/GlobalStyles.tsx
@@ -1200,6 +1200,15 @@ const promptInputCSS = (theme: Theme) => css`
   }
 `;
 
+const messageTokensCSS = (theme: Theme) => css`
+  :root,
+  .theme--${theme} {
+    --message-user-background-color: var(--global-color-gray-200);
+    --message-user-text-color: var(--global-text-color-900);
+    --message-user-border-radius: var(--global-rounding-medium);
+  }
+`;
+
 export const derivedCSS = (theme: Theme) =>
   css(
     baseTokensCSS(theme),
@@ -1218,7 +1227,8 @@ export const derivedCSS = (theme: Theme) =>
     borderAndGridCSS(theme),
     resizeHandleCSS(theme),
     badgeSizingCSS(theme),
-    promptInputCSS(theme)
+    promptInputCSS(theme),
+    messageTokensCSS(theme)
   );
 
 const appGlobalStylesCSS = css`

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -2,22 +2,12 @@ import { css } from "@emotion/react";
 import { isTextUIPart, type UIMessage } from "ai";
 import { useMemo } from "react";
 
+import { Message, MessageContent } from "@phoenix/components/ai/message";
 import { MarkdownBlock } from "@phoenix/components/markdown";
 
 import { groupMessageParts } from "./groupMessageParts";
 import { ToolPart } from "./ToolPart";
 import { ToolPartGroup } from "./ToolPartGroup";
-
-const userMessageCSS = css`
-  align-self: flex-end;
-  background-color: var(--global-color-primary-700);
-  color: var(--global-color-gray-50);
-  border-radius: var(--global-rounding-large) var(--global-rounding-large) 0
-    var(--global-rounding-large);
-  padding: var(--global-dimension-size-100) var(--global-dimension-size-150);
-  max-width: 75%;
-  word-wrap: break-word;
-`;
 
 const assistantMessageCSS = css`
   align-self: flex-start;
@@ -31,13 +21,15 @@ const assistantMessageCSS = css`
 
 /** Renders a user message bubble (right-aligned, primary colour). */
 export function UserMessage({ parts }: { parts: UIMessage["parts"] }) {
+  const text = parts
+    .filter(isTextUIPart)
+    .map((p) => p.text)
+    .join("");
+
   return (
-    <div css={userMessageCSS}>
-      {parts
-        .filter(isTextUIPart)
-        .map((p) => p.text)
-        .join("")}
-    </div>
+    <Message from="user">
+      <MessageContent>{text}</MessageContent>
+    </Message>
   );
 }
 

--- a/app/src/components/ai/message/Message.tsx
+++ b/app/src/components/ai/message/Message.tsx
@@ -1,0 +1,31 @@
+import { MessageContext } from "./MessageContext";
+import { messageCSS } from "./styles";
+import type { MessageProps } from "./types";
+
+/**
+ * Root container for a chat message. Provides the {@link MessageContext} so
+ * descendant components can read the `from` participant and renders a styled
+ * wrapper with layout direction based on the sender.
+ *
+ * @example
+ * ```tsx
+ * <Message from="user">
+ *   <MessageContent>Hello!</MessageContent>
+ * </Message>
+ *
+ * <Message from="assistant">
+ *   <MessageContent>
+ *     <MessageResponse>{markdown}</MessageResponse>
+ *   </MessageContent>
+ * </Message>
+ * ```
+ */
+export function Message({ children, ref, from, ...restProps }: MessageProps) {
+  return (
+    <MessageContext.Provider value={{ from }}>
+      <div ref={ref} css={messageCSS} data-from={from} {...restProps}>
+        {children}
+      </div>
+    </MessageContext.Provider>
+  );
+}

--- a/app/src/components/ai/message/MessageAction.tsx
+++ b/app/src/components/ai/message/MessageAction.tsx
@@ -1,0 +1,62 @@
+import { Button, TooltipTrigger } from "react-aria-components";
+
+import { Tooltip, TooltipArrow } from "../../core/tooltip";
+import { messageActionCSS } from "./styles";
+import type { MessageActionProps, MessageActionTooltip } from "./types";
+
+function resolveTooltip(tooltip: MessageActionTooltip) {
+  if (typeof tooltip === "string") {
+    return { content: tooltip, position: "top" as const };
+  }
+  return { position: "top" as const, ...tooltip };
+}
+
+/**
+ * An icon button intended for use inside {@link MessageActions}. Wraps a
+ * react-aria `Button` with consistent sizing and hover/focus styles. When a
+ * `tooltip` prop is provided the button is automatically wrapped in a
+ * `TooltipTrigger`.
+ *
+ * @example
+ * ```tsx
+ * <MessageAction label="Copy" tooltip="Copy to clipboard" onPress={handleCopy}>
+ *   <Icon svg={<Icons.DuplicateOutline />} />
+ * </MessageAction>
+ * ```
+ */
+export function MessageAction({
+  children,
+  ref,
+  label,
+  tooltip,
+  className,
+  ...restProps
+}: MessageActionProps) {
+  const button = (
+    <Button
+      ref={ref}
+      css={messageActionCSS}
+      className={className}
+      aria-label={label}
+      {...restProps}
+    >
+      {children}
+    </Button>
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  const { content, position } = resolveTooltip(tooltip);
+
+  return (
+    <TooltipTrigger delay={500} closeDelay={0}>
+      {button}
+      <Tooltip placement={position}>
+        <TooltipArrow />
+        {content}
+      </Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/app/src/components/ai/message/MessageActions.tsx
+++ b/app/src/components/ai/message/MessageActions.tsx
@@ -1,0 +1,32 @@
+import { messageActionsCSS } from "./styles";
+import type { MessageActionsProps } from "./types";
+
+/**
+ * Horizontal row of {@link MessageAction} buttons. Renders with
+ * `role="toolbar"` for accessibility and pushes itself to the trailing
+ * edge of the parent via `margin-left: auto`.
+ *
+ * Typically placed inside a {@link MessageToolbar}.
+ *
+ * @example
+ * ```tsx
+ * <MessageToolbar>
+ *   <MessageActions>
+ *     <MessageAction label="Copy" tooltip="Copy" onPress={handleCopy}>
+ *       <Icon svg={<Icons.DuplicateOutline />} />
+ *     </MessageAction>
+ *   </MessageActions>
+ * </MessageToolbar>
+ * ```
+ */
+export function MessageActions({
+  children,
+  ref,
+  ...restProps
+}: MessageActionsProps) {
+  return (
+    <div ref={ref} css={messageActionsCSS} role="toolbar" {...restProps}>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/ai/message/MessageBranch.tsx
+++ b/app/src/components/ai/message/MessageBranch.tsx
@@ -1,0 +1,55 @@
+import { useRef, useState } from "react";
+
+import { MessageBranchContext } from "./MessageBranchContext";
+import type { MessageBranchProps } from "./types";
+
+/**
+ * State provider for branch (version) navigation. Manages which branch
+ * is active and exposes navigation controls via {@link MessageBranchContext}.
+ *
+ * Wrap a {@link MessageBranchContent} and {@link MessageBranchSelector}
+ * inside this component to enable version switching.
+ *
+ * @example
+ * ```tsx
+ * <MessageBranch defaultBranch={0}>
+ *   <MessageBranchContent>
+ *     <MessageContent key="v1">...</MessageContent>
+ *     <MessageContent key="v2">...</MessageContent>
+ *   </MessageBranchContent>
+ *   <MessageToolbar>
+ *     <MessageBranchSelector>
+ *       <MessageBranchPrevious />
+ *       <MessageBranchPage />
+ *       <MessageBranchNext />
+ *     </MessageBranchSelector>
+ *   </MessageToolbar>
+ * </MessageBranch>
+ * ```
+ */
+export function MessageBranch({
+  children,
+  defaultBranch = 0,
+}: MessageBranchProps) {
+  const [activeBranch, setActiveBranch] = useState(defaultBranch);
+  const branchCountRef = useRef(0);
+
+  const safeSetActiveBranch = (index: number) => {
+    setActiveBranch(Math.max(0, Math.min(index, branchCountRef.current - 1)));
+  };
+
+  return (
+    <MessageBranchContext.Provider
+      value={{
+        activeBranch,
+        branchCount: branchCountRef.current,
+        setActiveBranch: safeSetActiveBranch,
+        setBranchCount: (count: number) => {
+          branchCountRef.current = count;
+        },
+      }}
+    >
+      {children}
+    </MessageBranchContext.Provider>
+  );
+}

--- a/app/src/components/ai/message/MessageBranchContent.tsx
+++ b/app/src/components/ai/message/MessageBranchContent.tsx
@@ -1,0 +1,31 @@
+import { Children } from "react";
+
+import { useMessageBranchContext } from "./MessageBranchContext";
+import type { MessageBranchContentProps } from "./types";
+
+/**
+ * Renders only the currently active branch child. Each direct child
+ * represents one branch version — pass them as an array. The component
+ * registers the total branch count with the parent {@link MessageBranch}
+ * so navigation controls stay in sync.
+ *
+ * Must be used within a {@link MessageBranch}.
+ *
+ * @example
+ * ```tsx
+ * <MessageBranchContent>
+ *   <MessageContent key="v1"><MessageResponse>{v1}</MessageResponse></MessageContent>
+ *   <MessageContent key="v2"><MessageResponse>{v2}</MessageResponse></MessageContent>
+ * </MessageBranchContent>
+ * ```
+ */
+export function MessageBranchContent({ children }: MessageBranchContentProps) {
+  const { activeBranch, setBranchCount } = useMessageBranchContext();
+  const childArray = Children.toArray(children);
+
+  // Write to the ref synchronously during render so sibling components
+  // (e.g. MessageBranchPage) read the correct count on the same pass.
+  setBranchCount(childArray.length);
+
+  return <>{childArray[activeBranch] ?? null}</>;
+}

--- a/app/src/components/ai/message/MessageBranchContext.tsx
+++ b/app/src/components/ai/message/MessageBranchContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+import type { MessageBranchContextValue } from "./types";
+
+export const MessageBranchContext =
+  createContext<MessageBranchContextValue | null>(null);
+
+/**
+ * Returns the nearest {@link MessageBranchContextValue} provided by a
+ * {@link MessageBranch} ancestor. Throws if called outside of a
+ * `<MessageBranch>`.
+ */
+export function useMessageBranchContext(): MessageBranchContextValue {
+  const context = useContext(MessageBranchContext);
+  if (!context) {
+    throw new Error(
+      "useMessageBranchContext must be used within a <MessageBranch>"
+    );
+  }
+  return context;
+}

--- a/app/src/components/ai/message/MessageBranchNext.tsx
+++ b/app/src/components/ai/message/MessageBranchNext.tsx
@@ -1,0 +1,31 @@
+import { Button } from "react-aria-components";
+
+import { Icon, Icons } from "../../core/icon";
+import { useMessageBranchContext } from "./MessageBranchContext";
+import { messageActionCSS } from "./styles";
+import type { MessageBranchNextProps } from "./types";
+
+/**
+ * Button that navigates to the next branch. Disables itself when the
+ * last branch is active. Must be used within a {@link MessageBranch}.
+ */
+export function MessageBranchNext({
+  ref,
+  ...restProps
+}: MessageBranchNextProps) {
+  const { activeBranch, branchCount, setActiveBranch } =
+    useMessageBranchContext();
+
+  return (
+    <Button
+      ref={ref}
+      css={messageActionCSS}
+      aria-label="Next version"
+      isDisabled={activeBranch >= branchCount - 1}
+      onPress={() => setActiveBranch(activeBranch + 1)}
+      {...restProps}
+    >
+      <Icon svg={<Icons.ArrowIosForwardOutline />} />
+    </Button>
+  );
+}

--- a/app/src/components/ai/message/MessageBranchPage.tsx
+++ b/app/src/components/ai/message/MessageBranchPage.tsx
@@ -1,0 +1,16 @@
+import { useMessageBranchContext } from "./MessageBranchContext";
+import { messageBranchPageCSS } from "./styles";
+
+/**
+ * Displays the current branch position as "{active} of {total}" text.
+ * Must be used within a {@link MessageBranch}.
+ */
+export function MessageBranchPage() {
+  const { activeBranch, branchCount } = useMessageBranchContext();
+
+  return (
+    <span css={messageBranchPageCSS}>
+      {activeBranch + 1} of {branchCount}
+    </span>
+  );
+}

--- a/app/src/components/ai/message/MessageBranchPrevious.tsx
+++ b/app/src/components/ai/message/MessageBranchPrevious.tsx
@@ -1,0 +1,30 @@
+import { Button } from "react-aria-components";
+
+import { Icon, Icons } from "../../core/icon";
+import { useMessageBranchContext } from "./MessageBranchContext";
+import { messageActionCSS } from "./styles";
+import type { MessageBranchPreviousProps } from "./types";
+
+/**
+ * Button that navigates to the previous branch. Disables itself when the
+ * first branch is active. Must be used within a {@link MessageBranch}.
+ */
+export function MessageBranchPrevious({
+  ref,
+  ...restProps
+}: MessageBranchPreviousProps) {
+  const { activeBranch, setActiveBranch } = useMessageBranchContext();
+
+  return (
+    <Button
+      ref={ref}
+      css={messageActionCSS}
+      aria-label="Previous version"
+      isDisabled={activeBranch <= 0}
+      onPress={() => setActiveBranch(activeBranch - 1)}
+      {...restProps}
+    >
+      <Icon svg={<Icons.ArrowIosBackOutline />} />
+    </Button>
+  );
+}

--- a/app/src/components/ai/message/MessageBranchSelector.tsx
+++ b/app/src/components/ai/message/MessageBranchSelector.tsx
@@ -1,0 +1,43 @@
+import { useMessageBranchContext } from "./MessageBranchContext";
+import { messageBranchSelectorCSS } from "./styles";
+import type { MessageBranchSelectorProps } from "./types";
+
+/**
+ * Container for branch navigation controls. Automatically hides itself
+ * when there is only one branch (or none). Renders with `role="group"`
+ * and an accessible label.
+ *
+ * Must be used within a {@link MessageBranch}.
+ *
+ * @example
+ * ```tsx
+ * <MessageBranchSelector>
+ *   <MessageBranchPrevious />
+ *   <MessageBranchPage />
+ *   <MessageBranchNext />
+ * </MessageBranchSelector>
+ * ```
+ */
+export function MessageBranchSelector({
+  children,
+  ref,
+  ...restProps
+}: MessageBranchSelectorProps) {
+  const { branchCount } = useMessageBranchContext();
+
+  if (branchCount <= 1) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      css={messageBranchSelectorCSS}
+      role="group"
+      aria-label="Version navigation"
+      {...restProps}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/ai/message/MessageContent.tsx
+++ b/app/src/components/ai/message/MessageContent.tsx
@@ -1,0 +1,26 @@
+import { messageContentCSS } from "./styles";
+import type { MessageContentProps } from "./types";
+
+/**
+ * Visual container for a message's body. Styling adapts based on the
+ * parent {@link Message}'s `from` prop — user messages render as a
+ * right-aligned bubble, assistant messages span the full width.
+ *
+ * @example
+ * ```tsx
+ * <Message from="user">
+ *   <MessageContent>Plain text content</MessageContent>
+ * </Message>
+ * ```
+ */
+export function MessageContent({
+  children,
+  ref,
+  ...restProps
+}: MessageContentProps) {
+  return (
+    <div ref={ref} css={messageContentCSS} {...restProps}>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/ai/message/MessageContext.tsx
+++ b/app/src/components/ai/message/MessageContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+import type { MessageContextValue } from "./types";
+
+export const MessageContext = createContext<MessageContextValue | null>(null);
+
+/**
+ * Returns the nearest {@link MessageContextValue} provided by a
+ * {@link Message} ancestor. Throws if called outside of a `<Message>`.
+ */
+export function useMessageContext(): MessageContextValue {
+  const context = useContext(MessageContext);
+  if (!context) {
+    throw new Error("useMessageContext must be used within a <Message>");
+  }
+  return context;
+}

--- a/app/src/components/ai/message/MessageResponse.tsx
+++ b/app/src/components/ai/message/MessageResponse.tsx
@@ -1,0 +1,31 @@
+import { MarkdownBlock } from "../../markdown/MarkdownBlock";
+import type { MessageResponseProps } from "./types";
+
+/**
+ * Renders a markdown string as rich content using {@link MarkdownBlock}.
+ * Supports both static and streaming render modes for incremental output.
+ *
+ * Should be placed inside a {@link MessageContent} for proper styling.
+ *
+ * @example
+ * ```tsx
+ * <MessageContent>
+ *   <MessageResponse>{markdownString}</MessageResponse>
+ * </MessageContent>
+ *
+ * // Streaming mode for incremental content
+ * <MessageContent>
+ *   <MessageResponse renderMode="streaming">{partial}</MessageResponse>
+ * </MessageContent>
+ * ```
+ */
+export function MessageResponse({
+  children,
+  renderMode = "static",
+}: MessageResponseProps) {
+  return (
+    <MarkdownBlock mode="markdown" renderMode={renderMode} margin="none">
+      {children}
+    </MarkdownBlock>
+  );
+}

--- a/app/src/components/ai/message/MessageToolbar.tsx
+++ b/app/src/components/ai/message/MessageToolbar.tsx
@@ -1,0 +1,30 @@
+import { messageToolbarCSS } from "./styles";
+import type { MessageToolbarProps } from "./types";
+
+/**
+ * Footer bar placed below a message's content. Provides a horizontal
+ * layout for branch navigation ({@link MessageBranchSelector}) and
+ * action buttons ({@link MessageActions}).
+ *
+ * @example
+ * ```tsx
+ * <Message from="assistant">
+ *   <MessageContent>...</MessageContent>
+ *   <MessageToolbar>
+ *     <MessageBranchSelector>...</MessageBranchSelector>
+ *     <MessageActions>...</MessageActions>
+ *   </MessageToolbar>
+ * </Message>
+ * ```
+ */
+export function MessageToolbar({
+  children,
+  ref,
+  ...restProps
+}: MessageToolbarProps) {
+  return (
+    <div ref={ref} css={messageToolbarCSS} {...restProps}>
+      {children}
+    </div>
+  );
+}

--- a/app/src/components/ai/message/index.ts
+++ b/app/src/components/ai/message/index.ts
@@ -1,0 +1,31 @@
+export { Message } from "./Message";
+export { MessageContent } from "./MessageContent";
+export { MessageResponse } from "./MessageResponse";
+export { MessageActions } from "./MessageActions";
+export { MessageAction } from "./MessageAction";
+export { MessageToolbar } from "./MessageToolbar";
+export { MessageBranch } from "./MessageBranch";
+export { MessageBranchContent } from "./MessageBranchContent";
+export { MessageBranchSelector } from "./MessageBranchSelector";
+export { MessageBranchPrevious } from "./MessageBranchPrevious";
+export { MessageBranchNext } from "./MessageBranchNext";
+export { MessageBranchPage } from "./MessageBranchPage";
+export { useMessageContext } from "./MessageContext";
+export { useMessageBranchContext } from "./MessageBranchContext";
+export type {
+  MessageFrom,
+  MessageProps,
+  MessageContentProps,
+  MessageResponseProps,
+  MessageActionsProps,
+  MessageActionProps,
+  MessageActionTooltip,
+  MessageToolbarProps,
+  MessageBranchProps,
+  MessageBranchContentProps,
+  MessageBranchSelectorProps,
+  MessageBranchPreviousProps,
+  MessageBranchNextProps,
+  MessageContextValue,
+  MessageBranchContextValue,
+} from "./types";

--- a/app/src/components/ai/message/styles.ts
+++ b/app/src/components/ai/message/styles.ts
@@ -1,0 +1,140 @@
+import { css } from "@emotion/react";
+
+// ---------------------------------------------------------------------------
+// Message (root container)
+// ---------------------------------------------------------------------------
+
+export const messageCSS = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-50);
+  font-size: var(--global-font-size-s);
+  line-height: var(--global-line-height-s);
+
+  &[data-from="user"] {
+    align-items: flex-end;
+  }
+
+  &[data-from="assistant"] {
+    align-items: flex-start;
+    width: 100%;
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// MessageContent
+// ---------------------------------------------------------------------------
+
+export const messageContentCSS = css`
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  min-width: 0;
+
+  [data-from="user"] > & {
+    background-color: var(--message-user-background-color);
+    color: var(--message-user-text-color);
+    border-radius: var(--message-user-border-radius);
+    padding: var(--global-dimension-size-100) var(--global-dimension-size-200);
+    max-width: 75%;
+  }
+
+  [data-from="assistant"] > & {
+    color: var(--global-text-color-900);
+    width: 100%;
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// MessageActions (container row)
+// ---------------------------------------------------------------------------
+
+export const messageActionsCSS = css`
+  display: flex;
+  align-items: center;
+  gap: var(--global-dimension-size-50);
+  margin-left: auto;
+`;
+
+// ---------------------------------------------------------------------------
+// MessageAction (icon button)
+// Mirrors promptInputButtonCSS from prompt-input/styles.ts
+// ---------------------------------------------------------------------------
+
+export const messageActionCSS = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: var(--global-border-size-thin) solid transparent;
+  border-radius: var(--global-rounding-small);
+  background-color: transparent;
+  color: var(--global-text-color-700);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
+  padding: 0;
+  flex: none;
+  width: var(--global-button-height-s);
+  min-width: var(--global-button-height-s);
+  height: var(--global-button-height-s);
+
+  .icon-wrap {
+    font-size: var(--global-font-size-l);
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+  }
+
+  &[data-hovered] {
+    background-color: var(--hover-background);
+    .icon-wrap {
+      opacity: 1;
+    }
+  }
+
+  &[data-pressed] {
+    background-color: var(--global-color-primary-100);
+    color: var(--global-text-color-900);
+  }
+
+  &[data-focus-visible] {
+    outline: var(--global-border-size-thick) solid var(--focus-ring-color);
+    outline-offset: var(--global-border-offset-thin);
+  }
+
+  &[data-disabled] {
+    opacity: var(--global-opacity-disabled);
+    cursor: not-allowed;
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// MessageToolbar (footer row)
+// ---------------------------------------------------------------------------
+
+export const messageToolbarCSS = css`
+  display: flex;
+  align-items: center;
+  gap: var(--global-dimension-size-100);
+  padding-top: var(--global-dimension-size-50);
+  width: 100%;
+`;
+
+// ---------------------------------------------------------------------------
+// MessageBranchSelector (nav container)
+// ---------------------------------------------------------------------------
+
+export const messageBranchSelectorCSS = css`
+  display: flex;
+  align-items: center;
+  gap: var(--global-dimension-size-50);
+`;
+
+// ---------------------------------------------------------------------------
+// MessageBranchPage ("1 of 3" text)
+// ---------------------------------------------------------------------------
+
+export const messageBranchPageCSS = css`
+  color: var(--global-text-color-500);
+  font-size: var(--global-font-size-s);
+  white-space: nowrap;
+  user-select: none;
+`;

--- a/app/src/components/ai/message/types.ts
+++ b/app/src/components/ai/message/types.ts
@@ -1,0 +1,138 @@
+import type { HTMLAttributes, ReactNode, Ref } from "react";
+import type { ButtonProps } from "react-aria-components";
+
+import type { DOMProps } from "../../core/types/dom";
+
+/**
+ * Which participant sent the message. Determines layout direction and styling.
+ * - `"user"` — right-aligned bubble with background color.
+ * - `"assistant"` — left-aligned, full-width, no background.
+ */
+export type MessageFrom = "user" | "assistant";
+
+// ---------------------------------------------------------------------------
+// Context values
+// ---------------------------------------------------------------------------
+
+export interface MessageContextValue {
+  from: MessageFrom;
+}
+
+export interface MessageBranchContextValue {
+  activeBranch: number;
+  branchCount: number;
+  setActiveBranch: (index: number) => void;
+  /** @internal Used by MessageBranchContent to register its child count. */
+  setBranchCount: (count: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component props
+// ---------------------------------------------------------------------------
+
+export interface MessageProps extends HTMLAttributes<HTMLDivElement>, DOMProps {
+  ref?: Ref<HTMLDivElement>;
+  /** Which participant sent this message. */
+  from: MessageFrom;
+  children: ReactNode;
+}
+
+export interface MessageContentProps
+  extends HTMLAttributes<HTMLDivElement>, DOMProps {
+  ref?: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+export interface MessageResponseProps extends DOMProps {
+  /** Markdown string to render. */
+  children: string;
+  /**
+   * Controls how Streamdown parses the markdown content.
+   * - `"static"` — parses the full content at once (default).
+   * - `"streaming"` — parses incrementally per-block with memoization.
+   * @default "static"
+   */
+  renderMode?: "static" | "streaming";
+}
+
+export interface MessageActionsProps
+  extends HTMLAttributes<HTMLDivElement>, DOMProps {
+  ref?: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+/**
+ * Tooltip configuration for a `MessageAction`.
+ *
+ * - **String** — rendered as simple tooltip text.
+ * - **Object** — allows custom placement.
+ *
+ * @example
+ * ```tsx
+ * tooltip="Copy to clipboard"
+ * tooltip={{ content: "Regenerate", position: "bottom" }}
+ * ```
+ */
+export type MessageActionTooltip =
+  | string
+  | {
+      /** Tooltip text content. */
+      content: string;
+      /**
+       * Tooltip position relative to the button.
+       * @default "top"
+       */
+      position?: "top" | "bottom" | "left" | "right";
+    };
+
+export interface MessageActionProps extends Omit<
+  ButtonProps,
+  "children" | "className"
+> {
+  ref?: Ref<HTMLButtonElement>;
+  /** Icon content. */
+  children: ReactNode;
+  /** Accessible label (applied as aria-label). */
+  label: string;
+  /** Optional tooltip shown on hover. */
+  tooltip?: MessageActionTooltip;
+  /** Additional CSS class name. */
+  className?: string;
+}
+
+export interface MessageToolbarProps
+  extends HTMLAttributes<HTMLDivElement>, DOMProps {
+  ref?: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+export interface MessageBranchProps extends DOMProps {
+  children: ReactNode;
+  /**
+   * The initially active branch index (zero-based).
+   * @default 0
+   */
+  defaultBranch?: number;
+}
+
+export interface MessageBranchContentProps {
+  /** One child per branch. Only the active branch is rendered. */
+  children: ReactNode[];
+}
+
+export interface MessageBranchSelectorProps
+  extends HTMLAttributes<HTMLDivElement>, DOMProps {
+  ref?: Ref<HTMLDivElement>;
+  children: ReactNode;
+}
+
+export interface MessageBranchPreviousProps extends Omit<
+  ButtonProps,
+  "children"
+> {
+  ref?: Ref<HTMLButtonElement>;
+}
+
+export interface MessageBranchNextProps extends Omit<ButtonProps, "children"> {
+  ref?: Ref<HTMLButtonElement>;
+}

--- a/app/stories/Message.stories.tsx
+++ b/app/stories/Message.stories.tsx
@@ -1,0 +1,407 @@
+import { css } from "@emotion/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { Icon, Icons } from "@phoenix/components";
+import {
+  Message,
+  MessageAction,
+  MessageActions,
+  MessageBranch,
+  MessageBranchContent,
+  MessageBranchNext,
+  MessageBranchPage,
+  MessageBranchPrevious,
+  MessageBranchSelector,
+  MessageContent,
+  MessageResponse,
+  MessageToolbar,
+} from "@phoenix/components/ai/message";
+
+const containerCSS = css`
+  width: 700px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--global-dimension-size-200);
+`;
+
+const meta = {
+  title: "AI/Message",
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleMarkdown = `## React Hooks Guide
+
+React hooks are functions that let you "hook into" React state and lifecycle features from function components.
+
+### useState
+Adds state to functional components:
+
+\`\`\`jsx
+const [count, setCount] = useState(0);
+
+return (
+  <button onClick={() => setCount(count + 1)}>
+    Count: {count}
+  </button>
+);
+\`\`\`
+
+### When to Use Hooks
+
+- **Function components** — hooks only work in function components
+- **Replacing class components** — modern React favors hooks over classes
+- **Sharing stateful logic** — create custom hooks to reuse logic`;
+
+/**
+ * A simple user message followed by an assistant markdown response.
+ */
+export const Default: Story = {
+  render: () => (
+    <div css={containerCSS}>
+      <Message from="user">
+        <MessageContent>How do React hooks work?</MessageContent>
+      </Message>
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse>{sampleMarkdown}</MessageResponse>
+        </MessageContent>
+      </Message>
+    </div>
+  ),
+};
+
+/**
+ * Assistant message with copy, retry, like/dislike action buttons in a toolbar.
+ */
+function WithActionsRender() {
+  const [liked, setLiked] = useState(false);
+  const [disliked, setDisliked] = useState(false);
+
+  return (
+    <div css={containerCSS}>
+      <Message from="user">
+        <MessageContent>Explain closures in JavaScript.</MessageContent>
+      </Message>
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse>
+            {`A **closure** is a function that has access to variables from its outer (enclosing) scope, even after the outer function has returned.
+
+\`\`\`js
+function makeCounter() {
+  let count = 0;
+  return () => ++count;
+}
+
+const counter = makeCounter();
+counter(); // 1
+counter(); // 2
+\`\`\`
+
+The inner function "closes over" the \`count\` variable, keeping it alive across calls.`}
+          </MessageResponse>
+        </MessageContent>
+        <MessageToolbar>
+          <MessageActions>
+            <MessageAction
+              label="Regenerate"
+              tooltip="Regenerate response"
+              onPress={() => {}}
+            >
+              <Icon svg={<Icons.Refresh />} />
+            </MessageAction>
+            <MessageAction
+              label="Like"
+              tooltip="Like this response"
+              onPress={() => setLiked((v) => !v)}
+            >
+              <Icon
+                svg={<Icons.ThumbsUpOutline />}
+                color={liked ? "blue-700" : "inherit"}
+              />
+            </MessageAction>
+            <MessageAction
+              label="Dislike"
+              tooltip="Dislike this response"
+              onPress={() => setDisliked((v) => !v)}
+            >
+              <Icon
+                svg={<Icons.ThumbsDownOutline />}
+                color={disliked ? "red-700" : "inherit"}
+              />
+            </MessageAction>
+            <MessageAction
+              label="Copy"
+              tooltip="Copy to clipboard"
+              onPress={() => {}}
+            >
+              <Icon svg={<Icons.DuplicateOutline />} />
+            </MessageAction>
+          </MessageActions>
+        </MessageToolbar>
+      </Message>
+    </div>
+  );
+}
+
+export const WithActions: Story = {
+  render: () => <WithActionsRender />,
+};
+
+const branchVersions = [
+  `## Version 1: Detailed
+
+React hooks are functions that let you "hook into" React state and lifecycle features from function components. Here's what you need to know:
+
+### Core Hooks
+
+- **useState** — adds state to functional components
+- **useEffect** — handles side effects like data fetching
+- **useContext** — consumes context values
+
+Would you like to explore more advanced hooks like \`useReducer\` or \`useMemo\`?`,
+
+  `## Version 2: Concise
+
+React hooks are special functions for using React features in function components. The most common ones:
+
+- \`useState\` — manage component state
+- \`useEffect\` — side effects (data fetching, subscriptions)
+- \`useRef\` — access DOM elements
+
+Which specific hook would you like to learn more about?`,
+
+  `## Version 3: With Table
+
+Hooks solve several problems: simpler code, reusable logic, better organization.
+
+| Hook | Purpose |
+|------|---------|
+| useState | Add state to components |
+| useEffect | Handle side effects |
+| useContext | Access context values |
+| useReducer | Complex state logic |
+
+The beauty of hooks is that they let you reuse stateful logic without changing your component hierarchy.`,
+];
+
+/**
+ * Assistant message with multiple response versions and branch navigation.
+ */
+export const WithBranching: Story = {
+  render: () => (
+    <div css={containerCSS}>
+      <Message from="user">
+        <MessageContent>How do React hooks work?</MessageContent>
+      </Message>
+      <Message from="assistant">
+        <MessageBranch defaultBranch={0}>
+          <MessageBranchContent>
+            {branchVersions.map((content, i) => (
+              <MessageContent key={i}>
+                <MessageResponse>{content}</MessageResponse>
+              </MessageContent>
+            ))}
+          </MessageBranchContent>
+          <MessageToolbar>
+            <MessageBranchSelector>
+              <MessageBranchPrevious />
+              <MessageBranchPage />
+              <MessageBranchNext />
+            </MessageBranchSelector>
+            <MessageActions>
+              <MessageAction
+                label="Regenerate"
+                tooltip="Regenerate response"
+                onPress={() => {}}
+              >
+                <Icon svg={<Icons.Refresh />} />
+              </MessageAction>
+              <MessageAction
+                label="Copy"
+                tooltip="Copy to clipboard"
+                onPress={() => {}}
+              >
+                <Icon svg={<Icons.DuplicateOutline />} />
+              </MessageAction>
+            </MessageActions>
+          </MessageToolbar>
+        </MessageBranch>
+      </Message>
+    </div>
+  ),
+};
+
+const streamingParts = [
+  "## Streaming",
+  "## Streaming Demo\n\nThis content",
+  "## Streaming Demo\n\nThis content is being **streamed** incrementally.",
+  "## Streaming Demo\n\nThis content is being **streamed** incrementally.\n\n```js\nconst greeting = 'Hello, world!';\nconsole.log(greeting);\n```",
+  "## Streaming Demo\n\nThis content is being **streamed** incrementally.\n\n```js\nconst greeting = 'Hello, world!';\nconsole.log(greeting);\n```\n\nStreaming complete!",
+];
+
+/**
+ * Assistant message being streamed with incremental content.
+ */
+function StreamingRender() {
+  const [partIndex, setPartIndex] = useState(0);
+
+  const advance = () => {
+    setPartIndex((prev) => (prev < streamingParts.length - 1 ? prev + 1 : 0));
+  };
+
+  return (
+    <div css={containerCSS}>
+      <Message from="user">
+        <MessageContent>Show me a streaming response.</MessageContent>
+      </Message>
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse
+            renderMode={
+              partIndex < streamingParts.length - 1 ? "streaming" : "static"
+            }
+          >
+            {streamingParts[partIndex]}
+          </MessageResponse>
+        </MessageContent>
+      </Message>
+      <button onClick={advance} type="button">
+        {partIndex < streamingParts.length - 1
+          ? "Advance stream"
+          : "Reset stream"}
+      </button>
+    </div>
+  );
+}
+
+export const Streaming: Story = {
+  render: () => <StreamingRender />,
+};
+
+/**
+ * Full chat layout with user messages, assistant responses with branching,
+ * actions, and markdown — all features combined.
+ */
+function GalleryRender() {
+  const [liked, setLiked] = useState<Record<string, boolean>>({});
+
+  const toggleLike = (key: string) => {
+    setLiked((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <div css={containerCSS}>
+      {/* Simple user message */}
+      <Message from="user">
+        <MessageContent>What is TypeScript?</MessageContent>
+      </Message>
+
+      {/* Simple assistant response with actions */}
+      <Message from="assistant">
+        <MessageContent>
+          <MessageResponse>
+            {`**TypeScript** is a statically typed superset of JavaScript that compiles to plain JavaScript. It adds optional type annotations, interfaces, and other features that help catch errors at compile time.
+
+\`\`\`ts
+function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+\`\`\``}
+          </MessageResponse>
+        </MessageContent>
+        <MessageToolbar>
+          <MessageActions>
+            <MessageAction
+              label="Like"
+              tooltip="Like"
+              onPress={() => toggleLike("msg-1")}
+            >
+              <Icon
+                svg={<Icons.ThumbsUpOutline />}
+                color={liked["msg-1"] ? "blue-700" : "inherit"}
+              />
+            </MessageAction>
+            <MessageAction label="Copy" tooltip="Copy" onPress={() => {}}>
+              <Icon svg={<Icons.DuplicateOutline />} />
+            </MessageAction>
+          </MessageActions>
+        </MessageToolbar>
+      </Message>
+
+      {/* Follow-up user message */}
+      <Message from="user">
+        <MessageContent>How does it compare to JavaScript?</MessageContent>
+      </Message>
+
+      {/* Branched assistant response */}
+      <Message from="assistant">
+        <MessageBranch defaultBranch={0}>
+          <MessageBranchContent>
+            <MessageContent key="v1">
+              <MessageResponse>
+                {`The key differences are:
+
+1. **Type safety** — TypeScript catches type errors at compile time
+2. **IDE support** — better autocomplete and refactoring
+3. **Interfaces** — define contracts for object shapes
+4. **Enums** — first-class support for enumerated values`}
+              </MessageResponse>
+            </MessageContent>
+            <MessageContent key="v2">
+              <MessageResponse>
+                {`| Feature | JavaScript | TypeScript |
+|---------|-----------|------------|
+| Types | Dynamic | Static |
+| Compilation | Interpreted | Compiled to JS |
+| IDE Support | Basic | Advanced |
+| Learning Curve | Lower | Higher |
+
+TypeScript is essentially JavaScript with guardrails.`}
+              </MessageResponse>
+            </MessageContent>
+          </MessageBranchContent>
+          <MessageToolbar>
+            <MessageBranchSelector>
+              <MessageBranchPrevious />
+              <MessageBranchPage />
+              <MessageBranchNext />
+            </MessageBranchSelector>
+            <MessageActions>
+              <MessageAction
+                label="Regenerate"
+                tooltip="Regenerate"
+                onPress={() => {}}
+              >
+                <Icon svg={<Icons.Refresh />} />
+              </MessageAction>
+              <MessageAction
+                label="Like"
+                tooltip="Like"
+                onPress={() => toggleLike("msg-2")}
+              >
+                <Icon
+                  svg={<Icons.ThumbsUpOutline />}
+                  color={liked["msg-2"] ? "blue-700" : "inherit"}
+                />
+              </MessageAction>
+              <MessageAction label="Copy" tooltip="Copy" onPress={() => {}}>
+                <Icon svg={<Icons.DuplicateOutline />} />
+              </MessageAction>
+            </MessageActions>
+          </MessageToolbar>
+        </MessageBranch>
+      </Message>
+    </div>
+  );
+}
+
+export const Gallery: Story = {
+  render: () => <GalleryRender />,
+};


### PR DESCRIPTION
## Summary

- Adds a composable `components/ai/message/` compound component system mirroring the Vercel AI SDK message pattern, built on react-aria primitives and Emotion CSS with Phoenix design tokens
- Includes `Message`, `MessageContent`, `MessageResponse`, `MessageAction`, `MessageActions`, `MessageToolbar`, and full branch navigation (`MessageBranch`, `MessageBranchContent`, `MessageBranchSelector`, `MessageBranchPrevious`, `MessageBranchNext`, `MessageBranchPage`)
- Adds 5 Storybook stories (Default, WithActions, WithBranching, Streaming, Gallery) demonstrating all use cases

## Test plan

- [ ] Run `pnpm --filter phoenix-app tsc --noEmit` — passes clean
- [ ] Run `pnpm --filter phoenix-app storybook` and verify all 5 stories under **AI/Message** render correctly in light and dark themes
- [ ] Test branch navigation (prev/next buttons, page indicator updates)
- [ ] Test tooltip hover on MessageAction buttons
- [ ] Verify keyboard accessibility (Tab through actions, Enter to activate)