### PR TITLE
fix(ci): pin changesets/action to cwd-fix commit

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: create and publish versions
         # Using PAT instead of GITHUB_TOKEN so that PRs created by this action
         # can trigger subsequent workflows (like publish) when merged
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        uses: changesets/action@2ae596f3dd74aaee4f346b31fda33a58528d3d40 # v1.7.0+cwd-fix (changesets/action#501)
         with:
           version: pnpm ci:version
           commit: "chore(js): update versions"


### PR DESCRIPTION
## Summary
- Pins `changesets/action` to a post-fix commit that properly passes `cwd` to `readChangesetState()` and `runVersion()`
- Fixes "There is no .changeset directory in this project" error in CI (changesets/action#501)
- v1.7.0 has a bug where the `cwd` input is ignored during the initial `.changeset` directory check, so it always looks at the repo root instead of `./js/`

## Test plan
- [ ] Merge a changeset and verify the publish workflow no longer errors