### PR TITLE
chore: update phoenix-cli skill to v3.0.0

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: phoenix-cli
-description: Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, and query the GraphQL API. Use when debugging AI/LLM applications, analyzing trace data, working with Phoenix observability, or investigating LLM performance issues.
+description: Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, query annotation configs, and use the GraphQL API. Use when debugging AI/LLM applications, analyzing trace data, working with Phoenix observability, investigating LLM performance issues, or checking Phoenix auth status.
 license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
   author: arize-ai
-  version: "2.0.0"
+  version: "3.0.0"
 ---
 
 # Phoenix CLI
@@ -25,6 +25,9 @@ px trace get <trace-id>
 px span list
 px dataset list
 px dataset get <name>
+px project list
+px annotation-config list
+px auth status
 ```
 
 ## Setup
@@ -37,14 +40,50 @@ export PHOENIX_API_KEY=your-api-key  # if auth is enabled
 
 Always use `--format raw --no-progress` when piping to `jq`.
 
+## Auth
+
+```bash
+px auth status                                # check connection and authentication
+px auth status --endpoint http://other:6006   # check a specific endpoint
+```
+
+## Projects
+
+```bash
+px project list                                            # list all projects (table view)
+px project list --format raw --no-progress | jq '.[].name' # project names as JSON
+```
+
 ## Traces
 
 ```bash
 px trace list --limit 20 --format raw --no-progress | jq .
 px trace list --last-n-minutes 60 --limit 20 --format raw --no-progress | jq '.[] | select(.status == "ERROR")'
+px trace list --since 2025-01-15T00:00:00Z --limit 50 --format raw --no-progress | jq .
 px trace list --format raw --no-progress | jq 'sort_by(-.duration) | .[0:5]'
 px trace get <trace-id> --format raw | jq .
 px trace get <trace-id> --format raw | jq '.spans[] | select(.status_code != "OK")'
+```
+
+### Trace JSON shape
+
+```
+Trace
+  traceId, status ("OK"|"ERROR"), duration (ms), startTime, endTime
+  rootSpan  — top-level span (parent_id: null)
+  spans[]
+    name, span_kind ("LLM"|"CHAIN"|"TOOL"|"RETRIEVER"|"EMBEDDING"|"AGENT"|"RERANKER"|"GUARDRAIL"|"EVALUATOR"|"UNKNOWN")
+    status_code ("OK"|"ERROR"|"UNSET"), parent_id, context.span_id
+    attributes
+      input.value, output.value          — raw input/output
+      llm.model_name, llm.provider
+      llm.token_count.prompt/completion/total
+      llm.token_count.prompt_details.cache_read
+      llm.token_count.completion_details.reasoning
+      llm.input_messages.{N}.message.role/content
+      llm.output_messages.{N}.message.role/content
+      llm.invocation_parameters          — JSON string (temperature, etc.)
+      exception.message                  — set if span errored
 ```
 
 ## Spans
@@ -52,10 +91,13 @@ px trace get <trace-id> --format raw | jq '.spans[] | select(.status_code != "OK
 ```bash
 px span list --limit 20                                    # recent spans (table view)
 px span list --last-n-minutes 60 --limit 50                # spans from last hour
+px span list --since 2025-01-15T00:00:00Z --limit 50       # spans since a timestamp
 px span list --span-kind LLM --limit 10                    # only LLM spans
 px span list --status-code ERROR --limit 20                # only errored spans
 px span list --name chat_completion --limit 10             # filter by span name
 px span list --trace-id <id> --format raw --no-progress | jq .   # all spans for a trace
+px span list --parent-id null --limit 10                   # only root spans
+px span list --parent-id <span-id> --limit 10              # only children of a span
 px span list --include-annotations --limit 10              # include annotation scores
 px span list output.json --limit 100                       # save to JSON file
 px span list --format raw --no-progress | jq '.[] | select(.status_code == "ERROR")'
@@ -69,30 +111,16 @@ Span
   status_code ("OK"|"ERROR"|"UNSET"), status_message
   context.span_id, context.trace_id, parent_id
   start_time, end_time
-  attributes (same as trace span attributes above)
+  attributes
+    input.value, output.value          — raw input/output
+    llm.model_name, llm.provider
+    llm.token_count.prompt/completion/total
+    llm.input_messages.{N}.message.role/content
+    llm.output_messages.{N}.message.role/content
+    llm.invocation_parameters          — JSON string (temperature, etc.)
+    exception.message                  — set if span errored
   annotations[] (with --include-annotations)
     name, result { score, label, explanation }
-```
-
-### Trace JSON shape
-
-```
-Trace
-  traceId, status ("OK"|"ERROR"), duration (ms), startTime, endTime
-  rootSpan  — top-level span (parent_id: null)
-  spans[]
-    name, span_kind ("LLM"|"CHAIN"|"TOOL"|"RETRIEVER"|"EMBEDDING"|"AGENT")
-    status_code ("OK"|"ERROR"), parent_id, context.span_id
-    attributes
-      input.value, output.value          — raw input/output
-      llm.model_name, llm.provider
-      llm.token_count.prompt/completion/total
-      llm.token_count.prompt_details.cache_read
-      llm.token_count.completion_details.reasoning
-      llm.input_messages.{N}.message.role/content
-      llm.output_messages.{N}.message.role/content
-      llm.invocation_parameters          — JSON string (temperature, etc.)
-      exception.message                  — set if span errored
 ```
 
 ## Sessions
@@ -124,10 +152,19 @@ SessionAnnotation (with --include-annotations)
 ```bash
 px dataset list --format raw --no-progress | jq '.[].name'
 px dataset get <name> --format raw | jq '.examples[] | {input, output: .expected_output}'
+px dataset get <name> --split train --format raw | jq .    # filter by split
+px dataset get <name> --version <version-id> --format raw | jq .
 px experiment list --dataset <name> --format raw --no-progress | jq '.[] | {id, name, failed_run_count}'
 px experiment get <id> --format raw --no-progress | jq '.[] | select(.error != null) | {input, error}'
 px prompt list --format raw --no-progress | jq '.[].name'
 px prompt get <name> --format text --no-progress   # plain text, ideal for piping to AI
+```
+
+## Annotation Configs
+
+```bash
+px annotation-config list                                           # list all configs (table view)
+px annotation-config list --format raw --no-progress | jq '.[].name' # config names as JSON
 ```
 
 ## GraphQL


### PR DESCRIPTION
## Summary
- Add missing commands: `px auth status`, `px project list`, `px annotation-config list`
- Add missing options: `--since`, `--parent-id` (spans), `--split`/`--version` (datasets)
- Fix JSON shape ordering so Span attributes are defined inline instead of referencing a section below
- Expand `span_kind` coverage to include RERANKER, GUARDRAIL, EVALUATOR, UNKNOWN

## Test plan
- [x] Benchmarked with 3 eval prompts (error investigation, experiment comparison, new instance setup)
- [x] With-skill: 100% pass rate across 15 assertions
- [x] Without-skill baseline: 53% pass rate — model hallucinates command names without guidance
- [x] Skill reduces token usage by 44% and wall time by 43% vs baseline