### PR TITLE
fix(agent): Remove empty INDEX.json skeleton files from PXI virtual filesystem

### DIFF
--- a/app/src/agent/tools/bash/context/filesystem/generatePageContextFiles.ts
+++ b/app/src/agent/tools/bash/context/filesystem/generatePageContextFiles.ts
@@ -2,7 +2,6 @@ import type { InitialFiles } from "just-bash";
 
 import { createManifestFile } from "@phoenix/agent/tools/bash/context/filesystem/manifest";
 import {
-  getPhoenixTopLevelIndexPaths,
   PHOENIX_META_ROOT,
   PHOENIX_ROOT,
 } from "@phoenix/agent/tools/bash/context/filesystem/pathConstants";
@@ -20,18 +19,6 @@ const PAGE_CONTEXT_MANIFEST_FRAGMENT =
 
 function createJsonFile(payload: unknown) {
   return JSON.stringify(payload, null, 2);
-}
-
-function createTopLevelSkeletonFiles() {
-  return Object.fromEntries(
-    getPhoenixTopLevelIndexPaths().map((filePath) => [
-      filePath,
-      createJsonFile({
-        path: filePath.replace(/\/INDEX\.json$/, ""),
-        entries: [],
-      }),
-    ])
-  );
 }
 
 function createMetadata({
@@ -85,7 +72,6 @@ export async function generatePageContextFiles({
 
   return {
     files: {
-      ...createTopLevelSkeletonFiles(),
       ...fileContents,
       [`${PHOENIX_META_ROOT}/context.json`]: createJsonFile(metadata),
       [`${PHOENIX_ROOT}/MANIFEST.md`]: createManifestFile({

--- a/app/src/agent/tools/bash/context/filesystem/pathConstants.ts
+++ b/app/src/agent/tools/bash/context/filesystem/pathConstants.ts
@@ -2,32 +2,3 @@ import { BASH_TOOL_READONLY_ROOT } from "@phoenix/agent/tools/bash/bashToolFiles
 
 export const PHOENIX_ROOT = BASH_TOOL_READONLY_ROOT;
 export const PHOENIX_META_ROOT = `${PHOENIX_ROOT}/_meta`;
-export const PHOENIX_PROJECTS_ROOT = `${PHOENIX_ROOT}/projects`;
-export const PHOENIX_TRACES_ROOT = `${PHOENIX_ROOT}/traces`;
-export const PHOENIX_DATASETS_ROOT = `${PHOENIX_ROOT}/datasets`;
-export const PHOENIX_EXPERIMENTS_ROOT = `${PHOENIX_ROOT}/experiments`;
-export const PHOENIX_PROMPTS_ROOT = `${PHOENIX_ROOT}/prompts`;
-export const PHOENIX_EVALUATORS_ROOT = `${PHOENIX_ROOT}/evaluators`;
-
-export function getPhoenixProjectRoot(projectId: string) {
-  return `${PHOENIX_PROJECTS_ROOT}/${projectId}`;
-}
-
-export function getPhoenixTraceRoot(traceId: string) {
-  return `${PHOENIX_TRACES_ROOT}/${traceId}`;
-}
-
-export function getPhoenixTablesRoot(entityRoot: string) {
-  return `${entityRoot}/tables`;
-}
-
-export function getPhoenixTopLevelIndexPaths() {
-  return [
-    `${PHOENIX_PROJECTS_ROOT}/INDEX.json`,
-    `${PHOENIX_TRACES_ROOT}/INDEX.json`,
-    `${PHOENIX_DATASETS_ROOT}/INDEX.json`,
-    `${PHOENIX_EXPERIMENTS_ROOT}/INDEX.json`,
-    `${PHOENIX_PROMPTS_ROOT}/INDEX.json`,
-    `${PHOENIX_EVALUATORS_ROOT}/INDEX.json`,
-  ] as const;
-}


### PR DESCRIPTION
## Summary

Aspirational dead code that probably isn't going to actually be used, should have been deleted / not pushed in the first place. Just leads to agent confusion.

- Removes the 6 empty `INDEX.json` skeleton files (`projects`, `traces`, `datasets`, `experiments`, `prompts`, `evaluators`) from the PXI agent's virtual filesystem
- Removes the associated unused path constants and helper functions from `pathConstants.ts`

## Motivation

These files contained only `{ "path": "...", "entries": [] }` — empty objects with no entries that provide zero information to the agent. Their presence in the virtual filesystem:

1. **Misleads the agent** into thinking it can enumerate entities by reading the index, wasting tool calls on dead-end exploration
2. **Adds noise** to `MANIFEST.md` and `ls /phoenix` output
3. **Implies a convention** (index-based entity discovery) that doesn't actually work

The agent already has GraphQL schema introspection and `phoenix-gql` to discover entities — these skeletons are redundant.