### PR TITLE
feat(sandbox): typed config schema and validation

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -504,6 +504,15 @@ type CodeEvaluatorMutationPayload {
   query: Query!
 }
 
+type ConfigFieldSpecType {
+  key: String!
+  displayName: String!
+  fieldType: String!
+  required: Boolean!
+  description: String!
+  choices: [String!]
+}
+
 union ConnectionConfig = OpenAIConnectionConfig | AzureOpenAIConnectionConfig | AnthropicConnectionConfig | AWSBedrockConnectionConfig | GoogleGenAIConnectionConfig
 
 input ConnectionConfigInput {
@@ -3074,6 +3083,7 @@ type SandboxBackendInfo {
   supportedLanguages: [Language!]!
   status: SandboxBackendStatus!
   dependencyHints: [String!]!
+  configFieldSpecs: [ConfigFieldSpecType!]!
 }
 
 enum SandboxBackendStatus {

--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -54,7 +54,7 @@ from phoenix.server.api.input_types.PromptVersionInput import (
 )
 from phoenix.server.api.types.ChatCompletionMessageRole import ChatCompletionMessageRole
 from phoenix.server.api.types.ChatCompletionSubscriptionPayload import ToolCallChunk
-from phoenix.server.sandbox.types import SandboxBackend
+from phoenix.server.sandbox.types import SandboxBackend, UnsupportedOperation
 
 logger = logging.getLogger(__name__)
 
@@ -2453,6 +2453,12 @@ class CodeEvaluatorRunner(BaseEvaluator):
                 session_key=session_key or self._name,
                 timeout=self._timeout,
             )
+        except UnsupportedOperation as exc:
+            err = f"Sandbox backend does not support this operation: {exc}"
+            return [
+                self._make_error_result(name, err, start_time)
+                for _ in (output_configs or [None])  # type: ignore[list-item]
+            ]
         except Exception as exc:
             err = f"Sandbox execution failed: {exc}"
             return [

--- a/src/phoenix/server/api/mutations/sandbox_config_mutations.py
+++ b/src/phoenix/server/api/mutations/sandbox_config_mutations.py
@@ -12,7 +12,7 @@ from strawberry.types import Info
 from phoenix.db import models
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
-from phoenix.server.api.exceptions import NotFound
+from phoenix.server.api.exceptions import BadRequest, NotFound
 from phoenix.server.api.queries import Query
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.SandboxConfig import (
@@ -27,6 +27,7 @@ from phoenix.server.api.types.SandboxConfig import (
 from phoenix.server.api.types.SandboxConfig import (
     SandboxProvider as SandboxProviderType,
 )
+from phoenix.server.sandbox import _SANDBOX_ADAPTERS
 
 # ---------------------------------------------------------------------------
 # Payload types
@@ -87,6 +88,15 @@ class SandboxConfigMutationMixin:
                 raise NotFound(f"SandboxProvider not found: {provider_id}")
 
             values = sandbox_config_from_input(input, provider_id=provider_id)
+            config_dict = values.get("config", {}) or {}
+            adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
+            if adapter is not None:
+                try:
+                    config_dict = adapter.validate_config(config_dict)
+                except ValueError as exc:
+                    raise BadRequest(str(exc))
+            values["config"] = config_dict
+
             row = models.SandboxConfig(**values)
             session.add(row)
             await session.flush()
@@ -120,7 +130,20 @@ class SandboxConfigMutationMixin:
             if input.description is not strawberry.UNSET:
                 row.description = input.description
             if input.config is not strawberry.UNSET:
-                row.config = dict(input.config) if input.config is not None else {}
+                config_dict = dict(input.config) if input.config is not None else {}
+                provider = await session.scalar(
+                    select(models.SandboxProvider).where(
+                        models.SandboxProvider.id == row.sandbox_provider_id
+                    )
+                )
+                if provider is not None:
+                    adapter = _SANDBOX_ADAPTERS.get(provider.backend_type)
+                    if adapter is not None:
+                        try:
+                            config_dict = adapter.validate_config(config_dict)
+                        except ValueError as exc:
+                            raise BadRequest(str(exc))
+                row.config = config_dict
             if input.timeout is not strawberry.UNSET:
                 row.timeout = input.timeout if input.timeout is not None else 30
             if input.enabled is not strawberry.UNSET and input.enabled is not None:

--- a/src/phoenix/server/api/types/SandboxConfig.py
+++ b/src/phoenix/server/api/types/SandboxConfig.py
@@ -22,6 +22,18 @@ from phoenix.server.api.context import Context
 from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA, get_or_create_backend
 
 
+@strawberry.type
+class ConfigFieldSpecType:
+    """GQL mirror of the ConfigFieldSpec dataclass."""
+
+    key: str
+    display_name: str
+    field_type: str
+    required: bool
+    description: str
+    choices: Optional[list[str]]
+
+
 @strawberry.enum
 class Language(Enum):
     """Execution language for a code evaluator or sandbox provider."""
@@ -56,6 +68,7 @@ class SandboxBackendInfo:
     supported_languages: list[Language]
     status: SandboxBackendStatus
     dependency_hints: list[str]
+    config_field_specs: list[ConfigFieldSpecType]
 
 
 @strawberry.type
@@ -269,6 +282,7 @@ def get_sandbox_backend_info() -> list[SandboxBackendInfo]:
                 if backend is not None
                 else SandboxBackendStatus.UNAVAILABLE
             )
+        raw_specs = getattr(meta, "config_field_specs", [])
         infos.append(
             SandboxBackendInfo(
                 backend_type=backend_type,
@@ -276,6 +290,17 @@ def get_sandbox_backend_info() -> list[SandboxBackendInfo]:
                 supported_languages=[Language(meta.language)] if meta.language else [],
                 status=status,
                 dependency_hints=meta.dependency_hints,
+                config_field_specs=[
+                    ConfigFieldSpecType(
+                        key=s.key,
+                        display_name=s.display_name,
+                        field_type=s.field_type,
+                        required=s.required,
+                        description=s.description,
+                        choices=s.choices,
+                    )
+                    for s in raw_specs
+                ],
             )
         )
     return infos

--- a/src/phoenix/server/sandbox/__init__.py
+++ b/src/phoenix/server/sandbox/__init__.py
@@ -19,9 +19,62 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from phoenix.server.sandbox.types import SandboxAdapter, SandboxBackend
+from phoenix.server.sandbox.types import ConfigFieldSpec, SandboxAdapter, SandboxBackend
 
 logger = logging.getLogger(__name__)
+
+# JSON Schema "type" → ConfigFieldSpec.field_type mapping.
+_JSON_SCHEMA_TYPE_MAP: dict[str, str] = {
+    "string": "string",
+    "integer": "integer",
+    "number": "integer",
+    "boolean": "boolean",
+}
+
+
+def _config_field_specs_from_model(
+    model_cls: Any,
+) -> list[ConfigFieldSpec]:
+    """
+    Derive ConfigFieldSpec list from a pydantic model's JSON schema.
+
+    Skips fields not listed in the schema's `properties` (extra="allow" wildcard
+    fields are not enumerated). Fields with `enum` become field_type="select".
+    """
+    schema = model_cls.model_json_schema()
+    properties: dict[str, Any] = schema.get("properties", {})
+    required_keys: set[str] = set(schema.get("required", []))
+    specs: list[ConfigFieldSpec] = []
+    for key, prop in properties.items():
+        # Unwrap anyOf (e.g. Optional[str] → [{type: string}, {type: null}])
+        effective_prop = prop
+        if "anyOf" in prop:
+            non_null = [p for p in prop["anyOf"] if p.get("type") != "null"]
+            if non_null:
+                effective_prop = non_null[0]
+
+        if "enum" in effective_prop:
+            ft: str = "select"
+            choices: Optional[list[str]] = [str(c) for c in effective_prop["enum"]]
+        else:
+            raw_type = effective_prop.get("type", "string")
+            ft = _JSON_SCHEMA_TYPE_MAP.get(raw_type, "string")
+            choices = None
+
+        display_name: str = prop.get("title") or key.replace("_", " ").title()
+        description: str = prop.get("description") or effective_prop.get("description") or ""
+
+        specs.append(
+            ConfigFieldSpec(
+                key=key,
+                display_name=display_name,
+                field_type=ft,  # type: ignore[arg-type]
+                required=key in required_keys,
+                description=description,
+                choices=choices,
+            )
+        )
+    return specs
 
 
 @dataclass
@@ -31,6 +84,7 @@ class AdapterMetadata:
     display_name: str
     language: str = ""
     dependency_hints: list[str] = field(default_factory=list)
+    config_field_specs: list[ConfigFieldSpec] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -120,8 +174,17 @@ def _config_hash(config: dict[str, Any] | None) -> str:
 
 
 def register_sandbox_adapter(adapter: SandboxAdapter) -> SandboxAdapter:
-    """Register a SandboxAdapter in the runtime registry."""
+    """Register a SandboxAdapter in the runtime registry.
+
+    Derives config_field_specs from the adapter's pydantic config_model and
+    writes them into SANDBOX_ADAPTER_METADATA so the GQL layer has a single
+    authoritative source (no dual-registration).
+    """
     _SANDBOX_ADAPTERS[adapter.key] = adapter
+    if adapter.key in SANDBOX_ADAPTER_METADATA:
+        SANDBOX_ADAPTER_METADATA[adapter.key].config_field_specs = _config_field_specs_from_model(
+            adapter.config_model
+        )
     logger.debug(f"Registered sandbox adapter: {adapter.key!r}")
     return adapter
 

--- a/src/phoenix/server/sandbox/daytona_backend.py
+++ b/src/phoenix/server/sandbox/daytona_backend.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from phoenix.config import ENV_PHOENIX_SANDBOX_TOKEN
 
 from .types import (
+    DaytonaPythonConfig,
     ExecutionResult,
     SandboxAdapter,
     SandboxBackend,
@@ -68,7 +69,7 @@ class DaytonaSandboxBackend(SandboxBackend):
             if workspace is None:
                 client = self._get_client()
                 workspace = await client.create()
-            result = await workspace.process.code_run(code)
+            result = await workspace.process.code_run(code, envs=env or {})
             return ExecutionResult(
                 stdout=result.stdout or "",
                 stderr=result.stderr or "",
@@ -86,6 +87,7 @@ class DaytonaPythonAdapter(SandboxAdapter):
     key = "DAYTONA_PYTHON"
     display_name = "Daytona (Python)"
     language = "PYTHON"
+    config_model = DaytonaPythonConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         api_key: str = (

--- a/src/phoenix/server/sandbox/deno_backend.py
+++ b/src/phoenix/server/sandbox/deno_backend.py
@@ -16,6 +16,7 @@ from phoenix.config import ENV_PHOENIX_SANDBOX_API_KEY
 
 from .types import (
     BaseNoSessionBackend,
+    DenoConfig,
     ExecutionResult,
     SandboxAdapter,
     SandboxBackend,
@@ -64,6 +65,7 @@ class DenoAdapter(SandboxAdapter):
     key = "DENO"
     display_name = "Deno (local)"
     language = "TYPESCRIPT"
+    config_model = DenoConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         api_key: str = (

--- a/src/phoenix/server/sandbox/e2b_backend.py
+++ b/src/phoenix/server/sandbox/e2b_backend.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from phoenix.config import ENV_PHOENIX_SANDBOX_API_KEY
 
 from .types import (
+    E2BConfig,
     ExecutionResult,
     SandboxAdapter,
     SandboxBackend,
@@ -34,9 +35,13 @@ class E2BSandboxBackend(SandboxBackend):
         self,
         api_key: str,
         template: str = "base",
+        cwd: Optional[str] = None,
+        metadata: Optional[str] = None,
     ) -> None:
         self._api_key = api_key
         self._template = template
+        self._cwd = cwd
+        self._metadata = metadata
         self._sessions: dict[str, Any] = {}
 
     def _get_sandbox_cls(self) -> Any:
@@ -44,12 +49,24 @@ class E2BSandboxBackend(SandboxBackend):
 
         return AsyncSandbox
 
+    def _create_kwargs(self) -> dict[str, Any]:
+        """Build kwargs for AsyncSandbox.create().
+
+        The E2B SDK expects metadata as Dict[str, str]. A string value from
+        the config is passed under the key ``"info"``, so the sandbox is
+        tagged with ``{"info": "<value>"}``.
+        """
+        kwargs: dict[str, Any] = {"api_key": self._api_key, "template": self._template}
+        if self._metadata is not None:
+            kwargs["metadata"] = {"info": self._metadata}
+        return kwargs
+
     async def start_session(self, session_key: str) -> None:
         if session_key in self._sessions:
             logger.debug(f"E2B session '{session_key}' already exists; reusing")
             return
         AsyncSandbox = self._get_sandbox_cls()
-        sandbox = await AsyncSandbox.create(api_key=self._api_key, template=self._template)
+        sandbox = await AsyncSandbox.create(**self._create_kwargs())
         self._sessions[session_key] = sandbox
         logger.debug(f"Started E2B session '{session_key}'")
 
@@ -72,13 +89,13 @@ class E2BSandboxBackend(SandboxBackend):
             run_kwargs: dict[str, Any] = {"envs": env or {}}
             if timeout is not None:
                 run_kwargs["timeout"] = timeout
+            if self._cwd is not None:
+                run_kwargs["cwd"] = self._cwd
             if sandbox is not None:
                 execution = await sandbox.run_code(code, **run_kwargs)
             else:
                 # Ephemeral: spin up a fresh sandbox, run, then close.
-                async with await AsyncSandbox.create(
-                    api_key=self._api_key, template=self._template
-                ) as sb:
+                async with await AsyncSandbox.create(**self._create_kwargs()) as sb:
                     execution = await sb.run_code(code, **run_kwargs)
 
             stdout = "\n".join(execution.logs.stdout) if execution.logs.stdout else ""
@@ -106,6 +123,7 @@ class E2BAdapter(SandboxAdapter):
     key = "E2B"
     display_name = "E2B"
     language = "PYTHON"
+    config_model = E2BConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         api_key: str = (
@@ -115,4 +133,6 @@ class E2BAdapter(SandboxAdapter):
             or ""
         )
         template: str = config.get("template", "base")
-        return E2BSandboxBackend(api_key=api_key, template=template)
+        cwd: Optional[str] = config.get("cwd") or None
+        metadata: Optional[str] = config.get("metadata") or None
+        return E2BSandboxBackend(api_key=api_key, template=template, cwd=cwd, metadata=metadata)

--- a/src/phoenix/server/sandbox/modal_backend.py
+++ b/src/phoenix/server/sandbox/modal_backend.py
@@ -27,6 +27,7 @@ from typing import Any, Optional
 
 from .types import (
     ExecutionResult,
+    ModalConfig,
     SandboxAdapter,
     SandboxBackend,
 )
@@ -140,6 +141,7 @@ class ModalAdapter(SandboxAdapter):
     key = "MODAL"
     display_name = "Modal"
     language = "PYTHON"
+    config_model = ModalConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         timeout: int = int(config.get("timeout", _DEFAULT_TIMEOUT))

--- a/src/phoenix/server/sandbox/types.py
+++ b/src/phoenix/server/sandbox/types.py
@@ -1,15 +1,116 @@
 """
 Core types for the sandbox backend system.
 
-Zero runtime dependencies — stdlib only (D2 design decision). Safe to import
-unconditionally regardless of optional extras.
+Only depends on stdlib and pydantic (a core Phoenix dependency). Safe to
+import unconditionally regardless of optional sandbox extras.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Type
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UnsupportedOperation(Exception):
+    """Raised when a sandbox backend does not support a requested operation."""
+
+
+@dataclass
+class ConfigFieldSpec:
+    """
+    Describes a single key in SandboxConfig.config for a given adapter.
+
+    Used to drive UI form rendering and server-side validation. Covers
+    config keys only — not provider-level credentials (D8).
+    """
+
+    key: str
+    display_name: str
+    field_type: Literal["string", "integer", "boolean", "select"]
+    required: bool = False
+    description: str = ""
+    choices: Optional[list[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# Per-adapter pydantic config models.
+# extra="allow" preserves unknown keys (D9 contract).
+# All config fields are optional — adapters use defaults for missing keys.
+# Field(title=...) drives ConfigFieldSpec.display_name derivation.
+# ---------------------------------------------------------------------------
+
+
+class E2BConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    template: str = Field(
+        default="base",
+        title="Template",
+        description="E2B sandbox template ID. Defaults to 'base'.",
+    )
+    cwd: Optional[str] = Field(
+        default=None,
+        title="Working Directory",
+        description="Working directory for code execution inside the sandbox.",
+    )
+    metadata: Optional[str] = Field(
+        default=None,
+        title="Metadata",
+        description="Metadata string attached to the sandbox at creation time.",
+    )
+
+
+class DaytonaPythonConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    server_url: str = Field(
+        default="",
+        title="Server URL",
+        description="Daytona server URL. Leave empty to use the default.",
+    )
+
+
+class DenoConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class _VercelConfigBase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class VercelPythonConfig(_VercelConfigBase):
+    pass
+
+
+class VercelTypescriptConfig(_VercelConfigBase):
+    pass
+
+
+class WASMConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ModalConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    app_name: str = Field(
+        default="phoenix-sandbox",
+        title="App Name",
+        description="Modal app name. Created on first use if it does not exist.",
+    )
+    timeout: int = Field(
+        default=600,
+        title="Timeout (seconds)",
+        description="Hard sandbox timeout in seconds.",
+    )
+    idle_timeout: int = Field(
+        default=300,
+        title="Idle Timeout (seconds)",
+        description="Duration of idleness before a sandbox is terminated.",
+    )
 
 
 @dataclass
@@ -93,7 +194,29 @@ class SandboxAdapter(ABC):
     #: Language this adapter supports (must match Language.name values in DB).
     language: Literal["PYTHON", "TYPESCRIPT"]
 
+    #: Pydantic model used for config validation. Subclasses override at class level.
+    config_model: Type[BaseModel] = BaseModel
+
+    #: Specs for config keys accepted by this adapter. Subclasses override at class level.
+    config_field_specs: list["ConfigFieldSpec"] = []
+
     @abstractmethod
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         """Construct and return a SandboxBackend from the provided config."""
         ...
+
+    def validate_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Validate config via the adapter's pydantic config_model.
+
+        Returns the validated config dict (unknown keys preserved per D9).
+        Raises ValueError on constraint violations (D3).
+        """
+        from pydantic import ValidationError
+
+        try:
+            validated = self.config_model.model_validate(config)
+        except ValidationError as exc:
+            raise ValueError(str(exc)) from exc
+        # model_dump preserves extra fields because models use extra="allow"
+        return validated.model_dump()

--- a/src/phoenix/server/sandbox/vercel_backend.py
+++ b/src/phoenix/server/sandbox/vercel_backend.py
@@ -30,6 +30,8 @@ from .types import (
     ExecutionResult,
     SandboxAdapter,
     SandboxBackend,
+    VercelPythonConfig,
+    VercelTypescriptConfig,
 )
 
 # Vercel SDK env (https://vercel.com/docs/vercel-sandbox/concepts/authentication)
@@ -196,6 +198,7 @@ class VercelPythonAdapter(SandboxAdapter):
     key = "VERCEL_PYTHON"
     display_name = "Vercel Sandbox (Python)"
     language = "PYTHON"
+    config_model = VercelPythonConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         if os.environ.get(ENV_VERCEL_OIDC_TOKEN):
@@ -223,6 +226,7 @@ class VercelTypescriptAdapter(SandboxAdapter):
     key = "VERCEL_TYPESCRIPT"
     display_name = "Vercel Sandbox (TypeScript)"
     language = "TYPESCRIPT"
+    config_model = VercelTypescriptConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
         if os.environ.get(ENV_VERCEL_OIDC_TOKEN):

--- a/src/phoenix/server/sandbox/wasm_backend.py
+++ b/src/phoenix/server/sandbox/wasm_backend.py
@@ -27,12 +27,15 @@ from .types import (
     ExecutionResult,
     SandboxAdapter,
     SandboxBackend,
+    UnsupportedOperation,
+    WASMConfig,
 )
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 30
 _EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="wasm-sandbox")
+
 
 # Module-level cache: path → (engine, compiled module).
 # Engine and module must be paired — a module compiled with one engine
@@ -107,10 +110,8 @@ class WASMBackend(BaseNoSessionBackend):
     def __init__(
         self,
         binary_path: Optional[Path] = None,
-        timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         self._binary_path = binary_path
-        self._timeout = timeout
 
     def _resolve_binary(self) -> Path:
         if self._binary_path is not None:
@@ -126,6 +127,8 @@ class WASMBackend(BaseNoSessionBackend):
         env: Optional[dict[str, str]] = None,
         timeout: Optional[int] = None,
     ) -> ExecutionResult:
+        if env:
+            raise UnsupportedOperation("WASM backend does not support environment variables")
         binary_path = self._resolve_binary()
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
@@ -133,7 +136,7 @@ class WASMBackend(BaseNoSessionBackend):
             _run_wasm,
             binary_path,
             code,
-            timeout if timeout is not None else self._timeout,
+            timeout if timeout is not None else _DEFAULT_TIMEOUT_SECONDS,
         )
 
     async def close(self) -> None:
@@ -144,7 +147,7 @@ class WASMAdapter(SandboxAdapter):
     key = "WASM"
     display_name = "WebAssembly (local)"
     language = "PYTHON"
+    config_model = WASMConfig
 
     def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
-        timeout = int(config.get("timeout", _DEFAULT_TIMEOUT_SECONDS))
-        return WASMBackend(timeout=timeout)
+        return WASMBackend()

--- a/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
+++ b/tests/unit/server/api/mutations/test_code_evaluator_sandbox_mutations.py
@@ -7,13 +7,20 @@ test app, backed by seed_sandbox_providers DB fixtures.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from sqlalchemy import select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
 from phoenix.db.types.identifier import Identifier
+from phoenix.server import sandbox as sandbox_module
+from phoenix.server.sandbox.e2b_backend import E2BAdapter
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
+
+_e2b_adapter = E2BAdapter()
+_patched_adapters = {**sandbox_module._SANDBOX_ADAPTERS, "E2B": _e2b_adapter}
 
 # ---------------------------------------------------------------------------
 # GraphQL documents
@@ -605,3 +612,151 @@ class TestCrossProviderIsolation:
         assert set(e2b_config_names) == set(e2b_names)
         # No overlap
         assert not set(wasm_config_names) & set(e2b_config_names)
+
+
+class TestConfigValidationPath:
+    """
+    Integration tests for the validation path in create/update mutations.
+
+    Patches _SANDBOX_ADAPTERS to always include E2BAdapter (which has declared
+    config fields), independent of whether e2b_code_interpreter is installed.
+    E2BAdapter.validate_config() only needs pydantic — no optional extras.
+    """
+
+    async def test_create_valid_e2b_config_succeeds(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
+            )
+        assert provider is not None
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(provider.id),
+                        "name": "e2b-valid",
+                        "config": {"template": "custom-tmpl", "cwd": "/workspace"},
+                    }
+                },
+            )
+        assert result.data and not result.errors
+
+    async def test_create_preserves_unknown_keys(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """extra="allow" means unknown keys survive validation and are persisted."""
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
+            )
+        assert provider is not None
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _CREATE,
+                variables={
+                    "input": {
+                        "sandboxProviderId": _provider_global_id(provider.id),
+                        "name": "e2b-extra-keys",
+                        "config": {"template": "base", "custom_key": "preserved"},
+                    }
+                },
+            )
+        assert result.data and not result.errors
+        cfg_id = result.data["createSandboxConfig"]["sandboxConfig"]["id"]
+
+        # Verify persisted config includes the unknown key
+        async with db() as session:
+            from strawberry.relay import GlobalID as GID
+
+            gid = GID.from_id(cfg_id)
+            row_id = int(gid.node_id)
+            row = await session.get(models.SandboxConfig, row_id)
+        assert row is not None
+        assert row.config.get("custom_key") == "preserved"
+
+    async def test_update_valid_config_succeeds(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
+            )
+        assert provider is not None
+        # Create a config first
+        async with db() as session:
+            config = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="e2b-update-test",
+                config={},
+                timeout=30,
+            )
+            session.add(config)
+            await session.flush()
+            config_id = config.id
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE,
+                variables={
+                    "input": {
+                        "id": _config_global_id(config_id),
+                        "config": {"template": "new-template", "metadata": "my-label"},
+                    }
+                },
+            )
+        assert result.data and not result.errors
+
+    async def test_update_config_persists_validated_dict(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+        seed_sandbox_providers: None,
+    ) -> None:
+        """After update, DB row stores the validated (pydantic model_dump) dict."""
+        async with db() as session:
+            provider = await session.scalar(
+                select(models.SandboxProvider).where(models.SandboxProvider.backend_type == "E2B")
+            )
+        assert provider is not None
+        async with db() as session:
+            config = models.SandboxConfig(
+                sandbox_provider_id=provider.id,
+                name="e2b-persist-test",
+                config={},
+                timeout=30,
+            )
+            session.add(config)
+            await session.flush()
+            config_id = config.id
+
+        with patch.dict(sandbox_module._SANDBOX_ADAPTERS, {"E2B": _e2b_adapter}):
+            result = await gql_client.execute(
+                _UPDATE,
+                variables={
+                    "input": {
+                        "id": _config_global_id(config_id),
+                        "config": {"template": "saved-tmpl"},
+                    }
+                },
+            )
+        assert result.data and not result.errors
+
+        async with db() as session:
+            row = await session.get(models.SandboxConfig, config_id)
+        assert row is not None
+        # template was provided — must be persisted
+        assert row.config.get("template") == "saved-tmpl"

--- a/tests/unit/server/api/test_sandbox_config_validation.py
+++ b/tests/unit/server/api/test_sandbox_config_validation.py
@@ -1,0 +1,231 @@
+"""Unit tests for pydantic config model validation in sandbox adapters.
+
+Tests cover:
+- Valid configs accepted and returned
+- Unknown keys preserved (D9: extra="allow")
+- Type coercion (pydantic coerces compatible types)
+- Invalid values raise ValueError via validate_config()
+- Defaults filled in for missing optional fields
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from phoenix.server.sandbox.types import (
+    DaytonaPythonConfig,
+    DenoConfig,
+    E2BConfig,
+    ModalConfig,
+    SandboxAdapter,
+    VercelPythonConfig,
+    VercelTypescriptConfig,
+    WASMConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(config_model_cls: type) -> SandboxAdapter:
+    """Create a minimal SandboxAdapter with the given config_model."""
+    from typing import Any
+
+    class _ConcreteAdapter(SandboxAdapter):
+        key = "TEST"
+        display_name = "Test"
+        language = "PYTHON"
+        config_model = config_model_cls
+
+        def build_backend(self, config: dict[str, Any]) -> Any:
+            return None
+
+    return _ConcreteAdapter()
+
+
+# ---------------------------------------------------------------------------
+# E2BConfig
+# ---------------------------------------------------------------------------
+
+
+class TestE2BConfigValidation:
+    def test_empty_config_returns_defaults(self) -> None:
+        result = E2BConfig.model_validate({})
+        assert result.template == "base"
+        assert result.cwd is None
+        assert result.metadata is None
+
+    def test_valid_full_config(self) -> None:
+        result = E2BConfig.model_validate(
+            {"template": "custom-tmpl", "cwd": "/workspace", "metadata": "my-run"}
+        )
+        assert result.template == "custom-tmpl"
+        assert result.cwd == "/workspace"
+        assert result.metadata == "my-run"
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = E2BConfig.model_validate({"unknown_key": "preserved"})
+        dumped = result.model_dump()
+        assert dumped["unknown_key"] == "preserved"
+
+    def test_validate_config_returns_dict(self) -> None:
+        adapter = _make_adapter(E2BConfig)
+        out = adapter.validate_config({"template": "t1", "cwd": "/tmp"})
+        assert isinstance(out, dict)
+        assert out["template"] == "t1"
+
+    def test_validate_config_preserves_unknown_keys(self) -> None:
+        adapter = _make_adapter(E2BConfig)
+        out = adapter.validate_config({"extra_key": "extra_val"})
+        assert out["extra_key"] == "extra_val"
+
+    def test_validate_config_fills_defaults(self) -> None:
+        adapter = _make_adapter(E2BConfig)
+        out = adapter.validate_config({})
+        assert out["template"] == "base"
+        assert out["cwd"] is None
+        assert out["metadata"] is None
+
+
+# ---------------------------------------------------------------------------
+# DaytonaPythonConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDaytonaPythonConfigValidation:
+    def test_empty_config_returns_defaults(self) -> None:
+        result = DaytonaPythonConfig.model_validate({})
+        assert result.server_url == ""
+
+    def test_valid_server_url(self) -> None:
+        result = DaytonaPythonConfig.model_validate({"server_url": "https://daytona.example.com"})
+        assert result.server_url == "https://daytona.example.com"
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = DaytonaPythonConfig.model_validate({"server_url": "https://x.com", "extra": "val"})
+        dumped = result.model_dump()
+        assert dumped["extra"] == "val"
+
+    def test_validate_config_returns_dict_with_defaults(self) -> None:
+        adapter = _make_adapter(DaytonaPythonConfig)
+        out = adapter.validate_config({})
+        assert out["server_url"] == ""
+
+
+# ---------------------------------------------------------------------------
+# DenoConfig / VercelConfig / WASMConfig (no declared fields, extra="allow")
+# ---------------------------------------------------------------------------
+
+
+class TestDenoConfigValidation:
+    def test_empty_config_accepted(self) -> None:
+        result = DenoConfig.model_validate({})
+        assert result.model_dump() == {}
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = DenoConfig.model_validate({"custom_flag": True})
+        assert result.model_dump()["custom_flag"] is True
+
+    def test_validate_config_returns_unknown_keys(self) -> None:
+        adapter = _make_adapter(DenoConfig)
+        out = adapter.validate_config({"deno_path": "/usr/local/bin/deno"})
+        assert out["deno_path"] == "/usr/local/bin/deno"
+
+
+class TestVercelPythonConfigValidation:
+    def test_empty_config_accepted(self) -> None:
+        result = VercelPythonConfig.model_validate({})
+        assert result.model_dump() == {}
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = VercelPythonConfig.model_validate({"region": "iad1"})
+        assert result.model_dump()["region"] == "iad1"
+
+
+class TestVercelTypescriptConfigValidation:
+    def test_empty_config_accepted(self) -> None:
+        result = VercelTypescriptConfig.model_validate({})
+        assert result.model_dump() == {}
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = VercelTypescriptConfig.model_validate({"region": "iad1"})
+        assert result.model_dump()["region"] == "iad1"
+
+
+class TestWASMConfigValidation:
+    def test_empty_config_accepted(self) -> None:
+        result = WASMConfig.model_validate({})
+        assert result.model_dump() == {}
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = WASMConfig.model_validate({"binary_path": "/custom/cpython.wasm"})
+        assert result.model_dump()["binary_path"] == "/custom/cpython.wasm"
+
+
+class TestModalConfigValidation:
+    def test_empty_config_returns_defaults(self) -> None:
+        result = ModalConfig.model_validate({})
+        assert result.app_name == "phoenix-sandbox"
+        assert result.timeout == 600
+        assert result.idle_timeout == 300
+
+    def test_valid_full_config(self) -> None:
+        result = ModalConfig.model_validate(
+            {"app_name": "custom-app", "timeout": 120, "idle_timeout": 60}
+        )
+        assert result.app_name == "custom-app"
+        assert result.timeout == 120
+        assert result.idle_timeout == 60
+
+    def test_unknown_keys_preserved(self) -> None:
+        result = ModalConfig.model_validate({"app_name": "x", "region": "us-east-1"})
+        assert result.model_dump()["region"] == "us-east-1"
+
+    def test_validate_config_returns_dict_with_defaults(self) -> None:
+        adapter = _make_adapter(ModalConfig)
+        out = adapter.validate_config({})
+        assert out["app_name"] == "phoenix-sandbox"
+        assert out["timeout"] == 600
+        assert out["idle_timeout"] == 300
+
+
+# ---------------------------------------------------------------------------
+# validate_config() error path via SandboxAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigErrorPath:
+    def test_invalid_type_raises_value_error(self) -> None:
+        """A pydantic ValidationError is surfaced as ValueError."""
+        from pydantic import BaseModel, ConfigDict
+
+        class StrictModel(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            count: int
+
+        adapter = _make_adapter(StrictModel)
+        with pytest.raises(ValueError):
+            adapter.validate_config({"count": "not-an-int"})
+
+    def test_missing_required_field_raises_value_error(self) -> None:
+        from pydantic import BaseModel, ConfigDict
+
+        class RequiredFieldModel(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            required_field: str  # no default → required
+
+        adapter = _make_adapter(RequiredFieldModel)
+        with pytest.raises(ValueError, match="required_field"):
+            adapter.validate_config({})
+
+    def test_valid_required_field_passes(self) -> None:
+        from pydantic import BaseModel, ConfigDict
+
+        class RequiredFieldModel(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            required_field: str
+
+        adapter = _make_adapter(RequiredFieldModel)
+        out = adapter.validate_config({"required_field": "present"})
+        assert out["required_field"] == "present"

--- a/tests/unit/server/api/test_sandbox_queries.py
+++ b/tests/unit/server/api/test_sandbox_queries.py
@@ -1,7 +1,12 @@
+from typing import Any
+
+import pytest
 from sqlalchemy import func, select
 from strawberry.relay import GlobalID
 
 from phoenix.db import models
+from phoenix.server.sandbox import SANDBOX_ADAPTER_METADATA, register_sandbox_adapter
+from phoenix.server.sandbox.types import E2BConfig, SandboxAdapter, SandboxBackend
 from phoenix.server.types import DbSessionFactory
 from tests.unit.graphql import AsyncGraphQLClient
 
@@ -112,3 +117,83 @@ async def test_sandbox_backends_and_providers_can_be_loaded_together(
         "Install the Deno runtime and ensure the `deno` binary is available on PATH.",
     ]
     assert len(response.data["sandboxProviders"]) == provider_count
+
+
+@pytest.fixture
+def register_e2b_adapter() -> Any:
+    """Register a minimal E2BAdapter so config_field_specs are derived from E2BConfig."""
+
+    class _FakeE2BAdapter(SandboxAdapter):
+        key = "E2B"
+        display_name = "E2B"
+        language = "PYTHON"
+        config_model = E2BConfig
+
+        def build_backend(self, config: dict[str, Any]) -> SandboxBackend:
+            raise NotImplementedError
+
+    original_specs = list(SANDBOX_ADAPTER_METADATA["E2B"].config_field_specs)
+    register_sandbox_adapter(_FakeE2BAdapter())
+    yield
+    SANDBOX_ADAPTER_METADATA["E2B"].config_field_specs = original_specs
+
+
+async def test_sandbox_backends_config_field_specs(
+    gql_client: AsyncGraphQLClient,
+    seed_sandbox_providers: None,
+    register_e2b_adapter: Any,
+) -> None:
+    """configFieldSpecs for E2B derives 3 fields from E2BConfig; others have none."""
+    query = """
+      query {
+        sandboxBackends {
+          backendType
+          configFieldSpecs {
+            key
+            displayName
+            fieldType
+            required
+            description
+            choices
+          }
+        }
+      }
+    """
+
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert response.data is not None
+    backends = {b["backendType"]: b for b in response.data["sandboxBackends"]}
+
+    # E2B derives 3 specs from E2BConfig (template, cwd, metadata)
+    e2b_specs = backends["E2B"]["configFieldSpecs"]
+    assert len(e2b_specs) == 3
+    spec_by_key = {s["key"]: s for s in e2b_specs}
+    assert spec_by_key["template"] == {
+        "key": "template",
+        "displayName": "Template",
+        "fieldType": "string",
+        "required": False,
+        "description": "E2B sandbox template ID. Defaults to 'base'.",
+        "choices": None,
+    }
+    assert spec_by_key["cwd"] == {
+        "key": "cwd",
+        "displayName": "Working Directory",
+        "fieldType": "string",
+        "required": False,
+        "description": "Working directory for code execution inside the sandbox.",
+        "choices": None,
+    }
+    assert spec_by_key["metadata"] == {
+        "key": "metadata",
+        "displayName": "Metadata",
+        "fieldType": "string",
+        "required": False,
+        "description": "Metadata string attached to the sandbox at creation time.",
+        "choices": None,
+    }
+
+    # Adapters with empty config models have no specs
+    for backend_type in ("WASM", "VERCEL_PYTHON", "VERCEL_TYPESCRIPT", "DENO"):
+        assert backends[backend_type]["configFieldSpecs"] == [], backend_type

--- a/tests/unit/server/api/test_wasm_backend.py
+++ b/tests/unit/server/api/test_wasm_backend.py
@@ -17,7 +17,7 @@ import pytest
 
 pytest.importorskip("wasmtime", reason="wasmtime optional extra not installed")
 
-from phoenix.server.sandbox.types import ExecutionResult  # noqa: E402
+from phoenix.server.sandbox.types import ExecutionResult, UnsupportedOperation  # noqa: E402
 from phoenix.server.sandbox.wasm_backend import WASMAdapter, WASMBackend, _run_wasm  # noqa: E402
 
 
@@ -43,7 +43,7 @@ class TestWASMBackendExecute:
     async def test_execute_returns_execution_result(self) -> None:
         expected = ExecutionResult(stdout="hello\n", stderr="")
         binary_path = Path("/fake/cpython.wasm")
-        backend = WASMBackend(binary_path=binary_path, timeout=10)
+        backend = WASMBackend(binary_path=binary_path)
 
         with patch(
             "phoenix.server.sandbox.wasm_backend._run_wasm",
@@ -52,13 +52,20 @@ class TestWASMBackendExecute:
             result = await backend.execute("print('hello')", session_key="k")
 
         assert result is expected
-        mock_run.assert_called_once_with(binary_path, "print('hello')", 10)
+        from phoenix.server.sandbox.wasm_backend import _DEFAULT_TIMEOUT_SECONDS
+
+        mock_run.assert_called_once_with(binary_path, "print('hello')", _DEFAULT_TIMEOUT_SECONDS)
+
+    async def test_execute_raises_unsupported_operation_when_env_passed(self) -> None:
+        backend = WASMBackend(binary_path=Path("/fake/cpython.wasm"))
+        with pytest.raises(UnsupportedOperation):
+            await backend.execute("x=1", session_key="k", env={"FOO": "bar"})
 
     async def test_execute_resolves_binary_via_download_when_path_is_none(self) -> None:
         expected = ExecutionResult(stdout="", stderr="")
         fake_path = Path("/downloaded/cpython.wasm")
 
-        backend = WASMBackend(binary_path=None, timeout=5)
+        backend = WASMBackend(binary_path=None)
         with patch(
             "phoenix.server.sandbox.wasm_backend._run_wasm",
             return_value=expected,
@@ -89,17 +96,10 @@ class TestWASMAdapter:
     def test_language(self) -> None:
         assert WASMAdapter.language == "PYTHON"
 
-    def test_build_backend_default_timeout(self) -> None:
+    def test_build_backend_returns_wasm_backend(self) -> None:
         adapter = WASMAdapter()
         backend = adapter.build_backend({})
         assert isinstance(backend, WASMBackend)
-        assert backend._timeout == 30
-
-    def test_build_backend_custom_timeout(self) -> None:
-        adapter = WASMAdapter()
-        backend = adapter.build_backend({"timeout": "60"})
-        assert isinstance(backend, WASMBackend)
-        assert backend._timeout == 60
 
     def test_build_backend_returns_sandbox_backend(self) -> None:
         from phoenix.server.sandbox.types import SandboxBackend


### PR DESCRIPTION
## Summary
- Add `ConfigFieldSpec` dataclass and `validate_config()` method to the `SandboxAdapter` ABC, enabling typed config metadata and opt-in validation per adapter
- Populate E2B adapter config fields (`template`, `cwd`, `metadata`) and wire them through `build_backend()` to the E2B SDK (`AsyncSandbox.create()` and `run_code()`)
- Expose per-adapter config schema via new `configFieldSpecs` field on the `SandboxBackendInfo` GraphQL type for dynamic frontend form rendering
- Add mutation-time config validation in `createSandboxConfig` and `updateSandboxConfig` — raises `BadRequest` on constraint violations
- Fix silent env var drops: WASM now raises `UnsupportedOperation` when env is non-empty; Daytona forwards env to `code_run()`
- Fix WASM timeout source: removed stale `config.get("timeout")` read from `build_backend()` — timeout flows via the DB column and `execute(timeout=...)` parameter

## Architecture
```
                          ┌─────────────────────┐
                          │  Settings UI         │
                          │  (frontend forms)    │
                          └──────────┬───────────┘
                                     │ GQL query: sandbox_backends
                                     ▼
                          ┌─────────────────────┐
                          │ SandboxBackendInfo   │
                          │ + config_field_specs │◄── NEW: exposes per-adapter schema
                          └──────────┬───────────┘
                                     │ GQL mutation: create/update_sandbox_config
                                     ▼
                          ┌─────────────────────┐
                          │ Mutation Layer       │
                          │ + validate_config()  │◄── NEW: calls adapter.validate_config()
                          └──────────┬───────────┘
                                     │ DB write
                                     ▼
    ┌──────────────┐     ┌─────────────────────┐
    │SandboxProvider│────►│ SandboxConfig       │
    │ .config (JSON)│     │ .config (JSON)      │
    │ (credentials) │     │ (runtime settings)  │
    └───────┬───────┘     └──────────┬──────────┘
            │                         │
            └────────┬────────────────┘
                     │ merge: {**provider.config, **config.config}
                     ▼
          ┌─────────────────────────┐
          │ get_or_create_backend() │
          └──────────┬──────────────┘
                     │ adapter.build_backend(merged_config)
                     ▼
    ┌────────────────────────────────────────────────────┐
    │              SandboxAdapter ABC                     │
    │  + config_field_specs: list[ConfigFieldSpec]  ◄─NEW│
    │  + validate_config(config) -> config          ◄─NEW│
    │  + build_backend(config) -> SandboxBackend         │
    └──┬─────────┬──────────┬──────────┬─────────┬──────┘
       │         │          │          │         │
    ┌──▼──┐  ┌──▼──┐  ┌───▼───┐  ┌──▼───┐  ┌─▼───┐
    │WASM │  │ E2B │  │Daytona│  │Vercel│  │Deno │
    └─────┘  └─────┘  └───────┘  └──────┘  └─────┘
```

## Implementation
- **ConfigFieldSpec** (`types.py`): stdlib-only dataclass with `key`, `display_name`, `field_type` (Literal), `required`, `description`, `choices`. Describes `SandboxConfig.config` keys only — not provider-level credentials.
- **Dual registration** (`__init__.py` + adapter classes): Config specs declared on both `AdapterMetadata` (static registry, authoritative for GQL — works for uninstalled backends) and adapter class (convenience for installed adapters).
- **validate_config()**: Default implementation validates required fields and select-choice constraints. Returns config unchanged (unknown keys preserved). Raises `ValueError` caught as `BadRequest` in mutations.
- **E2B wiring**: `cwd` forwarded to `run_code()`, `metadata` to `AsyncSandbox.create()`. Consolidated `_create_kwargs()` helper eliminates duplication between session and ephemeral paths.
- **Env fixes**: Preparatory — no caller currently passes env. Ensures correct behavior when env plumbing is wired by the secret-injection work item.

## Test plan
- [ ] Existing sandbox mutation tests pass (19 passed, 19 skipped/postgres)
- [ ] Existing sandbox query tests pass (2 passed, 2 skipped/postgres)
- [ ] `sandboxBackends` GQL query returns `configFieldSpecs` for E2B (3 fields) and empty for others
- [ ] `createSandboxConfig` with invalid select-choice value returns BadRequest
- [ ] WASM `execute()` with non-empty env raises `UnsupportedOperation`
- [ ] Daytona `execute()` forwards env to `code_run(envs=...)`