### PR TITLE
test: add PyPI install smoke workflow

### DIFF
--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -1,0 +1,126 @@
+name: PyPI Smoke Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *"
+  workflow_run:
+    workflows:
+      - Publish Python packages
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Default install and boot latest PyPI Phoenix (${{ matrix.installer }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        installer: [pip, uv]
+    env:
+      PYTHON_VERSION: "3.12"
+      UV_VERSION: "0.10.9"
+      PHOENIX_HOST: "127.0.0.1"
+      PHOENIX_PORT: "6606"
+    steps:
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install latest Phoenix from PyPI and verify startup
+        env:
+          PHOENIX_WORKING_DIR: ${{ runner.temp }}/phoenix-smoke
+          PHOENIX_SMOKE_LOG: ${{ runner.temp }}/phoenix-smoke-${{ matrix.installer }}.log
+        run: |
+          set -euo pipefail
+
+          python -m venv .pypi-smoke
+
+          if [ "${{ matrix.installer }}" = "pip" ]; then
+            .pypi-smoke/bin/python -m pip install --upgrade pip
+            .pypi-smoke/bin/python -m pip install arize-phoenix
+          else
+            uv pip install --python .pypi-smoke/bin/python arize-phoenix
+          fi
+
+          LATEST_VERSION=$(python -m pip index versions arize-phoenix --json | python - <<'PY'
+          import json
+          import sys
+
+          data = json.load(sys.stdin)
+          print(data["versions"][0])
+          PY
+          )
+
+          echo "Latest installer-visible version: ${LATEST_VERSION}"
+
+          INSTALLED_VERSION=$(.pypi-smoke/bin/python - <<'PY'
+          from importlib.metadata import version
+
+          print(version("arize-phoenix"))
+          PY
+          )
+
+          echo "Installed version: ${INSTALLED_VERSION}"
+
+          FAIL=0
+          if [ "${INSTALLED_VERSION}" != "${LATEST_VERSION}" ]; then
+            echo "::error::Expected an unpinned PyPI install to resolve ${LATEST_VERSION}, but it resolved ${INSTALLED_VERSION}."
+            FAIL=1
+          fi
+
+          mkdir -p "${PHOENIX_WORKING_DIR}"
+          .pypi-smoke/bin/arize-phoenix serve > "${PHOENIX_SMOKE_LOG}" 2>&1 &
+          SERVER_PID=$!
+          trap 'kill "${SERVER_PID}" >/dev/null 2>&1 || true' EXIT
+
+          HEALTHY=0
+          for _ in $(seq 1 90); do
+            if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+              echo "::error::Phoenix exited before the server became healthy."
+              FAIL=1
+              break
+            fi
+
+            STATUS=$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" "http://${PHOENIX_HOST}:${PHOENIX_PORT}/healthz" || true)
+            if [ "${STATUS}" = "200" ]; then
+              echo "Phoenix responded successfully on /healthz"
+              HEALTHY=1
+              break
+            fi
+
+            sleep 1
+          done
+
+          if [ "${HEALTHY}" -ne 1 ]; then
+            echo "::error::Phoenix did not become healthy on http://${PHOENIX_HOST}:${PHOENIX_PORT}/healthz"
+            FAIL=1
+          fi
+
+          if kill -0 "${SERVER_PID}" 2>/dev/null; then
+            kill "${SERVER_PID}" >/dev/null 2>&1 || true
+            wait "${SERVER_PID}" || true
+          fi
+
+          if [ "${FAIL}" -ne 0 ]; then
+            echo "Phoenix smoke log follows:"
+            cat "${PHOENIX_SMOKE_LOG}"
+            exit 1
+          fi
+
+      - name: Upload smoke log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-smoke-log-${{ matrix.installer }}
+          path: ${{ runner.temp }}/phoenix-smoke-${{ matrix.installer }}.log
+          if-no-files-found: ignore

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -153,3 +153,19 @@ jobs:
           name: pypi-smoke-log-${{ matrix.mode }}
           path: ${{ runner.temp }}/phoenix-smoke-${{ matrix.mode }}.log
           if-no-files-found: ignore
+
+  slack-notification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [smoke-test]
+    if: ${{ always() && github.event_name != 'pull_request' && needs.smoke-test.result == 'failure' }}
+    steps:
+      - name: Notify failure
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: PyPI smoke test failed\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -75,29 +75,11 @@ jobs:
 
           if [ "${{ matrix.verify_latest }}" = "true" ]; then
             INDEX_OUTPUT=$(python -m pip index versions arize-phoenix 2>&1)
-            LATEST_VERSION=$(INDEX_OUTPUT="${INDEX_OUTPUT}" python - <<'PY'
-            import os
-            import re
-
-            output = os.environ["INDEX_OUTPUT"]
-            match = re.search(r"arize-phoenix \(([^)]+)\)", output)
-            if match is None:
-                raise SystemExit(
-                    "Could not determine latest version from `pip index versions` output:\n"
-                    + output
-                )
-            print(match.group(1))
-            PY
-            )
+            LATEST_VERSION=$(INDEX_OUTPUT="${INDEX_OUTPUT}" python -c 'import os, re; output = os.environ["INDEX_OUTPUT"]; match = re.search(r"arize-phoenix \(([^)]+)\)", output); print(match.group(1)) if match else (_ for _ in ()).throw(SystemExit("Could not determine latest version from `pip index versions` output:\n" + output))')
 
             echo "Latest installer-visible version: ${LATEST_VERSION}"
 
-            INSTALLED_VERSION=$(.pypi-smoke/bin/python - <<'PY'
-            from importlib.metadata import version
-
-            print(version("arize-phoenix"))
-            PY
-            )
+            INSTALLED_VERSION=$(.pypi-smoke/bin/python -c 'from importlib.metadata import version; print(version("arize-phoenix"))')
 
             echo "Installed version: ${INSTALLED_VERSION}"
 

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -1,6 +1,9 @@
 name: PyPI Smoke Test
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/pypi-smoke-test.yml"
   workflow_dispatch:
   schedule:
     - cron: "0 13 * * *"

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -55,12 +55,14 @@ jobs:
             uv pip install --python .pypi-smoke/bin/python arize-phoenix
           fi
 
-          LATEST_VERSION=$(python -m pip index versions arize-phoenix --json | python - <<'PY'
-          import json
+          LATEST_VERSION=$(python -m pip index versions arize-phoenix | python - <<'PY'
+          import re
           import sys
 
-          data = json.load(sys.stdin)
-          print(data["versions"][0])
+          match = re.search(r"\(([^)]+)\)", sys.stdin.readline())
+          if match is None:
+              raise SystemExit("Could not determine latest version from `pip index versions` output")
+          print(match.group(1))
           PY
           )
 

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       PYTHON_VERSION: "3.12"
       UV_VERSION: "0.10.9"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PHOENIX_HOST: "127.0.0.1"
       PHOENIX_PORT: "6606"
     steps:
@@ -55,13 +56,18 @@ jobs:
             uv pip install --python .pypi-smoke/bin/python arize-phoenix
           fi
 
-          LATEST_VERSION=$(python -m pip index versions arize-phoenix | python - <<'PY'
+          INDEX_OUTPUT=$(python -m pip index versions arize-phoenix 2>&1)
+          LATEST_VERSION=$(INDEX_OUTPUT="${INDEX_OUTPUT}" python - <<'PY'
+          import os
           import re
-          import sys
 
-          match = re.search(r"\(([^)]+)\)", sys.stdin.readline())
+          output = os.environ["INDEX_OUTPUT"]
+          match = re.search(r"arize-phoenix \(([^)]+)\)", output)
           if match is None:
-              raise SystemExit("Could not determine latest version from `pip index versions` output")
+              raise SystemExit(
+                  "Could not determine latest version from `pip index versions` output:\n"
+                  + output
+              )
           print(match.group(1))
           PY
           )

--- a/.github/workflows/pypi-smoke-test.yml
+++ b/.github/workflows/pypi-smoke-test.yml
@@ -18,13 +18,22 @@ permissions:
 
 jobs:
   smoke-test:
-    name: Default install and boot latest PyPI Phoenix (${{ matrix.installer }})
+    name: Default install and boot latest PyPI Phoenix (${{ matrix.name }})
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        installer: [pip, uv]
+        include:
+          - name: pip install
+            mode: pip-install
+            verify_latest: true
+          - name: uv pip install
+            mode: uv-pip-install
+            verify_latest: true
+          - name: uv tool run
+            mode: uv-tool-run
+            verify_latest: false
     env:
       PYTHON_VERSION: "3.12"
       UV_VERSION: "0.10.9"
@@ -43,54 +52,63 @@ jobs:
       - name: Install latest Phoenix from PyPI and verify startup
         env:
           PHOENIX_WORKING_DIR: ${{ runner.temp }}/phoenix-smoke
-          PHOENIX_SMOKE_LOG: ${{ runner.temp }}/phoenix-smoke-${{ matrix.installer }}.log
+          PHOENIX_SMOKE_LOG: ${{ runner.temp }}/phoenix-smoke-${{ matrix.mode }}.log
         run: |
           set -euo pipefail
 
-          python -m venv .pypi-smoke
+          SERVER_CMD=""
 
-          if [ "${{ matrix.installer }}" = "pip" ]; then
+          if [ "${{ matrix.mode }}" = "pip-install" ]; then
+            python -m venv .pypi-smoke
             .pypi-smoke/bin/python -m pip install --upgrade pip
             .pypi-smoke/bin/python -m pip install arize-phoenix
-          else
+            SERVER_CMD=".pypi-smoke/bin/arize-phoenix serve"
+          elif [ "${{ matrix.mode }}" = "uv-pip-install" ]; then
+            python -m venv .pypi-smoke
             uv pip install --python .pypi-smoke/bin/python arize-phoenix
+            SERVER_CMD=".pypi-smoke/bin/arize-phoenix serve"
+          else
+            SERVER_CMD="uv tool run arize-phoenix serve"
           fi
 
-          INDEX_OUTPUT=$(python -m pip index versions arize-phoenix 2>&1)
-          LATEST_VERSION=$(INDEX_OUTPUT="${INDEX_OUTPUT}" python - <<'PY'
-          import os
-          import re
-
-          output = os.environ["INDEX_OUTPUT"]
-          match = re.search(r"arize-phoenix \(([^)]+)\)", output)
-          if match is None:
-              raise SystemExit(
-                  "Could not determine latest version from `pip index versions` output:\n"
-                  + output
-              )
-          print(match.group(1))
-          PY
-          )
-
-          echo "Latest installer-visible version: ${LATEST_VERSION}"
-
-          INSTALLED_VERSION=$(.pypi-smoke/bin/python - <<'PY'
-          from importlib.metadata import version
-
-          print(version("arize-phoenix"))
-          PY
-          )
-
-          echo "Installed version: ${INSTALLED_VERSION}"
-
           FAIL=0
-          if [ "${INSTALLED_VERSION}" != "${LATEST_VERSION}" ]; then
-            echo "::error::Expected an unpinned PyPI install to resolve ${LATEST_VERSION}, but it resolved ${INSTALLED_VERSION}."
-            FAIL=1
+
+          if [ "${{ matrix.verify_latest }}" = "true" ]; then
+            INDEX_OUTPUT=$(python -m pip index versions arize-phoenix 2>&1)
+            LATEST_VERSION=$(INDEX_OUTPUT="${INDEX_OUTPUT}" python - <<'PY'
+            import os
+            import re
+
+            output = os.environ["INDEX_OUTPUT"]
+            match = re.search(r"arize-phoenix \(([^)]+)\)", output)
+            if match is None:
+                raise SystemExit(
+                    "Could not determine latest version from `pip index versions` output:\n"
+                    + output
+                )
+            print(match.group(1))
+            PY
+            )
+
+            echo "Latest installer-visible version: ${LATEST_VERSION}"
+
+            INSTALLED_VERSION=$(.pypi-smoke/bin/python - <<'PY'
+            from importlib.metadata import version
+
+            print(version("arize-phoenix"))
+            PY
+            )
+
+            echo "Installed version: ${INSTALLED_VERSION}"
+
+            if [ "${INSTALLED_VERSION}" != "${LATEST_VERSION}" ]; then
+              echo "::error::Expected an unpinned PyPI install to resolve ${LATEST_VERSION}, but it resolved ${INSTALLED_VERSION}."
+              FAIL=1
+            fi
           fi
 
           mkdir -p "${PHOENIX_WORKING_DIR}"
-          .pypi-smoke/bin/arize-phoenix serve > "${PHOENIX_SMOKE_LOG}" 2>&1 &
+          bash -lc "${SERVER_CMD}" > "${PHOENIX_SMOKE_LOG}" 2>&1 &
           SERVER_PID=$!
           trap 'kill "${SERVER_PID}" >/dev/null 2>&1 || true' EXIT
 
@@ -132,6 +150,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: pypi-smoke-log-${{ matrix.installer }}
-          path: ${{ runner.temp }}/phoenix-smoke-${{ matrix.installer }}.log
+          name: pypi-smoke-log-${{ matrix.mode }}
+          path: ${{ runner.temp }}/phoenix-smoke-${{ matrix.mode }}.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs `arize-phoenix` from PyPI using default `pip` and `uv` resolution
- fail when the resolved version is not the latest installer-visible release and when the installed server cannot reach `/healthz`
- trigger the workflow on demand, on a schedule, and after Python package publishes so release regressions surface quickly