### PR TITLE
fix: Harden authFetch and add it to dataset upload path

### DIFF
--- a/app/src/authFetch.ts
+++ b/app/src/authFetch.ts
@@ -5,10 +5,17 @@ import { BASE_URL } from "@phoenix/config";
 import { createLoginRedirectUrl } from "./utils/routingUtils";
 
 const REFRESH_URL = BASE_URL + "/auth/refresh";
+const REFRESH_TIMEOUT_MS = 10_000;
 
 class UnauthorizedError extends Error {
   constructor() {
     super("Unauthorized");
+  }
+}
+
+class RefreshTimeoutError extends Error {
+  constructor() {
+    super("Refresh timed out");
   }
 }
 
@@ -53,20 +60,37 @@ export async function refreshTokens(): Promise<Response> {
     // There is already a refresh request in progress, so we should wait for it
     return refreshPromise;
   }
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => {
+    controller.abort(new RefreshTimeoutError());
+  }, REFRESH_TIMEOUT_MS);
   // This function should make a request to the server to refresh the access token
   refreshPromise = fetch(REFRESH_URL, {
     method: "POST",
-  }).then((response) => {
-    if (!response.ok) {
-      // for now force redirect to login page. This could re-throw with a custom error
-      // But for now, we'll just redirect
-      window.location.href = createLoginRedirectUrl();
-      // return a promise that never resolves, giving the browser time to redirect above
-      return new Promise(() => {});
-    }
-    // Clear the refreshPromise so that future requests will trigger a new refresh
-    refreshPromise = null;
-    return Promise.resolve(response);
-  });
-  return refreshPromise;
+    signal: controller.signal,
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new UnauthorizedError();
+      }
+      return response;
+    })
+    .catch((error: unknown) => {
+      // Failed refreshes should fail fast and redirect rather than leave requests hanging.
+      if (error instanceof Error && error.name === "AbortError") {
+        throw controller.signal.reason ?? error;
+      }
+      throw error;
+    })
+    .finally(() => {
+      window.clearTimeout(timeoutId);
+      refreshPromise = null;
+    });
+
+  try {
+    return await refreshPromise;
+  } catch (error) {
+    window.location.href = createLoginRedirectUrl();
+    throw error;
+  }
 }

--- a/app/src/authFetch.ts
+++ b/app/src/authFetch.ts
@@ -7,6 +7,17 @@ import { createLoginRedirectUrl } from "./utils/routingUtils";
 const REFRESH_URL = BASE_URL + "/auth/refresh";
 const REFRESH_TIMEOUT_MS = 10_000;
 
+declare global {
+  interface Window {
+    __PHOENIX_AUTH_REFRESH_TIMEOUT_MS__?: number;
+  }
+}
+
+function getRefreshTimeoutMs() {
+  // primarily exercised by tests, not production code
+  return window.__PHOENIX_AUTH_REFRESH_TIMEOUT_MS__ ?? REFRESH_TIMEOUT_MS;
+}
+
 class UnauthorizedError extends Error {
   constructor() {
     super("Unauthorized");
@@ -63,7 +74,7 @@ export async function refreshTokens(): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => {
     controller.abort(new RefreshTimeoutError());
-  }, REFRESH_TIMEOUT_MS);
+  }, getRefreshTimeoutMs());
   // This function should make a request to the server to refresh the access token
   refreshPromise = fetch(REFRESH_URL, {
     method: "POST",

--- a/app/src/pages/datasets/DatasetFromFileForm.tsx
+++ b/app/src/pages/datasets/DatasetFromFileForm.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import invariant from "tiny-invariant";
 
+import { authFetch } from "@phoenix/authFetch";
 import {
   Alert,
   Button,
@@ -543,7 +544,7 @@ export function DatasetFromFileForm({
         });
       }
 
-      return fetch(prependBasename("/v1/datasets/upload?sync=true"), {
+      return authFetch(prependBasename("/v1/datasets/upload?sync=true"), {
         method: "POST",
         body: formData,
       })
@@ -694,7 +695,9 @@ export function DatasetFromFileForm({
                 <span css={rowCountCSS}>
                   {totalRowCount !== null && totalRowCount > previewRows.length
                     ? `showing ${previewRows.length} of ${totalRowCount} rows`
-                    : `${previewRows.length} row${previewRows.length === 1 ? "" : "s"}`}
+                    : `${previewRows.length} row${
+                        previewRows.length === 1 ? "" : "s"
+                      }`}
                 </span>
               </div>
               <TabPanel css={previewTabPanelCSS} id="file">
@@ -759,7 +762,9 @@ export function DatasetFromFileForm({
               }) => (
                 <ColumnMultiSelector
                   label="Split Column (optional)"
-                  description={`Select one or more ${fileType === "csv" ? "column" : "key"}s to automatically assign examples to splits`}
+                  description={`Select one or more ${
+                    fileType === "csv" ? "column" : "key"
+                  }s to automatically assign examples to splits`}
                   columns={columns}
                   selectedColumns={value}
                   onChange={onChange}

--- a/app/tests/auth-refresh.spec.ts
+++ b/app/tests/auth-refresh.spec.ts
@@ -27,7 +27,7 @@ test("recovers from an expired session by refreshing auth", async ({
     await route.continue();
   });
 
-  await page.reload();
+  await page.goto("/projects");
   await page.waitForURL("**/projects");
 
   await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
@@ -59,7 +59,7 @@ test("redirects to login when session refresh fails", async ({ page }) => {
     });
   });
 
-  await page.reload();
+  await page.goto("/projects");
   await page.waitForURL("**/login?returnUrl=%2Fprojects");
 });
 
@@ -85,6 +85,6 @@ test("redirects to login when session refresh times out", async ({ page }) => {
     await route.abort();
   });
 
-  await page.reload();
+  await page.goto("/projects");
   await page.waitForURL("**/login?returnUrl=%2Fprojects");
 });

--- a/app/tests/auth-refresh.spec.ts
+++ b/app/tests/auth-refresh.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+// These tests exercise the client-side auth refresh paths by forcing GraphQL
+// requests to encounter an expired-session response through the UI.
+
+test("recovers from an expired session by refreshing auth", async ({
+  page,
+}) => {
+  let graphqlFailures = 0;
+  let refreshRequests = 0;
+
+  await page.route("**/graphql", async (route) => {
+    if (graphqlFailures === 0) {
+      graphqlFailures += 1;
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ errors: [{ message: "Unauthorized" }] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/auth/refresh", async (route) => {
+    refreshRequests += 1;
+    await route.continue();
+  });
+
+  await page.reload();
+  await page.waitForURL("**/projects");
+
+  await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
+  await expect.poll(() => refreshRequests).toBeGreaterThan(0);
+  expect(graphqlFailures).toBe(1);
+});
+
+test("redirects to login when session refresh fails", async ({ page }) => {
+  let graphqlFailures = 0;
+
+  await page.route("**/graphql", async (route) => {
+    if (graphqlFailures === 0) {
+      graphqlFailures += 1;
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ errors: [{ message: "Unauthorized" }] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/auth/refresh", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Unauthorized" }),
+    });
+  });
+
+  await page.reload();
+  await page.waitForURL("**/login?returnUrl=%2Fprojects");
+});
+
+test("redirects to login when session refresh times out", async ({ page }) => {
+  let graphqlFailures = 0;
+
+  await page.route("**/graphql", async (route) => {
+    if (graphqlFailures === 0) {
+      graphqlFailures += 1;
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ errors: [{ message: "Unauthorized" }] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/auth/refresh", async (route) => {
+    // Stall refresh past the authFetch timeout so the UI must fall back to login.
+    await new Promise((resolve) => setTimeout(resolve, 11_000));
+    await route.abort();
+  });
+
+  await page.reload();
+  await page.waitForURL("**/login?returnUrl=%2Fprojects");
+});

--- a/app/tests/auth-refresh.spec.ts
+++ b/app/tests/auth-refresh.spec.ts
@@ -1,13 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 // These tests exercise the client-side auth refresh paths by forcing GraphQL
 // requests to encounter an expired-session response through the UI.
+
+async function openProjectsPage(page: Page) {
+  await page.goto("/projects");
+  await page.waitForURL("**/projects");
+  await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
+}
 
 test("recovers from an expired session by refreshing auth", async ({
   page,
 }) => {
   let graphqlFailures = 0;
   let refreshRequests = 0;
+
+  await openProjectsPage(page);
 
   await page.route("**/graphql", async (route) => {
     if (graphqlFailures === 0) {
@@ -27,7 +35,7 @@ test("recovers from an expired session by refreshing auth", async ({
     await route.continue();
   });
 
-  await page.goto("/projects");
+  await page.reload();
   await page.waitForURL("**/projects");
 
   await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();
@@ -37,6 +45,8 @@ test("recovers from an expired session by refreshing auth", async ({
 
 test("redirects to login when session refresh fails", async ({ page }) => {
   let graphqlFailures = 0;
+
+  await openProjectsPage(page);
 
   await page.route("**/graphql", async (route) => {
     if (graphqlFailures === 0) {
@@ -59,12 +69,19 @@ test("redirects to login when session refresh fails", async ({ page }) => {
     });
   });
 
-  await page.goto("/projects");
+  await page.reload();
   await page.waitForURL("**/login?returnUrl=%2Fprojects");
 });
 
 test("redirects to login when session refresh times out", async ({ page }) => {
   let graphqlFailures = 0;
+  const refreshTimeoutMs = 200;
+
+  await page.addInitScript((timeoutMs) => {
+    window.__PHOENIX_AUTH_REFRESH_TIMEOUT_MS__ = timeoutMs;
+  }, refreshTimeoutMs);
+
+  await openProjectsPage(page);
 
   await page.route("**/graphql", async (route) => {
     if (graphqlFailures === 0) {
@@ -81,10 +98,10 @@ test("redirects to login when session refresh times out", async ({ page }) => {
 
   await page.route("**/auth/refresh", async (route) => {
     // Stall refresh past the authFetch timeout so the UI must fall back to login.
-    await new Promise((resolve) => setTimeout(resolve, 11_000));
+    await new Promise((resolve) => setTimeout(resolve, refreshTimeoutMs + 50));
     await route.abort();
   });
 
-  await page.goto("/projects");
+  await page.reload();
   await page.waitForURL("**/login?returnUrl=%2Fprojects");
 });

--- a/app/tests/auth-refresh.spec.ts
+++ b/app/tests/auth-refresh.spec.ts
@@ -3,7 +3,20 @@ import { expect, test, type Page } from "@playwright/test";
 // These tests exercise the client-side auth refresh paths by forcing GraphQL
 // requests to encounter an expired-session response through the UI.
 
+// reset browser state so that these tests do not poison the auth of other tests
+// without this, all tests take exponentially longer as they hit expiring auth sessions
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function loginAsMember(page: Page) {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("member@localhost.com");
+  await page.getByLabel("Password").fill("member123");
+  await page.getByRole("button", { name: "Log In", exact: true }).click();
+  await page.waitForURL("**/projects");
+}
+
 async function openProjectsPage(page: Page) {
+  await loginAsMember(page);
   await page.goto("/projects");
   await page.waitForURL("**/projects");
   await expect(page.getByRole("button", { name: "New Project" })).toBeVisible();

--- a/app/tests/datasets.spec.ts
+++ b/app/tests/datasets.spec.ts
@@ -1,6 +1,20 @@
 import { randomUUID } from "crypto";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
+function datasetRow(page: Page, datasetName: string) {
+  return page.getByTestId("datasets-table").getByRole("row").filter({
+    hasText: datasetName,
+  });
+}
+
+function datasetNameLink(page: Page, datasetName: string) {
+  return datasetRow(page, datasetName)
+    .locator("a")
+    .filter({
+      hasText: new RegExp(`^${datasetName}$`),
+    });
+}
+
 async function createDataset(
   page: Page,
   datasetName: string,
@@ -47,7 +61,7 @@ test.describe("Datasets", () => {
 
     await page.getByRole("button", { name: "Create Dataset" }).click();
     await expect(page.getByTestId("dialog")).not.toBeVisible();
-    await expect(page.getByRole("link", { name: datasetName })).toBeVisible();
+    await expect(datasetRow(page, datasetName)).toBeVisible();
   });
 
   test("can create a dataset from scratch and navigate to it", async ({
@@ -71,7 +85,7 @@ test.describe("Datasets", () => {
     await page.getByRole("button", { name: "Create Dataset" }).click();
     await expect(page.getByTestId("dialog")).not.toBeVisible();
 
-    await page.getByRole("link", { name: datasetName }).click();
+    await datasetNameLink(page, datasetName).click({ force: true });
     await page.waitForURL("**/datasets/**/examples");
     await expect(
       page.getByRole("heading", { name: datasetName })
@@ -121,18 +135,18 @@ test.describe("Datasets", () => {
     });
     await search.fill(`compiler-sort-${id}`);
 
-    await expect(page.getByRole("link", { name: datasetNameA })).toBeVisible();
-    await expect(page.getByRole("link", { name: datasetNameZ })).toBeVisible();
+    await expect(datasetRow(page, datasetNameA)).toBeVisible();
+    await expect(datasetRow(page, datasetNameZ)).toBeVisible();
 
     const table = page.getByTestId("datasets-table");
     await expect(table).toBeVisible();
     const nameHeader = page.getByRole("columnheader", { name: "name" }).first();
 
     await clickSortableHeaderAndExpect(nameHeader, "ascending");
-    await expect(page.getByRole("link", { name: datasetNameA })).toBeVisible();
+    await expect(datasetRow(page, datasetNameA)).toBeVisible();
 
     await clickSortableHeaderAndExpect(nameHeader, "descending");
-    await expect(page.getByRole("link", { name: datasetNameZ })).toBeVisible();
+    await expect(datasetRow(page, datasetNameZ)).toBeVisible();
 
     await search.fill(`no-match-${id}`);
     await expect(
@@ -142,9 +156,7 @@ test.describe("Datasets", () => {
     ).toBeVisible();
 
     await search.fill(datasetNameA);
-    await expect(page.getByRole("link", { name: datasetNameA })).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: datasetNameZ })
-    ).not.toBeVisible();
+    await expect(datasetRow(page, datasetNameA)).toBeVisible();
+    await expect(datasetRow(page, datasetNameZ)).not.toBeVisible();
   });
 });

--- a/app/tests/server-evaluators.spec.ts
+++ b/app/tests/server-evaluators.spec.ts
@@ -1,5 +1,19 @@
 import { randomUUID } from "crypto";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+function datasetRow(page: Page, datasetName: string) {
+  return page.getByTestId("datasets-table").getByRole("row").filter({
+    hasText: datasetName,
+  });
+}
+
+function datasetNameLink(page: Page, datasetName: string) {
+  return datasetRow(page, datasetName)
+    .locator("a")
+    .filter({
+      hasText: new RegExp(`^${datasetName}$`),
+    });
+}
 
 test.describe.serial("Server Evaluators", () => {
   const datasetName = `test-dataset-${randomUUID()}`;
@@ -34,10 +48,10 @@ test.describe.serial("Server Evaluators", () => {
     await expect(page.getByTestId("dialog")).not.toBeVisible();
 
     // Wait for the dataset to appear in the table
-    await expect(page.getByRole("link", { name: datasetName })).toBeVisible();
+    await expect(datasetRow(page, datasetName)).toBeVisible();
 
     // Navigate to the dataset to verify it was created
-    await page.getByRole("link", { name: datasetName }).click();
+    await datasetNameLink(page, datasetName).click({ force: true });
     await page.waitForURL("**/datasets/**/examples");
 
     // Verify dataset was created


### PR DESCRIPTION
## Summary
- fail fast when token refresh hangs or fails instead of leaving requests blocked indefinitely
- always clear shared refresh state so one bad refresh attempt cannot poison future requests
- route dataset upload through `authFetch` so expired sessions recover consistently there too

Resolves #9910

Related to #12383
Related to #12600