### PR TITLE
feat: include span and experiment run in error subscription payloads

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -419,6 +419,8 @@ type ChatCompletionSubscriptionError implements ChatCompletionSubscriptionPayloa
   datasetExampleId: ID
   repetitionNumber: Int
   message: String!
+  span: Span
+  experimentRun: ExperimentRun
 }
 
 type ChatCompletionSubscriptionExperiment implements ChatCompletionSubscriptionPayload {

--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -996,8 +996,20 @@ export function PlaygroundDatasetExamplesTable({
               instanceId,
               exampleId: chatCompletion.datasetExampleId,
               repetitionNumber: chatCompletion.repetitionNumber ?? 1,
-              patch: { errorMessage: chatCompletion.message },
+              patch: {
+                errorMessage: chatCompletion.message,
+                span: chatCompletion.span,
+                experimentRunId: chatCompletion.experimentRun?.id,
+              },
             });
+            if (chatCompletion.span) {
+              handleExperimentRunCost({
+                instanceId,
+                latencyMs: chatCompletion.span.latencyMs ?? null,
+                tokenCountTotal: chatCompletion.span.tokenCountTotal ?? null,
+                cost: chatCompletion.span.costSummary?.total?.cost ?? null,
+              });
+            }
             incrementRunsFailed(instanceId);
             break;
           case "TextChunk":
@@ -1609,6 +1621,25 @@ graphql`
         datasetExampleId
         repetitionNumber
         message
+        span {
+          id
+          tokenCountTotal
+          costSummary {
+            total {
+              cost
+            }
+          }
+          latencyMs
+          project {
+            id
+          }
+          context {
+            traceId
+          }
+        }
+        experimentRun {
+          id
+        }
       }
       ... on EvaluationChunk {
         datasetExampleId

--- a/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
+++ b/app/src/pages/playground/__generated__/PlaygroundDatasetExamplesTableSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f90db853eac2b71be1e6a3c4defbe3a0>>
+ * @generated SignedSource<<92c5fe412a1db375fe6bb3d12ad99aae>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -163,8 +163,27 @@ export type PlaygroundDatasetExamplesTableSubscription$data = {
   readonly chatCompletionOverDataset: {
     readonly __typename: "ChatCompletionSubscriptionError";
     readonly datasetExampleId: string | null;
+    readonly experimentRun: {
+      readonly id: string;
+    } | null;
     readonly message: string;
     readonly repetitionNumber: number | null;
+    readonly span: {
+      readonly context: {
+        readonly traceId: string;
+      };
+      readonly costSummary: {
+        readonly total: {
+          readonly cost: number | null;
+        };
+      } | null;
+      readonly id: string;
+      readonly latencyMs: number | null;
+      readonly project: {
+        readonly id: string;
+      };
+      readonly tokenCountTotal: number | null;
+    } | null;
   } | {
     readonly __typename: "ChatCompletionSubscriptionExperiment";
     readonly experiment: {
@@ -361,81 +380,44 @@ v11 = {
   "storageKey": null
 },
 v12 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "concreteType": "Span",
+  "kind": "LinkedField",
+  "name": "span",
+  "plural": false,
   "selections": [
-    (v3/*: any*/),
-    (v4/*: any*/),
+    (v6/*: any*/),
     {
       "alias": null,
       "args": null,
-      "concreteType": "Span",
+      "kind": "ScalarField",
+      "name": "tokenCountTotal",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanCostSummary",
       "kind": "LinkedField",
-      "name": "span",
+      "name": "costSummary",
       "plural": false,
       "selections": [
-        (v6/*: any*/),
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "tokenCountTotal",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SpanCostSummary",
+          "concreteType": "CostBreakdown",
           "kind": "LinkedField",
-          "name": "costSummary",
+          "name": "total",
           "plural": false,
           "selections": [
             {
               "alias": null,
               "args": null,
-              "concreteType": "CostBreakdown",
-              "kind": "LinkedField",
-              "name": "total",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "cost",
-                  "storageKey": null
-                }
-              ],
+              "kind": "ScalarField",
+              "name": "cost",
               "storageKey": null
             }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "latencyMs",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "Project",
-          "kind": "LinkedField",
-          "name": "project",
-          "plural": false,
-          "selections": (v9/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SpanContext",
-          "kind": "LinkedField",
-          "name": "context",
-          "plural": false,
-          "selections": [
-            (v11/*: any*/)
           ],
           "storageKey": null
         }
@@ -445,18 +427,57 @@ v12 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ExperimentRun",
+      "kind": "ScalarField",
+      "name": "latencyMs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Project",
       "kind": "LinkedField",
-      "name": "experimentRun",
+      "name": "project",
       "plural": false,
       "selections": (v9/*: any*/),
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SpanContext",
+      "kind": "LinkedField",
+      "name": "context",
+      "plural": false,
+      "selections": [
+        (v11/*: any*/)
+      ],
+      "storageKey": null
     }
+  ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ExperimentRun",
+  "kind": "LinkedField",
+  "name": "experimentRun",
+  "plural": false,
+  "selections": (v9/*: any*/),
+  "storageKey": null
+},
+v14 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v3/*: any*/),
+    (v4/*: any*/),
+    (v12/*: any*/),
+    (v13/*: any*/)
   ],
   "type": "ChatCompletionSubscriptionResult",
   "abstractKey": null
 },
-v13 = {
+v15 = {
   "kind": "InlineFragment",
   "selections": [
     (v3/*: any*/),
@@ -467,19 +488,21 @@ v13 = {
       "kind": "ScalarField",
       "name": "message",
       "storageKey": null
-    }
+    },
+    (v12/*: any*/),
+    (v13/*: any*/)
   ],
   "type": "ChatCompletionSubscriptionError",
   "abstractKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "evaluatorName",
   "storageKey": null
 },
-v15 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "ExperimentRunAnnotation",
@@ -534,14 +557,14 @@ v15 = {
   ],
   "storageKey": null
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "projectId",
   "storageKey": null
 },
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -567,15 +590,15 @@ return {
           (v5/*: any*/),
           (v8/*: any*/),
           (v10/*: any*/),
-          (v12/*: any*/),
-          (v13/*: any*/),
+          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               (v3/*: any*/),
               (v4/*: any*/),
-              (v14/*: any*/),
-              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -585,11 +608,11 @@ return {
                 "plural": false,
                 "selections": [
                   (v11/*: any*/),
-                  (v16/*: any*/)
+                  (v18/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v17/*: any*/)
+              (v19/*: any*/)
             ],
             "type": "EvaluationChunk",
             "abstractKey": null
@@ -619,15 +642,15 @@ return {
           (v5/*: any*/),
           (v8/*: any*/),
           (v10/*: any*/),
-          (v12/*: any*/),
-          (v13/*: any*/),
+          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               (v3/*: any*/),
               (v4/*: any*/),
-              (v14/*: any*/),
-              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -637,12 +660,12 @@ return {
                 "plural": false,
                 "selections": [
                   (v11/*: any*/),
-                  (v16/*: any*/),
+                  (v18/*: any*/),
                   (v6/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v17/*: any*/)
+              (v19/*: any*/)
             ],
             "type": "EvaluationChunk",
             "abstractKey": null
@@ -653,16 +676,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "59848e300014c13cbfa3a75b4db687ac",
+    "cacheID": "05cb4d6b7ab41e566e27ca08e220c0c0",
     "id": null,
     "metadata": {},
     "name": "PlaygroundDatasetExamplesTableSubscription",
     "operationKind": "subscription",
-    "text": "subscription PlaygroundDatasetExamplesTableSubscription(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    ... on TextChunk {\n      content\n      datasetExampleId\n      repetitionNumber\n    }\n    ... on ToolCallChunk {\n      id\n      datasetExampleId\n      repetitionNumber\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionExperiment {\n      experiment {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      datasetExampleId\n      repetitionNumber\n      span {\n        id\n        tokenCountTotal\n        costSummary {\n          total {\n            cost\n          }\n        }\n        latencyMs\n        project {\n          id\n        }\n        context {\n          traceId\n        }\n      }\n      experimentRun {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      datasetExampleId\n      repetitionNumber\n      message\n    }\n    ... on EvaluationChunk {\n      datasetExampleId\n      repetitionNumber\n      evaluatorName\n      experimentRunEvaluation {\n        id\n        name\n        label\n        score\n        annotatorKind\n        explanation\n        metadata\n        startTime\n      }\n      trace {\n        traceId\n        projectId\n        id\n      }\n      error\n    }\n  }\n}\n"
+    "text": "subscription PlaygroundDatasetExamplesTableSubscription(\n  $input: ChatCompletionOverDatasetInput!\n) {\n  chatCompletionOverDataset(input: $input) {\n    __typename\n    ... on TextChunk {\n      content\n      datasetExampleId\n      repetitionNumber\n    }\n    ... on ToolCallChunk {\n      id\n      datasetExampleId\n      repetitionNumber\n      function {\n        name\n        arguments\n      }\n    }\n    ... on ChatCompletionSubscriptionExperiment {\n      experiment {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionResult {\n      datasetExampleId\n      repetitionNumber\n      span {\n        id\n        tokenCountTotal\n        costSummary {\n          total {\n            cost\n          }\n        }\n        latencyMs\n        project {\n          id\n        }\n        context {\n          traceId\n        }\n      }\n      experimentRun {\n        id\n      }\n    }\n    ... on ChatCompletionSubscriptionError {\n      datasetExampleId\n      repetitionNumber\n      message\n      span {\n        id\n        tokenCountTotal\n        costSummary {\n          total {\n            cost\n          }\n        }\n        latencyMs\n        project {\n          id\n        }\n        context {\n          traceId\n        }\n      }\n      experimentRun {\n        id\n      }\n    }\n    ... on EvaluationChunk {\n      datasetExampleId\n      repetitionNumber\n      evaluatorName\n      experimentRunEvaluation {\n        id\n        name\n        label\n        score\n        annotatorKind\n        explanation\n        metadata\n        startTime\n      }\n      trace {\n        traceId\n        projectId\n        id\n      }\n      error\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "33535629bd23d07817368b2581abca97";
+(node as any).hash = "e035a08659fb9434a83d35b0b5de6b13";
 
 export default node;

--- a/src/phoenix/server/api/types/ChatCompletionSubscriptionPayload.py
+++ b/src/phoenix/server/api/types/ChatCompletionSubscriptionPayload.py
@@ -42,6 +42,8 @@ class ChatCompletionSubscriptionResult(ChatCompletionSubscriptionPayload):
 @strawberry.type
 class ChatCompletionSubscriptionError(ChatCompletionSubscriptionPayload):
     message: str
+    span: Optional[Span] = None
+    experiment_run: Optional[ExperimentRun] = None
 
 
 @strawberry.type

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -527,6 +527,7 @@ class TaskWorkItem(WorkItem):
                     message=str(error),
                     dataset_example_id=example_id,
                     repetition_number=self._repetition_number,
+                    experiment_run=ExperimentRun(id=db_run.id, db_record=db_run),
                 )
             )
             await self._running_experiment.on_failure(self, error)
@@ -599,11 +600,22 @@ class TaskWorkItem(WorkItem):
                     await self._running_experiment.on_failure(self, persist_err)
                     return
 
+                error_db_span = (
+                    task_db_trace.spans[0]
+                    if task_db_trace is not None and task_db_trace.spans
+                    else None
+                )
                 self._running_experiment._broadcast(
                     ChatCompletionSubscriptionError(
                         message=str(e),
                         dataset_example_id=example_id,
                         repetition_number=self._repetition_number,
+                        span=(
+                            Span(id=error_db_span.id, db_record=error_db_span)
+                            if error_db_span is not None
+                            else None
+                        ),
+                        experiment_run=ExperimentRun(id=db_run.id, db_record=db_run),
                     )
                 )
                 await self._running_experiment.on_failure(self, e)


### PR DESCRIPTION
Add optional span and experimentRun fields to ChatCompletionSubscriptionError so the frontend can display partial trace data (latency, token counts, cost) and link to the persisted error run for failed experiment examples.