### PR TITLE
fix: preserve explicit empty `outputs` and `metadata` lists in dataset uploads

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/datasets/__init__.py
@@ -763,8 +763,8 @@ class Datasets:
         split_keys: Iterable[str] = (),
         span_id_key: Optional[str] = None,
         inputs: Iterable[Mapping[str, Any]] = (),
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         dataset_description: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> Dataset:
@@ -823,7 +823,7 @@ class Datasets:
         """
         has_examples = examples is not None
         has_tabular = dataframe is not None or csv_file_path is not None
-        has_json = any(inputs) or any(outputs) or any(metadata)
+        has_json = any(inputs) or outputs is not None or metadata is not None
 
         if sum([has_examples, has_tabular, has_json]) > 1:
             raise ValueError(
@@ -895,8 +895,8 @@ class Datasets:
         split_keys: Iterable[str] = (),
         span_id_key: Optional[str] = None,
         inputs: Iterable[Mapping[str, Any]] = (),
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> Dataset:
         """
@@ -949,7 +949,7 @@ class Datasets:
 
         has_examples = examples is not None
         has_tabular = dataframe is not None or csv_file_path is not None
-        has_json = any(inputs) or any(outputs) or any(metadata)
+        has_json = any(inputs) or outputs is not None or metadata is not None
 
         if sum([has_examples, has_tabular, has_json]) > 1:
             raise ValueError(
@@ -1122,8 +1122,8 @@ class Datasets:
         *,
         dataset_name: str,
         inputs: Iterable[Mapping[str, Any]],
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         splits: Iterable[Any] = (),
         span_ids: Iterable[Optional[str]] = (),
         dataset_description: Optional[str] = None,
@@ -1135,8 +1135,8 @@ class Datasets:
         """
         # Convert to lists to handle generators and validate
         inputs_list = list(inputs)
-        outputs_list = list(outputs) if outputs else []
-        metadata_list = list(metadata) if metadata else []
+        outputs_list = list(outputs) if outputs is not None else None
+        metadata_list = list(metadata) if metadata is not None else None
         splits_list = list(splits) if splits else []
         span_ids_list = list(span_ids) if span_ids else []
 
@@ -1150,7 +1150,7 @@ class Datasets:
             ("outputs", outputs_list),
             ("metadata", metadata_list),
         ]:
-            if data:
+            if data is not None:
                 if len(data) != len(inputs_list):
                     raise ValueError(
                         f"{name} must have same length as inputs "
@@ -1177,9 +1177,9 @@ class Datasets:
             "inputs": inputs_list,
         }
         # Only include optional fields if they have meaningful values
-        if outputs_list:
+        if outputs_list is not None:
             payload["outputs"] = outputs_list
-        if metadata_list:
+        if metadata_list is not None:
             payload["metadata"] = metadata_list
         if splits_list and any(s is not None for s in splits_list):
             payload["splits"] = splits_list
@@ -1572,8 +1572,8 @@ class AsyncDatasets:
         split_keys: Iterable[str] = (),
         span_id_key: Optional[str] = None,
         inputs: Iterable[Mapping[str, Any]] = (),
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         dataset_description: Optional[str] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> Dataset:
@@ -1607,7 +1607,7 @@ class AsyncDatasets:
         """
         has_examples = examples is not None
         has_tabular = dataframe is not None or csv_file_path is not None
-        has_json = any(inputs) or any(outputs) or any(metadata)
+        has_json = any(inputs) or outputs is not None or metadata is not None
 
         if sum([has_examples, has_tabular, has_json]) > 1:
             raise ValueError(
@@ -1679,8 +1679,8 @@ class AsyncDatasets:
         split_keys: Iterable[str] = (),
         span_id_key: Optional[str] = None,
         inputs: Iterable[Mapping[str, Any]] = (),
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT_IN_SECONDS,
     ) -> Dataset:
         """
@@ -1730,7 +1730,7 @@ class AsyncDatasets:
 
         has_examples = examples is not None
         has_tabular = dataframe is not None or csv_file_path is not None
-        has_json = any(inputs) or any(outputs) or any(metadata)
+        has_json = any(inputs) or outputs is not None or metadata is not None
 
         if sum([has_examples, has_tabular, has_json]) > 1:
             raise ValueError(
@@ -1888,8 +1888,8 @@ class AsyncDatasets:
         *,
         dataset_name: str,
         inputs: Iterable[Mapping[str, Any]],
-        outputs: Iterable[Mapping[str, Any]] = (),
-        metadata: Iterable[Mapping[str, Any]] = (),
+        outputs: Optional[Iterable[Mapping[str, Any]]] = None,
+        metadata: Optional[Iterable[Mapping[str, Any]]] = None,
         splits: Iterable[Any] = (),
         span_ids: Iterable[Optional[str]] = (),
         dataset_description: Optional[str] = None,
@@ -1899,8 +1899,8 @@ class AsyncDatasets:
         """Async version of _upload_json_dataset."""
         # Convert to lists to handle generators and validate
         inputs_list = list(inputs)
-        outputs_list = list(outputs) if outputs else []
-        metadata_list = list(metadata) if metadata else []
+        outputs_list = list(outputs) if outputs is not None else None
+        metadata_list = list(metadata) if metadata is not None else None
         splits_list = list(splits) if splits else []
         span_ids_list = list(span_ids) if span_ids else []
 
@@ -1914,7 +1914,7 @@ class AsyncDatasets:
             ("outputs", outputs_list),
             ("metadata", metadata_list),
         ]:
-            if data:
+            if data is not None:
                 if len(data) != len(inputs_list):
                     raise ValueError(
                         f"{name} must have same length as inputs "
@@ -1941,9 +1941,9 @@ class AsyncDatasets:
             "inputs": inputs_list,
         }
         # Only include optional fields if they have meaningful values
-        if outputs_list:
+        if outputs_list is not None:
             payload["outputs"] = outputs_list
-        if metadata_list:
+        if metadata_list is not None:
             payload["metadata"] = metadata_list
         if splits_list and any(s is not None for s in splits_list):
             payload["splits"] = splits_list

--- a/packages/phoenix-client/tests/client/resources/datasets/test_empty_optional_lists.py
+++ b/packages/phoenix-client/tests/client/resources/datasets/test_empty_optional_lists.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+client_root = Path(__file__).resolve().parents[4] / "src" / "phoenix"
+
+phoenix_pkg = ModuleType("phoenix")
+phoenix_pkg.__path__ = [str(client_root)]
+sys.modules.setdefault("phoenix", phoenix_pkg)
+
+for name, path in {
+    "phoenix.client": client_root / "client",
+    "phoenix.client.resources": client_root / "client" / "resources",
+}.items():
+    module = ModuleType(name)
+    module.__path__ = [str(path)]
+    sys.modules.setdefault(name, module)
+
+datasets_module = importlib.import_module("phoenix.client.resources.datasets")
+AsyncDatasets = datasets_module.AsyncDatasets
+Datasets = datasets_module.Datasets
+
+
+@pytest.mark.parametrize("field", ["outputs", "metadata"])
+def test_sync_upload_rejects_explicit_empty_optional_lists(field: str) -> None:
+    datasets = Datasets(Mock())
+
+    with pytest.raises(ValueError, match=rf"{field} must have same length as inputs"):
+        datasets._upload_json_dataset(
+            dataset_name="test-dataset",
+            inputs=[{"question": "a"}, {"question": "b"}],
+            **{field: []},
+        )
+
+    datasets._client.post.assert_not_called()
+
+
+@pytest.mark.parametrize("field", ["outputs", "metadata"])
+@pytest.mark.asyncio
+async def test_async_upload_rejects_explicit_empty_optional_lists(field: str) -> None:
+    datasets = AsyncDatasets(AsyncMock())
+
+    with pytest.raises(ValueError, match=rf"{field} must have same length as inputs"):
+        await datasets._upload_json_dataset(
+            dataset_name="test-dataset",
+            inputs=[{"question": "a"}, {"question": "b"}],
+            **{field: []},
+        )
+
+    datasets._client.post.assert_not_called()

--- a/src/phoenix/server/api/routers/v1/datasets.py
+++ b/src/phoenix/server/api/routers/v1/datasets.py
@@ -701,7 +701,9 @@ def _process_json(
         raise ValueError("Input should be a list containing only dictionary objects")
     outputs, metadata, splits = data.get("outputs"), data.get("metadata"), data.get("splits")
     for k, v in {"outputs": outputs, "metadata": metadata}.items():
-        if v and not (isinstance(v, list) and len(v) == len(inputs) and _is_all_dict(v)):
+        if v is not None and not (
+            isinstance(v, list) and len(v) == len(inputs) and _is_all_dict(v)
+        ):
             raise ValueError(
                 f"{k} should be a list of same length as input containing only dictionary objects"
             )
@@ -769,8 +771,8 @@ def _process_json(
 
         example = ExampleContent(
             input=obj,
-            output=outputs[i] if outputs else {},
-            metadata=metadata[i] if metadata else {},
+            output=outputs[i] if outputs is not None else {},
+            metadata=metadata[i] if metadata is not None else {},
             splits=frozenset(split_set),
             span_id=span_id,
         )

--- a/tests/unit/server/api/routers/v1/test_datasets_empty_optional_lists.py
+++ b/tests/unit/server/api/routers/v1/test_datasets_empty_optional_lists.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from typing import Any, Mapping, Optional, cast
+
+import pytest
+
+
+def _load_process_json():
+    source_path = Path(__file__).resolve().parents[6] / "src" / "phoenix" / "server" / "api" / "routers" / "v1" / "datasets.py"
+    source = source_path.read_text(encoding="utf-8")
+    start = source.index("def _process_json(")
+    end = source.index("\n\nasync def _process_csv(", start)
+    function_source = source[start:end]
+
+    namespace = {
+        "Any": Any,
+        "Mapping": Mapping,
+        "Optional": Optional,
+        "cast": cast,
+        "Examples": object,
+        "Name": str,
+        "Description": str,
+        "DatasetAction": lambda value: value,
+        "_is_all_dict": lambda seq: all(isinstance(item, dict) for item in seq),
+    }
+    exec(function_source, namespace)
+    return namespace["_process_json"]
+
+
+_process_json = _load_process_json()
+
+
+@pytest.mark.parametrize("field", ["outputs", "metadata"])
+def test_process_json_rejects_explicit_empty_optional_lists(field: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"{field} should be a list of same length as input containing only dictionary objects",
+    ):
+        _process_json(
+            {
+                "name": "dataset",
+                "inputs": [{"question": "a"}, {"question": "b"}],
+                field: [],
+            }
+        )


### PR DESCRIPTION
Fixes #12609

## Problem

The JSON dataset ingestion path in `_process_json()` and both sync/async Python client upload helpers use truthiness checks (`if v`, `if outputs`, `if outputs_list`) instead of `is not None`, causing three compounding bugs when `outputs=[]` or `metadata=[]` is explicitly provided:

1. **Server validation skip**: `if v and not (...)` evaluates `[]` as falsy → length-mismatch validation is skipped entirely
2. **Server silent fill**: `outputs[i] if outputs else {}` fills every example with `{}` instead of raising an error
3. **Client payload drop**: `if outputs_list:` drops the empty list from the payload before it even reaches the server

Verified by executing the upstream logic directly:

```
[Server] outputs=[] was NOT caught (bug confirmed)
[Server] Examples created: [{'output': {}, ...}, {'output': {}, ...}]
[Client] payload = {'inputs': [...]}  # 'outputs' key missing
[DirectAPI] bool([]) = False → validation skipped
```

## Fix

### Server (`src/phoenix/server/api/routers/v1/datasets.py`)
- `if v` → `if v is not None` for validation
- `if outputs else {}` → `if outputs is not None else {}` for per-example construction

### Client (`packages/phoenix-client/.../datasets/__init__.py`)
- Parameter signatures: `outputs: Iterable[...] = ()` → `outputs: Optional[Iterable[...]] = None`
- `list(outputs) if outputs else []` → `list(outputs) if outputs is not None else None`
- `if outputs_list:` → `if outputs_list is not None:` for payload inclusion
- `has_json = any(outputs)` → `outputs is not None`
- Applied to both sync (`Datasets`) and async (`AsyncDatasets`) implementations

## Tests

- **Server**: `test_datasets_empty_optional_lists.py` — verifies `_process_json()` raises `ValueError` for `outputs=[]` and `metadata=[]`
- **Client**: `test_empty_optional_lists.py` — verifies both sync and async `_upload_json_dataset()` raise `ValueError` for empty lists

_This fix was developed with AI assistance and verified by a human._