### PR TITLE
feat(agent): add feedback actions to assistant messages

### DIFF
--- a/app/src/components/agent/AssistantMessageActions.tsx
+++ b/app/src/components/agent/AssistantMessageActions.tsx
@@ -1,0 +1,263 @@
+import { isTextUIPart } from "ai";
+import copy from "copy-to-clipboard";
+import { useState } from "react";
+
+import type { AgentUIMessage } from "@phoenix/agent/chat/types";
+import { authFetch } from "@phoenix/authFetch";
+import { Icon, Icons } from "@phoenix/components";
+import {
+  MessageAction,
+  MessageActions,
+  MessageToolbar,
+} from "@phoenix/components/ai/message";
+import { useViewer } from "@phoenix/contexts";
+import { prependBasename } from "@phoenix/utils/routingUtils";
+
+/**
+ * Annotation name used for both span- and trace-level user feedback on
+ * assistant messages. Matches the annotation config expected by the Phoenix
+ * backend and should stay in sync with any server-side consumers.
+ */
+const FEEDBACK_ANNOTATION_NAME = "user_feedback";
+
+type AssistantFeedback = "positive" | "negative";
+
+/**
+ * Shared shape of the annotation payload sent to the Phoenix REST API. Fields
+ * use snake_case because that is what the `/v1/*_annotations` endpoints
+ * expect on the wire.
+ */
+type AnnotationPayloadBase = {
+  annotator_kind: "HUMAN";
+  identifier: string;
+  metadata: Record<string, string>;
+  name: string;
+  result: {
+    label: AssistantFeedback;
+    score: number;
+  };
+};
+
+type SpanAnnotationPayload = AnnotationPayloadBase & { span_id: string };
+type TraceAnnotationPayload = AnnotationPayloadBase & { trace_id: string };
+
+/**
+ * Concatenates all text parts of an assistant message into a single string.
+ * Non-text parts (tool calls, etc.) are ignored, so the result is what a
+ * human would read as the assistant's response.
+ */
+function getAssistantMessageText(message: AgentUIMessage) {
+  return message.parts
+    .filter(isTextUIPart)
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Maps a thumbs-up/thumbs-down verdict to the `{ label, score }` result shape
+ * expected by the annotation API. Positive feedback scores 1, negative 0.
+ */
+function toFeedbackResult(feedback: AssistantFeedback) {
+  return feedback === "positive"
+    ? { label: "positive" as const, score: 1 }
+    : { label: "negative" as const, score: 0 };
+}
+
+/**
+ * Best-effort extraction of a human-readable error message from a failed
+ * annotation response. Falls back to the raw body or status code if the body
+ * is empty or not JSON with a `detail` field.
+ */
+async function getResponseErrorMessage(response: Response) {
+  const text = await response.text();
+  if (!text) {
+    return `Request failed with status ${response.status}`;
+  }
+  try {
+    const parsed = JSON.parse(text) as { detail?: string };
+    return typeof parsed.detail === "string" ? parsed.detail : text;
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * POSTs a single annotation to the given Phoenix endpoint and waits for the
+ * write to complete (`sync=true`) so the caller knows it was persisted.
+ * Throws with a descriptive message on non-2xx responses.
+ */
+async function postAnnotation({
+  endpoint,
+  payload,
+}: {
+  endpoint: "/v1/span_annotations" | "/v1/trace_annotations";
+  payload: SpanAnnotationPayload | TraceAnnotationPayload;
+}) {
+  const response = await authFetch(`${prependBasename(endpoint)}?sync=true`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data: [payload] }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getResponseErrorMessage(response));
+  }
+}
+
+/**
+ * Toolbar rendered below an assistant message with quick actions:
+ *
+ * - Thumbs up / thumbs down: writes a `user_feedback` annotation to both the
+ *   root span and the trace. Requires the message to carry `traceId`,
+ *   `rootSpanId`, and `sessionId` metadata.
+ * - Copy: copies the assistant's text response to the clipboard.
+ * - Trace: opens the associated trace in a new tab. Requires `traceId`.
+ *
+ * The component silently renders nothing if the message has no text and no
+ * metadata capable of supporting any action.
+ */
+export function AssistantMessageActions({
+  message,
+}: {
+  message: AgentUIMessage;
+}) {
+  const { viewer } = useViewer();
+  const [selectedFeedback, setSelectedFeedback] =
+    useState<AssistantFeedback | null>(null);
+  const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
+
+  const messageText = getAssistantMessageText(message);
+  const hasMessageText = messageText.trim().length > 0;
+  const metadata = message.metadata;
+  const canAnnotate =
+    typeof metadata?.traceId === "string" &&
+    typeof metadata?.rootSpanId === "string" &&
+    typeof metadata?.sessionId === "string";
+  const canOpenTrace = typeof metadata?.traceId === "string";
+
+  if (!hasMessageText && !canAnnotate && !canOpenTrace) {
+    return null;
+  }
+
+  const handleCopy = () => {
+    if (!hasMessageText) {
+      return;
+    }
+    copy(messageText);
+  };
+
+  const handleOpenTrace = () => {
+    if (!canOpenTrace || !metadata) {
+      return;
+    }
+    window.open(
+      prependBasename(`/redirects/traces/${metadata.traceId}`),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  };
+
+  const handleFeedback = async (feedback: AssistantFeedback) => {
+    if (!canAnnotate || !metadata || isSubmittingFeedback) {
+      return;
+    }
+    if (selectedFeedback === feedback) {
+      return;
+    }
+
+    setIsSubmittingFeedback(true);
+    // Using the username as the identifier makes feedback per-user: the same
+    // user re-submitting updates their entry, while different users produce
+    // distinct annotation records. Anonymous viewers fall back to the message
+    // id, which still deduplicates against the same message.
+    const identifier = viewer?.username ?? message.id;
+    const base = {
+      annotator_kind: "HUMAN" as const,
+      identifier,
+      metadata: {
+        assistant_message_id: message.id,
+        feedback,
+        root_span_id: metadata.rootSpanId,
+        session_id: metadata.sessionId,
+        trace_id: metadata.traceId,
+      },
+      name: FEEDBACK_ANNOTATION_NAME,
+      result: toFeedbackResult(feedback),
+    };
+
+    try {
+      await Promise.all([
+        postAnnotation({
+          endpoint: "/v1/span_annotations",
+          payload: { ...base, span_id: metadata.rootSpanId },
+        }),
+        postAnnotation({
+          endpoint: "/v1/trace_annotations",
+          payload: { ...base, trace_id: metadata.traceId },
+        }),
+      ]);
+      setSelectedFeedback(feedback);
+    } catch {
+      // Swallow errors; UI state simply won't reflect the feedback.
+    } finally {
+      setIsSubmittingFeedback(false);
+    }
+  };
+
+  return (
+    <MessageToolbar>
+      <MessageActions>
+        {canAnnotate ? (
+          <MessageAction
+            label="Thumbs up"
+            tooltip="Mark this response as helpful"
+            isDisabled={isSubmittingFeedback}
+            onPress={() => {
+              void handleFeedback("positive");
+            }}
+          >
+            <Icon
+              svg={<Icons.ThumbsUpOutline />}
+              color={selectedFeedback === "positive" ? "blue-700" : "inherit"}
+            />
+          </MessageAction>
+        ) : null}
+        {canAnnotate ? (
+          <MessageAction
+            label="Thumbs down"
+            tooltip="Mark this response as unhelpful"
+            isDisabled={isSubmittingFeedback}
+            onPress={() => {
+              void handleFeedback("negative");
+            }}
+          >
+            <Icon
+              svg={<Icons.ThumbsDownOutline />}
+              color={selectedFeedback === "negative" ? "red-700" : "inherit"}
+            />
+          </MessageAction>
+        ) : null}
+        {hasMessageText ? (
+          <MessageAction
+            label="Copy"
+            tooltip="Copy this response"
+            onPress={handleCopy}
+          >
+            <Icon svg={<Icons.DuplicateOutline />} />
+          </MessageAction>
+        ) : null}
+        {canOpenTrace ? (
+          <MessageAction
+            label="Trace"
+            tooltip="Open the trace for this response"
+            onPress={handleOpenTrace}
+          >
+            <Icon svg={<Icons.Trace />} />
+          </MessageAction>
+        ) : null}
+      </MessageActions>
+    </MessageToolbar>
+  );
+}

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -167,13 +167,22 @@ export function ChatView({
       <div className="chat__scroll">
         <div className="chat__messages">
           {messages.length === 0 && <EmptyState />}
-          {messages.map((message) =>
-            message.role === "user" ? (
-              <UserMessage key={message.id} parts={message.parts} />
-            ) : (
-              <AssistantMessage key={message.id} message={message} />
-            )
-          )}
+          {messages.map((message, index) => {
+            if (message.role === "user") {
+              return <UserMessage key={message.id} parts={message.parts} />;
+            }
+            // Only the last assistant message can still be streaming — hide
+            // its actions until the chat reports it is settled.
+            const isLast = index === messages.length - 1;
+            const showActions = !isLast || status === "ready";
+            return (
+              <AssistantMessage
+                key={message.id}
+                message={message}
+                showActions={showActions}
+              />
+            );
+          })}
           {status === "submitted" && <Loading />}
           {error && <ErrorMessage error={error} />}
           <div ref={bottomRef} />

--- a/app/src/components/agent/Chat.tsx
+++ b/app/src/components/agent/Chat.tsx
@@ -171,7 +171,7 @@ export function ChatView({
             message.role === "user" ? (
               <UserMessage key={message.id} parts={message.parts} />
             ) : (
-              <AssistantMessage key={message.id} parts={message.parts} />
+              <AssistantMessage key={message.id} message={message} />
             )
           )}
           {status === "submitted" && <Loading />}

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -39,11 +39,17 @@ export function UserMessage({ parts }: { parts: AgentUIMessage["parts"] }) {
  * parts. Consecutive runs of 3+ tool calls are collapsed into a
  * {@link ToolPartGroup} pool; shorter runs render individually as
  * {@link ToolPart} details.
+ *
+ * `showActions` gates the feedback/copy/trace toolbar — callers should set
+ * it to `false` while this particular message is still streaming so users
+ * don't interact with incomplete content.
  */
 export function AssistantMessage({
   message,
+  showActions = true,
 }: {
   message: AgentUIMessage;
+  showActions?: boolean;
 }) {
   const grouped = groupMessageParts(message.parts);
 
@@ -65,7 +71,9 @@ export function AssistantMessage({
                   </MarkdownBlock>
                 );
               case "tool-solo":
-                return <ToolPart key={`tool-${group.index}`} part={group.part} />;
+                return (
+                  <ToolPart key={`tool-${group.index}`} part={group.part} />
+                );
               case "tool-group":
                 return (
                   <ToolPartGroup
@@ -79,7 +87,7 @@ export function AssistantMessage({
           })}
         </div>
       </MessageContent>
-      <AssistantMessageActions message={message} />
+      {showActions ? <AssistantMessageActions message={message} /> : null}
     </Message>
   );
 }

--- a/app/src/components/agent/ChatMessage.tsx
+++ b/app/src/components/agent/ChatMessage.tsx
@@ -1,11 +1,11 @@
 import { css } from "@emotion/react";
 import { isTextUIPart } from "ai";
-import { useMemo } from "react";
 
 import type { AgentUIMessage } from "@phoenix/agent/chat/types";
 import { Message, MessageContent } from "@phoenix/components/ai/message";
 import { MarkdownBlock } from "@phoenix/components/markdown";
 
+import { AssistantMessageActions } from "./AssistantMessageActions";
 import { groupMessageParts } from "./groupMessageParts";
 import { ToolPart } from "./ToolPart";
 import { ToolPartGroup } from "./ToolPartGroup";
@@ -41,40 +41,45 @@ export function UserMessage({ parts }: { parts: AgentUIMessage["parts"] }) {
  * {@link ToolPart} details.
  */
 export function AssistantMessage({
-  parts,
+  message,
 }: {
-  parts: AgentUIMessage["parts"];
+  message: AgentUIMessage;
 }) {
-  const grouped = useMemo(() => groupMessageParts(parts), [parts]);
+  const grouped = groupMessageParts(message.parts);
 
   return (
-    <div css={assistantMessageCSS}>
-      {grouped.map((group) => {
-        switch (group.kind) {
-          case "text":
-            return (
-              <MarkdownBlock
-                key={`text-${group.index}`}
-                mode="markdown"
-                renderMode="streaming"
-                margin="none"
-              >
-                {group.part.type === "text" ? group.part.text : ""}
-              </MarkdownBlock>
-            );
-          case "tool-solo":
-            return <ToolPart key={`tool-${group.index}`} part={group.part} />;
-          case "tool-group":
-            return (
-              <ToolPartGroup
-                key={`pool-${group.startIndex}`}
-                parts={group.parts}
-              />
-            );
-          default:
-            return null;
-        }
-      })}
-    </div>
+    <Message from="assistant">
+      <MessageContent>
+        <div css={assistantMessageCSS}>
+          {grouped.map((group) => {
+            switch (group.kind) {
+              case "text":
+                return (
+                  <MarkdownBlock
+                    key={`text-${group.index}`}
+                    mode="markdown"
+                    renderMode="streaming"
+                    margin="none"
+                  >
+                    {group.part.type === "text" ? group.part.text : ""}
+                  </MarkdownBlock>
+                );
+              case "tool-solo":
+                return <ToolPart key={`tool-${group.index}`} part={group.part} />;
+              case "tool-group":
+                return (
+                  <ToolPartGroup
+                    key={`pool-${group.startIndex}`}
+                    parts={group.parts}
+                  />
+                );
+              default:
+                return null;
+            }
+          })}
+        </div>
+      </MessageContent>
+      <AssistantMessageActions message={message} />
+    </Message>
   );
 }


### PR DESCRIPTION
## Summary
- Adds an action toolbar below assistant messages: thumbs up/down feedback, copy, and open-trace (in a new tab).
- Feedback writes a `user_feedback` annotation to both the root span and the trace, keyed by the viewer's username when authenticated so re-submitting updates the same entry.
- Lifts `AssistantMessage` to receive the full message (not just `parts`) so action handlers can read `traceId`, `rootSpanId`, and `sessionId` from metadata.
<img width="2420" height="1240" alt="Screenshot 2026-04-14 at 2 13 57 PM" src="https://github.com/user-attachments/assets/ef0c5986-0643-44fa-96d5-3fa581525621" />
