### PR TITLE
fix: remove openinference dependency from migration

### DIFF
--- a/src/phoenix/db/migrations/versions/3be8647b87d8_add_token_columns_to_spans_table.py
+++ b/src/phoenix/db/migrations/versions/3be8647b87d8_add_token_columns_to_spans_table.py
@@ -10,7 +10,6 @@ from typing import Any, Optional, Sequence, TypedDict, Union
 
 import sqlalchemy as sa
 from alembic import op
-from openinference.semconv.trace import SpanAttributes
 from sqlalchemy import (
     JSON,
     Dialect,
@@ -106,8 +105,8 @@ down_revision: Union[str, None] = "10460e46d750"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-LLM_TOKEN_COUNT_PROMPT = SpanAttributes.LLM_TOKEN_COUNT_PROMPT.split(".")
-LLM_TOKEN_COUNT_COMPLETION = SpanAttributes.LLM_TOKEN_COUNT_COMPLETION.split(".")
+LLM_TOKEN_COUNT_PROMPT = "llm.token_count.prompt".split(".")
+LLM_TOKEN_COUNT_COMPLETION = "llm.token_count.completion".split(".")
 
 
 def upgrade() -> None:


### PR DESCRIPTION
Use inline string values instead of importing SpanAttributes from openinference, keeping the migration self-contained.