### PR TITLE
fix(sandbox): UI cleanup for code evaluator and sandbox settings

### DIFF
--- a/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
+++ b/app/src/components/evaluators/EditCodeEvaluatorDialogContent.tsx
@@ -13,6 +13,8 @@ import {
   ComboBoxItem,
   Flex,
   Heading,
+  Icon,
+  Icons,
   Input,
   Label,
   ListBox,
@@ -50,7 +52,6 @@ import {
   useEvaluatorStore,
   useEvaluatorStoreInstance,
 } from "@phoenix/contexts/EvaluatorContext";
-import { languageLabel } from "@phoenix/pages/settings/sandboxes/utils";
 import type { AnnotationConfig } from "@phoenix/store/evaluatorStore";
 import type {
   ClassificationChoice,
@@ -325,11 +326,30 @@ const CodeEvaluatorSourceEditor = ({
       <Heading level={2} weight="heavy">
         Evaluator Code
       </Heading>
-      <Text color="text-500">
-        Define an <code>evaluate</code> function that returns either a numeric
-        score or a categorical label.
-      </Text>
-      <div css={editorWrapCSS}>
+      <Flex direction="row" justifyContent="space-between" alignItems="center">
+        <Text color="text-500">
+          Define an <code>evaluate</code> function that returns either a numeric
+          score or a categorical label.
+        </Text>
+        <Button
+          size="S"
+          variant="default"
+          onPress={() => onChange(DEFAULT_CODE_EVALUATOR_SOURCE[language])}
+        >
+          <Icon svg={<Icons.Refresh />} />
+          Reset to default
+        </Button>
+      </Flex>
+      <div
+        css={editorWrapCSS}
+        onKeyDown={(e) => {
+          // Prevent Escape from propagating to the modal overlay,
+          // which would close the slideover and discard edits.
+          if (e.key === "Escape") {
+            e.stopPropagation();
+          }
+        }}
+      >
         <CodeMirror
           value={sourceCode}
           onChange={onChange}
@@ -574,6 +594,7 @@ const CodeEvaluatorSandboxField = ({
     <View marginBottom="size-200" flex="none">
       <ComboBox
         label="Sandbox config"
+        size="L"
         placeholder={
           sandboxConfigs.length > 0
             ? "Select a sandbox config"
@@ -602,14 +623,19 @@ const CodeEvaluatorSandboxField = ({
           <ComboBoxItem
             id={String(item.id)}
             key={item.id}
-            textValue={`${item.name} ${item.providerLabel}`}
+            textValue={item.name}
           >
             <Flex direction="column" gap="size-25">
               <Text>{item.name}</Text>
-              <Text color="text-700" size="S">
-                {item.providerLabel}
-                {item.description ? ` · ${item.description}` : ""}
-              </Text>
+              {item.description ? (
+                <Text color="text-700" size="S">
+                  {item.description}
+                </Text>
+              ) : (
+                <Text color="text-700" size="S">
+                  {item.providerLabel}
+                </Text>
+              )}
             </Flex>
           </ComboBoxItem>
         )}
@@ -639,10 +665,23 @@ export const mapSandboxConfigOptions = (
       name: config.name,
       description: config.description,
       providerLanguage: provider.language,
-      providerLabel: `${provider.backendType} ${languageLabel(provider.language)} provider`,
+      providerLabel: backendTypeLabel(provider.backendType),
     }))
   );
 };
+
+const BACKEND_TYPE_LABELS: Record<string, string> = {
+  WASM: "WebAssembly",
+  E2B: "E2B",
+  DAYTONA_PYTHON: "Daytona",
+  VERCEL_PYTHON: "Vercel",
+  VERCEL_TYPESCRIPT: "Vercel",
+  DENO: "Deno",
+  MODAL: "Modal",
+};
+
+const backendTypeLabel = (backendType: string): string =>
+  BACKEND_TYPE_LABELS[backendType] ?? backendType;
 
 const decodeRelayNodeId = (globalId: string) => {
   const decoded = globalThis.atob(globalId);

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -106,48 +106,6 @@ export function SandboxConfigDialogTrigger(
   );
 }
 
-/**
- * Inline link-style trigger for creating a config, pre-filled with a specific
- * provider. Used as a nudge on provider rows that have zero configs.
- */
-export function CreateConfigNudge({
-  providers,
-  defaultProvider,
-}: {
-  providers: ProviderRow[];
-  defaultProvider: ProviderRow;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
-      <Button size="S" variant="default">
-        Create a config
-      </Button>
-      <ModalOverlay>
-        <Modal size="L">
-          <Dialog>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>New Sandbox Config</DialogTitle>
-                <DialogTitleExtra>
-                  <DialogCloseButton slot="close" />
-                </DialogTitleExtra>
-              </DialogHeader>
-              <SandboxConfigDialogContent
-                mode="create"
-                providers={providers}
-                defaultProvider={defaultProvider}
-                onClose={() => setIsOpen(false)}
-              />
-            </DialogContent>
-          </Dialog>
-        </Modal>
-      </ModalOverlay>
-    </DialogTrigger>
-  );
-}
-
 type SandboxConfigDialogContentProps = (
   | { mode: "create"; providers: ProviderRow[]; defaultProvider?: ProviderRow }
   | { mode: "edit"; provider: SandboxProvider; config: SandboxConfig }

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -44,7 +44,7 @@ import type {
 import { languageLabel, parseConfigText, toPrettyJSONObject } from "./utils";
 
 type SandboxConfigDialogTriggerProps =
-  | { mode: "create"; providers: ProviderRow[] }
+  | { mode: "create"; providers: ProviderRow[]; defaultProvider?: ProviderRow }
   | { mode: "edit"; provider: SandboxProvider; config: SandboxConfig };
 
 export function SandboxConfigDialogTrigger(
@@ -87,6 +87,7 @@ export function SandboxConfigDialogTrigger(
                 <SandboxConfigDialogContent
                   mode="create"
                   providers={props.providers}
+                  defaultProvider={props.defaultProvider}
                   onClose={() => setIsOpen(false)}
                 />
               ) : (
@@ -105,14 +106,61 @@ export function SandboxConfigDialogTrigger(
   );
 }
 
+/**
+ * Inline link-style trigger for creating a config, pre-filled with a specific
+ * provider. Used as a nudge on provider rows that have zero configs.
+ */
+export function CreateConfigNudge({
+  providers,
+  defaultProvider,
+}: {
+  providers: ProviderRow[];
+  defaultProvider: ProviderRow;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button size="S" variant="default">
+        Create a config
+      </Button>
+      <ModalOverlay>
+        <Modal size="L">
+          <Dialog>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>New Sandbox Config</DialogTitle>
+                <DialogTitleExtra>
+                  <DialogCloseButton slot="close" />
+                </DialogTitleExtra>
+              </DialogHeader>
+              <SandboxConfigDialogContent
+                mode="create"
+                providers={providers}
+                defaultProvider={defaultProvider}
+                onClose={() => setIsOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  );
+}
+
 type SandboxConfigDialogContentProps = (
-  | { mode: "create"; providers: ProviderRow[] }
+  | { mode: "create"; providers: ProviderRow[]; defaultProvider?: ProviderRow }
   | { mode: "edit"; provider: SandboxProvider; config: SandboxConfig }
 ) & { onClose: () => void };
+
+function defaultConfigName(provider: ProviderRow): string {
+  return `${provider.backend.displayName} - ${languageLabel(provider.provider.language)}`;
+}
 
 function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
   const { mode, onClose } = props;
   const providers = mode === "create" ? props.providers : [];
+  const defaultProvider = mode === "create" ? props.defaultProvider : undefined;
   const notifySuccess = useNotifySuccess();
   const [error, setError] = useState<string | null>(null);
   const form = useForm<SandboxConfigFormValues>({
@@ -126,8 +174,8 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
             configText: toPrettyJSONObject(props.config.config),
           }
         : {
-            sandboxProviderId: "",
-            name: "",
+            sandboxProviderId: defaultProvider?.provider.id ?? "",
+            name: defaultProvider ? defaultConfigName(defaultProvider) : "",
             description: "",
             timeout: 30,
             configText: toPrettyJSONObject({}),
@@ -239,6 +287,22 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                     onSelectionChange={(key) => {
                       if (typeof key === "string") {
                         field.onChange(key);
+                        // Auto-fill the name when the current value is empty
+                        // or still matches a previously generated default.
+                        const currentName = form.getValues("name");
+                        const isDefaultName =
+                          !currentName ||
+                          providers.some(
+                            (p) => defaultConfigName(p) === currentName
+                          );
+                        if (isDefaultName) {
+                          const selected = providers.find(
+                            (p) => p.provider.id === key
+                          );
+                          if (selected) {
+                            form.setValue("name", defaultConfigName(selected));
+                          }
+                        }
                       }
                     }}
                     onBlur={field.onBlur}

--- a/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxConfigDialog.tsx
@@ -154,7 +154,7 @@ type SandboxConfigDialogContentProps = (
 ) & { onClose: () => void };
 
 function defaultConfigName(provider: ProviderRow): string {
-  return `${provider.backend.displayName} - ${languageLabel(provider.provider.language)}`;
+  return `${provider.backend.displayName}`;
 }
 
 function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
@@ -283,6 +283,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                   <ComboBox
                     label="Provider"
                     placeholder="Search providers"
+                    size="L"
                     selectedKey={field.value || null}
                     onSelectionChange={(key) => {
                       if (typeof key === "string") {
@@ -308,7 +309,6 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                     onBlur={field.onBlur}
                     isInvalid={fieldState.invalid}
                     errorMessage={fieldState.error?.message}
-                    size="M"
                     menuTrigger="focus"
                     defaultItems={providers ?? []}
                     renderEmptyState={() => <div>No providers found</div>}
@@ -317,7 +317,7 @@ function SandboxConfigDialogContent(props: SandboxConfigDialogContentProps) {
                       <ComboBoxItem
                         id={item.provider.id}
                         key={item.provider.id}
-                        textValue={`${item.backend.displayName} ${languageLabel(item.provider.language)}`}
+                        textValue={`${item.backend.displayName}`}
                       >
                         <Flex direction="column" gap="size-25">
                           <Text>{item.backend.displayName}</Text>

--- a/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
+++ b/app/src/pages/settings/sandboxes/SandboxProvidersCard.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { graphql, useMutation } from "react-relay";
@@ -152,7 +153,16 @@ function ProviderStatusText({ backend }: { backend: BackendInfo }) {
   return (
     <TooltipTrigger delay={100}>
       <TriggerWrap>
-        <Text color="text-700">{label}</Text>
+        <Text
+          color="text-700"
+          css={css`
+            text-decoration: underline dotted;
+            text-underline-offset: 2px;
+            cursor: help;
+          `}
+        >
+          {label}
+        </Text>
       </TriggerWrap>
       <RichTooltip width={320}>
         <Flex direction="column" gap="size-50">


### PR DESCRIPTION
Minor tweaks to improve UX of code sandbox evaluators:
- Fix provider select sizes and labels
- Prevent closing slideover on esc when focused in code editor
- default name in new sandbox configs