### PR TITLE
fix: set PostgreSQL serial sequence MINVALUE and enable CYCLE

### DIFF
--- a/app/src/api/__generated__/v1.ts
+++ b/app/src/api/__generated__/v1.ts
@@ -8130,7 +8130,7 @@ export interface operations {
                 order?: "asc" | "desc";
                 /** @description Maximum number of traces to return */
                 limit?: number;
-                /** @description Pagination cursor (Trace GlobalID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description If true, include full span details for each trace. This significantly increases response size and query latency, especially with large page sizes. Prefer fetching spans lazily for individual traces when possible. */
                 include_spans?: boolean;
@@ -8340,7 +8340,7 @@ export interface operations {
     spanSearch: {
         parameters: {
             query?: {
-                /** @description Pagination cursor (Span Global ID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description Maximum number of spans to return */
                 limit?: number;
@@ -8409,7 +8409,7 @@ export interface operations {
     getSpans: {
         parameters: {
             query?: {
-                /** @description Pagination cursor (Span Global ID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description Maximum number of spans to return */
                 limit?: number;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -8130,7 +8130,7 @@ export interface operations {
                 order?: "asc" | "desc";
                 /** @description Maximum number of traces to return */
                 limit?: number;
-                /** @description Pagination cursor (Trace GlobalID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description If true, include full span details for each trace. This significantly increases response size and query latency, especially with large page sizes. Prefer fetching spans lazily for individual traces when possible. */
                 include_spans?: boolean;
@@ -8340,7 +8340,7 @@ export interface operations {
     spanSearch: {
         parameters: {
             query?: {
-                /** @description Pagination cursor (Span Global ID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description Maximum number of spans to return */
                 limit?: number;
@@ -8409,7 +8409,7 @@ export interface operations {
     getSpans: {
         parameters: {
             query?: {
-                /** @description Pagination cursor (Span Global ID) */
+                /** @description Pagination cursor encoding the sort position of the next page */
                 cursor?: string | null;
                 /** @description Maximum number of spans to return */
                 limit?: number;

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -4252,10 +4252,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Pagination cursor (Trace GlobalID)",
+              "description": "Pagination cursor encoding the sort position of the next page",
               "title": "Cursor"
             },
-            "description": "Pagination cursor (Trace GlobalID)"
+            "description": "Pagination cursor encoding the sort position of the next page"
           },
           {
             "name": "include_spans",
@@ -4563,10 +4563,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Pagination cursor (Span Global ID)",
+              "description": "Pagination cursor encoding the sort position of the next page",
               "title": "Cursor"
             },
-            "description": "Pagination cursor (Span Global ID)"
+            "description": "Pagination cursor encoding the sort position of the next page"
           },
           {
             "name": "limit",
@@ -4800,10 +4800,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Pagination cursor (Span Global ID)",
+              "description": "Pagination cursor encoding the sort position of the next page",
               "title": "Cursor"
             },
-            "description": "Pagination cursor (Span Global ID)"
+            "description": "Pagination cursor encoding the sort position of the next page"
           },
           {
             "name": "limit",

--- a/scripts/ddl/generate_ddl_postgresql.py
+++ b/scripts/ddl/generate_ddl_postgresql.py
@@ -48,7 +48,7 @@ from typing import Any, Iterator
 
 import pglast
 import psycopg
-import testing.postgresql
+import testing.postgresql  # type: ignore[import-untyped]
 from alembic import command
 from alembic.config import Config
 from psycopg import sql
@@ -89,6 +89,7 @@ class TableInfo:
     foreign_keys: list[dict[str, Any]]
     indexes: list[dict[str, Any]]
     triggers: list[dict[str, Any]]
+    sequences: list[dict[str, Any]] | None = None
 
 
 @dataclass
@@ -295,6 +296,7 @@ class PostgreSQLDDLExtractor:
         foreign_keys = self._get_foreign_keys(schema, table_name)
         indexes = self._get_indexes(schema, table_name)
         triggers = self._get_triggers(schema, table_name)
+        sequences = self._get_sequences(schema, table_name)
 
         return TableInfo(
             table_name=table_name,
@@ -304,6 +306,7 @@ class PostgreSQLDDLExtractor:
             foreign_keys=foreign_keys,
             indexes=indexes,
             triggers=triggers,
+            sequences=sequences,
         )
 
     def _get_columns(self, schema: str, table_name: str) -> list[dict[str, Any]]:
@@ -452,6 +455,30 @@ class PostgreSQLDDLExtractor:
             query, (schema, table_name), f"getting triggers for {schema}.{table_name}"
         )
 
+    def _get_sequences(self, schema: str, table_name: str) -> list[dict[str, Any]]:
+        """Get sequences with non-default attributes for a table's serial columns."""
+        query = sql.SQL("""
+            SELECT
+                s.sequencename,
+                s.min_value,
+                s.max_value,
+                s.cycle
+            FROM pg_sequences s
+            JOIN pg_depend d ON d.objid = (
+                quote_ident(s.schemaname) || '.' || quote_ident(s.sequencename)
+            )::regclass
+            JOIN pg_class c ON c.oid = d.refobjid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = %s
+              AND c.relname = %s
+              AND d.deptype = 'a'
+              AND (s.min_value != 1 OR s.cycle)
+            ORDER BY s.sequencename
+        """)
+        return self._execute_query(
+            query, (schema, table_name), f"getting sequences for {schema}.{table_name}"
+        )
+
     def generate_ddl(self, table_info: TableInfo) -> str:
         """Generate DDL string for a single table."""
         ddl_parts: list[str] = []
@@ -485,6 +512,18 @@ class PostgreSQLDDLExtractor:
             ddl_parts.append("")
             for trigger in sorted_triggers:
                 ddl_parts.append(f"{trigger['action_statement']};")
+
+        # === Sequence Overrides ===
+        if table_info.sequences:
+            sorted_sequences = sorted(table_info.sequences, key=lambda x: x["sequencename"])
+            ddl_parts.append("")
+            for seq in sorted_sequences:
+                parts = [f"ALTER SEQUENCE {schema}.{seq['sequencename']}"]
+                if seq["min_value"] != 1:
+                    parts.append(f"MINVALUE {seq['min_value']}")
+                if seq["cycle"]:
+                    parts.append("CYCLE")
+                ddl_parts.append(f"{' '.join(parts)};")
 
         return "\n".join(ddl_parts)
 
@@ -918,9 +957,9 @@ class PostgreSQLDDLExtractor:
             constraint_def = f"CONSTRAINT {constraint_name} {constraint_type} ({column_list})"
             return self._wrap_line(constraint_def)
         elif constraint_type == "CHECK":
-            constraint_def = constraint.get("constraint_definition")
-            if constraint_def:
-                return self._wrap_line(constraint_def)
+            check_def: str | None = constraint.get("constraint_definition")
+            if check_def:
+                return self._wrap_line(check_def)
             return None
 
         return None

--- a/scripts/ddl/postgresql_schema.sql
+++ b/scripts/ddl/postgresql_schema.sql
@@ -84,6 +84,8 @@ CREATE TABLE public.projects (
 CREATE INDEX ix_projects_trace_retention_policy_id ON public.projects
     USING btree (trace_retention_policy_id);
 
+ALTER SEQUENCE public.projects_id_seq MINVALUE -2147483648 CYCLE;
+
 
 -- Table: project_annotation_configs
 -- ---------------------------------
@@ -248,6 +250,8 @@ CREATE INDEX ix_traces_project_rowid_start_time ON public.traces
 CREATE INDEX ix_traces_project_session_rowid ON public.traces
     USING btree (project_session_rowid);
 
+ALTER SEQUENCE public.traces_id_seq MINVALUE -2147483648 CYCLE;
+
 
 -- Table: spans
 -- ------------
@@ -289,6 +293,8 @@ CREATE INDEX ix_spans_start_time ON public.spans
     USING btree (start_time);
 CREATE INDEX ix_spans_trace_rowid ON public.spans
     USING btree (trace_rowid);
+
+ALTER SEQUENCE public.spans_id_seq MINVALUE -2147483648 CYCLE;
 
 
 -- Table: span_costs

--- a/src/phoenix/db/migrations/versions/e77bee06f3ac_set_serial_sequence_minvalue_and_cycle.py
+++ b/src/phoenix/db/migrations/versions/e77bee06f3ac_set_serial_sequence_minvalue_and_cycle.py
@@ -1,0 +1,82 @@
+"""set_serial_sequence_minvalue_and_cycle
+
+Revision ID: e77bee06f3ac
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-05 20:59:18.906153
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e77bee06f3ac"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_SERIAL_TABLES = (
+    "projects",
+    "spans",
+    "traces",
+)
+
+
+def upgrade() -> None:
+    # Set MINVALUE to the smallest 32-bit integer and enable CYCLE so sequences
+    # wrap around instead of erroring when they reach MAXVALUE. This is idempotent
+    # — safe to run on both new and existing deployments.
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in _SERIAL_TABLES:
+            op.execute(sa.text(f"ALTER SEQUENCE {table}_id_seq MINVALUE -2147483648 CYCLE"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in _SERIAL_TABLES:
+            # Restart at the first unused positive id. This avoids an immediate
+            # primary-key collision when positive ids already exist, while also
+            # moving the sequence out of any negative wrapped position before
+            # restoring the original MINVALUE.
+            op.execute(
+                sa.text(
+                    f"""
+                    DO $$
+                    DECLARE
+                        restart_value integer;
+                    BEGIN
+                        SELECT min(candidate)
+                        INTO restart_value
+                        FROM (
+                            SELECT 1 AS candidate
+                            WHERE NOT EXISTS (SELECT 1 FROM {table} WHERE id = 1)
+                            UNION ALL
+                            SELECT id + 1 AS candidate
+                            FROM {table} existing
+                            WHERE id > 0
+                              AND id < 2147483647
+                              AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM {table} next_row
+                                  WHERE next_row.id = existing.id + 1
+                              )
+                        ) candidates;
+
+                        ALTER SEQUENCE {table}_id_seq
+                            RESTART WITH 1
+                            MINVALUE 1
+                            NO CYCLE;
+
+                        IF restart_value IS NULL THEN
+                            PERFORM setval('{table}_id_seq', 2147483647, true);
+                        ELSE
+                            PERFORM setval('{table}_id_seq', restart_value, false);
+                        END IF;
+                    END $$;
+                    """
+                )
+            )

--- a/src/phoenix/server/api/routers/v1/pagination.py
+++ b/src/phoenix/server/api/routers/v1/pagination.py
@@ -1,0 +1,106 @@
+"""REST API cursor pagination helpers."""
+
+from __future__ import annotations
+
+import operator
+from typing import Any, Literal, Optional
+
+from fastapi import HTTPException
+from sqlalchemy import SQLColumnExpression, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.relay import GlobalID
+
+from phoenix.server.api.types.pagination import (
+    Cursor,
+    CursorSortColumn,
+    CursorSortColumnDataType,
+    CursorSortColumnValue,
+)
+
+CompareDirection = Literal["asc", "desc"]
+
+
+def encode_rest_cursor(
+    rowid: int,
+    sort_value: CursorSortColumnValue,
+    sort_column_type: CursorSortColumnDataType,
+) -> str:
+    return str(
+        Cursor(
+            rowid=rowid,
+            sort_column=CursorSortColumn(type=sort_column_type, value=sort_value),
+        )
+    )
+
+
+async def parse_rest_cursor(
+    session: AsyncSession,
+    cursor_str: str,
+    *,
+    model: type[Any],
+    sort_attr: str,
+    sort_column_type: CursorSortColumnDataType,
+) -> Cursor:
+    """Parse a REST pagination cursor.
+
+    Composite cursors encode ``(sort_value, rowid)``. Legacy GlobalID-only cursors
+    are resolved by loading the referenced row so pagination stays correct after
+    serial sequence wrap-around.
+    """
+    parsed: Optional[Cursor] = None
+    try:
+        parsed = Cursor.from_string(cursor_str)
+        if parsed.sort_column is not None:
+            return parsed
+    except Exception:
+        parsed = None
+
+    rowid: int
+    if parsed is not None:
+        rowid = parsed.rowid
+    else:
+        try:
+            rowid = int(GlobalID.from_id(cursor_str).node_id)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid cursor format: {cursor_str}",
+            ) from exc
+
+    row = await session.get(model, rowid)
+    if row is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid cursor format: {cursor_str}",
+        )
+    sort_value = getattr(row, sort_attr)
+    return Cursor(
+        rowid=rowid,
+        sort_column=CursorSortColumn(type=sort_column_type, value=sort_value),
+    )
+
+
+def apply_tuple_cursor_filter(
+    stmt: Any,
+    *,
+    sort_column: SQLColumnExpression[Any],
+    id_column: SQLColumnExpression[Any],
+    cursor: Cursor,
+    order: CompareDirection,
+    inclusive: bool = True,
+) -> Any:
+    """Apply a composite ``(sort_column, id)`` cursor filter."""
+    if order == "desc":
+        compare = operator.le if inclusive else operator.lt
+    else:
+        compare = operator.ge if inclusive else operator.gt
+
+    if cursor.sort_column is None:
+        return stmt.where(compare(id_column, cursor.rowid))
+
+    return stmt.where(
+        compare(
+            tuple_(sort_column, id_column),
+            (cursor.sort_column.value, cursor.rowid),
+        )
+    )

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -24,8 +24,14 @@ from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.utils import df_to_bytes
 from phoenix.server.api.routers.v1.annotations import SpanAnnotationData
+from phoenix.server.api.routers.v1.pagination import (
+    apply_tuple_cursor_filter,
+    encode_rest_cursor,
+    parse_rest_cursor,
+)
 from phoenix.server.api.routers.v1.validators import validate_enum_filter
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.pagination import CursorSortColumnDataType
 from phoenix.server.authorization import (
     is_not_locked,
     prevent_access_in_read_only_mode,
@@ -732,7 +738,10 @@ async def span_search_otlpv1(
             "it cannot contain slash (/), question mark (?), or pound sign (#) characters."
         )
     ),
-    cursor: Optional[str] = Query(default=None, description="Pagination cursor (Span Global ID)"),
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Pagination cursor encoding the sort position of the next page",
+    ),
     limit: int = Query(default=100, gt=0, le=1000, description="Maximum number of spans to return"),
     start_time: Optional[datetime] = Query(default=None, description="Inclusive lower bound time"),
     end_time: Optional[datetime] = Query(default=None, description="Exclusive upper bound time"),
@@ -761,55 +770,62 @@ async def span_search_otlpv1(
 
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        project_id = project.id
 
-    project_id: int = project.id
-    order_by = [models.Span.id.desc()]
-
-    stmt = (
-        select(
-            models.Span,
-            models.Trace.trace_id,
+        stmt = (
+            select(
+                models.Span,
+                models.Trace.trace_id,
+            )
+            .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
+            .where(models.Trace.project_rowid == project_id)
+            .order_by(models.Span.start_time.desc(), models.Span.id.desc())
         )
-        .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
-        .where(models.Trace.project_rowid == project_id)
-        .order_by(*order_by)
-    )
 
-    if start_time:
-        stmt = stmt.where(models.Span.start_time >= normalize_datetime(start_time, timezone.utc))
-    if end_time:
-        stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
-    if trace_id:
-        stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
-    if parent_id is not None:
-        if parent_id == "null":
-            stmt = stmt.where(models.Span.parent_id.is_(None))
-        else:
-            stmt = stmt.where(models.Span.parent_id == parent_id)
-    if name:
-        stmt = stmt.where(models.Span.name.in_(name))
-    if status_code:
-        stmt = stmt.where(
-            models.Span.status_code.in_(
-                validate_enum_filter(
-                    values=status_code, valid=_VALID_STATUS_CODES, param_name="status_code"
+        if start_time:
+            stmt = stmt.where(
+                models.Span.start_time >= normalize_datetime(start_time, timezone.utc)
+            )
+        if end_time:
+            stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
+        if trace_id:
+            stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
+        if parent_id is not None:
+            if parent_id == "null":
+                stmt = stmt.where(models.Span.parent_id.is_(None))
+            else:
+                stmt = stmt.where(models.Span.parent_id == parent_id)
+        if name:
+            stmt = stmt.where(models.Span.name.in_(name))
+        if status_code:
+            stmt = stmt.where(
+                models.Span.status_code.in_(
+                    validate_enum_filter(
+                        values=status_code, valid=_VALID_STATUS_CODES, param_name="status_code"
+                    )
                 )
             )
-        )
-    if attribute:
-        for af in attribute:
-            stmt = stmt.where(_parse_attribute(af))
+        if attribute:
+            for af in attribute:
+                stmt = stmt.where(_parse_attribute(af))
 
-    if cursor:
-        try:
-            cursor_rowid = int(GlobalID.from_id(cursor).node_id)
-            stmt = stmt.where(models.Span.id <= cursor_rowid)
-        except Exception:
-            raise HTTPException(status_code=422, detail="Invalid cursor")
+        if cursor:
+            parsed_cursor = await parse_rest_cursor(
+                session,
+                cursor,
+                model=models.Span,
+                sort_attr="start_time",
+                sort_column_type=CursorSortColumnDataType.DATETIME,
+            )
+            stmt = apply_tuple_cursor_filter(
+                stmt,
+                sort_column=models.Span.start_time,
+                id_column=models.Span.id,
+                cursor=parsed_cursor,
+                order="desc",
+            )
 
-    stmt = stmt.limit(limit + 1)
-
-    async with request.app.state.db.read() as session:
+        stmt = stmt.limit(limit + 1)
         rows: list[tuple[models.Span, str]] = [r async for r in await session.stream(stmt)]
 
     if not rows:
@@ -817,9 +833,13 @@ async def span_search_otlpv1(
 
     next_cursor: Optional[str] = None
     if len(rows) == limit + 1:
-        *rows, extra = rows  # extra is first item of next page
+        *rows, extra = rows
         span_extra, _ = extra
-        next_cursor = str(GlobalID("Span", str(span_extra.id)))
+        next_cursor = encode_rest_cursor(
+            span_extra.id,
+            span_extra.start_time,
+            CursorSortColumnDataType.DATETIME,
+        )
 
     # Convert ORM rows -> OTLP-style spans
     result_spans: list[OtlpSpan] = []
@@ -909,7 +929,10 @@ async def span_search(
             "it cannot contain slash (/), question mark (?), or pound sign (#) characters."
         )
     ),
-    cursor: Optional[str] = Query(default=None, description="Pagination cursor (Span Global ID)"),
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Pagination cursor encoding the sort position of the next page",
+    ),
     limit: int = Query(default=100, gt=0, le=1000, description="Maximum number of spans to return"),
     start_time: Optional[datetime] = Query(default=None, description="Inclusive lower bound time"),
     end_time: Optional[datetime] = Query(default=None, description="Exclusive upper bound time"),
@@ -943,63 +966,70 @@ async def span_search(
 ) -> SpansResponseBody:
     async with request.app.state.db.read() as session:
         project = await get_project_by_identifier(session, project_identifier)
+        project_id = project.id
 
-    project_id: int = project.id
-    order_by = [models.Span.id.desc()]
-
-    stmt = (
-        select(
-            models.Span,
-            models.Trace.trace_id,
+        stmt = (
+            select(
+                models.Span,
+                models.Trace.trace_id,
+            )
+            .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
+            .where(models.Trace.project_rowid == project_id)
+            .order_by(models.Span.start_time.desc(), models.Span.id.desc())
         )
-        .join(models.Trace, onclause=models.Trace.id == models.Span.trace_rowid)
-        .where(models.Trace.project_rowid == project_id)
-        .order_by(*order_by)
-    )
 
-    if start_time:
-        stmt = stmt.where(models.Span.start_time >= normalize_datetime(start_time, timezone.utc))
-    if end_time:
-        stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
-    if trace_id:
-        stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
-    if parent_id is not None:
-        if parent_id == "null":
-            stmt = stmt.where(models.Span.parent_id.is_(None))
-        else:
-            stmt = stmt.where(models.Span.parent_id == parent_id)
-    if name:
-        stmt = stmt.where(models.Span.name.in_(name))
-    if span_kind:
-        stmt = stmt.where(
-            models.Span.span_kind.in_(
-                validate_enum_filter(
-                    values=span_kind, valid=_VALID_SPAN_KINDS, param_name="span_kind"
+        if start_time:
+            stmt = stmt.where(
+                models.Span.start_time >= normalize_datetime(start_time, timezone.utc)
+            )
+        if end_time:
+            stmt = stmt.where(models.Span.start_time < normalize_datetime(end_time, timezone.utc))
+        if trace_id:
+            stmt = stmt.where(models.Trace.trace_id.in_(trace_id))
+        if parent_id is not None:
+            if parent_id == "null":
+                stmt = stmt.where(models.Span.parent_id.is_(None))
+            else:
+                stmt = stmt.where(models.Span.parent_id == parent_id)
+        if name:
+            stmt = stmt.where(models.Span.name.in_(name))
+        if span_kind:
+            stmt = stmt.where(
+                models.Span.span_kind.in_(
+                    validate_enum_filter(
+                        values=span_kind, valid=_VALID_SPAN_KINDS, param_name="span_kind"
+                    )
                 )
             )
-        )
-    if status_code:
-        stmt = stmt.where(
-            models.Span.status_code.in_(
-                validate_enum_filter(
-                    values=status_code, valid=_VALID_STATUS_CODES, param_name="status_code"
+        if status_code:
+            stmt = stmt.where(
+                models.Span.status_code.in_(
+                    validate_enum_filter(
+                        values=status_code, valid=_VALID_STATUS_CODES, param_name="status_code"
+                    )
                 )
             )
-        )
-    if attribute:
-        for af in attribute:
-            stmt = stmt.where(_parse_attribute(af))
+        if attribute:
+            for af in attribute:
+                stmt = stmt.where(_parse_attribute(af))
 
-    if cursor:
-        try:
-            cursor_rowid = int(GlobalID.from_id(cursor).node_id)
-        except Exception:
-            raise HTTPException(status_code=422, detail="Invalid cursor")
-        stmt = stmt.where(models.Span.id <= cursor_rowid)
+        if cursor:
+            parsed_cursor = await parse_rest_cursor(
+                session,
+                cursor,
+                model=models.Span,
+                sort_attr="start_time",
+                sort_column_type=CursorSortColumnDataType.DATETIME,
+            )
+            stmt = apply_tuple_cursor_filter(
+                stmt,
+                sort_column=models.Span.start_time,
+                id_column=models.Span.id,
+                cursor=parsed_cursor,
+                order="desc",
+            )
 
-    stmt = stmt.limit(limit + 1)
-
-    async with request.app.state.db.read() as session:
+        stmt = stmt.limit(limit + 1)
         rows: list[tuple[models.Span, str]] = [r async for r in await session.stream(stmt)]
 
     if not rows:
@@ -1007,9 +1037,13 @@ async def span_search(
 
     next_cursor: Optional[str] = None
     if len(rows) == limit + 1:
-        *rows, extra = rows  # extra is first item of next page
+        *rows, extra = rows
         span_extra, _ = extra
-        next_cursor = str(GlobalID("Span", str(span_extra.id)))
+        next_cursor = encode_rest_cursor(
+            span_extra.id,
+            span_extra.start_time,
+            CursorSortColumnDataType.DATETIME,
+        )
 
     # Convert ORM rows -> Phoenix spans
     result_spans: list[Span] = []

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -25,6 +25,7 @@ from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
 from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
 from phoenix.server.api.types.node import from_global_id_with_expected_type
+from phoenix.server.api.types.pagination import CursorSortColumnDataType
 from phoenix.server.api.types.Project import Project as ProjectNodeType
 from phoenix.server.api.types.ProjectSession import ProjectSession as ProjectSessionNodeType
 from phoenix.server.api.types.Span import Span as SpanNodeType
@@ -41,6 +42,7 @@ from phoenix.trace.otel import decode_otlp_span
 from phoenix.utilities.project import get_project_name
 
 from .models import V1RoutesBaseModel
+from .pagination import apply_tuple_cursor_filter, encode_rest_cursor, parse_rest_cursor
 from .utils import (
     PaginatedResponseBody,
     RequestBody,
@@ -137,7 +139,10 @@ async def list_project_traces(
     limit: int = Query(
         default=100, gt=0, le=1000, description="Maximum number of traces to return"
     ),
-    cursor: Optional[str] = Query(default=None, description="Pagination cursor (Trace GlobalID)"),
+    cursor: Optional[str] = Query(
+        default=None,
+        description="Pagination cursor encoding the sort position of the next page",
+    ),
     include_spans: bool = Query(
         default=False,
         description=(
@@ -206,15 +211,28 @@ async def list_project_traces(
         if end_time:
             stmt = stmt.where(models.Trace.start_time < normalize_datetime(end_time, timezone.utc))
 
+        sort_column_type = (
+            CursorSortColumnDataType.FLOAT
+            if sort == "latency_ms"
+            else CursorSortColumnDataType.DATETIME
+        )
+        sort_attr = "latency_ms" if sort == "latency_ms" else "start_time"
+
         if cursor:
-            try:
-                cursor_rowid = int(GlobalID.from_id(cursor).node_id)
-                if order == "desc":
-                    stmt = stmt.where(models.Trace.id <= cursor_rowid)
-                else:
-                    stmt = stmt.where(models.Trace.id >= cursor_rowid)
-            except (ValueError, TypeError):
-                raise HTTPException(status_code=422, detail=f"Invalid cursor format: {cursor}")
+            parsed_cursor = await parse_rest_cursor(
+                session,
+                cursor,
+                model=models.Trace,
+                sort_attr=sort_attr,
+                sort_column_type=sort_column_type,
+            )
+            stmt = apply_tuple_cursor_filter(
+                stmt,
+                sort_column=sort_col,
+                id_column=models.Trace.id,
+                cursor=parsed_cursor,
+                order=order,
+            )
 
         stmt = stmt.limit(limit + 1)
         traces = (await session.scalars(stmt)).all()
@@ -225,7 +243,12 @@ async def list_project_traces(
         next_cursor: Optional[str] = None
         if len(traces) == limit + 1:
             last_trace = traces[-1]
-            next_cursor = str(GlobalID(TraceNodeType.__name__, str(last_trace.id)))
+            sort_value = last_trace.latency_ms if sort == "latency_ms" else last_trace.start_time
+            next_cursor = encode_rest_cursor(
+                last_trace.id,
+                sort_value,
+                sort_column_type,
+            )
             traces = traces[:-1]
 
         trace_rowids = [t.id for t in traces]

--- a/src/phoenix/server/api/types/Project.py
+++ b/src/phoenix/server/api/types/Project.py
@@ -461,6 +461,9 @@ class Project(Node):
             stmt = sort_config.stmt
             if sort_config.dir is SortDir.desc:
                 cursor_rowid_column = desc(cursor_rowid_column)
+        else:
+            stmt = stmt.add_columns(models.Span.start_time)
+            cursor_rowid_column = (models.Span.start_time.asc(), models.Span.id.asc())
         if after:
             cursor = Cursor.from_string(after)
             if sort_config and cursor.sort_column:
@@ -476,9 +479,33 @@ class Project(Node):
                             (sort_column.value, cursor.rowid),
                         )
                     )
+            elif not sort_config:
+                if cursor.sort_column is None:
+                    async with info.context.db.read() as session:
+                        span = await session.get(models.Span, cursor.rowid)
+                    if span is not None:
+                        cursor = Cursor(
+                            rowid=cursor.rowid,
+                            sort_column=CursorSortColumn(
+                                type=CursorSortColumnDataType.DATETIME,
+                                value=span.start_time,
+                            ),
+                        )
+                if cursor.sort_column:
+                    stmt = stmt.where(
+                        operator.gt(
+                            tuple_(models.Span.start_time, models.Span.id),
+                            (cursor.sort_column.value, cursor.rowid),
+                        )
+                    )
+                else:
+                    stmt = stmt.where(models.Span.id > cursor.rowid)
             else:
                 stmt = stmt.where(models.Span.id > cursor.rowid)
-        stmt = stmt.order_by(cursor_rowid_column)
+        if isinstance(cursor_rowid_column, tuple):
+            stmt = stmt.order_by(*cursor_rowid_column)
+        else:
+            stmt = stmt.order_by(cursor_rowid_column)
         if root_spans_only:
             # A root span is either a span with no parent_id or an orphan span
             # (a span whose parent_id references a span that doesn't exist in the database)
@@ -511,6 +538,11 @@ class Project(Node):
                     assert len(span_record) > 1
                     cursor.sort_column = CursorSortColumn(
                         type=sort_config.column_data_type,
+                        value=span_record[1],
+                    )
+                elif len(span_record) > 1:
+                    cursor.sort_column = CursorSortColumn(
+                        type=CursorSortColumnDataType.DATETIME,
                         value=span_record[1],
                     )
                 cursors_and_nodes.append((cursor, Span(id=span_rowid)))

--- a/src/phoenix/server/api/types/ProjectSession.py
+++ b/src/phoenix/server/api/types/ProjectSession.py
@@ -167,6 +167,17 @@ class ProjectSession(Node):
         stmt = select(models.Trace).filter_by(project_session_rowid=self.id)
         if after:
             cursor = Cursor.from_string(after)
+            if cursor.sort_column is None:
+                async with info.context.db.read() as session:
+                    trace = await session.get(models.Trace, cursor.rowid)
+                if trace is not None:
+                    cursor = Cursor(
+                        rowid=cursor.rowid,
+                        sort_column=CursorSortColumn(
+                            type=CursorSortColumnDataType.DATETIME,
+                            value=trace.start_time,
+                        ),
+                    )
             if cursor.sort_column:
                 stmt = stmt.where(
                     operator.gt(

--- a/src/phoenix/server/api/types/Trace.py
+++ b/src/phoenix/server/api/types/Trace.py
@@ -9,7 +9,7 @@ import pandas as pd
 import strawberry
 from aioitertools.itertools import islice
 from openinference.semconv.trace import SpanAttributes
-from sqlalchemy import desc, or_, select
+from sqlalchemy import desc, or_, select, tuple_
 from strawberry import ID, UNSET, lazy
 from strawberry.relay import Connection, GlobalID, Node, NodeID
 from strawberry.types import Info
@@ -27,6 +27,8 @@ from phoenix.server.api.types.AnnotationSummary import AnnotationSummary
 from phoenix.server.api.types.CostBreakdown import CostBreakdown
 from phoenix.server.api.types.pagination import (
     Cursor,
+    CursorSortColumn,
+    CursorSortColumnDataType,
     CursorString,
     connection_from_cursors_and_nodes,
 )
@@ -281,12 +283,12 @@ class Trace(Node):
 
         # Build base query for spans in this trace
         base_query = (
-            select(models.Span.id)
+            select(models.Span.id, models.Span.start_time)
             .join(models.Trace)
             .where(models.Trace.id == self.id)
             # Sort descending because the root span tends to show up later
             # in the ingestion process.
-            .order_by(desc(models.Span.id))
+            .order_by(desc(models.Span.start_time), desc(models.Span.id))
         )
         # Handle cursor pagination (forward pagination only)
         if after is not UNSET and after is not None:
@@ -296,9 +298,25 @@ class Trace(Node):
                 cursor = Cursor.from_string(after)
             except Exception as e:
                 raise ValueError(f"Invalid cursor format: {after}") from e
-            # For descending order, "after" means we want spans with smaller IDs
-            # (going forward in descending order)
-            base_query = base_query.where(models.Span.id < cursor.rowid)
+            if cursor.sort_column is None:
+                async with info.context.db.read() as session:
+                    span = await session.get(models.Span, cursor.rowid)
+                if span is not None:
+                    cursor = Cursor(
+                        rowid=cursor.rowid,
+                        sort_column=CursorSortColumn(
+                            type=CursorSortColumnDataType.DATETIME,
+                            value=span.start_time,
+                        ),
+                    )
+            if cursor.sort_column:
+                base_query = base_query.where(
+                    tuple_(models.Span.start_time, models.Span.id)
+                    < (cursor.sort_column.value, cursor.rowid)
+                )
+            else:
+                # For descending order, "after" means we want spans with smaller IDs
+                base_query = base_query.where(models.Span.id < cursor.rowid)
         # Narrow by SpanFilter DSL (e.g. `span_kind == 'LLM'`, `status_code == 'ERROR'`)
         # before any root-span CTE wrapping, so the filter applies to the candidate set.
         if filter_condition:
@@ -322,7 +340,7 @@ class Trace(Node):
                 )
                 # Filter candidates to only root spans (NULL parent_id or orphan spans)
                 stmt = (
-                    select(candidate_spans.c.id)
+                    select(candidate_spans.c.id, candidate_spans.c.start_time)
                     .where(
                         or_(
                             candidate_spans.c.parent_id.is_(None),
@@ -331,7 +349,10 @@ class Trace(Node):
                             .exists(),
                         )
                     )
-                    .order_by(desc(candidate_spans.c.id))
+                    .order_by(
+                        desc(candidate_spans.c.start_time),
+                        desc(candidate_spans.c.id),
+                    )
                 )
             else:
                 # Only include explicit root spans (spans with parent_id = NULL)
@@ -346,13 +367,20 @@ class Trace(Node):
 
         cursors_and_nodes = []
         async with info.context.db.read() as session:
-            span_rowids = await session.stream_scalars(stmt)
-            async for span_rowid in islice(span_rowids, limit):
-                cursor = Cursor(rowid=span_rowid)
+            span_records = await session.stream(stmt)
+            async for span_record in islice(span_records, limit):
+                span_rowid: int = span_record[0]
+                cursor = Cursor(
+                    rowid=span_rowid,
+                    sort_column=CursorSortColumn(
+                        type=CursorSortColumnDataType.DATETIME,
+                        value=span_record[1],
+                    ),
+                )
                 cursors_and_nodes.append((cursor, Span(id=span_rowid)))
             has_next_page = True
             try:
-                await span_rowids.__anext__()
+                await span_records.__anext__()
             except StopAsyncIteration:
                 has_next_page = False
         return connection_from_cursors_and_nodes(

--- a/tests/integration/db_migrations/test_sequence_cycle.py
+++ b/tests/integration/db_migrations/test_sequence_cycle.py
@@ -1,0 +1,217 @@
+"""
+Tests that serial sequences with CYCLE wrap around correctly for spans and traces.
+
+After the migration sets MINVALUE to -2147483648 and enables CYCLE, sequences
+should wrap from MAXVALUE (2147483647) back to MINVALUE and continue inserting
+without error.
+"""
+
+from datetime import datetime, timezone
+from secrets import token_hex
+
+import pytest
+from alembic.config import Config
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from . import _down, _run_async, _up
+
+_MAX_INT32 = 2147483647
+_MIN_INT32 = -2147483648
+
+
+async def _set_sequence(engine: AsyncEngine, seq_name: str, value: int) -> None:
+    """Set a sequence to a specific value (next nextval returns value + 1)."""
+
+    def _do(conn: Connection) -> None:
+        conn.execute(text(f"SELECT setval('{seq_name}', {value}, true)"))
+        conn.commit()
+
+    await _run_async(engine, _do)
+
+
+async def _insert_trace(engine: AsyncEngine, project_rowid: int) -> int:
+    """Insert a trace and return its id."""
+
+    def _do(conn: Connection) -> int:
+        trace_id = conn.execute(
+            text(
+                "INSERT INTO traces (project_rowid, trace_id, start_time, end_time)"
+                " VALUES (:project_rowid, :trace_id, :start_time, :end_time)"
+                " RETURNING id"
+            ),
+            {
+                "project_rowid": project_rowid,
+                "trace_id": token_hex(16),
+                "start_time": datetime.now(timezone.utc),
+                "end_time": datetime.now(timezone.utc),
+            },
+        ).scalar()
+        conn.commit()
+        assert isinstance(trace_id, int)
+        return trace_id
+
+    return await _run_async(engine, _do)
+
+
+async def _insert_trace_with_id(engine: AsyncEngine, trace_rowid: int, project_rowid: int) -> int:
+    """Insert a trace with an explicit id and return it."""
+
+    def _do(conn: Connection) -> int:
+        trace_id = conn.execute(
+            text(
+                "INSERT INTO traces (id, project_rowid, trace_id, start_time, end_time)"
+                " VALUES (:id, :project_rowid, :trace_id, :start_time, :end_time)"
+                " RETURNING id"
+            ),
+            {
+                "id": trace_rowid,
+                "project_rowid": project_rowid,
+                "trace_id": token_hex(16),
+                "start_time": datetime.now(timezone.utc),
+                "end_time": datetime.now(timezone.utc),
+            },
+        ).scalar()
+        conn.commit()
+        assert isinstance(trace_id, int)
+        return trace_id
+
+    return await _run_async(engine, _do)
+
+
+async def _insert_span(engine: AsyncEngine, trace_rowid: int) -> int:
+    """Insert a span and return its id."""
+
+    def _do(conn: Connection) -> int:
+        span_id = conn.execute(
+            text(
+                "INSERT INTO spans"
+                " (trace_rowid, span_id, parent_id, name, span_kind,"
+                "  start_time, end_time, attributes, events,"
+                "  status_code, status_message,"
+                "  cumulative_error_count,"
+                "  cumulative_llm_token_count_prompt,"
+                "  cumulative_llm_token_count_completion)"
+                " VALUES"
+                " (:trace_rowid, :span_id, NULL, 'test', 'INTERNAL',"
+                "  :start_time, :end_time, '{}', '[]',"
+                "  'UNSET', '',"
+                "  0, 0, 0)"
+                " RETURNING id"
+            ),
+            {
+                "trace_rowid": trace_rowid,
+                "span_id": token_hex(16),
+                "start_time": datetime.now(timezone.utc),
+                "end_time": datetime.now(timezone.utc),
+            },
+        ).scalar()
+        conn.commit()
+        assert isinstance(span_id, int)
+        return span_id
+
+    return await _run_async(engine, _do)
+
+
+async def _insert_span_with_id(engine: AsyncEngine, span_rowid: int, trace_rowid: int) -> int:
+    """Insert a span with an explicit id and return it."""
+
+    def _do(conn: Connection) -> int:
+        span_id = conn.execute(
+            text(
+                "INSERT INTO spans"
+                " (id, trace_rowid, span_id, parent_id, name, span_kind,"
+                "  start_time, end_time, attributes, events,"
+                "  status_code, status_message,"
+                "  cumulative_error_count,"
+                "  cumulative_llm_token_count_prompt,"
+                "  cumulative_llm_token_count_completion)"
+                " VALUES"
+                " (:id, :trace_rowid, :span_id, NULL, 'test', 'INTERNAL',"
+                "  :start_time, :end_time, '{}', '[]',"
+                "  'UNSET', '',"
+                "  0, 0, 0)"
+                " RETURNING id"
+            ),
+            {
+                "id": span_rowid,
+                "trace_rowid": trace_rowid,
+                "span_id": token_hex(16),
+                "start_time": datetime.now(timezone.utc),
+                "end_time": datetime.now(timezone.utc),
+            },
+        ).scalar()
+        conn.commit()
+        assert isinstance(span_id, int)
+        return span_id
+
+    return await _run_async(engine, _do)
+
+
+async def _get_default_project_id(engine: AsyncEngine) -> int:
+    def _do(conn: Connection) -> int:
+        result = conn.execute(text("SELECT id FROM projects WHERE name = 'default'")).scalar()
+        assert isinstance(result, int)
+        return result
+
+    return await _run_async(engine, _do)
+
+
+@pytest.mark.skipif(
+    "os.environ.get('CI_TEST_DB_BACKEND', 'sqlite').lower() != 'postgresql'",
+    reason="Sequence CYCLE only applies to PostgreSQL",
+)
+async def test_traces_and_spans_sequence_cycle(
+    _engine: AsyncEngine,
+    _alembic_config: Config,
+    _schema: str,
+) -> None:
+    """Test that traces and spans sequences wrap around from MAXVALUE to MINVALUE."""
+    await _up(_engine, _alembic_config, "head", _schema)
+    project_id = await _get_default_project_id(_engine)
+    existing_positive_trace_id = await _insert_trace_with_id(_engine, 1, project_id)
+    existing_positive_span_id = await _insert_span_with_id(_engine, 1, existing_positive_trace_id)
+
+    # Position both sequences 2 before MAXVALUE
+    await _set_sequence(_engine, "traces_id_seq", _MAX_INT32 - 2)
+    await _set_sequence(_engine, "spans_id_seq", _MAX_INT32 - 2)
+
+    # Insert 4 traces: 2 before max, 2 after wrap-around
+    trace_ids = [await _insert_trace(_engine, project_id) for _ in range(4)]
+    assert trace_ids[0] == _MAX_INT32 - 1
+    assert trace_ids[1] == _MAX_INT32
+    assert trace_ids[2] == _MIN_INT32
+    assert trace_ids[3] == _MIN_INT32 + 1
+
+    # Insert 4 spans: 2 before max, 2 after wrap-around
+    span_ids = [await _insert_span(_engine, trace_ids[0]) for _ in range(4)]
+    assert span_ids[0] == _MAX_INT32 - 1
+    assert span_ids[1] == _MAX_INT32
+    assert span_ids[2] == _MIN_INT32
+    assert span_ids[3] == _MIN_INT32 + 1
+
+    # Verify the down migration succeeds and the rows are still accessible
+    await _down(_engine, _alembic_config, "aba52fffe1a1", _schema)
+
+    async def _get_all_trace_ids(engine: AsyncEngine) -> list[int]:
+        def _do(conn: Connection) -> list[int]:
+            rows = conn.execute(text("SELECT id FROM traces ORDER BY id")).fetchall()
+            return [row[0] for row in rows]
+
+        return await _run_async(engine, _do)
+
+    async def _get_all_span_ids(engine: AsyncEngine) -> list[int]:
+        def _do(conn: Connection) -> list[int]:
+            rows = conn.execute(text("SELECT id FROM spans ORDER BY id")).fetchall()
+            return [row[0] for row in rows]
+
+        return await _run_async(engine, _do)
+
+    assert sorted([existing_positive_trace_id, *trace_ids]) == await _get_all_trace_ids(_engine)
+    assert sorted([existing_positive_span_id, *span_ids]) == await _get_all_span_ids(_engine)
+
+    # After downgrade, sequences restart at the first unused positive id.
+    new_trace_id = await _insert_trace(_engine, project_id)
+    assert new_trace_id == 2
+    new_span_id = await _insert_span(_engine, new_trace_id)
+    assert new_span_id == 2

--- a/tests/unit/server/api/routers/v1/test_list_project_traces.py
+++ b/tests/unit/server/api/routers/v1/test_list_project_traces.py
@@ -262,6 +262,62 @@ class TestListProjectTraces:
         assert len(data["data"]) == 1
         assert data["next_cursor"] is None
 
+    async def test_list_traces_pagination_across_sequence_wrap(
+        self,
+        httpx_client: httpx.AsyncClient,
+        db: DbSessionFactory,
+    ) -> None:
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        trace_specs = [
+            (2, base_time + timedelta(hours=1)),
+            (1, base_time + timedelta(hours=2)),
+            (-2147483648, base_time + timedelta(hours=3)),
+            (-2147483647, base_time + timedelta(hours=4)),
+        ]
+
+        async with db() as session:
+            project_row_id = await session.scalar(
+                insert(models.Project).values(name=token_hex(16)).returning(models.Project.id)
+            )
+            assert project_row_id is not None
+            project = await session.get(models.Project, project_row_id)
+            assert project is not None
+
+            for trace_id, start_time in trace_specs:
+                await session.scalar(
+                    insert(models.Trace)
+                    .values(
+                        id=trace_id,
+                        trace_id=token_hex(16),
+                        project_rowid=project_row_id,
+                        start_time=start_time,
+                        end_time=start_time + timedelta(minutes=30),
+                    )
+                    .returning(models.Trace.id)
+                )
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"limit": 2},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 2
+        assert data["next_cursor"] is not None
+        page1_hours = {datetime.fromisoformat(item["start_time"]).hour for item in data["data"]}
+        assert page1_hours == {3, 4}
+
+        response = await httpx_client.get(
+            f"v1/projects/{project.name}/traces",
+            params={"limit": 2, "cursor": data["next_cursor"]},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 2
+        assert data["next_cursor"] is None
+        page2_hours = {datetime.fromisoformat(item["start_time"]).hour for item in data["data"]}
+        assert page2_hours == {1, 2}
+
     async def test_list_traces_time_range_filter(
         self,
         httpx_client: httpx.AsyncClient,

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -1057,6 +1057,131 @@ async def test_span_search_pagination(
             assert isinstance(span.status_code, str)
 
 
+async def test_span_search_pagination_across_sequence_wrap(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Spans with negative IDs after sequence wrap must paginate in start_time order."""
+    base_time = datetime.fromisoformat("2021-01-01T00:00:00+00:00")
+    span_specs = [
+        (2, base_time + timedelta(hours=1)),
+        (1, base_time + timedelta(hours=2)),
+        (-2147483648, base_time + timedelta(hours=3)),
+        (-2147483647, base_time + timedelta(hours=4)),
+    ]
+
+    async with db() as session:
+        project = models.Project(name="wrap-pagination-test")
+        session.add(project)
+        await session.flush()
+
+        trace = models.Trace(
+            project_rowid=project.id,
+            trace_id="wraptrace1",
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=5),
+        )
+        session.add(trace)
+        await session.flush()
+
+        for span_id, start_time in span_specs:
+            session.add(
+                models.Span(
+                    id=span_id,
+                    trace_rowid=trace.id,
+                    span_id=f"span-{span_id}",
+                    parent_id=None,
+                    name=f"span-{span_id}",
+                    span_kind="CHAIN",
+                    start_time=start_time,
+                    end_time=start_time + timedelta(seconds=30),
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+            )
+        await session.flush()
+
+    resp1 = await httpx_client.get(
+        "v1/projects/wrap-pagination-test/spans",
+        params={"limit": 2},
+    )
+    assert resp1.is_success
+    body1 = resp1.json()
+    assert len(body1["data"]) == 2
+    assert body1["next_cursor"] is not None
+    page1_names = {Span.model_validate(s).name for s in body1["data"]}
+    assert page1_names == {"span--2147483647", "span--2147483648"}
+
+    resp2 = await httpx_client.get(
+        "v1/projects/wrap-pagination-test/spans",
+        params={"limit": 2, "cursor": body1["next_cursor"]},
+    )
+    assert resp2.is_success
+    body2 = resp2.json()
+    assert len(body2["data"]) == 2
+    assert body2["next_cursor"] is None
+    page2_names = {Span.model_validate(s).name for s in body2["data"]}
+    assert page2_names == {"span-1", "span-2"}
+
+
+async def test_span_search_pagination_legacy_global_id_cursor(
+    httpx_client: httpx.AsyncClient,
+    db: DbSessionFactory,
+) -> None:
+    """Legacy GlobalID cursors still work by resolving the row's start_time."""
+    base_time = datetime.fromisoformat("2021-01-01T00:00:00+00:00")
+
+    async with db() as session:
+        project = models.Project(name="legacy-cursor-test")
+        session.add(project)
+        await session.flush()
+
+        trace = models.Trace(
+            project_rowid=project.id,
+            trace_id="legacytrace1",
+            start_time=base_time,
+            end_time=base_time + timedelta(hours=2),
+        )
+        session.add(trace)
+        await session.flush()
+
+        for span_id, minutes in [(30, 2), (20, 1), (10, 0)]:
+            session.add(
+                models.Span(
+                    id=span_id,
+                    trace_rowid=trace.id,
+                    span_id=f"legacy-span-{span_id}",
+                    parent_id=None,
+                    name=f"legacy-span-{span_id}",
+                    span_kind="CHAIN",
+                    start_time=base_time + timedelta(minutes=minutes),
+                    end_time=base_time + timedelta(minutes=minutes, seconds=30),
+                    attributes={},
+                    events=[],
+                    status_code="OK",
+                    status_message="",
+                    cumulative_error_count=0,
+                    cumulative_llm_token_count_prompt=0,
+                    cumulative_llm_token_count_completion=0,
+                )
+            )
+        await session.flush()
+
+    legacy_cursor = str(GlobalID("Span", "20"))
+    resp = await httpx_client.get(
+        "v1/projects/legacy-cursor-test/spans",
+        params={"cursor": legacy_cursor},
+    )
+    assert resp.is_success
+    names = [Span.model_validate(s).name for s in resp.json()["data"]]
+    assert names == ["legacy-span-20", "legacy-span-10"]
+
+
 async def test_span_attributes_conversion(
     httpx_client: httpx.AsyncClient, project_with_a_single_trace_and_span: None
 ) -> None:


### PR DESCRIPTION
Add a migration that sets MINVALUE to -2147483648 and enables CYCLE on all serial (32-bit) sequences. This doubles the usable ID range from ~2.1B to ~4.3B and allows sequences to wrap around instead of erroring when they reach MAXVALUE. Also update the DDL generator to emit ALTER SEQUENCE statements for sequences with non-default attributes.

Note: after CYCLE wraps around, sorting by ID will no longer correspond to insertion order (e.g. rows with negative IDs will sort before older positive-ID rows). Code that uses ID ordering as a proxy for creation time should use a timestamp column instead. Primary key collisions are theoretically possible after a full cycle, but moot at ~4.3B rows.