### PR TITLE
docs: Fix broken skill links in coding-agents docs

### DIFF
--- a/docs/phoenix/integrations/developer-tools/coding-agents.mdx
+++ b/docs/phoenix/integrations/developer-tools/coding-agents.mdx
@@ -177,13 +177,13 @@ This installs skills into the project's agent directory (for example, `.claude/s
 ### Available Skills
 
 <CardGroup cols={3}>
-  <Card title="phoenix-cli" href="https://github.com/Arize-ai/phoenix/blob/main/skills/phoenix-cli/SKILL.md">
+  <Card title="phoenix-cli" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-cli/SKILL.md">
     Debug LLM apps using Phoenix CLI for traces, experiments, datasets, and prompts. Recommended.
   </Card>
-  <Card title="phoenix-evals" href="https://github.com/Arize-ai/phoenix/blob/main/skills/phoenix-evals/SKILL.md">
+  <Card title="phoenix-evals" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-evals/SKILL.md">
     Build and run evaluators for AI/LLM apps across code-based and LLM-as-judge workflows.
   </Card>
-  <Card title="phoenix-tracing" href="https://github.com/Arize-ai/phoenix/blob/main/skills/phoenix-tracing/SKILL.md">
+  <Card title="phoenix-tracing" href="https://github.com/Arize-ai/phoenix/blob/main/.agents/skills/phoenix-tracing/SKILL.md">
     Implement OpenInference tracing conventions and instrumentation in Python and TypeScript.
   </Card>
 </CardGroup>


### PR DESCRIPTION
The skill files are located in .agents/skills/, not skills/.

https://claude.ai/code/session_01GpkvRkgaYMzhEaGzC6Sd7R