### PR TITLE
feat: use non-streaming for LLM evaluator calls

### DIFF
--- a/src/phoenix/server/api/evaluators.py
+++ b/src/phoenix/server/api/evaluators.py
@@ -354,6 +354,7 @@ class LLMEvaluator(BaseEvaluator):
                     tools=self._tools,
                     tracer=tracer_,
                     invocation_parameters=invocation_parameters,
+                    stream_model_output=False,
                 ):
                     if isinstance(chunk, ToolCallChunk):
                         if chunk.id not in tool_call_by_id:

--- a/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_builtin_evaluator_uses_name.yaml
+++ b/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_builtin_evaluator_uses_name.yaml
@@ -7,16 +7,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-test123","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-DQenaOE8L0g9sjGlwi6HwGsGALErZ","object":"chat.completion.chunk","created":1775245730,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-test123","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-DQenaOE8L0g9sjGlwi6HwGsGALErZ","object":"chat.completion.chunk","created":1775245730,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"huYHVqEzxTFu"}
 
 
-        data: {"id":"chatcmpl-test123","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+        data: {"id":"chatcmpl-DQenaOE8L0g9sjGlwi6HwGsGALErZ","object":"chat.completion.chunk","created":1775245730,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"RLqYLTMAzD6W"}
 
 
-        data: {"id":"chatcmpl-test123","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-DQenaOE8L0g9sjGlwi6HwGsGALErZ","object":"chat.completion.chunk","created":1775245730,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"UP"}
 
 
         data: [DONE]

--- a/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_evaluator_emits_evaluation_chunk_and_persists_annotation.yaml
+++ b/tests/unit/server/api/cassettes/test_subscriptions/TestChatCompletionOverDatasetSubscription.test_evaluator_emits_evaluation_chunk_and_persists_annotation.yaml
@@ -7,16 +7,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CoDjJc8wJmIZNB1DtquH1Z2sypsG7","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
+      string: 'data: {"id":"chatcmpl-DQeniezkYaBGWaP8dSic1mkKrTUVb","object":"chat.completion.chunk","created":1775245738,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CoDjJc8wJmIZNB1DtquH1Z2sypsG7","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"t6hGuJ9niiuK"}
+        data: {"id":"chatcmpl-DQeniezkYaBGWaP8dSic1mkKrTUVb","object":"chat.completion.chunk","created":1775245738,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"France"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"IbQPCFTYPjQo"}
 
 
-        data: {"id":"chatcmpl-CoDjJc8wJmIZNB1DtquH1Z2sypsG7","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"ZPbnKzvAta96"}
+        data: {"id":"chatcmpl-DQeniezkYaBGWaP8dSic1mkKrTUVb","object":"chat.completion.chunk","created":1775245738,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"OKE089cNUHiF"}
 
 
-        data: {"id":"chatcmpl-CoDjJc8wJmIZNB1DtquH1Z2sypsG7","object":"chat.completion.chunk","created":1766085213,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"Os"}
+        data: {"id":"chatcmpl-DQeniezkYaBGWaP8dSic1mkKrTUVb","object":"chat.completion.chunk","created":1775245738,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":21,"completion_tokens":1,"total_tokens":22,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"wG"}
 
 
         data: [DONE]
@@ -29,50 +29,30 @@ interactions:
       message: OK
 - request:
     body: '{"messages":[{"content":"You are an evaluator that assesses the correctness
-      of outputs.","role":"system"},{"content":"Input: {\"city\": \"Paris\"}\n\nOutput:
-      {\"task_output\": {\"messages\": [{\"role\": \"assistant\", \"content\": \"France\"}]}}\n\nIs
-      this output correct?","role":"user"}],"model":"gpt-4","stream":true,"stream_options":{"include_usage":true},"tools":[{"function":{"name":"correctness","description":"evaluates
-      the correctness of the output","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"}},"required":["label"]}},"type":"function"}]}'
+      of outputs.","role":"system"},{"content":"Input: {''city'': ''Paris''}\n\nOutput:
+      {''messages'': [{''role'': ''assistant'', ''content'': ''France''}], ''available_tools'':
+      []}\n\nIs this output correct?","role":"user"}],"model":"gpt-4","stream":false,"tool_choice":"required","tools":[{"type":"function","function":{"name":"correctness","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"}},"required":["label"]},"strict":null,"description":"evaluates
+      the correctness of the output"}}]}'
     headers: {}
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_aABUz9QoikDpYXHXhUkahsNF","type":"function","function":{"name":"correctness","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YW"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\n"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"t13n4"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"label"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"q"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"OX4Zf"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        \""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Kf0UZ"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"incorrect"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3f25JvmP9d9Wq3p"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"\n"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"p8HY"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jJPiBPB"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"sD3dsL"}
-
-
-        data: {"id":"chatcmpl-CoDjKsoAfzvBRP5btEnt9Vxx3B9AP","object":"chat.completion.chunk","created":1766085214,"model":"gpt-4-0613","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":103,"completion_tokens":14,"total_tokens":117,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"9SWgzWNln2F0Vrj"}
-
-
-        data: [DONE]
-
-
-        '
+      string: "{\n  \"id\": \"chatcmpl-DQenkImJhoauMjqwwwqLeZGXyTXmE\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775245740,\n  \"model\": \"gpt-4-0613\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
+        \           \"id\": \"call_4q0aw0YpXJlp7wsm38rZs30l\",\n            \"type\":
+        \"function\",\n            \"function\": {\n              \"name\": \"correctness\",\n
+        \             \"arguments\": \"{\\n\\\"label\\\": \\\"incorrect\\\"\\n}\"\n
+        \           }\n          }\n        ],\n        \"refusal\": null,\n        \"annotations\":
+        []\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n
+        \   }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 104,\n    \"completion_tokens\":
+        11,\n    \"total_tokens\": 115,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": null\n}\n"
     headers: {}
     status:
       code: 200

--- a/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_returns_correct_result.yaml
+++ b/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_returns_correct_result.yaml
@@ -2,105 +2,30 @@ interactions:
 - request:
     body: '{"messages":[{"content":"You are an evaluator. Assess whether the output
       correctly answers the input question.","role":"system"},{"content":"Input: What
-      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true},"temperature":0.0,"tool_choice":"required","tools":[{"function":{"name":"correctness","description":"Evaluates
-      the correctness of the output","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
-      explanation for the label"}},"required":["label","explanation"]}},"type":"function"}]}'
+      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":false,"temperature":0.0,"tool_choice":"required","tools":[{"type":"function","function":{"name":"correctness","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
+      explanation for the label"}},"required":["label","explanation"]},"strict":null,"description":"Evaluates
+      the correctness of the output"}}]}'
     headers: {}
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_tzE69nmyBDC4IcCBdusBeAbo","type":"function","function":{"name":"correctness","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6FBf8cMd7m"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KVA5IBtuXQfClM"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"label"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"gEN2g83zHORm"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rwvacUwA76Zl"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"correct"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Qt2B9D35kw"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pzEcL4j5V8QO"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ex"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"wBk84Vagmc2oxBS"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"planation"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"wrXWpFao"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YoddUFm6ccrb"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"The"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6pVJzVGrWdPu3N"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        output"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uXwpZeAlpH"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        correctly"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pDxmLQz"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        states"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5u2Fqtq4Mw"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        that"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pHRzK7F2vtiZ"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"2"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        +"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jMA1PMNGbK4RRNi"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"2"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        equals"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"t34zeZSBq9"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"4"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9CHG4IlawxI8V4"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"yjdoIAlb7i4t4nC"}
-
-
-        data: {"id":"chatcmpl-CyiuD2P4T82YTrmHFAqGnHtonI99q","object":"chat.completion.chunk","created":1768588333,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":34,"total_tokens":134,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"Q20aYsmf"}
-
-
-        data: [DONE]
-
-
-        '
+      string: "{\n  \"id\": \"chatcmpl-DQeuwqU8iYEn0jmW2dXui8MlYo5sn\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775246186,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
+        \           \"id\": \"call_yUjsmpi4tVtBJrk9lDCaeHXm\",\n            \"type\":
+        \"function\",\n            \"function\": {\n              \"name\": \"correctness\",\n
+        \             \"arguments\": \"{\\\"label\\\":\\\"correct\\\",\\\"explanation\\\":\\\"The
+        output correctly states that 2 + 2 equals 4.\\\"}\"\n            }\n          }\n
+        \       ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
+        \     \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n
+        \ ],\n  \"usage\": {\n    \"prompt_tokens\": 98,\n    \"completion_tokens\":
+        32,\n    \"total_tokens\": 130,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_ebf4e532f9\"\n}\n"
     headers: {}
     status:
       code: 200

--- a/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_with_invalid_api_key_returns_error.yaml
+++ b/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_with_invalid_api_key_returns_error.yaml
@@ -2,9 +2,9 @@ interactions:
 - request:
     body: '{"messages":[{"content":"You are an evaluator. Assess whether the output
       correctly answers the input question.","role":"system"},{"content":"Input: What
-      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true},"temperature":0.0,"tool_choice":"required","tools":[{"function":{"name":"correctness","description":"Evaluates
-      the correctness of the output","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
-      explanation for the label"}},"required":["label","explanation"]}},"type":"function"}]}'
+      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":false,"temperature":0.0,"tool_choice":"required","tools":[{"type":"function","function":{"name":"correctness","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
+      explanation for the label"}},"required":["label","explanation"]},"strict":null,"description":"Evaluates
+      the correctness of the output"}}]}'
     headers: {}
     method: POST
     uri: https://api.openai.com/v1/chat/completions

--- a/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_with_multipart_template.yaml
+++ b/tests/unit/server/api/helpers/cassettes/test_evaluators/TestLLMEvaluator.test_evaluate_with_multipart_template.yaml
@@ -2,105 +2,30 @@ interactions:
 - request:
     body: '{"messages":[{"content":"You are an evaluator. Assess whether the output
       correctly answers the input question.","role":"system"},{"content":"Input: What
-      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true},"temperature":0.0,"tool_choice":"required","tools":[{"function":{"name":"correctness","description":"Evaluates
-      the correctness of the output","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
-      explanation for the label"}},"required":["label","explanation"]}},"type":"function"}]}'
+      is 2 + 2?\n\nOutput: 4\n\nIs this output correct?","role":"user"}],"model":"gpt-4o-mini","stream":false,"temperature":0.0,"tool_choice":"required","tools":[{"type":"function","function":{"name":"correctness","parameters":{"type":"object","properties":{"label":{"type":"string","enum":["correct","incorrect"],"description":"correctness"},"explanation":{"type":"string","description":"Brief
+      explanation for the label"}},"required":["label","explanation"]},"strict":null,"description":"Evaluates
+      the correctness of the output"}}]}'
     headers: {}
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_iA6tkogq8ARzjB0U5YmBF2pX","type":"function","function":{"name":"correctness","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"EnP7rC9TPK"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mp9L8iqlFahpne"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"label"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3TshbJdp0ykq"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LVMfzVtZpKZU"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"correct"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"F8EzIGCKqx"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"cs6nJ10TsqDV"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ex"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZZV0MCWB8KISjUN"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"planation"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pU4Gh9p2"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"F2OJmaNezg0q"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"The"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"35LniPaQmA5Znp"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        output"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YDbhowKdr0"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        correctly"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PEm4sIE"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        states"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ksMgsGWqNM"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        that"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"f7AtyhDKSk9I"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"2"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        +"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"La4fnGttzTIgLbt"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"2"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        equals"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0CXofBSqz7"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        "}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"4"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":".\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BxSwAqTdYkj5u1"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"Lx3Zxe6KBYt4m3u"}
-
-
-        data: {"id":"chatcmpl-D2heglN0OwGnLQCUpdhvuSSaEp6ZG","object":"chat.completion.chunk","created":1769536838,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_29330a9688","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":34,"total_tokens":134,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"VP0Yasll"}
-
-
-        data: [DONE]
-
-
-        '
+      string: "{\n  \"id\": \"chatcmpl-DQeuxTymJCEuyiHxVY8ek4j3u2Pnt\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1775246187,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": null,\n        \"tool_calls\": [\n          {\n
+        \           \"id\": \"call_4uSe3KAiqGrrSqcUOZ4PzK37\",\n            \"type\":
+        \"function\",\n            \"function\": {\n              \"name\": \"correctness\",\n
+        \             \"arguments\": \"{\\\"label\\\":\\\"correct\\\",\\\"explanation\\\":\\\"The
+        output correctly states that 2 + 2 equals 4.\\\"}\"\n            }\n          }\n
+        \       ],\n        \"refusal\": null,\n        \"annotations\": []\n      },\n
+        \     \"logprobs\": null,\n      \"finish_reason\": \"tool_calls\"\n    }\n
+        \ ],\n  \"usage\": {\n    \"prompt_tokens\": 98,\n    \"completion_tokens\":
+        32,\n    \"total_tokens\": 130,\n    \"prompt_tokens_details\": {\n      \"cached_tokens\":
+        0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_ebf4e532f9\"\n}\n"
     headers: {}
     status:
       code: 200

--- a/tests/unit/server/api/helpers/test_evaluators.py
+++ b/tests/unit/server/api/helpers/test_evaluators.py
@@ -3157,27 +3157,35 @@ class TestLLMEvaluator:
         output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
-        text_response_body = (
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":""},'
-            '"finish_reason":null}],"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"I cannot evaluate this."},'
-            '"finish_reason":null}],"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],'
-            '"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,'
-            '"total_tokens":15}}\n\n'
-            "data: [DONE]\n\n"
+        text_response_body = json.dumps(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "I cannot evaluate this.",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }
         )
         with respx.mock:
             respx.post("https://api.openai.com/v1/chat/completions").mock(
                 return_value=httpx.Response(
                     200,
                     content=text_response_body,
-                    headers={"content-type": "text/event-stream"},
+                    headers={"content-type": "application/json"},
                 )
             )
             evaluation_results = await llm_evaluator.evaluate(
@@ -3328,30 +3336,45 @@ class TestLLMEvaluator:
         output_config: CategoricalOutputConfig,
         input_mapping: EvaluatorInputMappingInput,
     ) -> None:
-        tool_call_response_body = (
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":null,'
-            '"tool_calls":[{"index":0,"id":"call_abc123","type":"function",'
-            '"function":{"name":"correctness","arguments":""}}],"refusal":null},'
-            '"logprobs":null,"finish_reason":null}],"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,'
-            '"function":{"arguments":"{\\"explanation\\": \\"The output is correct.\\"}"}}]},'
-            '"logprobs":null,"finish_reason":null}],"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},'
-            '"finish_reason":"tool_calls"}],"usage":null}\n\n'
-            'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1700000000,'
-            '"model":"gpt-4o-mini","choices":[],"usage":{"prompt_tokens":10,'
-            '"completion_tokens":20,"total_tokens":30}}\n\n'
-            "data: [DONE]\n\n"
+        tool_call_response_body = json.dumps(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1700000000,
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_abc123",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "correctness",
+                                        "arguments": '{"explanation": "The output is correct."}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+            }
         )
         with respx.mock:
             respx.post("https://api.openai.com/v1/chat/completions").mock(
                 return_value=httpx.Response(
                     200,
                     content=tool_call_response_body,
-                    headers={"content-type": "text/event-stream"},
+                    headers={"content-type": "application/json"},
                 )
             )
             evaluation_results = await llm_evaluator.evaluate(

--- a/tests/unit/server/api/test_subscriptions.py
+++ b/tests/unit/server/api/test_subscriptions.py
@@ -2200,7 +2200,7 @@ class TestChatCompletionOverDatasetSubscription:
             assert not message
             assert len(tool_calls) == 1
             tool_call = tool_calls[0]
-            assert tool_call.pop("id") == "call_aABUz9QoikDpYXHXhUkahsNF"
+            assert tool_call.pop("id").startswith("call_")
             function = tool_call.pop("function")
             assert not tool_call
             assert function.pop("name") == "correctness"


### PR DESCRIPTION
Switch evaluator LLM calls to non-streaming so the full vendor response is captured as output.value on the span (via _raw_output_value). This preserves the complete response including usage details, stop reason, and other fields that chunk-based reconstruction drops.

Evaluators don't need streaming — they run silently and only extract tool call results from the response.