### PR TITLE
fix(experiments): fix lastError query failing on SQLite

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -1505,43 +1505,6 @@ type ExperimentEdge {
   node: Experiment!
 }
 
-type ExperimentError implements Node {
-  """The Globally Unique ID of this object"""
-  id: ID!
-  occurredAt: DateTime!
-  category: ExperimentErrorCategory!
-  message: String!
-  detail: ExperimentErrorDetail
-}
-
-enum ExperimentErrorCategory {
-  TASK
-  EVAL
-  EXPERIMENT
-}
-
-"""A connection to a list of items."""
-type ExperimentErrorConnection {
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [ExperimentErrorEdge!]!
-}
-
-union ExperimentErrorDetail = FailureDetail | RetriesExhaustedDetail
-
-"""An edge in a connection."""
-type ExperimentErrorEdge {
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: ExperimentError!
-}
-
-union ExperimentErrorWorkItemId = TaskWorkItemId | EvalWorkItemId
-
 type ExperimentJob implements Node {
   """The Globally Unique ID of this object"""
   id: ID!
@@ -1550,10 +1513,10 @@ type ExperimentJob implements Node {
   createdAt: DateTime!
 
   """Most recent error from this experiment, or null if no errors."""
-  lastError: ExperimentError
+  lastError: ExperimentLog
 
   """Errors recorded during experiment execution, most recent first."""
-  errors(first: Int = 50, last: Int, after: String, before: String): ExperimentErrorConnection!
+  errors(first: Int = 50, last: Int, after: String, before: String): ExperimentLogConnection!
   maxConcurrency: Int!
 
   """
@@ -1589,6 +1552,50 @@ enum ExperimentJobStatus {
   STOPPED
   ERROR
 }
+
+type ExperimentLog implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+  occurredAt: DateTime!
+  category: ExperimentLogCategory!
+  level: ExperimentLogLevel!
+  message: String!
+  detail: ExperimentLogDetail
+}
+
+enum ExperimentLogCategory {
+  TASK
+  EVAL
+  EXPERIMENT
+}
+
+"""A connection to a list of items."""
+type ExperimentLogConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ExperimentLogEdge!]!
+}
+
+union ExperimentLogDetail = FailureDetail | RetriesExhaustedDetail
+
+"""An edge in a connection."""
+type ExperimentLogEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ExperimentLog!
+}
+
+enum ExperimentLogLevel {
+  ERROR
+  WARN
+  INFO
+}
+
+union ExperimentLogWorkItemId = TaskWorkItemId | EvalWorkItemId
 
 type ExperimentMutationPayload {
   experiments: [Experiment!]!
@@ -1760,7 +1767,7 @@ input ExperimentRunSort {
 }
 
 type FailureDetail {
-  workItem: ExperimentErrorWorkItemId
+  workItem: ExperimentLogWorkItemId
   errorType: String!
   stackTrace: String
 }
@@ -2985,7 +2992,7 @@ type ResumeExperimentPayload {
 }
 
 type RetriesExhaustedDetail {
-  workItem: ExperimentErrorWorkItemId
+  workItem: ExperimentLogWorkItemId
   retryCount: Int!
   reason: String!
   stackTrace: String

--- a/app/src/pages/experiments/__generated__/ExperimentDetailsDialogQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentDetailsDialogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c1a59d0e9641e6a13c090aff7606ab86>>
+ * @generated SignedSource<<90db79410ceca10f7aac1accd23b6e01>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,8 +9,8 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type ExperimentErrorCategory = "EVAL" | "EXPERIMENT" | "TASK";
 export type ExperimentJobStatus = "COMPLETED" | "ERROR" | "RUNNING" | "STOPPED";
+export type ExperimentLogCategory = "EVAL" | "EXPERIMENT" | "TASK";
 export type GenerativeProviderKey = "ANTHROPIC" | "AWS" | "AZURE_OPENAI" | "CEREBRAS" | "DEEPSEEK" | "FIREWORKS" | "GOOGLE" | "GROQ" | "MOONSHOT" | "OLLAMA" | "OPENAI" | "PERPLEXITY" | "TOGETHER" | "XAI";
 export type OpenAIApiType = "CHAT_COMPLETIONS" | "RESPONSES";
 export type PromptTemplateFormat = "F_STRING" | "MUSTACHE" | "NONE";
@@ -45,7 +45,7 @@ export type ExperimentDetailsDialogQuery$data = {
       readonly errors: {
         readonly edges: ReadonlyArray<{
           readonly node: {
-            readonly category: ExperimentErrorCategory;
+            readonly category: ExperimentLogCategory;
             readonly detail: {
               readonly errorType?: string;
               readonly reason?: string;
@@ -59,7 +59,7 @@ export type ExperimentDetailsDialogQuery$data = {
         }>;
       };
       readonly lastError: {
-        readonly category: ExperimentErrorCategory;
+        readonly category: ExperimentLogCategory;
         readonly detail: {
           readonly errorType?: string;
           readonly reason?: string;
@@ -595,7 +595,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ExperimentError",
+                    "concreteType": "ExperimentLog",
                     "kind": "LinkedField",
                     "name": "lastError",
                     "plural": false,
@@ -605,7 +605,7 @@ return {
                   {
                     "alias": null,
                     "args": (v28/*: any*/),
-                    "concreteType": "ExperimentErrorConnection",
+                    "concreteType": "ExperimentLogConnection",
                     "kind": "LinkedField",
                     "name": "errors",
                     "plural": false,
@@ -613,7 +613,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExperimentErrorEdge",
+                        "concreteType": "ExperimentLogEdge",
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
@@ -621,7 +621,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ExperimentError",
+                            "concreteType": "ExperimentLog",
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
@@ -775,7 +775,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ExperimentError",
+                    "concreteType": "ExperimentLog",
                     "kind": "LinkedField",
                     "name": "lastError",
                     "plural": false,
@@ -785,7 +785,7 @@ return {
                   {
                     "alias": null,
                     "args": (v28/*: any*/),
-                    "concreteType": "ExperimentErrorConnection",
+                    "concreteType": "ExperimentLogConnection",
                     "kind": "LinkedField",
                     "name": "errors",
                     "plural": false,
@@ -793,7 +793,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExperimentErrorEdge",
+                        "concreteType": "ExperimentLogEdge",
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
@@ -801,7 +801,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ExperimentError",
+                            "concreteType": "ExperimentLog",
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -889,8 +889,8 @@ CREATE TABLE public.experiment_logs (
         ON DELETE CASCADE
 );
 
-CREATE INDEX ix_experiment_logs_experiment_id_occurred_at ON public.experiment_logs
-    USING btree (experiment_id, occurred_at DESC);
+CREATE INDEX ix_experiment_logs_experiment_id_occurred_at_errors ON public.experiment_logs
+    USING btree (experiment_id, occurred_at DESC) WHERE ((level)::text = 'ERROR'::text);
 
 
 -- Table: experiment_runs
@@ -925,26 +925,26 @@ CREATE INDEX ix_experiment_runs_dataset_example_id ON public.experiment_runs
     USING btree (dataset_example_id);
 
 
--- Table: experiment_eval_events
--- -----------------------------
-CREATE TABLE public.experiment_eval_events (
+-- Table: experiment_eval_logs
+-- ---------------------------
+CREATE TABLE public.experiment_eval_logs (
     id BIGINT NOT NULL,
     category VARCHAR NOT NULL DEFAULT 'EVAL'::character varying,
     experiment_run_id BIGINT NOT NULL,
     dataset_evaluator_id BIGINT NOT NULL,
-    CONSTRAINT pk_experiment_eval_events PRIMARY KEY (id),
+    CONSTRAINT pk_experiment_eval_logs PRIMARY KEY (id),
     CHECK (((category)::text = 'EVAL'::text)),
-    CONSTRAINT fk_experiment_eval_events_category_experiment_logs
+    CONSTRAINT fk_experiment_eval_logs_category_experiment_logs
         FOREIGN KEY
         (category, id)
         REFERENCES public.experiment_logs (category, id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_eval_events_dataset_evaluator_id_dataset__fe6f
+    CONSTRAINT fk_experiment_eval_logs_dataset_evaluator_id_dataset_evaluators
         FOREIGN KEY
         (dataset_evaluator_id)
         REFERENCES public.dataset_evaluators (id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_eval_events_experiment_run_id_experiment_runs
+    CONSTRAINT fk_experiment_eval_logs_experiment_run_id_experiment_runs
         FOREIGN KEY
         (experiment_run_id)
         REFERENCES public.experiment_runs (id)
@@ -1015,21 +1015,21 @@ CREATE INDEX ix_experiment_tags_user_id ON public.experiment_tags
     USING btree (user_id);
 
 
--- Table: experiment_task_events
--- -----------------------------
-CREATE TABLE public.experiment_task_events (
+-- Table: experiment_task_logs
+-- ---------------------------
+CREATE TABLE public.experiment_task_logs (
     id BIGINT NOT NULL,
     category VARCHAR NOT NULL DEFAULT 'TASK'::character varying,
     dataset_example_id BIGINT NOT NULL,
     repetition_number INTEGER NOT NULL,
-    CONSTRAINT pk_experiment_task_events PRIMARY KEY (id),
+    CONSTRAINT pk_experiment_task_logs PRIMARY KEY (id),
     CHECK (((category)::text = 'TASK'::text)),
-    CONSTRAINT fk_experiment_task_events_category_experiment_logs
+    CONSTRAINT fk_experiment_task_logs_category_experiment_logs
         FOREIGN KEY
         (category, id)
         REFERENCES public.experiment_logs (category, id)
         ON DELETE CASCADE,
-    CONSTRAINT fk_experiment_task_events_dataset_example_id_dataset_examples
+    CONSTRAINT fk_experiment_task_logs_dataset_example_id_dataset_examples
         FOREIGN KEY
         (dataset_example_id)
         REFERENCES public.dataset_examples (id)

--- a/src/phoenix/db/migrations/versions/aba52fffe1a1_add_experiment_jobs.py
+++ b/src/phoenix/db/migrations/versions/aba52fffe1a1_add_experiment_jobs.py
@@ -223,13 +223,15 @@ def upgrade() -> None:
             nullable=True,
         ),
         sa.Index(
-            "ix_experiment_logs_experiment_id_occurred_at",
+            "ix_experiment_logs_experiment_id_occurred_at_errors",
             "experiment_id",
             sa.text("occurred_at DESC"),
+            postgresql_where=sa.text("level = 'ERROR'"),
+            sqlite_where=sa.text("level = 'ERROR'"),
         ),
     )
     op.create_table(
-        "experiment_task_events",
+        "experiment_task_logs",
         sa.Column(
             "id",
             _Integer,
@@ -260,7 +262,7 @@ def upgrade() -> None:
         ),
     )
     op.create_table(
-        "experiment_eval_events",
+        "experiment_eval_logs",
         sa.Column(
             "id",
             _Integer,
@@ -316,8 +318,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("experiment_dataset_evaluators")
-    op.drop_table("experiment_eval_events")
-    op.drop_table("experiment_task_events")
+    op.drop_table("experiment_eval_logs")
+    op.drop_table("experiment_task_logs")
     op.drop_table("experiment_logs")
     op.drop_table("experiment_prompt_tasks")
     op.drop_table("experiment_jobs")

--- a/src/phoenix/db/models.py
+++ b/src/phoenix/db/models.py
@@ -180,6 +180,8 @@ GenerativeModelSDK: TypeAlias = Literal[
     "aws_bedrock",
 ]
 ExperimentStatus: TypeAlias = Literal["RUNNING", "COMPLETED", "STOPPED", "ERROR"]
+ExperimentLogCategory: TypeAlias = Literal["TASK", "EVAL", "EXPERIMENT"]
+ExperimentLogLevel: TypeAlias = Literal["ERROR", "WARN", "INFO"]
 
 
 class JSONB(JSON):
@@ -1854,13 +1856,13 @@ class ExperimentLog(HasId):
         ForeignKey("experiment_jobs.id", ondelete="CASCADE"),
     )
     occurred_at: Mapped[datetime] = mapped_column(UtcTimeStamp, server_default=func.now())
-    category: Mapped[str] = mapped_column(
+    category: Mapped[ExperimentLogCategory] = mapped_column(
         CheckConstraint(
             "category IN ('TASK', 'EVAL', 'EXPERIMENT')",
             name="valid_event_category",
         ),
     )
-    level: Mapped[str] = mapped_column(
+    level: Mapped[ExperimentLogLevel] = mapped_column(
         CheckConstraint(
             "level IN ('ERROR', 'WARN', 'INFO')",
             name="valid_event_level",
@@ -1881,9 +1883,11 @@ class ExperimentLog(HasId):
     __table_args__ = (
         UniqueConstraint("category", "id"),
         Index(
-            "ix_experiment_logs_experiment_id_occurred_at",
+            "ix_experiment_logs_experiment_id_occurred_at_errors",
             "experiment_id",
             occurred_at.desc(),
+            postgresql_where=text("level = 'ERROR'"),
+            sqlite_where=text("level = 'ERROR'"),
         ),
     )
 
@@ -1891,7 +1895,7 @@ class ExperimentLog(HasId):
 class ExperimentTaskLog(ExperimentLog):
     """Log row tied to a specific task job (dataset_example + repetition)."""
 
-    __tablename__ = "experiment_task_events"
+    __tablename__ = "experiment_task_logs"
     id: Mapped[int] = mapped_column(primary_key=True)
     category: Mapped[Literal["TASK"]] = mapped_column(
         CheckConstraint("category = 'TASK'", name="valid_category"),
@@ -1918,7 +1922,7 @@ class ExperimentTaskLog(ExperimentLog):
 class ExperimentEvalLog(ExperimentLog):
     """Log row tied to a specific eval job (experiment_run + evaluator)."""
 
-    __tablename__ = "experiment_eval_events"
+    __tablename__ = "experiment_eval_logs"
     id: Mapped[int] = mapped_column(primary_key=True)
     category: Mapped[Literal["EVAL"]] = mapped_column(
         CheckConstraint("category = 'EVAL'", name="valid_category"),

--- a/src/phoenix/server/api/dataloaders/last_experiment_errors.py
+++ b/src/phoenix/server/api/dataloaders/last_experiment_errors.py
@@ -1,13 +1,14 @@
-from typing import Optional
+from typing import Any, Optional
 
-from sqlalchemy import func, select
+from sqlalchemy import Select, Values, column, func, literal_column, select
 from sqlalchemy.orm import with_polymorphic
 from strawberry.dataloader import DataLoader
 
 from phoenix.db import models
+from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.server.types import DbSessionFactory
 
-Key = int
+Key = int  # Experiment ID
 Result = Optional[models.ExperimentLog]
 
 
@@ -20,25 +21,58 @@ class LastExperimentErrorsDataLoader(DataLoader[Key, Result]):
 
     async def _load_fn(self, keys: list[Key]) -> list[Result]:
         poly = with_polymorphic(models.ExperimentLog, "*")
-        # Rank logs per experiment by recency, then keep only the latest.
-        ranked = (
-            select(
-                models.ExperimentLog.id,
-                func.row_number()
-                .over(
-                    partition_by=models.ExperimentLog.experiment_id,
-                    order_by=models.ExperimentLog.occurred_at.desc(),
-                )
-                .label("rn"),
-            )
-            .where(models.ExperimentLog.experiment_id.in_(keys))
-            .subquery()
-        )
-        stmt = select(poly).join(ranked, poly.id == ranked.c.id).where(ranked.c.rn == 1)
-        by_experiment_id: dict[int, models.ExperimentLog] = {}
         async with self._db() as session:
+            dialect = SupportedSQLDialect(session.bind.dialect.name)
+            if dialect == SupportedSQLDialect.POSTGRESQL:
+                stmt = _postgresql_stmt(poly, keys)
+            else:
+                stmt = _sqlite_stmt(poly, keys)
+            by_experiment_id: dict[int, models.ExperimentLog] = {}
             for row in await session.scalars(stmt):
                 by_experiment_id[row.experiment_id] = row
             for row in by_experiment_id.values():
                 session.expunge(row)
         return [by_experiment_id.get(key) for key in keys]
+
+
+def _postgresql_stmt(poly: Any, keys: list[Key]) -> Select[Any]:
+    """Use LATERAL join for efficient index-only lookup on Postgres."""
+    keys_vals = (
+        Values(column("experiment_id", models.ExperimentLog.experiment_id.type))
+        .data([(k,) for k in keys])
+        .alias("keys")
+    )
+    latest = (
+        select(models.ExperimentLog.id)
+        .where(models.ExperimentLog.experiment_id == keys_vals.c.experiment_id)
+        .where(models.ExperimentLog.level == "ERROR")
+        .order_by(models.ExperimentLog.occurred_at.desc())
+        .limit(1)
+        .correlate(keys_vals)
+        .lateral("latest")
+    )
+    return (
+        select(poly)
+        .select_from(keys_vals)
+        .join(latest, literal_column("true"))
+        .join(poly, poly.id == latest.c.id)
+    )
+
+
+def _sqlite_stmt(poly: Any, keys: list[Key]) -> Select[Any]:
+    """Use ROW_NUMBER window function as fallback for SQLite."""
+    ranked = (
+        select(
+            models.ExperimentLog.id,
+            func.row_number()
+            .over(
+                partition_by=models.ExperimentLog.experiment_id,
+                order_by=models.ExperimentLog.occurred_at.desc(),
+            )
+            .label("rn"),
+        )
+        .where(models.ExperimentLog.experiment_id.in_(keys))
+        .where(models.ExperimentLog.level == "ERROR")
+        .subquery()
+    )
+    return select(poly).join(ranked, poly.id == ranked.c.id).where(ranked.c.rn == 1)

--- a/src/phoenix/server/api/helpers/playground_clients.py
+++ b/src/phoenix/server/api/helpers/playground_clients.py
@@ -101,7 +101,6 @@ from phoenix.server.api.types.GenerativeProvider import (
     GENERATIVE_PROVIDER_KEY_TO_PROVIDER_STRING,
     GenerativeProviderKey,
 )
-from phoenix.server.rate_limiters import RateLimiter
 from phoenix.utilities.json import jsonify
 
 if TYPE_CHECKING:

--- a/src/phoenix/server/api/types/ExperimentJob.py
+++ b/src/phoenix/server/api/types/ExperimentJob.py
@@ -20,7 +20,7 @@ from phoenix.server.api.types.pagination import ConnectionArgs, CursorString, co
 
 if TYPE_CHECKING:
     from .Experiment import Experiment
-    from .ExperimentError import ExperimentError
+    from .ExperimentLog import ExperimentLog
 
 
 @strawberry.enum
@@ -66,13 +66,13 @@ class ExperimentJob(Node):
     @strawberry.field(description="Most recent error from this experiment, or null if no errors.")  # type: ignore[untyped-decorator]
     async def last_error(
         self, info: Info[Context, None]
-    ) -> Annotated["ExperimentError", strawberry.lazy(".ExperimentError")] | None:
-        from .ExperimentError import ExperimentError
+    ) -> Annotated["ExperimentLog", strawberry.lazy(".ExperimentLog")] | None:
+        from .ExperimentLog import ExperimentLog
 
         row = await info.context.data_loaders.last_experiment_errors.load(self.id)
         if row is None:
             return None
-        return ExperimentError.from_orm(row)
+        return ExperimentLog.from_orm(row)
 
     @strawberry.field(description="Errors recorded during experiment execution, most recent first.")  # type: ignore[untyped-decorator]
     async def errors(
@@ -82,8 +82,8 @@ class ExperimentJob(Node):
         last: int | None = UNSET,
         after: CursorString | None = UNSET,
         before: CursorString | None = UNSET,
-    ) -> Connection[Annotated["ExperimentError", strawberry.lazy(".ExperimentError")]]:
-        from .ExperimentError import ExperimentError
+    ) -> Connection[Annotated["ExperimentLog", strawberry.lazy(".ExperimentLog")]]:
+        from .ExperimentLog import ExperimentLog
 
         args = ConnectionArgs(
             first=first,
@@ -94,9 +94,12 @@ class ExperimentJob(Node):
         poly = with_polymorphic(models.ExperimentLog, "*")
         async with info.context.db() as session:
             result = await session.scalars(
-                select(poly).where(poly.experiment_id == self.id).order_by(poly.occurred_at.desc())
+                select(poly)
+                .where(poly.experiment_id == self.id)
+                .where(poly.level == "ERROR")
+                .order_by(poly.occurred_at.desc())
             )
-            data = [ExperimentError.from_orm(row) for row in result.all()]
+            data = [ExperimentLog.from_orm(row) for row in result.all()]
         return connection_from_list(data=data, args=args)
 
     @strawberry.field

--- a/src/phoenix/server/api/types/ExperimentLog.py
+++ b/src/phoenix/server/api/types/ExperimentLog.py
@@ -17,10 +17,17 @@ from phoenix.server.bearer_auth import PhoenixUser
 
 
 @strawberry.enum
-class ExperimentErrorCategory(Enum):
+class ExperimentLogCategory(Enum):
     TASK = "TASK"
     EVAL = "EVAL"
     EXPERIMENT = "EXPERIMENT"
+
+
+@strawberry.enum
+class ExperimentLogLevel(Enum):
+    ERROR = "ERROR"
+    WARN = "WARN"
+    INFO = "INFO"
 
 
 # =============================================================================
@@ -54,13 +61,13 @@ class EvalWorkItemId:
         )
 
 
-ExperimentErrorWorkItemId = Annotated[
+ExperimentLogWorkItemId = Annotated[
     Union[TaskWorkItemId, EvalWorkItemId],
-    strawberry.union(name="ExperimentErrorWorkItemId"),
+    strawberry.union(name="ExperimentLogWorkItemId"),
 ]
 
 
-def _work_item_id_from_orm(row: models.ExperimentLog) -> ExperimentErrorWorkItemId | None:
+def _work_item_id_from_orm(row: models.ExperimentLog) -> ExperimentLogWorkItemId | None:
     if isinstance(row, models.ExperimentTaskLog):
         return TaskWorkItemId.from_orm(row)
     if isinstance(row, models.ExperimentEvalLog):
@@ -81,7 +88,7 @@ def _is_admin(info: Info[Context, None]) -> bool:
 
 @strawberry.type
 class FailureDetail:
-    work_item: ExperimentErrorWorkItemId | None
+    work_item: ExperimentLogWorkItemId | None
     error_type: str
     _stack_trace: Private[str | None] = None
 
@@ -104,7 +111,7 @@ class FailureDetail:
 
 @strawberry.type
 class RetriesExhaustedDetail:
-    work_item: ExperimentErrorWorkItemId | None
+    work_item: ExperimentLogWorkItemId | None
     retry_count: int
     reason: str
     _stack_trace: Private[str | None] = None
@@ -127,15 +134,15 @@ class RetriesExhaustedDetail:
         )
 
 
-ExperimentErrorDetail = Annotated[
+ExperimentLogDetail = Annotated[
     Union[FailureDetail, RetriesExhaustedDetail],
-    strawberry.union(name="ExperimentErrorDetail"),
+    strawberry.union(name="ExperimentLogDetail"),
 ]
 
 
 def _detail_from_orm(
     obj: log_types.ExperimentLogDetail, row: models.ExperimentLog
-) -> ExperimentErrorDetail:
+) -> ExperimentLogDetail:
     if obj.type == "failure":
         return FailureDetail.from_orm(obj, row)
     if obj.type == "retries_exhausted":
@@ -144,19 +151,21 @@ def _detail_from_orm(
 
 
 @strawberry.type
-class ExperimentError(Node):
+class ExperimentLog(Node):
     id: NodeID[int]
     occurred_at: datetime
-    category: ExperimentErrorCategory
+    category: ExperimentLogCategory
+    level: ExperimentLogLevel
     message: str
-    detail: ExperimentErrorDetail | None = None
+    detail: ExperimentLogDetail | None = None
 
     @classmethod
-    def from_orm(cls, row: models.ExperimentLog) -> ExperimentError:
+    def from_orm(cls, row: models.ExperimentLog) -> ExperimentLog:
         return cls(
             id=row.id,
             occurred_at=row.occurred_at,
-            category=ExperimentErrorCategory(row.category),
+            category=ExperimentLogCategory(row.category),
+            level=ExperimentLogLevel(row.level),
             message=row.message,
             detail=_detail_from_orm(row.detail, row) if row.detail else None,
         )

--- a/tests/unit/server/api/types/test_ExperimentJob.py
+++ b/tests/unit/server/api/types/test_ExperimentJob.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta
+from typing import NamedTuple
+
+import pytest
+from sqlalchemy import insert
+from strawberry.relay import GlobalID
+
+from phoenix.db import models
+from phoenix.server.api.types.ExperimentJob import ExperimentJob
+from phoenix.server.types import DbSessionFactory
+from tests.unit.graphql import AsyncGraphQLClient
+
+QUERY = """
+  query ($jobId: ID!) {
+    node(id: $jobId) {
+      ... on ExperimentJob {
+        lastError {
+          message
+          level
+        }
+        errors {
+          edges {
+            node {
+              message
+              level
+            }
+          }
+        }
+      }
+    }
+  }
+"""
+
+
+class ExperimentWithLogs(NamedTuple):
+    experiment_id: int
+
+
+@pytest.fixture
+async def experiment_with_logs(db: DbSessionFactory) -> ExperimentWithLogs:
+    """Create a dataset, experiment, experiment_job, and several experiment logs."""
+    t0 = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+    async with db() as session:
+        dataset_id = await session.scalar(
+            insert(models.Dataset).values(name="ds", metadata_={}).returning(models.Dataset.id)
+        )
+        version_id = await session.scalar(
+            insert(models.DatasetVersion)
+            .values(dataset_id=dataset_id, metadata_={})
+            .returning(models.DatasetVersion.id)
+        )
+        experiment_id = await session.scalar(
+            insert(models.Experiment)
+            .values(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                name="exp1",
+                repetitions=1,
+                metadata_={},
+            )
+            .returning(models.Experiment.id)
+        )
+        await session.execute(
+            insert(models.ExperimentJob).values(
+                id=experiment_id,
+                type="PROMPT",
+                status="COMPLETED",
+            )
+        )
+        # Three ERROR logs at different times, plus one INFO log that is newest.
+        await session.execute(
+            insert(models.ExperimentLog).values(
+                experiment_id=experiment_id,
+                occurred_at=t0,
+                category="EXPERIMENT",
+                level="ERROR",
+                message="old error",
+            )
+        )
+        await session.execute(
+            insert(models.ExperimentLog).values(
+                experiment_id=experiment_id,
+                occurred_at=t0 + timedelta(hours=2),
+                category="EXPERIMENT",
+                level="ERROR",
+                message="newest error",
+            )
+        )
+        await session.execute(
+            insert(models.ExperimentLog).values(
+                experiment_id=experiment_id,
+                occurred_at=t0 + timedelta(hours=1),
+                category="EXPERIMENT",
+                level="ERROR",
+                message="middle error",
+            )
+        )
+        await session.execute(
+            insert(models.ExperimentLog).values(
+                experiment_id=experiment_id,
+                occurred_at=t0 + timedelta(hours=10),
+                category="EXPERIMENT",
+                level="INFO",
+                message="info log that is newest overall",
+            )
+        )
+        await session.commit()
+    assert experiment_id is not None
+    return ExperimentWithLogs(experiment_id=experiment_id)
+
+
+async def test_experiment_job_last_error_and_errors(
+    gql_client: AsyncGraphQLClient,
+    experiment_with_logs: ExperimentWithLogs,
+) -> None:
+    job_id = str(
+        GlobalID(type_name=ExperimentJob.__name__, node_id=str(experiment_with_logs.experiment_id))
+    )
+    response = await gql_client.execute(query=QUERY, variables={"jobId": job_id})
+    assert not response.errors
+    assert response.data is not None
+    node = response.data["node"]
+
+    # lastError should be the most recent ERROR, ignoring the newer INFO log
+    assert node["lastError"] == {"message": "newest error", "level": "ERROR"}
+
+    # errors should return only ERROR-level logs, most recent first
+    messages = [edge["node"]["message"] for edge in node["errors"]["edges"]]
+    assert messages == ["newest error", "middle error", "old error"]
+    for edge in node["errors"]["edges"]:
+        assert edge["node"]["level"] == "ERROR"


### PR DESCRIPTION
Via opus:  
  The dataloader that fetches the most recent experiment error (LastExperimentErrorsDataLoader) was
  producing invalid SQL, crashing the experiment details pane.

  What happened: This dataloader originally queried a simple ExperimentError model. The query used a
  correlated subquery to find the latest error per experiment, and it worked because the outer and
  inner parts of the query used an explicit alias to distinguish their table references.

  The polymorphic refactor updated the outer query to use with_polymorphic() to load this hierarchy, 
  but the inner subquery was left pointing at the base model directly. SQLAlchemy treats these as the 
  same table — so it "optimized" the inner query by dropping its FROM clause, assuming it could just 
  reference the outer table. This produced SQL where the inner query referenced columns that no 
  longer had a table to belong to.

  Fix: Replaced the correlated subquery with a row_number() window function that ranks errors by
  recency and picks the top one. This avoids the table-reference ambiguity entirely and matches how
  other dataloaders in the codebase solve the same "get latest per group" problem.