### PR TITLE
fix(ci): ensure .changeset directory exists before changesets action

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -45,6 +45,13 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Ensure .changeset directory exists
+        working-directory: ./js
+        run: |
+          if [ ! -d ".changeset" ]; then
+            mkdir -p .changeset
+            echo '{"$schema":"https://unpkg.com/@changesets/config@3.0.4/schema.json","changelog":"@changesets/cli/changelog","commit":false,"fixed":[],"linked":[],"access":"restricted","baseBranch":"main","updateInternalDependencies":"patch","ignore":["phoenix-experiment-runner","demo-document-relevancy-experiment"],"privatePackages":{"version":false,"tag":false}}' > .changeset/config.json
+          fi
       - name: create and publish versions
         # Using PAT instead of GITHUB_TOKEN so that PRs created by this action
         # can trigger subsequent workflows (like publish) when merged


### PR DESCRIPTION
## Summary
- Adds a guard step in the TS packages publish workflow that creates `js/.changeset/` with the default `config.json` if the directory is missing
- This makes CI a no-op (no changesets to process) instead of failing with `Error: There is no .changeset directory in this project`

## Test plan
- [ ] Verify CI passes when `.changeset` directory exists (normal case, no behavior change)
- [ ] Verify CI no longer fails when `.changeset` directory is absent