### PR TITLE
refactor: Rename PXI env vars to PHOENIX_AGENTS_ prefix

### DIFF
--- a/.agents/skills/phoenix-pxi/SKILL.md
+++ b/.agents/skills/phoenix-pxi/SKILL.md
@@ -7,6 +7,8 @@ metadata:
 
 # Phoenix PXI Development
 
+Phoenix has a built-in AI assistant named **PXI** (pronounced "pixie"). PXI is the user-facing name for the assistant feature — backend configuration (env vars, project names) uses generic `agents`/`assistant` naming, not "PXI".
+
 Composable guidance for extending PXI across the Phoenix codebase.
 
 Before changing PXI behavior, identify which layer you are working in and read the relevant resource file.

--- a/.agents/skills/phoenix-pxi/resources/extending-frontend-tool-registry.md
+++ b/.agents/skills/phoenix-pxi/resources/extending-frontend-tool-registry.md
@@ -1,6 +1,6 @@
 # Extending The Frontend Tool Registry
 
-Use this guide when working on frontend-executed PXI tools in `app/src/agent/`.
+PXI ("pixie") is Phoenix's built-in AI assistant. Use this guide when working on frontend-executed PXI tools in `app/src/agent/`.
 
 ## Mental Model
 

--- a/.agents/skills/phoenix-pxi/resources/system-prompt-xml-conventions.md
+++ b/.agents/skills/phoenix-pxi/resources/system-prompt-xml-conventions.md
@@ -1,6 +1,6 @@
 # PXI System Prompt XML Conventions
 
-Use this guide when adding to, editing, or reviewing the PXI agent system prompt and any module that contributes lines to it.
+PXI ("pixie") is Phoenix's built-in AI assistant. Use this guide when adding to, editing, or reviewing the PXI agent system prompt and any module that contributes lines to it.
 
 ## Why XML
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,9 +1,18 @@
-# Optional HTTP collector endpoint used by the server-side agents to
-# export traces to a remote collector (in addition to local persistence).
-# PHOENIX_AGENTS_COLLECTOR_ENDPOINT=
-
-# Optional bearer token for authenticating with the remote collector.
-# PHOENIX_AGENTS_COLLECTOR_API_KEY=
-
-# Project name used for assistant agent traces (default: "assistant_agent").
-# PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME=
+export PHOENIX_SECRET=sa18f44bd9b6b4b0606e58a2d03d09039aee8283e0074c6517fda58577a07dd#A
+export PHOENIX_ENABLE_AUTH=True
+export PHOENIX_SMTP_HOSTNAME=smtp.sendgrid.net
+export PHOENIX_SMTP_PORT=587
+export PHOENIX_SMTP_USERNAME=apikey
+export PHOENIX_SMTP_PASSWORD=XXXXXXXXXXXXXXXX
+# Used for running chromatic visual tests on components
+export CHROMATIC_PROJECT_TOKEN=XXXXXXX
+# Use the react-compiler
+export PHOENIX_ENABLE_REACT_COMPILER=True
+# Turn off telemetry for local development
+export PHOENIX_TELEMETRY_ENABLED=False
+# Enable the agents feature (the /chat endpoint)
+export PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True
+# Optional: mirror agent traces to a remote Phoenix collector
+export PHOENIX_AGENTS_COLLECTOR_ENDPOINT=
+export PHOENIX_AGENTS_COLLECTOR_API_KEY=
+export PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME=assistant_agent

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,18 +1,9 @@
-export PHOENIX_SECRET=sa18f44bd9b6b4b0606e58a2d03d09039aee8283e0074c6517fda58577a07dd#A
-export PHOENIX_ENABLE_AUTH=True
-export PHOENIX_SMTP_HOSTNAME=smtp.sendgrid.net
-export PHOENIX_SMTP_PORT=587
-export PHOENIX_SMTP_USERNAME=apikey
-export PHOENIX_SMTP_PASSWORD=XXXXXXXXXXXXXXXX
-# Used for running chromatic visual tests on components
-export CHROMATIC_PROJECT_TOKEN=XXXXXXX
-# Use the react-compiler
-export PHOENIX_ENABLE_REACT_COMPILER=True
-# Turn off telemetry for local development
-export PHOENIX_TELEMETRY_ENABLED=False
-# Enable the agents feature (the /chat endpoint)
-export PHOENIX_DANGEROUSLY_ENABLE_AGENTS=True
-# Optional: mirror PXI chat traces to a remote Phoenix collector
-export PHOENIX_PXI_COLLECTOR_ENDPOINT=
-export PHOENIX_PXI_COLLECTOR_API_KEY=
-export PHOENIX_PXI_PROJECT_NAME=pxi_agent
+# Optional HTTP collector endpoint used by the server-side agents to
+# export traces to a remote collector (in addition to local persistence).
+# PHOENIX_AGENTS_COLLECTOR_ENDPOINT=
+
+# Optional bearer token for authenticating with the remote collector.
+# PHOENIX_AGENTS_COLLECTOR_API_KEY=
+
+# Project name used for assistant agent traces (default: "assistant_agent").
+# PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME=

--- a/src/phoenix/config.py
+++ b/src/phoenix/config.py
@@ -64,20 +64,19 @@ ENV_PHOENIX_COLLECTOR_ENDPOINT = "PHOENIX_COLLECTOR_ENDPOINT"
 The endpoint traces and evals are sent to. This must be set if the Phoenix
 server is running on a remote instance.
 """
-ENV_PHOENIX_PXI_COLLECTOR_ENDPOINT = "PHOENIX_PXI_COLLECTOR_ENDPOINT"
+ENV_PHOENIX_AGENTS_COLLECTOR_ENDPOINT = "PHOENIX_AGENTS_COLLECTOR_ENDPOINT"
 """
-Optional HTTP collector endpoint used by the server-side pxi tracer pipeline to
-mirror spans to a remote Phoenix collector in addition to local persistence.
+Optional HTTP collector endpoint used by the server-side agents to
+export traces to a remote collector. This is in addition to local persistence.
 """
-ENV_PHOENIX_PXI_COLLECTOR_API_KEY = "PHOENIX_PXI_COLLECTOR_API_KEY"
+ENV_PHOENIX_AGENTS_COLLECTOR_API_KEY = "PHOENIX_AGENTS_COLLECTOR_API_KEY"
 """
-Optional bearer token paired with PHOENIX_PXI_COLLECTOR_ENDPOINT for exporting
-PXI traces to a remote collector.
+Optional bearer token paired with PHOENIX_AGENTS_COLLECTOR_ENDPOINT for exporting
+agent traces to a remote collector.
 """
-ENV_PHOENIX_PXI_PROJECT_NAME = "PHOENIX_PXI_PROJECT_NAME"
+ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME = "PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME"
 """
-Project name used for PXI chat traces locally and when mirrored to a remote
-collector.
+Project name used for assistant agent traces.
 """
 ENV_PHOENIX_WORKING_DIR = "PHOENIX_WORKING_DIR"
 """
@@ -1244,16 +1243,16 @@ def get_env_phoenix_api_key() -> Optional[str]:
     return getenv(ENV_PHOENIX_API_KEY)
 
 
-def get_env_phoenix_pxi_collector_endpoint() -> Optional[str]:
-    return getenv(ENV_PHOENIX_PXI_COLLECTOR_ENDPOINT)
+def get_env_phoenix_agents_collector_endpoint() -> Optional[str]:
+    return getenv(ENV_PHOENIX_AGENTS_COLLECTOR_ENDPOINT)
 
 
-def get_env_phoenix_pxi_collector_api_key() -> Optional[str]:
-    return getenv(ENV_PHOENIX_PXI_COLLECTOR_API_KEY)
+def get_env_phoenix_agents_collector_api_key() -> Optional[str]:
+    return getenv(ENV_PHOENIX_AGENTS_COLLECTOR_API_KEY)
 
 
-def get_env_phoenix_pxi_project_name() -> str:
-    return getenv(ENV_PHOENIX_PXI_PROJECT_NAME, "pxi_agent")
+def get_env_phoenix_agents_assistant_project_name() -> str:
+    return getenv(ENV_PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME, "assistant_agent")
 
 
 class AuthSettings(NamedTuple):

--- a/src/phoenix/server/api/routers/chat_tracing.py
+++ b/src/phoenix/server/api/routers/chat_tracing.py
@@ -49,7 +49,7 @@ from opentelemetry.trace import (
 )
 from sqlalchemy import select
 
-from phoenix.config import get_env_phoenix_pxi_project_name
+from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.db.insertion.helpers import OnConflict, insert_on_conflict
 from phoenix.server.dml_event import SpanInsertEvent
@@ -264,16 +264,16 @@ _TOOL_JSON_SCHEMA = ToolAttributes.TOOL_JSON_SCHEMA
 
 
 async def ensure_project_exists(db: DbSessionFactory) -> int:
-    """Get or create the configured PXI project. Returns the ``project_id``.
+    """Get or create the configured assistant agent project. Returns the ``project_id``.
 
     Uses an insert-on-conflict path so concurrent first-time requests do not
     race on the unique project name.
     """
-    pxi_project_name = get_env_phoenix_pxi_project_name()
+    agent_project_name = get_env_phoenix_agents_assistant_project_name()
     async with db() as session:
         await session.execute(
             insert_on_conflict(
-                {"name": pxi_project_name},
+                {"name": agent_project_name},
                 table=models.Project,
                 dialect=db.dialect,
                 unique_by=("name",),
@@ -281,10 +281,12 @@ async def ensure_project_exists(db: DbSessionFactory) -> int:
             )
         )
         project_id = await session.scalar(
-            select(models.Project.id).where(models.Project.name == pxi_project_name)
+            select(models.Project.id).where(models.Project.name == agent_project_name)
         )
         if project_id is None:
-            raise RuntimeError(f"Failed to resolve PXI project '{pxi_project_name}' after insert")
+            raise RuntimeError(
+                f"Failed to resolve agent project '{agent_project_name}' after insert"
+            )
     return project_id
 
 

--- a/src/phoenix/server/api/routers/data_stream_protocol.py
+++ b/src/phoenix/server/api/routers/data_stream_protocol.py
@@ -422,7 +422,7 @@ async def stream_text(
     # Maximum backend tool loop iterations to prevent runaway loops.
     _MAX_BACKEND_TOOL_LOOPS = 5
 
-    from phoenix.config import get_env_phoenix_pxi_project_name
+    from phoenix.config import get_env_phoenix_agents_assistant_project_name
     from phoenix.server.api.routers.chat_tracing import (
         StreamAccumulator,
         create_agent_span,
@@ -452,7 +452,7 @@ async def stream_text(
                 tracer = Tracer(
                     span_cost_calculator=request.app.state.span_cost_calculator,
                     enable_remote_export=True,
-                    project_name=get_env_phoenix_pxi_project_name(),
+                    project_name=get_env_phoenix_agents_assistant_project_name(),
                 )
                 project_id = await ensure_project_exists(request.app.state.db)
                 agent_span = create_agent_span(

--- a/src/phoenix/tracers.py
+++ b/src/phoenix/tracers.py
@@ -19,8 +19,8 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace import format_span_id, format_trace_id
 
 from phoenix.config import (
-    get_env_phoenix_pxi_collector_api_key,
-    get_env_phoenix_pxi_collector_endpoint,
+    get_env_phoenix_agents_collector_api_key,
+    get_env_phoenix_agents_collector_endpoint,
 )
 from phoenix.db import models
 from phoenix.db.insertion.helpers import should_calculate_span_cost
@@ -62,7 +62,7 @@ def _build_remote_http_span_exporter(endpoint: str) -> SpanExporter:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
     headers = {}
-    if api_key := get_env_phoenix_pxi_collector_api_key():
+    if api_key := get_env_phoenix_agents_collector_api_key():
         headers["Authorization"] = f"Bearer {api_key}"
 
     return OTLPSpanExporter(
@@ -123,7 +123,7 @@ class Tracer(wrapt.ObjectProxy):  # type: ignore[misc]
 
         self._self_remote_exporter: Optional[SpanExporter] = None
         remote_collector_endpoint = (
-            remote_collector_endpoint or get_env_phoenix_pxi_collector_endpoint()
+            remote_collector_endpoint or get_env_phoenix_agents_collector_endpoint()
         )
         if enable_remote_export and remote_collector_endpoint:
             exporter_factory = remote_span_exporter_factory or _build_remote_http_span_exporter

--- a/tests/unit/server/api/routers/test_chat_tracing.py
+++ b/tests/unit/server/api/routers/test_chat_tracing.py
@@ -6,7 +6,7 @@ from openinference.semconv.trace import OpenInferenceSpanKindValues
 from opentelemetry.trace import format_span_id, format_trace_id
 from sqlalchemy import select
 
-from phoenix.config import get_env_phoenix_pxi_project_name
+from phoenix.config import get_env_phoenix_agents_assistant_project_name
 from phoenix.db import models
 from phoenix.server.api.routers.chat_tracing import (
     create_agent_span,
@@ -56,7 +56,7 @@ class TestEnsureProjectExists:
         async with db() as session:
             project = await session.get(models.Project, project_id)
             assert project is not None
-            assert project.name == get_env_phoenix_pxi_project_name()
+            assert project.name == get_env_phoenix_agents_assistant_project_name()
 
     @pytest.mark.asyncio
     async def test_returns_existing_project(self, db: DbSessionFactory) -> None:
@@ -80,7 +80,9 @@ class TestEnsureProjectExists:
             projects = (
                 (
                     await session.execute(
-                        select(models.Project).filter_by(name=get_env_phoenix_pxi_project_name())
+                        select(models.Project).filter_by(
+                            name=get_env_phoenix_agents_assistant_project_name()
+                        )
                     )
                 )
                 .scalars()

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -375,7 +375,9 @@ class TestTracer:
             captured_endpoint = endpoint
             return FakeRemoteExporter()
 
-        monkeypatch.setenv("PHOENIX_PXI_COLLECTOR_ENDPOINT", "https://env-collector.example")
+        monkeypatch.setenv(
+            "PHOENIX_AGENT_TRACES_COLLECTOR_ENDPOINT", "https://env-collector.example"
+        )
 
         Tracer(
             span_cost_calculator=span_cost_calculator,
@@ -407,7 +409,9 @@ class TestTracer:
             captured_endpoint = endpoint
             return FakeRemoteExporter()
 
-        monkeypatch.setenv("PHOENIX_PXI_COLLECTOR_ENDPOINT", "https://env-collector.example")
+        monkeypatch.setenv(
+            "PHOENIX_AGENT_TRACES_COLLECTOR_ENDPOINT", "https://env-collector.example"
+        )
 
         Tracer(
             span_cost_calculator=span_cost_calculator,
@@ -430,7 +434,7 @@ class TestTracer:
                 captured_headers = headers
 
         monkeypatch.setattr(otlp_http_trace_exporter, "OTLPSpanExporter", FakeOTLPSpanExporter)
-        monkeypatch.setenv("PHOENIX_PXI_COLLECTOR_API_KEY", "test-api-key")
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_API_KEY", "test-api-key")
 
         _build_remote_http_span_exporter("collector.example")
 
@@ -443,11 +447,12 @@ class TestTracer:
     ) -> None:
         tracer = Tracer(
             span_cost_calculator=span_cost_calculator,
-            project_name="pxi_agent",
+            project_name="assistant_agent",
         )
 
         assert (
-            tracer._self_provider.resource.attributes["openinference.project.name"] == "pxi_agent"
+            tracer._self_provider.resource.attributes["openinference.project.name"]
+            == "assistant_agent"
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_tracers.py
+++ b/tests/unit/test_tracers.py
@@ -375,9 +375,7 @@ class TestTracer:
             captured_endpoint = endpoint
             return FakeRemoteExporter()
 
-        monkeypatch.setenv(
-            "PHOENIX_AGENT_TRACES_COLLECTOR_ENDPOINT", "https://env-collector.example"
-        )
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "https://env-collector.example")
 
         Tracer(
             span_cost_calculator=span_cost_calculator,
@@ -409,9 +407,7 @@ class TestTracer:
             captured_endpoint = endpoint
             return FakeRemoteExporter()
 
-        monkeypatch.setenv(
-            "PHOENIX_AGENT_TRACES_COLLECTOR_ENDPOINT", "https://env-collector.example"
-        )
+        monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "https://env-collector.example")
 
         Tracer(
             span_cost_calculator=span_cost_calculator,


### PR DESCRIPTION
## Summary
- Renames all PXI-branded environment variables and config helpers to use a consistent `PHOENIX_AGENTS_` prefix (`PHOENIX_AGENTS_COLLECTOR_ENDPOINT`, `PHOENIX_AGENTS_COLLECTOR_API_KEY`, `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME`)
- Updates all getter functions, callers, and tests to match
- Adds clarification in agent skills that PXI ("pixie") is the assistant's user-facing name, not the feature/config name

This is in preparation for beta usage — the env var surface should use generic, feature-descriptive naming rather than the assistant's brand name.

## Test plan
- [ ] Verify existing agent tracing tests pass (`tests/unit/test_tracers.py`, `tests/unit/server/api/routers/test_chat_tracing.py`)
- [ ] Confirm no remaining references to old `PHOENIX_PXI_*` env vars