### PR TITLE
docs: Add Secrets endpoint to REST API reference docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -935,6 +935,12 @@
                     ]
                   },
                   {
+                    "group": "Secrets",
+                    "pages": [
+                      "docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets"
+                    ]
+                  },
+                  {
                     "group": "Users",
                     "pages": [
                       "docs/phoenix/sdk-api-reference/rest-api/api-reference/users/list-all-users",

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference.mdx
@@ -19,5 +19,6 @@ All endpoints in this section are relative to your Phoenix base URL and are vers
   <Card title="Prompts" href="/docs/phoenix/sdk-api-reference/rest-api/api-reference/prompts" icon="file-code" horizontal description="Prompt endpoints"/>
   <Card title="Projects" href="/docs/phoenix/sdk-api-reference/rest-api/api-reference/projects" icon="folder" horizontal description="Project endpoints"/>
   <Card title="Sessions" href="/docs/phoenix/sdk-api-reference/rest-api/api-reference/sessions" icon="messages" horizontal description="Session endpoints"/>
+  <Card title="Secrets" href="/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets" icon="key" horizontal description="Secret management endpoints"/>
   <Card title="Users" href="/docs/phoenix/sdk-api-reference/rest-api/api-reference/users" icon="users" horizontal description="User endpoints"/>
 </CardGroup>

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets.mdx
@@ -1,0 +1,4 @@
+---
+title: "Secrets"
+sidebarTitle: "Overview"
+---

--- a/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets.mdx
+++ b/docs/phoenix/sdk-api-reference/rest-api/api-reference/secrets/upsert-or-delete-secrets.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v1/secrets
+---


### PR DESCRIPTION
The PUT /v1/secrets endpoint was added in PR #12429 but was only
documented in release notes and the OpenAPI spec. This adds it to the
user-facing REST API reference alongside the other resource types.

https://claude.ai/code/session_01GMtG8XYT4a69AsqyU4L7Bg