### PR TITLE
fix(ui): simplify TS onboarding to use only phoenix-otel

### DIFF
--- a/app/src/components/project/integrationSnippets/phoenixOtel.ts
+++ b/app/src/components/project/integrationSnippets/phoenixOtel.ts
@@ -24,8 +24,7 @@ export function getOtelInitCodeTypescript({
 }: {
   projectName: string;
 }): string {
-  return `import { register } from "@arizeai/phoenix-otel";
-import { traceChain } from "@arizeai/openinference-core";
+  return `import { register, traceChain } from "@arizeai/phoenix-otel";
 
 const provider = register({
   projectName: "${projectName}",

--- a/app/src/pages/project/integrationRegistry.tsx
+++ b/app/src/pages/project/integrationRegistry.tsx
@@ -119,7 +119,7 @@ export const ONBOARDING_INTEGRATIONS: OnboardingIntegration[] = [
           "https://github.com/Arize-ai/openinference/tree/f897cd19ef39a15fea9ee3a8f5a6e929d7a54bf1/python/openinference-instrumentation",
       },
       TypeScript: {
-        packages: ["@arizeai/phoenix-otel", "@arizeai/openinference-core"],
+        packages: ["@arizeai/phoenix-otel"],
         getImplementationCode: getOtelInitCodeTypescript,
         docsHref:
           "https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument#typescript",


### PR DESCRIPTION
## Summary
- Remove `@arizeai/openinference-core` from the "Trace your app" TypeScript install packages — `@arizeai/phoenix-otel` re-exports everything from it
- Consolidate the two imports in the onboarding snippet into a single `import { register, traceChain } from "@arizeai/phoenix-otel"`

## Test plan
- [ ] Verify the "Trace your app" TypeScript onboarding shows only `@arizeai/phoenix-otel` in the install step
- [ ] Verify the implementation code snippet uses a single import from `@arizeai/phoenix-otel`