### PR TITLE
docs: add Python pre-release dependency version policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,7 @@ This repo uses a **Makefile** for all build, test, lint, and dev commands. Run `
 
 - Python packages are managed with `uv`
 - TypeScript packages are managed with `pnpm`
+
+## Python Dependency Version Policy
+
+**Never add pre-release versions to production dependencies in `pyproject.toml` files.** Pre-release suffixes (`aN`, `bN`, `rcN`, `.devN` per [PEP 440](https://peps.python.org/pep-0440/)) are implicitly excluded from pip's dependency resolution by default — they are only installed if explicitly requested via `--pre` or a pinned pre-release specifier. Adding a pre-release pin to a production dependency forces users to opt into unstable software or causes resolution failures. Dev/test dependency groups may use pre-release versions when necessary.


### PR DESCRIPTION
## Summary
- Adds a "Python Dependency Version Policy" section to `AGENTS.md` prohibiting pre-release versions (`aN`, `bN`, `rcN`, `.devN`) in production `pyproject.toml` dependencies
- Per [PEP 440](https://peps.python.org/pep-0440/), pip excludes pre-releases by default — pinning them in prod deps causes resolution failures for users
- Dev/test dependency groups are exempt

## Test plan
- [ ] Verify `AGENTS.md` renders correctly on GitHub
- [ ] Confirm the policy is visible in agent context during a new conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)