### PR TITLE
feat: Add span and trace annotation commands to the Phoenix CLI

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -6,6 +6,6 @@ This directory contains [skills](https://docs.anthropic.com/en/docs/claude-code/
 
 | Skill | Description |
 | ----- | ----------- |
-| [phoenix-cli](phoenix-cli/) | Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, and query the GraphQL API. |
+| [phoenix-cli](phoenix-cli/) | Debug LLM applications using the Phoenix CLI. Fetch traces, annotate spans and traces, analyze errors, inspect datasets, and query the GraphQL API. |
 | [phoenix-evals](phoenix-evals/) | Build and run evaluators for AI/LLM applications using Phoenix. Code first, LLM for nuance, validate against humans. |
 | [phoenix-tracing](phoenix-tracing/) | OpenInference semantic conventions and instrumentation for tracing LLM applications with Phoenix. Covers setup, span types, and production deployment. |

--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.
 metadata:
   author: arize-ai
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # Phoenix CLI
@@ -22,7 +22,9 @@ The CLI uses singular resource commands with subcommands like `list` and `get`:
 ```bash
 px trace list
 px trace get <trace-id>
+px trace annotate <trace-id>
 px span list
+px span annotate <span-id>
 px dataset list
 px dataset get <name>
 px project list
@@ -63,6 +65,8 @@ px trace list --since 2025-01-15T00:00:00Z --limit 50 --format raw --no-progress
 px trace list --format raw --no-progress | jq 'sort_by(-.duration) | .[0:5]'
 px trace get <trace-id> --format raw | jq .
 px trace get <trace-id> --format raw | jq '.spans[] | select(.status_code != "OK")'
+px trace annotate <trace-id> --name reviewer --label pass
+px trace annotate <trace-id> --name reviewer --score 0.9 --format raw --no-progress
 ```
 
 ### Trace JSON shape
@@ -101,6 +105,8 @@ px span list --parent-id <span-id> --limit 10              # only children of a 
 px span list --include-annotations --limit 10              # include annotation scores
 px span list output.json --limit 100                       # save to JSON file
 px span list --format raw --no-progress | jq '.[] | select(.status_code == "ERROR")'
+px span annotate <span-id> --name reviewer --label pass
+px span annotate <span-id> --name checker --score 1 --annotator-kind CODE
 ```
 
 ### Span JSON shape

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -118,6 +118,19 @@ px trace get abc123def456 --file trace.json
 
 ---
 
+### `px trace annotate <trace-id>`
+
+Create or update a human trace annotation by OpenTelemetry trace ID.
+
+```bash
+px trace annotate abc123def456 --name reviewer --label pass
+px trace annotate abc123def456 --name reviewer --score 0.9 --format raw --no-progress
+px trace annotate abc123def456 --name evaluator --label pass --annotator-kind LLM
+px trace annotate abc123def456 --name reviewer --explanation "needs follow-up"
+```
+
+---
+
 ### `px span list [file]`
 
 Fetch spans for the configured project with filtering options. Output is JSON.
@@ -157,6 +170,19 @@ px span list --span-kind LLM --format raw --no-progress | \
 
 # Root spans only, sorted by name
 px span list --parent-id null --format raw --no-progress | jq 'sort_by(.name)'
+```
+
+---
+
+### `px span annotate <span-id>`
+
+Create or update a human span annotation by OpenTelemetry span ID.
+
+```bash
+px span annotate 7e2f08cb43bbf521 --name reviewer --label pass
+px span annotate 7e2f08cb43bbf521 --name reviewer --score 0.9 --format raw --no-progress
+px span annotate 7e2f08cb43bbf521 --name checker --score 1 --annotator-kind CODE
+px span annotate 7e2f08cb43bbf521 --name reviewer --explanation "looks good"
 ```
 
 ---

--- a/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
@@ -49,6 +49,18 @@ function trimString(value: string | undefined): string | undefined {
   return trimmedValue.length > 0 ? trimmedValue : undefined;
 }
 
+function parseScore(score: string | number): number {
+  if (typeof score === "number") {
+    return score;
+  }
+  const trimmedScore = score.trim();
+  const numericScore = Number(trimmedScore);
+  if (!trimmedScore || !Number.isFinite(numericScore)) {
+    throw new Error("invalid score");
+  }
+  return numericScore;
+}
+
 function normalizeAnnotatorKind(
   targetType: AnnotationTargetType,
   annotatorKind: string | undefined
@@ -95,14 +107,13 @@ export function normalizeAnnotationInput({
   if (score === undefined) {
     normalizedScore = null;
   } else {
-    const numericScore =
-      typeof score === "number" ? score : Number.parseFloat(score.trim());
-    if (!Number.isFinite(numericScore)) {
+    try {
+      normalizedScore = parseScore(score);
+    } catch {
       throw new InvalidArgumentError(
         `Invalid value for --score: ${String(score)}\n  ${getAnnotateUsage(targetType)}`
       );
     }
-    normalizedScore = numericScore;
   }
 
   const normalizedLabel = trimString(label) ?? null;

--- a/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
@@ -1,0 +1,198 @@
+import { InvalidArgumentError } from "../exitCodes";
+
+export type AnnotationTargetType = "span" | "trace";
+export type AnnotatorKind = "HUMAN" | "LLM" | "CODE";
+
+export interface AnnotationMutationResult {
+  id: string;
+  targetType: AnnotationTargetType;
+  targetId: string;
+  name: string;
+  label: string | null;
+  score: number | null;
+  explanation: string | null;
+  annotatorKind: AnnotatorKind;
+  identifier: string;
+}
+
+export interface NormalizedAnnotationInput {
+  name: string;
+  label: string | null;
+  score: number | null;
+  explanation: string | null;
+  annotatorKind: AnnotatorKind;
+  result: {
+    label?: string | null;
+    score?: number;
+    explanation?: string | null;
+  };
+}
+
+function getTargetIdPlaceholder(targetType: AnnotationTargetType): string {
+  return targetType === "span" ? "<span-id>" : "<trace-id>";
+}
+
+function getAnnotateUsage(targetType: AnnotationTargetType): string {
+  const targetIdPlaceholder = getTargetIdPlaceholder(targetType);
+  return [
+    `px ${targetType} annotate ${targetIdPlaceholder} --name <name> --label <label>`,
+    `px ${targetType} annotate ${targetIdPlaceholder} --name <name> --score <number>`,
+    `px ${targetType} annotate ${targetIdPlaceholder} --name <name> --explanation <text>`,
+  ].join("\n  ");
+}
+
+function trimString(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+function normalizeAnnotatorKind(
+  targetType: AnnotationTargetType,
+  annotatorKind: string | undefined
+): AnnotatorKind {
+  if (annotatorKind === undefined) {
+    return "HUMAN";
+  }
+  const normalizedAnnotatorKind = annotatorKind.trim().toUpperCase();
+  if (
+    normalizedAnnotatorKind === "HUMAN" ||
+    normalizedAnnotatorKind === "LLM" ||
+    normalizedAnnotatorKind === "CODE"
+  ) {
+    return normalizedAnnotatorKind;
+  }
+  throw new InvalidArgumentError(
+    `Invalid value for --annotator-kind: ${annotatorKind}\n  Valid values: HUMAN, LLM, CODE\n  ${getAnnotateUsage(targetType)}`
+  );
+}
+
+export function normalizeAnnotationInput({
+  targetType,
+  name,
+  label,
+  score,
+  explanation,
+  annotatorKind,
+}: {
+  targetType: AnnotationTargetType;
+  name?: string;
+  label?: string;
+  score?: string | number;
+  explanation?: string;
+  annotatorKind?: string;
+}): NormalizedAnnotationInput {
+  const normalizedName = trimString(name);
+  if (!normalizedName) {
+    throw new InvalidArgumentError(
+      `Missing required flag --name.\n  ${getAnnotateUsage(targetType)}`
+    );
+  }
+
+  let normalizedScore: number | null;
+  if (score === undefined) {
+    normalizedScore = null;
+  } else {
+    const numericScore =
+      typeof score === "number" ? score : Number.parseFloat(score.trim());
+    if (!Number.isFinite(numericScore)) {
+      throw new InvalidArgumentError(
+        `Invalid value for --score: ${String(score)}\n  ${getAnnotateUsage(targetType)}`
+      );
+    }
+    normalizedScore = numericScore;
+  }
+
+  const normalizedLabel = trimString(label) ?? null;
+  const normalizedExplanation = trimString(explanation) ?? null;
+  const normalizedAnnotatorKind = normalizeAnnotatorKind(
+    targetType,
+    annotatorKind
+  );
+
+  const hasResult =
+    normalizedLabel !== null ||
+    normalizedScore !== null ||
+    normalizedExplanation !== null;
+  if (!hasResult) {
+    throw new InvalidArgumentError(
+      `At least one of --label, --score, or --explanation must be provided.\n  ${getAnnotateUsage(targetType)}`
+    );
+  }
+
+  const result: NormalizedAnnotationInput["result"] = {};
+  if (normalizedLabel !== null) {
+    result.label = normalizedLabel;
+  }
+  if (normalizedScore !== null) {
+    result.score = normalizedScore;
+  }
+  if (normalizedExplanation !== null) {
+    result.explanation = normalizedExplanation;
+  }
+
+  return {
+    name: normalizedName,
+    label: normalizedLabel,
+    score: normalizedScore,
+    explanation: normalizedExplanation,
+    annotatorKind: normalizedAnnotatorKind,
+    result,
+  };
+}
+
+export function buildAnnotationMutationResult({
+  id,
+  targetType,
+  targetId,
+  annotationInput,
+}: {
+  id: string;
+  targetType: AnnotationTargetType;
+  targetId: string;
+  annotationInput: NormalizedAnnotationInput;
+}): AnnotationMutationResult {
+  return {
+    id,
+    targetType,
+    targetId,
+    name: annotationInput.name,
+    label: annotationInput.label,
+    score: annotationInput.score,
+    explanation: annotationInput.explanation,
+    annotatorKind: annotationInput.annotatorKind,
+    identifier: "",
+  };
+}
+
+export function getAnnotationMutationHelpText(
+  targetType: AnnotationTargetType
+): string {
+  const targetIdPlaceholder = getTargetIdPlaceholder(targetType);
+  return [
+    "",
+    "Examples:",
+    `  px ${targetType} annotate ${targetIdPlaceholder} --name reviewer --label pass`,
+    `  px ${targetType} annotate ${targetIdPlaceholder} --name reviewer --score 0.9 --format raw --no-progress`,
+  ].join("\n");
+}
+
+export function getResponseErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const errorWithDetail = error as { detail?: unknown };
+    if (typeof errorWithDetail.detail === "string") {
+      return errorWithDetail.detail;
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+}

--- a/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/annotationMutationUtils.ts
@@ -1,4 +1,5 @@
 import { InvalidArgumentError } from "../exitCodes";
+import { parseNumber, trimToUndefined } from "../normalize";
 
 export type AnnotationTargetType = "span" | "trace";
 export type AnnotatorKind = "HUMAN" | "LLM" | "CODE";
@@ -28,12 +29,20 @@ export interface NormalizedAnnotationInput {
   };
 }
 
-function getTargetIdPlaceholder(targetType: AnnotationTargetType): string {
+function getTargetIdPlaceholder({
+  targetType,
+}: {
+  targetType: AnnotationTargetType;
+}): string {
   return targetType === "span" ? "<span-id>" : "<trace-id>";
 }
 
-function getAnnotateUsage(targetType: AnnotationTargetType): string {
-  const targetIdPlaceholder = getTargetIdPlaceholder(targetType);
+function getAnnotateUsage({
+  targetType,
+}: {
+  targetType: AnnotationTargetType;
+}): string {
+  const targetIdPlaceholder = getTargetIdPlaceholder({ targetType });
   return [
     `px ${targetType} annotate ${targetIdPlaceholder} --name <name> --label <label>`,
     `px ${targetType} annotate ${targetIdPlaceholder} --name <name> --score <number>`,
@@ -41,34 +50,19 @@ function getAnnotateUsage(targetType: AnnotationTargetType): string {
   ].join("\n  ");
 }
 
-function trimString(value: string | undefined): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  const trimmedValue = value.trim();
-  return trimmedValue.length > 0 ? trimmedValue : undefined;
-}
-
-function parseScore(score: string | number): number {
-  if (typeof score === "number") {
-    return score;
-  }
-  const trimmedScore = score.trim();
-  const numericScore = Number(trimmedScore);
-  if (!trimmedScore || !Number.isFinite(numericScore)) {
-    throw new Error("invalid score");
-  }
-  return numericScore;
-}
-
-function normalizeAnnotatorKind(
-  targetType: AnnotationTargetType,
-  annotatorKind: string | undefined
-): AnnotatorKind {
+function normalizeAnnotatorKind({
+  targetType,
+  annotatorKind,
+}: {
+  targetType: AnnotationTargetType;
+  annotatorKind: string | undefined;
+}): AnnotatorKind {
   if (annotatorKind === undefined) {
     return "HUMAN";
   }
-  const normalizedAnnotatorKind = annotatorKind.trim().toUpperCase();
+  const normalizedAnnotatorKind = trimToUndefined({
+    value: annotatorKind,
+  })?.toUpperCase();
   if (
     normalizedAnnotatorKind === "HUMAN" ||
     normalizedAnnotatorKind === "LLM" ||
@@ -77,7 +71,7 @@ function normalizeAnnotatorKind(
     return normalizedAnnotatorKind;
   }
   throw new InvalidArgumentError(
-    `Invalid value for --annotator-kind: ${annotatorKind}\n  Valid values: HUMAN, LLM, CODE\n  ${getAnnotateUsage(targetType)}`
+    `Invalid value for --annotator-kind: ${annotatorKind}\n  Valid values: HUMAN, LLM, CODE\n  ${getAnnotateUsage({ targetType })}`
   );
 }
 
@@ -96,10 +90,10 @@ export function normalizeAnnotationInput({
   explanation?: string;
   annotatorKind?: string;
 }): NormalizedAnnotationInput {
-  const normalizedName = trimString(name);
+  const normalizedName = trimToUndefined({ value: name });
   if (!normalizedName) {
     throw new InvalidArgumentError(
-      `Missing required flag --name.\n  ${getAnnotateUsage(targetType)}`
+      `Missing required flag --name.\n  ${getAnnotateUsage({ targetType })}`
     );
   }
 
@@ -108,20 +102,23 @@ export function normalizeAnnotationInput({
     normalizedScore = null;
   } else {
     try {
-      normalizedScore = parseScore(score);
-    } catch {
+      normalizedScore = parseNumber({
+        rawValue: score,
+        inputName: "--score",
+      });
+    } catch (error) {
       throw new InvalidArgumentError(
-        `Invalid value for --score: ${String(score)}\n  ${getAnnotateUsage(targetType)}`
+        `${error instanceof Error ? error.message : String(error)}\n  ${getAnnotateUsage({ targetType })}`
       );
     }
   }
 
-  const normalizedLabel = trimString(label) ?? null;
-  const normalizedExplanation = trimString(explanation) ?? null;
-  const normalizedAnnotatorKind = normalizeAnnotatorKind(
+  const normalizedLabel = trimToUndefined({ value: label }) ?? null;
+  const normalizedExplanation = trimToUndefined({ value: explanation }) ?? null;
+  const normalizedAnnotatorKind = normalizeAnnotatorKind({
     targetType,
-    annotatorKind
-  );
+    annotatorKind,
+  });
 
   const hasResult =
     normalizedLabel !== null ||
@@ -129,7 +126,7 @@ export function normalizeAnnotationInput({
     normalizedExplanation !== null;
   if (!hasResult) {
     throw new InvalidArgumentError(
-      `At least one of --label, --score, or --explanation must be provided.\n  ${getAnnotateUsage(targetType)}`
+      `At least one of --label, --score, or --explanation must be provided.\n  ${getAnnotateUsage({ targetType })}`
     );
   }
 
@@ -178,10 +175,12 @@ export function buildAnnotationMutationResult({
   };
 }
 
-export function getAnnotationMutationHelpText(
-  targetType: AnnotationTargetType
-): string {
-  const targetIdPlaceholder = getTargetIdPlaceholder(targetType);
+export function getAnnotationMutationHelpText({
+  targetType,
+}: {
+  targetType: AnnotationTargetType;
+}): string {
+  const targetIdPlaceholder = getTargetIdPlaceholder({ targetType });
   return [
     "",
     "Examples:",

--- a/js/packages/phoenix-cli/src/commands/formatAnnotationMutation.ts
+++ b/js/packages/phoenix-cli/src/commands/formatAnnotationMutation.ts
@@ -1,0 +1,38 @@
+import type { AnnotationMutationResult } from "./annotationMutationUtils";
+
+export type OutputFormat = "pretty" | "json" | "raw";
+
+export interface FormatAnnotationMutationOutputOptions {
+  annotation: AnnotationMutationResult;
+  format?: OutputFormat;
+}
+
+export function formatAnnotationMutationOutput({
+  annotation,
+  format,
+}: FormatAnnotationMutationOutputOptions): string {
+  const selectedFormat = format || "pretty";
+  if (selectedFormat === "raw") {
+    return JSON.stringify(annotation);
+  }
+  if (selectedFormat === "json") {
+    return JSON.stringify(annotation, null, 2);
+  }
+  return formatAnnotationMutationPretty(annotation);
+}
+
+function formatAnnotationMutationPretty(
+  annotation: AnnotationMutationResult
+): string {
+  return [
+    "Annotation upserted",
+    `  ID: ${annotation.id}`,
+    `  Target: ${annotation.targetType} ${annotation.targetId}`,
+    `  Name: ${annotation.name}`,
+    `  Label: ${annotation.label ?? "n/a"}`,
+    `  Score: ${annotation.score ?? "n/a"}`,
+    `  Explanation: ${annotation.explanation ?? "n/a"}`,
+    `  Annotator: ${annotation.annotatorKind}`,
+    `  Identifier: ${annotation.identifier || '""'}`,
+  ].join("\n");
+}

--- a/js/packages/phoenix-cli/src/commands/formatTraces.ts
+++ b/js/packages/phoenix-cli/src/commands/formatTraces.ts
@@ -190,6 +190,7 @@ function renderSpanNode(
   );
 
   const nextAncestors = [...opts.ancestors, opts.isLast];
+  renderSpanAnnotations(lines, span, nextAncestors);
   for (let i = 0; i < children.length; i++) {
     renderSpanNode(lines, children[i]!, {
       ancestors: nextAncestors,
@@ -205,6 +206,62 @@ function formatDurationMs(startTime: string, endTime: string): string {
     return "n/a";
   }
   return `${Math.max(0, endMs - startMs)}ms`;
+}
+
+function renderSpanAnnotations(
+  lines: string[],
+  span: Span,
+  ancestors: boolean[]
+): void {
+  const annotations = span.annotations;
+  if (!annotations?.length) {
+    return;
+  }
+
+  const detailPrefix =
+    "│  " +
+    ancestors
+      .map((ancestorIsLast) => (ancestorIsLast ? "   " : "│  "))
+      .join("");
+
+  lines.push(`${detailPrefix}annotations:`);
+  for (const annotation of annotations) {
+    const parts = [
+      annotation.name,
+      `[${annotation.annotator_kind}]`,
+      ...formatAnnotationResultParts(annotation.result),
+    ];
+    lines.push(`${detailPrefix}- ${parts.join(" ")}`);
+  }
+}
+
+function formatAnnotationResultParts(
+  result:
+    | {
+        label?: string | null;
+        score?: number | null;
+        explanation?: string | null;
+      }
+    | null
+    | undefined
+): string[] {
+  if (!result) {
+    return [];
+  }
+
+  const parts: string[] = [];
+  if (result.label !== undefined && result.label !== null) {
+    parts.push(`label=${JSON.stringify(result.label)}`);
+  }
+  if (result.score !== undefined && result.score !== null) {
+    parts.push(`score=${result.score}`);
+  }
+  if (result.explanation !== undefined && result.explanation !== null) {
+    parts.push(
+      `explanation=${JSON.stringify(truncateValue(result.explanation))}`
+    );
+  }
+  return parts;
 }
 
 function previewAttributeValue(value: unknown): string | undefined {
@@ -232,4 +289,11 @@ function previewAttributeValue(value: unknown): string | undefined {
     return `${str.slice(0, VALUE_PREVIEW_MAX_CHARS)}…`;
   }
   return str;
+}
+
+function truncateValue(value: string): string {
+  if (value.length <= VALUE_PREVIEW_MAX_CHARS) {
+    return value;
+  }
+  return value.slice(0, VALUE_PREVIEW_MAX_CHARS) + "…";
 }

--- a/js/packages/phoenix-cli/src/commands/formatTraces.ts
+++ b/js/packages/phoenix-cli/src/commands/formatTraces.ts
@@ -89,6 +89,7 @@ function formatTracePretty(trace: Trace): string {
     if (inputPreview || outputPreview) lines.push(`│`);
   }
 
+  renderTraceAnnotations(lines, trace);
   lines.push(`│  Spans:`);
 
   for (let i = 0; i < forest.length; i++) {
@@ -100,6 +101,24 @@ function formatTracePretty(trace: Trace): string {
 
   lines.push(`└─`);
   return lines.join("\n");
+}
+
+function renderTraceAnnotations(lines: string[], trace: Trace): void {
+  const annotations = trace.annotations;
+  if (!annotations?.length) {
+    return;
+  }
+
+  lines.push("│  Trace Annotations:");
+  for (const annotation of annotations) {
+    const parts = [
+      annotation.name,
+      `[${annotation.annotator_kind}]`,
+      ...formatAnnotationResultParts(annotation.result),
+    ];
+    lines.push(`│  - ${parts.join(" ")}`);
+  }
+  lines.push("│");
 }
 
 type Span = Trace["spans"][number];

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -428,7 +428,7 @@ export function createSpanAnnotateCommand(): Command {
       "pretty"
     )
     .option("--no-progress", "Disable progress indicators")
-    .addHelpText("after", getAnnotationMutationHelpText("span"))
+    .addHelpText("after", getAnnotationMutationHelpText({ targetType: "span" }))
     .action(spanAnnotateHandler);
 }
 

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -12,7 +12,20 @@ import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import type { SpanWithAnnotations } from "../trace";
-import { formatSpansOutput, type OutputFormat } from "./formatSpans";
+import {
+  buildAnnotationMutationResult,
+  getAnnotationMutationHelpText,
+  getResponseErrorMessage,
+  normalizeAnnotationInput,
+} from "./annotationMutationUtils";
+import {
+  formatAnnotationMutationOutput,
+  type OutputFormat as AnnotationMutationOutputFormat,
+} from "./formatAnnotationMutation";
+import {
+  formatSpansOutput,
+  type OutputFormat as SpanOutputFormat,
+} from "./formatSpans";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
 
 type Span = componentsV1["schemas"]["Span"];
@@ -21,7 +34,7 @@ interface SpanListOptions {
   endpoint?: string;
   project?: string;
   apiKey?: string;
-  format?: OutputFormat;
+  format?: SpanOutputFormat;
   progress?: boolean;
   limit?: number;
   lastNMinutes?: number;
@@ -32,6 +45,18 @@ interface SpanListOptions {
   traceId?: string[];
   parentId?: string;
   includeAnnotations?: boolean;
+}
+
+interface SpanAnnotateOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: AnnotationMutationOutputFormat;
+  progress?: boolean;
+  name?: string;
+  label?: string;
+  score?: string;
+  explanation?: string;
+  annotatorKind?: string;
 }
 
 /**
@@ -297,6 +322,116 @@ export function createSpanListCommand(): Command {
     .action(spanListHandler);
 }
 
+/**
+ * Handler for `span annotate`
+ */
+async function spanAnnotateHandler(
+  spanId: string,
+  options: SpanAnnotateOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const annotationInput = normalizeAnnotationInput({
+      targetType: "span",
+      name: options.name,
+      label: options.label,
+      score: options.score,
+      explanation: options.explanation,
+      annotatorKind: options.annotatorKind,
+    });
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Annotating span ${spanId}...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.POST("/v1/span_annotations", {
+      params: {
+        query: {
+          sync: true,
+        },
+      },
+      body: {
+        data: [
+          {
+            span_id: spanId,
+            name: annotationInput.name,
+            annotator_kind: annotationInput.annotatorKind,
+            result: annotationInput.result,
+            identifier: "",
+          },
+        ],
+      },
+    });
+
+    if (response.error) {
+      throw new Error(getResponseErrorMessage(response.error));
+    }
+
+    const insertedAnnotation = response.data?.data?.[0];
+    if (!insertedAnnotation) {
+      throw new Error(
+        "Phoenix did not return the inserted span annotation ID."
+      );
+    }
+
+    const annotation = buildAnnotationMutationResult({
+      id: insertedAnnotation.id,
+      targetType: "span",
+      targetId: spanId,
+      annotationInput,
+    });
+
+    const output = formatAnnotationMutationOutput({
+      annotation,
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error annotating span: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createSpanAnnotateCommand(): Command {
+  return new Command("annotate")
+    .description("Annotate a span by OpenTelemetry span ID")
+    .argument("<span-id>", "OpenTelemetry span ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--name <name>", "Annotation name")
+    .option("--label <label>", "Annotation label")
+    .option("--score <number>", "Annotation score")
+    .option("--explanation <text>", "Annotation explanation")
+    .option("--annotator-kind <kind>", "Annotation kind: HUMAN, LLM, or CODE")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText("after", getAnnotationMutationHelpText("span"))
+    .action(spanAnnotateHandler);
+}
+
 interface SpanDeleteOptions {
   endpoint?: string;
   apiKey?: string;
@@ -383,6 +518,7 @@ export function createSpanCommand(): Command {
   const command = new Command("span");
   command.description("Manage Phoenix spans");
   command.addCommand(createSpanListCommand());
+  command.addCommand(createSpanAnnotateCommand());
   command.addCommand(createSpanDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -13,8 +13,21 @@ import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import { buildTrace, groupSpansByTrace, type Trace } from "../trace";
-import { formatTraceOutput, type OutputFormat } from "./formatTraces";
-import { formatTracesOutput } from "./formatTraces";
+import {
+  buildAnnotationMutationResult,
+  getAnnotationMutationHelpText,
+  getResponseErrorMessage,
+  normalizeAnnotationInput,
+} from "./annotationMutationUtils";
+import {
+  formatAnnotationMutationOutput,
+  type OutputFormat as AnnotationMutationOutputFormat,
+} from "./formatAnnotationMutation";
+import {
+  formatTraceOutput,
+  formatTracesOutput,
+  type OutputFormat as TraceOutputFormat,
+} from "./formatTraces";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
 
 type Span = componentsV1["schemas"]["Span"];
@@ -23,7 +36,7 @@ interface TraceGetOptions {
   endpoint?: string;
   project?: string;
   apiKey?: string;
-  format?: OutputFormat;
+  format?: TraceOutputFormat;
   progress?: boolean;
   file?: string;
   includeAnnotations?: boolean;
@@ -33,13 +46,25 @@ interface TraceListOptions {
   endpoint?: string;
   project?: string;
   apiKey?: string;
-  format?: OutputFormat;
+  format?: TraceOutputFormat;
   progress?: boolean;
   limit?: number;
   lastNMinutes?: number;
   since?: string;
   maxConcurrent?: number;
   includeAnnotations?: boolean;
+}
+
+interface TraceAnnotateOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: AnnotationMutationOutputFormat;
+  progress?: boolean;
+  name?: string;
+  label?: string;
+  score?: string;
+  explanation?: string;
+  annotatorKind?: string;
 }
 
 /**
@@ -351,7 +376,7 @@ async function traceGetHandler(
     const trace = buildTrace({ spans });
 
     // Output trace
-    const outputFormat: OutputFormat = options.file
+    const outputFormat: TraceOutputFormat = options.file
       ? "json"
       : options.format || "pretty";
 
@@ -584,6 +609,116 @@ export function createTraceListCommand(): Command {
     .action(traceListHandler);
 }
 
+/**
+ * Handler for `trace annotate`
+ */
+async function traceAnnotateHandler(
+  traceId: string,
+  options: TraceAnnotateOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const annotationInput = normalizeAnnotationInput({
+      targetType: "trace",
+      name: options.name,
+      label: options.label,
+      score: options.score,
+      explanation: options.explanation,
+      annotatorKind: options.annotatorKind,
+    });
+
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Annotating trace ${traceId}...`,
+      noProgress: !options.progress,
+    });
+
+    const response = await client.POST("/v1/trace_annotations", {
+      params: {
+        query: {
+          sync: true,
+        },
+      },
+      body: {
+        data: [
+          {
+            trace_id: traceId,
+            name: annotationInput.name,
+            annotator_kind: annotationInput.annotatorKind,
+            result: annotationInput.result,
+            identifier: "",
+          },
+        ],
+      },
+    });
+
+    if (response.error) {
+      throw new Error(getResponseErrorMessage(response.error));
+    }
+
+    const insertedAnnotation = response.data?.data?.[0];
+    if (!insertedAnnotation) {
+      throw new Error(
+        "Phoenix did not return the inserted trace annotation ID."
+      );
+    }
+
+    const annotation = buildAnnotationMutationResult({
+      id: insertedAnnotation.id,
+      targetType: "trace",
+      targetId: traceId,
+      annotationInput,
+    });
+
+    const output = formatAnnotationMutationOutput({
+      annotation,
+      format: options.format,
+    });
+    writeOutput({ message: output });
+  } catch (error) {
+    writeError({
+      message: `Error annotating trace: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createTraceAnnotateCommand(): Command {
+  return new Command("annotate")
+    .description("Annotate a trace by OpenTelemetry trace ID")
+    .argument("<trace-id>", "OpenTelemetry trace ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--name <name>", "Annotation name")
+    .option("--label <label>", "Annotation label")
+    .option("--score <number>", "Annotation score")
+    .option("--explanation <text>", "Annotation explanation")
+    .option("--annotator-kind <kind>", "Annotation kind: HUMAN, LLM, or CODE")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .addHelpText("after", getAnnotationMutationHelpText("trace"))
+    .action(traceAnnotateHandler);
+}
+
 interface TraceDeleteOptions {
   endpoint?: string;
   apiKey?: string;
@@ -674,6 +809,7 @@ export function createTraceCommand(): Command {
   command.description("Manage Phoenix traces");
   command.addCommand(createTraceListCommand());
   command.addCommand(createTraceGetCommand());
+  command.addCommand(createTraceAnnotateCommand());
   command.addCommand(createTraceDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -759,7 +759,10 @@ export function createTraceAnnotateCommand(): Command {
       "pretty"
     )
     .option("--no-progress", "Disable progress indicators")
-    .addHelpText("after", getAnnotationMutationHelpText("trace"))
+    .addHelpText(
+      "after",
+      getAnnotationMutationHelpText({ targetType: "trace" })
+    )
     .action(traceAnnotateHandler);
 }
 

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -85,6 +85,10 @@ function attachTraceAnnotationsToTraces(
   }
 }
 
+function getResolvedTraceId(spans: Span[]): string | undefined {
+  return spans[0]?.context?.trace_id;
+}
+
 interface TraceGetOptions {
   endpoint?: string;
   project?: string;
@@ -395,6 +399,7 @@ async function traceGetHandler(
     });
 
     const traceSpans: SpanWithAnnotations[] = spans;
+    const resolvedTraceId = getResolvedTraceId(spans);
     let traceAnnotations: TraceAnnotation[] | undefined;
     if (options.includeAnnotations) {
       writeProgress({
@@ -405,7 +410,7 @@ async function traceGetHandler(
       traceAnnotations = await fetchTraceAnnotations({
         client,
         projectIdentifier: projectId,
-        traceIds: [traceId],
+        traceIds: resolvedTraceId ? [resolvedTraceId] : [traceId],
       });
 
       const spanIds = traceSpans

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -12,7 +12,12 @@ import {
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
-import { buildTrace, groupSpansByTrace, type Trace } from "../trace";
+import {
+  buildTrace,
+  groupSpansByTrace,
+  type SpanWithAnnotations,
+  type Trace,
+} from "../trace";
 import {
   buildAnnotationMutationResult,
   getAnnotationMutationHelpText,
@@ -29,8 +34,56 @@ import {
   type OutputFormat as TraceOutputFormat,
 } from "./formatTraces";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
+import {
+  fetchTraceAnnotations,
+  type TraceAnnotation,
+} from "./traceAnnotations";
 
 type Span = componentsV1["schemas"]["Span"];
+
+function attachSpanAnnotationsToSpans(
+  spans: SpanWithAnnotations[],
+  annotations: SpanAnnotation[]
+): void {
+  const annotationsBySpanId = new Map<string, SpanAnnotation[]>();
+  for (const annotation of annotations) {
+    const spanId = annotation.span_id;
+    if (!annotationsBySpanId.has(spanId)) {
+      annotationsBySpanId.set(spanId, []);
+    }
+    annotationsBySpanId.get(spanId)!.push(annotation);
+  }
+
+  for (const span of spans) {
+    const spanId = span.context?.span_id;
+    if (!spanId) continue;
+    const spanAnnotations = annotationsBySpanId.get(spanId);
+    if (spanAnnotations) {
+      span.annotations = spanAnnotations;
+    }
+  }
+}
+
+function attachTraceAnnotationsToTraces(
+  traces: Trace[],
+  annotations: TraceAnnotation[]
+): void {
+  const annotationsByTraceId = new Map<string, TraceAnnotation[]>();
+  for (const annotation of annotations) {
+    const traceId = annotation.trace_id;
+    if (!annotationsByTraceId.has(traceId)) {
+      annotationsByTraceId.set(traceId, []);
+    }
+    annotationsByTraceId.get(traceId)!.push(annotation);
+  }
+
+  for (const trace of traces) {
+    const traceAnnotations = annotationsByTraceId.get(trace.traceId);
+    if (traceAnnotations) {
+      trace.annotations = traceAnnotations;
+    }
+  }
+}
 
 interface TraceGetOptions {
   endpoint?: string;
@@ -341,39 +394,36 @@ async function traceGetHandler(
       noProgress: !options.progress,
     });
 
+    const traceSpans: SpanWithAnnotations[] = spans;
+    let traceAnnotations: TraceAnnotation[] | undefined;
     if (options.includeAnnotations) {
-      const spanIds = spans
+      writeProgress({
+        message: "Fetching trace and span annotations...",
+        noProgress: !options.progress,
+      });
+
+      traceAnnotations = await fetchTraceAnnotations({
+        client,
+        projectIdentifier: projectId,
+        traceIds: [traceId],
+      });
+
+      const spanIds = traceSpans
         .map((span) => span.context?.span_id)
         .filter((spanId): spanId is string => Boolean(spanId));
-      const annotations = await fetchSpanAnnotations({
+      const spanAnnotations = await fetchSpanAnnotations({
         client,
         projectIdentifier: projectId,
         spanIds,
       });
-
-      const annotationsBySpanId = new Map<string, SpanAnnotation[]>();
-      for (const annotation of annotations) {
-        const spanId = annotation.span_id;
-        if (!annotationsBySpanId.has(spanId)) {
-          annotationsBySpanId.set(spanId, []);
-        }
-        annotationsBySpanId.get(spanId)!.push(annotation);
-      }
-
-      for (const span of spans) {
-        const spanId = span.context?.span_id;
-        if (!spanId) continue;
-        const spanAnnotations = annotationsBySpanId.get(spanId);
-        if (spanAnnotations) {
-          (
-            span as typeof span & { annotations?: SpanAnnotation[] }
-          ).annotations = spanAnnotations;
-        }
-      }
+      attachSpanAnnotationsToSpans(traceSpans, spanAnnotations);
     }
 
     // Build trace
-    const trace = buildTrace({ spans });
+    const trace = buildTrace({ spans: traceSpans });
+    if (traceAnnotations?.length) {
+      trace.annotations = traceAnnotations;
+    }
 
     // Output trace
     const outputFormat: TraceOutputFormat = options.file
@@ -478,42 +528,31 @@ async function traceListHandler(
 
     if (options.includeAnnotations) {
       writeProgress({
-        message: "Fetching span annotations...",
+        message: "Fetching trace and span annotations...",
         noProgress: !options.progress,
       });
+
+      const traceAnnotations = await fetchTraceAnnotations({
+        client,
+        projectIdentifier: projectId,
+        traceIds: traces.map((trace) => trace.traceId),
+        maxConcurrent: options.maxConcurrent,
+      });
+      attachTraceAnnotationsToTraces(traces, traceAnnotations);
 
       const spanIds = traces
         .flatMap((trace) => trace.spans)
         .map((span) => span.context?.span_id)
         .filter((spanId): spanId is string => Boolean(spanId));
 
-      const annotations = await fetchSpanAnnotations({
+      const spanAnnotations = await fetchSpanAnnotations({
         client,
         projectIdentifier: projectId,
         spanIds,
         maxConcurrent: options.maxConcurrent,
       });
-
-      const annotationsBySpanId = new Map<string, SpanAnnotation[]>();
-      for (const annotation of annotations) {
-        const spanId = annotation.span_id;
-        if (!annotationsBySpanId.has(spanId)) {
-          annotationsBySpanId.set(spanId, []);
-        }
-        annotationsBySpanId.get(spanId)!.push(annotation);
-      }
-
       for (const trace of traces) {
-        for (const span of trace.spans) {
-          const spanId = span.context?.span_id;
-          if (!spanId) continue;
-          const spanAnnotations = annotationsBySpanId.get(spanId);
-          if (spanAnnotations) {
-            (
-              span as typeof span & { annotations?: SpanAnnotation[] }
-            ).annotations = spanAnnotations;
-          }
-        }
+        attachSpanAnnotationsToSpans(trace.spans, spanAnnotations);
       }
     }
 
@@ -566,7 +605,7 @@ export function createTraceGetCommand(): Command {
     .option("--file <path>", "Save trace to file instead of stdout")
     .option(
       "--include-annotations",
-      "Include span annotations in the trace export"
+      "Include trace and span annotations in the trace export"
     )
     .action(traceGetHandler);
 }
@@ -604,7 +643,7 @@ export function createTraceListCommand(): Command {
     )
     .option(
       "--include-annotations",
-      "Include span annotations in the trace export"
+      "Include trace and span annotations in the trace export"
     )
     .action(traceListHandler);
 }

--- a/js/packages/phoenix-cli/src/commands/traceAnnotations.ts
+++ b/js/packages/phoenix-cli/src/commands/traceAnnotations.ts
@@ -1,0 +1,115 @@
+import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+
+export type TraceAnnotation = componentsV1["schemas"]["TraceAnnotation"];
+
+const DEFAULT_PAGE_LIMIT = 1000;
+const DEFAULT_TRACE_IDS_CHUNK_SIZE = 100;
+const DEFAULT_MAX_CONCURRENT = 5;
+
+interface FetchTraceAnnotationsOptions {
+  client: PhoenixClient;
+  projectIdentifier: string;
+  traceIds: string[];
+  includeAnnotationNames?: string[];
+  excludeAnnotationNames?: string[];
+  pageLimit?: number;
+  maxConcurrent?: number;
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+async function fetchTraceAnnotationsForChunk({
+  client,
+  projectIdentifier,
+  traceIds,
+  includeAnnotationNames,
+  excludeAnnotationNames,
+  pageLimit,
+}: {
+  client: PhoenixClient;
+  projectIdentifier: string;
+  traceIds: string[];
+  includeAnnotationNames?: string[];
+  excludeAnnotationNames?: string[];
+  pageLimit: number;
+}): Promise<TraceAnnotation[]> {
+  const annotations: TraceAnnotation[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await client.GET(
+      "/v1/projects/{project_identifier}/trace_annotations",
+      {
+        params: {
+          path: {
+            project_identifier: projectIdentifier,
+          },
+          query: {
+            trace_ids: traceIds,
+            cursor,
+            limit: pageLimit,
+            include_annotation_names: includeAnnotationNames,
+            exclude_annotation_names: excludeAnnotationNames,
+          },
+        },
+      }
+    );
+
+    if (response.error || !response.data) {
+      throw new Error(
+        `Failed to fetch trace annotations: ${String(response.error)}`
+      );
+    }
+
+    annotations.push(...response.data.data);
+    cursor = response.data.next_cursor || undefined;
+  } while (cursor);
+
+  return annotations;
+}
+
+export async function fetchTraceAnnotations({
+  client,
+  projectIdentifier,
+  traceIds,
+  includeAnnotationNames,
+  excludeAnnotationNames,
+  pageLimit = DEFAULT_PAGE_LIMIT,
+  maxConcurrent = DEFAULT_MAX_CONCURRENT,
+}: FetchTraceAnnotationsOptions): Promise<TraceAnnotation[]> {
+  if (traceIds.length === 0) {
+    return [];
+  }
+
+  const uniqueTraceIds = Array.from(new Set(traceIds));
+  const chunks = chunkArray(uniqueTraceIds, DEFAULT_TRACE_IDS_CHUNK_SIZE);
+  const allAnnotations: TraceAnnotation[] = [];
+
+  for (let i = 0; i < chunks.length; i += maxConcurrent) {
+    const batch = chunks.slice(i, i + maxConcurrent);
+    const batchResults = await Promise.all(
+      batch.map((traceIdsChunk) =>
+        fetchTraceAnnotationsForChunk({
+          client,
+          projectIdentifier,
+          traceIds: traceIdsChunk,
+          includeAnnotationNames,
+          excludeAnnotationNames,
+          pageLimit,
+        })
+      )
+    );
+
+    for (const result of batchResults) {
+      allAnnotations.push(...result);
+    }
+  }
+
+  return allAnnotations;
+}

--- a/js/packages/phoenix-cli/src/normalize.ts
+++ b/js/packages/phoenix-cli/src/normalize.ts
@@ -1,0 +1,45 @@
+function formatValueForError({ value }: { value: number | string }): string {
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : "<empty>";
+}
+
+export function trimToUndefined({
+  value,
+}: {
+  value?: string;
+}): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+export function parseNumber({
+  rawValue,
+  inputName,
+}: {
+  rawValue: number | string;
+  inputName: string;
+}): number {
+  if (typeof rawValue === "number") {
+    if (Number.isFinite(rawValue)) {
+      return rawValue;
+    }
+  } else {
+    const trimmedValue = rawValue.trim();
+    const parsedValue = Number(trimmedValue);
+    if (trimmedValue.length > 0 && Number.isFinite(parsedValue)) {
+      return parsedValue;
+    }
+  }
+
+  throw new Error(
+    `Invalid value for ${inputName}: ${formatValueForError({ value: rawValue })}. Expected a finite number.`
+  );
+}

--- a/js/packages/phoenix-cli/src/trace.ts
+++ b/js/packages/phoenix-cli/src/trace.ts
@@ -2,6 +2,7 @@ import type { componentsV1 } from "@arizeai/phoenix-client";
 
 export type Span = componentsV1["schemas"]["Span"];
 export type SpanAnnotation = componentsV1["schemas"]["SpanAnnotation"];
+export type TraceAnnotation = componentsV1["schemas"]["TraceAnnotation"];
 export type SpanWithAnnotations = Span & { annotations?: SpanAnnotation[] };
 
 /**
@@ -9,6 +10,7 @@ export type SpanWithAnnotations = Span & { annotations?: SpanAnnotation[] };
  */
 export interface Trace {
   traceId: string;
+  annotations?: TraceAnnotation[];
   spans: SpanWithAnnotations[];
   rootSpan?: SpanWithAnnotations;
   startTime?: string;

--- a/js/packages/phoenix-cli/src/version.ts
+++ b/js/packages/phoenix-cli/src/version.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { trimToUndefined } from "./normalize";
+
 const CLI_PACKAGE_NAME = "@arizeai/phoenix-cli";
 const CLI_LATEST_VERSION_URL = `https://registry.npmjs.org/${encodeURIComponent(CLI_PACKAGE_NAME)}/latest`;
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 1500;
@@ -41,9 +43,7 @@ function getPackageJsonVersion({
   if (typeof packageJson.version !== "string") {
     return undefined;
   }
-
-  const version = packageJson.version.trim();
-  return version.length > 0 ? version : undefined;
+  return trimToUndefined({ value: packageJson.version });
 }
 
 function readCliVersionFromPackageJson(): string | undefined {
@@ -62,9 +62,7 @@ function readCliVersionFromEnvironment(): string | undefined {
   if (typeof process.env.npm_package_version !== "string") {
     return undefined;
   }
-
-  const version = process.env.npm_package_version.trim();
-  return version.length > 0 ? version : undefined;
+  return trimToUndefined({ value: process.env.npm_package_version });
 }
 
 export const CLI_VERSION =

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -1,0 +1,603 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AnnotationMutationResult } from "../src/commands/annotationMutationUtils";
+import { formatAnnotationMutationOutput } from "../src/commands/formatAnnotationMutation";
+import { createSpanCommand } from "../src/commands/span";
+import { createTraceCommand } from "../src/commands/trace";
+import { ExitCode } from "../src/exitCodes";
+
+function makeFetchMock(
+  responses: Array<
+    { ok: boolean; status?: number; body?: unknown } | { error: Error }
+  >
+) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation((requestOrUrl: Request | string) => {
+    const response = responses[callIndex++] ?? responses[responses.length - 1];
+    if ("error" in response) {
+      return Promise.reject(response.error);
+    }
+    const status = response.status ?? (response.ok ? 200 : 500);
+    const url =
+      requestOrUrl instanceof Request ? requestOrUrl.url : requestOrUrl;
+    return Promise.resolve({
+      ok: response.ok,
+      status,
+      statusText: response.ok ? "OK" : "Error",
+      url,
+      headers: new Headers(),
+      json: () => Promise.resolve(response.body ?? {}),
+      text: () => Promise.resolve(""),
+    });
+  });
+}
+
+function getFetchUrl(arg: unknown): string {
+  if (arg instanceof Request) return arg.url;
+  return String(arg);
+}
+
+function getFetchMethod(arg: unknown, init?: RequestInit): string {
+  if (arg instanceof Request) return arg.method;
+  return init?.method ?? "GET";
+}
+
+async function getFetchBody(
+  arg: unknown,
+  init?: RequestInit
+): Promise<unknown> {
+  if (arg instanceof Request) {
+    const text = await arg.clone().text();
+    return text ? JSON.parse(text) : undefined;
+  }
+  if (typeof init?.body === "string") {
+    return JSON.parse(init.body);
+  }
+  return undefined;
+}
+
+const BASE_ARGS = ["--endpoint", "http://localhost:6006", "--no-progress"];
+
+describe("formatAnnotationMutationOutput", () => {
+  const annotation: AnnotationMutationResult = {
+    id: "annotation-123",
+    targetType: "span",
+    targetId: "span-456",
+    name: "reviewer",
+    label: "pass",
+    score: 0.9,
+    explanation: "looks good",
+    annotatorKind: "HUMAN",
+    identifier: "",
+  };
+
+  it("formats pretty output for humans", () => {
+    const output = formatAnnotationMutationOutput({ annotation });
+    expect(output).toContain("Annotation upserted");
+    expect(output).toContain("ID: annotation-123");
+    expect(output).toContain("Target: span span-456");
+    expect(output).toContain("Name: reviewer");
+  });
+
+  it("formats json output", () => {
+    const output = formatAnnotationMutationOutput({
+      annotation,
+      format: "json",
+    });
+    expect(output).toBe(JSON.stringify(annotation, null, 2));
+  });
+
+  it("formats raw output", () => {
+    const output = formatAnnotationMutationOutput({
+      annotation,
+      format: "raw",
+    });
+    expect(output).toBe(JSON.stringify(annotation));
+  });
+});
+
+describe("span annotate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts a sync span annotation and returns raw structured output", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: [{ id: "span-annotation-1" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "annotate",
+        "span-123",
+        "--name",
+        " reviewer ",
+        "--label",
+        " pass ",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/span_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("sync=true");
+    expect(
+      getFetchMethod(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).toBe("POST");
+    await expect(
+      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).resolves.toEqual({
+      data: [
+        {
+          span_id: "span-123",
+          name: "reviewer",
+          annotator_kind: "HUMAN",
+          result: { label: "pass" },
+          identifier: "",
+        },
+      ],
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "span-annotation-1",
+        targetType: "span",
+        targetId: "span-123",
+        name: "reviewer",
+        label: "pass",
+        score: null,
+        explanation: null,
+        annotatorKind: "HUMAN",
+        identifier: "",
+      })
+    );
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes through a custom annotator kind for span annotation", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: [{ id: "span-annotation-3" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "annotate",
+        "span-789",
+        "--name",
+        "reviewer",
+        "--label",
+        "pass",
+        "--annotator-kind",
+        "code",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    await expect(
+      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).resolves.toEqual({
+      data: [
+        {
+          span_id: "span-789",
+          name: "reviewer",
+          annotator_kind: "CODE",
+          result: { label: "pass" },
+          identifier: "",
+        },
+      ],
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "span-annotation-3",
+        targetType: "span",
+        targetId: "span-789",
+        name: "reviewer",
+        label: "pass",
+        score: null,
+        explanation: null,
+        annotatorKind: "CODE",
+        identifier: "",
+      })
+    );
+  });
+
+  it("returns pretty output for a scored span annotation", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: [{ id: "span-annotation-2" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createSpanCommand().parseAsync(
+      [
+        "annotate",
+        "span-456",
+        "--name",
+        "reviewer",
+        "--score",
+        "0.9",
+        "--explanation",
+        " looks good ",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Target: span span-456")
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Explanation: looks good")
+    );
+  });
+
+  it("fails with INVALID_ARGUMENT when --name is missing", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        ["annotate", "span-123", "--label", "pass", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails with INVALID_ARGUMENT when all result fields are blank", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "span-123",
+          "--name",
+          "reviewer",
+          "--label",
+          "   ",
+          "--explanation",
+          "   ",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails with INVALID_ARGUMENT when --score is invalid", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "span-123",
+          "--name",
+          "reviewer",
+          "--score",
+          "not-a-number",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails with INVALID_ARGUMENT when --annotator-kind is invalid", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "span-123",
+          "--name",
+          "reviewer",
+          "--label",
+          "pass",
+          "--annotator-kind",
+          "bot",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 404 API errors", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: false,
+        status: 404,
+        body: { detail: "Spans with IDs missing-span do not exist." },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "missing-span",
+          "--name",
+          "reviewer",
+          "--label",
+          "pass",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error annotating span:")
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("404"));
+  });
+
+  it("uses NETWORK_ERROR on fetch failures", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        error: new TypeError("fetch failed"),
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "span-123",
+          "--name",
+          "reviewer",
+          "--label",
+          "pass",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.NETWORK_ERROR}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.NETWORK_ERROR);
+  });
+});
+
+describe("trace annotate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts a sync trace annotation and returns json output", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: [{ id: "trace-annotation-1" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "annotate",
+        "trace-123",
+        "--name",
+        "reviewer",
+        "--score",
+        "0.5",
+        "--format",
+        "json",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/trace_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[0][0])).toContain("sync=true");
+    await expect(
+      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).resolves.toEqual({
+      data: [
+        {
+          trace_id: "trace-123",
+          name: "reviewer",
+          annotator_kind: "HUMAN",
+          result: { score: 0.5 },
+          identifier: "",
+        },
+      ],
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          id: "trace-annotation-1",
+          targetType: "trace",
+          targetId: "trace-123",
+          name: "reviewer",
+          label: null,
+          score: 0.5,
+          explanation: null,
+          annotatorKind: "HUMAN",
+          identifier: "",
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  it("passes through a custom annotator kind for trace annotation", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: { data: [{ id: "trace-annotation-2" }] },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "annotate",
+        "trace-456",
+        "--name",
+        "reviewer",
+        "--score",
+        "0.7",
+        "--annotator-kind",
+        "llm",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    await expect(
+      getFetchBody(fetchMock.mock.calls[0][0], fetchMock.mock.calls[0][1])
+    ).resolves.toEqual({
+      data: [
+        {
+          trace_id: "trace-456",
+          name: "reviewer",
+          annotator_kind: "LLM",
+          result: { score: 0.7 },
+          identifier: "",
+        },
+      ],
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "trace-annotation-2",
+        targetType: "trace",
+        targetId: "trace-456",
+        name: "reviewer",
+        label: null,
+        score: 0.7,
+        explanation: null,
+        annotatorKind: "LLM",
+        identifier: "",
+      })
+    );
+  });
+
+  it("surfaces 500 API errors for trace annotation", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: false,
+        status: 500,
+        body: { detail: "Internal server error" },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createTraceCommand().parseAsync(
+        [
+          "annotate",
+          "trace-123",
+          "--name",
+          "reviewer",
+          "--label",
+          "pass",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.FAILURE}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.FAILURE);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error annotating trace:")
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("500"));
+  });
+});

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -336,6 +336,35 @@ describe("span annotate", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("fails with INVALID_ARGUMENT when --score contains trailing non-numeric characters", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createSpanCommand().parseAsync(
+        [
+          "annotate",
+          "span-123",
+          "--name",
+          "reviewer",
+          "--score",
+          "0abc",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fails with INVALID_ARGUMENT when --annotator-kind is invalid", async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
     vi.stubGlobal("fetch", fetchMock);
@@ -606,6 +635,86 @@ describe("trace get", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("uses the resolved full trace ID when fetching trace annotations for a prefix lookup", async () => {
+    const resolvedTraceId = "trace-1234567890abcdef";
+    const traceIdPrefix = "trace-1234";
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: {
+          data: {
+            id: "project-default",
+          },
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [
+            {
+              name: "root",
+              span_kind: "CHAIN",
+              parent_id: null,
+              status_code: "OK",
+              status_message: "",
+              start_time: "2026-01-13T10:00:00.000Z",
+              end_time: "2026-01-13T10:00:01.000Z",
+              attributes: {
+                "input.value": "hello",
+                "output.value": "world",
+              },
+              events: [],
+              context: {
+                trace_id: resolvedTraceId,
+                span_id: "span-123",
+              },
+            },
+          ],
+          next_cursor: null,
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [],
+          next_cursor: null,
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [],
+          next_cursor: null,
+        },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "get",
+        traceIdPrefix,
+        "--project",
+        "default",
+        "--include-annotations",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const traceAnnotationsUrl = new URL(
+      getFetchUrl(fetchMock.mock.calls[2][0])
+    );
+    expect(traceAnnotationsUrl.searchParams.getAll("trace_ids")).toEqual([
+      resolvedTraceId,
+    ]);
   });
 
   it("includes trace and span annotations in raw output when requested", async () => {

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -310,7 +310,7 @@ describe("span annotate", () => {
   it("fails with INVALID_ARGUMENT when --score is invalid", async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
     vi.stubGlobal("fetch", fetchMock);
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
@@ -334,12 +334,17 @@ describe("span annotate", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --score: not-a-number. Expected a finite number."
+      )
+    );
   });
 
   it("fails with INVALID_ARGUMENT when --score contains trailing non-numeric characters", async () => {
     const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
     vi.stubGlobal("fetch", fetchMock);
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
@@ -363,6 +368,11 @@ describe("span annotate", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --score: 0abc. Expected a finite number."
+      )
+    );
   });
 
   it("fails with INVALID_ARGUMENT when --annotator-kind is invalid", async () => {
@@ -628,6 +638,40 @@ describe("trace annotate", () => {
       expect.stringContaining("Error annotating trace:")
     );
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("500"));
+  });
+
+  it("fails with INVALID_ARGUMENT when trace --score is invalid", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createTraceCommand().parseAsync(
+        [
+          "annotate",
+          "trace-123",
+          "--name",
+          "reviewer",
+          "--score",
+          "NaN-ish",
+          ...BASE_ARGS,
+        ],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --score: NaN-ish. Expected a finite number."
+      )
+    );
   });
 });
 

--- a/js/packages/phoenix-cli/test/annotate.test.ts
+++ b/js/packages/phoenix-cli/test/annotate.test.ts
@@ -601,3 +601,139 @@ describe("trace annotate", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("500"));
   });
 });
+
+describe("trace get", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("includes trace and span annotations in raw output when requested", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        body: {
+          data: {
+            id: "project-default",
+          },
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [
+            {
+              name: "root",
+              span_kind: "CHAIN",
+              parent_id: null,
+              status_code: "OK",
+              status_message: "",
+              start_time: "2026-01-13T10:00:00.000Z",
+              end_time: "2026-01-13T10:00:01.000Z",
+              attributes: {
+                "input.value": "hello",
+                "output.value": "world",
+              },
+              events: [],
+              context: {
+                trace_id: "trace-123",
+                span_id: "span-123",
+              },
+            },
+          ],
+          next_cursor: null,
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [
+            {
+              id: "trace-annotation-1",
+              created_at: "2026-01-13T10:00:00.500Z",
+              updated_at: "2026-01-13T10:00:00.500Z",
+              source: "API",
+              user_id: null,
+              name: "reviewer",
+              annotator_kind: "HUMAN",
+              result: {
+                label: "pass",
+              },
+              metadata: null,
+              identifier: "",
+              trace_id: "trace-123",
+            },
+          ],
+          next_cursor: null,
+        },
+      },
+      {
+        ok: true,
+        body: {
+          data: [
+            {
+              id: "span-annotation-1",
+              created_at: "2026-01-13T10:00:00.750Z",
+              updated_at: "2026-01-13T10:00:00.750Z",
+              source: "API",
+              user_id: null,
+              name: "accuracy",
+              annotator_kind: "CODE",
+              result: {
+                score: 0.9,
+              },
+              metadata: null,
+              identifier: "",
+              span_id: "span-123",
+            },
+          ],
+          next_cursor: null,
+        },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "get",
+        "trace-123",
+        "--project",
+        "default",
+        "--include-annotations",
+        "--format",
+        "raw",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/projects/project-default/trace_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
+      "/v1/projects/project-default/span_annotations"
+    );
+
+    const output = stdoutSpy.mock.calls[0]?.[0];
+    expect(output).toBeTruthy();
+
+    const parsedOutput = JSON.parse(String(output));
+    expect(parsedOutput.annotations).toEqual([
+      expect.objectContaining({
+        id: "trace-annotation-1",
+        name: "reviewer",
+        trace_id: "trace-123",
+      }),
+    ]);
+    expect(parsedOutput.spans[0].annotations).toEqual([
+      expect.objectContaining({
+        id: "span-annotation-1",
+        name: "accuracy",
+        span_id: "span-123",
+      }),
+    ]);
+  });
+});

--- a/js/packages/phoenix-cli/test/cli.test.ts
+++ b/js/packages/phoenix-cli/test/cli.test.ts
@@ -54,7 +54,7 @@ describe("Phoenix CLI", () => {
 
     expect(traceCommand).toBeDefined();
     expect(traceCommand?.commands.map((command) => command.name())).toEqual(
-      expect.arrayContaining(["list", "get"])
+      expect.arrayContaining(["list", "get", "annotate"])
     );
     expect(
       program.commands.find((command) => command.name() === "traces")
@@ -70,6 +70,9 @@ describe("Phoenix CLI", () => {
     expect(spanCommand).toBeDefined();
     expect(spanCommand?.commands.map((command) => command.name())).toContain(
       "list"
+    );
+    expect(spanCommand?.commands.map((command) => command.name())).toContain(
+      "annotate"
     );
     expect(
       program.commands.find((command) => command.name() === "spans")

--- a/js/packages/phoenix-cli/test/normalize.test.ts
+++ b/js/packages/phoenix-cli/test/normalize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNumber, trimToUndefined } from "../src/normalize";
+
+describe("trimToUndefined", () => {
+  it("returns undefined for blank input", () => {
+    expect(trimToUndefined({ value: "   " })).toBeUndefined();
+  });
+
+  it("returns trimmed content for non-empty input", () => {
+    expect(trimToUndefined({ value: " reviewer " })).toBe("reviewer");
+  });
+});
+
+describe("parseNumber", () => {
+  it("parses a trimmed numeric string", () => {
+    expect(parseNumber({ rawValue: " 0.9 ", inputName: "--score" })).toBe(0.9);
+  });
+
+  it("throws a descriptive error for invalid numbers", () => {
+    expect(() =>
+      parseNumber({ rawValue: "not-a-number", inputName: "--score" })
+    ).toThrow(
+      "Invalid value for --score: not-a-number. Expected a finite number."
+    );
+  });
+
+  it("renders blank strings as empty in error messages", () => {
+    expect(() =>
+      parseNumber({ rawValue: "   ", inputName: "--score" })
+    ).toThrow("Invalid value for --score: <empty>. Expected a finite number.");
+  });
+});

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -79,6 +79,38 @@ const mockTraceWithError: Trace = {
   spans: [mockErrorSpan],
 };
 
+const mockTraceWithAnnotations: Trace = {
+  traceId: "annotated123",
+  spans: [
+    {
+      ...mockSpan1,
+      context: {
+        ...mockSpan1.context,
+        trace_id: "annotated123",
+      },
+      annotations: [
+        {
+          id: "annotation-1",
+          created_at: "2026-01-13T10:00:01.000Z",
+          updated_at: "2026-01-13T10:00:01.000Z",
+          source: "API",
+          user_id: null,
+          name: "reviewer",
+          annotator_kind: "HUMAN",
+          identifier: "",
+          metadata: null,
+          span_id: "span1",
+          result: {
+            label: "pass",
+            score: 0.9,
+            explanation: "Looks good",
+          },
+        },
+      ],
+    } as unknown as MockSpan,
+  ],
+};
+
 describe("Output Formatting", () => {
   describe("trace output - raw", () => {
     it("should format as compact JSON", () => {
@@ -148,6 +180,18 @@ describe("Output Formatting", () => {
       });
 
       expect(output).toContain("✗ failed_operation (UNKNOWN) - 100ms");
+    });
+
+    it("should render span annotations when present", () => {
+      const output = formatTraceOutput({
+        trace: mockTraceWithAnnotations,
+        format: "pretty",
+      });
+
+      expect(output).toContain("annotations:");
+      expect(output).toContain(
+        '- reviewer [HUMAN] label="pass" score=0.9 explanation="Looks good"'
+      );
     });
 
     it("should format array of traces", () => {

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -81,6 +81,24 @@ const mockTraceWithError: Trace = {
 
 const mockTraceWithAnnotations: Trace = {
   traceId: "annotated123",
+  annotations: [
+    {
+      id: "trace-annotation-1",
+      created_at: "2026-01-13T10:00:00.500Z",
+      updated_at: "2026-01-13T10:00:00.500Z",
+      source: "API",
+      user_id: null,
+      name: "trace-reviewer",
+      annotator_kind: "LLM",
+      identifier: "",
+      metadata: null,
+      trace_id: "annotated123",
+      result: {
+        label: "pass",
+        explanation: "Top level trace annotation",
+      },
+    },
+  ],
   spans: [
     {
       ...mockSpan1,
@@ -188,6 +206,10 @@ describe("Output Formatting", () => {
         format: "pretty",
       });
 
+      expect(output).toContain("Trace Annotations:");
+      expect(output).toContain(
+        '- trace-reviewer [LLM] label="pass" explanation="Top level trace annotation"'
+      );
       expect(output).toContain("annotations:");
       expect(output).toContain(
         '- reviewer [HUMAN] label="pass" score=0.9 explanation="Looks good"'


### PR DESCRIPTION
## Summary
- add `px span annotate` and `px trace annotate` for writing human/LLM/code annotations from the CLI
- return structured mutation output, add docs/examples, and cover the new commands with CLI tests
- make `trace get --include-annotations` surface both trace-level and span-level annotations so writes are easy to verify

## What changed
- add new annotate subcommands under `span` and `trace`
- support `--name`, `--label`, `--score`, `--explanation`, and `--annotator-kind`
- add shared annotation normalization / validation helpers and shared mutation formatting
- add a trace annotation fetch helper and extend trace output types
- update pretty trace rendering to show top-level trace annotations and per-span annotations when `--include-annotations` is set
- update the CLI README with usage examples

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- manual dogfooding against `http://localhost:6006` using:
  - `px trace annotate <trace-id> ...`
  - `px span annotate <span-id> ...`
  - `px trace get <trace-id> --include-annotations`
  - `px span list --trace-id <trace-id> --include-annotations`

## Notes
- `trace get` still uses the existing project-scoped span fetch path, so it still requires `--project` or `PHOENIX_PROJECT`
- this PR does not add a new REST endpoint for fetching a single trace
