### PR TITLE
fix(phoenix-client): make provider SDKs optional peer deps

### DIFF
--- a/js/.changeset/phoenix-client-optional-peer-sdks.md
+++ b/js/.changeset/phoenix-client-optional-peer-sdks.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": patch
+---
+
+Move `@anthropic-ai/sdk`, `openai`, and `ai` from `optionalDependencies` to optional `peerDependencies`. Consumers no longer get these provider SDKs installed automatically — they are only installed if the consumer already depends on them.

--- a/js/packages/phoenix-client/package.json
+++ b/js/packages/phoenix-client/package.json
@@ -108,10 +108,21 @@
     "tsx": "^4.19.3",
     "vitest": "^4.1.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@anthropic-ai/sdk": "^0.35.0",
     "ai": "^6.0.90",
     "openai": "^6.10.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "ai": {
+      "optional": true
+    },
+    "openai": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -396,9 +396,6 @@ importers:
 
   packages/phoenix-cli:
     dependencies:
-      '@clack/prompts':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@arizeai/openinference-semantic-conventions':
         specifier: ^1.1.0
         version: 1.1.0
@@ -408,6 +405,9 @@ importers:
       '@arizeai/phoenix-config':
         specifier: workspace:*
         version: link:../phoenix-config
+      '@clack/prompts':
+        specifier: ^1.0.1
+        version: 1.0.1
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -458,6 +458,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.29
         version: 3.0.29(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.35.0
+        version: 0.35.0
       '@arizeai/phoenix-evals':
         specifier: workspace:*
         version: link:../phoenix-evals
@@ -473,6 +476,12 @@ importers:
       '@types/node':
         specifier: ^20.17.22
         version: 20.19.33
+      ai:
+        specifier: ^6.0.90
+        version: 6.0.90(zod@4.3.6)
+      openai:
+        specifier: ^6.10.0
+        version: 6.22.0(ws@8.19.0)(zod@4.3.6)
       openapi-typescript:
         specifier: ^7.6.1
         version: 7.13.0(typescript@6.0.2)
@@ -482,16 +491,6 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(msw@2.12.10(@types/node@20.19.33)(typescript@6.0.2))(vite@8.0.3(@types/node@20.19.33)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
-    optionalDependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.35.0
-        version: 0.35.0
-      ai:
-        specifier: ^6.0.90
-        version: 6.0.90(zod@4.3.6)
-      openai:
-        specifier: ^6.10.0
-        version: 6.22.0(ws@8.19.0)(zod@4.3.6)
 
   packages/phoenix-config:
     devDependencies:
@@ -5377,7 +5376,6 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   '@arizeai/openinference-core@1.0.3':
     dependencies:


### PR DESCRIPTION
## Summary

- `@anthropic-ai/sdk`, `openai`, and `ai` were listed under `optionalDependencies` in `@arizeai/phoenix-client`, which confusingly still installs them by default — npm's `optionalDependencies` only means the install is allowed to *fail* silently, not that the deps are opt-in. As a result, consumers of `@arizeai/phoenix-client` were getting all three provider SDKs pulled into their `node_modules` automatically.
- These packages are only referenced as `import type` in `src/prompts/sdks/{toAnthropic,toAI,toOpenAI}.ts` — types-only, erased at runtime — so they are safe to move to `peerDependencies` with `peerDependenciesMeta.<name>.optional: true`. That's the standard pattern for "install only if the consumer already depends on it."
- Local dev/tests are unaffected: all three remain in `devDependencies`.

Verified by installing the built package into a clean project and confirming `node_modules/{@anthropic-ai,openai,ai}` are all absent.

## Test plan

- [x] `pnpm run test` in `js/packages/phoenix-client` (299 passed)
- [x] Clean consumer install (`npm i <local-tarball>`) no longer pulls in `@anthropic-ai/sdk`, `openai`, or `ai`
- [ ] CI green