### PR TITLE
fix(playground): track eval failures separately from completions

### DIFF
--- a/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
+++ b/app/src/pages/playground/PlaygroundDatasetExamplesTable.tsx
@@ -947,6 +947,9 @@ export function PlaygroundDatasetExamplesTable({
   const incrementEvalsCompleted = usePlaygroundContext(
     (state) => state.incrementEvalsCompleted
   );
+  const incrementEvalsFailed = usePlaygroundContext(
+    (state) => state.incrementEvalsFailed
+  );
   const initExperimentRunProgress = usePlaygroundContext(
     (state) => state.initExperimentRunProgress
   );
@@ -1050,7 +1053,11 @@ export function PlaygroundDatasetExamplesTable({
               annotationName: chatCompletion.evaluatorName,
               score: chatCompletion.experimentRunEvaluation?.score ?? null,
             });
-            incrementEvalsCompleted(instanceId);
+            if (chatCompletion.error != null) {
+              incrementEvalsFailed(instanceId);
+            } else {
+              incrementEvalsCompleted(instanceId);
+            }
             break;
           }
           // This should never happen
@@ -1068,6 +1075,7 @@ export function PlaygroundDatasetExamplesTable({
       appendExampleDataToolCallChunk,
       appendExampleDataEvaluationChunk,
       incrementEvalsCompleted,
+      incrementEvalsFailed,
       incrementRunsCompleted,
       incrementRunsFailed,
       playgroundStore,


### PR DESCRIPTION
fixes #10957

When an EvaluationChunk arrives with a non-null error field, the progress counter now calls incrementEvalsFailed instead of incrementEvalsCompleted. Previously every eval outcome was counted as completed regardless of whether the evaluator succeeded or failed, so the progress indicator never reflected evaluation errors.

The fix checks chatCompletion.error before deciding which counter to increment. incrementEvalsFailed already existed in the store and its type definitions but was never wired up in this handler.