### PR TITLE
chore: fix internal skill visibility in SKILL.md frontmatter

### DIFF
--- a/.agents/skills/phoenix-frontend/SKILL.md
+++ b/.agents/skills/phoenix-frontend/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: phoenix-frontend
 description: Frontend development guidelines for the Phoenix AI observability platform. Use when writing, reviewing, or modifying React components, TypeScript code, styles, or UI features in the app/ directory. Triggers on any frontend task — new components, UI changes, styling, accessibility fixes, form handling, or component refactoring. Also use when the user asks about frontend conventions or component patterns for this project. For design system rules (error display, layout, dialogs, tokens), use the phoenix-design skill.
-internal: true
+metadata:
+  internal: true
 ---
 
 # Phoenix Frontend Development

--- a/.agents/skills/phoenix-llms-txt/SKILL.md
+++ b/.agents/skills/phoenix-llms-txt/SKILL.md
@@ -5,7 +5,8 @@ description: >
   machine-readable docs map used by AI agents and the `px docs fetch` CLI. Use this
   skill whenever adding, auditing, or reorganizing llms.txt entries. Trigger when the
   user mentions llms.txt, docs index, px docs, or LLM-friendly documentation.
-internal: true
+metadata:
+  internal: true
 ---
 
 # Phoenix llms.txt Maintenance

--- a/.agents/skills/phoenix-pr-screenshot/SKILL.md
+++ b/.agents/skills/phoenix-pr-screenshot/SKILL.md
@@ -2,7 +2,8 @@
 name: phoenix-pr-screenshot
 description: Screenshot a running Phoenix feature and attach images to a GitHub PR. Builds the frontend, starts Phoenix with env vars, uses agent-browser to capture screenshots, uploads to GCS, and updates the PR body.
 user-invocable: true
-internal: true
+metadata:
+  internal: true
 ---
 
 # Phoenix PR Screenshot

--- a/.agents/skills/phoenix-release-notes/SKILL.md
+++ b/.agents/skills/phoenix-release-notes/SKILL.md
@@ -5,7 +5,8 @@ description: >
   user asks to write release notes, document a release, update release documentation, or mentions
   undocumented releases. Also trigger when the user wants to update GitHub release descriptions,
   add entries to the release notes page, or asks what changed in a recent Phoenix version.
-internal: true
+metadata:
+  internal: true
 ---
 
 # Release Notes

--- a/.agents/skills/phoenix-typescript/SKILL.md
+++ b/.agents/skills/phoenix-typescript/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: phoenix-typescript
 description: TypeScript conventions and patterns for any TypeScript code in the Phoenix monorepo — including js/packages/, app/, and any other TS directories. Use this skill whenever writing, reviewing, or modifying TypeScript code — new functions, types, exports, tests, or refactors. Also trigger when the user asks about TS patterns, naming conventions, or best practices for this project.
-internal: true
+metadata:
+  internal: true
 ---
 
 # Phoenix TypeScript Conventions


### PR DESCRIPTION
## Summary
- Five skills (`phoenix-frontend`, `phoenix-llms-txt`, `phoenix-pr-screenshot`, `phoenix-release-notes`, `phoenix-typescript`) were using top-level `internal: true` in their SKILL.md frontmatter, which the skills tooling doesn't recognize
- Moved `internal: true` under `metadata:` to match the pattern used by other correctly hidden skills (e.g. `phoenix-server`, `phoenix-design`, `phoenix-github`)
- This fixes `npx skills add Arize-ai/phoenix` showing internal skills to external users

## Test plan
- [ ] Run `npx skills add Arize-ai/phoenix` and verify only `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing` are listed