### PR TITLE
feat(ui): expose agentsConfig via GraphQL on settings page

### DIFF
--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -77,6 +77,18 @@ input AddSpansToDatasetInput {
   datasetVersionMetadata: JSON
 }
 
+type AgentsConfig {
+  """
+  The collector endpoint used by the server-side agents to export traces. Resolved from the PHOENIX_AGENTS_COLLECTOR_ENDPOINT environment variable.
+  """
+  collectorEndpoint: String
+
+  """
+  The project name used for assistant agent traces. Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable.
+  """
+  assistantProjectName: String!
+}
+
 interface Annotation {
   """Name of the annotation, e.g. 'helpfulness' or 'relevance'."""
   name: String!
@@ -2958,6 +2970,7 @@ type Query {
   dbStorageCapacityBytes: Float
   dbTableStats: [DbTableStats!]!
   serverStatus: ServerStatus!
+  agentsConfig: AgentsConfig!
   validateRegularExpression(regex: String!): ValidationResult!
   getSpanByOtelId(spanId: String!): Span
   getTraceByOtelId(traceId: String!): Trace

--- a/app/src/pages/settings/SettingsAgentsPage.tsx
+++ b/app/src/pages/settings/SettingsAgentsPage.tsx
@@ -1,6 +1,41 @@
-import { Card, Switch, View } from "@phoenix/components";
+import { css } from "@emotion/react";
+import { Suspense } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import {
+  Card,
+  CopyField,
+  CopyInput,
+  ExternalLink,
+  Flex,
+  Label,
+  Loading,
+  Switch,
+  Text,
+  View,
+} from "@phoenix/components";
 import { AgentSettingsForm } from "@phoenix/components/agent";
 import { usePreferencesContext } from "@phoenix/contexts/PreferencesContext";
+
+import type { SettingsAgentsPageQuery } from "./__generated__/SettingsAgentsPageQuery.graphql";
+
+function getProjectRedirectUrl(
+  collectorEndpoint: string,
+  projectName: string
+): string | null {
+  try {
+    const url = new URL(collectorEndpoint);
+    url.pathname = url.pathname
+      .replace(/\/v1\/traces\/?$/, "")
+      .replace(/\/$/, "");
+    url.pathname = `${url.pathname}/redirects/projects/${encodeURIComponent(projectName)}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
 
 function AssistantAgentEnabledSwitch() {
   const isAssistantAgentEnabled = usePreferencesContext(
@@ -20,6 +55,56 @@ function AssistantAgentEnabledSwitch() {
   );
 }
 
+function AssistantTraceCollectionInfo() {
+  const data = useLazyLoadQuery<SettingsAgentsPageQuery>(
+    graphql`
+      query SettingsAgentsPageQuery {
+        agentsConfig {
+          collectorEndpoint
+          assistantProjectName
+        }
+      }
+    `,
+    {}
+  );
+
+  const { collectorEndpoint, assistantProjectName } = data.agentsConfig;
+  const projectRedirectUrl = collectorEndpoint
+    ? getProjectRedirectUrl(collectorEndpoint, assistantProjectName)
+    : null;
+
+  return (
+    <Flex direction="column" gap="size-200">
+      <Text>Assistant agent traces are collected to the project below.</Text>
+      <CopyField value={assistantProjectName}>
+        <Label>Assistant Project Name</Label>
+        <CopyInput />
+        <Text slot="description">
+          {projectRedirectUrl ? (
+            <>
+              View traces in{" "}
+              <ExternalLink href={projectRedirectUrl}>
+                {assistantProjectName}
+              </ExternalLink>
+            </>
+          ) : (
+            "The project where assistant agent traces are recorded"
+          )}
+        </Text>
+      </CopyField>
+      <CopyField value={collectorEndpoint ?? ""}>
+        <Label>Collector Endpoint</Label>
+        <CopyInput />
+        <Text slot="description">
+          {collectorEndpoint
+            ? "Traces are also exported to this remote collector"
+            : "No remote collector configured — traces are only persisted locally"}
+        </Text>
+      </CopyField>
+    </Flex>
+  );
+}
+
 export function SettingsAgentsPage() {
   const isAssistantAgentEnabled = usePreferencesContext(
     (state) => state.isAssistantAgentEnabled
@@ -32,7 +117,18 @@ export function SettingsAgentsPage() {
       extra={<AssistantAgentEnabledSwitch />}
     >
       <View padding="size-200">
-        <AgentSettingsForm />
+        <Flex
+          direction="column"
+          gap="size-300"
+          css={css`
+            width: 100%;
+          `}
+        >
+          <Suspense fallback={<Loading />}>
+            <AssistantTraceCollectionInfo />
+          </Suspense>
+          <AgentSettingsForm />
+        </Flex>
       </View>
     </Card>
   );

--- a/app/src/pages/settings/__generated__/SettingsAgentsPageQuery.graphql.ts
+++ b/app/src/pages/settings/__generated__/SettingsAgentsPageQuery.graphql.ts
@@ -1,0 +1,82 @@
+/**
+ * @generated SignedSource<<faee4505431ded7b7385aa0fb5082e43>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SettingsAgentsPageQuery$variables = Record<PropertyKey, never>;
+export type SettingsAgentsPageQuery$data = {
+  readonly agentsConfig: {
+    readonly assistantProjectName: string;
+    readonly collectorEndpoint: string | null;
+  };
+};
+export type SettingsAgentsPageQuery = {
+  response: SettingsAgentsPageQuery$data;
+  variables: SettingsAgentsPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "AgentsConfig",
+    "kind": "LinkedField",
+    "name": "agentsConfig",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "collectorEndpoint",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "assistantProjectName",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SettingsAgentsPageQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SettingsAgentsPageQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "df131de67f0c140434276cfbaba53867",
+    "id": null,
+    "metadata": {},
+    "name": "SettingsAgentsPageQuery",
+    "operationKind": "query",
+    "text": "query SettingsAgentsPageQuery {\n  agentsConfig {\n    collectorEndpoint\n    assistantProjectName\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "695271dccb50b3b7fe2ebcff0c43e1da";
+
+export default node;

--- a/src/phoenix/server/api/queries.py
+++ b/src/phoenix/server/api/queries.py
@@ -20,6 +20,8 @@ from typing_extensions import TypeAlias, assert_never
 from phoenix.config import (
     ENV_PHOENIX_SQL_DATABASE_SCHEMA,
     get_env_database_allocated_storage_capacity_gibibytes,
+    get_env_phoenix_agents_assistant_project_name,
+    get_env_phoenix_agents_collector_endpoint,
     getenv,
 )
 from phoenix.db import models
@@ -70,6 +72,7 @@ from phoenix.server.api.input_types.ProjectSort import ProjectColumn, ProjectSor
 from phoenix.server.api.input_types.PromptFilter import PromptFilter
 from phoenix.server.api.input_types.PromptTemplateOptions import PromptTemplateOptions
 from phoenix.server.api.input_types.PromptVersionInput import PromptChatTemplateInput
+from phoenix.server.api.types.AgentsConfig import AgentsConfig
 from phoenix.server.api.types.AnnotationConfig import AnnotationConfig, to_gql_annotation_config
 from phoenix.server.api.types.ClassificationEvaluatorConfig import ClassificationEvaluatorConfig
 from phoenix.server.api.types.Dataset import Dataset
@@ -1590,6 +1593,13 @@ class Query:
     ) -> ServerStatus:
         return ServerStatus(
             insufficient_storage=info.context.db.should_not_insert_or_update,
+        )
+
+    @strawberry.field
+    def agents_config(self) -> AgentsConfig:
+        return AgentsConfig(
+            collector_endpoint=get_env_phoenix_agents_collector_endpoint(),
+            assistant_project_name=get_env_phoenix_agents_assistant_project_name(),
         )
 
     @strawberry.field

--- a/src/phoenix/server/api/types/AgentsConfig.py
+++ b/src/phoenix/server/api/types/AgentsConfig.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+import strawberry
+
+
+@strawberry.type
+class AgentsConfig:
+    collector_endpoint: Optional[str] = strawberry.field(
+        description=(
+            "The collector endpoint used by the server-side agents to export traces. "
+            "Resolved from the PHOENIX_AGENTS_COLLECTOR_ENDPOINT environment variable."
+        ),
+    )
+    assistant_project_name: str = strawberry.field(
+        description=(
+            "The project name used for assistant agent traces. "
+            "Resolved from the PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME environment variable."
+        ),
+    )

--- a/tests/unit/server/api/test_queries.py
+++ b/tests/unit/server/api/test_queries.py
@@ -465,6 +465,52 @@ async def test_db_table_stats(gql_client: AsyncGraphQLClient) -> None:
     assert set(s["tableName"] for s in data["dbTableStats"]) == set(models.Base.metadata.tables)
 
 
+async def test_agents_config_returns_env_values(
+    gql_client: AsyncGraphQLClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", "http://collector.example:4318")
+    monkeypatch.setenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", "custom_assistant")
+    query = """
+      query {
+        agentsConfig {
+          collectorEndpoint
+          assistantProjectName
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert data["agentsConfig"] == {
+        "collectorEndpoint": "http://collector.example:4318",
+        "assistantProjectName": "custom_assistant",
+    }
+
+
+async def test_agents_config_defaults_when_env_unset(
+    gql_client: AsyncGraphQLClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOENIX_AGENTS_COLLECTOR_ENDPOINT", raising=False)
+    monkeypatch.delenv("PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME", raising=False)
+    query = """
+      query {
+        agentsConfig {
+          collectorEndpoint
+          assistantProjectName
+        }
+      }
+    """
+    response = await gql_client.execute(query=query)
+    assert not response.errors
+    assert (data := response.data) is not None
+    assert data["agentsConfig"] == {
+        "collectorEndpoint": None,
+        "assistantProjectName": "assistant_agent",
+    }
+
+
 @pytest.fixture
 async def prompts_for_filtering(
     db: DbSessionFactory,


### PR DESCRIPTION

<img width="1362" height="1197" alt="Screenshot 2026-04-16 at 4 47 19 PM" src="https://github.com/user-attachments/assets/d44e91e8-3035-40db-9086-77f7b9227310" />


- Adds an `agentsConfig` GraphQL query that resolves `PHOENIX_AGENTS_COLLECTOR_ENDPOINT` and `PHOENIX_AGENTS_ASSISTANT_PROJECT_NAME` (the collector API key is intentionally not exposed).
- Surfaces the resolved project name and collector endpoint in the Assistant card on the Agents settings page so users can confirm traces are being collected.
- When a collector endpoint is configured, the project name links out to `{collectorHost}/redirects/projects/{projectName}` (stripping `/v1/traces`) so users can jump to the traces view.
