### PR TITLE
fix: use DISTINCT instead of GROUP BY in ProjectHasTracesDataLoader

### DIFF
--- a/src/phoenix/server/api/dataloaders/project_has_traces.py
+++ b/src/phoenix/server/api/dataloaders/project_has_traces.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import distinct, select
 from strawberry.dataloader import DataLoader
 from typing_extensions import TypeAlias
 
@@ -16,7 +16,7 @@ class ProjectHasTracesDataLoader(DataLoader[Key, Result]):
 
     async def _load_fn(self, keys: list[Key]) -> list[Result]:
         pid = models.Trace.project_rowid
-        stmt = select(pid).where(pid.in_(keys)).group_by(pid)
+        stmt = select(distinct(pid)).where(pid.in_(keys))
         async with self._db() as session:
             result = set(await session.scalars(stmt))
         return [key in result for key in keys]


### PR DESCRIPTION
GROUP BY scans all matching rows before grouping. DISTINCT allows the planner to short-circuit with a Limit when the IN clause has a single value, which is the common case (one project page at a time).

## Before
```
                                                   QUERY PLAN                                                    
-----------------------------------------------------------------------------------------------------------------
 Group  (cost=0.00..1073.29 rows=1 width=4) (actual time=0.029..11.405 rows=1 loops=1)
   ->  Seq Scan on traces  (cost=0.00..1073.29 rows=44903 width=4) (actual time=0.028..9.985 rows=45000 loops=1)
         Filter: (project_rowid = 1)
 Planning Time: 0.314 ms
 Execution Time: 11.472 ms
(5 rows)
```

## After
```
                                                 QUERY PLAN                                                  
-------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..0.02 rows=1 width=4) (actual time=0.044..0.045 rows=1 loops=1)
   ->  Seq Scan on traces  (cost=0.00..1073.29 rows=44903 width=4) (actual time=0.043..0.043 rows=1 loops=1)
         Filter: (project_rowid = 1)
 Planning Time: 0.981 ms
 Execution Time: 0.129 ms
(5 rows)
```
