### PR TITLE
feat(experiments): structured error details and sanitized messages

### DIFF
--- a/app/src/pages/experiments/ExperimentDetailsDialog.tsx
+++ b/app/src/pages/experiments/ExperimentDetailsDialog.tsx
@@ -1,4 +1,11 @@
 import { css } from "@emotion/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { formatDistance } from "date-fns";
 import {
   startTransition,
   Suspense,
@@ -7,15 +14,12 @@ import {
   useRef,
   useState,
 } from "react";
-import type { Key } from "react-aria-components";
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import type { PanelImperativeHandle } from "react-resizable-panels";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useParams } from "react-router";
 
 import {
-  Badge,
-  Button,
   Dialog,
   DialogCloseButton,
   DialogContent,
@@ -33,15 +37,18 @@ import {
   View,
 } from "@phoenix/components";
 import { JSONBlock } from "@phoenix/components/code";
-import { LoadMoreButton } from "@phoenix/components/core/LoadMoreButton";
+import { CopyToClipboardButton } from "@phoenix/components/core/copy";
 import { Skeleton } from "@phoenix/components/core/loading";
+import { LoadMoreButton } from "@phoenix/components/core/LoadMoreButton";
 import {
   ExperimentStatus,
   SequenceNumberToken,
 } from "@phoenix/components/experiment";
 import { resizeHandleCSS } from "@phoenix/components/resize";
+import { tableCSS } from "@phoenix/components/table/styles";
 import { LatencyText } from "@phoenix/components/trace/LatencyText";
 import { UserPicture } from "@phoenix/components/user/UserPicture";
+import { useViewer } from "@phoenix/contexts";
 import { useTimeFormatters } from "@phoenix/hooks";
 import {
   formatCost,
@@ -50,10 +57,13 @@ import {
 } from "@phoenix/utils/numberFormatUtils";
 
 import type {
+  ExperimentDetailsDialog_jobErrors$data,
+  ExperimentDetailsDialog_jobErrors$key,
+} from "./__generated__/ExperimentDetailsDialog_jobErrors.graphql";
+import type {
   ExperimentDetailsDialogQuery,
   ExperimentDetailsDialogQuery$data,
 } from "./__generated__/ExperimentDetailsDialogQuery.graphql";
-import type { ExperimentDetailsDialog_jobErrors$key } from "./__generated__/ExperimentDetailsDialog_jobErrors.graphql";
 
 function ExperimentDetailsDialogSkeleton() {
   return (
@@ -92,16 +102,10 @@ export function ExperimentDetailsDialog({
   );
 }
 
-const stackTraceCSS = css`
-  padding: var(--ac-global-dimension-size-100);
-  overflow-x: auto;
-  font-size: 12px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-  word-break: break-all;
-  margin: 0;
-  background: var(--ac-global-color-grey-100);
-  border-radius: var(--ac-global-rounding-small);
+const errorMessageCellCSS = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const detailRowCSS = css`
@@ -209,9 +213,7 @@ function ExperimentOverviewSection({
               <Text weight="heavy" size="S" color="text-700">
                 Metadata
               </Text>
-              <JSONBlock
-                value={JSON.stringify(experiment.metadata, null, 2)}
-              />
+              <JSONBlock value={JSON.stringify(experiment.metadata, null, 2)} />
             </View>
           )}
         </View>
@@ -283,10 +285,10 @@ function ExperimentTaskConfigSection({
         ) : (
           <View padding="size-200">
             <Text size="S" color="text-700">
-              This experiment was run via the SDK or API using custom code,
-              so task configuration details (model, prompt template,
-              parameters) are not stored with the experiment. To capture
-              these details, run experiments from the Playground.
+              This experiment was run via the SDK or API using custom code, so
+              task configuration details (model, prompt template, parameters)
+              are not stored with the experiment. To capture these details, run
+              experiments from the Playground.
             </Text>
           </View>
         )}
@@ -342,10 +344,7 @@ function ExperimentDetailsWithErrors({
               experiment={experiment}
               fullTimeFormatter={fullTimeFormatter}
             />
-            <ExperimentTaskConfigSection
-              taskConfig={taskConfig}
-              job={job}
-            />
+            <ExperimentTaskConfigSection taskConfig={taskConfig} job={job} />
           </DisclosureGroup>
         </div>
       </Panel>
@@ -359,13 +358,127 @@ function ExperimentDetailsWithErrors({
   );
 }
 
-function ErrorCategoryBadge({ category }: { category: string }) {
+/**
+ * Map raw error category to a human-readable level label.
+ */
+function categoryToLevel(category: string): string {
+  switch (category) {
+    case "EXPERIMENT":
+      return "Experiment";
+    case "TASK":
+      return "Task";
+    case "EVAL":
+      return "Eval";
+    default:
+      return category;
+  }
+}
+
+type ErrorNode =
+  ExperimentDetailsDialog_jobErrors$data["errors"]["edges"][number]["node"];
+
+type ErrorRow = {
+  id: string;
+  occurredAt: string;
+  occurredAtRaw: string;
+  category: string;
+  message: string;
+  detail: ErrorNode["detail"];
+};
+
+function formatWorkItem(detail: ErrorRow["detail"]): string | null {
+  if (!detail || detail.__typename === "%other") return null;
+  const workItem = detail.workItem;
+  if (!workItem || workItem.__typename === "%other") return null;
+  if (workItem.__typename === "TaskWorkItemId") {
+    return `Example ${workItem.datasetExampleId}, Rep ${workItem.repetitionNumber}`;
+  }
+  if (workItem.__typename === "EvalWorkItemId") {
+    return `Run ${workItem.experimentRunId}, Evaluator ${workItem.datasetEvaluatorId}`;
+  }
+  return null;
+}
+
+function formatDetailMessage(detail: ErrorRow["detail"]): string | null {
+  if (!detail || detail.__typename === "%other") return null;
+  if (detail.__typename === "RetriesExhaustedDetail") {
+    return `${detail.reason} (after ${detail.retryCount} retries)`;
+  }
+  if (detail.__typename === "FailureDetail") {
+    return detail.errorType;
+  }
+  return null;
+}
+
+function ErrorMessageCell({ row }: { row: ErrorRow }) {
+  const { viewer } = useViewer();
+  const isAdmin = !viewer || viewer.role.name === "ADMIN";
+  const detailMsg = formatDetailMessage(row.detail);
+  const displayText = detailMsg ?? row.message;
   return (
-    <Badge size="S" variant="danger">
-      {category}
-    </Badge>
+    <Flex
+      direction="row"
+      gap="size-50"
+      alignItems="center"
+      justifyContent="space-between"
+      css={css`
+        min-width: 0;
+      `}
+    >
+      <span title={row.message} css={errorMessageCellCSS}>
+        {displayText}
+      </span>
+      {isAdmin && (
+        <CopyToClipboardButton
+          text={row.message}
+          size="S"
+          tooltipText="Copy full message"
+        />
+      )}
+    </Flex>
   );
 }
+
+const ERROR_COL_LEVEL_WIDTH = 150;
+const ERROR_COL_TIME_WIDTH = 150;
+const ERROR_COL_WORK_ITEM_WIDTH = 250;
+
+const errorColumns: ColumnDef<ErrorRow>[] = [
+  {
+    header: "level",
+    accessorKey: "category",
+    cell: ({ row }) => (
+      <Text size="S" color="text-700">
+        {categoryToLevel(row.original.category)}
+      </Text>
+    ),
+  },
+  {
+    header: "time",
+    id: "occurredAt",
+    cell: ({ row }) => (
+      <Text size="S" title={row.original.occurredAt}>
+        {formatDistance(new Date(row.original.occurredAtRaw), new Date(), {
+          addSuffix: true,
+        })}
+      </Text>
+    ),
+  },
+  {
+    header: "work item",
+    id: "workItem",
+    cell: ({ row }) => (
+      <Text size="S" color="text-700">
+        {formatWorkItem(row.original.detail) ?? "—"}
+      </Text>
+    ),
+  },
+  {
+    header: "error",
+    id: "error",
+    cell: ({ row }) => <ErrorMessageCell row={row.original} />,
+  },
+];
 
 function JobErrorsSection({
   jobRef,
@@ -390,14 +503,37 @@ function JobErrorsSection({
               category
               message
               detail {
+                __typename
                 ... on FailureDetail {
                   errorType
                   stackTrace
+                  workItem {
+                    __typename
+                    ... on TaskWorkItemId {
+                      datasetExampleId
+                      repetitionNumber
+                    }
+                    ... on EvalWorkItemId {
+                      experimentRunId
+                      datasetEvaluatorId
+                    }
+                  }
                 }
                 ... on RetriesExhaustedDetail {
                   retryCount
                   reason
                   stackTrace
+                  workItem {
+                    __typename
+                    ... on TaskWorkItemId {
+                      datasetExampleId
+                      repetitionNumber
+                    }
+                    ... on EvalWorkItemId {
+                      experimentRunId
+                      datasetEvaluatorId
+                    }
+                  }
                 }
               }
             }
@@ -424,10 +560,26 @@ function JobErrorsSection({
   }, [data.errors]);
   const hasNextPage = data.errors?.pageInfo?.hasNextPage ?? false;
 
-  const [expandedKeys, setExpandedKeys] = useState<Set<Key>>(() => {
-    const first = errors[0];
-    return first ? new Set<Key>([first.id]) : new Set<Key>();
+  const tableData = useMemo(
+    () =>
+      errors.map((e) => ({
+        id: e.id,
+        occurredAt: fullTimeFormatter(new Date(e.occurredAt)),
+        occurredAtRaw: e.occurredAt,
+        category: e.category,
+        message: e.message,
+        detail: e.detail,
+      })),
+    [errors, fullTimeFormatter]
+  );
+
+  // eslint-disable-next-line react-hooks-js/incompatible-library
+  const table = useReactTable<ErrorRow>({
+    columns: errorColumns,
+    data: tableData,
+    getCoreRowModel: getCoreRowModel(),
   });
+
   const [isOuterExpanded, setIsOuterExpandedRaw] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
@@ -438,17 +590,6 @@ function JobErrorsSection({
     },
     [onExpandedChange]
   );
-
-  const allExpanded = errors.length > 0 && expandedKeys.size === errors.length;
-
-  const handleExpandCollapseAll = useCallback(() => {
-    if (allExpanded) {
-      setExpandedKeys(new Set<Key>());
-    } else {
-      setExpandedKeys(new Set<Key>(errors.map((err) => err.id)));
-      setIsOuterExpanded(true);
-    }
-  }, [allExpanded, errors, setIsOuterExpanded]);
 
   const loadMore = useCallback(() => {
     setIsLoadingMore(true);
@@ -473,12 +614,6 @@ function JobErrorsSection({
           setIsOuterExpanded(keys.has("errors"));
         }}
         css={css`
-          /* Suppress the trigger hover highlight when hovering the nested button */
-          [slot="trigger"]:has([data-expand-collapse]:hover):hover:not(
-              [disabled]
-            ) {
-            background-color: transparent;
-          }
           /* Hide the empty disclosure panel so it takes no space */
           .disclosure__panel {
             display: none;
@@ -490,34 +625,15 @@ function JobErrorsSection({
         `}
       >
         <Disclosure id="errors">
-          <DisclosureTrigger
-            arrowPosition="start"
-            justifyContent="space-between"
-          >
+          <DisclosureTrigger arrowPosition="start">
             <Heading level={3} weight="heavy">
               Errors
             </Heading>
-            {isOuterExpanded && (
-              <div
-                data-expand-collapse
-                onPointerDown={(e) => e.stopPropagation()}
-                onPointerUp={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Button
-                  size="S"
-                  variant="default"
-                  onPress={handleExpandCollapseAll}
-                >
-                  {allExpanded ? "Collapse All" : "Expand All"}
-                </Button>
-              </div>
-            )}
           </DisclosureTrigger>
           <DisclosurePanel>{null}</DisclosurePanel>
         </Disclosure>
       </DisclosureGroup>
-      {/* Collapsible panel for scrollable error items */}
+      {/* Collapsible panel for scrollable error table */}
       <Panel
         collapsible
         panelRef={panelRef}
@@ -529,53 +645,54 @@ function JobErrorsSection({
             overflow-y: auto;
             overflow-x: hidden;
             height: 100%;
-            padding-left: var(--global-dimension-size-50);
           `}
         >
-          <DisclosureGroup
-            expandedKeys={expandedKeys}
-            onExpandedChange={setExpandedKeys}
+          <table
+            css={[
+              tableCSS,
+              css`
+                table-layout: fixed;
+                width: 100%;
+              `,
+            ]}
           >
-            {errors.map((error) => (
-              <Disclosure key={error.id} id={error.id}>
-                <DisclosureTrigger arrowPosition="start">
-                  <ErrorCategoryBadge category={error.category} />
-                  <Text size="XS" color="text-700">
-                    {fullTimeFormatter(new Date(error.occurredAt))}
-                  </Text>
-                  <Text
-                    size="XS"
-                    color="text-700"
-                    css={css`
-                      flex: 1;
-                      min-width: 0;
-                      overflow: hidden;
-                      text-overflow: ellipsis;
-                      white-space: nowrap;
-                    `}
-                  >
-                    {error.message}
-                  </Text>
-                </DisclosureTrigger>
-                <DisclosurePanel>
-                  <View padding="size-200">
-                    <Flex direction="column" gap="size-50">
-                      <Text size="S">{error.message}</Text>
-                      {error.detail?.stackTrace ? (
-                        <pre css={stackTraceCSS}>
-                          {error.detail.stackTrace}
-                        </pre>
-                      ) : error.detail != null ? (
-                        <Text size="XS" color="text-500">
-                          Stack trace visible to admins only
-                        </Text>
-                      ) : null}
-                    </Flex>
-                  </View>
-                </DisclosurePanel>
-              </Disclosure>
-            ))}
-          </DisclosureGroup>
+            <colgroup>
+              <col style={{ width: ERROR_COL_LEVEL_WIDTH }} />
+              <col style={{ width: ERROR_COL_TIME_WIDTH }} />
+              <col style={{ width: ERROR_COL_WORK_ITEM_WIDTH }} />
+              <col />
+            </colgroup>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
           {hasNextPage && (
             <View padding="size-100">
               <Flex justifyContent="center">
@@ -737,7 +854,6 @@ function ExperimentDetailsDialogContent({
           taskConfig={taskConfig}
           fullTimeFormatter={fullTimeFormatter}
         />
-
       ) : (
         <div
           css={css`
@@ -745,17 +861,12 @@ function ExperimentDetailsDialogContent({
             overflow-y: auto;
           `}
         >
-          <DisclosureGroup
-            defaultExpandedKeys={["overview", "task-config"]}
-          >
+          <DisclosureGroup defaultExpandedKeys={["overview", "task-config"]}>
             <ExperimentOverviewSection
               experiment={experiment}
               fullTimeFormatter={fullTimeFormatter}
             />
-            <ExperimentTaskConfigSection
-              taskConfig={taskConfig}
-              job={job}
-            />
+            <ExperimentTaskConfigSection taskConfig={taskConfig} job={job} />
           </DisclosureGroup>
         </div>
       )}

--- a/app/src/pages/experiments/__generated__/ExperimentDetailsDialogJobErrorsQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentDetailsDialogJobErrorsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6930443d6df5c2a2f95421661c20ca23>>
+ * @generated SignedSource<<76122c105e8cf696312f1612a72d9aed>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,6 +82,60 @@ v5 = {
   "kind": "ScalarField",
   "name": "stackTrace",
   "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "workItem",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetExampleId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "repetitionNumber",
+          "storageKey": null
+        }
+      ],
+      "type": "TaskWorkItemId",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "experimentRunId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetEvaluatorId",
+          "storageKey": null
+        }
+      ],
+      "type": "EvalWorkItemId",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -132,7 +186,7 @@ return {
               {
                 "alias": null,
                 "args": (v4/*: any*/),
-                "concreteType": "ExperimentErrorConnection",
+                "concreteType": "ExperimentLogConnection",
                 "kind": "LinkedField",
                 "name": "errors",
                 "plural": false,
@@ -140,7 +194,7 @@ return {
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ExperimentErrorEdge",
+                    "concreteType": "ExperimentLogEdge",
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
@@ -148,7 +202,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExperimentError",
+                        "concreteType": "ExperimentLog",
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
@@ -194,7 +248,8 @@ return {
                                     "name": "errorType",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*: any*/),
+                                  (v6/*: any*/)
                                 ],
                                 "type": "FailureDetail",
                                 "abstractKey": null
@@ -216,7 +271,8 @@ return {
                                     "name": "reason",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*: any*/),
+                                  (v6/*: any*/)
                                 ],
                                 "type": "RetriesExhaustedDetail",
                                 "abstractKey": null
@@ -285,16 +341,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e0bab82f82b7c89385fe1f15b80bd4df",
+    "cacheID": "eb04dfb921b8566370dd3181f536a7cf",
     "id": null,
     "metadata": {},
     "name": "ExperimentDetailsDialogJobErrorsQuery",
     "operationKind": "query",
-    "text": "query ExperimentDetailsDialogJobErrorsQuery(\n  $errorsAfter: String\n  $errorsFirst: Int\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentDetailsDialog_jobErrors\n    id\n  }\n}\n\nfragment ExperimentDetailsDialog_jobErrors on ExperimentJob {\n  errors(first: $errorsFirst, after: $errorsAfter) {\n    edges {\n      node {\n        id\n        occurredAt\n        category\n        message\n        detail {\n          __typename\n          ... on FailureDetail {\n            errorType\n            stackTrace\n          }\n          ... on RetriesExhaustedDetail {\n            retryCount\n            reason\n            stackTrace\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
+    "text": "query ExperimentDetailsDialogJobErrorsQuery(\n  $errorsAfter: String\n  $errorsFirst: Int\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ExperimentDetailsDialog_jobErrors\n    id\n  }\n}\n\nfragment ExperimentDetailsDialog_jobErrors on ExperimentJob {\n  errors(first: $errorsFirst, after: $errorsAfter) {\n    edges {\n      node {\n        id\n        occurredAt\n        category\n        message\n        detail {\n          __typename\n          ... on FailureDetail {\n            errorType\n            stackTrace\n            workItem {\n              __typename\n              ... on TaskWorkItemId {\n                datasetExampleId\n                repetitionNumber\n              }\n              ... on EvalWorkItemId {\n                experimentRunId\n                datasetEvaluatorId\n              }\n            }\n          }\n          ... on RetriesExhaustedDetail {\n            retryCount\n            reason\n            stackTrace\n            workItem {\n              __typename\n              ... on TaskWorkItemId {\n                datasetExampleId\n                repetitionNumber\n              }\n              ... on EvalWorkItemId {\n                experimentRunId\n                datasetEvaluatorId\n              }\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d4a2296c001af88d92ab225a6bd5d18a";
+(node as any).hash = "27922b925fc0d1d2d6de2f340ffcd3fc";
 
 export default node;

--- a/app/src/pages/experiments/__generated__/ExperimentDetailsDialogQuery.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentDetailsDialogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7c094e56ba8dfee2c0a6e53bdbd0aaa3>>
+ * @generated SignedSource<<2cece2a80e3b1a8ca8930c59e59ebfbb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -424,7 +424,61 @@ v33 = {
   "name": "stackTrace",
   "storageKey": null
 },
-v34 = [
+v34 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "workItem",
+  "plural": false,
+  "selections": [
+    (v25/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetExampleId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "repetitionNumber",
+          "storageKey": null
+        }
+      ],
+      "type": "TaskWorkItemId",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "experimentRunId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetEvaluatorId",
+          "storageKey": null
+        }
+      ],
+      "type": "EvalWorkItemId",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
+},
+v35 = [
   (v26/*: any*/)
 ];
 return {
@@ -637,7 +691,7 @@ return {
                   {
                     "alias": null,
                     "args": (v32/*: any*/),
-                    "concreteType": "ExperimentErrorConnection",
+                    "concreteType": "ExperimentLogConnection",
                     "kind": "LinkedField",
                     "name": "errors",
                     "plural": false,
@@ -645,7 +699,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ExperimentErrorEdge",
+                        "concreteType": "ExperimentLogEdge",
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
@@ -653,7 +707,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ExperimentError",
+                            "concreteType": "ExperimentLog",
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
@@ -699,7 +753,8 @@ return {
                                         "name": "errorType",
                                         "storageKey": null
                                       },
-                                      (v33/*: any*/)
+                                      (v33/*: any*/),
+                                      (v34/*: any*/)
                                     ],
                                     "type": "FailureDetail",
                                     "abstractKey": null
@@ -721,7 +776,8 @@ return {
                                         "name": "reason",
                                         "storageKey": null
                                       },
-                                      (v33/*: any*/)
+                                      (v33/*: any*/),
+                                      (v34/*: any*/)
                                     ],
                                     "type": "RetriesExhaustedDetail",
                                     "abstractKey": null
@@ -821,7 +877,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v34/*: any*/),
+                            "selections": (v35/*: any*/),
                             "type": "AnthropicConnectionConfig",
                             "abstractKey": null
                           },
@@ -836,7 +892,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v34/*: any*/),
+                            "selections": (v35/*: any*/),
                             "type": "GoogleGenAIConnectionConfig",
                             "abstractKey": null
                           }
@@ -859,12 +915,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5b9fe510aee9a0c32744afac07298579",
+    "cacheID": "2303ec86564c8e6e4bb15826874fd2bf",
     "id": null,
     "metadata": {},
     "name": "ExperimentDetailsDialogQuery",
     "operationKind": "query",
-    "text": "query ExperimentDetailsDialogQuery(\n  $experimentId: ID!\n  $errorsFirst: Int = 20\n  $errorsAfter: String = null\n) {\n  experiment: node(id: $experimentId) {\n    __typename\n    ... on Experiment {\n      id\n      name\n      description\n      sequenceNumber\n      createdAt\n      updatedAt\n      metadata\n      repetitions\n      errorRate\n      runCount\n      expectedRunCount\n      averageRunLatencyMs\n      project {\n        id\n      }\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      costSummary {\n        total {\n          tokens\n          cost\n        }\n        prompt {\n          tokens\n          cost\n        }\n        completion {\n          tokens\n          cost\n        }\n      }\n      job {\n        status\n        createdAt\n        maxConcurrency\n        ...ExperimentDetailsDialog_jobErrors\n        taskConfig {\n          id\n          streamModelOutput\n          prompt {\n            modelProvider\n            modelName\n            templateType\n            templateFormat\n            invocationParameters\n          }\n          connection {\n            __typename\n            ... on OpenAIConnectionConfig {\n              __typename\n              baseUrl\n              openaiApiType\n            }\n            ... on AzureOpenAIConnectionConfig {\n              __typename\n              azureEndpoint\n              openaiApiType\n            }\n            ... on AnthropicConnectionConfig {\n              __typename\n              baseUrl\n            }\n            ... on AWSBedrockConnectionConfig {\n              __typename\n              regionName\n              endpointUrl\n            }\n            ... on GoogleGenAIConnectionConfig {\n              __typename\n              baseUrl\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentDetailsDialog_jobErrors on ExperimentJob {\n  errors(first: $errorsFirst, after: $errorsAfter) {\n    edges {\n      node {\n        id\n        occurredAt\n        category\n        message\n        detail {\n          __typename\n          ... on FailureDetail {\n            errorType\n            stackTrace\n          }\n          ... on RetriesExhaustedDetail {\n            retryCount\n            reason\n            stackTrace\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
+    "text": "query ExperimentDetailsDialogQuery(\n  $experimentId: ID!\n  $errorsFirst: Int = 20\n  $errorsAfter: String = null\n) {\n  experiment: node(id: $experimentId) {\n    __typename\n    ... on Experiment {\n      id\n      name\n      description\n      sequenceNumber\n      createdAt\n      updatedAt\n      metadata\n      repetitions\n      errorRate\n      runCount\n      expectedRunCount\n      averageRunLatencyMs\n      project {\n        id\n      }\n      user {\n        username\n        profilePictureUrl\n        id\n      }\n      costSummary {\n        total {\n          tokens\n          cost\n        }\n        prompt {\n          tokens\n          cost\n        }\n        completion {\n          tokens\n          cost\n        }\n      }\n      job {\n        status\n        createdAt\n        maxConcurrency\n        ...ExperimentDetailsDialog_jobErrors\n        taskConfig {\n          id\n          streamModelOutput\n          prompt {\n            modelProvider\n            modelName\n            templateType\n            templateFormat\n            invocationParameters\n          }\n          connection {\n            __typename\n            ... on OpenAIConnectionConfig {\n              __typename\n              baseUrl\n              openaiApiType\n            }\n            ... on AzureOpenAIConnectionConfig {\n              __typename\n              azureEndpoint\n              openaiApiType\n            }\n            ... on AnthropicConnectionConfig {\n              __typename\n              baseUrl\n            }\n            ... on AWSBedrockConnectionConfig {\n              __typename\n              regionName\n              endpointUrl\n            }\n            ... on GoogleGenAIConnectionConfig {\n              __typename\n              baseUrl\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment ExperimentDetailsDialog_jobErrors on ExperimentJob {\n  errors(first: $errorsFirst, after: $errorsAfter) {\n    edges {\n      node {\n        id\n        occurredAt\n        category\n        message\n        detail {\n          __typename\n          ... on FailureDetail {\n            errorType\n            stackTrace\n            workItem {\n              __typename\n              ... on TaskWorkItemId {\n                datasetExampleId\n                repetitionNumber\n              }\n              ... on EvalWorkItemId {\n                experimentRunId\n                datasetEvaluatorId\n              }\n            }\n          }\n          ... on RetriesExhaustedDetail {\n            retryCount\n            reason\n            stackTrace\n            workItem {\n              __typename\n              ... on TaskWorkItemId {\n                datasetExampleId\n                repetitionNumber\n              }\n              ... on EvalWorkItemId {\n                experimentRunId\n                datasetEvaluatorId\n              }\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/app/src/pages/experiments/__generated__/ExperimentDetailsDialog_jobErrors.graphql.ts
+++ b/app/src/pages/experiments/__generated__/ExperimentDetailsDialog_jobErrors.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d509312a4fee45cfc908fbdb90e84b7>>
+ * @generated SignedSource<<f31ad6f690eb66bf92d34609a7b2eb48>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,18 +9,52 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type ExperimentErrorCategory = "EVAL" | "EXPERIMENT" | "TASK";
+export type ExperimentLogCategory = "EVAL" | "EXPERIMENT" | "TASK";
 import { FragmentRefs } from "relay-runtime";
 export type ExperimentDetailsDialog_jobErrors$data = {
   readonly errors: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly category: ExperimentErrorCategory;
+        readonly category: ExperimentLogCategory;
         readonly detail: {
-          readonly errorType?: string;
-          readonly reason?: string;
-          readonly retryCount?: number;
-          readonly stackTrace?: string | null;
+          readonly __typename: "FailureDetail";
+          readonly errorType: string;
+          readonly stackTrace: string | null;
+          readonly workItem: {
+            readonly __typename: "EvalWorkItemId";
+            readonly datasetEvaluatorId: number;
+            readonly experimentRunId: number;
+          } | {
+            readonly __typename: "TaskWorkItemId";
+            readonly datasetExampleId: number;
+            readonly repetitionNumber: number;
+          } | {
+            // This will never be '%other', but we need some
+            // value in case none of the concrete values match.
+            readonly __typename: "%other";
+          } | null;
+        } | {
+          readonly __typename: "RetriesExhaustedDetail";
+          readonly reason: string;
+          readonly retryCount: number;
+          readonly stackTrace: string | null;
+          readonly workItem: {
+            readonly __typename: "EvalWorkItemId";
+            readonly datasetEvaluatorId: number;
+            readonly experimentRunId: number;
+          } | {
+            readonly __typename: "TaskWorkItemId";
+            readonly datasetExampleId: number;
+            readonly repetitionNumber: number;
+          } | {
+            // This will never be '%other', but we need some
+            // value in case none of the concrete values match.
+            readonly __typename: "%other";
+          } | null;
+        } | {
+          // This will never be '%other', but we need some
+          // value in case none of the concrete values match.
+          readonly __typename: "%other";
         } | null;
         readonly id: string;
         readonly message: string;
@@ -57,7 +91,68 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "stackTrace",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "workItem",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetExampleId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "repetitionNumber",
+          "storageKey": null
+        }
+      ],
+      "type": "TaskWorkItemId",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "experimentRunId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datasetEvaluatorId",
+          "storageKey": null
+        }
+      ],
+      "type": "EvalWorkItemId",
+      "abstractKey": null
+    }
+  ],
   "storageKey": null
 };
 return {
@@ -105,7 +200,7 @@ return {
     {
       "alias": "errors",
       "args": null,
-      "concreteType": "ExperimentErrorConnection",
+      "concreteType": "ExperimentLogConnection",
       "kind": "LinkedField",
       "name": "__ExperimentDetailsDialog_errors_connection",
       "plural": false,
@@ -113,7 +208,7 @@ return {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ExperimentErrorEdge",
+          "concreteType": "ExperimentLogEdge",
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
@@ -121,7 +216,7 @@ return {
             {
               "alias": null,
               "args": null,
-              "concreteType": "ExperimentError",
+              "concreteType": "ExperimentLog",
               "kind": "LinkedField",
               "name": "node",
               "plural": false,
@@ -156,6 +251,7 @@ return {
                   "name": "detail",
                   "plural": false,
                   "selections": [
+                    (v2/*: any*/),
                     {
                       "kind": "InlineFragment",
                       "selections": [
@@ -166,7 +262,8 @@ return {
                           "name": "errorType",
                           "storageKey": null
                         },
-                        (v2/*: any*/)
+                        (v3/*: any*/),
+                        (v4/*: any*/)
                       ],
                       "type": "FailureDetail",
                       "abstractKey": null
@@ -188,7 +285,8 @@ return {
                           "name": "reason",
                           "storageKey": null
                         },
-                        (v2/*: any*/)
+                        (v3/*: any*/),
+                        (v4/*: any*/)
                       ],
                       "type": "RetriesExhaustedDetail",
                       "abstractKey": null
@@ -196,13 +294,7 @@ return {
                   ],
                   "storageKey": null
                 },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "__typename",
-                  "storageKey": null
-                }
+                (v2/*: any*/)
               ],
               "storageKey": null
             },
@@ -251,6 +343,6 @@ return {
 };
 })();
 
-(node as any).hash = "d4a2296c001af88d92ab225a6bd5d18a";
+(node as any).hash = "27922b925fc0d1d2d6de2f340ffcd3fc";
 
 export default node;

--- a/src/phoenix/server/daemons/experiment_runner.py
+++ b/src/phoenix/server/daemons/experiment_runner.py
@@ -151,6 +151,19 @@ def _redact_stack_trace(error: BaseException) -> str:
     return raw
 
 
+def _sanitize_error_message(error: BaseException) -> str:
+    """Return a user-safe error summary: exception class name only.
+
+    Raw ``str(error)`` can leak internal paths, API keys, or other
+    sensitive details embedded by third-party SDKs.  We keep the
+    exception class name (e.g. ``TimeoutError``, ``RateLimitError``)
+    which is enough for users to understand what went wrong without
+    exposing internals.  The full detail is still available in the
+    server logs.
+    """
+    return type(error).__name__
+
+
 class LLMClient(Protocol):
     """Narrow interface for the LLM client methods the runner actually uses.
 
@@ -1040,7 +1053,7 @@ class CircuitBreaker:
         )
         if self._consecutive_failures >= self.threshold:
             self._tripped = True
-            self._trip_reason = str(error)
+            self._trip_reason = _sanitize_error_message(error)
             logger.warning(f"CircuitBreaker: TRIPPED after {self.threshold} consecutive failures")
             return True
         return False
@@ -1713,10 +1726,12 @@ class RunningExperiment:
         if breaker.record_failure(error):
             await self._handle_circuit_trip(
                 "task" if isinstance(work_item, TaskWorkItem) else "eval",
-                breaker.trip_reason or str(error),
+                breaker.trip_reason or _sanitize_error_message(error),
             )
             return
-        await self._retry_or_fail(work_item, f"transient error: {error}", error=error)
+        await self._retry_or_fail(
+            work_item, f"transient error: {_sanitize_error_message(error)}", error=error
+        )
 
     async def on_failure(
         self,
@@ -1734,7 +1749,7 @@ class RunningExperiment:
         await self._persist_log(
             self._make_log(
                 work_item,
-                message=str(error),
+                message=_sanitize_error_message(error),
                 detail=FailureDetail(
                     type="failure",
                     error_type=type(error).__name__,
@@ -1746,7 +1761,7 @@ class RunningExperiment:
         if breaker.record_failure(error):
             await self._handle_circuit_trip(
                 category.lower(),
-                breaker.trip_reason or str(error),
+                breaker.trip_reason or _sanitize_error_message(error),
             )
 
     async def on_timeout(self, work_item: WorkItem) -> None:


### PR DESCRIPTION
## Summary
- Switch experiment errors table to query structured `ExperimentLog` endpoint with `FailureDetail`/`RetriesExhaustedDetail` unions instead of raw `ExperimentRun.error` strings
- Add `_sanitize_error_message()` backend helper to prevent API keys and internal paths from leaking into the UI
- Relative timestamps, fixed column layout, truncated error text with admin-only copy button

## Test plan
- [ ] Run an experiment that hits errors (e.g. invalid model name) and verify the errors table shows sanitized class names, not raw exception strings
- [ ] Hover over timestamps to see full date
- [ ] Verify copy button appears for admin users and copies the message
- [ ] Verify non-admin users don't see the copy button