### PR TITLE
fix: fall back to email local part when name claim is empty

### DIFF
--- a/src/phoenix/server/api/routers/oauth2.py
+++ b/src/phoenix/server/api/routers/oauth2.py
@@ -748,10 +748,17 @@ async def _create_user(
     Returns:
         The created user
     """
+    email = user_info.email
+    # The users.username column is NOT NULL, but the OIDC `name` claim is
+    # optional and some IDPs omit it or return an empty string. Fall back
+    # to the local part of the email so we always have a non-empty value
+    # to satisfy the constraint; a random suffix is appended below if it
+    # collides with an existing username.
+    username = user_info.username or email.split("@", 1)[0]
     email_exists, username_exists = await _email_and_username_exist(
         session,
-        email=(email := user_info.email),
-        username=(username := user_info.username),
+        email=email,
+        username=username,
     )
     if email_exists:
         raise EmailAlreadyInUse(f"An account for {email} is already in use.")
@@ -763,7 +770,7 @@ async def _create_user(
             user_role_id=role_id,
             oauth2_client_id=oauth2_client_id,
             oauth2_user_id=user_info.idp_user_id,
-            username=_with_random_suffix(username) if username and username_exists else username,
+            username=_with_random_suffix(username) if username_exists else username,
             email=email,
             profile_picture_url=user_info.profile_picture_url,
             reset_password=False,


### PR DESCRIPTION
The OIDC `name` claim is optional and some IDPs omit it or return an empty string, which left `user_info.username` as `None`. `_create_user` then tried to insert `NULL` into the `users.username` column, which is `NOT NULL`, causing an `IntegrityError` / `NotNullViolationError` on sign-in.

This patch derives the username from the local part of the email when the `name` claim is missing or empty. The existing username-collision path still appends a random suffix so derived usernames remain unique.

Fixes #12601