### PR TITLE
fix: skip redundant header stats refetch on initial mount

### DIFF
--- a/app/src/pages/project/ProjectPageHeader.tsx
+++ b/app/src/pages/project/ProjectPageHeader.tsx
@@ -65,10 +65,10 @@ export function ProjectPageHeader(props: {
   // Refetch the count of traces if the fetchKey changes.
   // Skip the initial mount — the parent useLazyLoadQuery with
   // store-and-network already fetches fresh data.
-  const isFirstRender = useRef<boolean>(true);
+  const hasMounted = useRef<boolean>(false);
   useEffect(() => {
-    if (isFirstRender.current === true) {
-      isFirstRender.current = false;
+    if (!hasMounted.current) {
+      hasMounted.current = true;
       return;
     }
     startTransition(() => {


### PR DESCRIPTION
The `ProjectPageHeader` `useEffect` unconditionally called `refetch()` on mount, duplicating the network request already made by the parent `useLazyLoadQuery` with `store-and-network` fetch policy. Add an `hasMounted` guard following the same pattern used in `SpansTable` and `TracesTable`.