### PR TITLE
chore(deps): promote pydantic-ai to a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
   "arize-phoenix-otel>=0.15.0",
   "fastapi>=0.135.2",  # older versions raise AssertionError on 204 routes, see https://github.com/Arize-ai/phoenix/issues/12384
   "pydantic>=2.1.0", # exclude 2.0.* since it does not support the `json_encoders` configuration setting
+  "pydantic-ai>=1.62.0",
   "authlib",
   "arize-phoenix-client>=2.1.0",
   "email-validator",
@@ -125,7 +126,6 @@ dev = [
   "pyarrow-stubs",
   "pydantic>=1.0,!=2.0.*,<3",
   "mcp>=1.26.0",
-  "pydantic-ai>=1.62.0",
   "pyjwt",
   "pypistats",  # this is needed to type-check third-party packages
   "pyright[nodejs]==1.1.394",

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T14:35:26.33229Z"
+exclude-newer = "2026-04-13T00:19:33.900695Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -454,6 +454,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pydantic-ai" },
     { name = "pystache" },
     { name = "python-dateutil" },
     { name = "python-multipart" },
@@ -555,7 +556,6 @@ dev = [
     { name = "py-grpc-prometheus" },
     { name = "pyarrow-stubs" },
     { name = "pydantic" },
-    { name = "pydantic-ai" },
     { name = "pyjwt" },
     { name = "pypistats" },
     { name = "pyright", extra = ["nodejs"] },
@@ -646,6 +646,7 @@ requires-dist = [
     { name = "py-grpc-prometheus", marker = "extra == 'container'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.1.0" },
+    { name = "pydantic-ai", specifier = ">=1.62.0" },
     { name = "pystache" },
     { name = "python-dateutil" },
     { name = "python-multipart" },
@@ -721,7 +722,6 @@ dev = [
     { name = "py-grpc-prometheus" },
     { name = "pyarrow-stubs" },
     { name = "pydantic", specifier = ">=1.0,!=2.0.*,<3" },
-    { name = "pydantic-ai", specifier = ">=1.62.0" },
     { name = "pyjwt" },
     { name = "pypistats" },
     { name = "pyright", extras = ["nodejs"], specifier = "==1.1.394" },


### PR DESCRIPTION
## Summary
- PXI relies on `pydantic-ai` at runtime, but it currently lives in the `dev` dependency group, so `pip install arize-phoenix` leaves PXI non-functional.
- Move `pydantic-ai>=1.62.0` from the `dev` group into the main `dependencies` list in `pyproject.toml` and refresh `uv.lock` accordingly.

## Test plan
- [ ] `uv lock --check` is clean
- [ ] CI: lint, type-check, unit + integration tests pass
- [ ] Smoke test: install a fresh wheel and start PXI