### PR TITLE
fix(app): fix broken Playground button in prompts table

### DIFF
--- a/app/src/pages/prompts/PromptsTable.tsx
+++ b/app/src/pages/prompts/PromptsTable.tsx
@@ -199,7 +199,7 @@ export function PromptsTable(props: PromptsTableProps) {
                   leadingVisual={<Icon svg={<Icons.PlayCircleOutline />} />}
                   size="S"
                   aria-label="Open in playground"
-                  to={`${row.original.id}/playground`}
+                  to={`/playground?promptId=${encodeURIComponent(row.original.id)}`}
                 >
                   Playground
                 </LinkButton>


### PR DESCRIPTION
resolves #12488

The link used a relative path that resolved to /prompts/{id}/playground, a route that no longer exists. Updated to use /playground?promptId={id} to match the current route structure.