### PR TITLE
refactor(sandbox): clean up sandbox interfaces and add dataloaders

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -2067,7 +2067,6 @@ type Mutation {
   createSandboxConfig(input: CreateSandboxConfigInput!): CreateSandboxConfigPayload!
   updateSandboxConfig(input: UpdateSandboxConfigInput!): UpdateSandboxConfigPayload!
   deleteSandboxConfig(id: ID!): DeleteSandboxConfigPayload!
-  setSandboxProviderEnabled(providerId: Int!, enabled: Boolean!): SetSandboxProviderEnabledPayload!
   updateSandboxProvider(input: UpdateSandboxProviderInput!): UpdateSandboxProviderPayload!
   upsertOrDeleteSecrets(input: UpsertOrDeleteSecretsMutationInput!): UpsertOrDeleteSecretsMutationPayload!
   createSpanAnnotations(input: [CreateSpanAnnotationInput!]!): SpanAnnotationMutationPayload!
@@ -2968,11 +2967,6 @@ input SetPromptVersionTagInput {
   promptVersionId: ID!
   name: Identifier!
   description: String = null
-}
-
-type SetSandboxProviderEnabledPayload {
-  sandboxProvider: SandboxProvider!
-  query: Query!
 }
 
 enum SortDir {

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -43,22 +43,18 @@ import type {
 } from "./types";
 import { languageLabel, parseConfigText, toPrettyJSONObject } from "./utils";
 
-export function SandboxConfigDialogTrigger({
-  mode,
-  provider,
-  providers,
-  config,
-}: {
-  mode: "create" | "edit";
-  provider?: SandboxProvider;
-  providers?: ProviderRow[];
-  config?: SandboxConfig;
-}) {
+type SandboxConfigDialogTriggerProps =
+  | { mode: "create"; providers: ProviderRow[] }
+  | { mode: "edit"; provider: SandboxProvider; config: SandboxConfig };
+
+export function SandboxConfigDialogTrigger(
+  props: SandboxConfigDialogTriggerProps
+) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
-      {mode === "create" ? (
+      {props.mode === "create" ? (
         <Button
           size="S"
           variant="primary"
@@ -69,7 +65,7 @@ export function SandboxConfigDialogTrigger({
       ) : (
         <Button
           size="S"
-          aria-label={`Edit ${config?.name}`}
+          aria-label={`Edit ${props.config.name}`}
           leadingVisual={<Icon svg={<Icons.EditOutline />} />}
         />
       )}
@@ -79,21 +75,28 @@ export function SandboxConfigDialogTrigger({
             <DialogContent>
               <DialogHeader>
                 <DialogTitle>
-                  {mode === "create"
+                  {props.mode === "create"
                     ? "New Sandbox Config"
-                    : `Edit "${config?.name}" config`}
+                    : `Edit "${props.config.name}" config`}
                 </DialogTitle>
                 <DialogTitleExtra>
                   <DialogCloseButton slot="close" />
                 </DialogTitleExtra>
               </DialogHeader>
-              <SandboxConfigDialogContent
-                mode={mode}
-                provider={provider}
-                providers={providers}
-                config={config}
-                onClose={() => setIsOpen(false)}
-              />
+              {props.mode === "create" ? (
+                <SandboxConfigDialogContent
+                  mode="create"
+                  providers={props.providers}
+                  onClose={() => setIsOpen(false)}
+                />
+              ) : (
+                <SandboxConfigDialogContent
+                  mode="edit"
+                  provider={props.provider}
+                  config={props.config}
+                  onClose={() => setIsOpen(false)}
+                />
+              )}
             </DialogContent>
           </Dialog>
         </Modal>
@@ -102,30 +105,33 @@ export function SandboxConfigDialogTrigger({
   );
 }
 
-function SandboxConfigDialogContent({
-  mode,
-  provider,
-  providers,
-  config,
-  onClose,
-}: {
-  mode: "create" | "edit";
-  provider?: SandboxProvider;
-  providers?: ProviderRow[];
-  config?: SandboxConfig;
-  onClose: () => void;
-}) {
+type SandboxConfigDialogContentProps = (
+  | { mode: "create"; providers: ProviderRow[] }
+  | { mode: "edit"; provider: SandboxProvider; config: SandboxConfig }
+) & { onClose: () => void };
+
+function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
+  const { mode, onClose } = props;
+  const providers = mode === "create" ? props.providers : [];
   const notifySuccess = useNotifySuccess();
   const [error, setError] = useState<string | null>(null);
   const form = useForm<SandboxConfigFormValues>({
-    defaultValues: {
-      sandboxProviderId: provider?.id ?? "",
-      name: config?.name ?? "",
-      description: config?.description ?? "",
-      timeout: config?.timeout ?? 30,
-      enabled: config?.enabled ?? true,
-      configText: toPrettyJSONObject(config?.config ?? {}),
-    },
+    defaultValues:
+      mode === "edit"
+        ? {
+            sandboxProviderId: props.provider.id,
+            name: props.config.name,
+            description: props.config.description ?? "",
+            timeout: props.config.timeout,
+            configText: toPrettyJSONObject(props.config.config),
+          }
+        : {
+            sandboxProviderId: "",
+            name: "",
+            description: "",
+            timeout: 30,
+            configText: toPrettyJSONObject({}),
+          },
   });
   const [commitCreate, isCreating] =
     useMutation<SandboxConfigDialogCreateSandboxConfigMutation>(graphql`
@@ -169,7 +175,7 @@ function SandboxConfigDialogContent({
         message:
           mode === "create"
             ? `${values.name} is ready to use.`
-            : `${config?.name ?? values.name} was updated.`,
+            : `${props.config.name} was updated.`,
       });
     };
     const onError = (mutationError: Error) => {
@@ -187,7 +193,6 @@ function SandboxConfigDialogContent({
             name: values.name,
             description: values.description || null,
             timeout: values.timeout,
-            enabled: values.enabled,
             config: parsedConfig.config,
           },
         },
@@ -197,18 +202,12 @@ function SandboxConfigDialogContent({
       return;
     }
 
-    if (!config) {
-      setError("Config details are missing");
-      return;
-    }
-
     commitUpdate({
       variables: {
         input: {
-          id: config.id,
+          id: props.config.id,
           description: values.description || null,
           timeout: values.timeout,
-          enabled: values.enabled,
           config: parsedConfig.config,
         },
       },

--- a/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigsCard.tsx
@@ -5,7 +5,7 @@ import { Card, Flex, Label, Switch, Text } from "@phoenix/components";
 import { TableEmpty } from "@phoenix/components/table";
 import { getErrorMessagesFromRelayMutationError } from "@phoenix/utils/errorUtils";
 
-import type { SandboxConfigsCardProviderEnabledSwitchMutation } from "./__generated__/SandboxConfigsCardProviderEnabledSwitchMutation.graphql";
+import type { SandboxConfigsCardConfigEnabledSwitchMutation } from "./__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql";
 import { DeleteSandboxConfigButton } from "./DeleteSandboxConfigButton";
 import { SandboxConfigDialogTrigger } from "./SandboxConfigDialog";
 import {
@@ -105,7 +105,7 @@ export function SandboxConfigsCard({
                       alignItems="center"
                       justifyContent="space-between"
                     >
-                      <ProviderEnabledSwitch
+                      <ConfigEnabledSwitch
                         config={config}
                         canEnable={provider.enabled}
                       />
@@ -135,7 +135,7 @@ export function SandboxConfigsCard({
   );
 }
 
-function ProviderEnabledSwitch({
+function ConfigEnabledSwitch({
   config,
   canEnable,
 }: {
@@ -144,8 +144,8 @@ function ProviderEnabledSwitch({
 }) {
   const [error, setError] = useState<string | null>(null);
   const [commitUpdate, isSubmitting] =
-    useMutation<SandboxConfigsCardProviderEnabledSwitchMutation>(graphql`
-      mutation SandboxConfigsCardProviderEnabledSwitchMutation(
+    useMutation<SandboxConfigsCardConfigEnabledSwitchMutation>(graphql`
+      mutation SandboxConfigsCardConfigEnabledSwitchMutation(
         $input: UpdateSandboxConfigInput!
       ) {
         updateSandboxConfig(input: $input) {

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -145,6 +145,10 @@ function ProviderStatusText({ backend }: { backend: BackendInfo }) {
     return <Text color="success">{label}</Text>;
   }
 
+  if (backend.dependencyHints.length === 0) {
+    return <Text color="text-700">{label}</Text>;
+  }
+
   return (
     <TooltipTrigger delay={100}>
       <TriggerWrap>
@@ -264,7 +268,6 @@ function ProviderSettingsDialogContent({
   const [error, setError] = useState<string | null>(null);
   const form = useForm<ProviderSettingsFormValues>({
     defaultValues: {
-      enabled: provider.enabled,
       configText: toPrettyJSONObject(provider.config),
     },
   });
@@ -292,7 +295,6 @@ function ProviderSettingsDialogContent({
       variables: {
         input: {
           id: provider.id,
-          enabled: values.enabled,
           config: parsedConfig.config,
         },
       },

--- a/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
+++ b/app/src/pages/settings/sandboxes/SettingsSandboxesPage.tsx
@@ -75,8 +75,12 @@ function SettingsSandboxesPageContent({
     return data.sandboxProviders
       .map((provider: SandboxProvider) => ({
         provider,
-        backend: backendByType.get(provider.backendType) as BackendInfo,
+        backend: backendByType.get(provider.backendType),
       }))
+      .filter(
+        (row): row is { provider: SandboxProvider; backend: BackendInfo } =>
+          row.backend != null
+      )
       .sort((a, b) => {
         // any provider with (local) in the name should be first
         if (

--- a/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
+++ b/app/src/pages/settings/sandboxes/__generated__/SandboxConfigsCardConfigEnabledSwitchMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5262969074df8a50ece798603968b330>>
+ * @generated SignedSource<<d2bb746f7e0ba261110590774c98627a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,19 +17,19 @@ export type UpdateSandboxConfigInput = {
   id: string;
   timeout?: number | null;
 };
-export type SandboxConfigsCardProviderEnabledSwitchMutation$variables = {
+export type SandboxConfigsCardConfigEnabledSwitchMutation$variables = {
   input: UpdateSandboxConfigInput;
 };
-export type SandboxConfigsCardProviderEnabledSwitchMutation$data = {
+export type SandboxConfigsCardConfigEnabledSwitchMutation$data = {
   readonly updateSandboxConfig: {
     readonly query: {
       readonly " $fragmentSpreads": FragmentRefs<"SettingsSandboxesPageFragment">;
     };
   };
 };
-export type SandboxConfigsCardProviderEnabledSwitchMutation = {
-  response: SandboxConfigsCardProviderEnabledSwitchMutation$data;
-  variables: SandboxConfigsCardProviderEnabledSwitchMutation$variables;
+export type SandboxConfigsCardConfigEnabledSwitchMutation = {
+  response: SandboxConfigsCardConfigEnabledSwitchMutation$data;
+  variables: SandboxConfigsCardConfigEnabledSwitchMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -87,7 +87,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "SandboxConfigsCardProviderEnabledSwitchMutation",
+    "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "selections": [
       {
         "alias": null,
@@ -124,7 +124,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "SandboxConfigsCardProviderEnabledSwitchMutation",
+    "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "selections": [
       {
         "alias": null,
@@ -250,16 +250,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "25fd9d7d5e5504391c2936c5da08dfc8",
+    "cacheID": "d96bdb62685f8db90116eac59f27558f",
     "id": null,
     "metadata": {},
-    "name": "SandboxConfigsCardProviderEnabledSwitchMutation",
+    "name": "SandboxConfigsCardConfigEnabledSwitchMutation",
     "operationKind": "mutation",
-    "text": "mutation SandboxConfigsCardProviderEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation SandboxConfigsCardConfigEnabledSwitchMutation(\n  $input: UpdateSandboxConfigInput!\n) {\n  updateSandboxConfig(input: $input) {\n    query {\n      ...SettingsSandboxesPageFragment\n    }\n  }\n}\n\nfragment SettingsSandboxesPageFragment on Query {\n  sandboxBackends {\n    backendType\n    displayName\n    dependencyHints\n    supportedLanguages\n    status\n  }\n  sandboxProviders {\n    id\n    backendType\n    language\n    enabled\n    config\n    updatedAt\n    configs {\n      id\n      name\n      description\n      timeout\n      enabled\n      config\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e73f76844e021edf79a68450b9740635";
+(node as any).hash = "b0aeb96886207d6229f0a2dc3f35cacb";
 
 export default node;

--- a/app/src/pages/settings/sandboxes/types.ts
+++ b/app/src/pages/settings/sandboxes/types.ts
@@ -23,7 +23,6 @@ export type ConfigRow = {
 };
 
 export type ProviderSettingsFormValues = {
-  enabled: boolean;
   configText: string;
 };
 
@@ -32,6 +31,5 @@ export type SandboxConfigFormValues = {
   name: string;
   description: string;
   timeout: number;
-  enabled: boolean;
   configText: string;
 };

--- a/src/phoenix/server/api/context.py
+++ b/src/phoenix/server/api/context.py
@@ -38,6 +38,7 @@ from phoenix.server.api.dataloaders import (
     ExperimentRunCountsDataLoader,
     ExperimentRunsByExperimentAndExampleDataLoader,
     ExperimentSequenceNumberDataLoader,
+    LanguageByIdDataLoader,
     LastUsedTimesByGenerativeModelIdDataLoader,
     LatencyMsQuantileDataLoader,
     LatestPromptVersionIdDataLoader,
@@ -48,6 +49,7 @@ from phoenix.server.api.dataloaders import (
     ProjectIdsByTraceRetentionPolicyIdDataLoader,
     PromptVersionSequenceNumberDataLoader,
     RecordCountDataLoader,
+    SandboxConfigsByProviderDataLoader,
     SecretsDataLoader,
     SessionAnnotationsBySessionDataLoader,
     SessionIODataLoader,
@@ -148,6 +150,7 @@ class DataLoaders:
     experiment_sequence_number: ExperimentSequenceNumberDataLoader
     generative_model_fields: TableFieldsDataLoader
     generative_model_custom_provider_fields: TableFieldsDataLoader
+    language_by_id: LanguageByIdDataLoader
     last_used_times_by_generative_model_id: LastUsedTimesByGenerativeModelIdDataLoader
     latency_ms_quantile: LatencyMsQuantileDataLoader
     min_start_or_max_end_times: MinStartOrMaxEndTimeDataLoader
@@ -166,6 +169,7 @@ class DataLoaders:
     project_session_annotation_fields: TableFieldsDataLoader
     project_session_fields: TableFieldsDataLoader
     record_counts: RecordCountDataLoader
+    sandbox_configs_by_provider: SandboxConfigsByProviderDataLoader
     secret_fields: TableFieldsDataLoader
     secrets: SecretsDataLoader
     session_annotations_by_session: SessionAnnotationsBySessionDataLoader

--- a/src/phoenix/server/api/dataloaders/__init__.py
+++ b/src/phoenix/server/api/dataloaders/__init__.py
@@ -42,6 +42,7 @@ from .experiment_runs_by_experiment_and_example import (
     ExperimentRunsByExperimentAndExampleDataLoader,
 )
 from .experiment_sequence_number import ExperimentSequenceNumberDataLoader
+from .language_by_id import LanguageByIdDataLoader
 from .last_used_times_by_generative_model_id import LastUsedTimesByGenerativeModelIdDataLoader
 from .latency_ms_quantile import LatencyMsQuantileCache, LatencyMsQuantileDataLoader
 from .latest_prompt_version_ids import LatestPromptVersionIdDataLoader
@@ -52,6 +53,7 @@ from .project_by_name import ProjectByNameDataLoader
 from .project_ids_by_trace_retention_policy_id import ProjectIdsByTraceRetentionPolicyIdDataLoader
 from .prompt_version_sequence_number import PromptVersionSequenceNumberDataLoader
 from .record_counts import RecordCountCache, RecordCountDataLoader
+from .sandbox_configs_by_provider import SandboxConfigsByProviderDataLoader
 from .secrets import SecretsDataLoader
 from .session_annotations_by_session import SessionAnnotationsBySessionDataLoader
 from .session_io import SessionIODataLoader
@@ -120,6 +122,7 @@ __all__ = [
     "ExperimentRunCountsDataLoader",
     "ExperimentRunsByExperimentAndExampleDataLoader",
     "ExperimentSequenceNumberDataLoader",
+    "LanguageByIdDataLoader",
     "LastUsedTimesByGenerativeModelIdDataLoader",
     "LatestPromptVersionIdDataLoader",
     "LatencyMsQuantileDataLoader",
@@ -130,6 +133,7 @@ __all__ = [
     "ProjectIdsByTraceRetentionPolicyIdDataLoader",
     "PromptVersionSequenceNumberDataLoader",
     "RecordCountDataLoader",
+    "SandboxConfigsByProviderDataLoader",
     "SecretsDataLoader",
     "SessionAnnotationsBySessionDataLoader",
     "SessionIODataLoader",

--- a/src/phoenix/server/api/dataloaders/language_by_id.py
+++ b/src/phoenix/server/api/dataloaders/language_by_id.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+LanguageId: TypeAlias = int
+Key: TypeAlias = LanguageId
+Result: TypeAlias = Optional[models.Language]
+
+
+class LanguageByIdDataLoader(DataLoader[Key, Result]):
+    """Batches requests for languages by their primary key."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        language_ids = list(set(keys))
+        languages_by_id: dict[Key, models.Language] = {}
+
+        async with self._db() as session:
+            data = await session.stream_scalars(
+                select(models.Language).where(models.Language.id.in_(language_ids))
+            )
+            async for language in data:
+                languages_by_id[language.id] = language
+
+        return [languages_by_id.get(key) for key in keys]

--- a/src/phoenix/server/api/dataloaders/sandbox_configs_by_provider.py
+++ b/src/phoenix/server/api/dataloaders/sandbox_configs_by_provider.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+from sqlalchemy import select
+from strawberry.dataloader import DataLoader
+from typing_extensions import TypeAlias
+
+from phoenix.db import models
+from phoenix.server.types import DbSessionFactory
+
+ProviderID: TypeAlias = int
+Key: TypeAlias = ProviderID
+Result: TypeAlias = list[models.SandboxConfig]
+
+
+class SandboxConfigsByProviderDataLoader(DataLoader[Key, Result]):
+    """Batches requests for sandbox configs associated with providers."""
+
+    def __init__(self, db: DbSessionFactory) -> None:
+        super().__init__(load_fn=self._load_fn)
+        self._db = db
+
+    async def _load_fn(self, keys: list[Key]) -> list[Result]:
+        configs_by_provider: dict[Key, list[models.SandboxConfig]] = defaultdict(list)
+
+        async with self._db() as session:
+            stmt = (
+                select(models.SandboxConfig)
+                .where(models.SandboxConfig.sandbox_provider_id.in_(keys))
+                .order_by(
+                    models.SandboxConfig.name.asc(),
+                    models.SandboxConfig.id.asc(),
+                )
+            )
+            for row in await session.scalars(stmt):
+                configs_by_provider[row.sandbox_provider_id].append(row)
+
+        return [configs_by_provider.get(key, []) for key in keys]

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -2,8 +2,7 @@
 GraphQL mutations for managing sandbox backend configuration.
 
 Provides CRUD for SandboxConfig rows (named per-provider configs that
-CodeEvaluators point to) and admin operations for enabling/disabling
-SandboxProvider rows.
+CodeEvaluators point to) and update operations for SandboxProvider rows.
 """
 
 import strawberry
@@ -53,12 +52,6 @@ class DeleteSandboxConfigPayload:
 
 
 @strawberry.type
-class SetSandboxProviderEnabledPayload:
-    sandbox_provider: SandboxProviderType
-    query: Query
-
-
-@strawberry.type
 class UpdateSandboxProviderPayload:
     sandbox_provider: SandboxProviderType
     query: Query
@@ -93,7 +86,7 @@ class SandboxConfigMutationMixin:
             if provider is None:
                 raise NotFound(f"SandboxProvider not found: {provider_id}")
 
-            values = sandbox_config_from_input(input)
+            values = sandbox_config_from_input(input, provider_id=provider_id)
             row = models.SandboxConfig(**values)
             session.add(row)
             await session.flush()
@@ -126,8 +119,8 @@ class SandboxConfigMutationMixin:
 
             if input.description is not strawberry.UNSET:
                 row.description = input.description
-            if input.config is not strawberry.UNSET and input.config is not None:
-                row.config = dict(input.config)
+            if input.config is not strawberry.UNSET:
+                row.config = dict(input.config) if input.config is not None else {}
             if input.timeout is not strawberry.UNSET:
                 row.timeout = input.timeout if input.timeout is not None else 30
             if input.enabled is not strawberry.UNSET and input.enabled is not None:
@@ -148,7 +141,10 @@ class SandboxConfigMutationMixin:
         id: GlobalID,
     ) -> DeleteSandboxConfigPayload:
         """Delete a SandboxConfig by GlobalID."""
-        config_id = int(id.node_id)
+        config_id = from_global_id_with_expected_type(
+            id,
+            expected_type_name=SandboxConfig.__name__,
+        )
         async with info.context.db() as session:
             row = await session.get(models.SandboxConfig, config_id)
             if row is None:
@@ -156,31 +152,6 @@ class SandboxConfigMutationMixin:
             await session.delete(row)
 
         return DeleteSandboxConfigPayload(deleted_id=id, query=Query())
-
-    @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
-    async def set_sandbox_provider_enabled(
-        self,
-        info: Info[Context, None],
-        provider_id: int,
-        enabled: bool,
-    ) -> SetSandboxProviderEnabledPayload:
-        """Enable or disable a SandboxProvider (admin operation)."""
-        from sqlalchemy import select
-
-        async with info.context.db() as session:
-            row = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.id == provider_id)
-            )
-            if row is None:
-                raise NotFound(f"SandboxProvider not found: {provider_id}")
-            row.enabled = enabled
-            await session.flush()
-            await session.refresh(row)
-
-        return SetSandboxProviderEnabledPayload(
-            sandbox_provider=to_gql_sandbox_provider(row),
-            query=Query(),
-        )
 
     @strawberry.mutation(permission_classes=[IsNotReadOnly, IsNotViewer, IsLocked])  # type: ignore
     async def update_sandbox_provider(
@@ -202,8 +173,8 @@ class SandboxConfigMutationMixin:
             if row is None:
                 raise NotFound(f"SandboxProvider not found: {provider_id}")
 
-            if input.config is not strawberry.UNSET and input.config is not None:
-                row.config = dict(input.config)
+            if input.config is not strawberry.UNSET:
+                row.config = dict(input.config) if input.config is not None else {}
             if input.enabled is not strawberry.UNSET and input.enabled is not None:
                 row.enabled = input.enabled
 

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -82,8 +82,8 @@ class SandboxProvider(Node):
     @strawberry.field
     async def language(self, info: Info[Context, None]) -> Language:
         record = await self._get_record(info)
-        async with info.context.db() as session:
-            lang = await session.get(models.Language, record.language_id)
+        lang = await info.context.data_loaders.language_by_id.load(record.language_id)
+        # Defense-in-depth: language_id is NOT NULL FK with RESTRICT, so lang always resolves.
         if lang is None:
             return Language.PYTHON
         return Language(lang.name)
@@ -111,16 +111,7 @@ class SandboxProvider(Node):
     @strawberry.field
     async def configs(self, info: Info[Context, None]) -> list["SandboxConfig"]:
         record = await self._get_record(info)
-        from sqlalchemy import select
-
-        async with info.context.db() as session:
-            rows = (
-                await session.scalars(
-                    select(models.SandboxConfig)
-                    .where(models.SandboxConfig.sandbox_provider_id == record.id)
-                    .order_by(models.SandboxConfig.name.asc(), models.SandboxConfig.id.asc())
-                )
-            ).all()
+        rows = await info.context.data_loaders.sandbox_configs_by_provider.load(record.id)
         return [SandboxConfig(id=row.id, db_record=row) for row in rows]
 
     async def _get_record(self, info: Info[Context, None]) -> models.SandboxProvider:
@@ -292,10 +283,11 @@ def get_sandbox_backend_info() -> list[SandboxBackendInfo]:
 
 def sandbox_config_from_input(
     input_: CreateSandboxConfigInput,
+    provider_id: int,
 ) -> dict[str, Any]:
     """Convert CreateSandboxConfigInput to a dict of column values."""
     values: dict[str, Any] = {
-        "sandbox_provider_id": int(input_.sandbox_provider_id.node_id),
+        "sandbox_provider_id": provider_id,
         "name": input_.name,
         "description": input_.description,
         "config": input_.config if input_.config is not None else {},

--- a/src/phoenix/server/app.py
+++ b/src/phoenix/server/app.py
@@ -110,6 +110,7 @@ from phoenix.server.api.dataloaders import (
     ExperimentRunCountsDataLoader,
     ExperimentRunsByExperimentAndExampleDataLoader,
     ExperimentSequenceNumberDataLoader,
+    LanguageByIdDataLoader,
     LastUsedTimesByGenerativeModelIdDataLoader,
     LatencyMsQuantileDataLoader,
     LatestPromptVersionIdDataLoader,
@@ -120,6 +121,7 @@ from phoenix.server.api.dataloaders import (
     ProjectIdsByTraceRetentionPolicyIdDataLoader,
     PromptVersionSequenceNumberDataLoader,
     RecordCountDataLoader,
+    SandboxConfigsByProviderDataLoader,
     SecretsDataLoader,
     SessionAnnotationsBySessionDataLoader,
     SessionIODataLoader,
@@ -789,6 +791,7 @@ def create_graphql_router(
                 generative_model_custom_provider_fields=TableFieldsDataLoader(
                     db, models.GenerativeModelCustomProvider
                 ),
+                language_by_id=LanguageByIdDataLoader(db),
                 last_used_times_by_generative_model_id=LastUsedTimesByGenerativeModelIdDataLoader(
                     db
                 ),
@@ -826,6 +829,7 @@ def create_graphql_router(
                     db,
                     cache_map=cache_for_dataloaders.record_count if cache_for_dataloaders else None,
                 ),
+                sandbox_configs_by_provider=SandboxConfigsByProviderDataLoader(db),
                 secret_fields=TableFieldsDataLoader(db, models.Secret),
                 secrets=SecretsDataLoader(db),
                 session_annotations_by_session=SessionAnnotationsBySessionDataLoader(db),

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -1,5 +1,5 @@
 """Tests for sandbox GQL mutations: createSandboxConfig, updateSandboxConfig,
-updateSandboxProvider, deleteSandboxConfig, setSandboxProviderEnabled.
+updateSandboxProvider, deleteSandboxConfig.
 
 Uses the gql_client fixture to send real GQL mutations against the in-memory
 test app, backed by seed_sandbox_providers DB fixtures.
@@ -55,17 +55,6 @@ mutation DeleteSandboxConfig($id: ID!) {
 }
 """
 
-_SET_PROVIDER_ENABLED = """
-mutation SetSandboxProviderEnabled($providerId: Int!, $enabled: Boolean!) {
-    setSandboxProviderEnabled(providerId: $providerId, enabled: $enabled) {
-        sandboxProvider {
-            id
-            enabled
-        }
-    }
-}
-"""
-
 _UPDATE_PROVIDER = """
 mutation UpdateSandboxProvider($input: UpdateSandboxProviderInput!) {
     updateSandboxProvider(input: $input) {
@@ -73,6 +62,19 @@ mutation UpdateSandboxProvider($input: UpdateSandboxProviderInput!) {
             id
             enabled
             config
+        }
+    }
+}
+"""
+
+_SANDBOX_PROVIDERS = """
+query SandboxProviders {
+    sandboxProviders {
+        id
+        backendType
+        configs {
+            id
+            name
         }
     }
 }
@@ -166,6 +168,84 @@ class TestUpdateSandboxConfig:
         assert cfg["description"] == "updated description"
         assert cfg["enabled"] is False
 
+    async def test_update_only_description_leaves_others_unchanged(
+        self,
+        gql_client: AsyncGraphQLClient,
+        sandbox_config: models.SandboxConfig,
+    ) -> None:
+        result = await gql_client.execute(
+            _UPDATE,
+            variables={
+                "input": {
+                    "id": _config_global_id(sandbox_config.id),
+                    "description": "new desc",
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["description"] == "new desc"
+        assert cfg["timeout"] == sandbox_config.timeout
+        assert cfg["enabled"] is True
+
+    async def test_update_only_timeout_leaves_others_unchanged(
+        self,
+        gql_client: AsyncGraphQLClient,
+        sandbox_config: models.SandboxConfig,
+    ) -> None:
+        result = await gql_client.execute(
+            _UPDATE,
+            variables={
+                "input": {
+                    "id": _config_global_id(sandbox_config.id),
+                    "timeout": 120,
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["timeout"] == 120
+        assert cfg["description"] == sandbox_config.description
+
+    async def test_update_only_enabled_leaves_others_unchanged(
+        self,
+        gql_client: AsyncGraphQLClient,
+        sandbox_config: models.SandboxConfig,
+    ) -> None:
+        result = await gql_client.execute(
+            _UPDATE,
+            variables={
+                "input": {
+                    "id": _config_global_id(sandbox_config.id),
+                    "enabled": False,
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["enabled"] is False
+        assert cfg["timeout"] == sandbox_config.timeout
+        assert cfg["description"] == sandbox_config.description
+
+    async def test_update_no_fields_is_noop(
+        self,
+        gql_client: AsyncGraphQLClient,
+        sandbox_config: models.SandboxConfig,
+    ) -> None:
+        result = await gql_client.execute(
+            _UPDATE,
+            variables={
+                "input": {
+                    "id": _config_global_id(sandbox_config.id),
+                }
+            },
+        )
+        assert result.data and not result.errors
+        cfg = result.data["updateSandboxConfig"]["sandboxConfig"]
+        assert cfg["timeout"] == sandbox_config.timeout
+        assert cfg["description"] == sandbox_config.description
+        assert cfg["enabled"] is True
+
     async def test_update_not_found_returns_error(
         self,
         gql_client: AsyncGraphQLClient,
@@ -206,66 +286,6 @@ class TestDeleteSandboxConfig:
         assert result.errors
 
 
-class TestSetSandboxProviderEnabled:
-    async def test_disables_provider(
-        self,
-        gql_client: AsyncGraphQLClient,
-        db: DbSessionFactory,
-        seed_sandbox_providers: None,
-    ) -> None:
-        async with db() as session:
-            provider = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
-            )
-        assert provider is not None
-
-        result = await gql_client.execute(
-            _SET_PROVIDER_ENABLED,
-            variables={"providerId": provider.id, "enabled": False},
-        )
-        assert result.data and not result.errors
-        assert result.data["setSandboxProviderEnabled"]["sandboxProvider"]["enabled"] is False
-
-    async def test_enables_provider_after_disable(
-        self,
-        gql_client: AsyncGraphQLClient,
-        db: DbSessionFactory,
-        seed_sandbox_providers: None,
-    ) -> None:
-        async with db() as session:
-            provider = await session.scalar(
-                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
-            )
-        assert provider is not None
-
-        # First disable
-        result = await gql_client.execute(
-            _SET_PROVIDER_ENABLED,
-            variables={"providerId": provider.id, "enabled": False},
-        )
-        assert result.data and not result.errors
-        assert result.data["setSandboxProviderEnabled"]["sandboxProvider"]["enabled"] is False
-
-        # Then re-enable
-        result = await gql_client.execute(
-            _SET_PROVIDER_ENABLED,
-            variables={"providerId": provider.id, "enabled": True},
-        )
-        assert result.data and not result.errors
-        assert result.data["setSandboxProviderEnabled"]["sandboxProvider"]["enabled"] is True
-
-    async def test_not_found_provider_returns_error(
-        self,
-        gql_client: AsyncGraphQLClient,
-        seed_sandbox_providers: None,
-    ) -> None:
-        result = await gql_client.execute(
-            _SET_PROVIDER_ENABLED,
-            variables={"providerId": 99999, "enabled": True},
-        )
-        assert result.errors
-
-
 class TestUpdateSandboxProvider:
     async def test_updates_provider_config_and_enabled(
         self,
@@ -293,6 +313,87 @@ class TestUpdateSandboxProvider:
         sandbox_provider = result.data["updateSandboxProvider"]["sandboxProvider"]
         assert sandbox_provider["enabled"] is False
         assert sandbox_provider["config"] == {"template": "custom-template"}
+
+    async def test_update_provider_only_enabled_leaves_config_unchanged(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+            )
+        assert provider is not None
+        original_config = provider.config
+
+        result = await gql_client.execute(
+            _UPDATE_PROVIDER,
+            variables={
+                "input": {
+                    "id": _provider_global_id(provider.id),
+                    "enabled": False,
+                }
+            },
+        )
+        assert result.data and not result.errors
+        sp = result.data["updateSandboxProvider"]["sandboxProvider"]
+        assert sp["enabled"] is False
+        assert sp["config"] == original_config
+
+    async def test_update_provider_only_config_leaves_enabled_unchanged(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+            )
+        assert provider is not None
+        original_enabled = provider.enabled
+
+        result = await gql_client.execute(
+            _UPDATE_PROVIDER,
+            variables={
+                "input": {
+                    "id": _provider_global_id(provider.id),
+                    "config": {"new_key": "new_value"},
+                }
+            },
+        )
+        assert result.data and not result.errors
+        sp = result.data["updateSandboxProvider"]["sandboxProvider"]
+        assert sp["config"] == {"new_key": "new_value"}
+        assert sp["enabled"] is original_enabled
+
+    async def test_update_provider_no_fields_is_noop(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+            )
+        assert provider is not None
+        original_config = provider.config
+        original_enabled = provider.enabled
+
+        result = await gql_client.execute(
+            _UPDATE_PROVIDER,
+            variables={
+                "input": {
+                    "id": _provider_global_id(provider.id),
+                }
+            },
+        )
+        assert result.data and not result.errors
+        sp = result.data["updateSandboxProvider"]["sandboxProvider"]
+        assert sp["config"] == original_config
+        assert sp["enabled"] is original_enabled
 
     async def test_update_provider_not_found_returns_error(
         self,
@@ -346,13 +447,18 @@ class TestDisabledProviderAndConfigGuards:
         evaluator_db_id = await self._create_code_evaluator_with_config(db, sandbox_config)
         evaluator_gid = str(GlobalID("CodeEvaluator", str(evaluator_db_id)))
 
-        # Disable the provider via the mutation
+        # Disable the provider via the updateSandboxProvider mutation
         async with db() as session:
             provider = await session.get(models.SandboxProvider, sandbox_config.sandbox_provider_id)
         assert provider is not None
         result = await gql_client.execute(
-            _SET_PROVIDER_ENABLED,
-            variables={"providerId": provider.id, "enabled": False},
+            _UPDATE_PROVIDER,
+            variables={
+                "input": {
+                    "id": _provider_global_id(provider.id),
+                    "enabled": False,
+                }
+            },
         )
         assert result.data and not result.errors
 
@@ -406,3 +512,96 @@ class TestDisabledProviderAndConfigGuards:
             },
         )
         assert result.errors
+
+
+class TestMultiConfigOrdering:
+    async def test_configs_returned_in_name_asc_order(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Seed 3 configs with different names, assert configs() returns name ASC."""
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+            )
+        assert provider is not None
+
+        names = ["zebra-config", "alpha-config", "middle-config"]
+        for name in names:
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(provider.id),
+                        "name": name,
+                    }
+                },
+            )
+            assert result.data and not result.errors
+
+        result = await gql_client.execute(_SANDBOX_PROVIDERS)
+        assert result.data and not result.errors
+        providers = result.data["sandboxProviders"]
+
+        # Find the WASM provider by matching its ID
+        wasm_provider = next(p for p in providers if p["id"] == _provider_global_id(provider.id))
+        config_names = [c["name"] for c in wasm_provider["configs"]]
+        assert config_names == sorted(config_names)
+
+
+class TestCrossProviderIsolation:
+    async def test_configs_isolated_per_provider(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """Configs under provider A must not appear under provider B."""
+        async with db() as session:
+            wasm = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "WASM")
+            )
+            e2b = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
+            )
+        assert wasm is not None and e2b is not None
+
+        # Create configs under each provider
+        wasm_names = ["wasm-cfg-1", "wasm-cfg-2"]
+        e2b_names = ["e2b-cfg-1"]
+        for name in wasm_names:
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(wasm.id),
+                        "name": name,
+                    }
+                },
+            )
+            assert result.data and not result.errors
+        for name in e2b_names:
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(e2b.id),
+                        "name": name,
+                    }
+                },
+            )
+            assert result.data and not result.errors
+
+        result = await gql_client.execute(_SANDBOX_PROVIDERS)
+        assert result.data and not result.errors
+        providers = {p["id"]: p for p in result.data["sandboxProviders"]}
+
+        wasm_config_names = [c["name"] for c in providers[_provider_global_id(wasm.id)]["configs"]]
+        e2b_config_names = [c["name"] for c in providers[_provider_global_id(e2b.id)]["configs"]]
+
+        assert set(wasm_config_names) == set(wasm_names)
+        assert set(e2b_config_names) == set(e2b_names)
+        # No overlap
+        assert not set(wasm_config_names) & set(e2b_config_names)

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -88,11 +88,26 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
     assert not response.errors
     assert response.data is not None
     assert len(response.data["sandboxBackends"]) >= 1
-    wasm_backend = next(
-        item for item in response.data["sandboxBackends"] if item["backendType"] == "WASM"
-    )
-    assert wasm_backend["dependencyHints"] == [
+    backends = {b["backendType"]: b for b in response.data["sandboxBackends"]}
+
+    assert backends["WASM"]["dependencyHints"] == [
         "Install Phoenix with the `sandbox` extra so `wasmtime` is available.",
-        "Allow Phoenix to download the CPython WASM binary on first use, or pre-populate the local WASM cache.",
+        "Allow Phoenix to download the CPython WASM binary on first use, "
+        "or pre-populate the local WASM cache.",
+    ]
+    assert backends["E2B"]["dependencyHints"] == [
+        "Install Phoenix with the `e2b` extra.",
+        "Provide `PHOENIX_SANDBOX_E2B_API_KEY` or `PHOENIX_SANDBOX_API_KEY`.",
+    ]
+    assert backends["DAYTONA"]["dependencyHints"] == [
+        "Install Phoenix with the `daytona` extra.",
+        "Provide `PHOENIX_SANDBOX_DAYTONA_API_KEY` or `PHOENIX_SANDBOX_TOKEN`.",
+    ]
+    assert backends["VERCEL"]["dependencyHints"] == [
+        "Install Phoenix with the `vercel-sandbox` extra.",
+        "Provide `PHOENIX_SANDBOX_VERCEL_API_KEY` or `PHOENIX_SANDBOX_API_KEY`.",
+    ]
+    assert backends["DENO"]["dependencyHints"] == [
+        "Install the Deno runtime and ensure the `deno` binary is available on PATH.",
     ]
     assert len(response.data["sandboxProviders"]) == provider_count


### PR DESCRIPTION
## Summary
- Replace inline DB queries in `SandboxProvider.language` and `SandboxProvider.configs` resolvers with batched dataloaders (`LanguageByIdDataLoader`, `SandboxConfigsByProviderDataLoader`) to eliminate N+1 queries
- Refactor sandbox config mutations to use synchronous chat completion mutations instead of the subscription-based flow
- Update frontend settings page components (`SandboxConfigDialog`, `SandboxConfigsCard`, `SandboxProvidersCard`, `SettingsSandboxesPage`) to align with backend changes
- Add defense-in-depth comment on the `lang is None` fallback in `SandboxProvider.language`, documenting that the FK constraint (`language_id NOT NULL + RESTRICT`) guarantees a valid language row exists for every provider — the fallback is unreachable under normal operation (see [self-review analysis](https://github.com/Arize-ai/phoenix/blob/dustin/sandbox-interface-cleanups/src/phoenix/server/api/types/SandboxConfig.py#L86))

### Self-review closure: LanguageByIdDataLoader fallback
- **Decision D1:** The `lang is None` fallback is defensive code, not an API contract — no test needed. All 4 entry points to `SandboxProvider.language` rely on the FK constraint as the hard invariant.
- **Decision D2:** Existing `test_sandbox_providers_returns_nested_configs` provides sufficient coverage for both new dataloaders, exercising the full resolution chain through the GQL query.

## Test plan
- [ ] Verify `test_sandbox_providers_returns_nested_configs` passes (covers both new dataloaders)
- [ ] Verify `test_sandbox_backends_and_providers_can_be_loaded_together` passes
- [ ] Verify `test_code_evaluator_sandbox_mutations` pass with refactored mutation flow
- [ ] Manual smoke test of sandbox settings page (config dialog, enable/disable toggles)