### PR TITLE
feat(cli): add trace note support to px

### DIFF
--- a/.agents/skills/phoenix-cli/SKILL.md
+++ b/.agents/skills/phoenix-cli/SKILL.md
@@ -23,6 +23,7 @@ The CLI uses singular resource commands with subcommands like `list` and `get`:
 px trace list
 px trace get <trace-id>
 px trace annotate <trace-id>
+px trace add-note <trace-id>
 px span list
 px span annotate <span-id>
 px span add-note <span-id>
@@ -64,12 +65,13 @@ px trace list --limit 20 --format raw --no-progress | jq .
 px trace list --last-n-minutes 60 --limit 20 --format raw --no-progress | jq '.[] | select(.status == "ERROR")'
 px trace list --since 2025-01-15T00:00:00Z --limit 50 --format raw --no-progress | jq .
 px trace list --format raw --no-progress | jq 'sort_by(-.duration) | .[0:5]'
-px trace list --include-notes --format raw --no-progress | jq '.[].spans[].notes'
+px trace list --include-notes --format raw --no-progress | jq '.[].notes'
 px trace get <trace-id> --format raw | jq .
 px trace get <trace-id> --format raw | jq '.spans[] | select(.status_code != "OK")'
-px trace get <trace-id> --include-notes --format raw | jq '.spans[].notes'
+px trace get <trace-id> --include-notes --format raw | jq '.notes'
 px trace annotate <trace-id> --name reviewer --label pass
 px trace annotate <trace-id> --name reviewer --score 0.9 --format raw --no-progress
+px trace add-note <trace-id> --text "needs follow-up"
 ```
 
 ### Trace JSON shape
@@ -79,6 +81,8 @@ Trace
   traceId, status ("OK"|"ERROR"), duration (ms), startTime, endTime
   annotations[] (with --include-annotations, excludes note)
     name, result { score, label, explanation }
+  notes[] (with --include-notes)
+    name="note", result { explanation }
   rootSpan  — top-level span (parent_id: null)
   spans[]
     name, span_kind ("LLM"|"CHAIN"|"TOOL"|"RETRIEVER"|"EMBEDDING"|"AGENT"|"RERANKER"|"GUARDRAIL"|"EVALUATOR"|"UNKNOWN")

--- a/js/.changeset/phoenix-cli-trace-notes.md
+++ b/js/.changeset/phoenix-cli-trace-notes.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-cli": minor
+---
+
+Add trace note support to `px`. New `px trace add-note <trace-id> --text <text>` command creates a trace note, and `--include-notes` is now supported on `px trace get` and `px trace list` to fetch and render trace notes and span notes separately from annotations. Requires Phoenix server >= 14.13.0.

--- a/js/.changeset/phoenix-client-add-trace-note.md
+++ b/js/.changeset/phoenix-client-add-trace-note.md
@@ -1,0 +1,5 @@
+---
+"@arizeai/phoenix-client": minor
+---
+
+Add `addTraceNote()` helper for creating trace notes via `POST /v1/trace_notes`. The call performs a preflight server-version check and throws a descriptive error when the connected Phoenix server is too old. Requires Phoenix server >= 14.13.0.

--- a/js/packages/phoenix-cli/README.md
+++ b/js/packages/phoenix-cli/README.md
@@ -90,8 +90,8 @@ px trace list --since 2026-01-13T10:00:00Z       # since ISO timestamp
 | `--since <timestamp>`       | Traces since ISO timestamp             | —        |
 | `--format <format>`         | `pretty`, `json`, or `raw`             | `pretty` |
 | `--no-progress`             | Suppress progress output               | —        |
-| `--include-annotations`     | Include span annotations               | —        |
-| `--include-notes`           | Include span notes                     | —        |
+| `--include-annotations`     | Include trace and span annotations     | —        |
+| `--include-notes`           | Include trace and span notes           | —        |
 
 ```bash
 # Find ERROR traces
@@ -115,7 +115,7 @@ Fetch a single trace by ID.
 px trace get abc123def456
 px trace get abc123def456 --format raw | jq '.spans[] | select(.status_code != "OK")'
 px trace get abc123def456 --file trace.json
-px trace get abc123def456 --include-notes --format raw | jq '.spans[].notes'
+px trace get abc123def456 --include-notes --format raw | jq '{traceNotes: .notes, spanNotes: [.spans[].notes]}'
 ```
 
 ---
@@ -129,6 +129,17 @@ px trace annotate abc123def456 --name reviewer --label pass
 px trace annotate abc123def456 --name reviewer --score 0.9 --format raw --no-progress
 px trace annotate abc123def456 --name evaluator --label pass --annotator-kind LLM
 px trace annotate abc123def456 --name reviewer --explanation "needs follow-up"
+```
+
+---
+
+### `px trace add-note <trace-id>`
+
+Add a note to a trace by OpenTelemetry trace ID.
+
+```bash
+px trace add-note abc123def456 --text "needs follow-up"
+px trace add-note abc123def456 --text "agent triage complete" --format raw --no-progress
 ```
 
 ---

--- a/js/packages/phoenix-cli/src/commands/formatNoteMutation.ts
+++ b/js/packages/phoenix-cli/src/commands/formatNoteMutation.ts
@@ -27,6 +27,5 @@ function formatNoteMutationPretty(note: NoteMutationResult): string {
     `  ID: ${note.id}`,
     `  Target: ${note.targetType} ${note.targetId}`,
     `  Text: ${note.text}`,
-    `  Annotator: ${note.annotatorKind}`,
   ].join("\n");
 }

--- a/js/packages/phoenix-cli/src/commands/formatSpans.ts
+++ b/js/packages/phoenix-cli/src/commands/formatSpans.ts
@@ -1,4 +1,4 @@
-import type { SpanAnnotation, SpanWithAnnotations } from "../trace";
+import type { SpanAnnotation, SpanNote, SpanWithAnnotations } from "../trace";
 import { formatTable } from "./formatTable";
 
 export type OutputFormat = "pretty" | "json" | "raw";
@@ -89,7 +89,7 @@ function formatAnnotations(annotations: SpanAnnotation[] | undefined): string {
     .join(", ");
 }
 
-function formatNotes(notes: SpanAnnotation[] | undefined): string {
+function formatNotes(notes: SpanNote[] | undefined): string {
   if (!notes || notes.length === 0) return "";
   return notes
     .map((note) => note.result?.explanation?.replace(/\s+/g, " ").trim() || "")

--- a/js/packages/phoenix-cli/src/commands/formatTraces.ts
+++ b/js/packages/phoenix-cli/src/commands/formatTraces.ts
@@ -130,7 +130,12 @@ function renderTraceNotes(lines: string[], trace: Trace): void {
 
   lines.push("│  Trace Notes:");
   for (const note of notes) {
-    lines.push(`│  - ${formatNoteText(note.result?.explanation)}`);
+    renderNoteLines({
+      lines,
+      text: note.result?.explanation,
+      firstLinePrefix: "│  - ",
+      continuationPrefix: "│    ",
+    });
   }
   lines.push("│");
 }
@@ -287,7 +292,12 @@ function renderSpanNotes(
 
   lines.push(`${detailPrefix}notes:`);
   for (const note of notes) {
-    lines.push(`${detailPrefix}- ${formatNoteText(note.result?.explanation)}`);
+    renderNoteLines({
+      lines,
+      text: note.result?.explanation,
+      firstLinePrefix: `${detailPrefix}- `,
+      continuationPrefix: `${detailPrefix}  `,
+    });
   }
 }
 
@@ -354,15 +364,37 @@ function truncateValue(value: string): string {
   return value.slice(0, VALUE_PREVIEW_MAX_CHARS) + "…";
 }
 
-function formatNoteText(text: string | null | undefined): string {
+function formatNoteTextLines({
+  text,
+}: {
+  text: string | null | undefined;
+}): string[] {
   if (!text) {
-    return "(empty)";
+    return ["(empty)"];
   }
 
-  const normalizedText = text.replace(/\s+/g, " ").trim();
-  if (!normalizedText) {
-    return "(empty)";
+  const normalizedText = text.replace(/\r\n?/g, "\n");
+  if (!normalizedText.trim()) {
+    return ["(empty)"];
   }
 
-  return truncateValue(normalizedText);
+  return truncateValue(normalizedText).split("\n");
+}
+
+function renderNoteLines({
+  lines,
+  text,
+  firstLinePrefix,
+  continuationPrefix,
+}: {
+  lines: string[];
+  text: string | null | undefined;
+  firstLinePrefix: string;
+  continuationPrefix: string;
+}): void {
+  const noteLines = formatNoteTextLines({ text });
+  for (const [index, noteLine] of noteLines.entries()) {
+    const prefix = index === 0 ? firstLinePrefix : continuationPrefix;
+    lines.push(`${prefix}${noteLine}`);
+  }
 }

--- a/js/packages/phoenix-cli/src/commands/formatTraces.ts
+++ b/js/packages/phoenix-cli/src/commands/formatTraces.ts
@@ -90,6 +90,7 @@ function formatTracePretty(trace: Trace): string {
   }
 
   renderTraceAnnotations(lines, trace);
+  renderTraceNotes(lines, trace);
   lines.push(`│  Spans:`);
 
   for (let i = 0; i < forest.length; i++) {
@@ -117,6 +118,19 @@ function renderTraceAnnotations(lines: string[], trace: Trace): void {
       ...formatAnnotationResultParts(annotation.result),
     ];
     lines.push(`│  - ${parts.join(" ")}`);
+  }
+  lines.push("│");
+}
+
+function renderTraceNotes(lines: string[], trace: Trace): void {
+  const notes = trace.notes;
+  if (!notes?.length) {
+    return;
+  }
+
+  lines.push("│  Trace Notes:");
+  for (const note of notes) {
+    lines.push(`│  - ${formatNoteText(note.result?.explanation)}`);
   }
   lines.push("│");
 }

--- a/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
+++ b/js/packages/phoenix-cli/src/commands/noteMutationUtils.ts
@@ -1,6 +1,5 @@
 import { InvalidArgumentError } from "../exitCodes";
 import { trimToUndefined } from "../normalize";
-import type { AnnotatorKind } from "./annotationMutationUtils";
 
 export type NoteTargetType = "span" | "trace";
 export const NOTE_ANNOTATION_NAME = "note";
@@ -10,7 +9,6 @@ export interface NoteMutationResult {
   targetType: NoteTargetType;
   targetId: string;
   text: string;
-  annotatorKind: AnnotatorKind;
 }
 
 function getTargetIdPlaceholder({
@@ -58,19 +56,16 @@ export function buildNoteMutationResult({
   targetType,
   targetId,
   text,
-  annotatorKind,
 }: {
   id: string;
   targetType: NoteTargetType;
   targetId: string;
   text: string;
-  annotatorKind?: AnnotatorKind;
 }): NoteMutationResult {
   return {
     id,
     targetType,
     targetId,
     text,
-    annotatorKind: annotatorKind ?? "HUMAN",
   };
 }

--- a/js/packages/phoenix-cli/src/commands/span.ts
+++ b/js/packages/phoenix-cli/src/commands/span.ts
@@ -12,7 +12,11 @@ import {
 import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
-import type { SpanWithAnnotations } from "../trace";
+import {
+  buildSpanNote,
+  type SpanNote,
+  type SpanWithAnnotations,
+} from "../trace";
 import {
   buildAnnotationMutationResult,
   getAnnotationMutationHelpText,
@@ -289,13 +293,13 @@ async function spanListHandler(
         includeAnnotationNames: [NOTE_ANNOTATION_NAME],
       });
 
-      const notesBySpanId = new Map<string, SpanAnnotation[]>();
+      const notesBySpanId = new Map<string, SpanNote[]>();
       for (const note of notes) {
         const spanId = note.span_id;
         if (!notesBySpanId.has(spanId)) {
           notesBySpanId.set(spanId, []);
         }
-        notesBySpanId.get(spanId)!.push(note);
+        notesBySpanId.get(spanId)!.push(buildSpanNote(note));
       }
 
       for (const span of spans) {

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -14,10 +14,14 @@ import { assertDeletesEnabled, confirmOrExit } from "../confirm";
 import { ExitCode, getExitCodeForError } from "../exitCodes";
 import { writeError, writeOutput, writeProgress } from "../io";
 import {
+  buildSpanNote,
   buildTrace,
+  buildTraceNote,
   groupSpansByTrace,
+  type SpanNote,
   type SpanWithAnnotations,
   type Trace,
+  type TraceNote,
 } from "../trace";
 import {
   buildAnnotationMutationResult,
@@ -99,13 +103,13 @@ function attachSpanNotesToSpans(
   spans: SpanWithAnnotations[],
   notes: SpanAnnotation[]
 ): void {
-  const notesBySpanId = new Map<string, SpanAnnotation[]>();
+  const notesBySpanId = new Map<string, SpanNote[]>();
   for (const note of notes) {
     const spanId = note.span_id;
     if (!notesBySpanId.has(spanId)) {
       notesBySpanId.set(spanId, []);
     }
-    notesBySpanId.get(spanId)!.push(note);
+    notesBySpanId.get(spanId)!.push(buildSpanNote(note));
   }
 
   for (const span of spans) {
@@ -122,13 +126,13 @@ function attachTraceNotesToTraces(
   traces: Trace[],
   notes: TraceAnnotation[]
 ): void {
-  const notesByTraceId = new Map<string, TraceAnnotation[]>();
+  const notesByTraceId = new Map<string, TraceNote[]>();
   for (const note of notes) {
     const traceId = note.trace_id;
     if (!notesByTraceId.has(traceId)) {
       notesByTraceId.set(traceId, []);
     }
-    notesByTraceId.get(traceId)!.push(note);
+    notesByTraceId.get(traceId)!.push(buildTraceNote(note));
   }
 
   for (const trace of traces) {
@@ -521,7 +525,7 @@ async function traceGetHandler(
       trace.annotations = traceAnnotations;
     }
     if (traceNotes?.length) {
-      trace.notes = traceNotes;
+      trace.notes = traceNotes.map(buildTraceNote);
     }
 
     // Output trace

--- a/js/packages/phoenix-cli/src/commands/trace.ts
+++ b/js/packages/phoenix-cli/src/commands/trace.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { componentsV1, PhoenixClient } from "@arizeai/phoenix-client";
+import { addTraceNote } from "@arizeai/phoenix-client/traces";
 import { Command } from "commander";
 
 import { createPhoenixClient, resolveProjectId } from "../client";
@@ -29,11 +30,19 @@ import {
   type OutputFormat as AnnotationMutationOutputFormat,
 } from "./formatAnnotationMutation";
 import {
+  formatNoteMutationOutput,
+  type OutputFormat as NoteMutationOutputFormat,
+} from "./formatNoteMutation";
+import {
   formatTraceOutput,
   formatTracesOutput,
   type OutputFormat as TraceOutputFormat,
 } from "./formatTraces";
-import { NOTE_ANNOTATION_NAME } from "./noteMutationUtils";
+import {
+  buildNoteMutationResult,
+  NOTE_ANNOTATION_NAME,
+  normalizeNoteText,
+} from "./noteMutationUtils";
 import { fetchSpanAnnotations, type SpanAnnotation } from "./spanAnnotations";
 import {
   fetchTraceAnnotations,
@@ -109,6 +118,27 @@ function attachSpanNotesToSpans(
   }
 }
 
+function attachTraceNotesToTraces(
+  traces: Trace[],
+  notes: TraceAnnotation[]
+): void {
+  const notesByTraceId = new Map<string, TraceAnnotation[]>();
+  for (const note of notes) {
+    const traceId = note.trace_id;
+    if (!notesByTraceId.has(traceId)) {
+      notesByTraceId.set(traceId, []);
+    }
+    notesByTraceId.get(traceId)!.push(note);
+  }
+
+  for (const trace of traces) {
+    const traceNotes = notesByTraceId.get(trace.traceId);
+    if (traceNotes) {
+      trace.notes = traceNotes;
+    }
+  }
+}
+
 function getResolvedTraceId(spans: Span[]): string | undefined {
   return spans[0]?.context?.trace_id;
 }
@@ -148,6 +178,14 @@ interface TraceAnnotateOptions {
   score?: string;
   explanation?: string;
   annotatorKind?: string;
+}
+
+interface TraceAddNoteOptions {
+  endpoint?: string;
+  apiKey?: string;
+  format?: NoteMutationOutputFormat;
+  progress?: boolean;
+  text?: string;
 }
 
 /**
@@ -427,6 +465,7 @@ async function traceGetHandler(
     const traceSpans: SpanWithAnnotations[] = spans;
     const resolvedTraceId = getResolvedTraceId(spans);
     let traceAnnotations: TraceAnnotation[] | undefined;
+    let traceNotes: TraceAnnotation[] | undefined;
     if (options.includeAnnotations) {
       writeProgress({
         message: "Fetching trace and span annotations...",
@@ -453,8 +492,15 @@ async function traceGetHandler(
     }
     if (options.includeNotes) {
       writeProgress({
-        message: "Fetching span notes...",
+        message: "Fetching trace and span notes...",
         noProgress: !options.progress,
+      });
+
+      traceNotes = await fetchTraceAnnotations({
+        client,
+        projectIdentifier: projectId,
+        traceIds: resolvedTraceId ? [resolvedTraceId] : [traceId],
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
       });
 
       const spanIds = traceSpans
@@ -473,6 +519,9 @@ async function traceGetHandler(
     const trace = buildTrace({ spans: traceSpans });
     if (traceAnnotations?.length) {
       trace.annotations = traceAnnotations;
+    }
+    if (traceNotes?.length) {
+      trace.notes = traceNotes;
     }
 
     // Output trace
@@ -609,9 +658,18 @@ async function traceListHandler(
     }
     if (options.includeNotes) {
       writeProgress({
-        message: "Fetching span notes...",
+        message: "Fetching trace and span notes...",
         noProgress: !options.progress,
       });
+
+      const traceNotes = await fetchTraceAnnotations({
+        client,
+        projectIdentifier: projectId,
+        traceIds: traces.map((trace) => trace.traceId),
+        includeAnnotationNames: [NOTE_ANNOTATION_NAME],
+        maxConcurrent: options.maxConcurrent,
+      });
+      attachTraceNotesToTraces(traces, traceNotes);
 
       const spanIds = traces
         .flatMap((trace) => trace.spans)
@@ -681,7 +739,10 @@ export function createTraceGetCommand(): Command {
       "--include-annotations",
       "Include trace and span annotations in the trace export"
     )
-    .option("--include-notes", "Include span notes in the trace export")
+    .option(
+      "--include-notes",
+      "Include trace and span notes in the trace export"
+    )
     .action(traceGetHandler);
 }
 
@@ -720,7 +781,10 @@ export function createTraceListCommand(): Command {
       "--include-annotations",
       "Include trace and span annotations in the trace export"
     )
-    .option("--include-notes", "Include span notes in the trace export")
+    .option(
+      "--include-notes",
+      "Include trace and span notes in the trace export"
+    )
     .action(traceListHandler);
 }
 
@@ -837,6 +901,82 @@ export function createTraceAnnotateCommand(): Command {
     .action(traceAnnotateHandler);
 }
 
+async function traceAddNoteHandler(
+  traceId: string,
+  options: TraceAddNoteOptions
+): Promise<void> {
+  try {
+    const config = resolveConfig({
+      cliOptions: {
+        endpoint: options.endpoint,
+        apiKey: options.apiKey,
+      },
+    });
+
+    const validation = validateConfig({ config, projectRequired: false });
+    if (!validation.valid) {
+      writeError({
+        message: getConfigErrorMessage({ errors: validation.errors }),
+      });
+      process.exit(ExitCode.INVALID_ARGUMENT);
+    }
+
+    const noteText = normalizeNoteText({
+      targetType: "trace",
+      text: options.text,
+    });
+    const client = createPhoenixClient({ config });
+
+    writeProgress({
+      message: `Adding note to trace ${traceId}...`,
+      noProgress: !options.progress,
+    });
+
+    const result = await addTraceNote({
+      client,
+      traceNote: {
+        traceId,
+        note: noteText,
+      },
+    });
+
+    const note = buildNoteMutationResult({
+      id: result.id,
+      targetType: "trace",
+      targetId: traceId,
+      text: noteText,
+    });
+
+    writeOutput({
+      message: formatNoteMutationOutput({
+        note,
+        format: options.format,
+      }),
+    });
+  } catch (error) {
+    writeError({
+      message: `Error adding trace note: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    process.exit(getExitCodeForError(error));
+  }
+}
+
+export function createTraceAddNoteCommand(): Command {
+  return new Command("add-note")
+    .description("Add a note to a trace by OpenTelemetry trace ID")
+    .argument("<trace-id>", "OpenTelemetry trace ID")
+    .option("--endpoint <url>", "Phoenix API endpoint")
+    .option("--api-key <key>", "Phoenix API key for authentication")
+    .option("--text <text>", "Note text")
+    .option(
+      "--format <format>",
+      "Output format: pretty, json, or raw",
+      "pretty"
+    )
+    .option("--no-progress", "Disable progress indicators")
+    .action(traceAddNoteHandler);
+}
+
 interface TraceDeleteOptions {
   endpoint?: string;
   apiKey?: string;
@@ -928,6 +1068,7 @@ export function createTraceCommand(): Command {
   command.addCommand(createTraceListCommand());
   command.addCommand(createTraceGetCommand());
   command.addCommand(createTraceAnnotateCommand());
+  command.addCommand(createTraceAddNoteCommand());
   command.addCommand(createTraceDeleteCommand());
   return command;
 }

--- a/js/packages/phoenix-cli/src/trace.ts
+++ b/js/packages/phoenix-cli/src/trace.ts
@@ -3,9 +3,24 @@ import type { componentsV1 } from "@arizeai/phoenix-client";
 export type Span = componentsV1["schemas"]["Span"];
 export type SpanAnnotation = componentsV1["schemas"]["SpanAnnotation"];
 export type TraceAnnotation = componentsV1["schemas"]["TraceAnnotation"];
+
+type NoteResult = {
+  explanation?: string | null;
+};
+
+export type SpanNote = Omit<SpanAnnotation, "name" | "result"> & {
+  name: "note";
+  result?: NoteResult | null;
+};
+
+export type TraceNote = Omit<TraceAnnotation, "name" | "result"> & {
+  name: "note";
+  result?: NoteResult | null;
+};
+
 export type SpanWithAnnotations = Span & {
   annotations?: SpanAnnotation[];
-  notes?: SpanAnnotation[];
+  notes?: SpanNote[];
 };
 
 /**
@@ -14,13 +29,40 @@ export type SpanWithAnnotations = Span & {
 export interface Trace {
   traceId: string;
   annotations?: TraceAnnotation[];
-  notes?: TraceAnnotation[];
+  notes?: TraceNote[];
   spans: SpanWithAnnotations[];
   rootSpan?: SpanWithAnnotations;
   startTime?: string;
   endTime?: string;
   duration?: number;
   status?: string;
+}
+
+function buildNoteResult({
+  result,
+}: {
+  result: { explanation?: string | null } | null | undefined;
+}): NoteResult | null | undefined {
+  if (result === null || result === undefined) {
+    return result;
+  }
+  return { explanation: result.explanation ?? null };
+}
+
+export function buildSpanNote(annotation: SpanAnnotation): SpanNote {
+  return {
+    ...annotation,
+    name: "note",
+    result: buildNoteResult({ result: annotation.result }),
+  };
+}
+
+export function buildTraceNote(annotation: TraceAnnotation): TraceNote {
+  return {
+    ...annotation,
+    name: "note",
+    result: buildNoteResult({ result: annotation.result }),
+  };
 }
 
 /**

--- a/js/packages/phoenix-cli/src/trace.ts
+++ b/js/packages/phoenix-cli/src/trace.ts
@@ -14,6 +14,7 @@ export type SpanWithAnnotations = Span & {
 export interface Trace {
   traceId: string;
   annotations?: TraceAnnotation[];
+  notes?: TraceAnnotation[];
   spans: SpanWithAnnotations[];
   rootSpan?: SpanWithAnnotations;
   startTime?: string;

--- a/js/packages/phoenix-cli/test/cli.test.ts
+++ b/js/packages/phoenix-cli/test/cli.test.ts
@@ -54,7 +54,7 @@ describe("Phoenix CLI", () => {
 
     expect(traceCommand).toBeDefined();
     expect(traceCommand?.commands.map((command) => command.name())).toEqual(
-      expect.arrayContaining(["list", "get", "annotate"])
+      expect.arrayContaining(["list", "get", "annotate", "add-note"])
     );
     expect(
       program.commands.find((command) => command.name() === "traces")

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -6,7 +6,8 @@ import { ExitCode } from "../src/exitCodes";
 
 function makeFetchMock(
   responses: Array<
-    { ok: boolean; status?: number; body?: unknown } | { error: Error }
+    | { ok: boolean; status?: number; body?: unknown; text?: string }
+    | { error: Error }
   >
 ) {
   let callIndex = 0;
@@ -25,7 +26,7 @@ function makeFetchMock(
       url,
       headers: new Headers(),
       json: () => Promise.resolve(response.body ?? {}),
-      text: () => Promise.resolve(""),
+      text: () => Promise.resolve(response.text ?? ""),
     });
   });
 }
@@ -108,6 +109,32 @@ function makeSpanNoteResponse() {
           metadata: null,
           identifier: "px-span-note:1",
           span_id: "span-123",
+        },
+      ],
+      next_cursor: null,
+    },
+  } as const;
+}
+
+function makeTraceNoteResponse() {
+  return {
+    ok: true,
+    body: {
+      data: [
+        {
+          id: "trace-note-1",
+          created_at: "2026-01-13T10:00:00.500Z",
+          updated_at: "2026-01-13T10:00:00.500Z",
+          source: "API",
+          user_id: null,
+          name: "note",
+          annotator_kind: "HUMAN",
+          result: {
+            explanation: "trace note text",
+          },
+          metadata: null,
+          identifier: "px-trace-note:1",
+          trace_id: "trace-123",
         },
       ],
       next_cursor: null,
@@ -211,6 +238,109 @@ describe("span add-note", () => {
     await expect(
       createSpanCommand().parseAsync(
         ["add-note", "span-123", "--text", "   ", ...BASE_ARGS],
+        { from: "user" }
+      )
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid value for --text: <empty>. Expected non-empty text."
+      )
+    );
+  });
+});
+
+describe("trace add-note", () => {
+  it("posts a trace note and returns json output", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        text: "14.12.0",
+      },
+      {
+        ok: true,
+        body: { data: { id: "trace-note-1" } },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await createTraceCommand().parseAsync(
+      [
+        "add-note",
+        "trace-123",
+        "--text",
+        "  needs review  ",
+        "--format",
+        "json",
+        ...BASE_ARGS,
+      ],
+      { from: "user" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getFetchUrl(fetchMock.mock.calls[1][0])).toContain(
+      "/v1/trace_notes"
+    );
+    await expect(
+      getFetchBody(fetchMock.mock.calls[1][0], fetchMock.mock.calls[1][1])
+    ).resolves.toEqual({
+      data: {
+        trace_id: "trace-123",
+        note: "needs review",
+      },
+    });
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          id: "trace-note-1",
+          targetType: "trace",
+          targetId: "trace-123",
+          text: "needs review",
+          annotatorKind: "HUMAN",
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  it("fails with INVALID_ARGUMENT when --text is missing", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createTraceCommand().parseAsync(["add-note", "trace-123", ...BASE_ARGS], {
+        from: "user",
+      })
+    ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
+
+    expect(exitSpy).toHaveBeenCalledWith(ExitCode.INVALID_ARGUMENT);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails with INVALID_ARGUMENT when --text is blank", async () => {
+    const fetchMock = makeFetchMock([{ ok: true, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+
+    await expect(
+      createTraceCommand().parseAsync(
+        ["add-note", "trace-123", "--text", "   ", ...BASE_ARGS],
         { from: "user" }
       )
     ).rejects.toThrow(`process.exit:${ExitCode.INVALID_ARGUMENT}`);
@@ -331,11 +461,12 @@ describe("span note readback", () => {
   });
 });
 
-describe("trace span-note readback", () => {
-  it("includes span notes in trace get raw output when requested", async () => {
+describe("trace note readback", () => {
+  it("includes trace and span notes in trace get raw output when requested", async () => {
     const fetchMock = makeFetchMock([
       makeProjectResponse(),
       makeSpanPageResponse(),
+      makeTraceNoteResponse(),
       makeSpanNoteResponse(),
     ]);
     vi.stubGlobal("fetch", fetchMock);
@@ -356,17 +487,25 @@ describe("trace span-note readback", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
-      "/v1/projects/project-default/span_annotations"
+      "/v1/projects/project-default/trace_annotations"
     );
     expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "include_annotation_names=note"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
+      "/v1/projects/project-default/span_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
       "include_annotation_names=note"
     );
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
-    expect(parsedOutput.notes).toBeUndefined();
+    expect(parsedOutput.notes).toEqual([
+      expect.objectContaining({ id: "trace-note-1", name: "note" }),
+    ]);
     expect(parsedOutput.spans[0].notes).toEqual([
       expect.objectContaining({ id: "span-note-1", name: "note" }),
     ]);
@@ -416,10 +555,11 @@ describe("trace span-note readback", () => {
     expect(parsedOutput.spans[0].notes).toBeUndefined();
   });
 
-  it("includes span notes in trace list raw output when requested", async () => {
+  it("includes trace and span notes in trace list raw output when requested", async () => {
     const fetchMock = makeFetchMock([
       makeProjectResponse(),
       makeSpanPageResponse(),
+      makeTraceNoteResponse(),
       makeSpanNoteResponse(),
     ]);
     vi.stubGlobal("fetch", fetchMock);
@@ -439,14 +579,25 @@ describe("trace span-note readback", () => {
       { from: "user" }
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "/v1/projects/project-default/trace_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[2][0])).toContain(
+      "include_annotation_names=note"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
+      "/v1/projects/project-default/span_annotations"
+    );
+    expect(getFetchUrl(fetchMock.mock.calls[3][0])).toContain(
       "include_annotation_names=note"
     );
 
     const output = stdoutSpy.mock.calls[0]?.[0];
     const parsedOutput = JSON.parse(String(output));
-    expect(parsedOutput[0].notes).toBeUndefined();
+    expect(parsedOutput[0].notes).toEqual([
+      expect.objectContaining({ id: "trace-note-1", name: "note" }),
+    ]);
     expect(parsedOutput[0].spans[0].notes).toEqual([
       expect.objectContaining({ id: "span-note-1", name: "note" }),
     ]);

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -256,7 +256,7 @@ describe("trace add-note", () => {
     const fetchMock = makeFetchMock([
       {
         ok: true,
-        text: "14.12.0",
+        text: "14.13.0",
       },
       {
         ok: true,

--- a/js/packages/phoenix-cli/test/notes.test.ts
+++ b/js/packages/phoenix-cli/test/notes.test.ts
@@ -200,7 +200,6 @@ describe("span add-note", () => {
         targetType: "span",
         targetId: "span-123",
         text: "needs review",
-        annotatorKind: "HUMAN",
       })
     );
   });
@@ -300,7 +299,6 @@ describe("trace add-note", () => {
           targetType: "trace",
           targetId: "trace-123",
           text: "needs review",
-          annotatorKind: "HUMAN",
         },
         null,
         2

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -130,8 +130,25 @@ const mockTraceWithAnnotations: Trace = {
   ],
 };
 
-const mockTraceWithSpanNotes: Trace = {
+const mockTraceWithNotes: Trace = {
   traceId: "noted123",
+  notes: [
+    {
+      id: "trace-note-1",
+      created_at: "2026-01-13T10:00:00.500Z",
+      updated_at: "2026-01-13T10:00:00.500Z",
+      source: "API",
+      user_id: null,
+      name: "note",
+      annotator_kind: "HUMAN",
+      identifier: "px-trace-note:1",
+      metadata: null,
+      trace_id: "noted123",
+      result: {
+        explanation: "Trace note content",
+      },
+    },
+  ],
   spans: [
     {
       ...mockSpan1,
@@ -247,12 +264,14 @@ describe("Output Formatting", () => {
       );
     });
 
-    it("should render span notes when present", () => {
+    it("should render trace and span notes when present", () => {
       const output = formatTraceOutput({
-        trace: mockTraceWithSpanNotes,
+        trace: mockTraceWithNotes,
         format: "pretty",
       });
 
+      expect(output).toContain("Trace Notes:");
+      expect(output).toContain("- Trace note content");
       expect(output).toContain("notes:");
       expect(output).toContain("- Span note content");
     });
@@ -315,7 +334,7 @@ describe("Output Formatting", () => {
   describe("span output - pretty", () => {
     it("should include a notes column when notes are present", () => {
       const output = formatSpansOutput({
-        spans: mockTraceWithSpanNotes.spans,
+        spans: mockTraceWithNotes.spans,
         format: "pretty",
       });
 

--- a/js/packages/phoenix-cli/test/output.test.ts
+++ b/js/packages/phoenix-cli/test/output.test.ts
@@ -145,7 +145,7 @@ const mockTraceWithNotes: Trace = {
       metadata: null,
       trace_id: "noted123",
       result: {
-        explanation: "Trace note content",
+        explanation: "Trace note line 1\nTrace note line 2",
       },
     },
   ],
@@ -169,7 +169,7 @@ const mockTraceWithNotes: Trace = {
           metadata: null,
           span_id: "span1",
           result: {
-            explanation: "Span note content",
+            explanation: "Span note line 1\nSpan note line 2",
           },
         },
       ],
@@ -271,9 +271,11 @@ describe("Output Formatting", () => {
       });
 
       expect(output).toContain("Trace Notes:");
-      expect(output).toContain("- Trace note content");
+      expect(output).toContain("│  - Trace note line 1");
+      expect(output).toContain("│    Trace note line 2");
       expect(output).toContain("notes:");
-      expect(output).toContain("- Span note content");
+      expect(output).toContain("- Span note line 1");
+      expect(output).toContain("  Span note line 2");
     });
 
     it("should format array of traces", () => {
@@ -339,7 +341,7 @@ describe("Output Formatting", () => {
       });
 
       expect(output).toContain("notes");
-      expect(output).toContain("Span note content");
+      expect(output).toContain("Span note line 1 Span note line 2");
     });
   });
 });

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -53,6 +53,15 @@ export const ANNOTATE_SESSIONS: RouteRequirement = {
   minServerVersion: [12, 0, 0],
 };
 
+export const ADD_TRACE_NOTE: RouteRequirement = {
+  kind: "route",
+  method: "POST",
+  path: "/v1/trace_notes",
+  // This route is being introduced on the current development branch.
+  // Update this minimum version if the server release target changes before publish.
+  minServerVersion: [14, 12, 0],
+};
+
 export const GET_SPANS_TRACE_IDS: ParameterRequirement = {
   kind: "parameter",
   parameterName: "trace_id",
@@ -96,6 +105,7 @@ export const ALL_REQUIREMENTS: readonly CapabilityRequirement[] = [
   DELETE_SESSIONS,
   LIST_PROJECT_SESSIONS,
   ANNOTATE_SESSIONS,
+  ADD_TRACE_NOTE,
   GET_SPANS_TRACE_IDS,
   GET_SPANS_FILTERS,
   GET_SPANS_BY_ATTRIBUTE,

--- a/js/packages/phoenix-client/src/constants/serverRequirements.ts
+++ b/js/packages/phoenix-client/src/constants/serverRequirements.ts
@@ -57,9 +57,7 @@ export const ADD_TRACE_NOTE: RouteRequirement = {
   kind: "route",
   method: "POST",
   path: "/v1/trace_notes",
-  // This route is being introduced on the current development branch.
-  // Update this minimum version if the server release target changes before publish.
-  minServerVersion: [14, 12, 0],
+  minServerVersion: [14, 13, 0],
 };
 
 export const GET_SPANS_TRACE_IDS: ParameterRequirement = {

--- a/js/packages/phoenix-client/src/traces/addTraceNote.ts
+++ b/js/packages/phoenix-client/src/traces/addTraceNote.ts
@@ -1,0 +1,71 @@
+import { createClient } from "../client";
+import { ADD_TRACE_NOTE } from "../constants/serverRequirements";
+import type { ClientFn } from "../types/core";
+import { ensureServerCapability } from "../utils/serverVersionUtils";
+
+/**
+ * Parameters for a single trace note.
+ */
+export interface TraceNote {
+  /**
+   * The OpenTelemetry trace ID (hex format without 0x prefix).
+   */
+  traceId: string;
+  /**
+   * The note text to add to the trace.
+   */
+  note: string;
+}
+
+/**
+ * Parameters to add a trace note.
+ */
+export interface AddTraceNoteParams extends ClientFn {
+  traceNote: TraceNote;
+}
+
+/**
+ * Add a note to a trace.
+ *
+ * Notes are a special type of annotation that allow multiple entries per trace.
+ * Each note gets a unique timestamp-based identifier.
+ *
+ * @param params - The parameters to add a trace note.
+ * @returns The ID of the created note annotation.
+ *
+ * @example
+ * ```ts
+ * const result = await addTraceNote({
+ *   traceNote: {
+ *     traceId: "abc123",
+ *     note: "Needs review"
+ *   }
+ * });
+ * ```
+ */
+export async function addTraceNote({
+  client: _client,
+  traceNote,
+}: AddTraceNoteParams): Promise<{ id: string }> {
+  const client = _client ?? createClient();
+  await ensureServerCapability({ client, requirement: ADD_TRACE_NOTE });
+
+  const { data, error } = await client.POST("/v1/trace_notes", {
+    body: {
+      data: {
+        trace_id: traceNote.traceId.trim(),
+        note: traceNote.note,
+      },
+    },
+  });
+
+  if (error) {
+    throw new Error(`Failed to add trace note: ${error}`);
+  }
+
+  if (!data?.data) {
+    throw new Error("Failed to add trace note: no data returned");
+  }
+
+  return data.data;
+}

--- a/js/packages/phoenix-client/src/traces/index.ts
+++ b/js/packages/phoenix-client/src/traces/index.ts
@@ -1,1 +1,2 @@
+export * from "./addTraceNote";
 export * from "./getTraces";

--- a/js/packages/phoenix-client/test/setup.ts
+++ b/js/packages/phoenix-client/test/setup.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 
+// Capability-guard tests must unmock this module to exercise real version checks.
 vi.mock("../src/utils/serverVersionUtils", () => ({
   capabilityLabel: vi.fn(),
   ensureServerCapability: vi.fn(),

--- a/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
+++ b/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
@@ -19,7 +19,7 @@ describe("addTraceNote", () => {
 
   function makeClient() {
     return {
-      getServerVersion: async () => [14, 12, 0] as [number, number, number],
+      getServerVersion: async () => [14, 13, 0] as [number, number, number],
       POST: mockPOST,
     };
   }
@@ -92,7 +92,7 @@ describe("addTraceNote", () => {
   it("fails fast on older Phoenix servers", async () => {
     const guardedPOST = vi.fn();
     const mockClient = {
-      getServerVersion: async () => [14, 11, 0] as [number, number, number],
+      getServerVersion: async () => [14, 12, 0] as [number, number, number],
       POST: guardedPOST,
     };
 
@@ -104,7 +104,7 @@ describe("addTraceNote", () => {
           note: "This is a trace note",
         },
       })
-    ).rejects.toThrow(/requires Phoenix server >= 14\.12\.0/);
+    ).rejects.toThrow(/requires Phoenix server >= 14\.13\.0/);
 
     expect(guardedPOST).not.toHaveBeenCalled();
   });

--- a/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
+++ b/js/packages/phoenix-client/test/traces/addTraceNote.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.unmock("../../src/utils/serverVersionUtils");
+
+import { addTraceNote } from "../../src/traces/addTraceNote";
+
+const mockPOST = vi.fn();
+
+describe("addTraceNote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPOST.mockResolvedValue({
+      data: {
+        data: { id: "test-trace-note-id-1" },
+      },
+      error: null,
+    });
+  });
+
+  function makeClient() {
+    return {
+      getServerVersion: async () => [14, 12, 0] as [number, number, number],
+      POST: mockPOST,
+    };
+  }
+
+  it("adds a trace note", async () => {
+    const result = await addTraceNote({
+      client: makeClient() as never,
+      traceNote: {
+        traceId: "trace123",
+        note: "This is a trace note",
+      },
+    });
+
+    expect(result).toEqual({ id: "test-trace-note-id-1" });
+  });
+
+  it("trims the trace ID", async () => {
+    await addTraceNote({
+      client: makeClient() as never,
+      traceNote: {
+        traceId: "  trace123  ",
+        note: "This is a trace note",
+      },
+    });
+
+    expect(mockPOST).toHaveBeenCalledWith("/v1/trace_notes", {
+      body: {
+        data: {
+          trace_id: "trace123",
+          note: "This is a trace note",
+        },
+      },
+    });
+  });
+
+  it("throws when the API returns an error", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: "Trace not found",
+    });
+
+    await expect(
+      addTraceNote({
+        client: makeClient() as never,
+        traceNote: {
+          traceId: "missing-trace",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add trace note: Trace not found");
+  });
+
+  it("throws when no data is returned", async () => {
+    mockPOST.mockResolvedValueOnce({
+      data: undefined,
+      error: undefined,
+    });
+
+    await expect(
+      addTraceNote({
+        client: makeClient() as never,
+        traceNote: {
+          traceId: "trace123",
+          note: "This will fail",
+        },
+      })
+    ).rejects.toThrow("Failed to add trace note: no data returned");
+  });
+
+  it("fails fast on older Phoenix servers", async () => {
+    const guardedPOST = vi.fn();
+    const mockClient = {
+      getServerVersion: async () => [14, 11, 0] as [number, number, number],
+      POST: guardedPOST,
+    };
+
+    await expect(
+      addTraceNote({
+        client: mockClient as never,
+        traceNote: {
+          traceId: "trace123",
+          note: "This is a trace note",
+        },
+      })
+    ).rejects.toThrow(/requires Phoenix server >= 14\.12\.0/);
+
+    expect(guardedPOST).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `px trace add-note` for creating trace notes through the CLI
- extend `px trace get` and `px trace list` with `--include-notes` so trace notes and span notes can be read back separately from annotations
- add the `addTraceNote` TypeScript client helper and trace-note CLI/docs/test coverage
- keep `note` out of the generic `--include-annotations` path, narrow CLI note types, and improve pretty trace output for multi-line notes

## Testing
- `pnpm --dir js --filter @arizeai/phoenix-client exec vitest run test/traces/addTraceNote.test.ts`
- `pnpm --dir js --filter @arizeai/phoenix-cli exec vitest run test/cli.test.ts test/output.test.ts test/notes.test.ts`
- `pnpm --dir js --filter @arizeai/phoenix-client typecheck`
- `pnpm --dir js --filter @arizeai/phoenix-cli typecheck`
