### PR TITLE
fix(ci): use absolute cwd for changesets publish

### DIFF
--- a/.github/workflows/typescript-packages-publish.yml
+++ b/.github/workflows/typescript-packages-publish.yml
@@ -48,7 +48,8 @@ jobs:
       - name: create and publish versions
         # Using PAT instead of GITHUB_TOKEN so that PRs created by this action
         # can trigger subsequent workflows (like publish) when merged
-        # Pinned to v1.5.2 because v1.5.3+ broke cwd support (changesets/action#501)
+        # Pinned to v1.5.2 because released versions after that still break monorepo
+        # cwd handling; the upstream fix merged after v1.7.0 but is not released yet.
         uses: changesets/action@d183df40791e90508058cd180e6435cdd9ba16a4 # v1.5.2
         with:
           version: pnpm ci:version
@@ -56,7 +57,8 @@ jobs:
           title: "chore(js): update versions"
           publish: pnpm ci:publish
           createGithubReleases: true
-          cwd: "./js"
+          # v1.5.2 resolves cwd relative to the action runtime, not github.workspace.
+          cwd: "${{ github.workspace }}/js"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Use an absolute workspace path for `changesets/action` in the TypeScript packages publish workflow.

## What Changed
- kept `changesets/action` pinned to `v1.5.2`
- changed `cwd` from `./js` to `${{ github.workspace }}/js`
- updated the workflow comment to document why we are not moving to the latest released action yet

## Root Cause
The current failure on `main` is not fixed by upgrading to the latest released `changesets/action`.

`v1.5.2` still supports the monorepo flow here, but it resolves a relative `cwd` against the action runtime rather than the checked out repository, which causes `cwd: ./js` to fail with:

`The cwd: ./js does not exist!`

The upstream `cwd` fix merged after `v1.7.0`, but it has not been released yet, and pinning the unreleased commit is not usable because the action bundle is missing the built runtime artifact.

## Impact
This restores the changeset publish workflow on `main` without switching to an unreleased or partially packaged action revision.

## Validation
- parsed `.github/workflows/typescript-packages-publish.yml` successfully with Ruby YAML
- ran `git diff --check`
- inspected the failing workflow logs and upstream `changesets/action` issue/PR history
