### PR TITLE
docs(phoenix-otel): rewrite package docs for readability

### DIFF
--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/context-attributes.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/context-attributes.mdx
@@ -1,103 +1,23 @@
 ---
 title: "Context Attributes"
-description: "Propagate session IDs, user IDs, metadata, tags, prompt templates, and custom attributes to child spans"
+description: "Group traces by session, user, or request metadata so you can filter and evaluate them in Phoenix."
 ---
 
-`@arizeai/phoenix-otel` re-exports the OpenInference context setters from `@arizeai/openinference-core`. These functions write values into the OpenTelemetry context so helper-created spans and many instrumented child spans can inherit them automatically.
+A trace on its own tells you what happened. Context attributes tell you _who_ it happened for and _which conversation_ it belonged to. Once you tag spans with a session ID, a user ID, or request metadata, Phoenix lets you filter down to one user's traffic, replay a full conversation, or slice evaluation results by environment.
 
-Available setters:
-
-- `setSession(context, { sessionId })`
-- `setUser(context, { userId })`
-- `setMetadata(context, metadataObject)`
-- `setTags(context, string[])`
-- `setPromptTemplate(context, { template, variables?, version? })`
-- `setAttributes(context, attributes)`
-
-```bash
-npm install @arizeai/phoenix-otel
-```
-
-```ts
-import {
-  context,
-  setAttributes,
-  setMetadata,
-  setPromptTemplate,
-  setSession,
-  setTags,
-  setUser,
-} from "@arizeai/phoenix-otel";
-
-let ctx = context.active();
-ctx = setSession(ctx, { sessionId: "sess-42" });
-ctx = setUser(ctx, { userId: "user-7" });
-ctx = setMetadata(ctx, { tenant: "acme", environment: "prod" });
-ctx = setTags(ctx, ["support", "priority-high"]);
-ctx = setPromptTemplate(ctx, {
-  template: "Answer using docs about {topic}",
-  variables: { topic: "billing" },
-  version: "v3",
-});
-ctx = setAttributes(ctx, { "app.request_id": "req-123" });
-
-await context.with(ctx, async () => {
-  await doTracedWork();
-});
-```
+The setters below write values into the OpenTelemetry context. Any span created inside `context.with(...)` inherits them automatically — including spans from framework instrumentation and from the tracing helpers in [Tracing Helpers](./tracing-helpers).
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
   <ul>
-    <li><code>src/index.ts</code> re-exports the context helpers</li>
-    <li><code>node_modules/@arizeai/openinference-core/src/trace/contextAttributes.ts</code> implements the setter, getter, and clearer helpers</li>
+    <li><code>src/index.ts</code> exports the context helpers</li>
+    <li><code>node_modules/@arizeai/openinference-core/src/trace/contextAttributes.ts</code> implements the setters, getters, and clearers</li>
   </ul>
 </section>
 
-## How Context Propagation Works
+## Group A Conversation Into A Session
 
-Each setter takes a `Context` and returns a new `Context` with the value attached. Activate that context with `context.with()`. Any span created inside the callback can then inherit the propagated attributes.
-
-```ts
-import { context, setSession } from "@arizeai/phoenix-otel";
-
-const ctx = setSession(context.active(), { sessionId: "sess-123" });
-
-await context.with(ctx, async () => {
-  await myTracedFunction();
-});
-```
-
-Setters compose by chaining because each one returns the updated context:
-
-```ts
-import {
-  context,
-  setMetadata,
-  setSession,
-  setTags,
-  setUser,
-} from "@arizeai/phoenix-otel";
-
-const ctx = setTags(
-  setMetadata(
-    setUser(
-      setSession(context.active(), { sessionId: "sess-123" }),
-      { userId: "user-456" }
-    ),
-    { environment: "production", version: "1.4.2" }
-  ),
-  ["premium", "beta-feature"]
-);
-
-await context.with(ctx, () => runPipeline());
-```
-
-## API Reference
-
-### `setSession(context, session)`
-
-Attaches a session ID. Spans receive the `session.id` attribute.
+A session is how Phoenix knows which spans belong to the same conversation. Set one at the entry point of each request.
 
 ```ts
 import { context, setSession } from "@arizeai/phoenix-otel";
@@ -108,14 +28,9 @@ await context.with(
 );
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `session` | `{ sessionId: string }` | The session identifier. |
+Every span created inside `handleConversation()` gets `session.id` automatically. Open the session view in Phoenix and you can replay the whole conversation as a single thread.
 
-### `setUser(context, user)`
-
-Attaches a user ID. Spans receive the `user.id` attribute.
+## Attach A User
 
 ```ts
 import { context, setUser } from "@arizeai/phoenix-otel";
@@ -126,14 +41,11 @@ await context.with(
 );
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `user` | `{ userId: string }` | The user identifier. |
+With `user.id` on every span, you can filter Phoenix to one user's activity — useful when a customer reports a bug or when you want to see how an individual is using your app.
 
-### `setMetadata(context, metadata)`
+## Attach Request Metadata
 
-Attaches arbitrary key-value metadata. Serialized as JSON on the `metadata` span attribute.
+Use `setMetadata` for arbitrary key-value data: environment, region, deployment, feature flags, tenant IDs — anything you want to slice traces by.
 
 ```ts
 import { context, setMetadata } from "@arizeai/phoenix-otel";
@@ -148,32 +60,7 @@ await context.with(
 );
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `metadata` | `Record<string, unknown>` | Key-value pairs to attach. |
-
-### `setTags(context, tags)`
-
-Attaches a list of string tags.
-
-```ts
-import { context, setTags } from "@arizeai/phoenix-otel";
-
-await context.with(
-  setTags(context.active(), ["premium-user", "beta-feature", "high-priority"]),
-  () => handleRequest()
-);
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `tags` | `string[]` | Tags to attach. |
-
-### `setAttributes(context, attributes)`
-
-Attaches arbitrary span attributes. Unlike `setMetadata`, these become individual span attributes rather than a single serialized JSON blob.
+Metadata is stored as a single JSON blob on the span. If you want each key to be a separate filterable attribute instead, use `setAttributes`.
 
 ```ts
 import { context, setAttributes } from "@arizeai/phoenix-otel";
@@ -187,14 +74,22 @@ await context.with(
 );
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `attributes` | `Attributes` | Valid OpenTelemetry span attribute values. |
+## Tag Traces
 
-### `setPromptTemplate(context, promptTemplate)`
+Tags are a list of strings for coarse grouping — things like experiment names, feature flags, or priority bands.
 
-Attaches a prompt template and its variable bindings.
+```ts
+import { context, setTags } from "@arizeai/phoenix-otel";
+
+await context.with(
+  setTags(context.active(), ["premium-user", "beta-feature", "high-priority"]),
+  () => handleRequest()
+);
+```
+
+## Record The Prompt Template
+
+When an LLM call is templated, record the template and its variables separately from the rendered prompt. Phoenix uses this to cluster calls by template and to show you how variables vary across runs.
 
 ```ts
 import { context, setPromptTemplate } from "@arizeai/phoenix-otel";
@@ -209,33 +104,9 @@ await context.with(
 );
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `context` | `Context` | The current OpenTelemetry context. |
-| `promptTemplate` | `{ template: string; variables?: Record<string, string>; version?: string }` | Template text, bound variables, and optional version. |
+## Layer Them Together
 
-## Manual Span Propagation
-
-If you create spans manually with a plain OpenTelemetry tracer, copy the propagated attributes onto the span explicitly:
-
-```ts
-import {
-  context,
-  getAttributesFromContext,
-  trace,
-} from "@arizeai/phoenix-otel";
-
-const tracer = trace.getTracer("manual-tracer");
-const span = tracer.startSpan("manual-span");
-span.setAttributes(getAttributesFromContext(context.active()));
-span.end();
-```
-
-If you use `OITracer` instead of a plain tracer, it automatically merges context attributes during `startSpan()` and `startActiveSpan()`.
-
-## Combining Multiple Setters
-
-Build up context incrementally when different parts of your code learn different pieces of request metadata:
+Each setter returns a new context, so you compose them by passing each call into the next. A realistic request handler usually sets several at once:
 
 ```ts
 import {
@@ -276,16 +147,52 @@ async function handleRequest(userId: string, sessionId: string, question: string
 }
 ```
 
-## Clearing Context Values
+One call to `handleRequest` produces a fully tagged trace: session, user, metadata, agent span, and a nested tool span — all grouped and filterable in Phoenix.
 
-Each setter has a matching clearer:
+## Building Context Incrementally
 
-- `clearSession`
-- `clearUser`
-- `clearMetadata`
-- `clearTags`
-- `clearPromptTemplate`
-- `clearAttributes`
+If different parts of your code learn different pieces of request metadata, build up the context step by step. Each setter returns a new context, so you can chain them:
+
+```ts
+import {
+  context,
+  setMetadata,
+  setSession,
+  setTags,
+  setUser,
+} from "@arizeai/phoenix-otel";
+
+let ctx = context.active();
+ctx = setSession(ctx, { sessionId: "sess-42" });
+ctx = setUser(ctx, { userId: "user-7" });
+ctx = setMetadata(ctx, { tenant: "acme", environment: "prod" });
+ctx = setTags(ctx, ["support", "priority-high"]);
+
+await context.with(ctx, () => doTracedWork());
+```
+
+## Copying Context Onto A Manual Span
+
+If you create a span with a plain OpenTelemetry tracer (not one of the helpers), the propagated attributes do not transfer automatically. Copy them on with `getAttributesFromContext`:
+
+```ts
+import {
+  context,
+  getAttributesFromContext,
+  trace,
+} from "@arizeai/phoenix-otel";
+
+const tracer = trace.getTracer("manual-tracer");
+const span = tracer.startSpan("manual-span");
+span.setAttributes(getAttributesFromContext(context.active()));
+span.end();
+```
+
+`OITracer` (see [Manual Spans](./manual-spans)) does this merge for you automatically, which is usually the easier path.
+
+## Clearing Values
+
+Each setter has a matching clearer. Use them when you need to drop a value mid-request — for example, when exiting a user-scoped block back into shared infrastructure code.
 
 ```ts
 import {
@@ -295,23 +202,19 @@ import {
   clearSession,
   clearTags,
   clearUser,
-  context,
-  setMetadata,
-  setSession,
 } from "@arizeai/phoenix-otel";
-
-let ctx = setMetadata(
-  setSession(context.active(), { sessionId: "sess-123" }),
-  { environment: "prod" }
-);
-
-ctx = clearMetadata(ctx);
-ctx = clearSession(ctx);
-ctx = clearUser(ctx);
-ctx = clearTags(ctx);
-ctx = clearPromptTemplate(ctx);
-ctx = clearAttributes(ctx);
 ```
+
+## Setter Reference
+
+| Setter | Shape | What it produces |
+|--------|-------|------------------|
+| `setSession` | `{ sessionId: string }` | `session.id` attribute |
+| `setUser` | `{ userId: string }` | `user.id` attribute |
+| `setMetadata` | `Record<string, unknown>` | `metadata` attribute (JSON-serialized) |
+| `setTags` | `string[]` | `tag.tags` attribute |
+| `setAttributes` | `Attributes` | individual span attributes |
+| `setPromptTemplate` | `{ template, variables?, version? }` | prompt template attributes |
 
 <section className="hidden" data-agent-context="source-map" aria-label="Source map">
   <h2>Source Map</h2>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/manual-spans.mdx
@@ -1,79 +1,29 @@
 ---
 title: "Manual Spans"
-description: "Create raw OpenTelemetry spans, build OpenInference attributes, and redact sensitive data with @arizeai/phoenix-otel"
+description: "Drop to raw OpenTelemetry spans, build rich LLM/retriever attributes, and redact sensitive data before export."
 ---
 
-`@arizeai/phoenix-otel` re-exports the OpenTelemetry `trace`, `context`, and `SpanStatusCode` APIs, plus the `@arizeai/openinference-core` attribute builders, `OITracer`, and utility helpers.
+Most of the time, the [tracing helpers](./tracing-helpers) are the right tool — they cover agents, tools, chains, and LLM calls with a lot less boilerplate. Reach for manual spans when you need something the helpers do not give you: exact span timing, custom parent/child wiring, or low-level interop with an existing OpenTelemetry setup.
 
-For most use cases, prefer the tracing helpers covered in [Tracing Helpers](./tracing-helpers). Use manual spans when you need exact span timing, low-level OpenTelemetry interop, or explicit control over which attributes are recorded.
+This page also covers two things you will need even if you stay on the helpers:
+
+- **Attribute builders** for emitting OpenInference-shaped data on LLM, retriever, embedding, and tool spans
+- **`OITracer`** for redacting prompts, outputs, and embedding vectors before spans leave the process
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
   <ul>
-    <li><code>src/index.ts</code> re-exports the manual tracing surface</li>
+    <li><code>src/index.ts</code> exports the manual tracing surface</li>
     <li><code>src/register.ts</code> configures the Phoenix exporter and provider</li>
     <li><code>node_modules/@arizeai/openinference-core/src/helpers/attributeHelpers.ts</code> implements the attribute builders</li>
     <li><code>node_modules/@arizeai/openinference-core/src/trace/trace-config/OITracer.ts</code> implements redaction-aware tracing</li>
   </ul>
 </section>
 
-## Recommended First: OpenInference Helpers
-
-If you do not need low-level OpenTelemetry control, use the helper wrappers first:
+## Create A Span Manually
 
 ```ts
-import {
-  context,
-  register,
-  setMetadata,
-  setSession,
-  withSpan,
-} from "@arizeai/phoenix-otel";
-
-register({ projectName: "support-bot" });
-
-const retrieveDocs = withSpan(
-  async (query: string) => {
-    const response = await fetch(`/api/search?q=${query}`);
-    return response.json();
-  },
-  { name: "retrieve-docs", kind: "RETRIEVER" }
-);
-
-const generateAnswer = withSpan(
-  async (query: string, docs: unknown[]) => {
-    return `Answer based on ${docs.length} documents`;
-  },
-  { name: "generate-answer", kind: "LLM" }
-);
-
-const ragPipeline = withSpan(
-  async (query: string) => {
-    const docs = await retrieveDocs(query);
-    return generateAnswer(query, docs);
-  },
-  { name: "rag-pipeline", kind: "CHAIN" }
-);
-
-await context.with(
-  setMetadata(
-    setSession(context.active(), { sessionId: "session-abc-123" }),
-    { environment: "production" }
-  ),
-  () => ragPipeline("What is Phoenix?")
-);
-```
-
-## Raw OpenTelemetry Spans
-
-Use raw spans when you need full control over timing and attributes:
-
-```ts
-import {
-  SpanStatusCode,
-  register,
-  trace,
-} from "@arizeai/phoenix-otel";
+import { SpanStatusCode, register, trace } from "@arizeai/phoenix-otel";
 
 register({ projectName: "support-bot" });
 
@@ -93,11 +43,11 @@ await tracer.startActiveSpan("lookup-customer", async (span) => {
 });
 ```
 
-If you need context-propagated session, user, metadata, or prompt-template attributes on a plain tracer span, copy them explicitly with `getAttributesFromContext()` as shown on [Context Attributes](./context-attributes).
+If you want session, user, or metadata from the propagated context to land on this span, copy them on with `getAttributesFromContext()` — see [Context Attributes](./context-attributes).
 
-## Attribute Helper APIs
+## Emit Rich LLM Attributes
 
-Use the attribute helpers to build OpenInference-compatible attribute sets for LLM, retriever, embedding, tool, input, and output spans.
+Phoenix renders LLM spans natively — messages, token counts, invocation params — when you emit OpenInference attributes. Use `getLLMAttributes` to build the attribute set.
 
 ```ts
 import { getLLMAttributes, trace } from "@arizeai/phoenix-otel";
@@ -119,21 +69,23 @@ tracer.startActiveSpan("llm-inference", (span) => {
 });
 ```
 
-Common helpers:
+The same shape works inside a `withSpan` wrapper via `processOutput`, which is usually cleaner.
 
-- `getLLMAttributes`
-- `getEmbeddingAttributes`
-- `getRetrieverAttributes`
-- `getToolAttributes`
-- `getMetadataAttributes`
-- `getInputAttributes`
-- `getOutputAttributes`
-- `defaultProcessInput`
-- `defaultProcessOutput`
+### Attribute Builders
 
-## Trace Config And Redaction
+| Helper | For |
+|--------|-----|
+| `getLLMAttributes` | LLM calls (provider, model, messages, token counts, params) |
+| `getEmbeddingAttributes` | Embedding calls (model, embeddings, text) |
+| `getRetrieverAttributes` | Retrievers (documents with id, content, score) |
+| `getToolAttributes` | Tool calls (name, description, params, results) |
+| `getInputAttributes` | Generic input value on any span |
+| `getOutputAttributes` | Generic output value on any span |
+| `getMetadataAttributes` | Metadata on any span |
 
-`OITracer` wraps an OpenTelemetry tracer and applies OpenInference trace masking rules before attributes are written. It also merges propagated context attributes automatically.
+## Redact Sensitive Data Before Export
+
+`OITracer` wraps a regular OpenTelemetry tracer and applies OpenInference trace masking rules before attributes are written. It also merges propagated context attributes automatically. Use it when prompts, outputs, or embeddings might contain PII, credentials, or other data you cannot send to Phoenix.
 
 ```ts
 import {
@@ -163,7 +115,7 @@ const safeLLMCall = withSpan(
 );
 ```
 
-You can also configure masking via environment variables:
+You can also configure masking via environment variables, which is convenient when the redaction policy differs by environment:
 
 - `OPENINFERENCE_HIDE_INPUTS`
 - `OPENINFERENCE_HIDE_OUTPUTS`
@@ -176,9 +128,9 @@ You can also configure masking via environment variables:
 - `OPENINFERENCE_BASE64_IMAGE_MAX_LENGTH`
 - `OPENINFERENCE_HIDE_PROMPTS`
 
-## Utility Helpers
+## Safety Utilities
 
-The package also re-exports small safety utilities:
+Three small helpers for code paths where a throw would be worse than a silent failure:
 
 - `withSafety({ fn, onError? })` wraps a function and returns `null` if it throws
 - `safelyJSONStringify(value)` wraps `JSON.stringify`
@@ -191,13 +143,10 @@ import {
   withSafety,
 } from "@arizeai/phoenix-otel";
 
-const safeDivide = withSafety({
-  fn: (a: number, b: number) => a / b,
-});
+const safeDivide = withSafety({ fn: (a: number, b: number) => a / b });
 
 const serialized = safelyJSONStringify({ ok: true });
 const parsed = safelyJSONParse(serialized ?? "{}");
-const result = safeDivide(4, 2);
 ```
 
 <section className="hidden" data-agent-context="source-map" aria-label="Source map">

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/overview.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/overview.mdx
@@ -1,81 +1,62 @@
 ---
 title: "Overview"
-description: "Register OpenTelemetry with Phoenix and use OpenInference helpers from @arizeai/phoenix-otel"
+description: "Trace LLM apps to Phoenix with @arizeai/phoenix-otel — see every prompt, tool call, and retrieval as structured data you can inspect and evaluate."
 ---
 
-`@arizeai/phoenix-otel` is the Phoenix-focused OpenTelemetry package for Node.js. It handles provider setup, OTLP export, and instrumentation registration, then re-exports the full `@arizeai/openinference-core` helper surface and OpenInference semantic conventions from the same package path.
+`@arizeai/phoenix-otel` turns a Node.js app into something you can actually see inside. Once you call `register()`, every LLM call, tool invocation, retrieval, and agent step can flow to Phoenix as a structured span — with the prompt, the response, the tokens, the latency, and any metadata you attach. From there you can look at real conversations, compare runs, and evaluate specific steps with evals.
 
 ## Install
-
-Install the package and any OpenTelemetry instrumentations you want to use with it.
 
 ```bash
 npm install @arizeai/phoenix-otel
 ```
 
-### Add Instrumentations
-
-```bash
-npm install \
-  @arizeai/phoenix-otel \
-  @opentelemetry/instrumentation-http \
-  @opentelemetry/instrumentation-express
-```
-
-## What This Package Includes
-
-`@arizeai/phoenix-otel` combines Phoenix registration with OpenInference authoring APIs:
-
-- Phoenix registration: `register()`, `attachGlobalTracerProvider()`, `detachGlobalTracerProvider()`, `createNoOpProvider()`
-- OpenInference wrappers: `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`
-- decorators and context propagation: `observe()`, `setSession()`, `setUser()`, `setMetadata()`, `setTags()`, `setPromptTemplate()`, `setAttributes()`
-- attribute builders: `getLLMAttributes()`, `getRetrieverAttributes()`, `getEmbeddingAttributes()`, `getToolAttributes()`, `getMetadataAttributes()`, `getInputAttributes()`, `getOutputAttributes()`, `defaultProcessInput()`, `defaultProcessOutput()`
-- redaction and safety helpers: `OITracer`, `withSafety`, `safelyJSONStringify`, `safelyJSONParse`
-- OpenTelemetry utilities: `trace`, `context`, `SpanStatusCode`, `DiagLogLevel`, `registerInstrumentations()`
-
-The re-exported OpenInference wrappers resolve the default tracer when the wrapped function runs, so module-scoped traced helpers continue following global provider changes.
-
 ## Quick Start
 
+Point the SDK at your Phoenix instance, register a project, and wrap the functions you care about.
+
 ```ts
-import { register, traceChain } from "@arizeai/phoenix-otel";
+import { register, traceAgent, traceTool } from "@arizeai/phoenix-otel";
 
 const provider = register({ projectName: "support-bot" });
 
-const handleQuery = traceChain(
+const searchKB = traceTool(
   async (query: string) => {
-    return `Handled: ${query}`;
+    const res = await fetch(`/api/kb?q=${query}`);
+    return res.json();
   },
-  { name: "handle-query" }
+  { name: "search-kb" }
 );
 
-await handleQuery("Hello");
+const supportAgent = traceAgent(
+  async (question: string) => {
+    const docs = await searchKB(question);
+    return `Found ${docs.length} articles for: ${question}`;
+  },
+  { name: "support-agent" }
+);
+
+await supportAgent("How do I reset my password?");
 await provider.shutdown();
 ```
 
-If you want raw control over span shape, switch to `withSpan()` or the OpenTelemetry `trace` API. The package docs linked below cover both patterns.
+This sends two linked spans to Phoenix: a parent `support-agent` span with the user's question, and a child `search-kb` span showing the tool call. Open the trace in Phoenix and you can read the input, the output, the timing, and evaluate the retrieved docs against a rubric.
 
-## Docs And Source In `node_modules`
+## What You Can Trace
 
-After install, a coding agent can inspect the installed package directly:
+Most teams start with these three building blocks:
 
-```text
-node_modules/@arizeai/phoenix-otel/docs/
-node_modules/@arizeai/phoenix-otel/src/
-```
+- **Agent steps** — the entry point your user talks to. Wrap it with `traceAgent` to see the full decision flow.
+- **Tool calls** — functions the agent invokes (search, lookups, API calls). Wrap them with `traceTool` to see inputs, outputs, and latency per call.
+- **LLM calls and retrievers** — wrap with `withSpan` and use OpenInference attribute builders so Phoenix can render messages, token counts, and retrieved documents natively.
 
-Because `@arizeai/phoenix-otel` re-exports `@arizeai/openinference-core`, the dependency docs are also high-value local references:
+If your app is a simple pipeline rather than an agent, `traceChain` is the right wrapper for the top-level function.
 
-```text
-node_modules/@arizeai/openinference-core/docs/
-node_modules/@arizeai/openinference-core/src/
-```
+See [Tracing Helpers](./tracing-helpers) for recipes on each of these.
 
-## Configuration
+## Connect To Phoenix
 
-`register()` can use explicit options, environment variables, or both. If you pass a Phoenix base URL, the package normalizes it to the OTLP collector endpoint at `/v1/traces`.
-
-### Environment-Driven Setup
+`register()` accepts explicit options, reads environment variables, or both. Environment variables are the common choice for deployed apps.
 
 ```bash
 export PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
@@ -85,15 +66,13 @@ export PHOENIX_API_KEY=<your-api-key>
 ```ts
 import { register } from "@arizeai/phoenix-otel";
 
-const provider = register({
-  projectName: "support-bot",
-});
+const provider = register({ projectName: "support-bot" });
 ```
 
-### Explicit Setup
+For explicit setup (self-hosted, multi-environment, or when you want custom headers):
 
 ```ts
-import { DiagLogLevel, register } from "@arizeai/phoenix-otel";
+import { register } from "@arizeai/phoenix-otel";
 
 const provider = register({
   projectName: "support-bot",
@@ -104,34 +83,41 @@ const provider = register({
     "x-client-version": "1.4.2",
   },
   batch: true,
-  diagLogLevel: DiagLogLevel.INFO,
 });
 ```
 
-### Key Options
+Pass the Phoenix base URL and the package will normalize it to the OTLP trace endpoint.
+
+### Options
 
 | Option | Description |
 |--------|-------------|
 | `projectName` | Phoenix project name attached to exported spans. Defaults to `default`. |
-| `url` | Phoenix base URL or full collector endpoint. The package appends `/v1/traces` when needed. |
+| `url` | Phoenix base URL or full collector endpoint. Appends `/v1/traces` when needed. |
 | `apiKey` | API key sent as a bearer token. Falls back to `PHOENIX_API_KEY`. |
 | `headers` | Additional OTLP headers merged with the auth header. |
-| `batch` | `true` for batched export, `false` for immediate export during debugging. |
+| `batch` | `true` for batched export (production). `false` for immediate export (debugging). |
 | `instrumentations` | OpenTelemetry instrumentations to register with the provider. |
-| `spanProcessors` | Custom span processors. When provided, these replace the default Phoenix exporter setup. |
-| `global` | Whether to attach the provider to the global OpenTelemetry APIs automatically. |
+| `spanProcessors` | Custom span processors. Replaces the default Phoenix exporter setup. |
+| `global` | Whether to attach the provider to global OpenTelemetry APIs. |
 | `diagLogLevel` | OpenTelemetry diagnostic logging level. |
 
 ### Environment Variables
 
-| Variable | Use |
-|--------|-----|
+| Variable | Purpose |
+|----------|---------|
 | `PHOENIX_COLLECTOR_ENDPOINT` | Base Phoenix collector URL or full OTLP trace endpoint. |
 | `PHOENIX_API_KEY` | API key used when you do not pass `apiKey` explicitly. |
 
-## Instrumentation
+## Add Framework Instrumentation
 
-Pass OpenTelemetry instrumentations to `register()` to capture framework and library activity automatically.
+If your app uses Express, HTTP, or any other OpenTelemetry-instrumented library, pass the instrumentations to `register()` so framework activity shows up alongside your LLM spans.
+
+```bash
+npm install \
+  @opentelemetry/instrumentation-http \
+  @opentelemetry/instrumentation-express
+```
 
 ```ts
 import { register } from "@arizeai/phoenix-otel";
@@ -140,35 +126,17 @@ import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 
 register({
   projectName: "support-bot",
-  instrumentations: [
-    new HttpInstrumentation(),
-    new ExpressInstrumentation(),
-  ],
+  instrumentations: [new HttpInstrumentation(), new ExpressInstrumentation()],
 });
 ```
 
-- `registerInstrumentations()` is also re-exported for manual setups
-- auto-instrumentation works best when initialized very early in process startup
-- ESM projects often need manual library instrumentation rather than loader-based auto-instrumentation
+Initialize this as early as possible in process startup so instrumentations can hook the modules they patch.
 
-## Production
+## Running In Production
 
-### Enable Batch Processing
+Keep `batch: true` in production so spans are grouped before export. Disable batching only when you want immediate local feedback during development.
 
-Keep `batch: true` in production. The batch span processor groups spans before export, reducing request volume and export overhead. Disable batching only when you need immediate local feedback.
-
-```ts
-const provider = register({
-  projectName: "support-bot",
-  url: "https://app.phoenix.arize.com",
-  apiKey: process.env.PHOENIX_API_KEY,
-  batch: true,
-});
-```
-
-### Provider Lifecycle
-
-Flush and shut down the provider before process exit, otherwise in-flight batches can be lost.
+Always flush and shut down the provider before the process exits, otherwise in-flight batches can be lost.
 
 ```ts
 process.on("SIGTERM", async () => {
@@ -177,16 +145,16 @@ process.on("SIGTERM", async () => {
 });
 ```
 
-For short-lived processes such as scripts, CLI commands, and serverless handlers:
+For short-lived processes (scripts, CLI commands, serverless handlers):
 
 ```ts
 await doWork();
 await provider.shutdown();
 ```
 
-### Custom Span Processors
+### Custom Exporters
 
-If you need full control over export, pass your own `spanProcessors`. This replaces the default Phoenix exporter setup.
+If you need full control over export — for example to send to both Phoenix and a second backend — pass your own `spanProcessors`. This replaces the default Phoenix exporter setup, so you take responsibility for wiring it.
 
 ```ts
 import { register } from "@arizeai/phoenix-otel";
@@ -206,15 +174,15 @@ const provider = register({
 
 ## Troubleshooting
 
-When traces do not show up in Phoenix, check these common issues:
+If traces are not showing up in Phoenix:
 
-- confirm `projectName` is the project you are inspecting
+- confirm `projectName` matches the project you are inspecting
 - confirm `url` or `PHOENIX_COLLECTOR_ENDPOINT` points at the collector
-- confirm `PHOENIX_API_KEY` is present for authenticated environments
-- confirm registration happens before the instrumented work starts
-- call `await provider.shutdown()` before process exit when using batched export
+- confirm `PHOENIX_API_KEY` is present in authenticated environments
+- confirm registration runs before the instrumented work starts
+- confirm `await provider.shutdown()` runs before process exit when using batched export
 
-### Enable Diagnostic Logging
+Enable diagnostic logging to see what the exporter is doing:
 
 ```ts
 import { DiagLogLevel, register } from "@arizeai/phoenix-otel";
@@ -224,28 +192,13 @@ const provider = register({
   batch: false,
   diagLogLevel: DiagLogLevel.DEBUG,
 });
-
-await provider.shutdown();
 ```
 
-## Package Surface
+## Where To Next
 
-| Category | Exports |
-|----------|---------|
-| **Registration** | `register()`, `attachGlobalTracerProvider()`, `detachGlobalTracerProvider()`, `createNoOpProvider()` |
-| **Tracing helpers** | `withSpan()`, `traceChain()`, `traceAgent()`, `traceTool()`, `observe()` |
-| **Context attributes** | `setSession()`, `setUser()`, `setMetadata()`, `setTags()`, `setPromptTemplate()`, `setAttributes()`, `getAttributesFromContext()` |
-| **Attribute builders** | `getLLMAttributes()`, `getToolAttributes()`, `getRetrieverAttributes()`, `getEmbeddingAttributes()`, `getMetadataAttributes()` |
-| **Redaction and safety** | `OITracer`, `withSafety()`, `safelyJSONStringify()`, `safelyJSONParse()` |
-| **Semantic conventions** | `SemanticConventions`, `OpenInferenceSpanKind`, `MimeType` |
-| **OpenTelemetry** | `trace`, `context`, `SpanStatusCode`, `DiagLogLevel`, `suppressTracing`, `registerInstrumentations()` |
-| **Types** | `Tracer`, `Instrumentation`, `SpanTraceOptions`, `RegisterParams` |
-
-## Where To Start
-
-- [Tracing helpers](./tracing-helpers) for wrapping functions with `withSpan`, `traceChain`, `traceAgent`, `traceTool`, and `observe`
-- [Context attributes](./context-attributes) for propagating sessions, users, metadata, tags, prompt templates, and manual context propagation
-- [Manual spans](./manual-spans) for raw OpenTelemetry spans, attribute builders, `OITracer`, and utility helpers
+- [Tracing Helpers](./tracing-helpers) — wrap your agents, tools, chains, and LLM calls
+- [Context Attributes](./context-attributes) — group traces by session, user, or request metadata
+- [Manual Spans](./manual-spans) — drop to the OpenTelemetry API when you need exact control, plus redaction for sensitive data
 
 <section className="hidden" data-agent-context="source-map" aria-label="Source map">
   <h2>Source Map</h2>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/tracing-helpers.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-otel/tracing-helpers.mdx
@@ -1,115 +1,30 @@
 ---
 title: "Tracing Helpers"
-description: "Wrap functions and methods with OpenInference spans using withSpan, traceChain, traceAgent, traceTool, and observe"
+description: "Wrap agents, tools, chains, retrievers, and LLM calls so Phoenix sees them as structured spans you can inspect and evaluate."
 ---
 
-`@arizeai/phoenix-otel` re-exports the OpenInference tracing helpers from `@arizeai/openinference-core`, so you can configure Phoenix export and author traced functions from one package path.
+Tracing helpers turn ordinary functions into observable building blocks. Wrap your agent step, your tool call, or your retriever, and Phoenix will show the inputs, the outputs, the timing, and any errors — one span per invocation, nested under whichever span is active.
 
-```bash
-npm install @arizeai/phoenix-otel
-```
-
-```ts
-import { register, traceChain, traceTool } from "@arizeai/phoenix-otel";
-
-register({ projectName: "my-app" });
-
-const fetchWeather = traceTool(
-  async (city: string) => ({ city, temp: 72 }),
-  { name: "fetch-weather" }
-);
-
-const handleQuery = traceChain(
-  async (query: string) => {
-    const weather = await fetchWeather("San Francisco");
-    return `It is ${weather.temp}F in ${weather.city}`;
-  },
-  { name: "handle-query" }
-);
-
-await handleQuery("What's the weather?");
-```
+This page walks through the common patterns. If you need raw OpenTelemetry spans, see [Manual Spans](./manual-spans).
 
 <section className="hidden" data-agent-context="relevant-source-files" aria-label="Relevant source files">
   <h2>Relevant Source Files</h2>
   <ul>
-    <li><code>src/index.ts</code> re-exports the helper surface from <code>@arizeai/openinference-core</code></li>
-    <li><code>node_modules/@arizeai/openinference-core/src/helpers/withSpan.ts</code> implements wrapper behavior</li>
+    <li><code>src/index.ts</code> exports the helper surface</li>
+    <li><code>node_modules/@arizeai/openinference-core/src/helpers/withSpan.ts</code> implements the wrapper behavior</li>
     <li><code>node_modules/@arizeai/openinference-core/src/helpers/wrappers.ts</code> defines <code>traceChain</code>, <code>traceAgent</code>, and <code>traceTool</code></li>
     <li><code>node_modules/@arizeai/openinference-core/src/helpers/decorators.ts</code> defines <code>observe</code></li>
   </ul>
 </section>
 
-## Why These Re-Exports Matter
+## Trace An Agent Step
 
-`@arizeai/phoenix-otel` adds Phoenix registration and export. The tracing helpers themselves come from `@arizeai/openinference-core`.
-
-Those helpers resolve the default tracer when the wrapped function is invoked, not when the wrapper is created. That means:
-
-- functions wrapped at module load continue following later global provider changes
-- experiment-scoped providers still receive spans from previously defined helpers
-- you can keep using the same wrappers when moving between standalone tracing and experiment workflows
-
-## API Reference
-
-### `withSpan(fn, options?)`
-
-The general-purpose wrapper. All other helper wrappers build on it.
+`traceAgent` marks a function as the top of an agent's decision loop. Use it on the function your user or API actually calls.
 
 ```ts
-import { OpenInferenceSpanKind, withSpan } from "@arizeai/phoenix-otel";
+import { register, traceAgent } from "@arizeai/phoenix-otel";
 
-const retrieveDocs = withSpan(
-  async (query: string) => {
-    return [`Document for ${query}`];
-  },
-  {
-    name: "retrieve-docs",
-    kind: OpenInferenceSpanKind.RETRIEVER,
-  }
-);
-```
-
-**Options** (`SpanTraceOptions`):
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `string` | `fn.name` | Span name. Falls back to the function name. |
-| `kind` | `OpenInferenceSpanKind` | `CHAIN` | OpenInference span kind such as `CHAIN`, `AGENT`, `TOOL`, `LLM`, or `RETRIEVER`. |
-| `tracer` | `Tracer` | default tracer | Override the tracer instance. When omitted, the default tracer is resolved when the wrapper runs. |
-| `attributes` | `Attributes` | — | Base attributes merged into every span. |
-| `processInput` | `(...args) => Attributes` | `defaultProcessInput` | Custom function to extract span attributes from input arguments. |
-| `processOutput` | `(result) => Attributes` | `defaultProcessOutput` | Custom function to extract span attributes from the return value. |
-| `openTelemetrySpanKind` | `SpanKind` | `SpanKind.INTERNAL` | Underlying OpenTelemetry span kind. |
-
-**Behavior:**
-
-- wraps both sync and async functions
-- records input and output attributes automatically
-- records exceptions, marks the span as `ERROR`, closes the span, and re-throws
-- preserves the call-time `this` value
-
-### `traceChain(fn, options?)`
-
-Shorthand for `withSpan(fn, { ...options, kind: OpenInferenceSpanKind.CHAIN })`.
-
-```ts
-import { traceChain } from "@arizeai/phoenix-otel";
-
-const summarize = traceChain(
-  async (text: string) => {
-    return `Summary of ${text.length} chars`;
-  },
-  { name: "summarize" }
-);
-```
-
-### `traceAgent(fn, options?)`
-
-Shorthand for `withSpan(fn, { ...options, kind: OpenInferenceSpanKind.AGENT })`.
-
-```ts
-import { traceAgent } from "@arizeai/phoenix-otel";
+register({ projectName: "support-bot" });
 
 const supportAgent = traceAgent(
   async (question: string) => {
@@ -117,11 +32,15 @@ const supportAgent = traceAgent(
   },
   { name: "support-agent" }
 );
+
+await supportAgent("How do I reset my password?");
 ```
 
-### `traceTool(fn, options?)`
+In Phoenix, this shows up as an `AGENT` span with the question as input and the structured answer as output. Any tool or LLM spans you create inside the function will nest beneath it automatically.
 
-Shorthand for `withSpan(fn, { ...options, kind: OpenInferenceSpanKind.TOOL })`.
+## Trace A Tool Call
+
+`traceTool` wraps functions the agent can invoke — a search, a lookup, an external API call.
 
 ```ts
 import { traceTool } from "@arizeai/phoenix-otel";
@@ -135,9 +54,81 @@ const searchDocs = traceTool(
 );
 ```
 
-### `observe(options?)`
+Each call becomes a `TOOL` span under whichever span is active when it runs. This is where Phoenix lets you see whether the right tool ran with the right arguments, and whether its output actually helped.
 
-Decorator factory for class methods. Use TypeScript 5+ standard decorators.
+## Trace A Chain (Non-Agent Pipeline)
+
+If your app is a fixed pipeline rather than an agent, `traceChain` is the right wrapper for the top-level function. Everything else works the same.
+
+```ts
+import { traceChain } from "@arizeai/phoenix-otel";
+
+const summarize = traceChain(
+  async (text: string) => {
+    return `Summary of ${text.length} chars`;
+  },
+  { name: "summarize" }
+);
+```
+
+## Trace A Retriever Or LLM Call With Rich Attributes
+
+For retrievers and LLM calls, Phoenix can render a lot more detail — documents, messages, token counts — if you emit the OpenInference attributes for them. Use `withSpan` directly and pass a `processOutput` (or `processInput`) that shapes the return value into those attributes.
+
+```ts
+import {
+  OpenInferenceSpanKind,
+  getInputAttributes,
+  getRetrieverAttributes,
+  withSpan,
+} from "@arizeai/phoenix-otel";
+
+const retrieveDocs = withSpan(
+  async (query: string) => [
+    { id: "doc-1", content: "Phoenix is an observability platform." },
+    { id: "doc-2", content: "It supports tracing LLM applications." },
+  ],
+  {
+    name: "retrieve-docs",
+    kind: OpenInferenceSpanKind.RETRIEVER,
+    processInput: (query) => getInputAttributes(query),
+    processOutput: (documents) => getRetrieverAttributes({ documents }),
+  }
+);
+```
+
+The same pattern works for LLM calls with `getLLMAttributes`, embeddings with `getEmbeddingAttributes`, and tools with `getToolAttributes`. See [Manual Spans](./manual-spans) for the full list of attribute builders.
+
+## Compose Them Into A Pipeline
+
+The wrappers compose. Nest a tool inside an agent, and Phoenix will link the spans into a single trace.
+
+```ts
+import { register, traceAgent, traceTool } from "@arizeai/phoenix-otel";
+
+register({ projectName: "support-bot" });
+
+const searchKB = traceTool(
+  async (query: string) => [{ title: "Password Reset", body: "..." }],
+  { name: "search-kb" }
+);
+
+const supportAgent = traceAgent(
+  async (question: string) => {
+    const docs = await searchKB(question);
+    return `Based on ${docs.length} articles: ...`;
+  },
+  { name: "support-agent" }
+);
+
+await supportAgent("How do I reset my password?");
+```
+
+One trace, two spans, the relationship preserved.
+
+## Trace Class Methods With A Decorator
+
+If your code is object-oriented, `observe` is a decorator factory for class methods. It preserves `this` and uses the method name as the default span name.
 
 ```ts
 import { OpenInferenceSpanKind, observe } from "@arizeai/phoenix-otel";
@@ -155,80 +146,31 @@ class SupportBot {
 }
 ```
 
-`observe` preserves method `this` context and uses the method name as the default span name unless you pass `name`.
+Requires TypeScript 5+ standard decorators.
 
-## Input / Output Processing
+## What Happens On Errors
 
-By default, `withSpan` serializes function arguments into `input.value` and the return value into `output.value`. Override this with `processInput` and `processOutput` when you want richer OpenInference attributes.
+All the wrappers record exceptions onto the span, mark it as `ERROR`, close the span, and re-throw the original error. You get full visibility into failures without losing the exception semantics your caller expects.
 
-```ts
-import {
-  OpenInferenceSpanKind,
-  getInputAttributes,
-  getRetrieverAttributes,
-  withSpan,
-} from "@arizeai/phoenix-otel";
+## Options Reference
 
-const retriever = withSpan(
-  async (query: string) => [`Doc A for ${query}`, `Doc B for ${query}`],
-  {
-    name: "retriever",
-    kind: OpenInferenceSpanKind.RETRIEVER,
-    processInput: (query) => getInputAttributes(query),
-    processOutput: (documents) =>
-      getRetrieverAttributes({
-        documents: documents.map((content, index) => ({
-          id: `doc-${index}`,
-          content,
-        })),
-      }),
-  }
-);
-```
+All the wrappers (`withSpan`, `traceAgent`, `traceTool`, `traceChain`, and `observe`) accept the same options shape:
 
-The same customization pattern works with `traceChain`, `traceAgent`, and `traceTool`, since they all delegate to `withSpan`.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `name` | `string` | `fn.name` | Span name. Falls back to the function or method name. |
+| `kind` | `OpenInferenceSpanKind` | `CHAIN` | Span kind: `CHAIN`, `AGENT`, `TOOL`, `LLM`, `RETRIEVER`, `EMBEDDING`, etc. |
+| `tracer` | `Tracer` | default tracer | Override the tracer. When omitted, resolved at call time so global provider changes are picked up. |
+| `attributes` | `Attributes` | — | Base attributes merged into every span the wrapper creates. |
+| `processInput` | `(...args) => Attributes` | `defaultProcessInput` | Shape function arguments into span attributes. |
+| `processOutput` | `(result) => Attributes` | `defaultProcessOutput` | Shape the return value into span attributes. |
+| `openTelemetrySpanKind` | `SpanKind` | `INTERNAL` | Underlying OpenTelemetry span kind. |
 
-## Combining Helpers With Context Attributes
+`traceAgent`, `traceTool`, and `traceChain` are shorthands that fix `kind` to `AGENT`, `TOOL`, and `CHAIN` respectively. Anything you pass through their options is forwarded to `withSpan`.
 
-Tracing helpers compose naturally with [context attributes](./context-attributes). Wrap a call in `context.with()` to propagate session IDs, metadata, or tags to all child spans.
+## Using Helpers Inside Experiments
 
-```ts
-import {
-  context,
-  register,
-  setMetadata,
-  setSession,
-  traceAgent,
-  traceTool,
-} from "@arizeai/phoenix-otel";
-
-register({ projectName: "support-bot" });
-
-const searchKB = traceTool(
-  async (query: string) => [{ title: "Password Reset", body: "..." }],
-  { name: "search-kb" }
-);
-
-const supportAgent = traceAgent(
-  async (question: string) => {
-    const docs = await searchKB(question);
-    return `Based on ${docs.length} articles: ...`;
-  },
-  { name: "support-agent" }
-);
-
-await context.with(
-  setMetadata(
-    setSession(context.active(), { sessionId: "sess-abc-123" }),
-    { environment: "production", region: "us-east-1" }
-  ),
-  () => supportAgent("How do I reset my password?")
-);
-```
-
-## Use With Experiments
-
-When you run experiments with `@arizeai/phoenix-client`, the experiment framework can attach a per-run global provider. Because the wrappers resolve the default tracer at invocation time, traced functions defined at module scope still route spans to the active provider.
+When you run an experiment with `@arizeai/phoenix-client`, the experiment framework can attach a per-run global provider. Because the helpers resolve the default tracer at call time (not at wrap time), traced functions defined at module scope still route spans to whichever provider is active when they run — so you can reuse the same wrappers across standalone tracing and experiments.
 
 ```ts
 import { traceTool } from "@arizeai/phoenix-otel";
@@ -243,10 +185,8 @@ const classifyIntent = traceTool(
   { name: "classify-intent" }
 );
 
-const client = createClient();
-
 await runExperiment({
-  client,
+  client: createClient(),
   datasetId: "my-dataset",
   task: async (example) => classifyIntent(example.input.text as string),
   evaluators: [


### PR DESCRIPTION
## Summary
- Rewrites the four `@arizeai/phoenix-otel` doc pages (overview, tracing helpers, context attributes, manual spans) to drop the "re-export" framing and lead with what tracing gives the user.
- Reorganizes each page around tasks: trace an agent step, trace a tool call, trace a retriever with rich attributes, group a conversation into a session, attach a user, redact sensitive data.
- Keeps the essential option tables and environment variables, but moves them below runnable examples so the pages read as a guide first and a reference second.

## Test plan
- [ ] `node js/scripts/sync-package-docs.mjs phoenix-otel` succeeds (run locally)
- [ ] Preview the four pages on the Mintlify docs site and confirm nav links still resolve
- [ ] Spot-check that hidden agent-context sections still render cleanly