### PR TITLE
datasets: validate explicit empty outputs/metadata lists instead of skipping

### DIFF
--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -701,7 +701,7 @@ def _process_json(
         raise ValueError("Input should be a list containing only dictionary objects")
     outputs, metadata, splits = data.get("outputs"), data.get("metadata"), data.get("splits")
     for k, v in {"outputs": outputs, "metadata": metadata}.items():
-        if v and not (isinstance(v, list) and len(v) == len(inputs) and _is_all_dict(v)):
+        if v is not None and not (isinstance(v, list) and len(v) == len(inputs) and _is_all_dict(v)):
             raise ValueError(
                 f"{k} should be a list of same length as input containing only dictionary objects"
             )


### PR DESCRIPTION
The JSON dataset ingestion path used `if v` to guard validation of `outputs` and `metadata`, so an explicit empty list was treated identically to `None`. That meant `outputs=[]` bypassed the length check against `inputs`, and downstream each example was stored with `{}` as output.

Switch to `if v is not None` so empty lists are validated correctly: an empty list has length 0, which will never equal `len(inputs) > 0`, producing the expected `ValueError`.

Fixes #12609