### PR TITLE
feat: expose parent_span_id filter in Python SDK get_spans

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -439,6 +439,7 @@ class Spans:
         end_time: Optional[datetime] = None,
         trace_ids: Optional[Sequence[str]] = None,
         parent_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
         name: Optional[Union[str, Sequence[str]]] = None,
         span_kind: Optional[Union[str, Sequence[str]]] = None,
         status_code: Optional[Union[str, Sequence[str]]] = None,
@@ -458,6 +459,8 @@ class Spans:
                 Requires Phoenix server >= 13.9.0.
             parent_id (Optional[str]): Optional parent span ID to filter by.
                 Use "null" to get root spans only.
+            parent_span_id (Optional[str]): Optional parent span ID to filter by.
+                Filters spans whose parent has the given span ID.
             name (Optional[Union[str, Sequence[str]]]): Optional span name(s) to filter by.
                 Requires Phoenix server >= 13.15.0.
             span_kind (Optional[Union[str, Sequence[str]]]): Optional span kind(s) to filter
@@ -497,6 +500,8 @@ class Spans:
                 params["trace_id"] = list(trace_ids)
             if parent_id is not None:
                 params["parent_id"] = parent_id
+            if parent_span_id is not None:
+                params["parent_span_id"] = parent_span_id
             if name:
                 params["name"] = [name] if isinstance(name, str) else list(name)
             if span_kind:
@@ -1701,6 +1706,7 @@ class AsyncSpans:
         end_time: Optional[datetime] = None,
         trace_ids: Optional[Sequence[str]] = None,
         parent_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
         name: Optional[Union[str, Sequence[str]]] = None,
         span_kind: Optional[Union[str, Sequence[str]]] = None,
         status_code: Optional[Union[str, Sequence[str]]] = None,
@@ -1720,6 +1726,8 @@ class AsyncSpans:
                 Requires Phoenix server >= 13.9.0.
             parent_id (Optional[str]): Optional parent span ID to filter by.
                 Use "null" to get root spans only.
+            parent_span_id (Optional[str]): Optional parent span ID to filter by.
+                Filters spans whose parent has the given span ID.
             name (Optional[Union[str, Sequence[str]]]): Optional span name(s) to filter by.
                 Requires Phoenix server >= 13.15.0.
             span_kind (Optional[Union[str, Sequence[str]]]): Optional span kind(s) to filter
@@ -1759,6 +1767,8 @@ class AsyncSpans:
                 params["trace_id"] = list(trace_ids)
             if parent_id is not None:
                 params["parent_id"] = parent_id
+            if parent_span_id is not None:
+                params["parent_span_id"] = parent_span_id
             if name:
                 params["name"] = [name] if isinstance(name, str) else list(name)
             if span_kind:

--- a/packages/phoenix-client/tests/client/resources/spans/test_spans.py
+++ b/packages/phoenix-client/tests/client/resources/spans/test_spans.py
@@ -98,12 +98,22 @@ class TestGetSpansFilters:
         )
         assert len(spans) == 1
 
+    def test_parent_span_id_filter(self) -> None:
+        transport = _make_handler(expected_params={"parent_span_id": ["abc123"]})
+        client = httpx.Client(transport=transport, base_url="http://test")
+        spans = Spans(client).get_spans(
+            project_identifier="my-project",
+            parent_span_id="abc123",
+        )
+        assert len(spans) == 1
+
     def test_no_filters_omits_params(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             query_string = parse_qs(urlparse(str(request.url)).query)
             assert "name" not in query_string
             assert "span_kind" not in query_string
             assert "status_code" not in query_string
+            assert "parent_span_id" not in query_string
             return httpx.Response(
                 200,
                 json={"data": [_make_span()], "next_cursor": None},
@@ -122,6 +132,16 @@ class TestAsyncGetSpansFilters:
         spans = await AsyncSpans(client).get_spans(
             project_identifier="my-project",
             name="my-span",
+        )
+        assert len(spans) == 1
+
+    @pytest.mark.anyio
+    async def test_parent_span_id_filter(self) -> None:
+        transport = _make_handler(expected_params={"parent_span_id": ["abc123"]})
+        client = httpx.AsyncClient(transport=transport, base_url="http://test")
+        spans = await AsyncSpans(client).get_spans(
+            project_identifier="my-project",
+            parent_span_id="abc123",
         )
         assert len(spans) == 1
 


### PR DESCRIPTION
## Summary

Fixes #11971

- Adds an optional `parent_span_id: Optional[str]` parameter to both `Spans.get_spans()` (sync) and `AsyncSpans.get_spans()` (async) in the Python client SDK
- When provided, passes `parent_span_id` as a query parameter to the `v1/projects/{project_identifier}/spans` API endpoint
- Enables filtering spans by their parent's span ID, which is useful for session-based span retrieval

## Changes

- `packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py`: Added `parent_span_id` parameter to both sync and async `get_spans()` methods with docstring updates
- `packages/phoenix-client/tests/client/resources/spans/test_spans.py`: Added unit tests for `parent_span_id` filter in both `TestGetSpansFilters` and `TestAsyncGetSpansFilters`, plus assertion in `test_no_filters_omits_params`

## Test plan

- [x] All existing tests pass (14/14)
- [x] New `test_parent_span_id_filter` tests verify the query parameter is correctly passed for both sync and async clients
- [x] `test_no_filters_omits_params` updated to verify `parent_span_id` is not sent when not provided