### PR TITLE
feat: add trace note REST endpoint for Phoenix CLI

### DIFF
--- a/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api.mdx
+++ b/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api.mdx
@@ -1,0 +1,13 @@
+---
+title: "04.24.2026 Trace Notes API"
+description: "Add trace notes through a dedicated REST endpoint and reserve the note annotation name for note-specific APIs."
+---
+
+## Trace Notes API
+
+Phoenix now supports creating trace notes through `POST /v1/trace_notes`, which powers the Phoenix CLI command for adding a note to a trace.
+
+To keep note behavior consistent across APIs, the reserved annotation name `note` is no longer accepted on the generic annotation endpoints. Use the dedicated note endpoints instead:
+
+- `POST /v1/trace_notes` for trace notes
+- `POST /v1/span_notes` for span notes

--- a/docs/phoenix/release-notes/2026.mdx
+++ b/docs/phoenix/release-notes/2026.mdx
@@ -4,6 +4,7 @@ sidebarTitle: "Overview"
 ---
 
 <CardGroup>
+    <Card href="/docs/phoenix/release-notes/04-2026/04-24-2026-trace-notes-api" arrow="true" title="04.24.2026" icon="calendar" description="Dedicated trace notes REST API; reserve the note annotation name for trace and span note endpoints"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-22-2026-secrets-ui-and-evaluator-trace-id" arrow="true" title="04.22.2026" icon="calendar" description="Secrets settings page in Phoenix UI; trace_id parameter in experiment evaluators"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-20-2026-span-attribute-filter-cli-notes-and-opus-4-7" arrow="true" title="04.20.2026" icon="calendar" description="Span attribute filtering (Python, TypeScript, REST, CLI); px span add-note; Claude Opus 4.7 in playground"/>
     <Card href="/docs/phoenix/release-notes/04-2026/04-16-2026-azure-managed-identity-postgres" arrow="true" title="04.16.2026" icon="calendar" description="Azure managed identity authentication for PostgreSQL; arize-phoenix[azure] extra"/>

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/span-annotations.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/span-annotations.mdx
@@ -226,7 +226,7 @@ do {
 
 ## Span Notes
 
-`addSpanNote` attaches a free-text comment to a span. Unlike structured annotations (which are keyed by `name` + `identifier`), notes are append-only — each call creates a new note with a unique timestamp-based identifier, so multiple notes naturally accumulate on the same span.
+`addSpanNote` attaches a free-text comment to a span. Unlike structured annotations (which are keyed by `name` + `identifier`), notes are append-only — each call creates a new note with a unique UUIDv7 identifier, so multiple notes naturally accumulate on the same span.
 
 This makes notes a good mechanism for **open coding**: reviewers can leave qualitative observations on spans during exploratory analysis without needing to define annotation names or scoring rubrics up front. The accumulated notes can later inform what structured annotations to create.
 

--- a/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/span-annotations.mdx
+++ b/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/span-annotations.mdx
@@ -226,7 +226,7 @@ do {
 
 ## Span Notes
 
-`addSpanNote` attaches a free-text comment to a span. Unlike structured annotations (which are keyed by `name` + `identifier`), notes are append-only — each call creates a new note with a unique UUIDv7 identifier, so multiple notes naturally accumulate on the same span.
+`addSpanNote` attaches a free-text comment to a span. Unlike structured annotations (which are keyed by `name` + `identifier`), notes are append-only — each call creates a new note with a unique UUIDv4 identifier, so multiple notes naturally accumulate on the same span.
 
 This makes notes a good mechanism for **open coding**: reviewers can leave qualitative observations on spans during exploratory analysis without needing to define annotation names or scoring rubrics up front. The accumulated notes can later inform what structured annotations to create.
 

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -458,6 +458,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/trace_notes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a trace note
+         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.
+         */
+        post: operations["createTraceNote"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/traces/{trace_identifier}": {
         parameters: {
             query?: never;
@@ -1290,6 +1310,14 @@ export interface components {
              * @description Number of spans successfully queued for insertion
              */
             total_queued: number;
+        };
+        /** CreateTraceNoteRequestBody */
+        CreateTraceNoteRequestBody: {
+            data: components["schemas"]["TraceNoteData"];
+        };
+        /** CreateTraceNoteResponseBody */
+        CreateTraceNoteResponseBody: {
+            data: components["schemas"]["InsertedTraceAnnotation"];
         };
         /** CreateUserRequestBody */
         CreateUserRequestBody: {
@@ -3382,6 +3410,19 @@ export interface components {
             /** Spans */
             spans?: components["schemas"]["TraceSpanData"][] | null;
         };
+        /** TraceNoteData */
+        TraceNoteData: {
+            /**
+             * Trace Id
+             * @description OpenTelemetry Trace ID (hex format w/o 0x prefix)
+             */
+            trace_id: string;
+            /**
+             * Note
+             * @description The note text to add to the trace
+             */
+            note: string;
+        };
         /** TraceSpanData */
         TraceSpanData: {
             /** Id */
@@ -5051,6 +5092,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnnotateTracesResponseBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Trace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    createTraceNote: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTraceNoteRequestBody"];
+            };
+        };
+        responses: {
+            /** @description Trace note created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateTraceNoteResponseBody"];
                 };
             };
             /** @description Forbidden */

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -469,7 +469,7 @@ export interface paths {
         put?: never;
         /**
          * Create a trace note
-         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.
+         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.
          */
         post: operations["createTraceNote"];
         delete?: never;
@@ -574,7 +574,7 @@ export interface paths {
         put?: never;
         /**
          * Create a span note
-         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.
+         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.
          */
         post: operations["createSpanNote"];
         delete?: never;

--- a/js/packages/phoenix-client/src/__generated__/api/v1.ts
+++ b/js/packages/phoenix-client/src/__generated__/api/v1.ts
@@ -469,7 +469,7 @@ export interface paths {
         put?: never;
         /**
          * Create a trace note
-         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.
+         * @description Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
          */
         post: operations["createTraceNote"];
         delete?: never;
@@ -574,7 +574,7 @@ export interface paths {
         put?: never;
         /**
          * Create a span note
-         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.
+         * @description Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.
          */
         post: operations["createSpanNote"];
         delete?: never;

--- a/js/packages/phoenix-client/src/spans/addSpanNote.ts
+++ b/js/packages/phoenix-client/src/spans/addSpanNote.ts
@@ -27,7 +27,7 @@ export interface AddSpanNoteParams extends ClientFn {
  *
  * Notes are a special type of annotation that allow multiple entries per span
  * (unlike regular annotations which are unique by name and identifier).
- * Each note gets a unique UUIDv7 identifier.
+ * Each note gets a unique UUIDv4 identifier.
  *
  * @param params - The parameters to add a span note
  * @returns The ID of the created note annotation

--- a/js/packages/phoenix-client/src/spans/addSpanNote.ts
+++ b/js/packages/phoenix-client/src/spans/addSpanNote.ts
@@ -27,7 +27,7 @@ export interface AddSpanNoteParams extends ClientFn {
  *
  * Notes are a special type of annotation that allow multiple entries per span
  * (unlike regular annotations which are unique by name and identifier).
- * Each note gets a unique timestamp-based identifier.
+ * Each note gets a unique UUIDv7 identifier.
  *
  * @param params - The parameters to add a span note
  * @returns The ID of the created note annotation

--- a/packages/phoenix-client/examples/annotations/add_span_note_example.py
+++ b/packages/phoenix-client/examples/annotations/add_span_note_example.py
@@ -11,7 +11,7 @@ result = client.spans.add_span_note(
 print(f"Note created with ID: {result['id']}")
 
 # Multiple notes can be added to the same span
-# Each note gets a unique UUIDv7 identifier automatically
+# Each note gets a unique UUIDv4 identifier automatically
 result2 = client.spans.add_span_note(
     span_id="72dda197b0e1b3ef",
     note="Follow-up: investigated and found the issue was related to timeout settings.",

--- a/packages/phoenix-client/examples/annotations/add_span_note_example.py
+++ b/packages/phoenix-client/examples/annotations/add_span_note_example.py
@@ -11,7 +11,7 @@ result = client.spans.add_span_note(
 print(f"Note created with ID: {result['id']}")
 
 # Multiple notes can be added to the same span
-# Each note gets a unique timestamp-based identifier automatically
+# Each note gets a unique UUIDv7 identifier automatically
 result2 = client.spans.add_span_note(
     span_id="72dda197b0e1b3ef",
     note="Follow-up: investigated and found the issue was related to timeout settings.",

--- a/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/__generated__/v1/__init__.py
@@ -603,6 +603,11 @@ class TraceAnnotationsResponseBody(TypedDict):
     next_cursor: Optional[str]
 
 
+class TraceNoteData(TypedDict):
+    trace_id: str
+    note: str
+
+
 class TraceSpanData(TypedDict):
     id: str
     span_id: str
@@ -754,6 +759,14 @@ class CreateSpanNoteRequestBody(TypedDict):
 
 class CreateSpanNoteResponseBody(TypedDict):
     data: InsertedSpanAnnotation
+
+
+class CreateTraceNoteRequestBody(TypedDict):
+    data: TraceNoteData
+
+
+class CreateTraceNoteResponseBody(TypedDict):
+    data: InsertedTraceAnnotation
 
 
 class CreateUserRequestBody(TypedDict):

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -831,7 +831,7 @@ class Spans:
 
         Notes are a special type of annotation that allow multiple entries per span
         (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique UUIDv7 identifier automatically.
+        gets a unique UUIDv4 identifier automatically.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.
@@ -2106,7 +2106,7 @@ class AsyncSpans:
 
         Notes are a special type of annotation that allow multiple entries per span
         (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique UUIDv7 identifier automatically.
+        gets a unique UUIDv4 identifier automatically.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.

--- a/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/spans/__init__.py
@@ -831,7 +831,7 @@ class Spans:
 
         Notes are a special type of annotation that allow multiple entries per span
         (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique timestamp-based identifier automatically.
+        gets a unique UUIDv7 identifier automatically.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.
@@ -2106,7 +2106,7 @@ class AsyncSpans:
 
         Notes are a special type of annotation that allow multiple entries per span
         (unlike regular annotations which are unique by name and identifier). Each note
-        gets a unique timestamp-based identifier automatically.
+        gets a unique UUIDv7 identifier automatically.
 
         Args:
             span_id (str): The OpenTelemetry span ID of the span to add the note to.

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -11222,6 +11222,7 @@
         "properties": {
           "trace_id": {
             "type": "string",
+            "minLength": 1,
             "title": "Trace Id",
             "description": "OpenTelemetry Trace ID (hex format w/o 0x prefix)"
           },

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2726,6 +2726,68 @@
         }
       }
     },
+    "/v1/trace_notes": {
+      "post": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Create a trace note",
+        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.",
+        "operationId": "createTraceNote",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTraceNoteRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Trace note created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTraceNoteResponseBody"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trace not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/traces/{trace_identifier}": {
       "delete": {
         "tags": [
@@ -6116,6 +6178,30 @@
           "total_queued"
         ],
         "title": "CreateSpansResponseBody"
+      },
+      "CreateTraceNoteRequestBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TraceNoteData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateTraceNoteRequestBody"
+      },
+      "CreateTraceNoteResponseBody": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InsertedTraceAnnotation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "CreateTraceNoteResponseBody"
       },
       "CreateUserRequestBody": {
         "properties": {
@@ -11131,6 +11217,27 @@
           "end_time"
         ],
         "title": "TraceData"
+      },
+      "TraceNoteData": {
+        "properties": {
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id",
+            "description": "OpenTelemetry Trace ID (hex format w/o 0x prefix)"
+          },
+          "note": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Note",
+            "description": "The note text to add to the trace"
+          }
+        },
+        "type": "object",
+        "required": [
+          "trace_id",
+          "note"
+        ],
+        "title": "TraceNoteData"
       },
       "TraceSpanData": {
         "properties": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2732,7 +2732,7 @@
           "traces"
         ],
         "summary": "Create a trace note",
-        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.",
+        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.",
         "operationId": "createTraceNote",
         "requestBody": {
           "content": {
@@ -3505,7 +3505,7 @@
           "spans"
         ],
         "summary": "Create a span note",
-        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique timestamp-based identifier.",
+        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.",
         "operationId": "createSpanNote",
         "requestBody": {
           "content": {

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -2732,7 +2732,7 @@
           "traces"
         ],
         "summary": "Create a trace note",
-        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.",
+        "description": "Add a note annotation to a trace. Notes are special annotations that allow multiple entries per trace (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
         "operationId": "createTraceNote",
         "requestBody": {
           "content": {
@@ -3505,7 +3505,7 @@
           "spans"
         ],
         "summary": "Create a span note",
-        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv7 identifier.",
+        "description": "Add a note annotation to a span. Notes are special annotations that allow multiple entries per span (unlike regular annotations which are unique by name and identifier). Each note gets a unique UUIDv4 identifier.",
         "operationId": "createSpanNote",
         "requestBody": {
           "content": {

--- a/src/phoenix/server/api/helpers/annotations.py
+++ b/src/phoenix/server/api/helpers/annotations.py
@@ -1,3 +1,7 @@
+from secrets import randbits
+from time import time_ns
+from uuid import UUID
+
 from strawberry.relay import GlobalID
 
 
@@ -7,3 +11,21 @@ def get_user_identifier(user_id: int) -> str:
     """
     user_gid = str(GlobalID(type_name="User", node_id=str(user_id)))
     return f"px-app:{user_gid}"
+
+
+def get_note_identifier(prefix: str) -> str:
+    """
+    Generates a time-ordered UUIDv7 note identifier with the given prefix.
+    """
+    return f"{prefix}:{_uuid7()}"
+
+
+def _uuid7() -> UUID:
+    """
+    Create an RFC 9562 UUIDv7 using the current Unix timestamp in milliseconds.
+    """
+    unix_ts_ms = time_ns() // 1_000_000
+    rand_a = randbits(12)
+    rand_b = randbits(62)
+    uuid_int = (unix_ts_ms << 80) | (0x7 << 76) | (rand_a << 64) | (0b10 << 62) | rand_b
+    return UUID(int=uuid_int)

--- a/src/phoenix/server/api/helpers/annotations.py
+++ b/src/phoenix/server/api/helpers/annotations.py
@@ -23,6 +23,9 @@ def get_note_identifier(prefix: str) -> str:
 def _uuid7() -> UUID:
     """
     Create an RFC 9562 UUIDv7 using the current Unix timestamp in milliseconds.
+
+    Phoenix still supports Python 3.10, so we cannot rely on the standard library's
+    uuid.uuid7() helper until the minimum supported Python version is 3.14+.
     """
     unix_ts_ms = time_ns() // 1_000_000
     rand_a = randbits(12)

--- a/src/phoenix/server/api/helpers/annotations.py
+++ b/src/phoenix/server/api/helpers/annotations.py
@@ -1,6 +1,4 @@
-from secrets import randbits
-from time import time_ns
-from uuid import UUID
+from uuid import uuid4
 
 from strawberry.relay import GlobalID
 
@@ -15,20 +13,6 @@ def get_user_identifier(user_id: int) -> str:
 
 def get_note_identifier(prefix: str) -> str:
     """
-    Generates a time-ordered UUIDv7 note identifier with the given prefix.
+    Generates a UUIDv4 note identifier with the given prefix.
     """
-    return f"{prefix}:{_uuid7()}"
-
-
-def _uuid7() -> UUID:
-    """
-    Create an RFC 9562 UUIDv7 using the current Unix timestamp in milliseconds.
-
-    Phoenix still supports Python 3.10, so we cannot rely on the standard library's
-    uuid.uuid7() helper until the minimum supported Python version is 3.14+.
-    """
-    unix_ts_ms = time_ns() // 1_000_000
-    rand_a = randbits(12)
-    rand_b = randbits(62)
-    uuid_int = (unix_ts_ms << 80) | (0x7 << 76) | (rand_a << 64) | (0b10 << 62) | rand_b
-    return UUID(int=uuid_int)
+    return f"{prefix}:{uuid4()}"

--- a/src/phoenix/server/api/mutations/annotation_config_mutations.py
+++ b/src/phoenix/server/api/mutations/annotation_config_mutations.py
@@ -174,7 +174,7 @@ class AnnotationConfigMutationMixin:
             raise BadRequest("No annotation config provided")
 
         if name == "note":
-            raise BadRequest("The name 'note' is reserved for span notes")
+            raise BadRequest("The name 'note' is reserved for trace and span notes")
 
         async with info.context.db() as session:
             annotation_config = models.AnnotationConfig(
@@ -221,7 +221,7 @@ class AnnotationConfigMutationMixin:
             raise BadRequest("No annotation config provided")
 
         if name == "note":
-            raise BadRequest("The name 'note' is reserved for span notes")
+            raise BadRequest("The name 'note' is reserved for trace and span notes")
 
         async with info.context.db() as session:
             annotation_config = await session.get(models.AnnotationConfig, config_id)

--- a/src/phoenix/server/api/mutations/annotation_config_mutations.py
+++ b/src/phoenix/server/api/mutations/annotation_config_mutations.py
@@ -174,7 +174,10 @@ class AnnotationConfigMutationMixin:
             raise BadRequest("No annotation config provided")
 
         if name == "note":
-            raise BadRequest("The name 'note' is reserved for trace and span notes")
+            raise BadRequest(
+                "The name 'note' is reserved for trace and span notes and cannot be used "
+                "for annotation configs."
+            )
 
         async with info.context.db() as session:
             annotation_config = models.AnnotationConfig(
@@ -221,7 +224,10 @@ class AnnotationConfigMutationMixin:
             raise BadRequest("No annotation config provided")
 
         if name == "note":
-            raise BadRequest("The name 'note' is reserved for trace and span notes")
+            raise BadRequest(
+                "The name 'note' is reserved for trace and span notes and cannot be used "
+                "for annotation configs."
+            )
 
         async with info.context.db() as session:
             annotation_config = await session.get(models.AnnotationConfig, config_id)

--- a/src/phoenix/server/api/mutations/span_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/span_annotations_mutations.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Optional, cast
 
 import strawberry
@@ -10,7 +9,7 @@ from phoenix.db import models
 from phoenix.server.api.auth import IsLocked, IsNotReadOnly, IsNotViewer
 from phoenix.server.api.context import Context
 from phoenix.server.api.exceptions import BadRequest, NotFound, Unauthorized
-from phoenix.server.api.helpers.annotations import get_user_identifier
+from phoenix.server.api.helpers.annotations import get_note_identifier, get_user_identifier
 from phoenix.server.api.input_types.CreateSpanAnnotationInput import (
     CreateSpanAnnotationInput,
     CreateSpanNoteInput,
@@ -42,7 +41,10 @@ class SpanAnnotationMutationMixin:
             raise BadRequest("No span annotations provided.")
 
         if any(d.name == "note" for d in input):
-            raise BadRequest("Span notes are not supported in this endpoint.")
+            raise BadRequest(
+                "The name 'note' is reserved for trace and span notes. "
+                "Use the createSpanNote mutation or POST /v1/span_notes instead."
+            )
 
         assert isinstance(request := info.context.request, Request)
         user_id: Optional[int] = None
@@ -163,8 +165,7 @@ class SpanAnnotationMutationMixin:
             raise BadRequest(f"Invalid span ID: {annotation_input.span_id}")
 
         async with info.context.db() as session:
-            timestamp = datetime.now().isoformat()
-            note_identifier = f"px-span-note:{timestamp}"
+            note_identifier = get_note_identifier("px-span-note")
             values = {
                 "span_rowid": span_rowid,
                 "name": "note",

--- a/src/phoenix/server/api/mutations/trace_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_annotations_mutations.py
@@ -36,7 +36,10 @@ class TraceAnnotationMutationMixin:
         if not input:
             raise BadRequest("No trace annotations provided.")
         if any(annotation_input.name == "note" for annotation_input in input):
-            raise BadRequest("The name 'note' is reserved for trace and span notes")
+            raise BadRequest(
+                "The name 'note' is reserved for trace and span notes. "
+                "Use POST /v1/trace_notes instead."
+            )
 
         assert isinstance(request := info.context.request, Request)
         user_id: Optional[int] = None

--- a/src/phoenix/server/api/mutations/trace_annotations_mutations.py
+++ b/src/phoenix/server/api/mutations/trace_annotations_mutations.py
@@ -35,6 +35,8 @@ class TraceAnnotationMutationMixin:
     ) -> TraceAnnotationMutationPayload:
         if not input:
             raise BadRequest("No trace annotations provided.")
+        if any(annotation_input.name == "note" for annotation_input in input):
+            raise BadRequest("The name 'note' is reserved for trace and span notes")
 
         assert isinstance(request := info.context.request, Request)
         user_id: Optional[int] = None

--- a/src/phoenix/server/api/routers/v1/__init__.py
+++ b/src/phoenix/server/api/routers/v1/__init__.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends
 from fastapi.security import APIKeyHeader
 
-from phoenix.server.bearer_auth import PhoenixUser, is_authenticated
+from phoenix.server.authorization import (
+    prevent_access_in_read_only_mode,
+    restrict_access_by_viewers,
+)
+from phoenix.server.bearer_auth import is_authenticated
 
 from .annotation_configs import router as annotation_configs_router
 from .annotations import router as annotations_router
@@ -20,31 +24,6 @@ from .users import router as users_router
 from .utils import add_errors_to_responses
 
 REST_API_VERSION = "1.0"
-
-
-async def prevent_access_in_read_only_mode(request: Request) -> None:
-    """
-    Prevents access to the REST API in read-only mode.
-    """
-    if request.app.state.read_only:
-        raise HTTPException(
-            detail="The Phoenix REST API is disabled in read-only mode.",
-            status_code=403,
-        )
-
-
-async def restrict_access_by_viewers(request: Request) -> None:
-    """
-    Prevents access to the REST API for viewers, except for GET requests
-    and specific allowed POST routes.
-    """
-    if request.method == "GET":
-        return
-    if isinstance(request.user, PhoenixUser) and request.user.is_viewer:
-        raise HTTPException(
-            status_code=403,
-            detail="Viewers cannot perform this action.",
-        )
 
 
 def create_v1_router(authentication_enabled: bool) -> APIRouter:

--- a/src/phoenix/server/api/routers/v1/annotation_configs.py
+++ b/src/phoenix/server/api/routers/v1/annotation_configs.py
@@ -391,7 +391,10 @@ def _get_annotation_config_db_id(config_gid: str) -> int:
 def _reserve_note_annotation_name(data: AnnotationConfigData) -> str:
     name = data.name
     if name == "note":
-        raise HTTPException(status_code=409, detail="The name 'note' is reserved for span notes")
+        raise HTTPException(
+            status_code=409,
+            detail="The name 'note' is reserved for trace and span notes",
+        )
     return name
 
 

--- a/src/phoenix/server/api/routers/v1/annotation_configs.py
+++ b/src/phoenix/server/api/routers/v1/annotation_configs.py
@@ -393,7 +393,10 @@ def _reserve_note_annotation_name(data: AnnotationConfigData) -> str:
     if name == "note":
         raise HTTPException(
             status_code=409,
-            detail="The name 'note' is reserved for trace and span notes",
+            detail=(
+                "The name 'note' is reserved for trace and span notes and cannot be used "
+                "for annotation configs."
+            ),
         )
     return name
 

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -26,7 +26,11 @@ from phoenix.server.api.routers.utils import df_to_bytes
 from phoenix.server.api.routers.v1.annotations import SpanAnnotationData
 from phoenix.server.api.routers.v1.validators import validate_enum_filter
 from phoenix.server.api.types.node import from_global_id_with_expected_type
-from phoenix.server.authorization import is_not_locked
+from phoenix.server.authorization import (
+    is_not_locked,
+    prevent_access_in_read_only_mode,
+    restrict_access_by_viewers,
+)
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import SpanAnnotationInsertEvent, SpanDeleteEvent
 from phoenix.trace.attributes import flatten, unflatten
@@ -1193,7 +1197,11 @@ class CreateSpanNoteResponseBody(ResponseBody[InsertedSpanAnnotation]):
 
 @router.post(
     "/span_notes",
-    dependencies=[Depends(is_not_locked)],
+    dependencies=[
+        Depends(prevent_access_in_read_only_mode),
+        Depends(restrict_access_by_viewers),
+        Depends(is_not_locked),
+    ],
     operation_id="createSpanNote",
     summary="Create a span note",
     description=(

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -1207,7 +1207,7 @@ class CreateSpanNoteResponseBody(ResponseBody[InsertedSpanAnnotation]):
     description=(
         "Add a note annotation to a span. Notes are special annotations that allow "
         "multiple entries per span (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique UUIDv7 identifier."
+        "and identifier). Each note gets a unique UUIDv4 identifier."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Span not found"}]),
     response_description="Span note created successfully",
@@ -1222,7 +1222,7 @@ async def create_span_note(
 
     Notes are a special type of annotation that:
     - Have the fixed name "note"
-    - Use a UUIDv7 identifier to allow multiple notes per span
+    - Use a UUIDv4 identifier to allow multiple notes per span
     - Are always created with annotator_kind="HUMAN" and source="API"
     - Store the note text in the explanation field
     """

--- a/src/phoenix/server/api/routers/v1/spans.py
+++ b/src/phoenix/server/api/routers/v1/spans.py
@@ -1,5 +1,4 @@
 import json
-import warnings
 from asyncio import get_running_loop
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
@@ -22,6 +21,7 @@ from phoenix.datetime_utils import is_timezone_aware, normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect, get_ancestor_span_rowids
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.utils import df_to_bytes
 from phoenix.server.api.routers.v1.annotations import SpanAnnotationData
 from phoenix.server.api.routers.v1.validators import validate_enum_filter
@@ -1117,22 +1117,20 @@ async def annotate_spans(
 ) -> AnnotateSpansResponseBody:
     if not request_body.data:
         return AnnotateSpansResponseBody(data=[])
+    if any(data.name == "note" for data in request_body.data):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "The name 'note' is reserved for trace and span notes. "
+                "Use POST /v1/span_notes instead."
+            ),
+        )
 
     user_id: Optional[int] = None
     if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
         user_id = int(request.user.identity)
 
-    span_annotations = request_body.data
-    filtered_span_annotations = list(filter(lambda d: d.name != "note", span_annotations))
-    if len(filtered_span_annotations) != len(span_annotations):
-        warnings.warn(
-            (
-                "Span annotations with the name 'note' are not supported in this endpoint. "
-                "They will be ignored."
-            ),
-            UserWarning,
-        )
-    precursors = [d.as_precursor(user_id=user_id) for d in filtered_span_annotations]
+    precursors = [d.as_precursor(user_id=user_id) for d in request_body.data]
     if not sync:
         await request.state.enqueue_annotations(*precursors)
         return AnnotateSpansResponseBody(data=[])
@@ -1201,7 +1199,7 @@ class CreateSpanNoteResponseBody(ResponseBody[InsertedSpanAnnotation]):
     description=(
         "Add a note annotation to a span. Notes are special annotations that allow "
         "multiple entries per span (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique timestamp-based identifier."
+        "and identifier). Each note gets a unique UUIDv7 identifier."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Span not found"}]),
     response_description="Span note created successfully",
@@ -1216,7 +1214,7 @@ async def create_span_note(
 
     Notes are a special type of annotation that:
     - Have the fixed name "note"
-    - Use a timestamp-based identifier to allow multiple notes per span
+    - Use a UUIDv7 identifier to allow multiple notes per span
     - Are always created with annotator_kind="HUMAN" and source="API"
     - Store the note text in the explanation field
     """
@@ -1238,9 +1236,7 @@ async def create_span_note(
                 detail=f"Span with ID {note_data.span_id} not found",
             )
 
-        # Generate a unique identifier for the note using timestamp
-        timestamp = datetime.now(timezone.utc).isoformat()
-        note_identifier = f"px-span-note:{timestamp}"
+        note_identifier = get_note_identifier("px-span-note")
 
         # Create the annotation values
         values = {

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -22,6 +22,7 @@ from phoenix.datetime_utils import normalize_datetime
 from phoenix.db import models
 from phoenix.db.helpers import SupportedSQLDialect
 from phoenix.db.insertion.helpers import as_kv, insert_on_conflict
+from phoenix.server.api.helpers.annotations import get_note_identifier
 from phoenix.server.api.routers.v1.annotations import TraceAnnotationData
 from phoenix.server.api.types.node import from_global_id_with_expected_type
 from phoenix.server.api.types.Project import Project as ProjectNodeType
@@ -358,7 +359,10 @@ async def annotate_traces(
     if any(data.name == "note" for data in request_body.data):
         raise HTTPException(
             status_code=400,
-            detail="The name 'note' is reserved for trace and span notes",
+            detail=(
+                "The name 'note' is reserved for trace and span notes. "
+                "Use POST /v1/trace_notes instead."
+            ),
         )
 
     user_id: Optional[int] = None
@@ -440,7 +444,7 @@ class CreateTraceNoteResponseBody(ResponseBody[InsertedTraceAnnotation]):
     description=(
         "Add a note annotation to a trace. Notes are special annotations that allow "
         "multiple entries per trace (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique timestamp-based identifier."
+        "and identifier). Each note gets a unique UUIDv7 identifier."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Trace not found"}]),
     response_description="Trace note created successfully",
@@ -467,8 +471,7 @@ async def create_trace_note(
                 detail=f"Trace with ID {note_data.trace_id} not found",
             )
 
-        timestamp = datetime.now(timezone.utc).isoformat()
-        note_identifier = f"px-trace-note:{timestamp}"
+        note_identifier = get_note_identifier("px-trace-note")
 
         result = await session.execute(
             insert(models.TraceAnnotation)

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -29,7 +29,11 @@ from phoenix.server.api.types.Project import Project as ProjectNodeType
 from phoenix.server.api.types.ProjectSession import ProjectSession as ProjectSessionNodeType
 from phoenix.server.api.types.Span import Span as SpanNodeType
 from phoenix.server.api.types.Trace import Trace as TraceNodeType
-from phoenix.server.authorization import is_not_locked
+from phoenix.server.authorization import (
+    is_not_locked,
+    prevent_access_in_read_only_mode,
+    restrict_access_by_viewers,
+)
 from phoenix.server.bearer_auth import PhoenixUser
 from phoenix.server.dml_event import SpanDeleteEvent, TraceAnnotationInsertEvent
 from phoenix.server.prometheus import SPAN_QUEUE_REJECTIONS
@@ -438,7 +442,11 @@ class CreateTraceNoteResponseBody(ResponseBody[InsertedTraceAnnotation]):
 
 @router.post(
     "/trace_notes",
-    dependencies=[Depends(is_not_locked)],
+    dependencies=[
+        Depends(prevent_access_in_read_only_mode),
+        Depends(restrict_access_by_viewers),
+        Depends(is_not_locked),
+    ],
     operation_id="createTraceNote",
     summary="Create a trace note",
     description=(

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -2,7 +2,7 @@ import gzip
 import zlib
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Path, Query
 from google.protobuf.message import DecodeError
@@ -10,8 +10,8 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
     ExportTraceServiceResponse,
 )
-from pydantic import Field
-from sqlalchemy import delete, or_, select
+from pydantic import BeforeValidator, Field
+from sqlalchemy import delete, insert, or_, select
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import State
 from starlette.requests import Request
@@ -355,6 +355,11 @@ async def annotate_traces(
 ) -> AnnotateTracesResponseBody:
     if not request_body.data:
         return AnnotateTracesResponseBody(data=[])
+    if any(data.name == "note" for data in request_body.data):
+        raise HTTPException(
+            status_code=400,
+            detail="The name 'note' is reserved for trace and span notes",
+        )
 
     user_id: Optional[int] = None
     if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
@@ -401,6 +406,91 @@ async def annotate_traces(
             InsertedTraceAnnotation(id=str(GlobalID("TraceAnnotation", str(id_))))
             for id_ in inserted_ids
         ]
+    )
+
+
+class TraceNoteData(V1RoutesBaseModel):
+    trace_id: Annotated[
+        str, BeforeValidator(lambda value: value.strip() if isinstance(value, str) else value)
+    ] = Field(
+        min_length=1,
+        description="OpenTelemetry Trace ID (hex format w/o 0x prefix)",
+    )
+    note: Annotated[
+        str, BeforeValidator(lambda value: value.strip() if isinstance(value, str) else value)
+    ] = Field(
+        min_length=1,
+        description="The note text to add to the trace",
+    )
+
+
+class CreateTraceNoteRequestBody(RequestBody[TraceNoteData]):
+    data: TraceNoteData
+
+
+class CreateTraceNoteResponseBody(ResponseBody[InsertedTraceAnnotation]):
+    pass
+
+
+@router.post(
+    "/trace_notes",
+    dependencies=[Depends(is_not_locked)],
+    operation_id="createTraceNote",
+    summary="Create a trace note",
+    description=(
+        "Add a note annotation to a trace. Notes are special annotations that allow "
+        "multiple entries per trace (unlike regular annotations which are unique by name "
+        "and identifier). Each note gets a unique timestamp-based identifier."
+    ),
+    responses=add_errors_to_responses([{"status_code": 404, "description": "Trace not found"}]),
+    response_description="Trace note created successfully",
+    status_code=200,
+)
+async def create_trace_note(
+    request: Request,
+    request_body: CreateTraceNoteRequestBody,
+) -> CreateTraceNoteResponseBody:
+    note_data = request_body.data
+
+    user_id: Optional[int] = None
+    if request.app.state.authentication_enabled and isinstance(request.user, PhoenixUser):
+        user_id = int(request.user.identity)
+
+    async with request.app.state.db() as session:
+        trace_rowid = await session.scalar(
+            select(models.Trace.id).where(models.Trace.trace_id == note_data.trace_id)
+        )
+
+        if trace_rowid is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Trace with ID {note_data.trace_id} not found",
+            )
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        note_identifier = f"px-trace-note:{timestamp}"
+
+        result = await session.execute(
+            insert(models.TraceAnnotation)
+            .values(
+                trace_rowid=trace_rowid,
+                name="note",
+                label=None,
+                score=None,
+                explanation=note_data.note,
+                annotator_kind="HUMAN",
+                metadata_=dict(),
+                identifier=note_identifier,
+                source="API",
+                user_id=user_id,
+            )
+            .returning(models.TraceAnnotation.id)
+        )
+        annotation_id = result.scalar_one()
+
+    request.state.event_queue.put(TraceAnnotationInsertEvent((annotation_id,)))
+    return CreateTraceNoteResponseBody(
+        data=InsertedTraceAnnotation(id=str(GlobalID("TraceAnnotation", str(annotation_id))))
     )
 
 

--- a/src/phoenix/server/api/routers/v1/traces.py
+++ b/src/phoenix/server/api/routers/v1/traces.py
@@ -452,7 +452,7 @@ class CreateTraceNoteResponseBody(ResponseBody[InsertedTraceAnnotation]):
     description=(
         "Add a note annotation to a trace. Notes are special annotations that allow "
         "multiple entries per trace (unlike regular annotations which are unique by name "
-        "and identifier). Each note gets a unique UUIDv7 identifier."
+        "and identifier). Each note gets a unique UUIDv4 identifier."
     ),
     responses=add_errors_to_responses([{"status_code": 404, "description": "Trace not found"}]),
     response_description="Trace note created successfully",

--- a/src/phoenix/server/authorization.py
+++ b/src/phoenix/server/authorization.py
@@ -28,6 +28,31 @@ from phoenix.config import get_env_support_email
 from phoenix.server.bearer_auth import PhoenixUser
 
 
+def prevent_access_in_read_only_mode(request: Request) -> None:
+    """
+    Prevent access to mutating REST routes when the app is running in read-only mode.
+    """
+    if request.app.state.read_only:
+        raise HTTPException(
+            detail="The Phoenix REST API is disabled in read-only mode.",
+            status_code=403,
+        )
+
+
+def restrict_access_by_viewers(request: Request) -> None:
+    """
+    Prevent viewer users from accessing mutating REST routes when auth is enabled.
+    """
+    if not request.app.state.authentication_enabled or request.method == "GET":
+        return
+    user = getattr(request, "user", None)
+    if isinstance(user, PhoenixUser) and user.is_viewer:
+        raise HTTPException(
+            status_code=403,
+            detail="Viewers cannot perform this action.",
+        )
+
+
 def require_admin(request: Request) -> None:
     """
     FastAPI dependency to restrict access to admin or system users only.

--- a/tests/integration/_helpers.py
+++ b/tests/integration/_helpers.py
@@ -2245,6 +2245,7 @@ _VIEWER_BLOCKED_WRITE_OPERATIONS = (
     (422, "POST", "v1/span_notes"),
     (422, "POST", "v1/spans"),
     (422, "POST", "v1/trace_annotations"),
+    (422, "POST", "v1/trace_notes"),
     (415, "POST", "v1/traces"),
     # PUT routes
     (422, "PUT", "v1/annotation_configs/fake-id-{}"),

--- a/tests/unit/server/api/helpers/test_annotations.py
+++ b/tests/unit/server/api/helpers/test_annotations.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+
+from phoenix.server.api.helpers.annotations import get_note_identifier
+
+
+def test_get_note_identifier_uses_prefix_and_uuidv7() -> None:
+    identifier = get_note_identifier("px-trace-note")
+
+    prefix, uuid_value = identifier.split(":", maxsplit=1)
+
+    assert prefix == "px-trace-note"
+    assert UUID(uuid_value).version == 7
+
+
+def test_get_note_identifier_is_unique() -> None:
+    identifiers = {get_note_identifier("px-span-note") for _ in range(32)}
+
+    assert len(identifiers) == 32

--- a/tests/unit/server/api/helpers/test_annotations.py
+++ b/tests/unit/server/api/helpers/test_annotations.py
@@ -3,13 +3,13 @@ from uuid import UUID
 from phoenix.server.api.helpers.annotations import get_note_identifier
 
 
-def test_get_note_identifier_uses_prefix_and_uuidv7() -> None:
+def test_get_note_identifier_uses_prefix_and_uuidv4() -> None:
     identifier = get_note_identifier("px-trace-note")
 
     prefix, uuid_value = identifier.split(":", maxsplit=1)
 
     assert prefix == "px-trace-note"
-    assert UUID(uuid_value).version == 7
+    assert UUID(uuid_value).version == 4
 
 
 def test_get_note_identifier_is_unique() -> None:

--- a/tests/unit/server/api/mutations/test_annotation_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_annotation_config_mutations.py
@@ -435,7 +435,7 @@ class TestAnnotationConfigMutations:
         assert response.errors
         assert len(response.errors) == 1
         error = response.errors[0]
-        assert "The name 'note' is reserved for span notes" in error.message
+        assert "The name 'note' is reserved for trace and span notes" in error.message
 
     @pytest.mark.parametrize(
         ("update_config", "annotation_type"),
@@ -517,7 +517,7 @@ class TestAnnotationConfigMutations:
         assert update_response.errors
         assert len(update_response.errors) == 1
         error = update_response.errors[0]
-        assert "The name 'note' is reserved for span notes" in error.message
+        assert "The name 'note' is reserved for trace and span notes" in error.message
 
     @pytest.mark.parametrize(
         ("annotation_type", "config"),

--- a/tests/unit/server/api/mutations/test_annotation_config_mutations.py
+++ b/tests/unit/server/api/mutations/test_annotation_config_mutations.py
@@ -435,7 +435,10 @@ class TestAnnotationConfigMutations:
         assert response.errors
         assert len(response.errors) == 1
         error = response.errors[0]
-        assert "The name 'note' is reserved for trace and span notes" in error.message
+        assert (
+            "The name 'note' is reserved for trace and span notes and cannot be used "
+            "for annotation configs."
+        ) in error.message
 
     @pytest.mark.parametrize(
         ("update_config", "annotation_type"),
@@ -517,7 +520,10 @@ class TestAnnotationConfigMutations:
         assert update_response.errors
         assert len(update_response.errors) == 1
         error = update_response.errors[0]
-        assert "The name 'note' is reserved for trace and span notes" in error.message
+        assert (
+            "The name 'note' is reserved for trace and span notes and cannot be used "
+            "for annotation configs."
+        ) in error.message
 
     @pytest.mark.parametrize(
         ("annotation_type", "config"),

--- a/tests/unit/server/api/mutations/test_span_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_span_annotation_mutations.py
@@ -242,7 +242,7 @@ class TestSpanAnnotationMutations:
             "Use the createSpanNote mutation or POST /v1/span_notes instead."
         ) in response.errors[0].message
 
-    async def test_create_span_note_uses_uuidv7_identifier(
+    async def test_create_span_note_uses_uuidv4_identifier(
         self,
         gql_client: AsyncGraphQLClient,
         db: DbSessionFactory,
@@ -276,4 +276,4 @@ class TestSpanAnnotationMutations:
 
         assert annotation is not None
         assert annotation.identifier.startswith("px-span-note:")
-        assert UUID(annotation.identifier.removeprefix("px-span-note:")).version == 7
+        assert UUID(annotation.identifier.removeprefix("px-span-note:")).version == 4

--- a/tests/unit/server/api/mutations/test_span_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_span_annotation_mutations.py
@@ -1,7 +1,9 @@
 import datetime
 from typing import Any
+from uuid import UUID
 
 import pytest
+from sqlalchemy import select
 from strawberry.relay.types import GlobalID
 
 from phoenix.db import models
@@ -211,3 +213,67 @@ class TestSpanAnnotationMutations:
         assert ann2["label"] == "UPDATED_LABEL"
         assert ann2["score"] == 2.0
         assert ann2["explanation"] == "Updated explanation"
+
+    async def test_create_span_annotations_rejects_reserved_note_name(
+        self,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        response = await gql_client.execute(
+            self.CREATE_SPAN_ANNOTATIONS_MUTATION,
+            {
+                "input": [
+                    {
+                        "spanId": str(GlobalID("Span", "1")),
+                        "name": "note",
+                        "explanation": "This should fail",
+                        "annotatorKind": AnnotatorKind.HUMAN.name,
+                        "metadata": {},
+                        "identifier": "",
+                        "source": AnnotationSource.API.name,
+                    }
+                ]
+            },
+        )
+
+        assert response.data is None
+        assert response.errors
+        assert (
+            "The name 'note' is reserved for trace and span notes. "
+            "Use the createSpanNote mutation or POST /v1/span_notes instead."
+        ) in response.errors[0].message
+
+    async def test_create_span_note_uses_uuidv7_identifier(
+        self,
+        gql_client: AsyncGraphQLClient,
+        db: DbSessionFactory,
+    ) -> None:
+        mutation = """
+        mutation CreateSpanNote($annotationInput: CreateSpanNoteInput!) {
+          createSpanNote(annotationInput: $annotationInput) {
+            spanAnnotations {
+              id
+            }
+          }
+        }
+        """
+        response = await gql_client.execute(
+            mutation,
+            {
+                "annotationInput": {
+                    "spanId": str(GlobalID("Span", "1")),
+                    "note": "Needs review",
+                }
+            },
+        )
+
+        assert response.data is not None
+        assert not response.errors
+
+        async with db() as session:
+            annotation = await session.scalar(
+                select(models.SpanAnnotation).where(models.SpanAnnotation.name == "note")
+            )
+
+        assert annotation is not None
+        assert annotation.identifier.startswith("px-span-note:")
+        assert UUID(annotation.identifier.removeprefix("px-span-note:")).version == 7

--- a/tests/unit/server/api/mutations/test_trace_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_trace_annotation_mutations.py
@@ -225,3 +225,31 @@ class TestTraceAnnotationMutations:
         assert (data_delete := res_delete.data)
         deleted = data_delete["deleteTraceAnnotations"]["traceAnnotations"][0]
         assert deleted["id"] == ann4["id"]
+
+    async def test_trace_annotations_reject_reserved_note_name(
+        self,
+        _trace_data: models.Trace,
+        gql_client: AsyncGraphQLClient,
+    ) -> None:
+        trace_gid = str(GlobalID("Trace", str(_trace_data.id)))
+        response = await gql_client.execute(
+            self.QUERY,
+            {
+                "input": [
+                    {
+                        "traceId": trace_gid,
+                        "name": "note",
+                        "explanation": "This should fail",
+                        "annotatorKind": "HUMAN",
+                        "metadata": {},
+                        "identifier": "",
+                        "source": AnnotationSource.API.name,
+                    }
+                ]
+            },
+            operation_name="CreateTraceAnnotations",
+        )
+
+        assert response.data is None
+        assert response.errors
+        assert "The name 'note' is reserved for trace and span notes" in response.errors[0].message

--- a/tests/unit/server/api/mutations/test_trace_annotation_mutations.py
+++ b/tests/unit/server/api/mutations/test_trace_annotation_mutations.py
@@ -252,4 +252,7 @@ class TestTraceAnnotationMutations:
 
         assert response.data is None
         assert response.errors
-        assert "The name 'note' is reserved for trace and span notes" in response.errors[0].message
+        assert (
+            "The name 'note' is reserved for trace and span notes. "
+            "Use POST /v1/trace_notes instead."
+        ) in response.errors[0].message

--- a/tests/unit/server/api/routers/v1/test_annotation_configs.py
+++ b/tests/unit/server/api/routers/v1/test_annotation_configs.py
@@ -180,7 +180,10 @@ async def test_cannot_create_annotation_config_with_reserved_name_for_notes(
 ) -> None:
     response = await httpx_client.post("/v1/annotation_configs", json=annotation_config)
     assert response.status_code == 409
-    assert "The name 'note' is reserved" in response.text
+    assert (
+        "The name 'note' is reserved for trace and span notes and cannot be used "
+        "for annotation configs."
+    ) in response.text
 
 
 @pytest.mark.parametrize(
@@ -234,7 +237,10 @@ async def test_cannot_update_annotation_config_name_to_reserved_name_for_notes(
     update_config["name"] = "note"
     response = await httpx_client.put(f"/v1/annotation_configs/{config_id}", json=update_config)
     assert response.status_code == 409
-    assert "The name 'note' is reserved" in response.text
+    assert (
+        "The name 'note' is reserved for trace and span notes and cannot be used "
+        "for annotation configs."
+    ) in response.text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -1,6 +1,7 @@
 from asyncio import sleep
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional
+from uuid import UUID
 
 import httpx
 import pytest
@@ -61,6 +62,31 @@ async def test_rest_span_annotation(
     assert orm_annotation.metadata_ == dict()
 
 
+async def test_rest_span_annotation_rejects_note_name(
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+) -> None:
+    request_body = {
+        "data": [
+            {
+                "span_id": "7e2f08cb43bbf521",
+                "name": "note",
+                "annotator_kind": "HUMAN",
+                "result": {
+                    "explanation": "This should fail",
+                },
+                "metadata": {},
+            }
+        ]
+    }
+
+    response = await httpx_client.post("v1/span_annotations?sync=true", json=request_body)
+    assert response.status_code == 400
+    assert (
+        "The name 'note' is reserved for trace and span notes. Use POST /v1/span_notes instead."
+    ) in response.text
+
+
 async def test_rest_create_span_note(
     db: DbSessionFactory,
     httpx_client: httpx.AsyncClient,
@@ -99,6 +125,7 @@ async def test_rest_create_span_note(
     assert orm_annotation.explanation == note_text
     assert orm_annotation.source == "API"
     assert orm_annotation.identifier.startswith("px-span-note:")
+    assert UUID(orm_annotation.identifier.removeprefix("px-span-note:")).version == 7
     assert orm_annotation.label is None
     assert orm_annotation.score is None
     assert orm_annotation.metadata_ == dict()
@@ -156,6 +183,9 @@ async def test_rest_create_multiple_span_notes(
     # Verify each annotation has a unique identifier
     identifiers = [a.identifier for a in annotations]
     assert len(identifiers) == len(set(identifiers))  # All unique
+    assert all(
+        UUID(identifier.removeprefix("px-span-note:")).version == 7 for identifier in identifiers
+    )
 
 
 @pytest.fixture

--- a/tests/unit/server/api/routers/v1/test_spans.py
+++ b/tests/unit/server/api/routers/v1/test_spans.py
@@ -125,7 +125,7 @@ async def test_rest_create_span_note(
     assert orm_annotation.explanation == note_text
     assert orm_annotation.source == "API"
     assert orm_annotation.identifier.startswith("px-span-note:")
-    assert UUID(orm_annotation.identifier.removeprefix("px-span-note:")).version == 7
+    assert UUID(orm_annotation.identifier.removeprefix("px-span-note:")).version == 4
     assert orm_annotation.label is None
     assert orm_annotation.score is None
     assert orm_annotation.metadata_ == dict()
@@ -184,7 +184,7 @@ async def test_rest_create_multiple_span_notes(
     identifiers = [a.identifier for a in annotations]
     assert len(identifiers) == len(set(identifiers))  # All unique
     assert all(
-        UUID(identifier.removeprefix("px-span-note:")).version == 7 for identifier in identifiers
+        UUID(identifier.removeprefix("px-span-note:")).version == 4 for identifier in identifiers
     )
 
 

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -1,6 +1,7 @@
 from asyncio import sleep
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 import httpx
 import pytest
@@ -129,7 +130,9 @@ async def test_rest_trace_annotation_rejects_note_name(
 
     response = await httpx_client.post("v1/trace_annotations?sync=true", json=request_body)
     assert response.status_code == 400
-    assert "The name 'note' is reserved for trace and span notes" in response.text
+    assert (
+        "The name 'note' is reserved for trace and span notes. Use POST /v1/trace_notes instead."
+    ) in response.text
 
 
 async def test_rest_create_trace_note(
@@ -167,6 +170,7 @@ async def test_rest_create_trace_note(
     assert orm_annotation.explanation == note_text
     assert orm_annotation.source == "API"
     assert orm_annotation.identifier.startswith("px-trace-note:")
+    assert UUID(orm_annotation.identifier.removeprefix("px-trace-note:")).version == 7
     assert orm_annotation.label is None
     assert orm_annotation.score is None
     assert orm_annotation.metadata_ == dict()
@@ -218,6 +222,9 @@ async def test_rest_create_multiple_trace_notes(
 
     identifiers = [annotation.identifier for annotation in annotations]
     assert len(identifiers) == len(set(identifiers))
+    assert all(
+        UUID(identifier.removeprefix("px-trace-note:")).version == 7 for identifier in identifiers
+    )
 
 
 async def test_rest_create_trace_note_blank_text_rejected(

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -170,7 +170,7 @@ async def test_rest_create_trace_note(
     assert orm_annotation.explanation == note_text
     assert orm_annotation.source == "API"
     assert orm_annotation.identifier.startswith("px-trace-note:")
-    assert UUID(orm_annotation.identifier.removeprefix("px-trace-note:")).version == 7
+    assert UUID(orm_annotation.identifier.removeprefix("px-trace-note:")).version == 4
     assert orm_annotation.label is None
     assert orm_annotation.score is None
     assert orm_annotation.metadata_ == dict()
@@ -223,7 +223,7 @@ async def test_rest_create_multiple_trace_notes(
     identifiers = [annotation.identifier for annotation in annotations]
     assert len(identifiers) == len(set(identifiers))
     assert all(
-        UUID(identifier.removeprefix("px-trace-note:")).version == 7 for identifier in identifiers
+        UUID(identifier.removeprefix("px-trace-note:")).version == 4 for identifier in identifiers
     )
 
 

--- a/tests/unit/server/api/routers/v1/test_traces.py
+++ b/tests/unit/server/api/routers/v1/test_traces.py
@@ -109,6 +109,132 @@ async def test_rest_trace_annotation(
     assert orm_annotation.user_id is None
 
 
+async def test_rest_trace_annotation_rejects_note_name(
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+) -> None:
+    request_body = {
+        "data": [
+            {
+                "trace_id": "82c6c9c33ccc586e0d3bdf46b20db309",
+                "name": "note",
+                "annotator_kind": "HUMAN",
+                "result": {
+                    "explanation": "This should fail",
+                },
+                "metadata": {},
+            }
+        ]
+    }
+
+    response = await httpx_client.post("v1/trace_annotations?sync=true", json=request_body)
+    assert response.status_code == 400
+    assert "The name 'note' is reserved for trace and span notes" in response.text
+
+
+async def test_rest_create_trace_note(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+    fake: Faker,
+) -> None:
+    note_text = fake.pystr()
+    request_body = {
+        "data": {
+            "trace_id": "82c6c9c33ccc586e0d3bdf46b20db309",
+            "note": note_text,
+        }
+    }
+
+    response = await httpx_client.post("v1/trace_notes", json=request_body)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert "data" in response_data
+    assert "id" in response_data["data"]
+
+    async with db() as session:
+        orm_annotation = await session.scalar(
+            select(models.TraceAnnotation).where(
+                models.TraceAnnotation.name == "note",
+                models.TraceAnnotation.explanation == note_text,
+            )
+        )
+
+    assert orm_annotation is not None
+    assert orm_annotation.name == "note"
+    assert orm_annotation.annotator_kind == "HUMAN"
+    assert orm_annotation.explanation == note_text
+    assert orm_annotation.source == "API"
+    assert orm_annotation.identifier.startswith("px-trace-note:")
+    assert orm_annotation.label is None
+    assert orm_annotation.score is None
+    assert orm_annotation.metadata_ == dict()
+
+
+async def test_rest_create_trace_note_not_found(
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+) -> None:
+    request_body = {
+        "data": {
+            "trace_id": "nonexistent-trace-id",
+            "note": "This should fail",
+        }
+    }
+
+    response = await httpx_client.post("v1/trace_notes", json=request_body)
+    assert response.status_code == 404
+    assert "not found" in response.text.lower()
+
+
+async def test_rest_create_multiple_trace_notes(
+    db: DbSessionFactory,
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+    fake: Faker,
+) -> None:
+    note_texts = [fake.pystr() for _ in range(3)]
+
+    for note_text in note_texts:
+        request_body = {
+            "data": {
+                "trace_id": "82c6c9c33ccc586e0d3bdf46b20db309",
+                "note": note_text,
+            }
+        }
+        response = await httpx_client.post("v1/trace_notes", json=request_body)
+        assert response.status_code == 200
+
+    async with db() as session:
+        result = await session.execute(
+            select(models.TraceAnnotation).where(models.TraceAnnotation.name == "note")
+        )
+        annotations = list(result.scalars().all())
+
+    assert len(annotations) == 3
+    explanations = {annotation.explanation for annotation in annotations}
+    assert explanations == set(note_texts)
+
+    identifiers = [annotation.identifier for annotation in annotations]
+    assert len(identifiers) == len(set(identifiers))
+
+
+async def test_rest_create_trace_note_blank_text_rejected(
+    httpx_client: httpx.AsyncClient,
+    project_with_a_single_trace_and_span: Any,
+) -> None:
+    request_body = {
+        "data": {
+            "trace_id": "82c6c9c33ccc586e0d3bdf46b20db309",
+            "note": "   ",
+        }
+    }
+
+    response = await httpx_client.post("v1/trace_notes", json=request_body)
+    assert response.status_code == 422
+
+
 async def test_traces_endpoint_otlp_compliance(
     httpx_client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Summary

This PR adds a dedicated `POST /v1/trace_notes` endpoint for creating trace notes. The main motivation is to power a Phoenix CLI command that will add a note to a trace.

## What changed

- add `POST /v1/trace_notes` in the v1 traces router
- reserve the annotation name `note` in trace annotations and annotation config creation/update paths so notes flow through the dedicated endpoint
- generate a timestamp-based identifier for each note so multiple notes can be created on the same trace
- regenerate the OpenAPI schema plus Python and TypeScript generated clients
- add unit coverage for trace note creation, not found behavior, repeated note creation, blank note rejection, and reserved-name rejection
- add the new route to the integration endpoint coverage/auth matrix

## Testing

- `uv run pytest tests/unit/server/api/routers/v1/test_traces.py tests/unit/server/api/mutations/test_trace_annotation_mutations.py tests/unit/server/api/mutations/test_annotation_config_mutations.py -q`
- `uv run pytest tests/integration/server/test_launch_app.py::TestLaunchApp::test_api_access -q`
- `uv run pytest 'tests/integration/auth/test_auth.py::TestApiAccessViaCookiesOrApiKeys::test_role_based_access_control[UserRoleInput.VIEWER]' -q`\n- `pnpm run --silent typecheck` in `js/packages/phoenix-client`\n- manual `curl` verification of `POST /v1/trace_notes` for success, missing-trace `404`, blank-note `422`, and `POST /v1/trace_annotations?sync=true` rejecting `name=note` with `400`