### PR TITLE
feat(client): pass through trace_id to experiment evaluators

### DIFF
--- a/packages/phoenix-client/examples/experiments/experiment_trace_evaluator.py
+++ b/packages/phoenix-client/examples/experiments/experiment_trace_evaluator.py
@@ -1,0 +1,225 @@
+"""
+Example: Evaluating a tool-calling agent's trajectory with experiments
+
+This example simulates a simple tool-calling agent that answers questions by
+dispatching to the right tool (get_weather, get_time). It then uses Phoenix
+experiments to verify the agent called the correct tool for each question by
+inspecting the trace spans.
+
+Flow:
+1. Define the agent's tools (traced with OpenTelemetry so spans are recorded)
+2. Create a dataset of questions with expected tool calls
+3. Run the agent against each dataset example as an experiment
+4. Evaluate by fetching spans from each run's trace to check tool usage
+
+Prerequisites:
+- Phoenix server running on http://localhost:6006
+- pip install arize-phoenix-client arize-phoenix-otel openinference-semconv
+"""
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+from opentelemetry import trace
+
+import phoenix.otel
+from phoenix.client import Client
+from phoenix.client.resources.experiments.evaluators import create_evaluator
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# Register the global tracer provider so that tool spans are exported to Phoenix.
+# The experiment runner creates its own tracer for the root span, but any child
+# spans created inside the task (our tool functions) use the global tracer.
+# OTel context propagation ensures they share the same trace_id.
+#
+# Both register() and Client() default to http://localhost:6006. Override via
+# PHOENIX_COLLECTOR_ENDPOINT / PHOENIX_PORT environment variables if needed.
+
+phoenix.otel.register()
+tracer = trace.get_tracer(__name__)
+client = Client()
+
+# ---------------------------------------------------------------------------
+# Step 1: Define the agent's tools
+# ---------------------------------------------------------------------------
+# Each tool is wrapped in an OpenTelemetry span with the TOOL span kind so that
+# calling it creates a TOOL span in the active trace. This is what lets us
+# inspect tool usage after the fact.
+
+OPENINFERENCE_SPAN_KIND = SpanAttributes.OPENINFERENCE_SPAN_KIND
+TOOL = OpenInferenceSpanKindValues.TOOL.value
+
+
+def get_weather(location: str) -> dict[str, Any]:
+    with tracer.start_as_current_span("get_weather") as span:
+        span.set_attribute(OPENINFERENCE_SPAN_KIND, TOOL)
+        span.set_attribute("tool.parameters", f'{{"location": "{location}"}}')
+        result = {
+            "location": location,
+            "temperature": 72,
+            "condition": "sunny",
+        }
+        return result
+
+
+def get_time(tz: str) -> dict[str, Any]:
+    with tracer.start_as_current_span("get_time") as span:
+        span.set_attribute(OPENINFERENCE_SPAN_KIND, TOOL)
+        span.set_attribute("tool.parameters", f'{{"timezone": "{tz}"}}')
+        result = {
+            "timezone": tz,
+            "time": datetime.now(timezone.utc).strftime("%I:%M %p"),
+        }
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Define the agent
+# ---------------------------------------------------------------------------
+# A minimal tool-calling agent: it reads the user question, decides which tool
+# to call, invokes it, and returns a natural-language answer.
+
+
+def run_agent(question: str) -> str:
+    q = question.lower()
+    if "weather" in q:
+        city = question.split("in ")[-1].rstrip("?").strip()
+        result = get_weather(city)
+        return (
+            f"The weather in {result['location']} is "
+            f"{result['temperature']}F and {result['condition']}."
+        )
+    if "time" in q:
+        tz = "Asia/Tokyo" if "tokyo" in q else "UTC"
+        result = get_time(tz)
+        return f"The time in {result['timezone']} is {result['time']}."
+    return "I don't know how to answer that."
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Build the evaluator
+# ---------------------------------------------------------------------------
+# After each experiment run, we fetch the TOOL spans from its trace and check
+# whether the expected tool was called. This validates the agent's routing
+# logic end-to-end.
+#
+# We use a factory function (like the TS example) because the evaluator needs
+# the project name to query spans, and the experiment auto-generates its project
+# name at runtime. The evaluator receives `trace_id` automatically because it's
+# declared as a parameter name — the experiment framework binds it from the
+# task run's trace.
+
+
+def create_tool_call_evaluator(project_name: str) -> Any:
+    """Create an evaluator that checks whether the expected tool was called."""
+
+    @create_evaluator(kind="CODE", name="has-expected-tool-call")
+    def tool_call_evaluator(expected: dict[str, Any], trace_id: str) -> dict[str, Any]:
+        if not trace_id:
+            return {
+                "label": "no trace",
+                "score": 0,
+                "explanation": "No trace ID available for this task run",
+            }
+
+        # Fetch only TOOL spans from this experiment run's trace
+        tool_spans = client.spans.get_spans(
+            project_identifier=project_name,
+            trace_ids=[trace_id],
+            span_kind="TOOL",
+        )
+
+        expected_tool = (expected or {}).get("expected_tool", "")
+        tool_names = [s["name"] for s in tool_spans]
+        found = any(expected_tool in name for name in tool_names)
+
+        return {
+            "label": "tool called" if found else "no tool call",
+            "score": 1 if found else 0,
+            "explanation": (
+                f"Found tool spans: {tool_names}"
+                if found
+                else f"Expected '{expected_tool}' but found: {tool_names or 'none'}"
+            ),
+            "metadata": {"tool_span_count": len(tool_spans), "tool_names": tool_names},
+        }
+
+    return tool_call_evaluator
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Run the experiment and evaluate
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    # 4a. Create a dataset of questions, each annotated with which tool the
+    #     agent should call.
+    dataset = client.datasets.create_dataset(
+        name="tool-call-example-dataset",
+        dataset_description="Questions that require tool use",
+        inputs=[
+            {"question": "What is the weather in San Francisco?"},
+            {"question": "What time is it in Tokyo?"},
+            {"question": "What is the weather in London?"},
+        ],
+        outputs=[
+            {"expected_tool": "get_weather"},
+            {"expected_tool": "get_time"},
+            {"expected_tool": "get_weather"},
+        ],
+    )
+
+    # 4b. Run the agent against every dataset example. We don't pass evaluators
+    #     here because we need spans to be fully ingested before evaluating.
+    #     The task receives `input` (the input dict from each dataset example).
+    experiment = client.experiments.run_experiment(
+        dataset=dataset,
+        task=lambda input: run_agent(input["question"]),
+    )
+
+    project_name = experiment["project_name"]
+    print(f"\nProject: {project_name}")
+    print("\n--- Experiment Runs ---")
+    for run in experiment["task_runs"]:
+        print(
+            f"  example={run['dataset_example_id']}"
+            f"  trace_id={run.get('trace_id', 'N/A')}"
+            f"  output={str(run['output'])[:80]}"
+        )
+
+    # 4c. Brief pause to let Phoenix finish ingesting the exported spans.
+    #     The experiment's task spans are exported via OTLP, and Phoenix needs
+    #     a moment to process them before they're queryable.
+    print("\nWaiting for span ingestion...")
+    time.sleep(3)
+
+    # 4d. Evaluate: fetch spans from each run's trace and verify tool usage.
+    assert project_name is not None
+    evaluated = client.experiments.evaluate_experiment(
+        experiment=experiment,
+        evaluators=[create_tool_call_evaluator(project_name)],
+    )
+
+    print("\n--- Evaluation Results ---")
+    for eval_run in evaluated["evaluation_runs"]:
+        result = eval_run.result
+        if result is None:
+            print(f"  [{eval_run.name}]  error={eval_run.error}")
+            continue
+        # result may be a single EvaluationResult or a sequence
+        if isinstance(result, dict):
+            print(
+                f"  [{eval_run.name}]"
+                f"  label={result.get('label')}"
+                f"  score={result.get('score')}"
+                f"  explanation={result.get('explanation')}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/phoenix-client/examples/experiments/experiment_trace_evaluator.py
+++ b/packages/phoenix-client/examples/experiments/experiment_trace_evaluator.py
@@ -21,10 +21,10 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+import phoenix.otel
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry import trace
 
-import phoenix.otel
 from phoenix.client import Client
 from phoenix.client.resources.experiments.evaluators import create_evaluator
 

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/__init__.py
@@ -1915,6 +1915,7 @@ class Experiments:
                     input=example["input"],
                     metadata=example["metadata"],
                     example=example,
+                    trace_id=experiment_run.get("trace_id"),
                 )
             except BaseException as exc:
                 span.record_exception(exc)
@@ -3669,6 +3670,7 @@ class AsyncExperiments:
                     input=example["input"],
                     metadata=example["metadata"],
                     example=example,
+                    trace_id=experiment_run.get("trace_id"),
                 )
             except BaseException as exc:
                 span.record_exception(exc)

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/evaluators.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/evaluators.py
@@ -57,7 +57,15 @@ def get_func_name(fn: Callable[..., Any]) -> str:
 def validate_evaluator_signature(sig: inspect.Signature) -> None:
     """Check that the wrapped function has a valid signature for use as an evaluator."""
     params = sig.parameters
-    valid_named_params = {"input", "output", "expected", "reference", "metadata", "example"}
+    valid_named_params = {
+        "input",
+        "output",
+        "expected",
+        "reference",
+        "metadata",
+        "example",
+        "trace_id",
+    }
     if len(params) == 0:
         raise ValueError("Evaluation function must have at least one parameter.")
     if len(params) > 1:
@@ -90,6 +98,7 @@ def _bind_evaluator_signature(sig: inspect.Signature, **kwargs: Any) -> inspect.
         "reference": copy.deepcopy(kwargs.get("reference")),
         "metadata": copy.deepcopy(kwargs.get("metadata")),
         "example": example_proxy,
+        "trace_id": kwargs.get("trace_id"),
     }
 
     params = sig.parameters
@@ -157,6 +166,7 @@ def create_evaluator(
         `reference`: An alias for `expected`
         `metadata`: Metadata associated with the dataset example
         `example`: The dataset `Example` object with all associated fields
+        `trace_id`: The trace ID from the experiment task run, if available
 
     Args:
         kind (str | AnnotatorKind): Broadly indicates how the evaluator scores an experiment run.

--- a/packages/phoenix-client/src/phoenix/client/resources/experiments/types.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/experiments/types.py
@@ -219,7 +219,15 @@ class Evaluator(Protocol):
 def _validate_evaluator_signature(sig: inspect.Signature) -> None:
     """Validate that a function signature is compatible with evaluator requirements."""
     params = sig.parameters
-    valid_named_params = {"input", "output", "expected", "reference", "metadata", "example"}
+    valid_named_params = {
+        "input",
+        "output",
+        "expected",
+        "reference",
+        "metadata",
+        "example",
+        "trace_id",
+    }
     if len(params) == 0:
         raise ValueError("Evaluator function must have at least one parameter.")
     if len(params) > 1:

--- a/packages/phoenix-client/tests/client/resources/experiments/test_trace_id_binding.py
+++ b/packages/phoenix-client/tests/client/resources/experiments/test_trace_id_binding.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 import inspect
 from typing import Any, Optional
 

--- a/packages/phoenix-client/tests/client/resources/experiments/test_trace_id_binding.py
+++ b/packages/phoenix-client/tests/client/resources/experiments/test_trace_id_binding.py
@@ -1,0 +1,167 @@
+import inspect
+from typing import Any, Optional
+
+import pytest
+
+from phoenix.client.resources.experiments.evaluators import (
+    _bind_evaluator_signature,
+    create_evaluator,
+    validate_evaluator_signature,
+)
+from phoenix.client.resources.experiments.types import (
+    _validate_evaluator_signature,
+)
+
+
+class TestValidateEvaluatorSignatureAcceptsTraceId:
+    """Test that trace_id is accepted as a valid parameter name."""
+
+    def test_trace_id_only(self) -> None:
+        def evaluator(trace_id: str) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        validate_evaluator_signature(sig)
+
+    def test_trace_id_with_output(self) -> None:
+        def evaluator(output: Any, trace_id: str) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        validate_evaluator_signature(sig)
+
+    def test_trace_id_with_all_params(self) -> None:
+        def evaluator(
+            input: Any,
+            output: Any,
+            expected: Any,
+            metadata: Any,
+            trace_id: str,
+        ) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        validate_evaluator_signature(sig)
+
+
+class TestPrivateValidateEvaluatorSignatureAcceptsTraceId:
+    """Test that _validate_evaluator_signature also accepts trace_id."""
+
+    def test_trace_id_only(self) -> None:
+        def evaluator(trace_id: str) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        _validate_evaluator_signature(sig)
+
+    def test_trace_id_with_output(self) -> None:
+        def evaluator(output: Any, trace_id: str) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        _validate_evaluator_signature(sig)
+
+
+class TestBindEvaluatorSignatureWithTraceId:
+    """Test that trace_id is correctly bound in evaluator signatures."""
+
+    def test_trace_id_bound_when_requested(self) -> None:
+        def evaluator(output: Any, trace_id: Optional[str] = None) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        bound = _bind_evaluator_signature(
+            sig,
+            output="test output",
+            trace_id="abc123",
+        )
+        assert bound.arguments["trace_id"] == "abc123"
+
+    def test_trace_id_none_when_missing(self) -> None:
+        def evaluator(output: Any, trace_id: Optional[str] = None) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        bound = _bind_evaluator_signature(
+            sig,
+            output="test output",
+        )
+        assert bound.arguments["trace_id"] is None
+
+    def test_trace_id_not_bound_when_not_in_signature(self) -> None:
+        def evaluator(output: Any) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        bound = _bind_evaluator_signature(
+            sig,
+            output="test output",
+            trace_id="abc123",
+        )
+        assert "trace_id" not in bound.arguments
+
+    def test_trace_id_with_all_params(self) -> None:
+        def evaluator(
+            input: Any,
+            output: Any,
+            expected: Any,
+            metadata: Any,
+            trace_id: Optional[str] = None,
+        ) -> bool:
+            return True
+
+        sig = inspect.signature(evaluator)
+        bound = _bind_evaluator_signature(
+            sig,
+            input={"question": "test"},
+            output="test output",
+            expected={"answer": "expected"},
+            metadata={"key": "value"},
+            trace_id="trace-xyz",
+        )
+        assert bound.arguments["trace_id"] == "trace-xyz"
+        assert bound.arguments["output"] == "test output"
+
+
+class TestCreateEvaluatorWithTraceId:
+    """Test that evaluators created with create_evaluator receive trace_id."""
+
+    def test_sync_evaluator_receives_trace_id(self) -> None:
+        received: dict[str, Any] = {}
+
+        @create_evaluator(kind="CODE", name="test-eval")
+        def evaluator(output: Any, trace_id: Optional[str] = None) -> bool:
+            received["trace_id"] = trace_id
+            return True
+
+        evaluator.evaluate(
+            output="test",
+            trace_id="abc123",
+        )
+        assert received["trace_id"] == "abc123"
+
+    def test_sync_evaluator_receives_none_trace_id(self) -> None:
+        received: dict[str, Any] = {}
+
+        @create_evaluator(kind="CODE", name="test-eval-none")
+        def evaluator(output: Any, trace_id: Optional[str] = None) -> bool:
+            received["trace_id"] = trace_id
+            return True
+
+        evaluator.evaluate(output="test")
+        assert received["trace_id"] is None
+
+    @pytest.mark.anyio
+    async def test_async_evaluator_receives_trace_id(self) -> None:
+        received: dict[str, Any] = {}
+
+        @create_evaluator(kind="CODE", name="test-eval-async")
+        async def evaluator(output: Any, trace_id: Optional[str] = None) -> bool:
+            received["trace_id"] = trace_id
+            return True
+
+        await evaluator.async_evaluate(
+            output="test",
+            trace_id="async-trace-123",
+        )
+        assert received["trace_id"] == "async-trace-123"

--- a/tests/integration/client/test_experiments.py
+++ b/tests/integration/client/test_experiments.py
@@ -9,12 +9,11 @@ from unittest.mock import patch
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from strawberry.relay import GlobalID
-
 from phoenix.client import AsyncClient
 from phoenix.client import Client as SyncClient
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.datasets import Dataset
+from strawberry.relay import GlobalID
 
 from .._helpers import (  # pyright: ignore[reportPrivateUsage]
     _AppInfo,

--- a/tests/integration/client/test_experiments.py
+++ b/tests/integration/client/test_experiments.py
@@ -1371,6 +1371,59 @@ class TestExperimentsIntegration:
             assert eval_run.result.get("label") == "has_example"
 
     @pytest.mark.parametrize("is_async", [True, False])
+    async def test_evaluator_receives_task_run_trace_id(
+        self,
+        is_async: bool,
+        _app: _AppInfo,
+    ) -> None:
+        api_key = _app.admin_secret
+
+        from phoenix.client import AsyncClient
+        from phoenix.client import Client as SyncClient
+
+        Client = AsyncClient if is_async else SyncClient
+
+        dataset = await _await_or_return(
+            Client(base_url=_app.base_url, api_key=api_key).datasets.create_dataset(
+                name=f"test_trace_id_binding_{token_hex(4)}",
+                inputs=[
+                    {"text": "first"},
+                    {"text": "second"},
+                ],
+                outputs=[
+                    {"expected": "FIRST"},
+                    {"expected": "SECOND"},
+                ],
+            )
+        )
+
+        received_trace_ids: list[str] = []
+
+        def task(input: Dict[str, Any]) -> str:
+            return input["text"].upper()
+
+        def evaluator(output: str, trace_id: Optional[str] = None) -> float:
+            assert trace_id is not None
+            received_trace_ids.append(trace_id)
+            return 1.0 if trace_id else 0.0
+
+        result = await _await_or_return(
+            Client(base_url=_app.base_url, api_key=api_key).experiments.run_experiment(
+                dataset=dataset,
+                task=task,
+                evaluators=[evaluator],
+                experiment_name=f"test_trace_id_eval_{token_hex(4)}",
+                print_summary=False,
+            )
+        )
+
+        task_run_trace_ids = [run["trace_id"] for run in result["task_runs"]]
+
+        assert len(received_trace_ids) == len(task_run_trace_ids) == 2
+        assert all(trace_id is not None for trace_id in task_run_trace_ids)
+        assert received_trace_ids == cast(list[str], task_run_trace_ids)
+
+    @pytest.mark.parametrize("is_async", [True, False])
     async def test_task_dynamic_parameter_binding(
         self,
         is_async: bool,

--- a/tests/integration/client/test_experiments.py
+++ b/tests/integration/client/test_experiments.py
@@ -9,11 +9,12 @@ from unittest.mock import patch
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from strawberry.relay import GlobalID
+
 from phoenix.client import AsyncClient
 from phoenix.client import Client as SyncClient
 from phoenix.client.__generated__ import v1
 from phoenix.client.resources.datasets import Dataset
-from strawberry.relay import GlobalID
 
 from .._helpers import (  # pyright: ignore[reportPrivateUsage]
     _AppInfo,
@@ -1400,7 +1401,7 @@ class TestExperimentsIntegration:
         received_trace_ids: list[str] = []
 
         def task(input: Dict[str, Any]) -> str:
-            return input["text"].upper()
+            return cast(str, input["text"].upper())
 
         def evaluator(output: str, trace_id: Optional[str] = None) -> float:
             assert trace_id is not None
@@ -1421,7 +1422,7 @@ class TestExperimentsIntegration:
 
         assert len(received_trace_ids) == len(task_run_trace_ids) == 2
         assert all(trace_id is not None for trace_id in task_run_trace_ids)
-        assert received_trace_ids == cast(list[str], task_run_trace_ids)
+        assert received_trace_ids == task_run_trace_ids
 
     @pytest.mark.parametrize("is_async", [True, False])
     async def test_task_dynamic_parameter_binding(


### PR DESCRIPTION
## Summary
- Thread `trace_id` through the experiment evaluator pipeline so evaluator functions can access the originating trace ID
- Update evaluator type signatures and the `__init__` exports to support the new parameter
- Add unit tests for trace ID binding and integration tests for end-to-end trace ID passthrough

Closes #12454, #12167